### PR TITLE
preflight: ask the probe for a passphrase, and fit every node

### DIFF
--- a/gentoo_install/exec/preflight.py
+++ b/gentoo_install/exec/preflight.py
@@ -165,11 +165,15 @@ def _busybox_problems(machine: Machine) -> list[str]:
     return problems
 
 
-def _passphrase_problems(config: InstallConfig) -> list[str]:
+def _passphrase_problems(config: InstallConfig, probe: Probe) -> list[str]:
     """Read every passphrase file before the first disk is touched.
 
     `zpool create` rejects a short passphrase only once the pool's vdevs have
     been partitioned, which leaves the disk wiped and the install stopped.
+
+    Through the probe, because everything preflight decides has to come from
+    its declared inputs: opening the path here made the same configuration and
+    the same probe answer differently on two machines.
     """
     problems: list[str] = []
     graph = config.disk.graph
@@ -185,10 +189,9 @@ def _passphrase_problems(config: InstallConfig) -> list[str]:
         if not source:
             problems.append(f"{device} is encrypted but names no passphrase_file")
             continue
-        try:
-            passphrase = Path(source).read_text().strip("\n")
-        except OSError as error:
-            problems.append(f"{device}: {source} cannot be read: {error}")
+        passphrase, unreadable = probe.passphrase(source)
+        if unreadable:
+            problems.append(f"{device}: {source} cannot be read: {unreadable}")
             continue
         if not passphrase:
             problems.append(f"{device}: {source} is empty")
