### PR TITLE
tests: keep the network answer out of the command that prints it

### DIFF
--- a/tests/unit/test_proxmox.py
+++ b/tests/unit/test_proxmox.py
@@ -672,3 +672,17 @@ def test_the_guest_is_asked_to_configure_its_interface() -> None:
     brought = source.index("ip link set")
     polled = source.index("NETWORK_UP") if "NETWORK_UP" in source else len(source)
     assert brought < polled, "configure first, then poll"
+
+
+def test_no_marker_appears_in_the_command_that_prints_it() -> None:
+    """The shell echoes the line it was given. A reader waiting for a marker
+    matched the echo and returned before the work had started — twice: the
+    result archive in ninety seconds, and the network probe on its first pass
+    with no address on the interface at all."""
+    from tests.vm import cluster
+    from tests.vm.results import CONSOLE_CLOSE, CONSOLE_OPEN, console_command
+
+    watched = (cluster.NETWORK_UP, cluster.NETWORK_DOWN, CONSOLE_OPEN, CONSOLE_CLOSE)
+    for command in (console_command("/tmp/results"), cluster.NETWORK_PROBE):
+        for marker in watched:
+            assert marker not in command, f"{marker} appears whole in {command[:80]!r}"

--- a/tests/vm/cluster.py
+++ b/tests/vm/cluster.py
@@ -247,6 +247,19 @@ NETWORK_PATIENCE: Final[float] = 300.0
 #: attempts thirty seconds apart against a host that was answering.
 NETWORK_PAUSE: Final[float] = 10.0
 
+#: What the guest is asked, and the two answers it can give. Neither answer
+#: appears whole in the command: the shell echoes the line it was given, and a
+#: reader waiting for `NETWORK_UP` matched that echo and returned on the first
+#: pass with no address on the interface at all.
+NETWORK_UP: Final[str] = "NETWORK_UP"
+NETWORK_DOWN: Final[str] = "NETWORK_DOWN"
+NETWORK_PROBE: Final[str] = (
+    "curl -sS -o /dev/null --max-time 20 "
+    "https://distfiles.gentoo.org/releases/amd64/autobuilds/"
+    "latest-stage3-amd64-systemd.txt "
+    "&& printf 'NETWORK_%s\\n' UP || printf 'NETWORK_%s\\n' DOWN"
+)
+
 
 def wait_for_network(link: Reconnecting) -> None:
     """Configure the guest's interface, then wait until it can reach a mirror.
@@ -266,14 +279,9 @@ def wait_for_network(link: Reconnecting) -> None:
     )
     link.run("dhcpcd -w -t 30 >/dev/null 2>&1 || true", timeout=120.0)
     deadline = time.monotonic() + NETWORK_PATIENCE
-    probe = (
-        "curl -sS -o /dev/null --max-time 20 "
-        "https://distfiles.gentoo.org/releases/amd64/autobuilds/"
-        "latest-stage3-amd64-systemd.txt && echo NETWORK_UP || echo NETWORK_DOWN"
-    )
     while time.monotonic() < deadline:
-        link.send(probe)
-        if b"NETWORK_UP" in link.expect(r"NETWORK_UP|NETWORK_DOWN", timeout=60.0):
+        link.send(NETWORK_PROBE)
+        if NETWORK_UP.encode() in link.expect(rf"{NETWORK_UP}|{NETWORK_DOWN}", timeout=60.0):
             return
         time.sleep(NETWORK_PAUSE)
     raise ConsoleTimeout(f"the guest had no network after {NETWORK_PATIENCE:.0f}s")


### PR DESCRIPTION
The shell echoes the line it was given. Waiting for `NETWORK_UP` matched that
echo and returned on the first pass, with no address on the interface at all,
so every guest went straight into an installer that could reach nothing.

Second time this shape has cost a campaign — the result archive was the first
— so a test now holds every marker out of the command that prints it.