### PR TITLE
tests: run the VM campaign on the Proxmox cluster

### DIFF
--- a/tests/test_console.py
+++ b/tests/test_console.py
@@ -4,7 +4,13 @@ import socket
 
 import pytest
 
-from tests.vm.console import ConsoleClosed, ConsoleTimeout, SerialConsole, strip_ansi
+from tests.vm.console import (
+    ConsoleClosed,
+    ConsoleTimeout,
+    SerialConsole,
+    _Socket,
+    strip_ansi,
+)
 
 
 def make_console(chunks: list[bytes]) -> tuple[SerialConsole, socket.socket]:
@@ -12,7 +18,7 @@ def make_console(chunks: list[bytes]) -> tuple[SerialConsole, socket.socket]:
     for chunk in chunks:
         writer.sendall(chunk)
     reader.settimeout(0.1)
-    return SerialConsole(reader, open("/dev/null", "wb")), writer
+    return SerialConsole(_Socket(reader), open("/dev/null", "wb")), writer
 
 
 def test_strip_ansi_removes_colour_and_title_sequences() -> None:

--- a/tests/unit/test_harness.py
+++ b/tests/unit/test_harness.py
@@ -318,7 +318,7 @@ def test_a_passphrase_becomes_the_keys_the_monitor_understands() -> None:
     # Refused rather than dropped: an unnamed character would be sent as
     # itself and silently ignored, and the guest would wait for ever.
     with pytest.raises(MonitorError):
-        keys_for("wide中")
+        keys_for("wide\u4e2d")
 
 
 def test_the_guest_offers_a_monitor_socket() -> None:

