### PR TITLE
cli: check the mirror an install will use, not the package site

### DIFF
--- a/gentoo_install/cli.py
+++ b/gentoo_install/cli.py
@@ -43,8 +43,9 @@ from .model.config import (
 from .exec.config import load
 from .model.parse import TOP_LEVEL
 from .model.serialise import to_toml
-from .plan.build import DEFAULT_MIRROR, build
+from .plan.build import DEFAULT_MIRROR, build, stage3_mirror
 from .plan.operations import Context, Operation, Stage
+from .plan.portage import variant_of
 from .plan.render import render, summarise
 
 #: The country whose mirrors are the ones worth offering. Every other answer,
@@ -113,10 +114,12 @@ def main(argv: Sequence[str] | None = None) -> int:
     try:
         _require_root(arguments)
         if _needs_network(arguments):
-            # Before the reachability check: an unset clock makes every HTTPS
+            # Before any reachability check: an unset clock makes every HTTPS
             # request fail, and the message would name the network instead.
             _check_the_clock()
-            _require_network()
+            if arguments.config is None:
+                # The menu reads every version from the package site.
+                _require_network()
         if arguments.config is None:
             if arguments.missing_commands:
                 # Nothing to derive a layout from, so answer for the commands
@@ -146,6 +149,8 @@ def main(argv: Sequence[str] | None = None) -> int:
                 )
             )
             return EXIT_OK
+        if _needs_network(arguments):
+            _require_mirror(config, arguments.mirror)
         operations = build(config, load_catalog(), mirror=arguments.mirror)
         if arguments.dry_run:
             print(render(operations), end="")
@@ -448,6 +453,20 @@ def _kernel_versions(atom: str) -> tuple[tuple[str, bool], ...]:
     if atom in _OVERLAY_PACKAGES:
         return fetch.overlay_versions(atom)
     return fetch.package_versions(atom)
+
+
+def _require_mirror(config: InstallConfig, fallback: str) -> None:
+    """The address this install will fetch its stage3 from, and no other.
+
+    `packages.gentoo.org` is what the menu reads; an install given a
+    configuration never touches it. Requiring it stopped five installs on a
+    network where the chosen mirror answered and that site did not.
+    """
+    mirror = stage3_mirror(config, fallback)
+    if not fetch.mirror_online(mirror, variant_of(config)):
+        raise errors.PreflightFailed(
+            f"this machine cannot reach {mirror}; the install fetches its stage3 there"
+        )
 
 
 def _needs_network(arguments: argparse.Namespace) -> bool:

--- a/gentoo_install/exec/fetch.py
+++ b/gentoo_install/exec/fetch.py
@@ -304,21 +304,39 @@ ONLINE_TRIES: Final[int] = 3
 ONLINE_PAUSE: Final[float] = 2.0
 
 
-def online() -> bool:
-    """Whether the package site answers.
+def reachable(url: str) -> bool:
+    """Whether a URL answers, tried `ONLINE_TRIES` times.
 
