### PR TITLE
tests: read a command's output between two markers

### DIFF
--- a/tests/unit/test_proxmox.py
+++ b/tests/unit/test_proxmox.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import shlex
 import struct
 import urllib.request
 from pathlib import Path
@@ -693,10 +694,47 @@ def test_no_marker_appears_in_the_command_that_prints_it() -> None:
     from tests.vm import cluster
     from tests.vm.results import CONSOLE_CLOSE, CONSOLE_OPEN, console_command
 
-    watched = (cluster.NETWORK_UP, cluster.NETWORK_DONE, CONSOLE_OPEN, CONSOLE_CLOSE)
-    for command in (console_command("/tmp/results"), cluster.NETWORK_PROBE):
+    watched = (
+        cluster.NETWORK_UP,
+        cluster.NETWORK_DONE,
+        CONSOLE_OPEN,
+        CONSOLE_CLOSE,
+        cluster._begin(7),
+        cluster._done(7),
+    )
+    commands = (
+        console_command("/tmp/results"),
+        cluster.NETWORK_PROBE,
+        cluster._marked("findmnt --output TARGET,SOURCE,FSTYPE", 7),
+    )
+    for command in commands:
         for marker in watched:
             assert marker not in command, f"{marker} appears whole in {command[:80]!r}"
+
+
+def test_a_command_answers_with_what_it_printed_and_not_with_its_own_echo() -> None:
+    """`findmnt --noheadings --list --output TARGET,SOURCE,FSTYPE` was checked
+    for `/`, and the echo of that command carries one. A guest whose `findmnt`
+    printed nothing passed the mount check on the echoed line alone.
+
+    Run against a real `sh` with the echo in front of it, the way a console
+    carries one.
+    """
+    import subprocess
+
+    from tests.vm import cluster
+
+    command = cluster._marked("findmnt --output TARGET,SOURCE,FSTYPE", 7)
+    # `sh -x`-free: the echo is what a terminal adds, so it is written here.
+    said = subprocess.run(
+        ["sh", "-c", f"printf '%s\n' {shlex.quote(command)}; {command}"],
+        capture_output=True,
+        check=False,
+    ).stdout
+    answer = said.split(cluster._begin(7).encode())[-1]
+    answer = answer.split(cluster._done(7).encode())[0]
+    assert b"findmnt" not in answer, answer
+    assert b"TARGET,SOURCE,FSTYPE" not in answer, answer
 
 
 def test_the_nodes_are_asked_for_a_medium_in_china_first() -> None:

--- a/tests/vm/cluster.py
+++ b/tests/vm/cluster.py
@@ -640,6 +640,28 @@ COLLECT_PATIENCE: Final[float] = 900.0
 RECONNECT_TRIES: Final[int] = 4
 
 
+#: What says a command started and what says it finished. Neither appears
+#: whole in the line the console is given: the shell echoes that line back,
+#: and a reader waiting for the end marker matched the echo and returned
+#: before the command had run. `printf` assembles them in the guest instead.
+_BEGIN_TEXT: Final[str] = "MARK_{token}_BEGIN"
+_DONE_TEXT: Final[str] = "MARK_{token}_DONE"
+
+
+def _marked(command: str, token: int) -> str:
+    return (
+        f"printf 'MARK_%s_BEGIN\\n' {token}; {command}; printf 'MARK_%s_DONE\\n' {token}"
+    )
+
+
+def _begin(token: int) -> str:
+    return _BEGIN_TEXT.format(token=token)
+
+
+def _done(token: int) -> str:
+    return _DONE_TEXT.format(token=token)
+
+
 class Reconnecting:
     """A console that opens another one when the cluster drops it.
 
@@ -683,9 +705,9 @@ class Reconnecting:
     def run(self, command: str, timeout: float = 120.0) -> None:
         for attempt in range(self._tries):
             token = next(self._marks)
-            self.console.send(f"{command}; echo MARK_{token}_DONE")
+            self.console.send(_marked(command, token))
             try:
-                self.console.expect(rf"MARK_{token}_DONE", timeout)
+                self.console.expect(_done(token), timeout)
                 return
             except ConsoleClosed:
                 if attempt + 1 == self._tries:
@@ -699,10 +721,10 @@ class Reconnecting:
         would be started a second time on a target it has half written.
         """
         token = next(self._marks)
-        self.console.send(f"{command}; echo MARK_{token}_DONE")
+        self.console.send(_marked(command, token))
         for attempt in range(self._tries):
             try:
-                self.console.expect(rf"MARK_{token}_DONE", timeout)
+                self.console.expect(_done(token), timeout)
                 return
             except ConsoleClosed:
                 if attempt + 1 == self._tries:
@@ -710,23 +732,25 @@ class Reconnecting:
                 self.reopen()
 
     def expect_output(self, command: str, timeout: float = 120.0) -> bytes:
-        """Run a command and answer with what it printed.
+        """Run a command and answer with what it printed, and nothing else.
 
-        `run` only waits for the marker; a check on the installed system has
-        to read the reply. The marker is still what says the command finished,
-        so a command that prints nothing is not mistaken for one that hung.
+        Between the two markers, not up to the last one: the shell echoes the
+        line it was given, so what came back began with the command itself.
+        `findmnt --output TARGET,SOURCE,FSTYPE` was checked for `/` and the
+        echo of that command carries one, so the check passed on a guest whose
+        `findmnt` printed nothing at all.
         """
-        token = next(self._marks)
-        self.console.send(f"{command}; echo MARK_{token}_DONE")
         for attempt in range(self._tries):
+            token = next(self._marks)
+            self.console.send(_marked(command, token))
             try:
-                said = self.console.expect(rf"MARK_{token}_DONE", timeout)
-                return said
+                self.console.expect(_begin(token), timeout)
+                said = self.console.expect(_done(token), timeout)
+                return said.split(_DONE_TEXT.format(token=token).encode())[0]
             except ConsoleClosed:
                 if attempt + 1 == self._tries:
                     raise
                 self.reopen()
-                self.console.send(f"{command}; echo MARK_{token}_DONE")
         raise ConsoleClosed("the console could not be reopened")
 
     def send(self, line: str) -> None:


### PR DESCRIPTION
The shell echoes the line it was given, so `MARK_n_DONE` matched its own echo: `Reconnecting.run`, `wait_for` and `expect_output` all returned before the command had run, and every read answered with the *previous* command's output. Measured on a live guest today — five probes, five answers shifted by one.

`expect_output` compounded it. It returned everything up to the end marker, echo included, and the `INSIDE` mount check looks for `/` in `findmnt --noheadings --list --output TARGET,SOURCE,FSTYPE` — a string the echoed command carries. A guest whose `findmnt` printed nothing passed.

Both markers are now assembled by `printf` in the guest, the same fix the result archive and the network probe already carry, and the output is taken between them.