### PR TITLE
tests: leave the guest link alone until the medium has had its chance

### DIFF
--- a/tests/unit/test_proxmox.py
+++ b/tests/unit/test_proxmox.py
@@ -658,20 +658,23 @@ def test_every_question_asked_inside_names_what_would_fail_it() -> None:
         assert wanted, f"{name} compares against nothing"
 
 
-def test_the_guest_is_asked_to_configure_its_interface() -> None:
-    """A fresh guest has no global address at all: `curl -4` and `curl -6`
-    both answer nothing and `ip address show scope global` prints an empty
-    list. The medium boots with `nodhcp`, so waiting alone waits for ever."""
+def test_the_link_is_left_alone_until_the_medium_has_had_its_chance() -> None:
+    """The medium runs NetworkManager, and an interface raised from outside it
+    is one NetworkManager then leaves alone: `ip link set up` at the start was
+    enough to stop it configuring the guest, and `curl` answered `Could not
+    connect to server` in ten milliseconds where before it had reached the
+    mirror. A medium with no manager still needs the ask, so it happens late
+    and once."""
     import inspect
 
     from tests.vm import cluster
 
     source = inspect.getsource(cluster.wait_for_network)
-    assert "ip link set" in source, "the link has to be brought up"
-    assert "dhcpcd" in source, "something has to ask for an address"
-    brought = source.index("ip link set")
-    polled = source.index("NETWORK_UP") if "NETWORK_UP" in source else len(source)
-    assert brought < polled, "configure first, then poll"
+    polled = source.index("NETWORK_PROBE")
+    raised = source.index("ip link set")
+    assert polled < raised, "poll first; touch the link only if nothing happens"
+    assert "NetworkManager" in source, "and never when the medium has a manager"
+    assert "asked = True" in source, "once, not on every pass"
 
 
 def test_no_marker_appears_in_the_command_that_prints_it() -> None:

--- a/tests/vm/cluster.py
+++ b/tests/vm/cluster.py
@@ -278,29 +278,30 @@ def wait_for_network(link: Reconnecting) -> None:
     is what an operator does before installing. The runs that used to succeed
     were the ones where something else had configured it in time.
     """
-    # Bring the link up and leave the addressing to whatever the medium runs.
-    # An `dhcpcd` started beside the medium's own NetworkManager fought it for
-    # the same interface and left the guest with no route at all: `curl`
-    # answered `Could not connect to server` in ten milliseconds, where before
-    # it had reached the mirror. The name differs by machine type, `enp0s2`
-    # under q35 and `eth0` elsewhere, so every ethernet interface is raised.
-    link.run(
-        "for one in /sys/class/net/e*; do ip link set \"$(basename $one)\" up; done",
-        timeout=60.0,
-    )
+    # Nothing is touched at first. The medium runs NetworkManager, and an
+    # interface raised from outside it is one NetworkManager then leaves
+    # alone: `ip link set up` here was enough to stop it configuring the
+    # guest, and `curl` answered `Could not connect to server` in ten
+    # milliseconds where before it had reached the mirror.
     deadline = time.monotonic() + NETWORK_PATIENCE
+    asked = False
     while time.monotonic() < deadline:
         link.send(NETWORK_PROBE)
         if NETWORK_UP.encode() in link.expect(rf"{NETWORK_UP}|{NETWORK_DOWN}", timeout=60.0):
             return
         time.sleep(NETWORK_PAUSE)
-        if time.monotonic() > deadline - NETWORK_PATIENCE / 2:
-            # Half the patience gone and still nothing: the medium has no
-            # manager of its own, so ask for an address directly. Late rather
-            # than first, because doing it first is what broke the mediums
-            # that do.
-            link.run("pgrep -x NetworkManager >/dev/null || dhcpcd -w -t 20 >/dev/null 2>&1 "
-                     "|| true", timeout=90.0)
+        if time.monotonic() > deadline - NETWORK_PATIENCE / 2 and not asked:
+            # Half the patience gone and still nothing, so the medium has no
+            # manager of its own: raise the link and ask for an address. Once,
+            # and late, because doing it first is what stopped the mediums
+            # that do have one.
+            asked = True
+            link.run(
+                "pgrep -x NetworkManager >/dev/null || { "
+                'for one in /sys/class/net/e*; do ip link set "$(basename $one)" up; done; '
+                "dhcpcd -w -t 20 >/dev/null 2>&1; }; true",
+                timeout=90.0,
+            )
     raise ConsoleTimeout(f"the guest had no network after {NETWORK_PATIENCE:.0f}s")
 
 


### PR DESCRIPTION
The medium runs NetworkManager, and an interface raised from outside it is one
NetworkManager then leaves alone. Bringing the link up at the start was enough
to stop it configuring the guest: `curl` answered `Could not connect to
server` in ten milliseconds, where the same medium had reached the mirror
before the harness touched anything.

A medium with no manager of its own still needs to be asked, so that happens
once and only after half the patience has passed with no route.