### PR TITLE
tests: boot the disk that was written and read the system back

### DIFF
--- a/tests/unit/test_proxmox.py
+++ b/tests/unit/test_proxmox.py
@@ -627,3 +627,32 @@ def test_the_network_wait_returns_as_soon_as_the_guest_answers() -> None:
     link = cluster.Reconnecting(Late, tries=1)
     cluster.wait_for_network(link)
     assert len(tries) == 3
+
+
+def test_a_run_is_not_green_until_the_installed_system_answers() -> None:
+    """The install finishing is half the question. A machine can reach a login
+    prompt with the wrong filesystem mounted, no fstab and the wrong locale,
+    and every check before this one would still be green."""
+    import inspect
+
+    from tests.vm import cluster
+
+    source = inspect.getsource(cluster.install_one)
+    assert "boot_and_check" in source
+    ok = source.index("Verdict.OK")
+    checked = source.index("boot_and_check")
+    assert checked < ok, "the verdict cannot be OK before the system was read"
+
+
+def test_every_question_asked_inside_names_what_would_fail_it() -> None:
+    """A check with nothing to compare against passes on any machine, which is
+    the shape a coverage claim hides behind."""
+    from tests.vm.cluster import INSIDE
+
+    named = {name for name, _, _ in INSIDE}
+    assert {"os-release", "mounts", "fstab", "locale"} <= named
+    for name, command, wanted in INSIDE:
+        assert command.strip(), name
+        if name in ("hostname", "kernel"):
+            continue  # collected for the report; their value is the fixture's
+        assert wanted, f"{name} compares against nothing"

--- a/tests/vm/cluster.py
+++ b/tests/vm/cluster.py
@@ -34,7 +34,7 @@ from gentoo_install.model.device import Existing, Luks, ZfsPool
 from gentoo_install.model.config import MirrorRegion, Sync
 from gentoo_install.exec.config import load
 from gentoo_install.model.serialise import to_toml
