### PR TITLE
model: move reading a configuration file into exec

### DIFF
--- a/gentoo_install/cli.py
+++ b/gentoo_install/cli.py
@@ -40,7 +40,8 @@ from .model.config import (
     MirrorRegion,
     PortageConfig,
 )
-from .model.parse import TOP_LEVEL, load
+from .exec.config import load
+from .model.parse import TOP_LEVEL
 from .model.serialise import to_toml
 from .plan.build import DEFAULT_MIRROR, build
 from .plan.operations import Operation, Stage

--- a/gentoo_install/exec/config.py
+++ b/gentoo_install/exec/config.py
@@ -1,0 +1,27 @@
+"""Reading a configuration off this machine.
+
+The model parses a mapping and nothing else. Opening a path is I/O, so it
+lives here: with `load` in `model/parse.py` the declared `model -> plan ->
+exec` boundary was false, and a model test could not cover configuration
+loading without a real file on the host.
+"""
+
+from __future__ import annotations
+
+import tomllib
+from pathlib import Path
+
+from ..errors import ConfigError
+from ..model.config import InstallConfig
+from ..model.parse import parse
+
+
+def load(path: Path) -> InstallConfig:
+    """Read a TOML file and parse it, or say which file and why not."""
+    try:
+        raw = tomllib.loads(path.read_text(encoding="utf-8"))
+    except tomllib.TOMLDecodeError as error:
+        raise ConfigError(f"{path}: {error}") from error
+    except OSError as error:
+        raise ConfigError(f"{path}: {error}") from error
+    return parse(raw)

--- a/gentoo_install/model/parse.py
+++ b/gentoo_install/model/parse.py
@@ -78,16 +78,6 @@ TOP_LEVEL: Final[frozenset[str]] = frozenset(
 )
 
 
-def load(path: Path) -> InstallConfig:
-    try:
-        raw = tomllib.loads(path.read_text(encoding="utf-8"))
-    except tomllib.TOMLDecodeError as error:
-        raise ConfigError(f"{path}: {error}") from error
-    except OSError as error:
-        raise ConfigError(f"{path}: {error}") from error
-    return parse(raw)
-
-
 def parse(raw: Mapping[str, Any]) -> InstallConfig:
     version = _int(raw, "config_version", "", default=CONFIG_VERSION)
     if version > CONFIG_VERSION:

--- a/tests/golden/test_golden.py
+++ b/tests/golden/test_golden.py
@@ -13,7 +13,7 @@ from pathlib import Path
 import pytest
 
 from gentoo_install.data import load_catalog
-from gentoo_install.model.parse import load
+from gentoo_install.exec.config import load
 from gentoo_install.plan.build import build
 from gentoo_install.plan.render import render
 

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -13,7 +13,7 @@ from gentoo_install.exec import fetch
 from gentoo_install.exec.runner import Runner
 from gentoo_install.cli import EXIT_CONFIG, EXIT_OK, EXIT_PREFLIGHT, main
 from gentoo_install.errors import ConfigError
-from gentoo_install.model.parse import load
+from gentoo_install.exec.config import load
 
 FIXTURES = Path(__file__).resolve().parents[1] / "fixtures"
 
