### PR TITLE
tui: say the passphrase length above the field

### DIFF
--- a/gentoo_install/data/locale/ja.toml
+++ b/gentoo_install/data/locale/ja.toml
@@ -16,6 +16,7 @@
 "Encrypt the pool?" = "この pool を暗号化しますか？"
 "Passphrase" = "パスフレーズ"
 "Passphrase again" = "パスフレーズをもう一度"
+"At least {count} characters." = "{count} 文字以上で入力してください。"
 "The passphrase is too short." = "パスフレーズが短すぎます。"
 "The two do not match." = "2 回の入力が一致しません。"
 "Leave without installing?" = "インストールせずに終了しますか？"

--- a/gentoo_install/data/locale/ko.toml
+++ b/gentoo_install/data/locale/ko.toml
@@ -16,6 +16,7 @@
 "Encrypt the pool?" = "이 pool을 암호화하시겠습니까?"
 "Passphrase" = "패스프레이즈"
 "Passphrase again" = "패스프레이즈 다시 입력"
+"At least {count} characters." = "{count}자 이상이어야 합니다."
 "The passphrase is too short." = "패스프레이즈가 너무 짧습니다."
 "The two do not match." = "두 입력이 일치하지 않습니다."
 "Leave without installing?" = "설치하지 않고 나가시겠습니까?"

--- a/gentoo_install/data/locale/zh-CN.toml
+++ b/gentoo_install/data/locale/zh-CN.toml
@@ -16,6 +16,7 @@
 "Encrypt the pool?" = "要加密此 pool 吗？"
 "Passphrase" = "密码短语"
 "Passphrase again" = "再次输入密码短语"
+"At least {count} characters." = "至少 {count} 个字符。"
 "The passphrase is too short." = "密码短语太短。"
 "The two do not match." = "两次输入不一致。"
 "Leave without installing?" = "放弃安装并离开？"

--- a/gentoo_install/data/locale/zh-TW.toml
+++ b/gentoo_install/data/locale/zh-TW.toml
@@ -16,6 +16,7 @@
 "Encrypt the pool?" = "要加密此 pool 嗎？"
 "Passphrase" = "密語"
 "Passphrase again" = "再次輸入密語"
+"At least {count} characters." = "至少 {count} 個字元。"
 "The passphrase is too short." = "密語太短。"
 "The two do not match." = "兩次輸入不一致。"
 "Leave without installing?" = "放棄安裝並離開？"

--- a/gentoo_install/tui/screens.py
+++ b/gentoo_install/tui/screens.py
@@ -1871,9 +1871,13 @@ def _ask_passphrase(screen: Screen, context: Context) -> str:
     log is what people paste into bug reports.
     """
     translate = context.translate
+    hint = translate("At least {count} characters.").format(count=PASSPHRASE_MINIMUM)
     while True:
         first = TextField(
-            title=translate("Passphrase"), masked=True, footer=footer(translate)
+            title=translate("Passphrase"),
+            masked=True,
+            detail=hint,
+            footer=footer(translate),
         ).run(screen)
         if not first.chosen:
             return ""
@@ -1884,7 +1888,10 @@ def _ask_passphrase(screen: Screen, context: Context) -> str:
             _say(screen, context, translate("The passphrase is too short."))
             continue
         again = TextField(
-            title=translate("Passphrase again"), masked=True, footer=footer(translate)
+            title=translate("Passphrase again"),
+            masked=True,
+            detail=hint,
+            footer=footer(translate),
         ).run(screen)
         if not again.chosen:
             return ""

--- a/tests/unit/test_tui_app.py
+++ b/tests/unit/test_tui_app.py
@@ -339,6 +339,37 @@ def test_a_passphrase_zfs_would_refuse_is_caught_before_the_disks_are_touched() 
     assert "too short" in "\n".join("\n".join(frame) for frame in screen.frames)
 
 
+def test_the_passphrase_field_says_the_length_before_it_is_typed() -> None:
+    """`The passphrase is too short.` arrives after the operator has typed one
+    and says nothing about how long it has to be, so the second attempt is a
+    guess. The field states the minimum above it, and states the number the
+    code enforces rather than one written out beside it."""
+    at = context()
+    keys = ["KEY_DOWN", "\n", *list("longenough"), "\n", *list("longenough"), "\n"]
+    screen = FakeScreen(keys=keys)
+    screens.encryption_screen(screen, config(), at)
+    drawn = "\n".join("\n".join(frame) for frame in screen.frames)
+    assert str(screens.PASSPHRASE_MINIMUM) in drawn, drawn
+    typed = [frame for frame in screen.frames if any("Passphrase" in one for one in frame)]
+    assert typed, "no passphrase field was drawn"
+    for frame in typed:
+        assert any(str(screens.PASSPHRASE_MINIMUM) in one for one in frame), frame
+
+
+def test_every_catalog_translates_the_passphrase_hint() -> None:
+    """A hint that falls back to English on a Chinese console is a hint the
+    operator it was written for cannot read."""
+    import tomllib
+    from pathlib import Path as _Path
+
+    source = "At least {count} characters."
+    for catalog in sorted(_Path("gentoo_install/data/locale").glob("*.toml")):
+        said = tomllib.loads(catalog.read_text())["strings"]
+        assert source in said, f"{catalog.name} has no hint"
+        assert "{count}" in said[source], f"{catalog.name} dropped the placeholder"
+        assert said[source] != source, f"{catalog.name} left it in English"
+
+
 def test_declining_encryption_clears_the_passphrase() -> None:
     at = context()
     at.choice = replace(at.choice, passphrase_file="/run/keys/old")


### PR DESCRIPTION
`The passphrase is too short.` arrives only after the operator has typed one, and it names no number, so the second attempt is a guess. Both passphrase fields now carry the minimum above the box, where it is readable before anything is typed.

The hint is formatted from `PASSPHRASE_MINIMUM` rather than written out beside it, so the number shown is the number enforced. `zpool create` is what sets it at eight.

All four catalogs carry the string; a test asserts none falls back to English and none drops the `{count}` placeholder.