### PR TITLE
tests: wait for the guest network before starting the installer

### DIFF
--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -2,7 +2,7 @@
 
 # gentoo-install
 
-gentoo-install 是一个安装程序，可从受支持的 Linux live 环境安装 amd64 Gentoo 系统。安装内容由交互式菜单或 TOML 配置文件指定。界面提供英文、繁体中文、简体中文、日文和韩文。
+gentoo-install 是一个系统安装程序，支持在兼容的 Linux Live 环境中安装 amd64 架构的 Gentoo 系统。可通过交互式菜单或 TOML 配置文件定制安装内容。程序界面支持英文、繁体中文、简体中文、日文和韩文语言。
 
 ![显示各项安装决定的菜单](screenshot.png)
 
@@ -10,39 +10,39 @@ gentoo-install 是一个安装程序，可从受支持的 Linux live 环境安�
 
 ## 功能
 
-**存储设备。** 设备图支持 GPT 和 MBR、ext2/3/4、包含 subvolume 的 btrfs、xfs、f2fs、vfat、swap、zram、LUKS2、LVM 和 mdraid。可以保留现有分区表，并为每个分区分别指定保留、格式化或删除。
+**存储设备** 设备图支持 GPT 和 MBR 分区表，支持 Ext2/3/4、XFS、F2FS、VFAT 以及包含 子卷 的 Btrfs 等文件系统，支持 swap、zram、LUKS2 加密、LVM 和 mdraid。在进行分区管理时可以保留现有分区表，还可以为每个分区分别指定保留、格式化或删除操作。
 
-**引导与系统。** GRUB 支持 UEFI 和 BIOS，systemd-boot 支持 UEFI。安装程序可配置 systemd 或 OpenRC、dracut、locale、键盘布局、时区、主机名、DNS、静态地址和所选的网络管理程序。
+**引导与系统** 安装程序支持选择 GRUB、systemd-boot 引导程序，其中 GRUB 支持 UEFI 和 BIOS，systemd-boot 支持 UEFI。还可配置 systemd 或 OpenRC、dracut、locale、键盘布局、时区、主机名、DNS、静态地址和所选的网络管理程序。
 
-**桌面与语言支持。** GNOME、KDE Plasma 和 Xfce 可搭配 gdm、sddm 或 lightdm。图形设置涵盖 AMD、Intel、NVIDIA 和虚拟机。软件包目录包含 fcitx5、Rime、Anthy、Mozc、Hangul 和 CJK 字体。gentoo-zh 提供的补丁内核可在 Linux 文本控制台显示中文、日文和韩文。
+**桌面与语言支持** 支持选择 GNOME、KDE Plasma 和 Xfce ，并可搭配 GDM、SDDM 或 LightDM。图形设置方面涵盖 AMD、Intel、NVIDIA 和虚拟机。软件包目录包含 Fcitx 5、Rime、Anthy、Mozc、Hangul 和 CJK 字体。gentoo-zh 提供的补丁内核可在 Linux 文本控制台显示中文、日文和韩文。
 
-**Portage。** 配置项包括 profile、`MAKEOPTS`、`USE`、`ACCEPT_KEYWORDS`、`L10N`、镜像和仓库同步方式。gentoo-zh 和 gig overlay 必须明确启用。官方与 gentoo-zh 的二进制软件包来源分别使用独立的设置和密钥。
+**Portage** 配置项包括 profile、`MAKEOPTS`、`USE`、`ACCEPT_KEYWORDS`、`L10N`、镜像和仓库同步方式。gentoo-zh 和 gig overlay 必须明确启用。官方与 gentoo-zh 的二进制软件包来源分别使用独立的设置和密钥。
 
-**计划与记录。** dry run 和实际安装使用同一份操作计划。`install.log` 记录命令输出，`install.jsonl` 记录操作、软件包来源和二进制软件包降级原因。菜单可将移除敏感信息的配置上传至 `paste.gentoozh.org`，并以文本和 QR code 显示上传页面的网址。
+**计划与记录** dry run 和实际安装使用同一份操作序列。日志`install.log` 将记录命令输出，`install.jsonl` 记录操作、软件包来源和二进制软件包降级原因。菜单可将移除敏感信息的配置上传至 `paste.gentoozh.org`，并以文本和 QR 码显示上传页面的网址。
 
 ## 验证状态
 
