### PR TITLE
Fix two package tables that name what the system cannot install

### DIFF
--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -71,9 +71,12 @@ package_for() {
 	lvm:* | pvcreate:* | vgcreate:* | lvcreate:*) printf 'lvm2' ;;
 	gpg:*) printf 'gnupg' ;;
 	zpool:debian | zfs:debian | zpool:ubuntu | zfs:ubuntu) printf 'zfsutils-linux' ;;
-	# archzfs is a third-party repository, so there is nothing to name here;
-	# `probe.zfs_support()` refuses the layout before this would matter.
-	zpool:arch | zfs:arch) printf 'zfs-utils' ;;
+	# Nothing official provides these on Arch: `zfs-utils` is in archzfs, a
+	# third-party repository the medium has not configured, and `pacman -S
+	# zfs-utils` on a stock image answers `target not found`. Empty, so the
+	# launcher says the medium cannot supply them instead of printing a
+	# command that fails.
+	zpool:arch | zfs:arch) ;;
 	udevadm:alpine) printf 'eudev' ;;
 	udevadm:debian | udevadm:ubuntu) printf 'udev' ;;
 	udevadm:fedora | udevadm:rhel | udevadm:centos) printf 'systemd-udev' ;;
@@ -163,8 +166,13 @@ case " $* " in
 esac
 if [ -n "$missing" ]; then
 	packages=""
+	unavailable=""
 	for command in $missing; do
 		package=$(package_for "$command" "$family")
+		if [ -z "$package" ]; then
+			unavailable="$unavailable $command"
+			continue
+		fi
 		# Two commands often come from one package; naming it twice reads as
 		# though the operator has to install it twice.
 		case " $packages " in
@@ -173,10 +181,13 @@ if [ -n "$missing" ]; then
 		esac
 	done
 	say "missing commands:$(printf ' %s' $missing)"
-	if manager=$(install_command "$family"); then
+	if [ -n "$unavailable" ]; then
+		say "this system has no package for:$unavailable"
+	fi
+	if [ -n "$packages" ] && manager=$(install_command "$family"); then
 		say "run: $manager$packages"
 	else
-		say "install the packages providing them, then run this again"
+		say "install what provides them, then run this again"
 	fi
 	exit 1
 fi

--- a/gentoo_install/data/packages/anthy.toml
+++ b/gentoo_install/data/packages/anthy.toml
@@ -1,5 +1,10 @@
 # Japanese input through fcitx. Separate from the Chinese schemas, so a user
 # can have one without the other. The engine fcitx addresses is `anthy`.
-packages = ["app-i18n/fcitx-anthy", "app-i18n/anthy"]
+#
+# The backend is not named here. `fcitx-anthy-5.1.10` depends on
+# `app-i18n/anthy-unicode` and only 5.1.8 and older on `app-i18n/anthy`, so
+# naming either one merges a second implementation the installed fcitx does
+# not address.
+packages = ["app-i18n/fcitx-anthy"]
 input_framework = "fcitx"
 input_method = "anthy"

--- a/tests/unit/test_bootstrap.py
+++ b/tests/unit/test_bootstrap.py
@@ -223,3 +223,43 @@ def test_every_storage_command_names_its_real_provider() -> None:
                 ["sh", "-c", script, "_", command, family], capture_output=True, text=True
             ).stdout.strip()
             assert said == wanted[command], (command, family, said)
+
+
+def test_arch_is_not_told_to_install_a_package_it_cannot_reach() -> None:
+    """`zfs-utils` is in archzfs, a third-party repository a stock live image
+    has not configured, so `pacman -S zfs-utils` answers `target not found`.
+    Naming it reads as an instruction that works."""
+    import subprocess
+    from pathlib import Path
+
+    source = (Path(__file__).resolve().parents[2] / "bootstrap.sh").read_text()
+    start = source.index("package_for()")
+    script = source[start : source.index("\n}\n", start) + 3] + '\npackage_for "$1" "$2"\n'
+
+    for command in ("zpool", "zfs"):
+        said = subprocess.run(
+            ["sh", "-c", script, "_", command, "arch"], capture_output=True, text=True
+        ).stdout.strip()
+        assert said == "", (command, said)
+
+
+def test_arch_is_told_what_it_cannot_supply_instead_of_a_failing_command(
+    tmp_path: Path,
+) -> None:
+    """On a stock Arch image with nothing but python on PATH, the launcher
+    names every missing command. The zfs pair has no official package, so the
+    line for them says so rather than putting them in a `pacman` command that
+    answers `target not found`."""
+    said = run(
+        tmp_path,
+        "ID=arch\n",
+        "--config",
+        "tests/fixtures/vm-zfs.toml",
+        path=only_python(tmp_path),
+    )
+    assert "missing commands:" in said
+    assert "this system has no package for:" in said
+    for command in ("zpool", "zfs"):
+        assert command in said.split("this system has no package for:")[1].splitlines()[0]
+    installs = [line for line in said.splitlines() if line.startswith("run: pacman")]
+    assert not any("zfs-utils" in line for line in installs), installs

--- a/tests/unit/test_plan.py
+++ b/tests/unit/test_plan.py
@@ -745,3 +745,14 @@ def test_the_input_method_variables_reach_a_session_a_display_manager_starts() -
     ).apply(recorder)
     written = {str(path): text for path, text in recorder.files.items()}
     assert "XMODIFIERS=@im=fcitx" in written["/etc/environment"]
+
+
+def test_the_anthy_group_names_no_backend_of_its_own() -> None:
+    """`fcitx-anthy-5.1.10` depends on `app-i18n/anthy-unicode` and 5.1.8 and
+    older on `app-i18n/anthy`. Naming either one here merges a second Japanese
+    input backend that the fcitx actually installed does not address."""
+    from gentoo_install.data import load_catalog
+
+    group = load_catalog()["anthy"]
+    assert group.packages == ("app-i18n/fcitx-anthy",)
+    assert not any(name.endswith(("/anthy", "/anthy-unicode")) for name in group.packages)


### PR DESCRIPTION
`zfs-utils` is in archzfs, a third-party repository a stock Arch live image
has not configured, so the launcher printed a `pacman` line that answers
`target not found`. It now says the system cannot supply the command.

`fcitx-anthy-5.1.10` depends on `app-i18n/anthy-unicode` and 5.1.8 and older
on `app-i18n/anthy`, so naming a backend in the group merges a second one the
installed fcitx does not address.