### PR TITLE
tests: reopen a dropped console instead of losing the run

### DIFF
--- a/tests/unit/test_proxmox.py
+++ b/tests/unit/test_proxmox.py
@@ -411,7 +411,86 @@ def test_the_editor_is_reopened_with_escape_not_a_second_e() -> None:
         def snapshot(self, seconds: float) -> bytes:
             return self.screens.pop(0) if self.screens else b""
 
+        def send(self, line: str) -> None:
+            self.sent.append(line)
+
+        def expect(self, pattern: str, timeout: float) -> bytes:
+            raise AssertionError("the editor is read by snapshot, not by expect")
+
     console = Slow()
     screen = _editor_screen(console, 30.0)
     assert b"setparams" in screen
     assert console.sent == ["e", "\x1b", "e"]
+
+
+def test_a_long_install_is_never_sent_twice_after_a_reconnect() -> None:
+    """A console dropped mid-install is reopened and listened to again. Handing
+    the command over a second time would start another install on a target the
+    first one has half written."""
+    from tests.vm.cluster import Reconnecting
+    from tests.vm.console import ConsoleClosed
+
+    sent: list[str] = []
+    opened: list[int] = []
+
+    class Flaky:
+        def __init__(self, drops: int) -> None:
+            self.drops = drops
+
+        def send(self, line: str) -> None:
+            sent.append(line)
+
+        def send_raw(self, keys: str) -> None:
+            sent.append(keys)
+
+        def snapshot(self, seconds: float) -> bytes:
+            return b""
+
+        def expect(self, pattern: str, timeout: float) -> bytes:
+            if self.drops:
+                self.drops -= 1
+                raise ConsoleClosed("the guest closed the serial connection")
+            return b"MARK_1_DONE"
+
+    def open_console() -> Flaky:
+        opened.append(1)
+        return Flaky(drops=1 if len(opened) < 3 else 0)
+
+    link = Reconnecting(open_console, tries=4)
+    link.wait_for("sh install.sh", timeout=5.0)
+
+    commands = [one for one in sent if "install.sh" in one]
+    assert len(commands) == 1, commands
+    assert len(opened) == 3, "one open, then one per drop"
+
+
+def test_a_short_command_is_sent_again_after_a_reconnect() -> None:
+    """The shell never received it, so waiting for its marker would wait for
+    ever."""
+    from tests.vm.cluster import Reconnecting
+    from tests.vm.console import ConsoleClosed
+
+    sent: list[str] = []
+
+    class Once:
+        def __init__(self, drop: bool) -> None:
+            self.drop = drop
+
+        def send(self, line: str) -> None:
+            sent.append(line)
+
+        def send_raw(self, keys: str) -> None:
+            sent.append(keys)
+
+        def snapshot(self, seconds: float) -> bytes:
+            return b""
+
+        def expect(self, pattern: str, timeout: float) -> bytes:
+            if self.drop:
+                raise ConsoleClosed("dropped")
+            return b"done"
+
+    opens = [Once(drop=True), Once(drop=False)]
+    link = Reconnecting(lambda: opens.pop(0), tries=3)
+    link.run("mkdir -p /mnt/driver")
+    assert [one for one in sent if "mkdir" in one].__len__() == 2

--- a/tests/vm/cluster.py
+++ b/tests/vm/cluster.py
@@ -16,6 +16,7 @@ what separates a slow mirror from a dead guest.
 from __future__ import annotations
 
 import argparse
+import itertools
 import queue
 import sys
 import threading
@@ -40,6 +41,7 @@ from .proxmox import (
     GuestSpec,
     Node,
     ProxmoxError,
+    Line,
     append_to_cmdline,
     append_to_cmdline_blind,
 )
