### PR TITLE
tests: ask four Chinese mirrors for a medium before Gentoo's own

### DIFF
--- a/tests/unit/test_proxmox.py
+++ b/tests/unit/test_proxmox.py
@@ -686,3 +686,16 @@ def test_no_marker_appears_in_the_command_that_prints_it() -> None:
     for command in (console_command("/tmp/results"), cluster.NETWORK_PROBE):
         for marker in watched:
             assert marker not in command, f"{marker} appears whole in {command[:80]!r}"
+
+
+def test_the_nodes_are_asked_for_a_medium_in_china_first() -> None:
+    """The cluster is in China and a gibibyte from Gentoo's own mirror is slow
+    enough to be worth avoiding. `mirrors.ustc.edu.cn` is absent on purpose: it
+    answers 403 to wget, which is what Proxmox downloads with."""
+    from tests.vm.cluster import MIRRORS
+
+    assert MIRRORS[-1] == "https://distfiles.gentoo.org", "the fallback comes last"
+    chinese = [one for one in MIRRORS if one.endswith(".cn/gentoo")]
+    assert len(chinese) >= 4, MIRRORS
+    assert all(one in MIRRORS[: len(chinese)] for one in chinese), "and they come first"
+    assert not any("ustc" in one for one in MIRRORS), "USTC refuses wget"

--- a/tests/vm/cluster.py
+++ b/tests/vm/cluster.py
@@ -58,12 +58,19 @@ RESULT_DIR: Final[str] = "/tmp/gentoo-install-results"
 #: China, so a node reaches these far faster than an upload from the
 #: workstation would, and the bytes never cross the workstation's link.
 #:
-#: `mirrors.ustc.edu.cn` is not among them: it answers `403 Forbidden` to
-#: Proxmox's downloader, which is wget, while serving the same URL to anything
-#: else. The installer reads it happily; only this path has to avoid it.
+#: `mirrors.ustc.edu.cn` is not among them, and it is the fastest of the set
+#: from these nodes. It answers `403 Forbidden` to Proxmox's downloader, which
+#: is wget, while serving the same URL to anything else. Measured again on
+#: 2026-08-10: `Wget/1.21.4` gets 403 from USTC and 206 from tuna, nju, zju
+#: and hust. The installer reads USTC happily; only this path has to avoid it.
 MIRRORS: Final[tuple[str, ...]] = (
     "https://mirrors.tuna.tsinghua.edu.cn/gentoo",
     "https://mirror.nju.edu.cn/gentoo",
+    "https://mirrors.zju.edu.cn/gentoo",
+    "https://mirrors.hust.edu.cn/gentoo",
+    "https://mirrors.bfsu.edu.cn/gentoo",
+    # Last, and only if every Chinese mirror refused: the nodes are in China
+    # and a gibibyte from here is slow enough to be worth avoiding.
     "https://distfiles.gentoo.org",
 )
 


### PR DESCRIPTION
The nodes are in China and a gibibyte from `distfiles.gentoo.org` is slow
enough to be worth avoiding, so it is the last resort rather than the third.

`mirrors.ustc.edu.cn` stays out although it is the fastest of the set from
these nodes: it answers `403 Forbidden` to `Wget/1.21.4`, which is what
Proxmox downloads with, while serving the same URL to anything else. Measured
again today, against 206 from tuna, nju, zju and hust.