### PR TITLE
cli: carry a recorded degradation across a resume

### DIFF
--- a/gentoo_install/cli.py
+++ b/gentoo_install/cli.py
@@ -21,7 +21,7 @@ from . import errors
 from .errors import GentooInstallError
 from .data import load_catalog
 from .exec import fetch, preflight
-from .exec.apply import Machine, apply, completed
+from .exec.apply import Machine, already_degraded, apply, completed
 from .exec.probe import Probe
 from .exec.runner import Runner, write_file
 from .log import Journal
@@ -243,6 +243,14 @@ def install(config: InstallConfig, operations: tuple[Operation, ...], arguments:
             config=config, runner=runner, probe=probe, work=work, mountpoint=arguments.target
         )
         finished = completed(journal) if arguments.resume else frozenset()
+        if arguments.resume:
+            # Replayed before anything runs. The operation that recorded an
+            # unusable binary host has already completed and is skipped, so
+            # without this the next `Emerge` asked that host for packages the
+            # earlier run had declared untrusted.
+            for what in sorted(already_degraded(journal)):
+                machine.given_up.add(what)
+                record(f"resuming: {what} was already unavailable")
         if finished:
             record(f"resuming: {len(finished)} operations were finished by an earlier run")
         # The closing stage unmounts, so the target has to still be mounted

--- a/gentoo_install/exec/apply.py
+++ b/gentoo_install/exec/apply.py
@@ -262,6 +262,24 @@ def identity(operation: Operation) -> str:
     return hashlib.sha256(together.encode()).hexdigest()[:16]
 
 
+def already_degraded(journal: Journal | None) -> set[str]:
+    """What a previous run gave up on, so a resume gives up on it too.
+
+    Without this a resumed run rebuilt an empty `given_up`: the operation that
+    recorded an unusable binary host had already completed and was skipped, so
+    the next `Emerge` asked the host for packages the earlier run had declared
+    untrusted, and the record of where each package came from changed across
+    the resume boundary.
+    """
+    if journal is None:
+        return set()
+    return {
+        str(entry["what"])
+        for entry in journal.replay()
+        if entry.get("event") == "degraded" and entry.get("what")
+    }
+
+
 def completed(journal: Journal | None) -> frozenset[tuple[int, str]]:
     """Operations a previous run finished, as position and description.
 

--- a/tests/unit/test_resume.py
+++ b/tests/unit/test_resume.py
@@ -248,3 +248,39 @@ def test_a_changed_payload_is_not_skipped_either() -> None:
 
     assert identity(Noted(text="emerge")) != identity(Noted(text="emerge plasma"))
     assert identity(Noted(text="emerge")) == identity(Noted(text="emerge"))
+
+
+def test_a_resume_gives_up_on_what_the_first_run_gave_up_on(tmp_path: Path) -> None:
+    """The operation that recorded an unusable binary host has already
+    completed and is skipped, so a resumed run rebuilt an empty `given_up` and
+    the next `Emerge` asked that host for packages the earlier run had
+    declared untrusted. The record of where each package came from then
+    changed across the resume boundary."""
+    from gentoo_install.exec.apply import already_degraded
+    from gentoo_install.log import Journal
+
+    journal = Journal(tmp_path / "install.jsonl")
+    journal.degraded("binary packages", "the host answered no signature")
+    journal.write("operation", position=0, description="merge", status="done")
+
+    assert already_degraded(journal) == {"binary packages"}
+    assert already_degraded(None) == set()
+
+
+def test_an_emerge_after_a_resume_still_builds_from_source(tmp_path: Path) -> None:
+    """The whole point of restoring it: `BINPKG_OPTIONS` on a host the first
+    run refused would fetch exactly what it refused."""
+    from gentoo_install.exec.apply import already_degraded
+    from gentoo_install.log import Journal
+    from gentoo_install.plan.portage import BINARY_PACKAGES, Emerge
+    from tests.unit.recorder import Recorder
+
+    journal = Journal(tmp_path / "install.jsonl")
+    journal.degraded(BINARY_PACKAGES, "the key was never signed")
+
+    recorder = Recorder()
+    for what in already_degraded(journal):
+        recorder.given_up.add(what)
+    Emerge(packages=("app-editors/nano",), summary="editor", binary_packages=True).apply(recorder)
+    merged = " ".join(" ".join(one) for one in recorder.in_target)
+    assert "--usepkg=n" in merged and "--getbinpkg=n" in merged, merged


### PR DESCRIPTION
The operation that recorded an unusable binary host has already completed and
is skipped, so a resumed run rebuilt an empty `given_up`: the next `Emerge`
asked that host for packages the earlier run had declared untrusted, and the
record of where each package came from changed across the resume boundary.