@@ -182,7 +182,7 @@ def test_the_menu_names_openssl_before_it_asks_anything(
     assert main([]) == EXIT_PREFLIGHT
     assert "the menu needs openssl" in capsys.readouterr().err
     # A file carries its hashes, so an install from one needs none of it.
-    from gentoo_install.model.parse import load
+    from gentoo_install.exec.config import load
 
     assert "openssl" not in preflight.required_commands(load(FIXTURES / "ext4-bios.toml"))
 

--- a/tests/unit/test_exec.py
+++ b/tests/unit/test_exec.py
@@ -143,7 +143,7 @@ def test_every_filesystem_the_installer_can_make_has_a_required_command() -> Non
 
     assert set(MKFS) == set(FilesystemType)
 
-    from gentoo_install.model.parse import load
+    from gentoo_install.exec.config import load
 
     encrypted = preflight.required_commands(load(Path("tests/fixtures/btrfs-luks.toml")))
     assert {"cryptsetup", "mkfs.btrfs", "btrfs"} <= encrypted
@@ -416,7 +416,7 @@ def test_the_disk_a_mirrored_root_boots_from_is_the_same_on_every_run(tmp_path: 
     `grub-install` wrote the bootloader to whichever came out."""
     from gentoo_install.exec.apply import Machine
     from gentoo_install.model.device import MdRaid, RaidLevel
-    from gentoo_install.model.parse import load
+    from gentoo_install.exec.config import load
 
     layout = load(Path("tests/fixtures/vm-mdraid.toml"))
     array = layout.disk.graph.of_type(MdRaid)[0]
@@ -592,7 +592,7 @@ def test_a_medium_with_no_zfs_stops_before_the_disks_are_touched(
 ) -> None:
     """The installer runs off whatever medium is to hand, and most of them have
     no ZFS; `zpool create` finds that out after the disks are partitioned."""
-    from gentoo_install.model.parse import load
+    from gentoo_install.exec.config import load
 
     pooled = load(Path("tests/fixtures/vm-zfs.toml"))
     probe = probe_of(tmp_path)

--- a/tests/unit/test_harness.py
+++ b/tests/unit/test_harness.py
@@ -51,7 +51,7 @@ def test_every_fixture_names_a_disk_the_harness_creates() -> None:
     harness numbered the serials, so preflight refused them twenty seconds in
     and they had never once installed anything."""
     from gentoo_install.model.device import Existing
-    from gentoo_install.model.parse import load
+    from gentoo_install.exec.config import load
 
     root = Path(__file__).resolve().parents[1]
     for path in sorted((root / "fixtures").glob("*.toml")):
@@ -68,7 +68,7 @@ def test_every_encrypted_fixture_names_where_its_passphrase_lives() -> None:
     encrypted without one fails preflight before the disks are touched, which
     is right, and means the fixture could never run."""
     from gentoo_install.model.device import Luks, ZfsPool
-    from gentoo_install.model.parse import load
+    from gentoo_install.exec.config import load
 
     root = Path(__file__).resolve().parents[1]
     for path in sorted((root / "fixtures").glob("*.toml")):

--- a/tests/unit/test_layers.py
+++ b/tests/unit/test_layers.py
@@ -1,0 +1,71 @@
+"""The three layers, checked by reading the source rather than by convention.
+
+`model/` holds data and validation with no I/O, `plan/` derives operations as
+pure functions, and `exec/` is the only place that touches the machine. Each
+of these was true when it was written and each one drifted once.
+"""
+
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+PACKAGE = Path(__file__).resolve().parents[2] / "gentoo_install"
+
+#: What reading a file looks like in an AST. `Path.read_text` and friends are
+#: attribute calls; `open` is a bare name.
+_READERS = frozenset({"read_text", "read_bytes", "write_text", "write_bytes", "open"})
+
+
+def _modules(layer: str) -> list[Path]:
+    return sorted(one for one in (PACKAGE / layer).rglob("*.py") if one.is_file())
+
+
+def _calls(tree: ast.AST) -> list[tuple[str, int]]:
+    found: list[tuple[str, int]] = []
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.Call):
+            continue
+        target = node.func
+        if isinstance(target, ast.Attribute) and target.attr in _READERS:
+            found.append((target.attr, node.lineno))
+        elif isinstance(target, ast.Name) and target.id == "open":
+            found.append((target.id, node.lineno))
+    return found
+
+
+def test_the_model_layer_opens_no_file() -> None:
+    """`load(path)` lived in `model/parse.py`, so the declared boundary was
+    false and a model test could not cover configuration loading without a
+    real file on the host. Reading a path is I/O; it belongs to `exec/`."""
+    offenders: list[str] = []
+    for module in _modules("model"):
+        for name, line in _calls(ast.parse(module.read_text())):
+            offenders.append(f"{module.relative_to(PACKAGE)}:{line} calls {name}")
+    assert not offenders, offenders
+
+
+def test_the_model_layer_runs_no_command() -> None:
+    """`exec/runner.py` is the only module allowed to import subprocess."""
+    for layer in ("model", "plan"):
+        for module in _modules(layer):
+            tree = ast.parse(module.read_text())
+            imported = {
+                alias.name
+                for node in ast.walk(tree)
+                if isinstance(node, ast.Import)
+                for alias in node.names
+            }
+            assert "subprocess" not in imported, module
+
+
+def test_the_model_layer_imports_nothing_below_it() -> None:
+    """Calls go downward only: `model` knows nothing of `plan`, `exec` or the
+    interface, and `plan` knows nothing of `exec` or the interface."""
+    forbidden = {"model": ("plan", "exec", "tui"), "plan": ("exec", "tui")}
+    for layer, below in forbidden.items():
+        for module in _modules(layer):
+            source = module.read_text()
+            for other in below:
+                assert f"from ..{other}" not in source, f"{module}: imports {other}"
+                assert f"from gentoo_install.{other}" not in source, f"{module}: {other}"

--- a/tests/unit/test_parse.py
+++ b/tests/unit/test_parse.py
@@ -27,7 +27,8 @@ from gentoo_install.model.device import (
     RaidMetadata,
     Subvolume,
 )
-from gentoo_install.model.parse import load, parse
+from gentoo_install.exec.config import load
+from gentoo_install.model.parse import parse
 from gentoo_install.model.size import Size
 
 FIXTURES = Path(__file__).resolve().parents[1] / "fixtures"

--- a/tests/unit/test_plan.py
+++ b/tests/unit/test_plan.py
@@ -24,7 +24,7 @@ from gentoo_install.model.config import (
     SystemConfig,
 )
 from gentoo_install.model.device import Node, Partition, PartitionRole
-from gentoo_install.model.parse import load
+from gentoo_install.exec.config import load
 from gentoo_install.model.validate import validate
 from gentoo_install.plan import disk as plan_disk
 from gentoo_install.plan.system import EnableService
@@ -414,7 +414,7 @@ def test_an_openrc_desktop_gets_dbus_and_elogind_without_a_display_manager() -> 
 
     from gentoo_install.data import load_catalog
     from gentoo_install.model.config import InitSystem
-    from gentoo_install.model.parse import load
+    from gentoo_install.exec.config import load
     from gentoo_install.plan.build import build
     from gentoo_install.plan.packages import SESSION_PACKAGES
     from gentoo_install.plan.system import EnableService
@@ -447,7 +447,7 @@ def test_each_rime_schema_is_a_group_the_operator_can_tick() -> None:
     from pathlib import Path as _Path
 
     from gentoo_install.data import load_catalog
-    from gentoo_install.model.parse import load
+    from gentoo_install.exec.config import load
     from gentoo_install.plan.build import build
 
     catalog = load_catalog()
@@ -474,7 +474,7 @@ def test_every_engine_the_operator_picked_is_in_the_fcitx_profile() -> None:
     from pathlib import Path as _Path
 
     from gentoo_install.data import load_catalog
-    from gentoo_install.model.parse import load
+    from gentoo_install.exec.config import load
     from gentoo_install.plan.build import build
     from gentoo_install.plan.packages import WriteInputMethodProfile
 

--- a/tests/unit/test_plan_boot.py
+++ b/tests/unit/test_plan_boot.py
@@ -32,7 +32,7 @@ from gentoo_install.model.device import (
     ZfsPool,
 )
 from gentoo_install.model.size import Size
-from gentoo_install.model.parse import load
+from gentoo_install.exec.config import load
 from gentoo_install.model.validate import validate
 from gentoo_install.plan import bootloader, kernel
 from gentoo_install.plan.portage import Emerge

--- a/tests/unit/test_plan_disk.py
+++ b/tests/unit/test_plan_disk.py
@@ -27,7 +27,7 @@ from gentoo_install.model.device import (
     VolumeGroup,
     ZfsPool,
 )
-from gentoo_install.model.parse import load
+from gentoo_install.exec.config import load
 from gentoo_install.model.size import Size
 from gentoo_install.plan import disk
 from gentoo_install.plan.operations import Stage
@@ -437,7 +437,7 @@ def test_a_swap_partition_makes_preflight_ask_for_mkswap() -> None:
     """`MakeSwap` runs it, and only filesystems contributed to the list, so a
     medium without it passed and died after the disks were partitioned."""
     from gentoo_install.exec import preflight
-    from gentoo_install.model.parse import load
+    from gentoo_install.exec.config import load
 
     wanted = preflight.required_commands(load(Path("tests/fixtures/vm-bios.toml")))
     assert {"mkswap", "swapoff"} <= wanted
@@ -447,7 +447,7 @@ def test_the_lvm_check_names_the_binaries_the_plan_runs() -> None:
     """A medium carrying lvm2 as one multicall binary without its symlinks
     passed on `lvm` and then died at `pvcreate`."""
     from gentoo_install.exec import preflight
-    from gentoo_install.model.parse import load
+    from gentoo_install.exec.config import load
 
     wanted = preflight.required_commands(load(Path("tests/fixtures/vm-lvm.toml")))
     assert {"pvcreate", "vgcreate", "lvcreate"} <= wanted

--- a/tests/unit/test_plan_system.py
+++ b/tests/unit/test_plan_system.py
@@ -571,7 +571,7 @@ def test_an_openrc_storage_service_is_enabled_after_its_package_is_merged() -> N
     from pathlib import Path
 
     from gentoo_install.data import load_catalog
-    from gentoo_install.model.parse import load
+    from gentoo_install.exec.config import load
     from gentoo_install.plan.build import build
 
     for fixture, package, service in (
@@ -636,7 +636,7 @@ def test_openrc_brings_up_the_storage_stack_it_has_a_service_for() -> None:
     them a volume group that does not carry the root never activates."""
     from pathlib import Path
 
-    from gentoo_install.model.parse import load
+    from gentoo_install.exec.config import load
 
     # The fixture is already openrc; the systemd half has to be built from it.
     lvm = load(Path("tests/fixtures/vm-lvm.toml"))
@@ -819,7 +819,7 @@ def test_the_resolver_link_is_the_last_thing_written() -> None:
     from pathlib import Path as FilePath
 
     from gentoo_install.data import load_catalog as catalog_of
-    from gentoo_install.model.parse import load as load_config
+    from gentoo_install.exec.config import load as load_config
     from gentoo_install.plan.build import build as whole_plan
     from gentoo_install.plan.portage import Emerge
     from gentoo_install.plan.system import LinkResolvConf
@@ -927,7 +927,7 @@ def test_the_host_keys_exist_before_dracut_converts_them() -> None:
     from pathlib import Path as Where
 
     from gentoo_install.data import load_catalog
-    from gentoo_install.model.parse import load as load_config
+    from gentoo_install.exec.config import load as load_config
     from gentoo_install.plan.build import build as build_plan
 
     where = Where(__file__).resolve().parents[1] / "fixtures" / "vm-unlock.toml"

--- a/tests/unit/test_resume.py
+++ b/tests/unit/test_resume.py
@@ -140,7 +140,7 @@ def test_the_running_installer_says_where_it_is_and_how_long_it_has_taken() -> N
     from gentoo_install.exec.runner import Runner
     from gentoo_install.plan.build import build
     from gentoo_install.data import load_catalog
-    from gentoo_install.model.parse import load
+    from gentoo_install.exec.config import load
     from gentoo_install.exec.apply import Machine
 
     assert _elapsed(0) == "0:00:00"

--- a/tests/unit/test_serialise.py
+++ b/tests/unit/test_serialise.py
@@ -111,7 +111,7 @@ def test_a_size_is_written_as_a_literal_and_not_as_a_table() -> None:
     """`Size` is a frozen dataclass, so the writer recursed into it and
     produced `[system.zram]`, which the parser then refused. A saved
     configuration holding zram or a build tmpfs could not be loaded back."""
-    from gentoo_install.model.parse import load
+    from gentoo_install.exec.config import load
     from gentoo_install.model.size import Size
 
     started = load(Path(__file__).resolve().parents[1] / "fixtures" / "vm-binpkg.toml")

--- a/tests/unit/test_tui_curses.py
+++ b/tests/unit/test_tui_curses.py
@@ -173,7 +173,7 @@ from pathlib import Path
 
 from gentoo_install.data import load_catalog
 from gentoo_install.i18n import Catalog
-from gentoo_install.model.parse import load
+from gentoo_install.exec.config import load
 from gentoo_install.plan.build import build
 from gentoo_install.model import mirrors
 from gentoo_install.model import compat

--- a/tests/unit/test_validate.py
+++ b/tests/unit/test_validate.py
@@ -9,7 +9,7 @@ from gentoo_install.errors import ValidationFailed
 from gentoo_install.model.config import InitSystem
 from gentoo_install.model.device import Mountpoint, Node, Partition, PartitionRole
 from gentoo_install.model.size import Size
-from gentoo_install.model.parse import load
+from gentoo_install.exec.config import load
 from gentoo_install.model.validate import validate
 
 from .layouts import encrypted_root, config, ext4_on_gpt, i, zfs_root

--- a/tests/vm/cluster.py
+++ b/tests/vm/cluster.py
@@ -30,7 +30,7 @@ from typing import Final, Protocol
 from gentoo_install.model.config import InstallConfig
 from gentoo_install.model.device import Existing
 from gentoo_install.model.config import MirrorRegion, Sync
-from gentoo_install.model.parse import load
+from gentoo_install.exec.config import load
 from gentoo_install.model.serialise import to_toml
 from .console import ConsoleClosed, ConsoleTimeout, SerialConsole
 from .driver import build as build_driver

--- a/tests/vm/run.py
+++ b/tests/vm/run.py
@@ -33,7 +33,7 @@ from gentoo_install.model.device import (
     ZfsPool,
 )
 from gentoo_install.model.config import Networking
-from gentoo_install.model.parse import load
+from gentoo_install.exec.config import load
 from gentoo_install.plan.system import _network_service as network_service
 
 from .console import PASSWORD_PROMPT, SerialConsole


### PR DESCRIPTION
Opening a path is I/O, so `load` in `model/parse.py` made the declared
`model -> plan -> exec` boundary false and a model test could not cover
configuration loading without a real file on the host. `parse(raw)` stays the
model entry point.

`tests/unit/test_layers.py` reads the AST and rejects file I/O, `subprocess`
and downward imports under `model/` and `plan/`.