### PR TITLE
tests: offer a slot for every guest a node can hold

### DIFF
--- a/tests/unit/test_proxmox.py
+++ b/tests/unit/test_proxmox.py
@@ -364,3 +364,25 @@ def test_every_dispatched_job_answers_exactly_once(
     assert (answered.name, answered.verdict) == ("vm-lvm", Verdict.ERROR)
     assert "WebSocketError" in answered.detail
     assert done.empty(), "one job, one answer"
+
+
+def test_a_node_offers_a_slot_for_every_guest_it_can_hold() -> None:
+    """One slot per node capped a six-node cluster with 51 GiB spare at three
+    guests at a time, with twenty jobs queued behind them."""
+    from tests.vm import cluster
+    from tests.vm.cluster import GUEST_MEMORY_MIB, NODE_HEADROOM_BYTES, free_slots
+    from tests.vm.proxmox import Node
+
+    guest = GUEST_MEMORY_MIB * 1024**2
+
+    class Counted(Api):
+        def nodes(self) -> list[Node]:
+            return [
+                Node(name="big", free_bytes=NODE_HEADROOM_BYTES + guest * 3, cores=4),
+                Node(name="one", free_bytes=NODE_HEADROOM_BYTES + guest, cores=4),
+                Node(name="none", free_bytes=NODE_HEADROOM_BYTES + guest - 1, cores=4),
+            ]
+
+    names = [node.name for node in free_slots(Counted(host="nowhere.invalid"))]
+    assert names == ["big", "big", "big", "one"]
+    assert "none" not in names, "the headroom is left free on every node"

--- a/tests/vm/cluster.py
+++ b/tests/vm/cluster.py
@@ -251,9 +251,18 @@ def rewrite_fixtures(
 
 
 def free_slots(api: Api) -> list[Node]:
-    """Nodes with room for one more guest, most free first."""
-    need = GUEST_MEMORY_MIB * 1024**2 + NODE_HEADROOM_BYTES
-    return [one for one in api.nodes() if one.free_bytes >= need]
+    """One entry per guest the cluster can hold, most free node first.
+
+    A node appears as many times as it has room for, not once: returning one
+    slot per node capped a six-node cluster with 51 GiB spare at three guests
+    at a time, and the queue behind them was twenty deep.
+    """
+    need = GUEST_MEMORY_MIB * 1024**2
+    slots: list[Node] = []
+    for node in api.nodes():
+        room = node.free_bytes - NODE_HEADROOM_BYTES
+        slots += [node] * max(0, int(room // need))
+    return slots
 
 
 class Stoppable(Protocol):


### PR DESCRIPTION
One slot per node capped a six-node cluster with 51 GiB spare at three
guests at a time, with twenty jobs queued behind them. A node now appears
in the schedule as many times as it has room for, and the headroom that
keeps a node answering is still left free.