### PR TITLE
tui: put three row values through the catalog

### DIFF
--- a/gentoo_install/data/locale/ja.toml
+++ b/gentoo_install/data/locale/ja.toml
@@ -456,3 +456,6 @@
 "one table for both families, and what a new rule set uses" = "両アドレスファミリを 1 つのテーブルで扱う。新規のルールセットはこちら"
 "An SSH server answers the whole network. A firewall is worth installing with it; the Firewall row under Network does that and writes no rules, so the policy stays the operator's." = "SSH サーバーはネットワーク全体から接続を受け付けます。ファイアウォールの併用を推奨します。ネットワーク欄のファイアウォール項目はパッケージを導入するだけで、ルールは書き込みません。方針は運用者が決めます。"
 "Both ship an empty rule set, and the installer writes none: a policy it chose could drop port 22, and a machine reached only over SSH would then need a console to be reached at all." = "どちらも既定のルールセットは空で、インストーラーもルールを書き込みません。インストーラーが決めた方針は 22 番ポートを遮断しうるため、SSH でしか到達できないマシンはコンソールなしでは操作できなくなります。"
+"{count} authorised" = "{count} 件を許可"
+"manual, {count} partitions" = "手動、{count} 個のパーティション"
+"{flags} (stage3 default)" = "{flags}（stage3 の既定値）"

--- a/gentoo_install/data/locale/ko.toml
+++ b/gentoo_install/data/locale/ko.toml
@@ -456,3 +456,6 @@
 "one table for both families, and what a new rule set uses" = "두 주소 계열을 하나의 테이블로 다루며, 새 규칙 집합은 이쪽"
 "An SSH server answers the whole network. A firewall is worth installing with it; the Firewall row under Network does that and writes no rules, so the policy stays the operator's." = "SSH 서버는 네트워크 전체의 접속을 받습니다. 방화벽을 함께 설치하기를 권장합니다. 네트워크 영역의 방화벽 항목은 패키지만 설치하고 규칙은 작성하지 않으므로, 정책은 운영자가 정합니다."
 "Both ship an empty rule set, and the installer writes none: a policy it chose could drop port 22, and a machine reached only over SSH would then need a console to be reached at all." = "두 패키지 모두 기본 규칙 집합이 비어 있으며, 설치 프로그램도 규칙을 작성하지 않습니다. 설치 프로그램이 정한 정책은 22번 포트를 차단할 수 있어, SSH로만 접근하는 시스템은 콘솔 없이는 접근할 수 없게 됩니다."
+"{count} authorised" = "{count}개 승인됨"
+"manual, {count} partitions" = "수동, 파티션 {count}개"
+"{flags} (stage3 default)" = "{flags}(stage3 기본값)"

--- a/gentoo_install/data/locale/zh-CN.toml
+++ b/gentoo_install/data/locale/zh-CN.toml
@@ -457,3 +457,6 @@
 "one table for both families, and what a new rule set uses" = "两种地址族共用一张表，新规则采用这套"
 "An SSH server answers the whole network. A firewall is worth installing with it; the Firewall row under Network does that and writes no rules, so the policy stays the operator's." = "SSH 服务对整个网络开放。建议一并安装防火墙；网络区块的防火墙那一列只安装软件包、不写规则，策略仍由操作者决定。"
 "Both ship an empty rule set, and the installer writes none: a policy it chose could drop port 22, and a machine reached only over SSH would then need a console to be reached at all." = "两者默认的规则集都是空的，安装器也不会写入任何规则：安装器代为决定的策略可能挡掉 22 端口，只能通过 SSH 连上的机器届时需要控制台才能访问。"
+"{count} authorised" = "已授权 {count} 把"
+"manual, {count} partitions" = "手动，{count} 个分区"
+"{flags} (stage3 default)" = "{flags}（stage3 默认值）"

