### PR TITLE
tests: unlock an encrypted disk before waiting for a login

### DIFF
--- a/tests/unit/test_proxmox.py
+++ b/tests/unit/test_proxmox.py
@@ -748,3 +748,73 @@ def test_the_nodes_are_asked_for_a_medium_in_china_first() -> None:
     assert len(chinese) >= 4, MIRRORS
     assert all(one in MIRRORS[: len(chinese)] for one in chinese), "and they come first"
     assert not any("ustc" in one for one in MIRRORS), "USTC refuses wget"
+
+
+def test_an_encrypted_disk_is_unlocked_before_a_login_is_waited_for(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Nothing answered the prompt, so an encrypted install that had worked
+    was failed ten minutes later for not reaching a login it was never going
+    to reach unattended.
+
+    One scripted console per encrypted layout, and a BIOS one whose prompt is
+    on the VGA console and never reaches the serial port at all.
+    """
+    from dataclasses import replace
+
+    from gentoo_install.exec.config import load
+    from gentoo_install.model.config import Firmware as BootFirmware
+    from tests.vm import cluster
+    from tests.vm.cluster import Reconnecting
+    from tests.vm.console import DISK_PASSPHRASE
+
+    class Scripted:
+        """Answers with a passphrase prompt until one is sent, then `login:`."""
+
+        def __init__(self) -> None:
+            self.sent: list[str] = []
+            self.keys: list[str] = []
+
+        def send(self, line: str) -> None:
+            self.sent.append(line)
+
+        def send_raw(self, keys: str) -> None:
+            self.sent.append(keys)
+
+        def snapshot(self, seconds: float) -> bytes:
+            return b""
+
+        def expect(self, pattern: str, timeout: float) -> bytes:
+            if DISK_PASSPHRASE in self.sent:
+                return b"gentoo login:"
+            return b"Enter passphrase for hd0,gpt2:"
+
+    class Silent(Scripted):
+        """A guest whose keys go through the API, not the serial port."""
+
+        def send_keys(self, keys: list[str]) -> None:
+            self.keys.extend(keys)
+
+    for name, firmware in (
+        ("vm-luks", BootFirmware.UEFI),
+        ("vm-zfs-encrypted", BootFirmware.UEFI),
+        ("vm-bios-luks", BootFirmware.BIOS),
+    ):
+        installation = load(Path("tests/fixtures") / f"{name}.toml")
+        assert installation.bootloader.firmware is firmware, name
+        console = Silent()
+        link = Reconnecting(lambda: console, tries=1)
+        # No wait for GRUB: the sleep is what the real path spends and this
+        # test is not measuring it.
+        monkeypatch.setattr(cluster, "GRUB_PROMPT_SECONDS", 0.0)
+        said = cluster._unlock(console, link, installation)
+        assert said == "", f"{name}: {said}"
+        assert console.sent.count(DISK_PASSPHRASE) == 1, f"{name}: {console.sent}"
+        if firmware is BootFirmware.BIOS:
+            assert console.keys, f"{name}: nothing was typed at GRUB"
+            assert console.keys[-1] == "ret", console.keys
+
+    plain = load(Path("tests/fixtures/vm-binpkg.toml"))
+    console = Silent()
+    assert cluster._unlock(console, Reconnecting(lambda: console, tries=1), plain) == ""
+    assert console.sent == [], "a plain disk was sent a passphrase"

--- a/tests/vm/cluster.py
+++ b/tests/vm/cluster.py
@@ -29,13 +29,22 @@ from collections import Counter
 from collections.abc import Callable, Mapping
 from typing import Final, Protocol
 
+from gentoo_install.model.config import Firmware as BootFirmware
 from gentoo_install.model.config import InstallConfig
 from gentoo_install.model.device import Existing, Luks, ZfsPool
 from gentoo_install.model.config import MirrorRegion, Sync
 from gentoo_install.exec.config import load
 from gentoo_install.model.serialise import to_toml
-from .console import PASSWORD_PROMPT, ConsoleClosed, ConsoleTimeout, SerialConsole
+from .console import (
+    DISK_PASSPHRASE,
+    PASSPHRASE_PROMPT,
+    PASSWORD_PROMPT,
+    ConsoleClosed,
+    ConsoleTimeout,
+    SerialConsole,
+)
 from .driver import build as build_driver
+from .monitor import keys_for
 from .proxmox import (
     Api,
     Guest,
@@ -240,10 +249,6 @@ def prepare(
     if driver not in api.isos(node):
         api.upload_iso(node, driver_path, driver)
 
-
-#: The disk passphrase these runs use. Not a root password: zfs takes at least
-#: eight characters, and a real install does not reuse one for the other.
-DISK_PASSPHRASE: Final[str] = "install-disk"
 
 
 #: How long a guest is given to reach a mirror. Generous, because the link
@@ -779,6 +784,55 @@ INSIDE: Final[tuple[tuple[str, str, str], ...]] = (
 )
 
 
+#: How long SeaBIOS and GRUB take to reach the cryptomount prompt. Nothing on
+#: the serial port marks it, so the passphrase is typed after this, and a
+#: wrong guess costs one retry at the next prompt, which is waited for.
+GRUB_PROMPT_SECONDS: Final[float] = 30.0
+
+#: How many prompts are answered before the passphrase is called wrong. A
+#: wrong one brings the prompt back and each one re-arms the timeout, so an
+#: unbounded loop would never fail.
+UNLOCK_TRIES: Final[int] = 5
+
+
+class Typeable(Protocol):
+    """All the unlock step needs of a guest: GRUB's prompt never reaches the
+    serial port, so the passphrase goes to the screen as keystrokes."""
+
+    def send_keys(self, keys: list[str]) -> None: ...
+
+
+def _unlock(guest: Typeable, link: Reconnecting, installation: InstallConfig) -> str:
+    """Answer every passphrase prompt on the way to a login.
+
+    Nothing did, so an encrypted install that had worked was failed ten
+    minutes later for not reaching a login prompt it was never going to reach
+    unattended.
+
+    GRUB unlocks an encrypted BIOS disk before it reads `grub.cfg`, so that
+    prompt is on the VGA console whatever `GRUB_TERMINAL` says: it is typed
+    through the API's `sendkey` rather than waited for.
+    """
+    graph = installation.disk.graph
+    encrypted = bool(graph.of_type(Luks)) or any(
+        pool.encrypted for pool in graph.of_type(ZfsPool)
+    )
+    if not encrypted:
+        return ""
+    if installation.bootloader.firmware is BootFirmware.BIOS:
+        time.sleep(GRUB_PROMPT_SECONDS)
+        guest.send_keys([*keys_for(DISK_PASSPHRASE), "ret"])
+    for _ in range(UNLOCK_TRIES):
+        try:
+            said = link.expect(rf"{PASSPHRASE_PROMPT}|login:", timeout=BOOT_PATIENCE)
+        except (ConsoleTimeout, ConsoleClosed) as error:
+            return f"the encrypted disk asked for nothing and booted nowhere: {error}"[:200]
+        if b"login:" in said:
+            return ""
+        link.send(DISK_PASSPHRASE)
+    return "the disk kept asking for a passphrase; it is not the one installed"
+
+
 def boot_and_check(
     guest: Guest, link: Reconnecting, log: Path, installation: InstallConfig
 ) -> str:
@@ -793,6 +847,9 @@ def boot_and_check(
     guest.boot_from_disk()
     guest.start()
     link.reopen()
+    refused = _unlock(guest, link, installation)
+    if refused:
+        return refused
     try:
         link.expect(r"login:", timeout=BOOT_PATIENCE)
     except (ConsoleTimeout, ConsoleClosed) as error:

--- a/tests/vm/console.py
+++ b/tests/vm/console.py
@@ -34,6 +34,17 @@ def strip_ansi(data: bytes) -> bytes:
 #: carries the localized forms. This is the one CJK literal the tests allow.
 PASSWORD_PROMPT = r"[Pp]assword:|密码：|密碼："
 
+#: What GRUB and the initramfs say when they want a disk passphrase. GRUB asks
+#: because `/boot` is inside the container and the initramfs asks to open the
+#: root, so one passphrase is prompted for twice unless a keyfile is embedded.
+PASSPHRASE_PROMPT = r"[Ee]nter passphrase|Please enter passphrase|password for"
+
+#: The passphrase every encrypted fixture installs. Not the root password: zfs
+#: takes at least eight characters, and a real install does not reuse one for
+#: the other. Here rather than in each runner, so the local runs and the
+#: cluster runs cannot install one and answer with another.
+DISK_PASSPHRASE = "install-disk"
+
 
 class Channel(Protocol):
     """What a console needs of its transport, and nothing more.

--- a/tests/vm/run.py
+++ b/tests/vm/run.py
@@ -36,7 +36,7 @@ from gentoo_install.model.config import Networking
 from gentoo_install.exec.config import load
 from gentoo_install.plan.system import _network_service as network_service
 
-from .console import PASSWORD_PROMPT, SerialConsole
+from .console import DISK_PASSPHRASE, PASSPHRASE_PROMPT, PASSWORD_PROMPT, SerialConsole
 from .monitor import type_text
 from .driver import REPOSITORY, build as build_driver
 from .media import MEDIA, Medium
@@ -50,10 +50,6 @@ TARGET_SIZE = "40G"
 #: The password in `fixtures/vm-binpkg.toml`, as plain text. It exists so the
 #: harness can log into what it installed; nothing else uses it.
 INSTALLED_PASSWORD = "install"
-
-#: The disk passphrase, which is not the root password: zfs takes at least
-#: eight characters, and a real install does not reuse one for the other.
-DISK_PASSPHRASE = "install-disk"
 
 #: How long SeaBIOS and GRUB take to reach the cryptomount prompt. Measured on
 #: this machine at about twenty seconds; the extra ten is for a loaded host.
@@ -226,11 +222,6 @@ def pin_resolver(console: SerialConsole) -> None:
     """
     console.run("printf 'nameserver 1.1.1.1\\nnameserver 8.8.8.8\\n' > /etc/resolv.conf")
 
-
-#: What GRUB and the initramfs say when they want a passphrase. GRUB asks
-#: because /boot is inside the container, the initramfs asks to open the root:
-#: two prompts for one passphrase unless a keyfile is embedded.
-PASSPHRASE_PROMPT = r"[Ee]nter passphrase|Please enter passphrase|password for"
 
 
 def unlock_and_login(


### PR DESCRIPTION
`boot_and_check` waited for `login:` straight after the reboot. A LUKS root and an encrypted ZFS root ask for `install-disk` first and nothing answered, so every encrypted fixture was failed after ten minutes however correct the install was. The BIOS one looked worse still: GRUB unlocks before it reads `grub.cfg`, so its prompt is on the VGA console whatever `GRUB_TERMINAL` says, and the serial log showed no activity at all.

The passphrase and the prompt pattern move to `console.py`. Two copies of `DISK_PASSPHRASE` existed, one per runner, which is how a fixture gets installed with one passphrase and answered with another.

Three scripted consoles — LUKS, encrypted ZFS, BIOS LUKS — assert the passphrase is sent once on the right channel, and a plain layout is sent none.