### PR TITLE
mirrors: drop three dead git addresses and two stage3 sources

### DIFF
--- a/gentoo_install/model/mirrors.py
+++ b/gentoo_install/model/mirrors.py
@@ -30,6 +30,13 @@ class Site:
     distfiles: str
     git: str = ""
     rsync: str = ""
+    #: Whether the site serves `releases/`, which is where the stage3 comes
+    #: from. False for a site that carries the files and not the archives:
+    #: `mirror.xtom.com.hk` answers 200 for `releases/amd64/autobuilds/` and
+    #: 404 for the pointer file inside it, and `ftp.twaren.net` answers 403 to
+    #: this installer's own downloader while serving a browser. An install told
+    #: to use either one stopped with no stage3.
+    releases: bool = True
 
 
 #: The main tree. Taken from the project's own mirror list; the git and rsync
@@ -37,11 +44,13 @@ class Site:
 #: to every host, because the paths do not follow one: USTC serves git at
 #: `/gentoo.git` and rsync from another hostname entirely.
 GENTOO_SITES: Final[tuple[Site, ...]] = (
+    # No git column: `/git/gentoo-portage.git`, `/git/gentoo.git` and
+    # `/gentoo-portage.git` were each asked and none of them answered. A sync
+    # method falls back to a site that has it rather than to a dead address.
     Site(
         "tuna", "Tsinghua TUNA", "Beijing",
         "https://mirrors.tuna.tsinghua.edu.cn/gentoo",
-        "https://mirrors.tuna.tsinghua.edu.cn/git/gentoo-portage.git",
-        "rsync://mirrors.tuna.tsinghua.edu.cn/gentoo-portage",
+        rsync="rsync://mirrors.tuna.tsinghua.edu.cn/gentoo-portage",
     ),
     Site(
         "bfsu", "BFSU", "Beijing",
@@ -58,7 +67,6 @@ GENTOO_SITES: Final[tuple[Site, ...]] = (
     Site(
         "zju", "Zhejiang University", "Hangzhou",
         "https://mirrors.zju.edu.cn/gentoo",
-        "https://mirrors.zju.edu.cn/git/gentoo-portage.git",
     ),
     Site(
         "nju", "Nanjing University", "Nanjing",
@@ -68,7 +76,6 @@ GENTOO_SITES: Final[tuple[Site, ...]] = (
     Site(
         "sdu", "Shandong University", "Qingdao",
         "https://mirrors.sdu.edu.cn/gentoo",
-        "https://mirrors.sdu.edu.cn/git/gentoo-portage.git",
     ),
     Site(
         "hust", "HUST", "Wuhan",
@@ -93,7 +100,10 @@ GENTOO_SITES: Final[tuple[Site, ...]] = (
         "https://hippocamp.cn.ext.planetunix.net/pub/gentoo",
         rsync="rsync://hippocamp.cn.ext.planetunix.net/gentoo-portage",
     ),
-    Site("xtom-hk", "xTom", "Hong Kong", "https://mirror.xtom.com.hk/gentoo"),
+    Site(
+        "xtom-hk", "xTom", "Hong Kong", "https://mirror.xtom.com.hk/gentoo",
+        releases=False,
+    ),
     Site("rackspace-hk", "Rackspace", "Hong Kong", "https://mirror.rackspace.com/gentoo"),
     # http, not https: the only address this one answers on.
     Site("aditsu-hk", "aditsu", "Hong Kong", "http://gentoo.aditsu.net:8000"),
@@ -101,6 +111,7 @@ GENTOO_SITES: Final[tuple[Site, ...]] = (
         "nchc-tw", "NCHC", "Taiwan",
         "http://ftp.twaren.net/Linux/Gentoo",
         rsync="rsync://ftp.twaren.net/gentoo-portage",
+        releases=False,
     ),
     Site("cicku-tw", "CICKU", "Taiwan", "https://tw.mirrors.cicku.me/gentoo"),
     Site("freedif-sg", "Freedif", "Singapore", "https://mirror.freedif.org/gentoo"),

--- a/gentoo_install/plan/build.py
+++ b/gentoo_install/plan/build.py
@@ -32,15 +32,23 @@ def stage3_mirror(config: InstallConfig, fallback: str = DEFAULT_MIRROR) -> str:
     holds. Reading it as `no choice was made` sent every region-only install
     back to `distfiles.gentoo.org`: a run from the cluster in China fetched
     the stage3 there with `cn` selected.
+
+    Only sites that carry `releases/` are considered, whichever was chosen: an
+    install told to use one that does not stopped with no stage3 at all.
     """
     chosen = config.portage.mirrors.site
-    offered = mirrors.gentoo_sites(config.portage.mirrors.region)
+    offered = [
+        site for site in mirrors.gentoo_sites(config.portage.mirrors.region) if site.releases
+    ]
     if not chosen:
         return offered[0].distfiles if offered else fallback
     for site in offered:
         if site.key == chosen:
             return site.distfiles
-    return fallback
+    # The site was chosen for its distfiles and does not carry `releases/`.
+    # Falling back is the only way the stage3 arrives at all: xTom answers 404
+    # for the pointer file and `ftp.twaren.net` answers 403 to this downloader.
+    return offered[0].distfiles if offered else fallback
 
 
 def build(config: InstallConfig, catalog: packages.Catalog, *, mirror: str = DEFAULT_MIRROR) -> tuple[Operation, ...]:

--- a/tests/golden/btrfs-luks.txt
+++ b/tests/golden/btrfs-luks.txt
@@ -34,7 +34,7 @@
   fetch the first ebuild repository snapshot with emerge-webrsync
   select profile default/linux/amd64/23.0/desktop/systemd
   install git, which every later repository sync needs: emerge dev-vcs/git
-  point repository gentoo at https://mirrors.tuna.tsinghua.edu.cn/git/gentoo-portage.git, commit signatures verified
+  point repository gentoo at https://mirrors.bfsu.edu.cn/git/gentoo-portage.git, commit signatures verified
   sync repository gentoo
   point repository gentoo-zh at https://mirrors.cernet.edu.cn/gentoo-zh.git
   sync repository gentoo-zh

--- a/tests/mirrors_probe.py
+++ b/tests/mirrors_probe.py
@@ -1,0 +1,109 @@
+"""Ask every mirror in the tables whether it serves what the table claims.
+
+Run by hand, not in the suite: it is a network measurement, and a mirror that
+is down for an hour is not a defect in this repository. What it finds is used
+to correct `model/mirrors.py`, which is the only place those addresses live.
+
+    python3 -m tests.mirrors_probe
+
+`layout.conf` is not the marker for `distfiles`: `mirror.xtom.com.hk` serves
+the directory and not that file, and asking for it reported a working mirror
+as broken. A `Range` header is not used either, because `ftp.twaren.net`
+answers `403` to one and `200` to the same request without it.
+"""
+
+from __future__ import annotations
+
+import concurrent.futures as futures
+import subprocess
+import sys
+import urllib.error
+import urllib.request
+from dataclasses import dataclass
+from typing import Final
+
+from gentoo_install.model import mirrors
+
+TIMEOUT: Final[float] = 25.0
+
+#: What each column has to answer for the table to be telling the truth.
+DISTFILES_MARKER: Final[str] = "distfiles/"
+RELEASES_MARKER: Final[str] = "releases/amd64/autobuilds/latest-stage3-amd64-systemd.txt"
+BINPKG_MARKER: Final[str] = "binpkgs/x86-64/Packages"
+
+
+@dataclass(frozen=True)
+class Answer:
+    table: str
+    site: str
+    column: str
+    said: str
+
+    @property
+    def good(self) -> bool:
+        return self.said in ("200", "206", "ok")
+
+
+def _http(url: str) -> str:
+    try:
+        with urllib.request.urlopen(url, timeout=TIMEOUT) as answer:
+            answer.read(64)
+            return str(answer.status)
+    except urllib.error.HTTPError as error:
+        return f"HTTP {error.code}"
+    except (urllib.error.URLError, TimeoutError, OSError) as error:
+        return type(error).__name__
+
+
+def _rsync(uri: str) -> str:
+    said = subprocess.run(
+        ["rsync", "--contimeout=15", "--timeout=15", "--list-only", f"{uri}/"],
+        capture_output=True,
+        text=True,
+        timeout=90,
+    )
+    return "ok" if said.returncode == 0 else f"rsync {said.returncode}"
+
+
+def _git(uri: str) -> str:
+    said = subprocess.run(
+        ["git", "ls-remote", "--heads", uri],
+        capture_output=True,
+        text=True,
+        timeout=120,
+        env={"GIT_TERMINAL_PROMPT": "0", "PATH": "/usr/bin:/bin"},
+    )
+    return "ok" if said.returncode == 0 else f"git {said.returncode}"
+
+
+def ask(table: str, site: mirrors.Site) -> list[Answer]:
+    base = site.distfiles.rstrip("/")
+    marker = RELEASES_MARKER if table == "gentoo" else BINPKG_MARKER
+    found = [
+        Answer(table, site.key, "distfiles", _http(f"{base}/{DISTFILES_MARKER}")),
+        Answer(table, site.key, marker.split("/")[0], _http(f"{base}/{marker}")),
+    ]
+    if site.git:
+        found.append(Answer(table, site.key, "git", _git(site.git)))
+    if site.rsync:
+        found.append(Answer(table, site.key, "rsync", _rsync(site.rsync)))
+    return found
+
+
+def main() -> int:
+    work = [("gentoo", site) for site in mirrors.GENTOO_SITES]
+    work += [("gentoo-zh", site) for site in mirrors.GENTOOZH_SITES]
+    answers: list[Answer] = []
+    with futures.ThreadPoolExecutor(max_workers=12) as pool:
+        for got in pool.map(lambda one: ask(*one), work):
+            answers.extend(got)
+    for answer in sorted(answers, key=lambda one: (one.good, one.table, one.site)):
+        print(f"{' ' if answer.good else '!'} {answer.table:9} "
+              f"{answer.site:16} {answer.column:9} {answer.said}")
+    broken = [one for one in answers if not one.good]
+    print(f"\n{len(answers) - len(broken)}/{len(answers)} answered")
+    return 1 if broken else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/unit/test_plan_portage.py
+++ b/tests/unit/test_plan_portage.py
@@ -489,3 +489,41 @@ def test_the_stage3_comes_from_the_mirror_the_operator_chose() -> None:
     # Nothing chosen at all is still the official one, which is the region's
     # first as well as what the flag defaults to.
     assert stage3_mirror(config()) == DEFAULT_MIRROR
+
+
+def test_a_mirror_without_releases_is_never_the_stage3_source() -> None:
+    """`mirror.xtom.com.hk` answers 200 for `releases/amd64/autobuilds/` and
+    404 for the pointer file inside it, and `ftp.twaren.net` answers 403 to
+    this installer's downloader while serving a browser. An install told to
+    use either one stopped with no stage3 at all."""
+    from dataclasses import replace
+
+    from gentoo_install.model import mirrors
+    from gentoo_install.model.config import MirrorConfig, MirrorRegion
+    from gentoo_install.plan.build import stage3_mirror
+
+    from .layouts import config
+
+    for key in ("xtom-hk", "nchc-tw"):
+        site = next(one for one in mirrors.GENTOO_SITES if one.key == key)
+        assert not site.releases, f"{key} is recorded as carrying releases"
+        chosen = replace(
+            config(),
+            portage=replace(
+                config().portage,
+                mirrors=MirrorConfig(region=MirrorRegion.CN, site=key),
+            ),
+        )
+        assert stage3_mirror(chosen) != site.distfiles
+        assert stage3_mirror(chosen).startswith("https://"), key
+
+
+def test_every_offered_region_resolves_a_stage3_source() -> None:
+    """A region whose sites all lacked `releases/` would fall through to a
+    fallback nobody chose."""
+    from gentoo_install.model import mirrors
+    from gentoo_install.model.config import MirrorRegion
+
+    for region in MirrorRegion:
+        carrying = [one for one in mirrors.gentoo_sites(region) if one.releases]
+        assert carrying, region


### PR DESCRIPTION
Every site in `model/mirrors.py` was asked for every column it claims.

`tuna`, `zju` and `sdu` answer nothing on any git path, so their git column is
empty and a git sync falls back to a site that has one.

`mirror.xtom.com.hk` answers 200 for `releases/amd64/autobuilds/` and 404 for
the pointer file inside it, and `ftp.twaren.net` answers 403 to this
installer's downloader while serving a browser. Both are recorded as carrying
no releases, and `stage3_mirror` skips them.

`tests/mirrors_probe.py` re-runs the audit; it is not in the suite, because a
mirror down for an hour is not a defect here.