--- a/gentoo_install/data/locale/zh-TW.toml
+++ b/gentoo_install/data/locale/zh-TW.toml
@@ -457,3 +457,6 @@
 "one table for both families, and what a new rule set uses" = "兩種位址家族共用一張表，新規則採用這套"
 "An SSH server answers the whole network. A firewall is worth installing with it; the Firewall row under Network does that and writes no rules, so the policy stays the operator's." = "SSH 服務對整個網路開放。建議一併安裝防火牆；網路區塊的防火牆那一列只安裝套件、不寫規則，策略仍由操作者決定。"
 "Both ship an empty rule set, and the installer writes none: a policy it chose could drop port 22, and a machine reached only over SSH would then need a console to be reached at all." = "兩者預設的規則集都是空的，安裝器也不會寫入任何規則：安裝器代為決定的策略可能擋掉 22 埠，只能透過 SSH 連上的機器屆時需要主控台才能存取。"
+"{count} authorised" = "已授權 {count} 把"
+"manual, {count} partitions" = "手動，{count} 個分割區"
+"{flags} (stage3 default)" = "{flags}（stage3 預設值）"

--- a/gentoo_install/tui/settings.py
+++ b/gentoo_install/tui/settings.py
@@ -335,7 +335,12 @@ def _remote_unlock(config: InstallConfig, context: Context) -> str:
 
 def _keys(config: InstallConfig, context: Context) -> str:
     count = len(config.system.authorized_keys)
-    return f"{count} authorised" if count else context.translate("none")
+    if not count:
+        return context.translate("none")
+    # A template through the catalog, so the number stays a number and the
+    # word around it is translated. The whole string was English before, in
+    # the middle of a translated menu.
+    return context.translate("{count} authorised").format(count=count)
 
 
 def _mirror(config: InstallConfig, context: Context) -> str:
@@ -384,7 +389,9 @@ def _reuse_writes_no_table(config: InstallConfig, context: Context) -> str:
 
 def _layout(config: InstallConfig, context: Context) -> str:
     if context.manual:
-        return f"manual, {len(context.layout.slices)} partitions"
+        return context.translate("manual, {count} partitions").format(
+            count=len(context.layout.slices)
+        )
     return context.choice.layout.value
 
 
@@ -496,7 +503,9 @@ def _cflags(config: InstallConfig, context: Context) -> str:
     from ..model.config import PortageConfig
 
     flags = config.portage.common_flags
-    return f"{flags} (stage3 default)" if flags == PortageConfig().common_flags else flags
+    if flags != PortageConfig().common_flags:
+        return flags
+    return context.translate("{flags} (stage3 default)").format(flags=flags)
 
 
 def _extra(config: InstallConfig, context: Context) -> str:

--- a/tests/unit/test_i18n.py
+++ b/tests/unit/test_i18n.py
@@ -271,3 +271,32 @@ def test_the_blocked_row_reads_the_table_rather_than_the_exception() -> None:
 
     source = inspect.getsource(app._blocked)
     assert "describe(context.translate)" in source, source
+
+
+def test_no_setting_row_shows_an_untranslated_english_word() -> None:
+    """A row's value is drawn beside a translated label. `2 authorised`,
+    `manual, 3 partitions` and `-O2 -pipe (stage3 default)` were English in the
+    middle of a translated menu, because they were built with an f-string
+    instead of a catalog template.
+
+    Read from the source rather than by rendering: a row whose value depends on
+    a probed machine cannot be produced here, and the defect is the literal.
+    """
+    import ast
+    from pathlib import Path
+
+    settings = Path(__file__).resolve().parents[2] / "gentoo_install/tui/settings.py"
+    tree = ast.parse(settings.read_text())
+    #: Words that are prose rather than an identifier, a unit or an acronym.
+    prose = {"authorised", "partitions", "default", "none", "manual", "unset", "and"}
+    offenders: list[str] = []
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.JoinedStr):
+            continue
+        for piece in node.values:
+            if not isinstance(piece, ast.Constant) or not isinstance(piece.value, str):
+                continue
+            for word in piece.value.replace("(", " ").replace(",", " ").split():
+                if word.lower() in prose:
+                    offenders.append(f"line {node.lineno}: {piece.value!r}")
+    assert not offenders, offenders


### PR DESCRIPTION
`2 authorised`, `manual, 3 partitions` and `-O2 -pipe (stage3 default)` were
English in the middle of a translated menu, because they were built with an
f-string instead of a catalog template. The numbers and the flags stay
literal; the words around them are translated.

A test reads the source and rejects prose inside an f-string in `settings.py`.