### PR TITLE
tui: derive the follow-up row from what changed, and honour cancel

### DIFF
--- a/gentoo_install/tui/screens.py
+++ b/gentoo_install/tui/screens.py
@@ -1405,22 +1405,29 @@ def settle(
         lines.append(f"{translate('Extra groups')}: {' '.join(joins)}")
     if profile:
         lines.append(f"{translate('Profile')}: {profile}")
-    # Three answers rather than two. The row the values land on is somewhere
-    # else in the menu, and an operator who wants to look at them now would
-    # otherwise have to leave, find it, and remember what they were checking.
-    where = use_flags_screen if flags else video_cards_screen
+    # A third answer only when there is something to open. The row is derived
+    # from what actually changed: with a profile and no flags it offered `Yes,
+    # and open VIDEO_CARDS`, which edits a value this choice did not touch.
+    where = use_flags_screen if flags else video_cards_screen if cards else None
     named = translate("USE flags") if flags else translate("VIDEO_CARDS")
-    asked: Menu[str] = Menu(
-        title=f"{translate('This choice also sets')} — {', '.join(lines)}",
-        items=[
-            Item(label=translate("No"), value="no"),
-            Item(label=translate("Yes"), value="yes"),
+    items = [
+        Item(label=translate("No"), value="no"),
+        Item(label=translate("Yes"), value="yes"),
+    ]
+    if where is not None:
+        # The row the values land on is somewhere else in the menu, and an
+        # operator who wants to look at them now would otherwise have to leave,
+        # find it, and remember what they were checking.
+        items.append(
             Item(
                 label=f"{translate('Yes, and open')} {named}",
                 value="open",
                 detail=translate("editable"),
-            ),
-        ],
+            )
+        )
+    asked: Menu[str] = Menu(
+        title=f"{translate('This choice also sets')} — {', '.join(lines)}",
+        items=items,
         footer=footer(translate),
     )
     answered = asked.run(screen)
@@ -1434,10 +1441,15 @@ def settle(
             video_cards=(*after.portage.video_cards, *cards),
         ),
     )
-    if answered.unwrap()[0] == "open":
+    if answered.unwrap()[0] == "open" and where is not None:
         opened = where(screen, pinned, context)
         if opened.chosen:
             return Answer(Outcome.CHOSE, opened.unwrap())
+        if opened.outcome is Outcome.CANCELLED:
+            # Cancelling reaches the application's leave confirmation. Reading
+            # it as `keep what was pinned` committed a desktop and a profile
+            # the operator had just refused.
+            return Answer(Outcome.CANCELLED)
     return Answer(Outcome.CHOSE, pinned)
 
 

--- a/tests/unit/test_automatic.py
+++ b/tests/unit/test_automatic.py
@@ -321,15 +321,56 @@ def test_the_confirmation_can_open_the_row_the_values_landed_on() -> None:
     at = context()
     before = config(ext4_on_gpt())
     after = replace(before, packages=replace(before.packages, desktop="plasma"))
-    # Down twice to "Yes, and open", enter; then q out of the USE row it opens.
+    # Down twice to "Yes, and open", enter; then backspace out of the USE row.
     answer = screens.settle(
-        FakeScreen(keys=[*down(2), "\n", "q"], lines=30, columns=110), at, before, after
+        FakeScreen(keys=[*down(2), "\n", "KEY_BACKSPACE"], lines=30, columns=110),
+        at,
+        before,
+        after,
     )
     pinned = answer.unwrap()
     assert "wayland" in pinned.portage.use
-    # Cancelling the row it opened keeps the pinned values rather than undoing
-    # the choice that produced them.
+    # Backspace is local: leaving the row it opened keeps the pinned values
+    # rather than undoing the choice that produced them.
     assert pinned.packages.desktop == "plasma"
+
+
+def test_cancelling_the_row_it_opened_cancels_the_choice() -> None:
+    """`q` reaches the application's leave confirmation. Reading it as `keep
+    what was pinned` committed a desktop and a profile the operator had just
+    refused."""
+    from tests.unit.fake_screen import FakeScreen
+    from tests.unit.test_tui_app import context, down
+
+    before = config(ext4_on_gpt())
+    after = replace(before, packages=replace(before.packages, desktop="plasma"))
+    answer = screens.settle(
+        FakeScreen(keys=[*down(2), "\n", "q"], lines=30, columns=110),
+        context(),
+        before,
+        after,
+    )
+    from gentoo_install.tui.widgets import Outcome
+
+    assert answer.outcome is Outcome.CANCELLED
+    assert answer.value is None
+
+
+def test_a_profile_only_change_offers_no_row_to_open() -> None:
+    """With no flags and no cards, the third answer read `Yes, and open
+    VIDEO_CARDS`, which edits a value the choice did not touch."""
+    from tests.unit.fake_screen import FakeScreen
+    from tests.unit.test_tui_app import context, down
+
+    before = config(ext4_on_gpt())
+    after = replace(
+        before, portage=replace(before.portage, profile="default/linux/amd64/23.0/no-multilib")
+    )
+    screen = FakeScreen(keys=[*down(1), "\n"], lines=30, columns=110)
+    answer = screens.settle(screen, context(), before, after)
+    assert answer.unwrap().portage.profile.endswith("no-multilib")
+    drawn = " ".join(line for frame in screen.frames for line in frame)
+    assert "VIDEO_CARDS" not in drawn, drawn
 
 
 def test_every_screen_that_picks_a_group_carrying_use_confirms_it() -> None:


### PR DESCRIPTION
Changing a desktop to none leaves the profile as the only added value. The
confirmation still offered `Yes, and open VIDEO_CARDS`, which edits something
the choice did not touch, and cancelling the row it opened was read as `keep
what was pinned`: the desktop and profile the operator had just refused were
committed.