### PR TITLE
compat: let a reused array under the esp meet the firmware rule

### DIFF
--- a/gentoo_install/cli.py
+++ b/gentoo_install/cli.py
@@ -22,7 +22,7 @@ from .errors import GentooInstallError
 from .data import load_catalog
 from .exec import fetch, preflight
 from .exec.apply import Machine, already_degraded, apply, completed
-from .exec.probe import Probe
+from .exec.probe import Probe, with_probed_facts
 from .exec.runner import Runner, write_file
 from .log import Journal
 from .model.size import Size
@@ -151,6 +151,14 @@ def main(argv: Sequence[str] | None = None) -> int:
             return EXIT_OK
         if _needs_network(arguments):
             _require_mirror(config, arguments.mirror)
+        if not arguments.dry_run:
+            # Before the plan is derived, because `build` validates: a reused
+            # esp on an array carries its metadata version only after the
+            # machine has been asked for it. Not on a dry run, which is meant
+            # to answer on a machine that has none of the hardware.
+            config = with_probed_facts(
+                config, Probe(runner=Runner(log=lambda line: None), work=arguments.work)
+            )
         operations = build(config, load_catalog(), mirror=arguments.mirror)
         if arguments.dry_run:
             print(render(operations), end="")

--- a/gentoo_install/exec/probe.py
+++ b/gentoo_install/exec/probe.py
@@ -13,12 +13,13 @@ import platform
 import re
 import shutil
 import time
-from dataclasses import dataclass, field
+from dataclasses import dataclass, field, replace
 from pathlib import Path
 from typing import ClassVar, Final, Iterable, Mapping
 
-from ..errors import DeviceNotFound
-from ..model.device import DeviceId
+from ..errors import CommandFailed, DeviceNotFound
+from ..model.config import InstallConfig
+from ..model.device import DeviceGraph, DeviceId, Existing
 from .runner import Runner
 
 EFI_MARKER: Final[Path] = Path("/sys/firmware/efi")
@@ -292,6 +293,28 @@ class Probe:
 
     #: Where udev keeps the names that survive the kernel renumbering disks.
     BY_ID: ClassVar[Path] = Path("/dev/disk/by-id")
