### PR TITLE
tui: require a visit only of a row with a detected default

### DIFF
--- a/gentoo_install/tui/settings.py
+++ b/gentoo_install/tui/settings.py
@@ -55,6 +55,13 @@ class Setting:
     #: answer` is wrong for a confirmation: there is no field to fill, and the
     #: operator is being asked to agree to something.
     missing: str = "still needs an answer"
+    #: Whether this row starts on a value read from this machine. Such a row
+    #: has to be opened before it counts as answered: an install that erases a
+    #: drive nobody looked at is what the requirement exists to prevent. A row
+    #: with no detected default needs no visit — its value can only have come
+    #: from the operator, and counting it as missing made the Install row say
+    #: `root password: still needs an answer` beside a row reading `set`.
+    detected: bool = False
     #: Why this row cannot be opened right now, or empty when it can. A row
     #: whose answer the rest of the configuration has already settled is drawn
     #: with the reason rather than opening a screen that changes nothing.
@@ -64,13 +71,20 @@ class Setting:
 def settled(setting: Setting, config: InstallConfig, context: Context) -> bool:
     """Whether a required row counts as answered.
 
-    Opened, not merely non-empty: the mirror and the disk both start on a value
-    read from this machine, and an install that erases a drive nobody looked at
-    is the failure the requirement exists to prevent.
+    A row with a detected default has to be opened as well as filled: the
+    mirror and the disk both start on a value read from this machine, and an
+    install that erases a drive nobody looked at is the failure the
+    requirement exists to prevent.
+
+    Every other row counts as answered when it has a value. The root password
+    has no detected default, so requiring a visit made the Install row say it
+    still needed an answer beside a row that read `set`.
     """
     if setting.value(config, context) == UNSET:
         return False
-    return setting.key in context.visited or not setting.required
+    if not setting.required or not setting.detected:
+        return True
+    return setting.key in context.visited
 
 
 def style_of(setting: Setting, config: InstallConfig, context: Context) -> Style:
