### PR TITLE
tests: reopen the GRUB editor with escape, not a second e

### DIFF
--- a/tests/unit/test_proxmox.py
+++ b/tests/unit/test_proxmox.py
@@ -386,3 +386,32 @@ def test_a_node_offers_a_slot_for_every_guest_it_can_hold() -> None:
     names = [node.name for node in free_slots(Counted(host="nowhere.invalid"))]
     assert names == ["big", "big", "big", "one"]
     assert "none" not in names, "the headroom is left free on every node"
+
+
+def test_the_editor_is_reopened_with_escape_not_a_second_e() -> None:
+    """A bare second `e` types the letter into the command line. ESC discards
+    the edits in the editor and does nothing in the menu, so it is safe in
+    both, and one run read `no GRUB entry to edit on this screen` off a
+    countdown line eight seconds from booting."""
+    from tests.vm.proxmox import _editor_screen
+
+    class Slow:
+        """Answers the menu once, then the editor."""
+
+        def __init__(self) -> None:
+            self.sent: list[str] = []
+            self.screens = [
+                b"\x1b[54;01H   The highlighted entry will be executed automatically in 8s.",
+                GENTOO_EDITOR,
+            ]
+
+        def send_raw(self, keys: str) -> None:
+            self.sent.append(keys)
+
+        def snapshot(self, seconds: float) -> bytes:
+            return self.screens.pop(0) if self.screens else b""
+
+    console = Slow()
+    screen = _editor_screen(console, 30.0)
+    assert b"setparams" in screen
+    assert console.sent == ["e", "\x1b", "e"]

--- a/tests/vm/proxmox.py
+++ b/tests/vm/proxmox.py
@@ -27,7 +27,7 @@ import urllib.request
 import uuid
 from dataclasses import dataclass, field
 from pathlib import Path
-from typing import Any, Final
+from typing import Any, Final, Protocol
 
 from .console import ConsoleClosed, ConsoleTimeout, SerialConsole
 from .monitor import keys_for
@@ -607,8 +607,7 @@ def append_to_cmdline(console: SerialConsole, extra: str, timeout: float = 30.0)
     landed on it, and the entry booted unchanged with a broken search line.
     """
     hold_the_menu(console)
-    console.send_raw("e")
-    screen = console.snapshot(min(timeout, 5.0))
+    screen = _editor_screen(console, timeout)
     down = _line_of_linux(screen)
     console.send_raw(GRUB_NEXT_LINE * down + GRUB_END_OF_LINE)
     time.sleep(0.5)
@@ -679,6 +678,38 @@ def append_to_cmdline_blind(
             guest.reset()
             console = SerialConsole(guest.console(), log.open("ab"))
     raise ProxmoxError(f"the kernel never spoke after editing GRUB blind: {last}")
+
+
+class Editable(Protocol):
+    """What opening GRUB's editor needs of a console: keys in, screen out."""
+
+    def send_raw(self, keys: str) -> None: ...
+
+    def snapshot(self, seconds: float) -> bytes: ...
+
+
+def _editor_screen(console: Editable, timeout: float) -> bytes:
+    """Press `e` until GRUB draws the entry, and answer with that screen.
+
+    One press is not enough. The menu redraws itself when its countdown is
+    stopped, and a snapshot taken into that redraw holds the menu rather than
+    the editor: a run read `no GRUB entry to edit on this screen` off a
+    countdown line eight seconds from booting.
+    """
+    deadline = time.monotonic() + timeout
+    seen = b""
+    console.send_raw("e")
+    while time.monotonic() < deadline:
+        seen = console.snapshot(3.0)
+        if b"setparams" in seen:
+            return seen
+        # ESC first, and only then `e` again: in the editor it discards the
+        # edits and returns to the menu, and in the menu it does nothing. A
+        # bare second `e` would type the letter into the command line.
+        console.send_raw("\x1b")
+        time.sleep(0.5)
+        console.send_raw("e")
+    raise ProxmoxError(f"GRUB never opened its editor: {seen[-400:]!r}")
 
 
 def _line_of_linux(screen: bytes) -> int:


### PR DESCRIPTION
The menu redraws itself when its countdown is stopped, and a snapshot taken
into that redraw holds the menu rather than the editor: one run read `no GRUB
entry to edit on this screen` off a countdown line eight seconds from booting.

A bare second `e` would type the letter into the command line, so ESC comes
first: it discards the edits in the editor and does nothing in the menu.