+
+    def mdraid_metadata(self, selector: str) -> str:
+        """The metadata version an array already on the machine carries.
+
+        Empty when the device is not an array. The model cannot read a
+        superblock, so a reused RAID1 esp met no compatibility rule at all
+        until this was injected before validation, although firmware cannot
+        read a member whose superblock sits at the start.
+        """
+        try:
+            said = self.runner.run(["mdadm", "--detail", "--export", selector], check=False)
+        except (CommandFailed, OSError):
+            # A medium without mdadm says nothing about a superblock, and that
+            # is not a reason to stop: the array rule simply does not fire.
+            return ""
+        if said.returncode != 0:
+            return ""
+        for line in said.stdout.splitlines():
+            name, _, value = line.partition("=")
+            if name.strip() == "MD_METADATA" and value.strip():
+                return value.strip()
+        return ""
 
     def passphrase(self, source: str) -> tuple[str, str]:
         """What a passphrase file holds, and why it could not be read.
@@ -682,3 +705,27 @@ class Probe:
             if line.startswith("MemTotal:"):
                 return int(line.split()[1]) * 1024
         return 0
+
+
+def with_probed_facts(config: InstallConfig, probe: Probe) -> InstallConfig:
+    """Fill in what only the machine can say, before anything validates it.
+
+    The model stays parseable without the hardware, so a reused device carries
+    a selector and nothing else. Its mdraid metadata is read here: a reused
+    RAID1 esp with a superblock at the start met no compatibility rule at all
+    without it, and firmware cannot read such a member.
+    """
+    graph = config.disk.graph
+    reused = [one for one in graph.of_type(Existing) if not one.mdraid_metadata]
+    if not reused:
+        return config
+    known = {one.id: probe.mdraid_metadata(one.selector) for one in reused}
+    if not any(known.values()):
+        return config
+    nodes = [
+        replace(one, mdraid_metadata=known[one.id])
+        if isinstance(one, Existing) and known.get(one.id)
+        else one
+        for one in graph.nodes.values()
+    ]
+    return replace(config, disk=replace(config.disk, graph=DeviceGraph.build(nodes)))

--- a/gentoo_install/model/compat.py
+++ b/gentoo_install/model/compat.py
@@ -23,6 +23,7 @@ from .config import (
 )
 from .device import (
     Existing,
+    RaidMetadata,
     T,
     DeviceGraph,
     DeviceId,
@@ -256,6 +257,19 @@ def traits_of(config: InstallConfig) -> frozenset[Trait]:
             continue
         found.add(Trait.ESP_ON_MDRAID)
         if array.metadata.superblock_at_start:
+            found.add(Trait.ESP_MDRAID_SUPERBLOCK_AT_START)
+    # A reused array is `Existing` and carries no `MdRaid` node, so the loop
+    # above never sees it, and `_on_esp` cannot answer for it either: that
+    # reads what a device is built from, and a reused array is built from
+    # nothing this model knows. The evidence is above it instead — the esp
+    # mount is what stands on it. The probe writes the metadata version.
+    mounted = esp_mount(graph)
+    beneath = {node.id for node in _chain(graph, mounted.id)} if mounted else set()
+    for reused in graph.of_type(Existing):
+        if not reused.mdraid_metadata or reused.id not in beneath:
+            continue
+        found.add(Trait.ESP_ON_MDRAID)
+        if RaidMetadata(reused.mdraid_metadata).superblock_at_start:
             found.add(Trait.ESP_MDRAID_SUPERBLOCK_AT_START)
 
     for table in _nodes_under(graph, config.disk.root, PartitionTable):

--- a/gentoo_install/model/device.py
+++ b/gentoo_install/model/device.py
@@ -110,6 +110,12 @@ class Existing(Node):
 
     selector: str
     wipe: bool = False
+    #: The mdraid metadata version this device already carries, when it is an
+    #: array being reused. Empty for anything else, and filled in by the probe
+    #: before validation: the model cannot read a superblock, and without it a
+    #: reused RAID1 esp with metadata 1.1 or 1.2 met no rule at all, although
+    #: firmware cannot read a member whose superblock is at the start.
+    mdraid_metadata: str = ""
 
 
 @dataclass(frozen=True)

--- a/tests/unit/test_compat.py
+++ b/tests/unit/test_compat.py
@@ -23,6 +23,7 @@ from gentoo_install.model.config import (
     SystemConfig,
 )
 from gentoo_install.model.device import (
+    Existing,
     Filesystem,
     FilesystemType,
     Luks,
@@ -448,3 +449,36 @@ def test_a_separate_vfat_boot_is_still_readable() -> None:
     assert Trait.KERNEL_OFF_ESP not in compat.traits_of(
         boots(config(nodes), Bootloader.SYSTEMD_BOOT, Firmware.UEFI)
     )
+
+
+def reused_esp(metadata: str) -> list[Node]:
+    """An esp on an array already assembled on the machine.
+
+    `Existing` and nothing else: the model cannot read a superblock, so the
+    version is injected by the probe before validation.
+    """
+    nodes: list[Node] = [
+        node
+        for node in ext4_on_gpt()
+        if node.id not in {i("espfs"), i("mnt-esp"), i("esp")}
+    ]
+    nodes += [
+        Existing(id=i("esp"), selector="/dev/md0", mdraid_metadata=metadata),
+        Filesystem(id=i("espfs"), device=i("esp"), kind=FilesystemType.VFAT),
+        Mountpoint(id=i("mnt-esp"), source=i("espfs"), path=PurePosixPath("/efi")),
+    ]
+    return nodes
+
+
+def test_a_reused_array_under_the_esp_meets_the_firmware_rule() -> None:
+    """An esp the plan creates carries an `MdRaid` node; a reused one is
+    `Existing` and carries nothing, so a RAID1 esp with metadata 1.1 or 1.2
+    met no rule at all although firmware cannot read a member whose superblock
+    sits at the start."""
+    at_start = traits_of(config(reused_esp("1.2")))
+    at_end = traits_of(config(reused_esp("1.0")))
+
+    assert Trait.ESP_ON_MDRAID in at_start
+    assert Trait.ESP_MDRAID_SUPERBLOCK_AT_START in at_start
+    assert Trait.ESP_ON_MDRAID in at_end
+    assert Trait.ESP_MDRAID_SUPERBLOCK_AT_START not in at_end


### PR DESCRIPTION
An esp the plan creates carries an `MdRaid` node with its metadata version. A
reused one is `Existing` and carries nothing, so a RAID1 esp with metadata 1.1
or 1.2 met no compatibility rule at all, although firmware cannot read a member
whose superblock sits at the start.

The probe reads `MD_METADATA` and fills it in before validation, and the trait
is derived from what stands on the array rather than from what it is built on:
a reused array is built from nothing this model knows.

This is the last open item in `reviewed.md`.