### PR TITLE
fetch: back off between reachability attempts, and stagger guests

### DIFF
--- a/gentoo_install/exec/fetch.py
+++ b/gentoo_install/exec/fetch.py
@@ -296,11 +296,14 @@ def egress_country() -> str:
     return ""
 
 
-#: How many times the site is asked before the machine is called offline, and
-#: how long to wait between. One attempt was enough to stop an install on a
-#: link that answered five runs in a row and timed out on the sixth; the check
-#: guards the whole run, so a single lost packet must not decide it.
-ONLINE_TRIES: Final[int] = 3
+#: How many times the address is asked before the machine is called offline,
+#: and the first pause between attempts, which doubles. The check guards the
+#: whole run, so a single lost packet must not decide it, and a fixed two
+#: seconds was not enough spread: twelve guests starting together each failed
+#: three attempts inside ninety seconds against a host that was answering.
+#: Five attempts back off 2, 4, 8 and 16 seconds, half a minute in all, which
+#: is nothing beside the install it is guarding.
+ONLINE_TRIES: Final[int] = 5
 ONLINE_PAUSE: Final[float] = 2.0
 
 
@@ -315,7 +318,7 @@ def reachable(url: str) -> bool:
             _read(url)
         except DownloadFailed:
             if attempt + 1 < ONLINE_TRIES:
-                time.sleep(ONLINE_PAUSE)
+                time.sleep(ONLINE_PAUSE * 2**attempt)
             continue
         return True
     return False

--- a/tests/unit/test_stage3_pointer.py
+++ b/tests/unit/test_stage3_pointer.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+import time
+
 import pytest
 
 from gentoo_install.errors import DownloadFailed
@@ -79,6 +81,17 @@ def test_the_variant_picks_the_pointer(monkeypatch: pytest.MonkeyPatch, variant:
     monkeypatch.setattr(fetch, "_read", record)
     fetch._newest("https://distfiles.gentoo.org/releases/amd64/autobuilds", variant)
     assert asked[0].endswith(f"latest-stage3-amd64-{variant}.txt")
+
+
+def test_the_pause_between_attempts_grows(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A fixed two seconds was not enough spread: twelve guests starting
+    together each failed every attempt inside ninety seconds against a host
+    that was answering."""
+    slept: list[float] = []
+    monkeypatch.setattr(fetch, "_read", lambda url: (_ for _ in ()).throw(DownloadFailed("no")))
+    monkeypatch.setattr(time, "sleep", slept.append)
+    assert fetch.reachable("https://example.invalid/x") is False
+    assert slept == [2.0, 4.0, 8.0, 16.0], slept
 
 
 def test_one_lost_request_does_not_declare_the_machine_offline(

--- a/tests/vm/cluster.py
+++ b/tests/vm/cluster.py
@@ -101,6 +101,11 @@ NODE_HEADROOM_BYTES: Final[int] = 2 * 1024**3
 WATCH_EVERY: Final[float] = 600.0
 WATCH_STRIKES: Final[int] = 3
 
+#: Between starting one guest and the next. They all reach for the same mirror
+#: in their first minute, and twelve starting together each failed the
+#: reachability check against a host that was answering.
+STAGGER: Final[float] = 8.0
+
 #: How long the schedule waits before looking at capacity again while jobs are
 #: still queued. A node's free memory lags what is actually running on it, so
 #: the first look after a guest is deleted can still read it as full: with only
@@ -501,6 +506,8 @@ def run(
                 running[job.name] = thread
                 thread.start()
                 print(f"→ {job.name} on {node.name} ({len(waiting)} waiting)", flush=True)
+                if waiting and slots:
+                    time.sleep(STAGGER)
             try:
                 # Collected one at a time, never as a set: a fixture that takes
                 # an hour must not hold back one that took six minutes. Waiting


### PR DESCRIPTION
Twelve cluster guests start within a second of each other and all reach for
the same mirror in their first minute. Each failed three attempts two seconds
apart against a host that was answering, and the whole install stopped.

Five attempts now back off 2, 4, 8 and 16 seconds, half a minute in all, and
the schedule leaves eight seconds between starting one guest and the next.