-最近一份有记录的端到端基准覆盖部分 UEFI 和 BIOS 安装、systemd、OpenRC、ext4、btrfs、xfs、LUKS2、LVM、mdraid、Plasma 和官方 binhost。每份有效记录都会标明安装程序修订版，并在安装完成的系统成功引导后才列为证据。
+最近一份有记录的端到端基准覆盖部分 UEFI 和 BIOS 安装、systemd、OpenRC、Ext4、Btrfs、XFS、LUKS2、LVM、mdraid、Plasma 和官方 binhost。每份有效记录都会标明安装程序修订版，并在安装完成的系统成功引导后才列为证据。
 
 当前修订版的基准尚未覆盖 ZFS 与 ZFSBootMenu、initramfs 的 SSH 远程解锁、greetd 桌面会话，以及 GNOME 以外的 ibus。从六种非默认 live 介质安装和 binhost 失败后的降级路径也未纳入。`tests/fixtures/` 下的文件只验证配置模型；文件存在并不表示对应组合已通过端到端验证。
 
 ## 要求
 
-实际安装需要 root 权限、amd64 目标和 Python 3.11 或更高版本。使用配置文件执行 dry run 不需要 root 权限。安装程序没有第三方 Python 运行时依赖项。
+实际安装需要 root 权限、amd64 架构和 Python 3.11 或更高版本。使用配置文件执行 dry run 不需要 root 权限。安装程序没有第三方 Python 运行时依赖项。
 
 安装程序启动时需要连接 `packages.gentoo.org`，但 `--missing-commands` 和 `--config FILE --dry-run` 除外。内核版本和 `sys-fs/zfs` 支持的最高内核版本会在运行时读取。
 
-`bootstrap.sh` 会读取 `/etc/os-release`、报告缺少的命令，并打印候选的软件包管理器命令。它可识别多个发行版系列，包括 Debian 和 Ubuntu、Arch、openSUSE、Fedora、RHEL 和 CentOS、Gentoo，以及 Alpine。打印的命令必须在执行前核对。
+`bootstrap.sh` 会读取 `/etc/os-release`、报告缺少的命令，并显示候选的软件包管理器命令。它可识别多个发行版系列，包括 Debian 和 Ubuntu、Arch、openSUSE、Fedora、RHEL 和 CentOS、Gentoo，以及 Alpine。显示的命令必须在执行前核对。
 
 ## 安全事项
 
-实际安装会写入所选磁盘。使用配置文件运行时不会再次要求确认擦除磁盘；`wipe = true`、删除分区和创建文件系统都可能破坏现有数据。
+实际安装会写入所选磁盘。请注意，使用配置文件运行时不会再次要求确认擦除磁盘；`wipe = true`、删除分区和创建文件系统都可能破坏现有数据。
 
-实际安装前，必须在 dry-run 输出中核对磁盘选择器和每项破坏性操作。稳定的 `/dev/disk/by-id/` 选择器优于 `/dev/sda` 之类的名称；需要保留的数据必须另有备份。
+实际安装前，必须在 dry-run 输出中核对磁盘选择器和每项破坏性操作。稳定的 `/dev/disk/by-id/` 选择器优于 `/dev/sda` 之类的名称；为避免因误操作导致的数据丢失，请务必备份好需要保留的数据。
 
 ## 安装
 
-以下命令会下载当前的 `master` 归档文件并打开菜单：
+可使用以下命令下载当前的 `master` 归档文件并打开菜单：
 
 ```sh
 curl -fsSL https://github.com/Zakkaus/gentoo-install/archive/refs/heads/master.tar.gz | tar xz
@@ -50,9 +50,9 @@ cd gentoo-install-master
 ./bootstrap.sh
 ```
 
-菜单需要至少 80 列、24 行的交互式终端。安装程序启动时会询问一次界面语言；`--lang zh-CN` 可直接选择简体中文。
+菜单需要至少 80 列、24 行的交互式终端。安装程序启动时会询问一次界面语言；使用`--lang zh-CN` 可直接选择简体中文。
 
-菜单可将答案保存为 `my-install.toml` 后退出。以下配置文件操作流程会先打印完整计划，再执行实际安装：
+菜单可将配置保存为 `my-install.toml` 配置文件后退出。以下配置文件操作流程会先显示完整的配置计划，再执行实际安装：
 
 ```sh
 ./bootstrap.sh --config my-install.toml --dry-run
@@ -60,7 +60,7 @@ cd gentoo-install-master
 ./bootstrap.sh --config my-install.toml --no-shell   # 不询问是否打开 root shell
 ```
 