-    Asked of the site the install reads rather than of any host: a machine
-    behind a portal resolves names and still cannot fetch an ebuild.
+    Asked of the address the run will actually read rather than of any host: a
+    machine behind a portal resolves names and still cannot fetch anything.
     """
     for attempt in range(ONLINE_TRIES):
         try:
-            _read(f"{PACKAGES_API}/sys-kernel/gentoo-kernel-bin.json")
+            _read(url)
         except DownloadFailed:
             if attempt + 1 < ONLINE_TRIES:
                 time.sleep(ONLINE_PAUSE)
             continue
         return True
     return False
+
+
+def online() -> bool:
+    """Whether the package site answers. The menu reads every version from it."""
+    return reachable(f"{PACKAGES_API}/sys-kernel/gentoo-kernel-bin.json")
+
+
+def mirror_online(mirror: str, variant: str) -> bool:
+    """Whether the mirror an install was told to use answers.
+
+    The stage3 comes from here and nothing else has to answer: a run given a
+    configuration never reads `packages.gentoo.org`, and requiring it stopped
+    five installs on a network where the mirror was reachable and that site
+    was not.
+    """
+    return reachable(
+        f"{mirror.rstrip('/')}/{STAGE3_PATH}/latest-stage3-amd64-{variant}.txt"
+    )
 
 
 def package_versions(atom: str) -> tuple[tuple[str, bool], ...]:

--- a/gentoo_install/plan/portage.py
+++ b/gentoo_install/plan/portage.py
@@ -537,7 +537,7 @@ def build(
     portage = config.portage
     gentoo = PurePosixPath("/var/db/repos/gentoo")
     operations: list[Operation] = [
-        InstallStage3(mirror=mirror, variant=_variant(config)),
+        InstallStage3(mirror=mirror, variant=variant_of(config)),
         PrepareChroot(),
     ]
     operations += [
@@ -751,5 +751,5 @@ def _l10n(config: InstallConfig) -> tuple[str, ...]:
     return tuple(tags)
 
 
-def _variant(config: InstallConfig) -> str:
+def variant_of(config: InstallConfig) -> str:
     return "systemd" if config.system.init is InitSystem.SYSTEMD else "openrc"

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -13,6 +13,7 @@ from gentoo_install.exec import fetch
 from gentoo_install.exec.runner import Runner
 from gentoo_install.cli import EXIT_CONFIG, EXIT_OK, EXIT_PREFLIGHT, main
 from gentoo_install.errors import ConfigError
+from gentoo_install.plan.build import DEFAULT_MIRROR
 from gentoo_install.exec.config import load
 
 FIXTURES = Path(__file__).resolve().parents[1] / "fixtures"
@@ -627,3 +628,39 @@ def test_a_busybox_applet_counts_as_a_missing_command(tmp_path: Path) -> None:
     assert set(present) <= said, (present, said)
     # Without a probe the old answer stands: on PATH is enough.
     assert not _absent(present)
+
+
+def test_a_configured_install_checks_its_mirror_and_not_the_package_site(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """`packages.gentoo.org` is what the menu reads. Requiring it stopped five
+    installs on a network where the chosen mirror answered and that site did
+    not."""
+    asked: list[str] = []
+
+    def reachable(url: str) -> bool:
+        asked.append(url)
+        return True
+
+    monkeypatch.setattr(fetch, "reachable", reachable)
+    monkeypatch.setattr(cli, "_check_the_clock", lambda: None)
+    monkeypatch.setattr(cli, "_require_root", lambda arguments: None)
+    code = main(["--config", "tests/fixtures/btrfs-luks.toml", "--dry-run"])
+    assert code == EXIT_OK
+    assert not asked, "a dry run reads nothing at all"
+
+    code = main(["--config", "tests/fixtures/btrfs-luks.toml", "--missing-commands"])
+    assert code == EXIT_OK
+    assert not asked
+
+
+def test_the_mirror_check_names_the_mirror_it_could_not_reach(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from gentoo_install import errors
+    from gentoo_install.exec.config import load
+
+    monkeypatch.setattr(fetch, "reachable", lambda url: False)
+    config = load(Path("tests/fixtures/btrfs-luks.toml"))
+    with pytest.raises(errors.PreflightFailed, match="tuna"):
+        cli._require_mirror(config, DEFAULT_MIRROR)

--- a/tests/vm/cluster.py
+++ b/tests/vm/cluster.py
@@ -24,12 +24,12 @@ import time
 import urllib.request
 from dataclasses import dataclass, field, replace
 from enum import Enum
-from pathlib import Path
+from pathlib import Path, PurePosixPath
 from collections.abc import Callable
 from typing import Final, Protocol
 
 from gentoo_install.model.config import InstallConfig
-from gentoo_install.model.device import Existing
+from gentoo_install.model.device import Existing, Luks, ZfsPool
 from gentoo_install.model.config import MirrorRegion, Sync
 from gentoo_install.exec.config import load
 from gentoo_install.model.serialise import to_toml
@@ -221,6 +221,29 @@ def prepare(
         api.upload_iso(node, driver_path, driver)
 
 
+#: The disk passphrase these runs use. Not a root password: zfs takes at least
+#: eight characters, and a real install does not reuse one for the other.
+DISK_PASSPHRASE: Final[str] = "install-disk"
+
+
+def stage_passphrases(link: Reconnecting, installation: InstallConfig) -> None:
+    """Put the passphrases where the layout says they are.
+
+    An operator does this by hand before an unattended install. Without it an
+    encrypted layout stops at `pool: /run/gentoo-install-keys/pool cannot be
+    read`, which is the installer refusing correctly and the harness not having
+    done its part.
+    """
+    graph = installation.disk.graph
+    wanted = [node.passphrase_file for node in graph.of_type(Luks) if node.passphrase_file]
+    wanted += [node.passphrase_file for node in graph.of_type(ZfsPool) if node.passphrase_file]
+    for source in wanted:
+        parent = PurePosixPath(source).parent
+        link.run(f"mkdir -p {parent} && chmod 700 {parent}")
+        link.run(f"printf '%s' '{DISK_PASSPHRASE}' > {source}")
+        link.run(f"chmod 600 {source}")
+
+
 def rewrite_fixtures(
     jobs: list[Job], into: Path, region: MirrorRegion, sync: Sync
 ) -> Path:
@@ -343,6 +366,7 @@ def install_one(
         # cluster hands out a real configuration, and it is IPv6 with DNS64.
         # Writing IPv4 resolvers over it left every mirror unreachable:
         # `Failed to connect to mirrors.tuna.tsinghua.edu.cn:443 after 111 ms`.
+        stage_passphrases(link, load(job.fixture))
         link.run("mkdir -p /mnt/driver")
         link.run("mountpoint -q /mnt/driver || mount -o ro /dev/sr1 /mnt/driver")
         link.run(f"mkdir -p {RESULT_DIR}")


### PR DESCRIPTION
`packages.gentoo.org` is what the menu reads for its version lists. An install
given a configuration never touches it, and requiring it stopped five installs
on a network where the chosen mirror answered and that site did not.

The cluster harness also stages the passphrases an encrypted layout expects,
which is what an operator does by hand before an unattended run.