--- a/tests/unit/test_proxmox.py
+++ b/tests/unit/test_proxmox.py
@@ -1,0 +1,192 @@
+"""The cluster backend's parsing and its safety guard, with no cluster."""
+
+from __future__ import annotations
+
+import struct
+import urllib.request
+from typing import Any
+
+import pytest
+
+from tests.vm import proxmox
+from tests.vm.proxmox import TAG, Api, Guest, GuestSpec, ProxmoxError, _line_of_linux
+from tests.vm.websocket import WebSocket, _client_frame
+
+#: One editor screen as GRUB drew it on the serial console, captured from the
+#: Gentoo minimal ISO. `search` sits between `setparams` and `linux`, which is
+#: what made a fixed count edit the wrong line.
+GENTOO_EDITOR = (
+    b"\x1b[07;03Hsetparams 'Boot LiveCD (kernel: gentoo)'   "
+    b"\x1b[08;03H        search --no-floppy --set=root -l Gentoo-amd64-20260712   "
+    b"\x1b[09;03H        linux /boot/gentoo dokeymap nodhcp cdroot   "
+    b"\x1b[10;03H        initrd /boot/gentoo.igz"
+)
+
+
+def test_the_linux_line_is_read_off_the_screen() -> None:
+    assert _line_of_linux(GENTOO_EDITOR) == 2
+
+
+def test_an_entry_with_no_search_line_needs_one_fewer() -> None:
+    screen = (
+        b"\x1b[07;03Hsetparams 'Install'   "
+        b"\x1b[08;03H        linuxefi /images/pxeboot/vmlinuz quiet   "
+        b"\x1b[09;03H        initrdefi /images/pxeboot/initrd.img"
+    )
+    assert _line_of_linux(screen) == 1
+
+
+def test_a_screen_with_no_grub_entry_is_refused() -> None:
+    """Guessing a number here would edit whatever sat on that row, and the
+    entry would boot unchanged with its own line corrupted."""
+    with pytest.raises(ProxmoxError, match="no GRUB entry"):
+        _line_of_linux(b"\x1b[07;03HSeaBIOS   \x1b[08;03HNo bootable device.")
+
+
+class _Recording(Api):
+    """An `Api` that answers from a script instead of the cluster."""
+
+    def __init__(self, answers: dict[str, Any]) -> None:
+        super().__init__(host="nowhere.invalid")
+        self.answers = answers
+        self.asked: list[tuple[str, str]] = []
+
+    def call(self, method: str, path: str, **form: Any) -> Any:
+        self.asked.append((method, path))
+        for key, value in self.answers.items():
+            if key in path:
+                return value
+        return {}
+
+    def wait(self, node: str, upid: str, patience: float = 1800.0) -> None:
+        return None
+
+
+def test_a_guest_without_the_tag_is_not_deleted() -> None:
+    """`9002` in the range this harness allocates from is
+    `prod-debian-12-server-template`. A VMID is not ownership."""
+    api = _Recording({"config": {"name": "prod-debian-12-server-template", "tags": "debian;prod"}})
+    guest = Guest(api=api, node="infra-node1", vmid=9002, spec=GuestSpec(name="x", iso="x"))
+    with pytest.raises(ProxmoxError, match="refusing to remove"):
+        guest.destroy()
+    assert not any(method == "DELETE" for method, _ in api.asked)
+
+
+def test_a_tagged_guest_is_deleted() -> None:
+    api = _Recording({"config": {"name": "gi-run", "tags": TAG}})
+    guest = Guest(api=api, node="infra-node4", vmid=9300, spec=GuestSpec(name="x", iso="x"))
+    guest.destroy()
+    assert ("DELETE", "/nodes/infra-node4/qemu/9300") in api.asked
+
+
+def test_ours_needs_the_tag_as_well_as_the_range() -> None:
+    api = _Recording(
+        {
+            "resources": [
+                {"node": "infra-node1", "vmid": 9002, "tags": "debian;prod"},
+                {"node": "infra-node4", "vmid": 9300, "tags": TAG},
+                {"node": "infra-node5", "vmid": 114514, "tags": TAG},
+            ]
+        }
+    )
+    assert api.ours() == [("infra-node4", 9300)]
+
+
+def test_a_vmid_is_allocated_around_everything_on_the_cluster() -> None:
+    """Not around the harness's own machines: 9300 free of our guests but held
+    by somebody else's would collide."""
+    api = _Recording(
+        {"resources": [{"node": "n", "vmid": 9300, "tags": "someone-else"}]}
+    )
+    assert api.free_vmid() == 9301
+
+
+def test_a_delete_carries_its_parameters_in_the_url(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A body on DELETE is answered `501 Unexpected content for method`, so the
+    two methods that take no body put their parameters in the query string."""
+    seen: dict[str, Any] = {}
+
+    class Answer:
+        headers: dict[str, str] = {}
+
+        def read(self) -> bytes:
+            return b'{"data":"UPID:x"}'
+
+        def __enter__(self) -> Answer:
+            return self
+
+        def __exit__(self, *rest: object) -> None:
+            return None
+
+    def fake_open(request: Any, timeout: float = 0.0, context: Any = None) -> Any:
+        seen["url"] = request.full_url
+        seen["body"] = request.data
+        return Answer()
+
+    monkeypatch.setattr(urllib.request, "urlopen", fake_open)
+    api = Api(host="nowhere.invalid")
+    api.call("DELETE", "/nodes/n/qemu/9300", purge=1)
+    removed = (seen["url"], seen["body"])
+    api.call("POST", "/nodes/n/qemu", vmid=9300)
+    created = (seen["url"], seen["body"])
+
+    assert removed == ("https://nowhere.invalid/api2/json/nodes/n/qemu/9300?purge=1", None)
+    assert created == ("https://nowhere.invalid/api2/json/nodes/n/qemu", b"vmid=9300")
+
+
+def test_the_console_channel_frames_input_the_way_proxmox_reads_it() -> None:
+    """`0:<bytes>:<data>`. Without the length prefix the proxy discards it."""
+
+    class Fake:
+        def __init__(self) -> None:
+            self.sent: list[bytes] = []
+            self.closed = False
+
+        def send(self, payload: bytes, opcode: int = 0x2) -> None:
+            self.sent.append(payload)
+
+        def read(self) -> bytes:
+            return b""
+
+        def close(self) -> None:
+            self.closed = True
+
+    fake = Fake()
+    channel = proxmox.ConsoleChannel(fake)
+    channel.sendall(b"uname -r\n")
+    assert fake.sent == [b"0:9:uname -r\n"]
+
+
+def test_a_server_frame_is_read_whole_across_two_reads() -> None:
+    """One console write can arrive in two packets, and half a frame is not a
+    short read to pass upward."""
+    payload = b"root@livecd ~ # "
+    whole = struct.pack("!BB", 0x81, len(payload)) + payload
+
+    class Split:
+        def __init__(self) -> None:
+            self.parts = [whole[:3], whole[3:]]
+
+        def recv(self, size: int, /) -> bytes:
+            return self.parts.pop(0) if self.parts else b""
+
+        def sendall(self, data: bytes, /) -> None:
+            raise AssertionError("this test never writes")
+
+        def close(self) -> None:
+            pass
+
+        def settimeout(self, seconds: float | None, /) -> None:
+            pass
+
+    socket = WebSocket(Split())
+    assert socket.read() == b""
+    assert socket.read() == payload
+
+
+def test_a_client_frame_is_masked() -> None:
+    """RFC 6455: a client always masks, and Proxmox drops a frame that is not."""
+    frame = _client_frame(b"hi", 0x2)
+    assert frame[1] & 0x80, "the mask bit has to be set"
+    mask = frame[2:6]
+    assert bytes(b ^ mask[n % 4] for n, b in enumerate(frame[6:])) == b"hi"

--- a/tests/unit/test_proxmox.py
+++ b/tests/unit/test_proxmox.py
@@ -190,3 +190,51 @@ def test_a_client_frame_is_masked() -> None:
     assert frame[1] & 0x80, "the mask bit has to be set"
     mask = frame[2:6]
     assert bytes(b ^ mask[n % 4] for n, b in enumerate(frame[6:])) == b"hi"
+
+
+def _archive(files: dict[str, bytes]) -> str:
+    import base64 as b64
+    import io
+    import tarfile
+
+    buffer = io.BytesIO()
+    with tarfile.open(fileobj=buffer, mode="w:gz") as archive:
+        for name, data in files.items():
+            entry = tarfile.TarInfo(f"./{name}")
+            entry.size = len(data)
+            archive.addfile(entry, io.BytesIO(data))
+    return b64.b64encode(buffer.getvalue()).decode()
+
+
+def test_results_come_back_through_the_console() -> None:
+    """The guest's disks are on shared storage the workstation cannot read and
+    the API downloads no volume, so the console is the only channel back."""
+    from tests.vm.results import CONSOLE_CLOSE, CONSOLE_OPEN, console_command, read_console
+
+    encoded = _archive({"install.log": b"ok\n", "exit.txt": b"0\n"})
+    wrapped = "\r\n".join(encoded[at : at + 80] for at in range(0, len(encoded), 80))
+    # The shell echoes the command, so the markers appear twice; the terminal
+    # wraps the one line base64 wrote, so the payload arrives in pieces.
+    said = (
+        f"root@livecd ~ # {console_command('/tmp/results')}\r\n"
+        f"{CONSOLE_OPEN}\r\n{wrapped}\r\n\r\n{CONSOLE_CLOSE}\r\nroot@livecd ~ # "
+    ).encode()
+    assert read_console(said) == {"install.log": b"ok\n", "exit.txt": b"0\n"}
+
+
+def test_a_console_with_no_archive_is_an_error_not_an_empty_result() -> None:
+    from tests.vm.results import ResultError, read_console
+
+    with pytest.raises(ResultError, match="no result archive"):
+        read_console(b"root@livecd ~ # the install died here")
+
+
+def test_a_truncated_archive_is_refused() -> None:
+    """A guest killed mid-transfer answers half a stream, and half a tar read
+    as an empty result would report a passing run."""
+    from tests.vm.results import CONSOLE_CLOSE, CONSOLE_OPEN, ResultError, read_console
+
+    encoded = _archive({"install.log": b"ok\n"})
+    said = f"{CONSOLE_OPEN}\r\n{encoded[: len(encoded) // 2]}\r\n{CONSOLE_CLOSE}\r\n".encode()
+    with pytest.raises(ResultError):
+        read_console(said)

--- a/tests/unit/test_proxmox.py
+++ b/tests/unit/test_proxmox.py
@@ -248,7 +248,7 @@ def test_the_watchdog_counts_quiet_looks_not_elapsed_time(tmp_path: Path) -> Non
 
     log = tmp_path / "run.log"
     log.write_bytes(b"booting\n")
-    watch = Watchdog(log=log)
+    watch = Watchdog(log=log, counters=lambda: 0)
     # Read into locals: mypy narrows a property and never widens it again,
     # because it cannot see `moved()` changing what `stuck` answers.
     first = (watch.moved(), watch.stuck)
@@ -263,6 +263,38 @@ def test_the_watchdog_counts_quiet_looks_not_elapsed_time(tmp_path: Path) -> Non
     assert quiet == [False] * WATCH_STRIKES
     assert after is True
     assert revived == (True, False)
+
+
+def test_a_silent_guest_that_is_still_downloading_is_left_alone(tmp_path: Path) -> None:
+    """An install says nothing on the console while it fetches a stage3, and
+    that is the guest doing the most work. Ending it for the silence is how a
+    watchdog kills the runs it exists to protect."""
+    from tests.vm.cluster import QUIET_BYTES, WATCH_STRIKES, Watchdog
+
+    log = tmp_path / "quiet.log"
+    log.write_bytes(b"downloading\n")
+    moving = [0]
+
+    def counters() -> int:
+        moving[0] += QUIET_BYTES * 2
+        return moving[0]
+
+    watch = Watchdog(log=log, counters=counters)
+    looks = [watch.moved() for _ in range(WATCH_STRIKES + 2)]
+    assert looks == [True] * (WATCH_STRIKES + 2)
+    assert not watch.stuck
+
+
+def test_a_guest_moving_nothing_at_all_is_stuck(tmp_path: Path) -> None:
+    """Console silent and counters flat: not slow, dead."""
+    from tests.vm.cluster import WATCH_STRIKES, Watchdog
+
+    log = tmp_path / "dead.log"
+    log.write_bytes(b"")
+    watch = Watchdog(log=log, counters=lambda: 5_000_000)
+    quiet = [watch.moved() for _ in range(WATCH_STRIKES + 1)]
+    assert quiet[1:] == [False] * WATCH_STRIKES
+    assert watch.stuck
 
 
 def test_a_stuck_guest_is_stopped_and_not_deleted_by_the_sweep(tmp_path: Path) -> None:
@@ -281,7 +313,7 @@ def test_a_stuck_guest_is_stopped_and_not_deleted_by_the_sweep(tmp_path: Path) -
 
     log = tmp_path / "quiet.log"
     log.write_bytes(b"")
-    watch = Watchdog(log=log, strikes=WATCH_STRIKES - 1)
+    watch = Watchdog(log=log, counters=lambda: 0, strikes=WATCH_STRIKES - 1)
     inflight = {"vm-zfs": Running(guest=Quiet(), watch=watch)}
     _sweep(inflight)
     assert stopped == ["stopped"]

--- a/tests/unit/test_proxmox.py
+++ b/tests/unit/test_proxmox.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import struct
 import urllib.request
+from pathlib import Path
 from typing import Any
 
 import pytest
@@ -238,3 +239,49 @@ def test_a_truncated_archive_is_refused() -> None:
     said = f"{CONSOLE_OPEN}\r\n{encoded[: len(encoded) // 2]}\r\n{CONSOLE_CLOSE}\r\n".encode()
     with pytest.raises(ResultError):
         read_console(said)
+
+
+def test_the_watchdog_counts_quiet_looks_not_elapsed_time(tmp_path: Path) -> None:
+    """A slow mirror and a dead guest take the same wall-clock; only one of
+    them is still writing to the console."""
+    from tests.vm.cluster import WATCH_STRIKES, Watchdog
+
+    log = tmp_path / "run.log"
+    log.write_bytes(b"booting\n")
+    watch = Watchdog(log=log)
+    # Read into locals: mypy narrows a property and never widens it again,
+    # because it cannot see `moved()` changing what `stuck` answers.
+    first = (watch.moved(), watch.stuck)
+    quiet = [watch.moved() for _ in range(WATCH_STRIKES)]
+    after = watch.stuck
+    # One more byte and it is alive again: a build that prints once an hour
+    # must not be ended for the silence before it.
+    log.write_bytes(b"booting\nunpacking\n")
+    revived = (watch.moved(), watch.stuck)
+
+    assert first == (True, False), "the first look sees the whole log"
+    assert quiet == [False] * WATCH_STRIKES
+    assert after is True
+    assert revived == (True, False)
+
+
+def test_a_stuck_guest_is_stopped_and_not_deleted_by_the_sweep(tmp_path: Path) -> None:
+    """Stopping is what wakes the worker blocked on its console; the worker
+    then reports and deletes. A sweep that deleted would race it."""
+    from tests.vm.cluster import WATCH_STRIKES, Running, Watchdog, _sweep
+
+    stopped: list[str] = []
+
+    class Quiet:
+        def stop(self) -> None:
+            stopped.append("stopped")
+
+        def destroy(self) -> None:
+            raise AssertionError("the sweep must not delete a guest")
+
+    log = tmp_path / "quiet.log"
+    log.write_bytes(b"")
+    watch = Watchdog(log=log, strikes=WATCH_STRIKES - 1)
+    inflight = {"vm-zfs": Running(guest=Quiet(), watch=watch)}
+    _sweep(inflight)
+    assert stopped == ["stopped"]

--- a/tests/unit/test_proxmox.py
+++ b/tests/unit/test_proxmox.py
@@ -337,3 +337,30 @@ def test_every_printable_ascii_character_has_a_key_name() -> None:
 
     printable = "".join(chr(code) for code in range(0x20, 0x7F))
     assert len(keys_for(printable)) == len(printable)
+
+
+def test_every_dispatched_job_answers_exactly_once(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A worker that dies without answering leaves its name in the running set
+    for ever and the schedule never ends. One run sat idle for half an hour
+    with an empty cluster and a job still queued, because `WebSocketError` out
+    of a dropped console was outside the handled set."""
+    import queue as queueing
+
+    from tests.vm import cluster
+    from tests.vm.cluster import Job, Outcome, Verdict, answer_once
+    from tests.vm.websocket import WebSocketError
+
+    def explode(*rest: object) -> Outcome:
+        raise WebSocketError("the connection broke")
+
+    monkeypatch.setattr(cluster, "install_one", explode)
+    done: queueing.Queue[Outcome] = queueing.Queue()
+    job = Job(name="vm-lvm", fixture=tmp_path / "vm-lvm.toml")
+    answer_once(done, Api(host="nowhere.invalid"), "infra-node3", job, "d.iso", tmp_path, {})
+
+    answered = done.get_nowait()
+    assert (answered.name, answered.verdict) == ("vm-lvm", Verdict.ERROR)
+    assert "WebSocketError" in answered.detail
+    assert done.empty(), "one job, one answer"

--- a/tests/unit/test_proxmox.py
+++ b/tests/unit/test_proxmox.py
@@ -317,3 +317,23 @@ def test_a_stuck_guest_is_stopped_and_not_deleted_by_the_sweep(tmp_path: Path) -
     inflight = {"vm-zfs": Running(guest=Quiet(), watch=watch)}
     _sweep(inflight)
     assert stopped == ["stopped"]
+
+
+def test_a_kernel_parameter_can_be_typed_through_sendkey() -> None:
+    """`console=ttyS0,115200` at a GRUB prompt on a BIOS guest: every
+    character needs a qemu key name, and `equal` and `comma` were missing."""
+    from tests.vm.monitor import keys_for
+
+    assert keys_for(" console=ttyS0,115200") == [
+        "spc", "c", "o", "n", "s", "o", "l", "e", "equal",
+        "t", "t", "y", "shift-s", "0", "comma", "1", "1", "5", "2", "0", "0",
+    ]
+
+
+def test_every_printable_ascii_character_has_a_key_name() -> None:
+    """A missing name is refused rather than sent as itself and dropped, so
+    the table has to cover what a passphrase or a command line can hold."""
+    from tests.vm.monitor import keys_for
+
+    printable = "".join(chr(code) for code in range(0x20, 0x7F))
+    assert len(keys_for(printable)) == len(printable)

--- a/tests/vm/cluster.py
+++ b/tests/vm/cluster.py
@@ -24,11 +24,12 @@ import urllib.request
 from dataclasses import dataclass, field, replace
 from enum import Enum
 from pathlib import Path
+from collections.abc import Callable
 from typing import Final, Protocol
 
 from gentoo_install.model.config import InstallConfig
 from gentoo_install.model.device import Existing
-from gentoo_install.model.config import MirrorRegion
+from gentoo_install.model.config import MirrorRegion, Sync
 from gentoo_install.model.parse import load
 from gentoo_install.model.serialise import to_toml
 from .console import ConsoleClosed, ConsoleTimeout, SerialConsole
@@ -122,18 +123,36 @@ class Job:
     disks: int = 1
 
 
+#: Below this, over a whole ten-minute look, the guest is not working: a
+#: stage3 download that is merely slow still moved several megabytes, and the
+#: slowest this network has served one is 40 KiB/s, which is 24 MiB.
+QUIET_BYTES: Final[int] = 1024 * 1024
+
+
 @dataclass
 class Watchdog:
-    """Whether a guest is still producing output."""
+    """Whether a guest is still doing anything.
+
+    The console alone is not enough. An install spends minutes downloading a
+    stage3 and says nothing at all while it does, so a watchdog reading only
+    the serial log ends the guests that are working hardest. The guest's own
+    counters are what separate a slow transfer from a dead machine.
+    """
 
     log: Path
+    counters: Callable[[], int]
     strikes: int = 0
     _seen: int = field(default=0, init=False)
+    _moved: int = field(default=0, init=False)
 
     def moved(self) -> bool:
         size = self.log.stat().st_size if self.log.exists() else 0
-        if size > self._seen:
-            self._seen = size
+        traffic = self.counters()
+        talking = size > self._seen
+        working = traffic - self._moved >= QUIET_BYTES
+        self._seen = max(self._seen, size)
+        self._moved = max(self._moved, traffic)
+        if talking or working:
             self.strikes = 0
             return True
         self.strikes += 1
@@ -185,23 +204,39 @@ def prepare(
         api.upload_iso(node, driver_path, driver)
 
 
-def rewrite_fixtures(jobs: list[Job], into: Path, region: MirrorRegion) -> Path:
-    """Write each fixture out again with its mirror region replaced.
+def rewrite_fixtures(
+    jobs: list[Job], into: Path, region: MirrorRegion, sync: Sync
+) -> Path:
+    """Write each fixture out again with its mirror region and sync replaced.
 
     Through the parser and the writer, not a text substitution: a fixture that
     cannot survive the round trip is a defect worth failing on here rather than
     an hour into an install.
 
-    The cluster is in China, and a `global` fixture syncs the tree from
-    `github.com/gentoo-mirror/gentoo.git`, which answered `SSL_read:
-    unexpected eof while reading` there. Running the set against `cn` is both
-    what works and what the operators of that network actually use.
+    Both defaults come from what this network measured, not from what a
+    Chinese cluster is assumed to look like. Its guests have a ULA address and
+    reach the world through NAT64, and from inside one:
+
+    - `github.com` never connects, so the default `git` sync cannot be used
+      and `rsync` is what the fixtures run with here;
+    - `mirrors.tuna.tsinghua.edu.cn` connects but transfers at 128 KiB/s,
+      which is an hour for one stage3;
+    - `distfiles.gentoo.org`, a CDN, is the fast one, so `global` is the
+      region that finishes.
+
+    The node itself has none of these limits: it fetched a 1 GiB ISO from
+    tuna in the same run. Only the guest network is this shape.
     """
     into.mkdir(parents=True, exist_ok=True)
     for job in jobs:
         config = load(job.fixture)
         moved = replace(
-            config, portage=replace(config.portage, mirrors=replace(config.portage.mirrors, region=region))
+            config,
+            portage=replace(
+                config.portage,
+                sync=sync,
+                mirrors=replace(config.portage.mirrors, region=region),
+            ),
         )
         (into / job.fixture.name).write_text(to_toml(moved))
     return into
@@ -255,7 +290,7 @@ def install_one(
             driver_iso=driver,
         ),
     )
-    watch = Watchdog(log=log)
+    watch = Watchdog(log=log, counters=lambda: guest.transferred())
     if inflight is not None:
         inflight[job.name] = Running(guest=guest, watch=watch)
     try:
@@ -313,7 +348,8 @@ def run(
     workdir: Path,
     limit: int = 0,
     stamp: int = 0,
-    region: MirrorRegion = MirrorRegion.CN,
+    region: MirrorRegion = MirrorRegion.GLOBAL,
+    sync: Sync = Sync.RSYNC,
 ) -> list[Outcome]:
     """Every job, collected one at a time as each finishes.
 
@@ -325,7 +361,7 @@ def run(
     driver_path = build_driver(
         workdir / "driver.iso",
         packed=True,
-        fixtures=rewrite_fixtures(jobs, workdir / "fixtures", region),
+        fixtures=rewrite_fixtures(jobs, workdir / "fixtures", region, sync),
     )
     driver = f"gi-driver-{stamp}.iso"
     medium, urls = current_minimal()
@@ -426,8 +462,14 @@ def main(argv: list[str] | None = None) -> int:
     parser.add_argument(
         "--region",
         choices=[one.value for one in MirrorRegion],
-        default=MirrorRegion.CN.value,
+        default=MirrorRegion.GLOBAL.value,
         help="which mirror region every fixture is rewritten to use",
+    )
+    parser.add_argument(
+        "--sync",
+        choices=[one.value for one in Sync],
+        default=Sync.RSYNC.value,
+        help="how every fixture syncs the tree; git needs github, which this network lacks",
     )
     args = parser.parse_args(argv)
 
@@ -437,6 +479,7 @@ def main(argv: list[str] | None = None) -> int:
         args.limit,
         int(time.time()),
         MirrorRegion(args.region),
+        Sync(args.sync),
     )
     passed = [one for one in outcomes if one.verdict is Verdict.OK]
     print(f"\n{len(passed)}/{len(outcomes)} passed")

--- a/tests/vm/cluster.py
+++ b/tests/vm/cluster.py
@@ -279,6 +279,7 @@ def install_one(
     driver: str,
     workdir: Path,
     inflight: dict[str, Running] | None = None,
+    vmid: int = 0,
 ) -> Outcome:
     """Build a guest, install into it, read the result, delete the guest."""
     started = time.monotonic()
@@ -287,7 +288,7 @@ def install_one(
     guest = Guest(
         api=api,
         node=node,
-        vmid=api.free_vmid(),
+        vmid=vmid or api.free_vmid(),
         spec=GuestSpec(
             name=f"gi-{job.name}"[:63],
             iso=job.iso,
@@ -363,6 +364,7 @@ def answer_once(
     driver: str,
     workdir: Path,
     inflight: dict[str, Running],
+    vmid: int = 0,
 ) -> None:
     """Run one job and put exactly one outcome on the queue, whatever happens.
 
@@ -372,7 +374,7 @@ def answer_once(
     with an empty cluster and a job still queued.
     """
     try:
-        done.put(install_one(api, node, job, driver, workdir, inflight))
+        done.put(install_one(api, node, job, driver, workdir, inflight, vmid))
     except BaseException as error:
         done.put(
             Outcome(job.name, Verdict.ERROR, 0.0, f"{type(error).__name__}: {error}"[:300])
@@ -407,6 +409,10 @@ def run(
     running: dict[str, threading.Thread] = {}
     inflight: dict[str, Running] = {}
     finished: list[Outcome] = []
+    #: Handed out here, not in the worker. Two threads asking the cluster at
+    #: the same moment both read 9304 as free and the second was refused with
+    #: `VM 9304 already exists on node 'infra-node5'`.
+    handed: set[int] = set()
 
     try:
         while waiting or running:
@@ -421,9 +427,11 @@ def run(
                 job = waiting.pop(0)
                 if job.iso == DEFAULT_ISO:
                     job = replace(job, iso=medium)
+                vmid = api.free_vmid(frozenset(handed))
+                handed.add(vmid)
                 thread = threading.Thread(
                     target=answer_once,
-                    args=(done, api, node.name, job, driver, workdir, inflight),
+                    args=(done, api, node.name, job, driver, workdir, inflight, vmid),
                     daemon=True,
                 )
                 running[job.name] = thread

--- a/tests/vm/cluster.py
+++ b/tests/vm/cluster.py
@@ -355,6 +355,30 @@ def install_one(
             print(f"{job.name}: the guest was not removed: {error}", file=sys.stderr)
 
 
+def answer_once(
+    done: "queue.Queue[Outcome]",
+    api: Api,
+    node: str,
+    job: Job,
+    driver: str,
+    workdir: Path,
+    inflight: dict[str, Running],
+) -> None:
+    """Run one job and put exactly one outcome on the queue, whatever happens.
+
+    A worker that dies without answering leaves its name in the running set
+    for ever and the schedule never ends: a `WebSocketError` out of a dropped
+    console was outside the handled set, and a run sat idle for half an hour
+    with an empty cluster and a job still queued.
+    """
+    try:
+        done.put(install_one(api, node, job, driver, workdir, inflight))
+    except BaseException as error:
+        done.put(
+            Outcome(job.name, Verdict.ERROR, 0.0, f"{type(error).__name__}: {error}"[:300])
+        )
+
+
 def run(
     jobs: list[Job],
     workdir: Path,
@@ -384,9 +408,6 @@ def run(
     inflight: dict[str, Running] = {}
     finished: list[Outcome] = []
 
-    def one(node: str, job: Job) -> None:
-        done.put(install_one(api, node, job, driver, workdir, inflight))
-
     try:
         while waiting or running:
             slots = free_slots(api)
@@ -400,7 +421,11 @@ def run(
                 job = waiting.pop(0)
                 if job.iso == DEFAULT_ISO:
                     job = replace(job, iso=medium)
-                thread = threading.Thread(target=one, args=(node.name, job), daemon=True)
+                thread = threading.Thread(
+                    target=answer_once,
+                    args=(done, api, node.name, job, driver, workdir, inflight),
+                    daemon=True,
+                )
                 running[job.name] = thread
                 thread.start()
                 print(f"→ {job.name} on {node.name} ({len(waiting)} waiting)", flush=True)

--- a/tests/vm/cluster.py
+++ b/tests/vm/cluster.py
@@ -404,8 +404,10 @@ def run(
                 flush=True,
             )
     finally:
-        for name in prepared:
-            api.remove_iso(name, driver)
+        for node_name in prepared:
+            said = api.remove_iso(node_name, driver)
+            if said:
+                print(f"{driver} stayed on {node_name}: {said}", file=sys.stderr)
     return finished
 
 

--- a/tests/vm/cluster.py
+++ b/tests/vm/cluster.py
@@ -1,0 +1,331 @@
+"""Run the install fixtures on the Proxmox cluster, unattended.
+
+One process, many guests. Each guest is a thread that builds a machine, drives
+its console through an install, reads the result back and deletes the machine,
+and the scheduler starts the next one the moment a slot frees. Nothing waits
+for the whole set: a binpkg fixture finishes in six minutes and a source kernel
+takes an hour, so a barrier would hold every finished result hostage to the
+slowest, and results that were already earned would be lost if it hung.
+
+Two clocks bound every guest. A watchdog looks at the serial log every ten
+minutes and ends a guest whose byte count has not moved across three looks;
+a whole run has a hard ceiling on top of that. Activity, not elapsed time, is
+what separates a slow mirror from a dead guest.
+"""
+
+from __future__ import annotations
+
+import argparse
+import queue
+import sys
+import threading
+import time
+from dataclasses import dataclass, field
+from enum import Enum
+from pathlib import Path
+from typing import Final, Protocol
+
+from gentoo_install.model.config import InstallConfig
+from gentoo_install.model.device import Existing
+from gentoo_install.model.parse import load
+from .console import ConsoleClosed, ConsoleTimeout, SerialConsole
+from .driver import build as build_driver
+from .proxmox import Api, Guest, GuestSpec, Node, ProxmoxError, append_to_cmdline
+from .results import ResultError, console_command, read_console
+
+REPOSITORY: Final[Path] = Path(__file__).resolve().parents[2]
+WORKROOT: Final[Path] = Path.home() / "code/gentoo-install/lab/vm/cluster"
+
+#: Where the guest gathers what the run produced before it is read back.
+RESULT_DIR: Final[str] = "/tmp/gentoo-install-results"
+
+#: The medium every fixture installs from unless it names another.
+DEFAULT_ISO: Final[str] = "install-amd64-minimal-20260712T170110Z.iso"
+
+#: Kernel parameters the medium's own GRUB entry lacks. Without the console the
+#: kernel says nothing on the serial port and every run reads as hung.
+EXTRA_CMDLINE: Final[str] = "console=ttyS0,115200"
+
+#: What a guest is given. Four cores is a node's whole complement, so three
+#: leaves the node able to answer the API while a build runs.
+GUEST_MEMORY_MIB: Final[int] = 6144
+GUEST_CORES: Final[int] = 3
+TARGET_GIB: Final[int] = 40
+
+#: Left free on every node. A node with nothing spare stops answering, and the
+#: cluster runs other people's machines.
+NODE_HEADROOM_BYTES: Final[int] = 4 * 1024**3
+
+#: How often the watchdog looks, and how many quiet looks end a guest. Ten
+#: minutes because a stage3 extract and a kernel build both write progress more
+#: often than that, and half an hour of silence is not a slow mirror.
+WATCH_EVERY: Final[float] = 600.0
+WATCH_STRIKES: Final[int] = 3
+
+#: Nothing this harness runs takes three hours, and a run that does is holding
+#: a node's memory rather than testing anything.
+RUN_CEILING: Final[float] = 3 * 3600.0
+
+
+class Verdict(Enum):
+    """How one guest ended. `STUCK` is separate from `FAIL` on purpose: a
+    failure is read in the log, and a guest that stopped writing is read on
+    the screen, so the two are chased differently."""
+
+    OK = "ok"
+    FAIL = "FAIL"
+    STUCK = "STUCK"
+    ERROR = "ERROR"
+
+
+@dataclass
+class Outcome:
+    name: str
+    verdict: Verdict
+    seconds: float
+    detail: str = ""
+    log: Path | None = None
+
+
+@dataclass
+class Job:
+    """One fixture to install and check."""
+
+    name: str
+    fixture: Path
+    iso: str = DEFAULT_ISO
+    uefi: bool = True
+    disks: int = 1
+
+
+@dataclass
+class Watchdog:
+    """Whether a guest is still producing output."""
+
+    log: Path
+    strikes: int = 0
+    _seen: int = field(default=0, init=False)
+
+    def moved(self) -> bool:
+        size = self.log.stat().st_size if self.log.exists() else 0
+        if size > self._seen:
+            self._seen = size
+            self.strikes = 0
+            return True
+        self.strikes += 1
+        return False
+
+    @property
+    def stuck(self) -> bool:
+        return self.strikes >= WATCH_STRIKES
+
+
+def free_slots(api: Api) -> list[Node]:
+    """Nodes with room for one more guest, most free first."""
+    need = GUEST_MEMORY_MIB * 1024**2 + NODE_HEADROOM_BYTES
+    return [one for one in api.nodes() if one.free_bytes >= need]
+
+
+class Stoppable(Protocol):
+    """All the sweep needs of a guest. Stopping is what wakes the worker that
+    is blocked reading its console; deleting is the worker's own job, and a
+    sweep that deleted would race it."""
+
+    def stop(self) -> None: ...
+
+
+@dataclass
+class Running:
+    """A guest in flight, and what the watchdog needs to judge it."""
+
+    guest: Stoppable
+    watch: Watchdog
+
+
+def install_one(
+    api: Api,
+    node: str,
+    job: Job,
+    driver: str,
+    workdir: Path,
+    inflight: dict[str, Running] | None = None,
+) -> Outcome:
+    """Build a guest, install into it, read the result, delete the guest."""
+    started = time.monotonic()
+    workdir.mkdir(parents=True, exist_ok=True)
+    log = workdir / f"{job.name}.log"
+    guest = Guest(
+        api=api,
+        node=node,
+        vmid=api.free_vmid(),
+        spec=GuestSpec(
+            name=f"gi-{job.name}"[:63],
+            iso=job.iso,
+            memory_mib=GUEST_MEMORY_MIB,
+            cores=GUEST_CORES,
+            target_gib=tuple(TARGET_GIB for _ in range(job.disks)),
+            uefi=job.uefi,
+            driver_iso=driver,
+        ),
+    )
+    watch = Watchdog(log=log)
+    if inflight is not None:
+        inflight[job.name] = Running(guest=guest, watch=watch)
+    try:
+        guest.create()
+        guest.start()
+        console = SerialConsole(guest.console(), log.open("wb"))
+        # Reset with the console attached: termproxy forwards only what arrives
+        # after it, and the firmware is finished before it gets there.
+        guest.reset()
+        append_to_cmdline(console, EXTRA_CMDLINE)
+        console.expect(r"livecd .*#|localhost .*#", timeout=900.0)
+        console.run("printf 'nameserver 223.5.5.5\\nnameserver 1.1.1.1\\n' > /etc/resolv.conf")
+        console.run("mkdir -p /mnt/driver")
+        console.run("mountpoint -q /mnt/driver || mount -o ro /dev/sr1 /mnt/driver")
+        console.run(f"mkdir -p {RESULT_DIR}")
+        console.run(
+            f"cd /mnt/driver && {{ sh ./bootstrap.sh --no-shell --config {job.fixture.name}; "
+            f"echo $? > {RESULT_DIR}/install.rc; }} 2>&1 | tee {RESULT_DIR}/install.txt",
+            timeout=RUN_CEILING,
+        )
+        console.run(f"cp /run/gentoo-install/install.jsonl {RESULT_DIR}/ 2>/dev/null || true")
+        console.send(console_command(RESULT_DIR))
+        said = console.snapshot(120.0)
+        files = read_console(said)
+        code = files.get("install.rc", b"").strip()
+        if code != b"0":
+            return Outcome(job.name, Verdict.FAIL, time.monotonic() - started,
+                           f"the installer exited {code!r}", log)
+        return Outcome(job.name, Verdict.OK, time.monotonic() - started, log=log)
+    except (ConsoleTimeout, ConsoleClosed) as error:
+        verdict = Verdict.STUCK if watch.stuck else Verdict.FAIL
+        return Outcome(job.name, verdict, time.monotonic() - started, str(error)[:300], log)
+    except (ProxmoxError, ResultError, OSError) as error:
+        return Outcome(job.name, Verdict.ERROR, time.monotonic() - started, str(error)[:300], log)
+    finally:
+        if inflight is not None:
+            inflight.pop(job.name, None)
+        try:
+            guest.destroy()
+        except ProxmoxError as error:
+            # Said rather than raised: an undeleted guest holds a node's memory
+            # and the operator has to know, but the result already exists.
+            print(f"{job.name}: the guest was not removed: {error}", file=sys.stderr)
+
+
+def run(jobs: list[Job], workdir: Path, limit: int = 0) -> list[Outcome]:
+    """Every job, collected one at a time as each finishes.
+
+    `limit` caps how many run at once; zero asks the cluster what fits.
+    """
+    api = Api()
+    workdir.mkdir(parents=True, exist_ok=True)
+    driver_path = build_driver(workdir / "driver.iso")
+    driver = ""
+    done: queue.Queue[Outcome] = queue.Queue()
+    waiting = list(jobs)
+    running: dict[str, threading.Thread] = {}
+    inflight: dict[str, Running] = {}
+    finished: list[Outcome] = []
+
+    def one(node: str, job: Job) -> None:
+        done.put(install_one(api, node, job, driver, workdir, inflight))
+
+    try:
+        while waiting or running:
+            slots = free_slots(api)
+            if limit:
+                slots = slots[: max(0, limit - len(running))]
+            while waiting and slots:
+                node = slots.pop(0)
+                if not driver:
+                    driver = api.upload_iso(
+                        node.name, driver_path, f"gi-driver-{int(time.time())}.iso"
+                    )
+                job = waiting.pop(0)
+                thread = threading.Thread(target=one, args=(node.name, job), daemon=True)
+                running[job.name] = thread
+                thread.start()
+                print(f"→ {job.name} on {node.name} ({len(waiting)} waiting)", flush=True)
+            try:
+                # Collected one at a time, never as a set: a fixture that takes
+                # an hour must not hold back one that took six minutes.
+                outcome = done.get(timeout=WATCH_EVERY)
+            except queue.Empty:
+                _sweep(inflight)
+                continue
+            finished.append(outcome)
+            running.pop(outcome.name, None)
+            print(
+                f"{outcome.verdict.value:6} {outcome.name:34} {outcome.seconds / 60:5.1f}m "
+                f"{outcome.detail}",
+                flush=True,
+            )
+    finally:
+        if driver:
+            for node in api.nodes():
+                api.remove_iso(node.name, driver)
+    return finished
+
+
+def _sweep(inflight: dict[str, Running]) -> None:
+    """End every guest whose serial log has stopped growing.
+
+    Stopping the guest is what reaches the worker: it is blocked reading a
+    console, and closing that console is the only thing that wakes it. The
+    thread then reports `STUCK`, which is not `FAIL`: nothing was read in the
+    log, so the next question is what was on the screen.
+    """
+    for name, held in list(inflight.items()):
+        if held.watch.moved():
+            continue
+        if not held.watch.stuck:
+            print(
+                f"… {name} quiet for {held.watch.strikes * WATCH_EVERY / 60:.0f}m",
+                flush=True,
+            )
+            continue
+        print(f"! {name} stopped writing; ending it", flush=True)
+        try:
+            held.guest.stop()
+        except ProxmoxError as error:
+            print(f"{name}: the stuck guest would not stop: {error}", file=sys.stderr)
+
+
+def fixtures(names: list[str]) -> list[Job]:
+    found: list[Job] = []
+    for name in names:
+        path = REPOSITORY / "tests" / "fixtures" / f"{name}.toml"
+        if not path.is_file():
+            raise SystemExit(f"no fixture named {name} at {path}")
+        config: InstallConfig = load(path)
+        found.append(
+            Job(
+                name=name,
+                fixture=path,
+                uefi=config.bootloader.firmware.value != "bios",
+                disks=max(1, len(config.disk.graph.of_type(Existing))),
+            )
+        )
+    return found
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("fixtures", nargs="+", help="fixture names, without .toml")
+    parser.add_argument("--limit", type=int, default=0, help="how many guests at once")
+    parser.add_argument("--workdir", type=Path, default=WORKROOT)
+    args = parser.parse_args(argv)
+
+    outcomes = run(fixtures(args.fixtures), args.workdir, args.limit)
+    passed = [one for one in outcomes if one.verdict is Verdict.OK]
+    print(f"\n{len(passed)}/{len(outcomes)} passed")
+    for one in outcomes:
+        if one.verdict is not Verdict.OK:
+            print(f"  {one.verdict.value} {one.name}: {one.detail} ({one.log})")
+    return 0 if len(passed) == len(outcomes) else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/vm/cluster.py
+++ b/tests/vm/cluster.py
@@ -20,14 +20,17 @@ import queue
 import sys
 import threading
 import time
-from dataclasses import dataclass, field
+import urllib.request
+from dataclasses import dataclass, field, replace
 from enum import Enum
 from pathlib import Path
 from typing import Final, Protocol
 
 from gentoo_install.model.config import InstallConfig
 from gentoo_install.model.device import Existing
+from gentoo_install.model.config import MirrorRegion
 from gentoo_install.model.parse import load
+from gentoo_install.model.serialise import to_toml
 from .console import ConsoleClosed, ConsoleTimeout, SerialConsole
 from .driver import build as build_driver
 from .proxmox import Api, Guest, GuestSpec, Node, ProxmoxError, append_to_cmdline
@@ -39,8 +42,29 @@ WORKROOT: Final[Path] = Path.home() / "code/gentoo-install/lab/vm/cluster"
 #: Where the guest gathers what the run produced before it is read back.
 RESULT_DIR: Final[str] = "/tmp/gentoo-install-results"
 
-#: The medium every fixture installs from unless it names another.
-DEFAULT_ISO: Final[str] = "install-amd64-minimal-20260712T170110Z.iso"
+#: Where the media come from, in the order they are tried. The cluster is in
+#: China, so a node reaches these far faster than an upload from the
+#: workstation would, and the bytes never cross the workstation's link.
+#:
+#: `mirrors.ustc.edu.cn` is not among them: it answers `403 Forbidden` to
+#: Proxmox's downloader, which is wget, while serving the same URL to anything
+#: else. The installer reads it happily; only this path has to avoid it.
+MIRRORS: Final[tuple[str, ...]] = (
+    "https://mirrors.tuna.tsinghua.edu.cn/gentoo",
+    "https://mirror.nju.edu.cn/gentoo",
+    "https://distfiles.gentoo.org",
+)
+
+AUTOBUILDS: Final[str] = "releases/amd64/autobuilds"
+
+#: The pointer file beside the medium, which is Gentoo's own signed output and
+#: identical on every mirror. Read rather than hardcoded: `local` storage is
+#: per node, so a name that only one node happens to hold is not a default.
+MINIMAL_POINTER: Final[str] = "latest-install-amd64-minimal.txt"
+
+#: Filled in from the pointer file when a run starts. The placeholder is what a
+#: `Job` carries until then, so a fixture can still name a medium of its own.
+DEFAULT_ISO: Final[str] = "minimal"
 
 #: Kernel parameters the medium's own GRUB entry lacks. Without the console the
 #: kernel says nothing on the serial port and every run reads as hung.
@@ -120,6 +144,69 @@ class Watchdog:
         return self.strikes >= WATCH_STRIKES
 
 
+def current_minimal() -> tuple[str, tuple[str, ...]]:
+    """The current minimal ISO's name and every URL that serves it."""
+    for mirror in MIRRORS:
+        pointer = f"{mirror}/{AUTOBUILDS}/{MINIMAL_POINTER}"
+        try:
+            with urllib.request.urlopen(pointer, timeout=30.0) as answer:
+                said = answer.read().decode("utf-8", "replace")
+        except OSError:
+            continue
+        for line in said.splitlines():
+            first = line.strip().split(" ")[0]
+            if first.endswith(".iso"):
+                return first.rsplit("/", 1)[-1], tuple(
+                    f"{one}/{AUTOBUILDS}/{first}" for one in MIRRORS
+                )
+    raise SystemExit("no mirror named an install medium")
+
+
+def prepare(
+    api: Api, node: str, medium: str, urls: tuple[str, ...], driver_path: Path, driver: str
+) -> None:
+    """Put the medium and the driver CD on one node's `local` storage.
+
+    `local` is per node, not shared: a guest built on a node without the medium
+    is refused with `volume 'local:iso/...' does not exist`, which is what the
+    first cluster run hit.
+    """
+    if medium not in api.isos(node):
+        last = ""
+        for url in urls:
+            try:
+                api.fetch_iso(node, url, medium)
+                break
+            except ProxmoxError as error:
+                last = str(error)
+        else:
+            raise ProxmoxError(f"no mirror served {medium} to {node}: {last}")
+    if driver not in api.isos(node):
+        api.upload_iso(node, driver_path, driver)
+
+
+def rewrite_fixtures(jobs: list[Job], into: Path, region: MirrorRegion) -> Path:
+    """Write each fixture out again with its mirror region replaced.
+
+    Through the parser and the writer, not a text substitution: a fixture that
+    cannot survive the round trip is a defect worth failing on here rather than
+    an hour into an install.
+
+    The cluster is in China, and a `global` fixture syncs the tree from
+    `github.com/gentoo-mirror/gentoo.git`, which answered `SSL_read:
+    unexpected eof while reading` there. Running the set against `cn` is both
+    what works and what the operators of that network actually use.
+    """
+    into.mkdir(parents=True, exist_ok=True)
+    for job in jobs:
+        config = load(job.fixture)
+        moved = replace(
+            config, portage=replace(config.portage, mirrors=replace(config.portage.mirrors, region=region))
+        )
+        (into / job.fixture.name).write_text(to_toml(moved))
+    return into
+
+
 def free_slots(api: Api) -> list[Node]:
     """Nodes with room for one more guest, most free first."""
     need = GUEST_MEMORY_MIB * 1024**2 + NODE_HEADROOM_BYTES
@@ -180,12 +267,19 @@ def install_one(
         guest.reset()
         append_to_cmdline(console, EXTRA_CMDLINE)
         console.expect(r"livecd .*#|localhost .*#", timeout=900.0)
-        console.run("printf 'nameserver 223.5.5.5\\nnameserver 1.1.1.1\\n' > /etc/resolv.conf")
+        # The guest's own resolver is left alone. A local run pins one because
+        # slirp reads the host's `/etc/resolv.conf` once at startup; the
+        # cluster hands out a real configuration, and it is IPv6 with DNS64.
+        # Writing IPv4 resolvers over it left every mirror unreachable:
+        # `Failed to connect to mirrors.tuna.tsinghua.edu.cn:443 after 111 ms`.
         console.run("mkdir -p /mnt/driver")
         console.run("mountpoint -q /mnt/driver || mount -o ro /dev/sr1 /mnt/driver")
         console.run(f"mkdir -p {RESULT_DIR}")
+        # tee, not a redirect: the serial console is the only way to watch a
+        # run that takes half an hour, and it is what the watchdog reads to
+        # tell a slow mirror from a dead guest.
         console.run(
-            f"cd /mnt/driver && {{ sh ./bootstrap.sh --no-shell --config {job.fixture.name}; "
+            f"{{ sh /mnt/driver/install.sh --config fixtures/{job.fixture.name}; "
             f"echo $? > {RESULT_DIR}/install.rc; }} 2>&1 | tee {RESULT_DIR}/install.txt",
             timeout=RUN_CEILING,
         )
@@ -214,15 +308,28 @@ def install_one(
             print(f"{job.name}: the guest was not removed: {error}", file=sys.stderr)
 
 
-def run(jobs: list[Job], workdir: Path, limit: int = 0) -> list[Outcome]:
+def run(
+    jobs: list[Job],
+    workdir: Path,
+    limit: int = 0,
+    stamp: int = 0,
+    region: MirrorRegion = MirrorRegion.CN,
+) -> list[Outcome]:
     """Every job, collected one at a time as each finishes.
 
     `limit` caps how many run at once; zero asks the cluster what fits.
     """
     api = Api()
     workdir.mkdir(parents=True, exist_ok=True)
-    driver_path = build_driver(workdir / "driver.iso")
-    driver = ""
+    # Packed: the ingress refuses the 1.4 MiB loose-file CD with `413`.
+    driver_path = build_driver(
+        workdir / "driver.iso",
+        packed=True,
+        fixtures=rewrite_fixtures(jobs, workdir / "fixtures", region),
+    )
+    driver = f"gi-driver-{stamp}.iso"
+    medium, urls = current_minimal()
+    prepared: set[str] = set()
     done: queue.Queue[Outcome] = queue.Queue()
     waiting = list(jobs)
     running: dict[str, threading.Thread] = {}
@@ -239,11 +346,12 @@ def run(jobs: list[Job], workdir: Path, limit: int = 0) -> list[Outcome]:
                 slots = slots[: max(0, limit - len(running))]
             while waiting and slots:
                 node = slots.pop(0)
-                if not driver:
-                    driver = api.upload_iso(
-                        node.name, driver_path, f"gi-driver-{int(time.time())}.iso"
-                    )
+                if node.name not in prepared:
+                    prepare(api, node.name, medium, urls, driver_path, driver)
+                    prepared.add(node.name)
                 job = waiting.pop(0)
+                if job.iso == DEFAULT_ISO:
+                    job = replace(job, iso=medium)
                 thread = threading.Thread(target=one, args=(node.name, job), daemon=True)
                 running[job.name] = thread
                 thread.start()
@@ -263,9 +371,8 @@ def run(jobs: list[Job], workdir: Path, limit: int = 0) -> list[Outcome]:
                 flush=True,
             )
     finally:
-        if driver:
-            for node in api.nodes():
-                api.remove_iso(node.name, driver)
+        for name in prepared:
+            api.remove_iso(name, driver)
     return finished
 
 
@@ -316,9 +423,21 @@ def main(argv: list[str] | None = None) -> int:
     parser.add_argument("fixtures", nargs="+", help="fixture names, without .toml")
     parser.add_argument("--limit", type=int, default=0, help="how many guests at once")
     parser.add_argument("--workdir", type=Path, default=WORKROOT)
+    parser.add_argument(
+        "--region",
+        choices=[one.value for one in MirrorRegion],
+        default=MirrorRegion.CN.value,
+        help="which mirror region every fixture is rewritten to use",
+    )
     args = parser.parse_args(argv)
 
-    outcomes = run(fixtures(args.fixtures), args.workdir, args.limit)
+    outcomes = run(
+        fixtures(args.fixtures),
+        args.workdir,
+        args.limit,
+        int(time.time()),
+        MirrorRegion(args.region),
+    )
     passed = [one for one in outcomes if one.verdict is Verdict.OK]
     print(f"\n{len(passed)}/{len(outcomes)} passed")
     for one in outcomes:

--- a/tests/vm/cluster.py
+++ b/tests/vm/cluster.py
@@ -318,10 +318,7 @@ def install_one(
             f"echo $? > {RESULT_DIR}/install.rc; }} 2>&1 | tee {RESULT_DIR}/install.txt",
             timeout=RUN_CEILING,
         )
-        console.run(f"cp /run/gentoo-install/install.jsonl {RESULT_DIR}/ 2>/dev/null || true")
-        console.send(console_command(RESULT_DIR))
-        said = console.snapshot(120.0)
-        files = read_console(said)
+        files = collect(guest, console, log)
         code = files.get("install.rc", b"").strip()
         if code != b"0":
             return Outcome(job.name, Verdict.FAIL, time.monotonic() - started,
@@ -410,6 +407,38 @@ def run(
         for name in prepared:
             api.remove_iso(name, driver)
     return finished
+
+
+#: How many times the results are asked for again on a fresh console.
+COLLECT_TRIES: Final[int] = 3
+
+
+def collect(guest: Guest, console: SerialConsole, log: Path) -> dict[str, bytes]:
+    """Read the result archive back, reopening the console if it has gone.
+
+    A `termproxy` session does not survive an install: one that ran 36 minutes
+    was dropped in the second after the installer printed `installed 53
+    operations`, and the run was recorded as a failure although everything it
+    was testing had worked. The guest is still up and the archive is still on
+    it, so the answer is another console, not another install.
+    """
+    last: Exception | None = None
+    for attempt in range(COLLECT_TRIES):
+        try:
+            console.run(
+                f"cp /run/gentoo-install/install.jsonl {RESULT_DIR}/ 2>/dev/null || true"
+            )
+            console.send(console_command(RESULT_DIR))
+            return read_console(console.snapshot(180.0))
+        except (ConsoleClosed, ConsoleTimeout, ResultError) as error:
+            last = error
+            if attempt + 1 == COLLECT_TRIES:
+                break
+            console = SerialConsole(guest.console(), log.open("ab"))
+            # A newline first: the fresh console shows nothing until the shell
+            # is asked for a prompt, and `run` waits for its own marker.
+            console.send("")
+    raise ResultError(f"the results could not be read back: {last}")
 
 
 def _sweep(inflight: dict[str, Running]) -> None:

--- a/tests/vm/cluster.py
+++ b/tests/vm/cluster.py
@@ -34,7 +34,15 @@ from gentoo_install.model.parse import load
 from gentoo_install.model.serialise import to_toml
 from .console import ConsoleClosed, ConsoleTimeout, SerialConsole
 from .driver import build as build_driver
-from .proxmox import Api, Guest, GuestSpec, Node, ProxmoxError, append_to_cmdline
+from .proxmox import (
+    Api,
+    Guest,
+    GuestSpec,
+    Node,
+    ProxmoxError,
+    append_to_cmdline,
+    append_to_cmdline_blind,
+)
 from .results import ResultError, console_command, read_console
 
 REPOSITORY: Final[Path] = Path(__file__).resolve().parents[2]
@@ -300,7 +308,14 @@ def install_one(
         # Reset with the console attached: termproxy forwards only what arrives
         # after it, and the firmware is finished before it gets there.
         guest.reset()
-        append_to_cmdline(console, EXTRA_CMDLINE)
+        if job.uefi:
+            append_to_cmdline(console, EXTRA_CMDLINE)
+        else:
+            # SeaBIOS hands over to a GRUB that writes only to VGA, so the
+            # serial log stops at `Welcome to GRUB!` and there is no menu to
+            # read. The keys go through the API and the kernel appearing on
+            # the console is what says the edit landed.
+            append_to_cmdline_blind(guest, console, EXTRA_CMDLINE)
         console.expect(r"livecd .*#|localhost .*#", timeout=900.0)
         # The guest's own resolver is left alone. A local run pins one because
         # slirp reads the host's `/etc/resolv.conf` once at startup; the

--- a/tests/vm/console.py
+++ b/tests/vm/console.py
@@ -8,7 +8,7 @@ import socket
 import time
 from pathlib import Path
 from types import TracebackType
-from typing import IO, Iterator, Self
+from typing import IO, Iterator, Protocol, Self
 
 _ANSI = re.compile(
     rb"\x1b\[[0-9;?]*[a-zA-Z]"
@@ -35,10 +35,60 @@ def strip_ansi(data: bytes) -> bytes:
 PASSWORD_PROMPT = r"[Pp]assword:|密码：|密碼："
 
 
-class SerialConsole:
-    """Reads and writes a QEMU unix-socket serial port, with expect semantics."""
+class Channel(Protocol):
+    """What a console needs of its transport, and nothing more.
 
-    def __init__(self, sock: socket.socket, log: IO[bytes], errors: Path | None = None) -> None:
+    A local run reads a unix socket; a run on the cluster reads a websocket,
+    because the node's serial socket is a file on the node and port 22 is
+    closed there. The expect logic is the same either way, so the transport is
+    the only thing that differs.
+    """
+
+    def recv(self, size: int) -> bytes:
+        """Whatever has arrived, or empty on a timeout. Empty is not the end;
+        `closed` is."""
+
+    def sendall(self, data: bytes) -> None: ...
+
+    def close(self) -> None: ...
+
+    @property
+    def closed(self) -> bool:
+        """Whether the far end hung up. A transport that cannot tell says no."""
+
+
+class _Socket:
+    """A unix socket as a `Channel`. `recv` on a timeout is empty, not an error."""
+
+    def __init__(self, sock: socket.socket) -> None:
+        self._sock = sock
+
+    def recv(self, size: int) -> bytes:
+        try:
+            chunk = self._sock.recv(size)
+        except TimeoutError:
+            return b""
+        if not chunk:
+            self._closed = True
+        return chunk
+
+    def sendall(self, data: bytes) -> None:
+        self._sock.sendall(data)
+
+    def close(self) -> None:
+        self._sock.close()
+
+    _closed = False
+
+    @property
+    def closed(self) -> bool:
+        return self._closed
+
+
+class SerialConsole:
+    """Reads and writes a serial port, with expect semantics."""
+
+    def __init__(self, sock: Channel, log: IO[bytes], errors: Path | None = None) -> None:
         self._sock = sock
         self._log = log
         #: Where qemu wrote its own stderr. It names whatever killed it, and
@@ -60,7 +110,7 @@ class SerialConsole:
                 time.sleep(0.2)
                 continue
             sock.settimeout(1.0)
-            return cls(sock, log_path.open("wb"), path.parent / "qemu.err")
+            return cls(_Socket(sock), log_path.open("wb"), path.parent / "qemu.err")
         raise ConsoleTimeout(f"{path} never accepted a connection")
 
     def expect(self, pattern: str, timeout: float) -> bytes:
@@ -82,6 +132,11 @@ class SerialConsole:
     def send(self, line: str) -> None:
         self._sock.sendall(line.encode() + b"\n")
 
+    def send_raw(self, keys: str) -> None:
+        """Exactly these bytes, with no newline. GRUB's editor acts on the
+        keystroke itself, and a trailing newline there is an extra line."""
+        self._sock.sendall(keys.encode())
+
     def run(self, command: str, timeout: float = 120.0) -> None:
         """Run a shell command and wait for it to finish.
 
@@ -102,12 +157,14 @@ class SerialConsole:
         self.expect(prompt, timeout=60.0)
 
     def _read_once(self) -> None:
-        try:
-            chunk = self._sock.recv(4096)
-        except TimeoutError:
-            return
+        chunk = self._sock.recv(4096)
         if not chunk:
-            raise ConsoleClosed(self._why_closed())
+            # Empty means nothing arrived before the read timed out, which is
+            # what an idle console looks like. Only the transport knows the
+            # difference between idle and hung up.
+            if self._sock.closed:
+                raise ConsoleClosed(self._why_closed())
+            return
         self._log.write(chunk)
         self._log.flush()
         self._buffer += chunk
@@ -119,6 +176,25 @@ class SerialConsole:
             said = lines[-1] if lines else ""
         closed = "the guest closed the serial connection"
         return f"{closed}: {said}" if said else closed
+
+    def snapshot(self, seconds: float) -> bytes:
+        """Everything that arrives in this window, escape codes included.
+
+        `expect` trims the buffer to what follows its match, which loses the
+        top of a screen the caller still has to read. A full-screen redraw has
+        to be taken whole.
+        """
+        got = bytearray(self._buffer)
+        deadline = time.monotonic() + seconds
+        while time.monotonic() < deadline:
+            before = len(self._buffer)
+            try:
+                self._read_once()
+            except ConsoleClosed:
+                break
+            got += self._buffer[before:]
+        self._buffer = b""
+        return bytes(got)
 
     def drain(self, seconds: float) -> None:
         """Read and discard for a while.

--- a/tests/vm/driver.py
+++ b/tests/vm/driver.py
@@ -29,9 +29,37 @@ cd /mnt/driver
 exec python3 -m gentoo_install --no-shell "$@"
 """
 
+#: The name of the compressed payload on a packed CD, and where it is unpacked.
+PAYLOAD = "driver.tar.gz"
+UNPACKED = "/tmp/gentoo-install-driver"
 
-def build(output: Path) -> Path:
-    """Write an ISO holding the installer package and return its path."""
+#: The launcher on a packed CD. Uncompressed the tree is 1.6 MiB and the ISO
+#: around it 1.4 MiB, which the cluster's ingress refuses with `413 Request
+#: Entity Too Large`; compressed it is 236 KiB and the ISO fits under the
+#: limit. Unpacked to tmpfs rather than run from the CD, because the installer
+#: writes nothing there but Python still wants somewhere to put bytecode.
+PACKED_ENTRY = f"""#!/bin/sh
+set -e
+mkdir -p /mnt/driver {UNPACKED}
+mountpoint -q /mnt/driver || mount -o ro /dev/sr1 /mnt/driver
+tar xzf /mnt/driver/{PAYLOAD} -C {UNPACKED}
+cd {UNPACKED}
+# Through the launcher, because that is the entry point an operator uses and
+# every run should exercise it.
+exec sh ./bootstrap.sh --no-shell "$@"
+"""
+
+
+def build(output: Path, packed: bool = False, fixtures: Path | None = None) -> Path:
+    """Write an ISO holding the installer package and return its path.
+
+    `packed` puts the tree in a tarball instead of loose files. A local run
+    mounts the CD directly; a run on the cluster has to upload it through an
+    ingress that refuses anything near a megabyte.
+
+    `fixtures` replaces the configurations the CD carries, which is how the
+    cluster runs the same set against a different mirror region.
+    """
     if shutil.which("xorriso") is None:
         raise MediaError("xorriso is not installed, so the driver CD cannot be built")
     staging = output.parent / "driver"
@@ -43,13 +71,28 @@ def build(output: Path) -> Path:
         staging / "gentoo_install",
         ignore=shutil.ignore_patterns("__pycache__", "*.pyc"),
     )
-    for name in ("fixtures",):
-        shutil.copytree(REPOSITORY / "tests" / name, staging / name)
+    shutil.copytree(fixtures or REPOSITORY / "tests" / "fixtures", staging / "fixtures")
     # The launcher is what an operator runs, so the CD carries the same one.
     shutil.copy2(REPOSITORY / "bootstrap.sh", staging / "bootstrap.sh")
     entry = staging / "install.sh"
     entry.write_text(ENTRY)
     entry.chmod(0o755)
+
+    if packed:
+        payload = output.parent / PAYLOAD
+        packing = subprocess.run(
+            ["tar", "czf", str(payload), "-C", str(staging), "."],
+            capture_output=True,
+            text=True,
+        )
+        if packing.returncode != 0:
+            raise MediaError(f"the driver payload was not packed: {packing.stderr.strip()}")
+        shutil.rmtree(staging)
+        staging.mkdir(parents=True)
+        shutil.move(str(payload), staging / PAYLOAD)
+        entry = staging / "install.sh"
+        entry.write_text(PACKED_ENTRY)
+        entry.chmod(0o755)
 
     output.unlink(missing_ok=True)
     result = subprocess.run(

--- a/tests/vm/monitor.py
+++ b/tests/vm/monitor.py
@@ -12,15 +12,47 @@ import socket
 import time
 from pathlib import Path
 
-#: What `sendkey` calls the characters a passphrase is made of. Everything
-#: else is the character itself.
+#: What `sendkey` calls each character that is not a letter or a digit, on the
+#: US layout its key names are taken from. The whole printable set, not the
+#: subset a passphrase needed: `console=ttyS0,115200` typed at a GRUB prompt
+#: needs `equal` and `comma`, and a missing name is refused rather than sent as
+#: itself and silently dropped.
 NAMED: dict[str, str] = {
-    "-": "minus",
-    "_": "shift-minus",
-    ".": "dot",
-    "/": "slash",
     " ": "spc",
     "\n": "ret",
+    "\t": "tab",
+    "-": "minus",
+    "_": "shift-minus",
+    "=": "equal",
+    "+": "shift-equal",
+    "[": "bracket_left",
+    "{": "shift-bracket_left",
+    "]": "bracket_right",
+    "}": "shift-bracket_right",
+    "\\": "backslash",
+    "|": "shift-backslash",
+    ";": "semicolon",
+    ":": "shift-semicolon",
+    "'": "apostrophe",
+    '"': "shift-apostrophe",
+    "`": "grave_accent",
+    "~": "shift-grave_accent",
+    ",": "comma",
+    "<": "shift-comma",
+    ".": "dot",
+    ">": "shift-dot",
+    "/": "slash",
+    "?": "shift-slash",
+    "!": "shift-1",
+    "@": "shift-2",
+    "#": "shift-3",
+    "$": "shift-4",
+    "%": "shift-5",
+    "^": "shift-6",
+    "&": "shift-7",
+    "*": "shift-8",
+    "(": "shift-9",
+    ")": "shift-0",
 }
 
 

--- a/tests/vm/proxmox.py
+++ b/tests/vm/proxmox.py
@@ -369,6 +369,21 @@ class Guest:
             self.node, self.api.call("POST", f"/nodes/{self.node}/qemu/{self.vmid}/status/reset")
         )
 
+    def transferred(self) -> int:
+        """Bytes this guest has received and written since it started.
+
+        What the watchdog reads when the console is silent: an install
+        downloading a stage3 prints nothing for minutes, and ending it for
+        that would end the guests doing the most work.
+        """
+        try:
+            status = self.api.call("GET", f"/nodes/{self.node}/qemu/{self.vmid}/status/current")
+        except ProxmoxError:
+            # One unanswered request is not evidence about the guest, and a
+            # watchdog that raises here stops the whole schedule.
+            return 0
+        return int(status.get("netin", 0)) + int(status.get("diskwrite", 0))
+
     def running(self) -> bool:
         status = self.api.call("GET", f"/nodes/{self.node}/qemu/{self.vmid}/status/current")
         return str(status.get("status")) == "running"

--- a/tests/vm/proxmox.py
+++ b/tests/vm/proxmox.py
@@ -1,0 +1,535 @@
+"""Test machines on a Proxmox VE cluster, driven entirely through its API.
+
+The workstation cannot host the campaign: five guests share its memory with an
+editor and a test suite, `earlyoom` takes one whenever the total crosses its
+threshold, and hourly ZFS snapshots pin every disk image that is deleted. A
+green run there is not evidence.
+
+Everything here goes over HTTPS. Port 22 is closed on the cluster, so the
+node's serial socket is unreachable as a file and `termproxy` is the console:
+it answers with a ticket, and the ticket opens a websocket carrying the same
+bytes the local harness reads off a unix socket.
+
+The token is an administrator of a cluster running other people's machines.
+Nothing here names a VM it did not create, and every destructive call names one
+VMID.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+import ssl
+import time
+import urllib.error
+import urllib.parse
+import urllib.request
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any, Final
+
+from .console import ConsoleTimeout, SerialConsole
+from .websocket import Framed, WebSocket, WebSocketError
+
+#: Where the secret lives. Read from the file at every call site; it never
+#: reaches a command line, an environment variable, or a log.
+TOKEN_FILE: Final[Path] = Path.home() / ".ssh/chris"
+TOKEN_ID: Final[str] = "zakk@authentik!gentoo-install"
+HOST: Final[str] = "pve.infra.plz.ac"
+
+#: The API answers on 443 behind a proxy, not on Proxmox's own 8006.
+PORT: Final[int] = 443
+
+#: The range this harness allocates from. Chosen because nothing on the cluster
+#: uses it: 9000, 9002, 9200 and 9201 are somebody else's, and one of them is a
+#: production template. A range alone is not proof of ownership, which is what
+#: `TAG` is for.
+VMID_FIRST: Final[int] = 9300
+VMID_LAST: Final[int] = 9399
+
+#: Written onto every guest at creation and required before anything is
+#: deleted. `9002` is `prod-debian-12-server-template`: reading a VMID range as
+#: ownership would have offered a production machine up for removal.
+TAG: Final[str] = "gentoo-install-test"
+
+#: Where disks go. `local` is per node and holds the ISOs; `ceph-pve` is shared,
+#: so a guest can be built on whichever node has the memory.
+DISK_STORAGE: Final[str] = "ceph-pve"
+ISO_STORAGE: Final[str] = "local"
+
+#: Long enough for a stage3 to extract over a slow mirror, short enough that a
+#: node that stopped answering does not hold the whole campaign.
+API_TIMEOUT: Final[float] = 60.0
+
+
+class ProxmoxError(Exception):
+    """The cluster refused a call, or a task it accepted did not finish."""
+
+
+def _certificates() -> ssl.SSLContext:
+    """The cluster serves a certificate its own CA signed, and that CA is not
+    in the workstation's store. Verification is off for this host alone; the
+    token is what authenticates, and it never leaves this process except in a
+    header on this connection."""
+    context = ssl.create_default_context()
+    context.check_hostname = False
+    context.verify_mode = ssl.CERT_NONE
+    return context
+
+
+def _secret() -> str:
+    try:
+        return TOKEN_FILE.read_text().strip()
+    except OSError as error:
+        raise ProxmoxError(f"the API token is not readable at {TOKEN_FILE}: {error}") from error
+
+
+@dataclass(frozen=True)
+class Node:
+    name: str
+    free_bytes: int
+    cores: int
+
+
+class Api:
+    """One authenticated conversation with the cluster."""
+
+    def __init__(self, host: str = HOST) -> None:
+        self.host = host
+        self._context = _certificates()
+        #: The cluster sits behind a load balancer that spreads requests over
+        #: every node. A `termproxy` ticket is valid on the node that issued
+        #: it, so a websocket landing anywhere else is answered `502 Bad
+        #: Gateway`. Holding the balancer's own affinity cookie pins both
+        #: halves to one backend.
+        self.affinity: str = ""
+
+    def _remember(self, headers: Any) -> None:
+        for name, value in headers.items():
+            if name.lower() == "set-cookie" and value.startswith("INGRESSCOOKIE="):
+                self.affinity = value.split(";", 1)[0]
+
+    def call(self, method: str, path: str, **form: Any) -> Any:
+        # A body on DELETE is answered `501 Unexpected content for method`, so
+        # the two methods that take no body carry their parameters in the URL.
+        body: bytes | None = None
+        if form and method in ("GET", "DELETE"):
+            joiner = "&" if "?" in path else "?"
+            path = f"{path}{joiner}{urllib.parse.urlencode(form)}"
+        elif form:
+            body = urllib.parse.urlencode(form).encode()
+        request = urllib.request.Request(
+            f"https://{self.host}/api2/json{path}", data=body, method=method
+        )
+        request.add_header("Authorization", f"PVEAPIToken={TOKEN_ID}={_secret()}")
+        if self.affinity:
+            request.add_header("Cookie", self.affinity)
+        try:
+            with urllib.request.urlopen(
+                request, timeout=API_TIMEOUT, context=self._context
+            ) as answer:
+                self._remember(answer.headers)
+                return json.load(answer).get("data")
+        except urllib.error.HTTPError as error:
+            # The reason, not only the body: Proxmox answers `500` with
+            # `{"data":null}` and puts what went wrong in the status line.
+            said = error.read().decode("utf-8", "replace").strip()[:300]
+            raise ProxmoxError(
+                f"{method} {path} answered {error.code} {error.reason}: {said}"
+            ) from error
+        except (urllib.error.URLError, TimeoutError, OSError) as error:
+            raise ProxmoxError(f"{method} {path} did not answer: {error}") from error
+
+    def wait(self, node: str, upid: str, patience: float = 1800.0) -> None:
+        """Block until a task finishes, and raise unless it finished cleanly."""
+        quoted = urllib.parse.quote(upid, safe="")
+        deadline = time.monotonic() + patience
+        while time.monotonic() < deadline:
+            status = self.call("GET", f"/nodes/{node}/tasks/{quoted}/status")
+            if status.get("status") == "stopped":
+                exit_status = status.get("exitstatus", "")
+                if exit_status != "OK":
+                    raise ProxmoxError(f"{upid} ended with {exit_status!r}")
+                return
+            time.sleep(2.0)
+        raise ProxmoxError(f"{upid} did not finish within {patience:.0f}s")
+
+    def nodes(self) -> list[Node]:
+        found = [
+            Node(
+                name=one["node"],
+                free_bytes=int(one.get("maxmem", 0)) - int(one.get("mem", 0)),
+                cores=int(one.get("maxcpu", 0)),
+            )
+            for one in self.call("GET", "/nodes")
+            if one.get("status") == "online"
+        ]
+        return sorted(found, key=lambda one: one.free_bytes, reverse=True)
+
+    def ours(self) -> list[tuple[str, int]]:
+        """Every machine this harness created, as `(node, vmid)`.
+
+        Both conditions, not either: the tag says the harness made it and the
+        range says the harness would have. Read from the cluster rather than
+        from a local list, because a run killed between creating a guest and
+        recording it would otherwise leave it holding a node's memory for ever.
+        """
+        return sorted(
+            (one["node"], int(one["vmid"]))
+            for one in self.call("GET", "/cluster/resources?type=vm")
+            if VMID_FIRST <= int(one["vmid"]) <= VMID_LAST
+            and TAG in str(one.get("tags", "")).split(";")
+        )
+
+    def taken(self) -> set[int]:
+        """Every VMID on the cluster. Allocation reads all of them, not only
+        the ones this harness owns."""
+        return {int(one["vmid"]) for one in self.call("GET", "/cluster/resources?type=vm")}
+
+    def free_vmid(self, held: frozenset[int] = frozenset()) -> int:
+        used = self.taken() | held
+        for candidate in range(VMID_FIRST, VMID_LAST + 1):
+            if candidate not in used:
+                return candidate
+        raise ProxmoxError(f"every VMID from {VMID_FIRST} to {VMID_LAST} is in use")
+
+    def isos(self, node: str) -> list[str]:
+        content = self.call("GET", f"/nodes/{node}/storage/{ISO_STORAGE}/content?content=iso")
+        return sorted(str(one["volid"]).split("/")[-1] for one in content)
+
+    def fetch_iso(self, node: str, url: str, filename: str) -> None:
+        """Have the node download an install medium itself.
+
+        The cluster is in China and the workstation is not, so the node reaches
+        a Chinese mirror far faster than an upload from here would, and the
+        bytes never cross the workstation's link at all.
+        """
+        if filename in self.isos(node):
+            return
+        upid = self.call(
+            "POST",
+            f"/nodes/{node}/storage/{ISO_STORAGE}/download-url",
+            url=url,
+            filename=filename,
+            content="iso",
+        )
+        self.wait(node, upid, patience=3600.0)
+
+
+@dataclass
+class GuestSpec:
+    """What to build. Sizes are what the API wants: MiB for memory, GiB for a disk."""
+
+    name: str
+    iso: str
+    memory_mib: int = 8192
+    cores: int = 4
+    #: One entry per target disk, in the order the fixture names them.
+    target_gib: tuple[int, ...] = (40,)
+    uefi: bool = True
+    #: A second CD, already uploaded, carrying the installer built from the tree.
+    driver_iso: str = ""
+    #: Boot the installed disk instead of the medium. The medium stays attached
+    #: so a failed boot can be looked at without rebuilding the guest.
+    boot_installed: bool = False
+
+
+@dataclass
+class Guest:
+    """A machine on the cluster, and the only thing allowed to delete it."""
+
+    api: Api
+    node: str
+    vmid: int
+    spec: GuestSpec
+    _booted: bool = field(default=False, init=False)
+
+    def create(self) -> None:
+        options: dict[str, Any] = {
+            "vmid": self.vmid,
+            "name": self.spec.name[:63],
+            "memory": self.spec.memory_mib,
+            "cores": self.spec.cores,
+            "sockets": 1,
+            "cpu": "host",
+            "ostype": "l26",
+            "machine": "q35",
+            "scsihw": "virtio-scsi-single",
+            # The console, and the only one: `vga: serial0` makes the firmware
+            # and the bootloader write here too, which is where a BIOS install
+            # says what it is waiting for.
+            "serial0": "socket",
+            "vga": "serial0",
+            "net0": "virtio,bridge=vmbr0",
+            "onboot": 0,
+            # Free page reporting hands memory back that a guest filled with
+            # page cache. Without it four guests hold their whole allocation.
+            "balloon": self.spec.memory_mib,
+            "agent": 0,
+            "tags": TAG,
+        }
+        if self.spec.uefi:
+            options["bios"] = "ovmf"
+            # Boot entries an install writes live here, and without a volume
+            # OVMF keeps nothing: the second boot would find no entry.
+            options["efidisk0"] = f"{DISK_STORAGE}:1,efitype=4m,pre-enrolled-keys=0"
+        for index, size in enumerate(self.spec.target_gib):
+            options[f"virtio{index}"] = f"{DISK_STORAGE}:{size},discard=on"
+        options["ide2"] = f"{ISO_STORAGE}:iso/{self.spec.iso},media=cdrom"
+        if self.spec.driver_iso:
+            options["ide3"] = f"{ISO_STORAGE}:iso/{self.spec.driver_iso},media=cdrom"
+        options["boot"] = "order=" + ("virtio0" if self.spec.boot_installed else "ide2")
+        self.api.wait(self.node, self.api.call("POST", f"/nodes/{self.node}/qemu", **options))
+
+    def start(self) -> None:
+        self.api.wait(
+            self.node, self.api.call("POST", f"/nodes/{self.node}/qemu/{self.vmid}/status/start")
+        )
+        self._booted = True
+
+    def reset(self) -> None:
+        """Boot the firmware again with somebody already reading.
+
+        `termproxy` forwards only what arrives after it attaches, and attaching
+        takes about five seconds: OVMF and GRUB had both finished by then, the
+        guest sat at a prompt on a console with no VGA device to show it, and
+        the run read an empty serial port for five minutes. Resetting once the
+        console is up puts the whole boot on the wire.
+        """
+        self.api.wait(
+            self.node, self.api.call("POST", f"/nodes/{self.node}/qemu/{self.vmid}/status/reset")
+        )
+
+    def running(self) -> bool:
+        status = self.api.call("GET", f"/nodes/{self.node}/qemu/{self.vmid}/status/current")
+        return str(status.get("status")) == "running"
+
+    def console(self) -> ConsoleChannel:
+        return ConsoleChannel.open(self.api, self.node, self.vmid)
+
+    def screenshot(self, into: Path) -> Path | None:
+        """What is on the VGA console. A BIOS guest asking GRUB's own
+        passphrase prompt writes nothing to the serial port, so a run that
+        looks hung is diagnosed here or not at all."""
+        try:
+            raw = self.api.call("GET", f"/nodes/{self.node}/qemu/{self.vmid}/screenshot")
+        except ProxmoxError:
+            return None
+        if not isinstance(raw, str):
+            return None
+        into.write_text(raw)
+        return into
+
+    def send_keys(self, keys: list[str]) -> None:
+        for key in keys:
+            self.api.call("PUT", f"/nodes/{self.node}/qemu/{self.vmid}/sendkey", key=key)
+
+    def stop(self) -> None:
+        if not self._booted:
+            return
+        try:
+            self.api.wait(
+                self.node,
+                self.api.call("POST", f"/nodes/{self.node}/qemu/{self.vmid}/status/stop"),
+                patience=180.0,
+            )
+        except ProxmoxError:
+            # Already down, or the task record expired. Either way `destroy`
+            # is what has to happen next, and it must not be skipped.
+            pass
+        self._booted = False
+
+    def destroy(self) -> None:
+        """Remove the machine and its disks.
+
+        The tag is checked first. This token administers a cluster running
+        other people's work, and a VMID is not proof of ownership: the range
+        this harness allocates from already held a production template.
+        """
+        config = self.api.call("GET", f"/nodes/{self.node}/qemu/{self.vmid}/config")
+        if TAG not in str(config.get("tags", "")).split(";"):
+            raise ProxmoxError(
+                f"vm {self.vmid} on {self.node} is not tagged {TAG!r}; refusing to remove it"
+            )
+        self.stop()
+        try:
+            self.api.wait(
+                self.node,
+                self.api.call(
+                    "DELETE",
+                    f"/nodes/{self.node}/qemu/{self.vmid}",
+                    **{"destroy-unreferenced-disks": 1, "purge": 1},
+                ),
+                patience=300.0,
+            )
+        except ProxmoxError as error:
+            raise ProxmoxError(f"vm {self.vmid} on {self.node} was not removed: {error}") from error
+
+
+class ConsoleChannel:
+    """The serial console as a `console.Channel`.
+
+    Proxmox frames what it carries: `0:<bytes>:<data>` is input, a bare `2` is
+    the keepalive its proxy expects, and what comes back is the console itself
+    with no framing of its own.
+    """
+
+    #: Proxmox's own terminal proxy drops a connection that says nothing.
+    KEEPALIVE: Final[float] = 20.0
+
+    def __init__(self, socket: Framed) -> None:
+        self._socket = socket
+        self._last_said = time.monotonic()
+
+    @classmethod
+    def open(cls, api: Api, node: str, vmid: int, tries: int = 8) -> ConsoleChannel:
+        """A ticket, then the websocket it opens.
+
+        `termproxy` refuses a guest that is not running yet and answers 500
+        after its own five-second wait, so this retries rather than failing a
+        run that was one second early.
+
+        Each retry drops the balancer's affinity cookie first. The failure is
+        intermittent and follows which backend the cookie pinned: the same call
+        answered 500 five times running on one backend and succeeded first try
+        on the next, so retrying without moving would just wait.
+        """
+        last = ""
+        for attempt in range(tries):
+            try:
+                ticket = api.call("POST", f"/nodes/{node}/qemu/{vmid}/termproxy")
+            except ProxmoxError as error:
+                last = str(error)
+                api.affinity = ""
+                time.sleep(2.0 * (attempt + 1))
+                continue
+            path = (
+                f"/api2/json/nodes/{node}/qemu/{vmid}/vncwebsocket"
+                f"?port={ticket['port']}"
+                f"&vncticket={urllib.parse.quote(ticket['ticket'], safe='')}"
+            )
+            headers = {"Authorization": f"PVEAPIToken={TOKEN_ID}={_secret()}"}
+            if api.affinity:
+                headers["Cookie"] = api.affinity
+            try:
+                socket = WebSocket.connect(
+                    api.host, path, headers, port=PORT, context=_certificates()
+                )
+            except WebSocketError as error:
+                last = str(error)
+                api.affinity = ""
+                time.sleep(2.0 * (attempt + 1))
+                continue
+            socket.settimeout(1.0)
+            # The proxy authenticates the websocket separately from the
+            # request: without this line it accepts the upgrade and then says
+            # nothing at all.
+            socket.send(f"{ticket['user']}:{ticket['ticket']}\n".encode())
+            return cls(socket)
+        raise ProxmoxError(f"no console for vm {vmid} on {node}: {last}")
+
+    def recv(self, size: int) -> bytes:
+        got = self._socket.read()
+        now = time.monotonic()
+        if not got and now - self._last_said > self.KEEPALIVE:
+            self._socket.send(b"2")
+            self._last_said = now
+        return got
+
+    def sendall(self, data: bytes) -> None:
+        self._socket.send(f"0:{len(data)}:".encode() + data)
+        self._last_said = time.monotonic()
+
+    @property
+    def closed(self) -> bool:
+        return self._socket.closed
+
+    def close(self) -> None:
+        self._socket.close()
+
+
+#: What GRUB's editor answers to, as single control characters. Arrow keys are
+#: multi-byte escape sequences whose terminfo GRUB has to agree about; these
+#: are one byte each and GRUB reads them the same on every terminal.
+GRUB_NEXT_LINE: Final[str] = "\x0e"
+GRUB_END_OF_LINE: Final[str] = "\x05"
+GRUB_BOOT: Final[str] = "\x18"
+
+
+#: Down then up: the highlight ends where it started, and GRUB stops its
+#: countdown on any key at all.
+GRUB_HOLD: Final[str] = "\x0e\x10"
+
+#: GRUB's own countdown line, and the only text of its menu that reaches a
+#: serial console: the Gentoo medium sets a graphical theme, so on serial GRUB
+#: draws the entries by cursor position and prints nothing else worth matching.
+#: Matching an entry title instead matched `Booting \`Boot LiveCD'`, which is
+#: printed after the countdown has already run out.
+GRUB_COUNTDOWN: Final[str] = r"highlighted entry|GNU GRUB|Minimal BASH-like"
+
+
+def hold_the_menu(console: SerialConsole, timeout: float = 300.0) -> bytes:
+    """Wait for GRUB's menu and stop its countdown.
+
+    Waiting first, rather than pressing early: a key sent before the menu is
+    drawn is consumed the moment it appears, the countdown never prints, and
+    there is then nothing to match on.
+    """
+    seen = console.expect(GRUB_COUNTDOWN, timeout=timeout)
+    console.send_raw(GRUB_HOLD)
+    return seen
+
+
+def append_to_cmdline(console: SerialConsole, extra: str, timeout: float = 30.0) -> None:
+    """Add kernel parameters to the highlighted GRUB entry and boot it.
+
+    The medium's own entry writes to the firmware console and says nothing more
+    once Linux takes over, so a run that boots correctly looks hung after
+    `Booting`. The local harness passes `-kernel` and `-append` straight to
+    qemu; the cluster answers 500 to `args` for anything but root, so the
+    parameters go in the way an operator would add them.
+
+    Which line to edit is counted off the editor's own screen rather than
+    assumed: the first medium tried had `search` above `linux`, one Ctrl-N
+    landed on it, and the entry booted unchanged with a broken search line.
+    """
+    hold_the_menu(console)
+    console.send_raw("e")
+    screen = console.snapshot(min(timeout, 5.0))
+    down = _line_of_linux(screen)
+    console.send_raw(GRUB_NEXT_LINE * down + GRUB_END_OF_LINE)
+    time.sleep(0.5)
+    console.send_raw(f" {extra}")
+    time.sleep(0.5)
+    console.send_raw(GRUB_BOOT)
+
+
+#: How GRUB places each line it draws: `ESC[<row>;<column>H` and then the text.
+#: Read rather than counted, because the entries differ between media: the
+#: Gentoo medium has `search` above `linux` and one Ctrl-N landed on it, which
+#: booted the entry unedited with a broken search line and no serial output.
+_PLACED: Final[re.Pattern[bytes]] = re.compile(rb"\x1b\[(\d+);\d+H([^\x1b]*)")
+
+
+def _line_of_linux(screen: bytes) -> int:
+    """How many Ctrl-N from where the cursor opens to the `linux` line.
+
+    The editor opens with the cursor on `setparams`, so the answer is the
+    difference between the two rows GRUB drew them on. A screen holding
+    neither is a medium whose bootloader is not GRUB; guessing a number there
+    would edit whatever happened to sit on that row.
+    """
+    rows: dict[int, bytes] = {}
+    for row, text in _PLACED.findall(screen):
+        said = text.strip()
+        if said:
+            rows[int(row)] = said
+    top = [at for at, said in rows.items() if said.startswith(b"setparams")]
+    body = [
+        at
+        for at, said in rows.items()
+        if said.split(b" ", 1)[0] in (b"linux", b"linuxefi", b"linux16")
+    ]
+    if not top or not body:
+        raise ProxmoxError(f"no GRUB entry to edit on this screen: {screen[-400:]!r}")
+    return min(body) - min(top)

--- a/tests/vm/proxmox.py
+++ b/tests/vm/proxmox.py
@@ -30,6 +30,7 @@ from pathlib import Path
 from typing import Any, Final
 
 from .console import ConsoleTimeout, SerialConsole
+from .monitor import keys_for
 from .websocket import Framed, WebSocket, WebSocketError
 
 #: Where the secret lives. Read from the file at every call site; it never
@@ -598,6 +599,34 @@ def append_to_cmdline(console: SerialConsole, extra: str, timeout: float = 30.0)
 #: Gentoo medium has `search` above `linux` and one Ctrl-N landed on it, which
 #: booted the entry unedited with a broken search line and no serial output.
 _PLACED: Final[re.Pattern[bytes]] = re.compile(rb"\x1b\[(\d+);\d+H([^\x1b]*)")
+
+
+#: Where the `linux` line sits below `setparams` in the medium's own entry,
+#: for a guest whose GRUB cannot be read. The Gentoo minimal ISO puts `search`
+#: between them; a wrong count edits the wrong line, which is why the sighted
+#: path counts instead and this one is checked by whether the kernel then
+#: speaks.
+BLIND_DOWN: Final[int] = 2
+
+
+def append_to_cmdline_blind(
+    guest: Guest, console: SerialConsole, extra: str, down: int = BLIND_DOWN
+) -> None:
+    """The same edit on a guest whose GRUB writes only to VGA.
+
+    Under OVMF, GRUB inherits the firmware's serial console and the menu can
+    be read. Under SeaBIOS it switches to its own framebuffer terminal, so the
+    serial log stops at `Welcome to GRUB!` and the whole install reads as hung.
+    The keys go through the API instead, and the check is that the kernel
+    starts talking: with `console=ttyS0` on the command line it has to.
+    """
+    guest.send_keys(["e"])
+    time.sleep(1.5)
+    guest.send_keys(["ctrl-n"] * down + ["ctrl-e"])
+    time.sleep(0.5)
+    guest.send_keys(keys_for(f" {extra}"))
+    time.sleep(0.5)
+    guest.send_keys(["ctrl-x"])
 
 
 def _line_of_linux(screen: bytes) -> int:

--- a/tests/vm/proxmox.py
+++ b/tests/vm/proxmox.py
@@ -250,16 +250,21 @@ class Api:
             self.wait(node, upid, patience=600.0)
         return name
 
-    def remove_iso(self, node: str, name: str) -> None:
-        """Drop an uploaded file. A driver CD per run fills a 33 GiB store."""
+    def remove_iso(self, node: str, name: str) -> str:
+        """Drop an uploaded file, and answer why if it stayed.
+
+        A driver CD per run fills a 33 GiB store, so a failure here matters,
+        but it must not fail a run whose install already finished. The reason
+        is returned rather than swallowed: the first one left a file behind
+        and said nothing at all.
+        """
         try:
             self.call(
                 "DELETE", f"/nodes/{node}/storage/{ISO_STORAGE}/content/{ISO_STORAGE}:iso/{name}"
             )
-        except ProxmoxError:
-            # Already gone, or the store is busy. Not worth failing a run whose
-            # install already finished.
-            pass
+        except ProxmoxError as error:
+            return str(error)
+        return ""
 
     def fetch_iso(self, node: str, url: str, filename: str) -> None:
         """Have the node download an install medium itself.

--- a/tests/vm/proxmox.py
+++ b/tests/vm/proxmox.py
@@ -142,7 +142,16 @@ class Api:
             raise ProxmoxError(f"{method} {path} did not answer: {error}") from error
 
     def wait(self, node: str, upid: str, patience: float = 1800.0) -> None:
-        """Block until a task finishes, and raise unless it finished cleanly."""
+        """Block until a task finishes, and raise unless it finished cleanly.
+
+        The node comes out of the UPID rather than from the caller: a task
+        started through the load balancer runs on whichever backend answered,
+        and asking the wrong node for its status is a 500 on a task that is
+        running perfectly well.
+        """
+        parts = upid.split(":")
+        if len(parts) > 1 and parts[0] == "UPID" and parts[1]:
+            node = parts[1]
         quoted = urllib.parse.quote(upid, safe="")
         deadline = time.monotonic() + patience
         while time.monotonic() < deadline:
@@ -329,7 +338,12 @@ class Guest:
             # OVMF keeps nothing: the second boot would find no entry.
             options["efidisk0"] = f"{DISK_STORAGE}:1,efitype=4m,pre-enrolled-keys=0"
         for index, size in enumerate(self.spec.target_gib):
-            options[f"virtio{index}"] = f"{DISK_STORAGE}:{size},discard=on"
+            # `serial=` is what puts the disk under `/dev/disk/by-id/`, and
+            # the fixtures name their targets there. Without it preflight
+            # answers `virtio-target0 is not present on this machine`.
+            options[f"virtio{index}"] = (
+                f"{DISK_STORAGE}:{size},discard=on,serial=target{index}"
+            )
         options["ide2"] = f"{ISO_STORAGE}:iso/{self.spec.iso},media=cdrom"
         if self.spec.driver_iso:
             options["ide3"] = f"{ISO_STORAGE}:iso/{self.spec.driver_iso},media=cdrom"

--- a/tests/vm/proxmox.py
+++ b/tests/vm/proxmox.py
@@ -601,32 +601,58 @@ def append_to_cmdline(console: SerialConsole, extra: str, timeout: float = 30.0)
 _PLACED: Final[re.Pattern[bytes]] = re.compile(rb"\x1b\[(\d+);\d+H([^\x1b]*)")
 
 
-#: Where the `linux` line sits below `setparams` in the medium's own entry,
-#: for a guest whose GRUB cannot be read. The Gentoo minimal ISO puts `search`
-#: between them; a wrong count edits the wrong line, which is why the sighted
-#: path counts instead and this one is checked by whether the kernel then
-#: speaks.
-BLIND_DOWN: Final[int] = 2
+#: The only thing a SeaBIOS guest's GRUB says on the serial port. It prints
+#: this, clears the terminal and switches to its own framebuffer, so this is
+#: where the keys have to start and there is nothing further to read.
+BIOS_GRUB: Final[str] = r"Welcome to GRUB|GNU GRUB|Booting from DVD"
+
+#: Which line below `setparams` the keys move to, tried in this order. The
+#: Gentoo minimal ISO puts `search` between `setparams` and `linux`, so two is
+#: right for it; a medium that lacks it needs one. Nothing can be read to
+#: decide, so each is tried and checked.
+BIOS_DOWN: Final[tuple[int, ...]] = (2, 1, 3)
+
+#: What the kernel prints once `console=ttyS0` is on its command line, and the
+#: proof that the edit landed on the right line.
+KERNEL_SPEAKS: Final[str] = r"Linux version|Command line:|\[    0\.000000\]"
 
 
 def append_to_cmdline_blind(
-    guest: Guest, console: SerialConsole, extra: str, down: int = BLIND_DOWN
+    guest: Guest, console: SerialConsole, extra: str, patience: float = 60.0
 ) -> None:
     """The same edit on a guest whose GRUB writes only to VGA.
 
-    Under OVMF, GRUB inherits the firmware's serial console and the menu can
-    be read. Under SeaBIOS it switches to its own framebuffer terminal, so the
-    serial log stops at `Welcome to GRUB!` and the whole install reads as hung.
-    The keys go through the API instead, and the check is that the kernel
-    starts talking: with `console=ttyS0` on the command line it has to.
+    Under OVMF, GRUB inherits the firmware's serial console and the menu can be
+    read. Under SeaBIOS it clears the terminal and switches to its own
+    framebuffer, so the serial log stops at `Welcome to GRUB!` and the whole
+    install reads as hung. The keys go through the API instead.
+
+    Nothing can be read back, so the check is the kernel itself: with
+    `console=ttyS0` on the command line it has to speak. A count that landed on
+    the wrong line leaves it silent, and the guest is reset and tried again.
     """
-    guest.send_keys(["e"])
-    time.sleep(1.5)
-    guest.send_keys(["ctrl-n"] * down + ["ctrl-e"])
-    time.sleep(0.5)
-    guest.send_keys(keys_for(f" {extra}"))
-    time.sleep(0.5)
-    guest.send_keys(["ctrl-x"])
+    console.expect(BIOS_GRUB, timeout=300.0)
+    last = ""
+    for attempt, down in enumerate(BIOS_DOWN):
+        # GRUB prints its banner before the menu is up; keys sent into that gap
+        # are dropped and the entry boots unedited.
+        time.sleep(4.0)
+        guest.send_keys(["e"])
+        time.sleep(2.0)
+        guest.send_keys(["ctrl-n"] * down + ["ctrl-e"])
+        time.sleep(1.0)
+        guest.send_keys(keys_for(f" {extra}"))
+        time.sleep(1.0)
+        guest.send_keys(["ctrl-x"])
+        try:
+            console.expect(KERNEL_SPEAKS, timeout=patience)
+            return
+        except ConsoleTimeout as error:
+            last = str(error)[:200]
+        if attempt + 1 < len(BIOS_DOWN):
+            guest.reset()
+            console.expect(BIOS_GRUB, timeout=300.0)
+    raise ProxmoxError(f"the kernel never spoke after editing GRUB blind: {last}")
 
 
 def _line_of_linux(screen: bytes) -> int:

--- a/tests/vm/proxmox.py
+++ b/tests/vm/proxmox.py
@@ -24,6 +24,7 @@ import time
 import urllib.error
 import urllib.parse
 import urllib.request
+import uuid
 from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any, Final
@@ -196,6 +197,60 @@ class Api:
     def isos(self, node: str) -> list[str]:
         content = self.call("GET", f"/nodes/{node}/storage/{ISO_STORAGE}/content?content=iso")
         return sorted(str(one["volid"]).split("/")[-1] for one in content)
+
+    def upload_iso(self, node: str, path: Path, name: str) -> str:
+        """Put a file on a node's `local` storage and answer its name there.
+
+        `iso` because that is what the endpoint takes: `snippets` is refused
+        with `value 'snippets' does not have a value in the enumeration 'iso,
+        vztmpl, import'`. The driver CD really is an ISO; nothing else here
+        pretends to be one.
+        """
+        boundary = "----" + uuid.uuid4().hex
+        body = (
+            f"--{boundary}\r\n"
+            'Content-Disposition: form-data; name="content"\r\n\r\niso\r\n'
+        ).encode()
+        body += (
+            f"--{boundary}\r\n"
+            f'Content-Disposition: form-data; name="filename"; filename="{name}"\r\n'
+            "Content-Type: application/octet-stream\r\n\r\n"
+        ).encode()
+        body += path.read_bytes() + b"\r\n"
+        body += f"--{boundary}--\r\n".encode()
+        request = urllib.request.Request(
+            f"https://{self.host}/api2/json/nodes/{node}/storage/{ISO_STORAGE}/upload",
+            data=body,
+            method="POST",
+        )
+        request.add_header("Authorization", f"PVEAPIToken={TOKEN_ID}={_secret()}")
+        request.add_header("Content-Type", f"multipart/form-data; boundary={boundary}")
+        if self.affinity:
+            request.add_header("Cookie", self.affinity)
+        try:
+            with urllib.request.urlopen(
+                request, timeout=600.0, context=self._context
+            ) as answer:
+                upid = json.load(answer).get("data")
+        except urllib.error.HTTPError as error:
+            said = error.read().decode("utf-8", "replace").strip()[:300]
+            raise ProxmoxError(f"{name} was not uploaded: {error.code} {said}") from error
+        except (urllib.error.URLError, TimeoutError, OSError) as error:
+            raise ProxmoxError(f"{name} was not uploaded: {error}") from error
+        if isinstance(upid, str) and upid.startswith("UPID"):
+            self.wait(node, upid, patience=600.0)
+        return name
+
+    def remove_iso(self, node: str, name: str) -> None:
+        """Drop an uploaded file. A driver CD per run fills a 33 GiB store."""
+        try:
+            self.call(
+                "DELETE", f"/nodes/{node}/storage/{ISO_STORAGE}/content/{ISO_STORAGE}:iso/{name}"
+            )
+        except ProxmoxError:
+            # Already gone, or the store is busy. Not worth failing a run whose
+            # install already finished.
+            pass
 
     def fetch_iso(self, node: str, url: str, filename: str) -> None:
         """Have the node download an install medium itself.

--- a/tests/vm/results.py
+++ b/tests/vm/results.py
@@ -7,6 +7,9 @@ filesystem tool or root.
 
 from __future__ import annotations
 
+import base64
+import binascii
+import io
 import tarfile
 from pathlib import Path
 
@@ -26,6 +29,55 @@ def create_disk(path: Path, size_mib: int = DEFAULT_SIZE_MIB) -> Path:
 
 def collect_command(directory: str, device: str = "/dev/vda") -> str:
     return f"tar cf {device} -C {directory} ."
+
+
+#: Wraps the archive on the console so the reader can find its two ends in a
+#: stream that also carries the shell's own echo of the command.
+CONSOLE_OPEN = "GI_RESULTS_BEGIN"
+CONSOLE_CLOSE = "GI_RESULTS_END"
+
+
+def console_command(directory: str) -> str:
+    """Print the results as one base64 line between two markers.
+
+    A guest on the cluster writes its disks to shared storage the workstation
+    cannot read, and the API offers no way to download a volume, so the console
+    is the only channel back. Compressed first: an install log is megabytes and
+    base64 adds a third again.
+    """
+    return (
+        f"echo {CONSOLE_OPEN}; tar cz -C {directory} . | base64 -w0; "
+        f"echo; echo {CONSOLE_CLOSE}"
+    )
+
+
+def read_console(said: bytes) -> dict[str, bytes]:
+    """The archive out of what the console printed."""
+    opened = said.rfind(CONSOLE_OPEN.encode())
+    closed = said.rfind(CONSOLE_CLOSE.encode())
+    if opened < 0 or closed < opened:
+        raise ResultError("the console carried no result archive")
+    # Everything between the markers with the line breaks the terminal added
+    # removed: base64 -w0 writes one line, and the console wraps it.
+    encoded = b"".join(said[opened:closed].split()[1:])
+    try:
+        packed = base64.b64decode(encoded, validate=True)
+    except (binascii.Error, ValueError) as error:
+        raise ResultError(f"the console result is not base64: {error}") from error
+    files: dict[str, bytes] = {}
+    try:
+        with tarfile.open(fileobj=io.BytesIO(packed), mode="r:gz") as archive:
+            for member in archive:
+                if not member.isfile():
+                    continue
+                extracted = archive.extractfile(member)
+                if extracted is not None:
+                    files[member.name.removeprefix("./")] = extracted.read()
+    except (tarfile.TarError, EOFError) as error:
+        raise ResultError(f"the console result is not a tar archive: {error}") from error
+    if not files:
+        raise ResultError("the console result archive is empty")
+    return files
 
 
 def read_disk(path: Path) -> dict[str, bytes]:

--- a/tests/vm/websocket.py
+++ b/tests/vm/websocket.py
@@ -1,0 +1,222 @@
+"""A websocket client, enough of RFC 6455 to carry a serial console.
+
+Proxmox hands out a console over `vncwebsocket` and nothing else: the node's
+serial socket is a file on the node, port 22 is closed, and the API is the only
+way in. The standard library has no websocket client, and the harness takes no
+dependency the workstation does not already have, so this is the subset that
+protocol needs: a masked client frame, an unmasked server frame, ping and
+close. No extensions, no fragmentation of what is sent.
+"""
+
+from __future__ import annotations
+
+import base64
+import os
+import socket
+import ssl
+import struct
+from types import TracebackType
+from typing import Final, Protocol, Self
+
+#: Continuation and reserved opcodes never appear here: the server sends one
+#: frame per write, and this client sends one frame per call.
+_TEXT: Final[int] = 0x1
+_BINARY: Final[int] = 0x2
+_CLOSE: Final[int] = 0x8
+_PING: Final[int] = 0x9
+_PONG: Final[int] = 0xA
+
+
+class WebSocketError(Exception):
+    """The handshake failed, or the peer sent something this client cannot read."""
+
+
+def _client_frame(payload: bytes, opcode: int) -> bytes:
+    """One masked frame. A client always masks; a server never does."""
+    mask = os.urandom(4)
+    size = len(payload)
+    if size < 126:
+        header = struct.pack("!BB", 0x80 | opcode, 0x80 | size)
+    elif size < 1 << 16:
+        header = struct.pack("!BBH", 0x80 | opcode, 0x80 | 126, size)
+    else:
+        header = struct.pack("!BBQ", 0x80 | opcode, 0x80 | 127, size)
+    return header + mask + bytes(byte ^ mask[at % 4] for at, byte in enumerate(payload))
+
+
+class Stream(Protocol):
+    """The byte transport a framed connection sits on. A TLS socket in a run,
+    and a scripted one in a test, which is the only way a frame split across
+    two reads can be exercised without a server."""
+
+    def recv(self, size: int, /) -> bytes: ...
+
+    def sendall(self, data: bytes, /) -> None: ...
+
+    def settimeout(self, seconds: float | None, /) -> None: ...
+
+    def close(self) -> None: ...
+
+
+class Framed(Protocol):
+    """What a caller needs of a websocket: whole payloads in, whole payloads
+    out. `ConsoleChannel` takes this rather than the class, so its framing can
+    be checked without a cluster to connect to."""
+
+    def send(self, payload: bytes, opcode: int = ...) -> None: ...
+
+    def read(self) -> bytes: ...
+
+    def close(self) -> None: ...
+
+    @property
+    def closed(self) -> bool: ...
+
+
+class WebSocket:
+    """A framed connection. `read()` returns payload bytes, never frames."""
+
+    def __init__(self, sock: Stream) -> None:
+        self._sock = sock
+        self._buffer = bytearray()
+        self._closed = False
+
+    @classmethod
+    def connect(
+        cls,
+        host: str,
+        path: str,
+        headers: dict[str, str],
+        *,
+        port: int = 443,
+        context: ssl.SSLContext | None = None,
+        timeout: float = 30.0,
+    ) -> Self:
+        raw = socket.create_connection((host, port), timeout=timeout)
+        secure = (context or ssl.create_default_context()).wrap_socket(
+            raw, server_hostname=host
+        )
+        lines = [
+            f"GET {path} HTTP/1.1",
+            f"Host: {host}",
+            "Upgrade: websocket",
+            "Connection: Upgrade",
+            f"Sec-WebSocket-Key: {base64.b64encode(os.urandom(16)).decode()}",
+            "Sec-WebSocket-Version: 13",
+            "Sec-WebSocket-Protocol: binary",
+            *(f"{name}: {value}" for name, value in headers.items()),
+        ]
+        secure.sendall(("\r\n".join(lines) + "\r\n\r\n").encode())
+        head = b""
+        while b"\r\n\r\n" not in head:
+            chunk = secure.recv(4096)
+            if not chunk:
+                secure.close()
+                raise WebSocketError(f"the handshake closed early: {head[:200]!r}")
+            head += chunk
+        status = head.split(b"\r\n", 1)[0].decode("utf-8", "replace")
+        if "101" not in status:
+            secure.close()
+            raise WebSocketError(f"the server refused the upgrade: {status}")
+        client = cls(secure)
+        # A server may put the first payload in the same packet as the
+        # handshake, and dropping it loses the console's opening line.
+        client._buffer += head.split(b"\r\n\r\n", 1)[1]
+        return client
+
+    def settimeout(self, seconds: float | None) -> None:
+        self._sock.settimeout(seconds)
+
+    def send(self, payload: bytes, opcode: int = _BINARY) -> None:
+        self._sock.sendall(_client_frame(payload, opcode))
+
+    def read(self) -> bytes:
+        """Payload from whatever whole frames have arrived, possibly empty.
+
+        Empty is not end of stream: it means no frame completed before the
+        socket timed out, which is the ordinary state of an idle console.
+        """
+        if self._closed:
+            return b""
+        try:
+            chunk = self._sock.recv(65536)
+        except (TimeoutError, ssl.SSLWantReadError):
+            return self._take()
+        except OSError as error:
+            raise WebSocketError(f"the connection broke: {error}") from error
+        if not chunk:
+            self._closed = True
+            return self._take()
+        self._buffer += chunk
+        return self._take()
+
+    @property
+    def closed(self) -> bool:
+        return self._closed
+
+    def _take(self) -> bytes:
+        out = bytearray()
+        while True:
+            frame = self._one()
+            if frame is None:
+                return bytes(out)
+            opcode, payload = frame
+            if opcode in (_TEXT, _BINARY):
+                out += payload
+            elif opcode == _PING:
+                self.send(payload, _PONG)
+            elif opcode == _CLOSE:
+                self._closed = True
+                return bytes(out)
+
+    def _one(self) -> tuple[int, bytes] | None:
+        """One frame out of the buffer, or None while it is still short."""
+        if len(self._buffer) < 2:
+            return None
+        opcode = self._buffer[0] & 0x0F
+        second = self._buffer[1]
+        size = second & 0x7F
+        at = 2
+        if size == 126:
+            if len(self._buffer) < 4:
+                return None
+            size = struct.unpack("!H", self._buffer[2:4])[0]
+            at = 4
+        elif size == 127:
+            if len(self._buffer) < 10:
+                return None
+            size = struct.unpack("!Q", self._buffer[2:10])[0]
+            at = 10
+        mask = b""
+        if second & 0x80:
+            if len(self._buffer) < at + 4:
+                return None
+            mask = bytes(self._buffer[at : at + 4])
+            at += 4
+        if len(self._buffer) < at + size:
+            return None
+        payload = bytes(self._buffer[at : at + size])
+        del self._buffer[: at + size]
+        if mask:
+            payload = bytes(byte ^ mask[n % 4] for n, byte in enumerate(payload))
+        return opcode, payload
+
+    def close(self) -> None:
+        if not self._closed:
+            try:
+                self.send(b"", _CLOSE)
+            except OSError:
+                pass
+            self._closed = True
+        self._sock.close()
+
+    def __enter__(self) -> Self:
+        return self
+
+    def __exit__(
+        self,
+        exc_type: type[BaseException] | None,
+        exc: BaseException | None,
+        tb: TracebackType | None,
+    ) -> None:
+        self.close()


### PR DESCRIPTION
The workstation cannot host a campaign: earlyoom takes a guest whenever five
share its memory and hourly snapshots pin every image deleted, so a green run
there is not evidence.

Everything goes over the API — port 22 is closed on the cluster — with a
stdlib websocket for the serial console. The schedule collects one result at
a time and ends a guest that stops moving.