### PR TITLE
tests: wait for the result marker instead of a fixed window

### DIFF
--- a/tests/unit/test_proxmox.py
+++ b/tests/unit/test_proxmox.py
@@ -515,3 +515,33 @@ def test_guests_already_placed_are_subtracted_from_what_a_node_reports() -> None
     assert len(free_slots(api, {"one": 2})) == 1
     assert free_slots(api, {"one": 3}) == []
     assert free_slots(api, {"one": 9}) == [], "never negative"
+
+
+def test_the_archive_is_waited_for_rather_than_timed() -> None:
+    """An install log runs to twelve megabytes and the console carries it a
+    chunk at a time. A fixed window caught only the shell's echo of the
+    command and reported `the console result is not base64`."""
+    import inspect
+
+    from tests.vm import cluster
+
+    source = inspect.getsource(cluster.collect)
+    assert "expect(CONSOLE_CLOSE" in source
+    assert "snapshot(" not in source, "a fixed window cannot tell short from unfinished"
+
+
+def test_an_echoed_command_is_not_read_as_the_archive() -> None:
+    """The shell echoes the line, so both markers appear before any output. A
+    reader that stops at the first pair decodes the command itself."""
+    from tests.vm.results import CONSOLE_CLOSE, CONSOLE_OPEN, ResultError, read_console
+
+    echoed = (
+        f"root@livecd ~ # echo {CONSOLE_OPEN}; tar cz -C /tmp . | base64 -w0; "
+        f"echo; echo {CONSOLE_CLOSE}\r\n"
+    ).encode()
+    with pytest.raises(ResultError):
+        read_console(echoed)
+
+    encoded = _archive({"install.rc": b"0\n"})
+    whole = echoed + f"{CONSOLE_OPEN}\r\n{encoded}\r\n{CONSOLE_CLOSE}\r\n".encode()
+    assert read_console(whole) == {"install.rc": b"0\n"}

--- a/tests/vm/cluster.py
+++ b/tests/vm/cluster.py
@@ -46,7 +46,7 @@ from .proxmox import (
     append_to_cmdline,
     append_to_cmdline_blind,
 )
-from .results import ResultError, console_command, read_console
+from .results import CONSOLE_CLOSE, ResultError, console_command, read_console
 
 REPOSITORY: Final[Path] = Path(__file__).resolve().parents[2]
 WORKROOT: Final[Path] = Path.home() / "code/gentoo-install/lab/vm/cluster"
@@ -532,6 +532,13 @@ def run(
 #: How many times the results are asked for again on a fresh console.
 COLLECT_TRIES: Final[int] = 3
 
+#: How long the archive has to arrive. An install log runs to twelve megabytes
+#: and compresses to about one, which is another third again as base64, and
+#: the console carries it a chunk at a time. A fixed window of three minutes
+#: caught only the shell's echo of the command and reported `the console
+#: result is not base64`; the end marker is what says it is finished.
+COLLECT_PATIENCE: Final[float] = 900.0
+
 #: How many times a dropped console is reopened before a run is given up on.
 RECONNECT_TRIES: Final[int] = 4
 
@@ -629,7 +636,9 @@ def collect(guest: Guest, link: "Reconnecting", log: Path) -> dict[str, bytes]:
         try:
             link.run(f"cp /run/gentoo-install/install.jsonl {RESULT_DIR}/ 2>/dev/null || true")
             link.send(console_command(RESULT_DIR))
-            return read_console(link.snapshot(180.0))
+            # Waited for, not timed: the marker is what says the archive is
+            # whole, and `expect` answers with everything read up to it.
+            return read_console(link.expect(CONSOLE_CLOSE, timeout=COLLECT_PATIENCE))
         except (ConsoleClosed, ConsoleTimeout, ResultError) as error:
             last = error
             if attempt + 1 == COLLECT_TRIES:


### PR DESCRIPTION
An install log runs to twelve megabytes and compresses to about one, which is
another third again as base64, and the console carries it a chunk at a time. A
fixed three-minute window caught only the shell's echo of the command and
reported `the console result is not base64`. The end marker is what says the
archive is whole.