@@ -538,7 +552,7 @@ def _cjk_kernel_only(config: InstallConfig, context: Context) -> str:
 #: The disk, as one subject. Six rows in a menu of thirty read as six unrelated
 #: decisions; behind one row they read as the layout they describe.
 DISK: Final[tuple[Setting, ...]] = (
-    Setting("disk", "Drive", _drive, screens.disk_screen, required=True),
+    Setting("disk", "Drive", _drive, screens.disk_screen, required=True, detected=True),
     Setting(
         "table", "Partition table", _table, screens.table_screen,
         unavailable=_reuse_writes_no_table,
@@ -642,8 +656,16 @@ SETTINGS: Final[tuple[Setting, ...]] = (
     Setting("keymap", "Keyboard layout", lambda c, x: c.system.keymap, screens.keymap_screen),
     Setting("locale", "System language", lambda c, x: c.system.locale, screens.locale_screen),
     Setting("timezone", "Timezone", lambda c, x: c.system.timezone, screens.timezone_screen),
-    Setting("mirror", "Mirrors", _mirror, screens.mirror_screen, required=True),
-    Setting("storage", "Disk", _summary(DISK), nested("Disk", DISK), required=True, rows=DISK),
+    Setting("mirror", "Mirrors", _mirror, screens.mirror_screen, required=True, detected=True),
+    Setting(
+        "storage",
+        "Disk",
+        _summary(DISK),
+        nested("Disk", DISK),
+        required=True,
+        rows=DISK,
+        detected=True,
+    ),
     Setting("hostname", "Hostname", lambda c, x: c.system.hostname, screens.system_screen),
     Setting("firstboot", "Run once at first boot", _first_boot, screens.first_boot_screen),
     Setting("system", "Init system", _summary(INIT), nested("Init system", INIT), rows=INIT),
@@ -655,6 +677,9 @@ SETTINGS: Final[tuple[Setting, ...]] = (
         nested("Compiler", COMPILER),
         required=True,
         rows=COMPILER,
+        # `MAKEOPTS` starts at this machine's core count, which is a detected
+        # value and not an answer.
+        detected=True,
     ),
     Setting("root", "Root password", _root, screens.root_password_screen, required=True),
     Setting("user", "User account", _user, screens.user_screen),

--- a/tests/unit/test_tui_app.py
+++ b/tests/unit/test_tui_app.py
@@ -1481,9 +1481,14 @@ def test_the_rows_say_not_set_in_the_language_the_menu_is_in() -> None:
     assert _drawn(root, blank, at) == at.translate("required")
 
 
-def test_a_required_row_has_to_be_opened_and_not_only_filled_in() -> None:
+def test_a_detected_row_has_to_be_opened_and_not_only_filled_in() -> None:
     """The mirror and the disk start on a value read from this machine, so a
-    check for `UNSET` alone let an install erase a drive nobody looked at."""
+    check for `UNSET` alone let an install erase a drive nobody looked at.
+
+    Only those rows. A row with no detected default is answered by its value:
+    requiring a visit there made the Install row say `root password: still
+    needs an answer` beside a row that read `set`.
+    """
     at = context()
     at.confirmed = {one.selector for one in compat.destroyed(config().disk.graph)}
     ready = replace(
@@ -1499,8 +1504,10 @@ def test_a_required_row_has_to_be_opened_and_not_only_filled_in() -> None:
         for one in (group.rows if any(r.required for r in group.rows) else (group,))
         if one.required
     ]
+    detected = [one for one in required if one.detected]
     named = settings.unanswered(ready, at)
-    assert {one.label for one in required} <= {one.label for one in named}
+    assert {one.label for one in detected} <= {one.label for one in named}
+    assert "Root password" not in {one.label for one in named}
     at.visited.update(one.key for one in required)
     assert settings.unanswered(ready, at) == ()
 
@@ -1961,3 +1968,52 @@ def test_no_screen_prints_the_by_id_selector() -> None:
         drawn = "\n".join("\n".join(frame) for frame in screen.frames)
         assert named not in drawn, (name, drawn)
         assert "/dev/sda" in drawn, (name, drawn)
+
+
+def test_a_filled_row_is_not_still_asked_for() -> None:
+    """The Install row said `root password: still needs an answer` beside a row
+    reading `set`. A visit is required only of a row that starts on a value
+    read from this machine, because that is the one an operator can accept
+    without having looked at it."""
+    from dataclasses import replace
+
+    from gentoo_install.tui import app, settings
+
+    from .fake_screen import FakeScreen
+    from .layouts import config, ext4_on_gpt
+
+    at = context()
+    at.columns = 200
+    base = config(ext4_on_gpt())
+    empty = replace(base, system=replace(base.system, root_password_hash="", users=()))
+    assert "Root password" in app._blocked(empty, at)
+
+    row = next(one for one in settings.SETTINGS if one.key == "root")
+    assert row.edit is not None
+    typed = list("hunter2") + ["\n"] + list("hunter2") + ["\n"]
+    # Deliberately not marking it visited: the value is the answer.
+    done = row.edit(FakeScreen(keys=typed, lines=24), empty, at).unwrap()
+    assert settings._root(done, at) == "set"
+    assert "Root password" not in app._blocked(done, at)
+
+
+def test_a_detected_row_still_has_to_be_opened() -> None:
+    """The mirror and the drive both start on something read from the machine,
+    and an install that erases a drive nobody looked at is what the
+    requirement exists to prevent."""
+    from gentoo_install.tui import app, settings
+
+    from .layouts import config, ext4_on_gpt
+
+    at = context()
+    at.columns = 200
+    whole = config(ext4_on_gpt())
+    for key in ("mirror", "storage", "compiler"):
+        row = next(one for one in settings.SETTINGS if one.key == key)
+        assert row.detected, key
+        assert not settings.settled(row, whole, at), key
+    # `Disk` is a group whose own rows carry the requirement, so the row
+    # behind it is what gets named.
+    said = app._blocked(whole, at)
+    for label in ("Mirrors", "Drive", "Compiler"):
+        assert label in said, said


### PR DESCRIPTION
The Install row said `root password: still needs an answer` beside a row that
read `set`, because a required row counted as answered only once it had been
opened.

That rule guards a value read from this machine — the mirror, the drive, and
`MAKEOPTS` from the core count — where accepting a default nobody looked at
can erase a disk. A row the operator has to fill in has no such default, so
having a value is the answer.