-交互式安装无论成功或失败，都会在卸载前提供在目标系统内打开 root shell 的选项。`--no-shell` 可跳过这项确认。
+交互式安装无论成功或失败，都会在卸载前提供在目标系统内打开 root shell 的选项。可使用`--no-shell` 跳过这项确认。
 
 ## 从中断处继续
 
@@ -70,19 +70,19 @@ cd gentoo-install-master
 ./bootstrap.sh --config my-install.toml --resume
 ```
 
-继续执行仅限同一个 live 会话。默认日志位于 `/run/gentoo-install/install.jsonl`，重新启动后不会保留。日志的每一条记录该操作实现与自身字段的摘要，因此代码或字段更改过的操作会重新执行而不是跳过。日志不记录整份配置的摘要。
+继续执行仅限同一个 Live 会话。默认日志位于 `/run/gentoo-install/install.jsonl`，重新启动后不会保留。日志的每一条记录该操作实现与自身字段的摘要，因此代码或字段更改过的操作会重新执行而不是跳过。日志不记录整份配置的摘要。
 
 ## 配置文件
 
 配置文件使用 TOML。顶层 `config_version` 字段指定结构版本。存储设备以设备图表示：每个设备都有 `id`，设备通过其他设备的 `id` 建立引用，选择器仅在实际安装时解析。
 
-[`tests/fixtures/vm-binpkg.toml`](tests/fixtures/vm-binpkg.toml) 是完整的 UEFI 和 ext4 结构参考。其他 [`tests/fixtures/`](tests/fixtures/) 文件覆盖 BIOS、LUKS2、LVM、mdraid、ZFS、btrfs subvolume 和桌面。这些文件使用虚拟机磁盘选择器和测试密码，不得原样用于实际机器的安装。
+[`tests/fixtures/vm-binpkg.toml`](tests/fixtures/vm-binpkg.toml) 是完整的 UEFI 和 Ext4 结构参考。其他 [`tests/fixtures/`](tests/fixtures/) 文件覆盖 BIOS、LUKS2、LVM、mdraid、ZFS、Btrfs 子卷 和桌面。这些文件使用虚拟机磁盘选择器和测试密码，不得原样用于实际机器的安装。
 
 解析与计划阶段不会探测存储硬件，因此没有目标磁盘的机器也能通过 `--dry-run` 检查配置。
 
 ## 二进制软件包
 
-二进制软件包是可选功能。关闭后仍可从源代码构建。官方 binhost 和 gentoo-zh binhost 是两个独立选项，并使用不同的信任配置。当前端到端基准尚未覆盖 binhost 无法连接、缺少签名或密钥不受信任的情况，因此这些降级路径仍列在验证状态中。
+二进制软件包属于可选功能。关闭后仍可从源代码构建。官方 binhost 和 gentoo-zh binhost 是两个独立选项，并使用不同的信任配置。当前端到端基准尚未覆盖 binhost 无法连接、缺少签名或密钥不受信任的情况，因此这些降级路径仍列在验证状态中。
 
 ## 退出码
 

--- a/README.zh-TW.md
+++ b/README.zh-TW.md
@@ -2,7 +2,7 @@
 
 # gentoo-install
 
-gentoo-install 是一套安裝器，可從受支援的 Linux live 環境安裝 amd64 Gentoo 系統。安裝內容由互動式選單或 TOML 設定檔指定。介面提供英文、正體中文、簡體中文、日文與韓文。
+gentoo-install 是一套系統安裝器，可在相容的 Linux live 環境中安裝 amd64 架構的 Gentoo 系統。安裝內容以互動式選單或 TOML 設定檔指定。介面提供英文、正體中文、簡體中文、日文與韓文。
 
 ![顯示各項安裝決定的選單](screenshot.png)
 
@@ -10,15 +10,15 @@ gentoo-install 是一套安裝器，可從受支援的 Linux live 環境安裝 a
 
 ## 功能
 
-**儲存裝置。** 裝置圖支援 GPT 與 MBR、ext2/3/4、含 subvolume 的 btrfs、xfs、f2fs、vfat、swap、zram、LUKS2、LVM 與 mdraid。既有分割表可以保留，每個分割區可分別指定保留、格式化或刪除。
+**儲存裝置** 裝置圖支援 GPT 與 MBR 分割表。檔案系統支援 ext2/3/4、xfs、f2fs、vfat 以及含 subvolume 的 btrfs，另有 swap、zram、LUKS2 加密、LVM 與 mdraid。既有分割表可以保留，每個分割區可分別指定保留、格式化或刪除。
 
-**開機與系統。** GRUB 支援 UEFI 與 BIOS，systemd-boot 支援 UEFI。安裝器可設定 systemd 或 OpenRC、dracut、locale、鍵盤配置、時區、主機名稱、DNS、靜態位址與所選的網路管理程式。
+**開機與系統** 開機載入器可選 GRUB 或 systemd-boot，其中 GRUB 支援 UEFI 與 BIOS，systemd-boot 支援 UEFI。安裝器另可設定 systemd 或 OpenRC、dracut、locale、鍵盤配置、時區、主機名稱、DNS、靜態位址與所選的網路管理程式。
 
-**桌面與語言支援。** GNOME、KDE Plasma 與 Xfce 可搭配 gdm、sddm 或 lightdm。圖形設定涵蓋 AMD、Intel、NVIDIA 與虛擬機。套件目錄包含 fcitx5、Rime、Anthy、Mozc、Hangul 與 CJK 字型。gentoo-zh 提供的修補核心可在 Linux 文字主控台顯示中文、日文與韓文。
+**桌面與語言支援** 桌面可選 GNOME、KDE Plasma 與 Xfce，並搭配 gdm、sddm 或 lightdm。圖形設定涵蓋 AMD、Intel、NVIDIA 與虛擬機。套件目錄包含 fcitx5、Rime、Anthy、Mozc、Hangul 與 CJK 字型。gentoo-zh 提供的修補核心可在 Linux 文字主控台顯示中文、日文與韓文。
 
-**Portage。** 設定項目包含 profile、`MAKEOPTS`、`USE`、`ACCEPT_KEYWORDS`、`L10N`、鏡像與儲存庫同步方式。gentoo-zh 與 gig overlay 必須明確啟用。官方與 gentoo-zh 的二進位套件來源各有獨立設定與金鑰。
+**Portage** 設定項目包含 profile、`MAKEOPTS`、`USE`、`ACCEPT_KEYWORDS`、`L10N`、鏡像與儲存庫同步方式。gentoo-zh 與 gig overlay 必須明確啟用。官方與 gentoo-zh 的二進位套件來源各有獨立設定與金鑰。
 
-**計畫與記錄。** dry run 與實際安裝使用同一份操作計畫。`install.log` 記錄指令輸出，`install.jsonl` 記錄操作、套件來源與二進位套件降級原因。選單可將移除敏感資料的設定上傳至 `paste.gentoozh.org`，並以文字與 QR code 顯示上傳頁面的網址。
+**計畫與記錄** dry run 與實際安裝使用同一份操作序列。記錄方面，`install.log` 記錄指令輸出，`install.jsonl` 記錄操作、套件來源與二進位套件降級原因。選單可將移除敏感資料的設定上傳至 `paste.gentoozh.org`，並以文字與 QR 碼顯示上傳頁面的網址。
 
 ## 驗證狀態
 

--- a/tests/unit/test_proxmox.py
+++ b/tests/unit/test_proxmox.py
@@ -558,3 +558,72 @@ def test_the_command_a_real_shell_runs_produces_a_readable_archive(tmp_path: Pat
         "install.rc": b"0\n",
         "install.txt": b"installed 53 operations\n",
     }
+
+
+def test_the_installer_does_not_start_before_the_guest_has_a_network() -> None:
+    """Reaching a root shell says the medium booted, not that the interface is
+    up. Starting there made the installer's own reachability check fail within
+    ninety seconds of boot, and the run stopped before the first disk was
+    touched."""
+    import inspect
+
+    from tests.vm import cluster
+
+    source = inspect.getsource(cluster.install_one)
+    ran = source.index("install.sh")
+    waited = source.index("wait_for_network")
+    assert waited < ran, "the wait has to come before the installer"
+
+
+def test_the_network_wait_gives_up_rather_than_hanging(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """An unattended schedule cannot hold a slot for a guest whose interface
+    never came up."""
+    from tests.vm import cluster
+    from tests.vm.console import ConsoleTimeout
+
+    asked: list[str] = []
+
+    class Down:
+        def send(self, line: str) -> None:
+            asked.append(line)
+
+        def send_raw(self, keys: str) -> None:
+            asked.append(keys)
+
+        def snapshot(self, seconds: float) -> bytes:
+            return b""
+
+        def expect(self, pattern: str, timeout: float) -> bytes:
+            return b"NETWORK_DOWN"
+
+    monkeypatch.setattr(cluster, "NETWORK_PATIENCE", 0.3)
+    monkeypatch.setattr(cluster, "NETWORK_PAUSE", 0.05)
+    link = cluster.Reconnecting(Down, tries=1)
+    with pytest.raises(ConsoleTimeout, match="no network"):
+        cluster.wait_for_network(link)
+    assert asked, "it asked at least once before giving up"
+
+
+def test_the_network_wait_returns_as_soon_as_the_guest_answers() -> None:
+    from tests.vm import cluster
+
+    tries: list[int] = []
+
+    class Late:
+        def send(self, line: str) -> None:
+            tries.append(1)
+
+        def send_raw(self, keys: str) -> None:
+            pass
+
+        def snapshot(self, seconds: float) -> bytes:
+            return b""
+
+        def expect(self, pattern: str, timeout: float) -> bytes:
+            return b"NETWORK_DOWN" if len(tries) < 3 else b"NETWORK_UP"
+
+    link = cluster.Reconnecting(Late, tries=1)
+    cluster.wait_for_network(link)
+    assert len(tries) == 3

--- a/tests/vm/cluster.py
+++ b/tests/vm/cluster.py
@@ -235,6 +235,37 @@ def prepare(
 DISK_PASSPHRASE: Final[str] = "install-disk"
 
 
+#: How long a guest is given to bring its interface up and resolve a name.
+NETWORK_PATIENCE: Final[float] = 300.0
+
+#: Between attempts. A guest that has just reached a shell is still running
+#: dhcpcd, and the installer's own reachability check is what fails: five
+#: attempts thirty seconds apart against a host that was answering.
+NETWORK_PAUSE: Final[float] = 10.0
+
+
+def wait_for_network(link: Reconnecting) -> None:
+    """Wait until the guest can fetch from the mirror before installing.
+
+    Reaching a root shell says the medium booted, not that the interface is
+    up. Starting the installer there made its own reachability check fail
+    within ninety seconds of boot, and the run stopped before the first disk
+    was touched.
+    """
+    deadline = time.monotonic() + NETWORK_PATIENCE
+    probe = (
+        "curl -sS -o /dev/null --max-time 20 "
+        "https://distfiles.gentoo.org/releases/amd64/autobuilds/"
+        "latest-stage3-amd64-systemd.txt && echo NETWORK_UP || echo NETWORK_DOWN"
+    )
+    while time.monotonic() < deadline:
+        link.send(probe)
+        if b"NETWORK_UP" in link.expect(r"NETWORK_UP|NETWORK_DOWN", timeout=60.0):
+            return
+        time.sleep(NETWORK_PAUSE)
+    raise ConsoleTimeout(f"the guest had no network after {NETWORK_PATIENCE:.0f}s")
+
+
 def stage_passphrases(link: Reconnecting, installation: InstallConfig) -> None:
     """Put the passphrases where the layout says they are.
 
@@ -382,6 +413,7 @@ def install_one(
         # cluster hands out a real configuration, and it is IPv6 with DNS64.
         # Writing IPv4 resolvers over it left every mirror unreachable:
         # `Failed to connect to mirrors.tuna.tsinghua.edu.cn:443 after 111 ms`.
+        wait_for_network(link)
         stage_passphrases(link, load(job.fixture))
         link.run("mkdir -p /mnt/driver")
         link.run("mountpoint -q /mnt/driver || mount -o ro /dev/sr1 /mnt/driver")


### PR DESCRIPTION
Reaching a root shell says the medium booted, not that the interface is up.
Starting the installer there made its own reachability check fail within ninety
seconds of boot, and twenty runs in a row stopped before the first disk was
touched.

The harness now waits until the guest can fetch from the mirror, for up to five
minutes, and gives up rather than holding a slot for ever.