### PR TITLE
tests: bring the guest interface up instead of waiting for it

### DIFF
--- a/tests/unit/test_proxmox.py
+++ b/tests/unit/test_proxmox.py
@@ -656,3 +656,19 @@ def test_every_question_asked_inside_names_what_would_fail_it() -> None:
         if name in ("hostname", "kernel"):
             continue  # collected for the report; their value is the fixture's
         assert wanted, f"{name} compares against nothing"
+
+
+def test_the_guest_is_asked_to_configure_its_interface() -> None:
+    """A fresh guest has no global address at all: `curl -4` and `curl -6`
+    both answer nothing and `ip address show scope global` prints an empty
+    list. The medium boots with `nodhcp`, so waiting alone waits for ever."""
+    import inspect
+
+    from tests.vm import cluster
+
+    source = inspect.getsource(cluster.wait_for_network)
+    assert "ip link set" in source, "the link has to be brought up"
+    assert "dhcpcd" in source, "something has to ask for an address"
+    brought = source.index("ip link set")
+    polled = source.index("NETWORK_UP") if "NETWORK_UP" in source else len(source)
+    assert brought < polled, "configure first, then poll"

--- a/tests/vm/cluster.py
+++ b/tests/vm/cluster.py
@@ -249,13 +249,22 @@ NETWORK_PAUSE: Final[float] = 10.0
 
 
 def wait_for_network(link: Reconnecting) -> None:
-    """Wait until the guest can fetch from the mirror before installing.
+    """Configure the guest's interface, then wait until it can reach a mirror.
 
-    Reaching a root shell says the medium booted, not that the interface is
-    up. Starting the installer there made its own reachability check fail
-    within ninety seconds of boot, and the run stopped before the first disk
-    was touched.
+    Waiting alone was not enough, and measuring said why: a fresh guest has no
+    global address at all, `curl -4` and `curl -6` both answer nothing, and
+    `ip address show scope global` prints an empty list. The medium boots with
+    `nodhcp` and leaves the link unconfigured, so something has to ask — which
+    is what an operator does before installing. The runs that used to succeed
+    were the ones where something else had configured it in time.
     """
+    # Every ethernet interface, because the name differs by machine type:
+    # `enp0s2` under q35 here and `eth0` elsewhere.
+    link.run(
+        "for one in /sys/class/net/e*; do ip link set \"$(basename $one)\" up; done",
+        timeout=60.0,
+    )
+    link.run("dhcpcd -w -t 30 >/dev/null 2>&1 || true", timeout=120.0)
     deadline = time.monotonic() + NETWORK_PATIENCE
     probe = (
         "curl -sS -o /dev/null --max-time 20 "


### PR DESCRIPTION
Measured on a fresh cluster guest: no global address at all, `curl -4` and
`curl -6` both answering nothing, and `ip address show scope global` printing
an empty list. The medium boots with `nodhcp` and leaves the link
unconfigured, so the wait added earlier waited for something nobody had asked
for. The runs that used to succeed were the ones where something else had
configured it in time.