### PR TITLE
cli: count a busybox applet as a missing command

### DIFF
--- a/gentoo_install/cli.py
+++ b/gentoo_install/cli.py
@@ -120,7 +120,16 @@ def main(argv: Sequence[str] | None = None) -> int:
             if arguments.missing_commands:
                 # Nothing to derive a layout from, so answer for the commands
                 # every install needs whatever it is about to do.
-                print("\n".join(sorted(_absent((*preflight.ALWAYS, *preflight.MENU_ONLY)))))
+                print(
+                    "\n".join(
+                        sorted(
+                            _absent(
+                                (*preflight.ALWAYS, *preflight.MENU_ONLY),
+                                _probe_for(arguments),
+                            )
+                        )
+                    )
+                )
                 return EXIT_OK
             chosen = _from_menu(arguments)
             if chosen is None:
@@ -130,7 +139,11 @@ def main(argv: Sequence[str] | None = None) -> int:
         else:
             config = load(arguments.config)
         if arguments.missing_commands:
-            print("\n".join(sorted(_absent(preflight.required_commands(config)))))
+            print(
+                "\n".join(
+                    sorted(_absent(preflight.required_commands(config), _probe_for(arguments)))
+                )
+            )
             return EXIT_OK
         operations = build(config, load_catalog(), mirror=arguments.mirror)
         if arguments.dry_run:
@@ -391,8 +404,35 @@ def _offer_a_shell(
     record("the shell exited; unmounting")
 
 
-def _absent(wanted: Iterable[str]) -> set[str]:
-    return {command for command in wanted if shutil.which(command) is None}
+def _absent(wanted: Iterable[str], probe: Probe | None = None) -> set[str]:
+    """What this machine cannot run for the install.
+
+    Absent from PATH, or present as an implementation the install cannot use.
+    busybox provides `tar`, `mount`, `umount`, `blkid` and `swapon` without the
+    options every one of them is called with; counting those as installed left
+    the launcher with no package to offer and the preflight refusing the run
+    after the disks were already partitioned.
+    """
+    names = list(wanted)
+    missing = {command for command in names if shutil.which(command) is None}
+    if probe is None:
+        return missing
+    judged = [
+        command
+        for command in names
+        if command in preflight.GNU_ONLY and command not in missing
+    ]
+    versions = probe.versions(judged)
+    for command in judged:
+        if preflight.GNU_ONLY[command][0] not in versions.get(command, ""):
+            missing.add(command)
+    return missing
+
+
+def _probe_for(arguments: argparse.Namespace) -> Probe:
+    """A probe that says nothing: `--missing-commands` writes one command per
+    line and the launcher reads every line of it."""
+    return Probe(runner=Runner(log=lambda line: None), work=arguments.work)
 
 
 #: The overlay that carries the patched kernel. Its packages are on no package

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -596,3 +596,34 @@ def test_the_menu_starts_from_the_firmware_the_machine_booted() -> None:
             if one.when is not compat.Trait.ROOT_LOCKED
         ]
         assert not broken, broken
+
+
+def test_a_busybox_applet_counts_as_a_missing_command(tmp_path: Path) -> None:
+    """busybox provides `tar` without `--xattrs` and `mount` without
+    `--rbind`. Reporting them as installed left the launcher with no package
+    to offer and the preflight refusing the run after the disks were already
+    partitioned."""
+    from gentoo_install.cli import _absent
+    from gentoo_install.exec.probe import Probe
+    from gentoo_install.exec.runner import Result, Runner
+
+    class Busybox(Runner):
+        def run(
+            self,
+            argv: Sequence[str],
+            *,
+            check: bool = True,
+            input_text: str | None = None,
+            timeout: float | None = None,
+        ) -> Result:
+            said = f"{argv[0]} (BusyBox v1.36.1) multi-call binary"
+            return Result(argv=tuple(argv), returncode=0, stdout=said, stderr="", seconds=0.0)
+
+    probe = Probe(runner=Busybox(log=lambda line: None), work=tmp_path)
+    # Only commands actually on this PATH can be judged; the rest are absent
+    # either way and say nothing about the implementation check.
+    present = [name for name in ("tar", "mount", "blkid") if shutil.which(name)]
+    said = _absent(present, probe)
+    assert set(present) <= said, (present, said)
+    # Without a probe the old answer stands: on PATH is enough.
+    assert not _absent(present)


### PR DESCRIPTION
busybox provides `tar` without `--xattrs` and `mount` without `--rbind`, and
`--missing-commands` used `shutil.which` alone. Reporting them as installed
left the launcher with no package to offer and the preflight refusing the run
after the disks were already partitioned.