-from .console import ConsoleClosed, ConsoleTimeout, SerialConsole
+from .console import PASSWORD_PROMPT, ConsoleClosed, ConsoleTimeout, SerialConsole
 from .driver import build as build_driver
 from .proxmox import (
     Api,
@@ -116,6 +116,10 @@ POLL_WHILE_QUEUED: Final[float] = 20.0
 #: Nothing this harness runs takes three hours, and a run that does is holding
 #: a node's memory rather than testing anything.
 RUN_CEILING: Final[float] = 3 * 3600.0
+
+#: How long the installed system has to reach a login prompt. A first boot
+#: builds the initramfs cache and, on openrc, runs every service in order.
+BOOT_PATIENCE: Final[float] = 600.0
 
 
 class Verdict(Enum):
@@ -433,6 +437,12 @@ def install_one(
         if code != b"0":
             return Outcome(job.name, Verdict.FAIL, time.monotonic() - started,
                            f"the installer exited {code!r}", log)
+        # The install finishing is half the question. The other half is whether
+        # the machine it produced comes up and carries what was asked for, and
+        # nothing in the log above can answer that.
+        wrong = boot_and_check(guest, link, log, load(job.fixture))
+        if wrong:
+            return Outcome(job.name, Verdict.FAIL, time.monotonic() - started, wrong, log)
         return Outcome(job.name, Verdict.OK, time.monotonic() - started, log=log)
     except (ConsoleTimeout, ConsoleClosed) as error:
         verdict = Verdict.STUCK if watch.stuck else Verdict.FAIL
@@ -651,6 +661,26 @@ class Reconnecting:
                     raise
                 self.reopen()
 
+    def expect_output(self, command: str, timeout: float = 120.0) -> bytes:
+        """Run a command and answer with what it printed.
+
+        `run` only waits for the marker; a check on the installed system has
+        to read the reply. The marker is still what says the command finished,
+        so a command that prints nothing is not mistaken for one that hung.
+        """
+        token = next(self._marks)
+        self.console.send(f"{command}; echo MARK_{token}_DONE")
+        for attempt in range(self._tries):
+            try:
+                said = self.console.expect(rf"MARK_{token}_DONE", timeout)
+                return said
+            except ConsoleClosed:
+                if attempt + 1 == self._tries:
+                    raise
+                self.reopen()
+                self.console.send(f"{command}; echo MARK_{token}_DONE")
+        raise ConsoleClosed("the console could not be reopened")
+
     def send(self, line: str) -> None:
         self.console.send(line)
 
@@ -659,6 +689,55 @@ class Reconnecting:
 
     def snapshot(self, seconds: float) -> bytes:
         return self.console.snapshot(seconds)
+
+
+#: The password `tests/fixtures/*.toml` set on the installed system. It exists
+#: so the harness can log into what it built; nothing else uses it.
+INSTALLED_PASSWORD: Final[str] = "install"
+
+#: What the installed system is asked about, and what the answer has to hold.
+#: One table, so a check cannot be added without saying what would fail it.
+INSIDE: Final[tuple[tuple[str, str, str], ...]] = (
+    ("os-release", "cat /etc/os-release", "Gentoo"),
+    ("mounts", "findmnt --noheadings --list --output TARGET,SOURCE,FSTYPE", "/"),
+    ("fstab", "cat /etc/fstab", "UUID="),
+    ("hostname", "cat /etc/hostname 2>/dev/null || cat /etc/conf.d/hostname", ""),
+    ("locale", "locale", "LANG="),
+    ("kernel", "uname -r", ""),
+)
+
+
+def boot_and_check(
+    guest: Guest, link: Reconnecting, log: Path, installation: InstallConfig
+) -> str:
+    """Boot the disk that was just written and read the system back.
+
+    Answers an empty string when everything asked for is there, and what is
+    wrong otherwise. Booting is not the test: a machine can reach a login
+    prompt with the wrong filesystem mounted, no fstab and the wrong locale,
+    and every check above this one would still be green.
+    """
+    guest.stop()
+    guest.boot_from_disk()
+    guest.start()
+    link.reopen()
+    try:
+        link.expect(r"login:", timeout=BOOT_PATIENCE)
+    except (ConsoleTimeout, ConsoleClosed) as error:
+        return f"the installed system did not reach a login prompt: {error}"[:200]
+    link.send("root")
+    link.expect(PASSWORD_PROMPT, timeout=120.0)
+    link.send(INSTALLED_PASSWORD)
+    try:
+        link.expect(r"#|\$", timeout=120.0)
+    except (ConsoleTimeout, ConsoleClosed) as error:
+        return f"root could not log into the installed system: {error}"[:200]
+
+    for name, command, wanted in INSIDE:
+        said = link.expect_output(command, timeout=120.0)
+        if wanted and wanted.encode() not in said:
+            return f"{name}: the installed system does not say {wanted!r}"
+    return ""
 
 
 def collect(guest: Guest, link: "Reconnecting", log: Path) -> dict[str, bytes]:

--- a/tests/vm/proxmox.py
+++ b/tests/vm/proxmox.py
@@ -365,6 +365,21 @@ class Guest:
         )
         self._booted = True
 
+    def boot_from_disk(self) -> None:
+        """Point the firmware at the installed disk and forget the medium.
+
+        The install is only half the question: the other half is whether the
+        machine it produced comes up and carries the settings that were asked
+        for. `order=virtio0` is what makes the firmware try the target rather
+        than the CD it was built with.
+        """
+        self.api.wait(
+            self.node,
+            self.api.call(
+                "PUT", f"/nodes/{self.node}/qemu/{self.vmid}/config", boot="order=virtio0"
+            ),
+        )
+
     def reset(self) -> None:
         """Boot the firmware again with somebody already reading.
 


### PR DESCRIPTION
A run was green when the installer exited zero. That is half the question: a
machine can reach a login prompt with the wrong filesystem mounted, no fstab
and the wrong locale, and nothing in the install log says otherwise.

After a successful install the guest is pointed at the target disk, booted,
logged into, and asked what it actually carries. Each question in the table
names the answer that would fail it; a check comparing against nothing passes
on any machine.