@@ -323,7 +326,7 @@ def inspect(
         if unusable:
             fatal.append(f"{unusable}, and this configuration makes a pool")
 
-    fatal += _passphrase_problems(config)
+    fatal += _passphrase_problems(config, probe)
     fatal += _capacity_problems(config, probe)
 
     if not machine.release_key:

--- a/gentoo_install/exec/probe.py
+++ b/gentoo_install/exec/probe.py
@@ -293,6 +293,19 @@ class Probe:
     #: Where udev keeps the names that survive the kernel renumbering disks.
     BY_ID: ClassVar[Path] = Path("/dev/disk/by-id")
 
+    def passphrase(self, source: str) -> tuple[str, str]:
+        """What a passphrase file holds, and why it could not be read.
+
+        Exactly one of the two is empty. Asked of the probe rather than opened
+        where it is judged: preflight is meant to be reproducible from its
+        declared inputs, and reading a host path directly made the same
+        configuration and the same probe answer differently on two machines.
+        """
+        try:
+            return Path(source).read_text().strip("\n"), ""
+        except OSError as error:
+            return "", str(error)
+
     def names_for(self, selector: str) -> tuple[str, ...]:
         """Every spelling of one device the operator might reasonably type.
 

--- a/tests/unit/test_exec.py
+++ b/tests/unit/test_exec.py
@@ -20,7 +20,7 @@ from gentoo_install.exec.runner import Result, Runner, under
 from gentoo_install.model.config import Bootloader, BootloaderConfig, Firmware, InstallConfig
 from gentoo_install.model.device import DeviceId, Existing, Node
 
-from .layouts import config, ext4_on_gpt, i
+from .layouts import config, encrypted_root, ext4_on_gpt, i
 
 
 def runner(tmp_path: Path) -> Runner:
@@ -424,15 +424,42 @@ def test_a_short_zfs_passphrase_is_caught_before_the_disk_is_touched(tmp_path: P
             bootloader=BootloaderConfig(kind=Bootloader.ZFSBOOTMENU, firmware=Firmware.UEFI),
         )
 
+    probe = probe_of(tmp_path)
     key = tmp_path / "key"
     key.write_text("1234567")
-    problems = preflight._passphrase_problems(with_key(str(key)))
+    problems = preflight._passphrase_problems(with_key(str(key)), probe)
     assert len(problems) == 1 and "at least 8" in problems[0]
 
     key.write_text("12345678")
-    assert preflight._passphrase_problems(with_key(str(key))) == []
-    assert "cannot be read" in preflight._passphrase_problems(with_key(str(tmp_path / "gone")))[0]
-    assert "names no passphrase_file" in preflight._passphrase_problems(with_key(""))[0]
+    assert preflight._passphrase_problems(with_key(str(key)), probe) == []
+    missing = preflight._passphrase_problems(with_key(str(tmp_path / "gone")), probe)
+    assert "cannot be read" in missing[0]
+    assert "names no passphrase_file" in preflight._passphrase_problems(with_key(""), probe)[0]
+
+
+def test_the_passphrase_report_comes_from_the_probe_and_not_from_the_host(
+    tmp_path: Path,
+) -> None:
+    """Two hosts, one with `/keys/root` present and one without, gave different
+    reports for the same configuration and the same probe: preflight opened the
+    path itself. Everything it decides has to come from its declared inputs."""
+    from gentoo_install.model.device import Luks
+
+    class Answering(Probe):
+        def passphrase(self, source: str) -> tuple[str, str]:
+            return ("hunter22", "") if source == "/keys/root" else ("", "no such file")
+
+    from gentoo_install.model.device import DeviceGraph
+
+    nodes = [
+        replace(one, passphrase_file="/keys/root") if isinstance(one, Luks) else one
+        for one in encrypted_root()
+    ]
+    whole = config(encrypted_root())
+    named = replace(whole, disk=replace(whole.disk, graph=DeviceGraph.build(nodes)))
+    fake = Answering(runner=Runner(log=lambda line: None), work=tmp_path)
+    assert preflight._passphrase_problems(named, fake) == []
+    assert not Path("/keys/root").exists(), "the answer came from the probe, not the host"
 
 
 def test_a_uuid_is_read_from_the_device_and_not_from_the_cache(tmp_path: Path) -> None:

--- a/tests/vm/cluster.py
+++ b/tests/vm/cluster.py
@@ -82,15 +82,18 @@ DEFAULT_ISO: Final[str] = "minimal"
 #: kernel says nothing on the serial port and every run reads as hung.
 EXTRA_CMDLINE: Final[str] = "console=ttyS0,115200"
 
-#: What a guest is given. Four cores is a node's whole complement, so three
-#: leaves the node able to answer the API while a build runs.
-GUEST_MEMORY_MIB: Final[int] = 6144
-GUEST_CORES: Final[int] = 3
+#: What a guest is given. Four gibibytes rather than six, so the three nodes
+#: with about 6 GiB spare can each take one instead of none: the installer
+#: warns below 5 GiB and builds in `/var/tmp` rather than a tmpfs, which is
+#: slower and correct. Two cores of a node's four leaves it able to answer the
+#: API while a build runs.
+GUEST_MEMORY_MIB: Final[int] = 4096
+GUEST_CORES: Final[int] = 2
 TARGET_GIB: Final[int] = 40
 
-#: Left free on every node. A node with nothing spare stops answering, and the
-#: cluster runs other people's machines.
-NODE_HEADROOM_BYTES: Final[int] = 4 * 1024**3
+#: Left free on every node whatever else is scheduled. A node with nothing
+#: spare stops answering, and this cluster runs other people's machines.
+NODE_HEADROOM_BYTES: Final[int] = 2 * 1024**3
 
 #: How often the watchdog looks, and how many quiet looks end a guest. Ten
 #: minutes because a stage3 extract and a kernel build both write progress more


### PR DESCRIPTION
Preflight opened the passphrase file where it judged it, so the same
configuration and the same probe gave different reports on two machines.
Everything preflight decides now comes from its declared inputs.

A cluster guest is given four gibibytes rather than six, so the three nodes
with about 6 GiB spare take one each instead of none: eleven concurrent guests
across all six nodes, none of them over-committed.