### PR TITLE
cli: say why the mirror could not be reached

### DIFF
--- a/gentoo_install/cli.py
+++ b/gentoo_install/cli.py
@@ -479,9 +479,10 @@ def _require_mirror(config: InstallConfig, fallback: str) -> None:
     network where the chosen mirror answered and that site did not.
     """
     mirror = stage3_mirror(config, fallback)
-    if not fetch.mirror_online(mirror, variant_of(config)):
+    said = fetch.why_mirror_unreachable(mirror, variant_of(config))
+    if said:
         raise errors.PreflightFailed(
-            f"this machine cannot reach {mirror}; the install fetches its stage3 there"
+            f"this machine cannot reach {mirror}; the install fetches its stage3 there: {said}"
         )
 
 

--- a/gentoo_install/exec/fetch.py
+++ b/gentoo_install/exec/fetch.py
@@ -307,26 +307,46 @@ ONLINE_TRIES: Final[int] = 5
 ONLINE_PAUSE: Final[float] = 2.0
 
 
+def why_unreachable(url: str) -> str:
+    """Empty when the URL answers, and why it did not otherwise.
+
+    The reason is carried out, not discarded. `cannot reach X` sent a run to
+    look at the network when the answer was a certificate the medium could not
+    verify, and a whole campaign was diagnosed twice over for want of one
+    sentence.
+    """
+    said = ""
+    for attempt in range(ONLINE_TRIES):
+        try:
+            _read(url)
+        except DownloadFailed as error:
+            said = str(error)
+            if attempt + 1 < ONLINE_TRIES:
+                time.sleep(ONLINE_PAUSE * 2**attempt)
+            continue
+        return ""
+    return said
+
+
 def reachable(url: str) -> bool:
     """Whether a URL answers, tried `ONLINE_TRIES` times.
 
     Asked of the address the run will actually read rather than of any host: a
     machine behind a portal resolves names and still cannot fetch anything.
     """
-    for attempt in range(ONLINE_TRIES):
-        try:
-            _read(url)
-        except DownloadFailed:
-            if attempt + 1 < ONLINE_TRIES:
-                time.sleep(ONLINE_PAUSE * 2**attempt)
-            continue
-        return True
-    return False
+    return not why_unreachable(url)
 
 
 def online() -> bool:
     """Whether the package site answers. The menu reads every version from it."""
     return reachable(f"{PACKAGES_API}/sys-kernel/gentoo-kernel-bin.json")
+
+
+def why_mirror_unreachable(mirror: str, variant: str) -> str:
+    """Empty when the mirror answers, and why it did not otherwise."""
+    return why_unreachable(
+        f"{mirror.rstrip('/')}/{STAGE3_PATH}/latest-stage3-amd64-{variant}.txt"
+    )
 
 
 def mirror_online(mirror: str, variant: str) -> bool:

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -638,11 +638,11 @@ def test_a_configured_install_checks_its_mirror_and_not_the_package_site(
     not."""
     asked: list[str] = []
 
-    def reachable(url: str) -> bool:
+    def why(url: str) -> str:
         asked.append(url)
-        return True
+        return ""
 
-    monkeypatch.setattr(fetch, "reachable", reachable)
+    monkeypatch.setattr(fetch, "why_unreachable", why)
     monkeypatch.setattr(cli, "_check_the_clock", lambda: None)
     monkeypatch.setattr(cli, "_require_root", lambda arguments: None)
     code = main(["--config", "tests/fixtures/btrfs-luks.toml", "--dry-run"])
@@ -660,7 +660,13 @@ def test_the_mirror_check_names_the_mirror_it_could_not_reach(
     from gentoo_install import errors
     from gentoo_install.exec.config import load
 
-    monkeypatch.setattr(fetch, "reachable", lambda url: False)
+    monkeypatch.setattr(
+        fetch, "why_unreachable", lambda url: "certificate verify failed: unable to get issuer"
+    )
     config = load(Path("tests/fixtures/btrfs-luks.toml"))
-    with pytest.raises(errors.PreflightFailed, match="tuna"):
+    with pytest.raises(errors.PreflightFailed, match="tuna") as raised:
         cli._require_mirror(config, DEFAULT_MIRROR)
+    # The reason is carried out, not discarded: `cannot reach X` sent a run to
+    # look at the network when the answer was a certificate the medium could
+    # not verify.
+    assert "certificate verify failed" in str(raised.value)


### PR DESCRIPTION
`this machine cannot reach X` discarded the reason. Twenty cluster runs stopped
there while `curl` fetched the same URL from the same guest a second earlier,
and the message sent the diagnosis to the network twice over.

The reason is now carried out with the failure.