@@ -321,36 +323,40 @@ def install_one(
     try:
         guest.create()
         guest.start()
-        console = SerialConsole(guest.console(), log.open("wb"))
+        log.write_bytes(b"")
+        link = Reconnecting.to(guest, log)
+        console = link.console
         # Reset with the console attached: termproxy forwards only what arrives
         # after it, and the firmware is finished before it gets there.
         guest.reset()
         if job.uefi:
-            append_to_cmdline(console, EXTRA_CMDLINE)
+            append_to_cmdline(link, EXTRA_CMDLINE)
         else:
             # SeaBIOS hands over to a GRUB that writes only to VGA, so the
             # serial log stops at `Welcome to GRUB!` and there is no menu to
             # read. The keys go through the API and the kernel appearing on
             # the console is what says the edit landed.
-            console = append_to_cmdline_blind(guest, console, log, EXTRA_CMDLINE)
-        console.expect(r"livecd .*#|localhost .*#", timeout=900.0)
+            append_to_cmdline_blind(guest, link, EXTRA_CMDLINE)
+        link.expect(r"livecd .*#|localhost .*#", timeout=900.0)
         # The guest's own resolver is left alone. A local run pins one because
         # slirp reads the host's `/etc/resolv.conf` once at startup; the
         # cluster hands out a real configuration, and it is IPv6 with DNS64.
         # Writing IPv4 resolvers over it left every mirror unreachable:
         # `Failed to connect to mirrors.tuna.tsinghua.edu.cn:443 after 111 ms`.
-        console.run("mkdir -p /mnt/driver")
-        console.run("mountpoint -q /mnt/driver || mount -o ro /dev/sr1 /mnt/driver")
-        console.run(f"mkdir -p {RESULT_DIR}")
+        link.run("mkdir -p /mnt/driver")
+        link.run("mountpoint -q /mnt/driver || mount -o ro /dev/sr1 /mnt/driver")
+        link.run(f"mkdir -p {RESULT_DIR}")
         # tee, not a redirect: the serial console is the only way to watch a
         # run that takes half an hour, and it is what the watchdog reads to
         # tell a slow mirror from a dead guest.
-        console.run(
+        # `wait_for`, not `run`: a console dropped mid-install is reopened and
+        # listened to again, never handed the command a second time.
+        link.wait_for(
             f"{{ sh /mnt/driver/install.sh --config fixtures/{job.fixture.name}; "
             f"echo $? > {RESULT_DIR}/install.rc; }} 2>&1 | tee {RESULT_DIR}/install.txt",
             timeout=RUN_CEILING,
         )
-        files = collect(guest, console, log)
+        files = collect(guest, link, log)
         code = files.get("install.rc", b"").strip()
         if code != b"0":
             return Outcome(job.name, Verdict.FAIL, time.monotonic() - started,
@@ -482,8 +488,90 @@ def run(
 #: How many times the results are asked for again on a fresh console.
 COLLECT_TRIES: Final[int] = 3
 
+#: How many times a dropped console is reopened before a run is given up on.
+RECONNECT_TRIES: Final[int] = 4
 
-def collect(guest: Guest, console: SerialConsole, log: Path) -> dict[str, bytes]:
+
+class Reconnecting:
+    """A console that opens another one when the cluster drops it.
+
+    A `termproxy` session does not survive an install, and under a full
+    schedule it does not always survive a boot: three guests reported `the
+    guest closed the serial connection` a minute in, with the kernel visibly
+    running in what the log had already captured. The guest is fine; only the
+    connection to it is gone.
+
+    `run` re-sends its command after a reconnect, because the shell never
+    received it. `wait_for` does not: the command is already running in the
+    guest, and sending it again would start a second install.
+    """
+
+    def __init__(self, open_console: Callable[[], Line], tries: int = RECONNECT_TRIES) -> None:
+        self._open = open_console
+        self._tries = tries
+        self._marks = itertools.count(1)
+        self.console: Line = open_console()
+
+    @classmethod
+    def to(cls, guest: Guest, log: Path, tries: int = RECONNECT_TRIES) -> Reconnecting:
+        return cls(lambda: SerialConsole(guest.console(), log.open("ab")), tries)
+
+    def reopen(self) -> None:
+        self.console = self._open()
+        # The reopened console shows nothing until the shell is asked for a
+        # prompt, and every wait below is looking for text.
+        self.console.send("")
+
+    def expect(self, pattern: str, timeout: float) -> bytes:
+        for attempt in range(self._tries):
+            try:
+                return self.console.expect(pattern, timeout)
+            except ConsoleClosed:
+                if attempt + 1 == self._tries:
+                    raise
+                self.reopen()
+        raise ConsoleClosed("the console could not be reopened")
+
+    def run(self, command: str, timeout: float = 120.0) -> None:
+        for attempt in range(self._tries):
+            token = next(self._marks)
+            self.console.send(f"{command}; echo MARK_{token}_DONE")
+            try:
+                self.console.expect(rf"MARK_{token}_DONE", timeout)
+                return
+            except ConsoleClosed:
+                if attempt + 1 == self._tries:
+                    raise
+                self.reopen()
+
+    def wait_for(self, command: str, timeout: float) -> None:
+        """Send a command once and wait for it however long it takes.
+
+        Reconnecting does not re-send it: an install that is already running
+        would be started a second time on a target it has half written.
+        """
+        token = next(self._marks)
+        self.console.send(f"{command}; echo MARK_{token}_DONE")
+        for attempt in range(self._tries):
+            try:
+                self.console.expect(rf"MARK_{token}_DONE", timeout)
+                return
+            except ConsoleClosed:
+                if attempt + 1 == self._tries:
+                    raise
+                self.reopen()
+
+    def send(self, line: str) -> None:
+        self.console.send(line)
+
+    def send_raw(self, keys: str) -> None:
+        self.console.send_raw(keys)
+
+    def snapshot(self, seconds: float) -> bytes:
+        return self.console.snapshot(seconds)
+
+
+def collect(guest: Guest, link: "Reconnecting", log: Path) -> dict[str, bytes]:
     """Read the result archive back, reopening the console if it has gone.
 
     A `termproxy` session does not survive an install: one that ran 36 minutes
@@ -495,19 +583,14 @@ def collect(guest: Guest, console: SerialConsole, log: Path) -> dict[str, bytes]
     last: Exception | None = None
     for attempt in range(COLLECT_TRIES):
         try:
-            console.run(
-                f"cp /run/gentoo-install/install.jsonl {RESULT_DIR}/ 2>/dev/null || true"
-            )
-            console.send(console_command(RESULT_DIR))
-            return read_console(console.snapshot(180.0))
+            link.run(f"cp /run/gentoo-install/install.jsonl {RESULT_DIR}/ 2>/dev/null || true")
+            link.send(console_command(RESULT_DIR))
+            return read_console(link.snapshot(180.0))
         except (ConsoleClosed, ConsoleTimeout, ResultError) as error:
             last = error
             if attempt + 1 == COLLECT_TRIES:
                 break
-            console = SerialConsole(guest.console(), log.open("ab"))
-            # A newline first: the fresh console shows nothing until the shell
-            # is asked for a prompt, and `run` waits for its own marker.
-            console.send("")
+            link.reopen()
     raise ResultError(f"the results could not be read back: {last}")
 
 

--- a/tests/vm/proxmox.py
+++ b/tests/vm/proxmox.py
@@ -581,7 +581,7 @@ GRUB_HOLD: Final[str] = "\x0e\x10"
 GRUB_COUNTDOWN: Final[str] = r"highlighted entry|GNU GRUB|Minimal BASH-like"
 
 
-def hold_the_menu(console: SerialConsole, timeout: float = 300.0) -> bytes:
+def hold_the_menu(console: Line, timeout: float = 300.0) -> bytes:
     """Wait for GRUB's menu and stop its countdown.
 
     Waiting first, rather than pressing early: a key sent before the menu is
@@ -593,7 +593,7 @@ def hold_the_menu(console: SerialConsole, timeout: float = 300.0) -> bytes:
     return seen
 
 
-def append_to_cmdline(console: SerialConsole, extra: str, timeout: float = 30.0) -> None:
+def append_to_cmdline(console: Line, extra: str, timeout: float = 30.0) -> None:
     """Add kernel parameters to the highlighted GRUB entry and boot it.
 
     The medium's own entry writes to the firmware console and says nothing more
@@ -641,8 +641,8 @@ KERNEL_SPEAKS: Final[str] = r"Linux version|Command line:|\[    0\.000000\]"
 
 
 def append_to_cmdline_blind(
-    guest: Guest, console: SerialConsole, log: Path, extra: str, patience: float = 60.0
-) -> SerialConsole:
+    guest: Guest, link: "Reopenable", extra: str, patience: float = 60.0
+) -> None:
     """The same edit on a guest whose GRUB writes only to VGA.
 
     Under OVMF, GRUB inherits the firmware's serial console and the menu can be
@@ -654,6 +654,7 @@ def append_to_cmdline_blind(
     `console=ttyS0` on the command line it has to speak. A count that landed on
     the wrong line leaves it silent, and the guest is reset and tried again.
     """
+    console = link.console
     last = ""
     for attempt, down in enumerate(BIOS_DOWN):
         # Timed, not read: this guest's GRUB draws on VGA and says nothing on
@@ -668,7 +669,7 @@ def append_to_cmdline_blind(
         guest.send_keys(["ctrl-x"])
         try:
             console.expect(KERNEL_SPEAKS, timeout=patience)
-            return console
+            return
         except (ConsoleTimeout, ConsoleClosed) as error:
             last = str(error)[:200]
         if attempt + 1 < len(BIOS_DOWN):
@@ -676,19 +677,38 @@ def append_to_cmdline_blind(
             # new one: the first guest to take a second attempt reported `the
             # guest closed the serial connection` a minute in.
             guest.reset()
-            console = SerialConsole(guest.console(), log.open("ab"))
+            link.reopen()
+            console = link.console
     raise ProxmoxError(f"the kernel never spoke after editing GRUB blind: {last}")
 
 
-class Editable(Protocol):
-    """What opening GRUB's editor needs of a console: keys in, screen out."""
+class Line(Protocol):
+    """What driving a guest needs of a console: keys in, text out.
+
+    A protocol rather than `SerialConsole`, because a cluster run drives a
+    console that reopens itself when the cluster drops it, and because a test
+    can then script one.
+    """
+
+    def send(self, line: str) -> None: ...
 
     def send_raw(self, keys: str) -> None: ...
 
     def snapshot(self, seconds: float) -> bytes: ...
 
+    def expect(self, pattern: str, timeout: float) -> bytes: ...
 
-def _editor_screen(console: Editable, timeout: float) -> bytes:
+
+class Reopenable(Protocol):
+    """A console that can be replaced with another one to the same guest. A
+    reset drops the console with it, and the next attempt needs a live one."""
+
+    console: Line
+
+    def reopen(self) -> None: ...
+
+
+def _editor_screen(console: Line, timeout: float) -> bytes:
     """Press `e` until GRUB draws the entry, and answer with that screen.
 
     One press is not enough. The menu redraws itself when its countdown is


### PR DESCRIPTION
A `termproxy` session does not always survive a boot under a full schedule:
three guests reported `the guest closed the serial connection` a minute in,
with the kernel visibly running in what the log had already captured.

A short command is sent again after a reconnect, because the shell never
received it. A long install is only listened to again: handing it over twice
would start a second install on a target the first had half written.