### PR TITLE
plan: point ZFSBootMenu at the pool the root is on

### DIFF
--- a/gentoo_install/plan/bootloader.py
+++ b/gentoo_install/plan/bootloader.py
@@ -331,7 +331,7 @@ def build(config: InstallConfig) -> list[Operation]:
             InstallSystemdBoot(esp=esp),
         ]
     elif kind is Bootloader.ZFSBOOTMENU and esp is not None and esp_device is not None:
-        pool = _pool_name(config)
+        pool, dataset = _root_pool_and_dataset(config)
         operations += [
             # Without the stub systemd ships behind its `boot` flag,
             # generate-zbm writes loose components and no bootable image.
@@ -343,7 +343,7 @@ def build(config: InstallConfig) -> list[Operation]:
             ),
             InstallZfsBootMenu(
                 pool=pool,
-                dataset=_root_dataset(config, pool),
+                dataset=dataset,
                 esp=esp,
                 esp_device=esp_device,
                 kernel_params=(*unlock_parameters(config), *config.bootloader.kernel_params),
@@ -478,16 +478,23 @@ def _esp_partition(config: InstallConfig) -> DeviceId | None:
     return None
 
 
-def _pool_name(config: InstallConfig) -> str:
-    pools = config.disk.graph.of_type(ZfsPool)
-    return pools[0].name if pools else ""
+def _root_pool_and_dataset(config: InstallConfig) -> tuple[str, str]:
+    """The pool `/` is on and the dataset that holds it, from one graph edge.
 
-
-def _root_dataset(config: InstallConfig, pool: str) -> str:
+    Both were read separately, and the pool was whichever `ZfsPool` came first
+    in the graph: a layout with a data pool beside the root pool had
+    `bootfs=tank/ROOT/gentoo` set on `tank`, a dataset no pool has, and the
+    install stopped at the bootloader with everything else already written.
+    Reordering two equivalent `disk.devices` entries changed the answer.
+    """
     graph = config.disk.graph
     root = graph.nodes.get(config.disk.root)
-    if isinstance(root, Mountpoint):
-        source = graph.nodes.get(root.source)
-        if isinstance(source, ZfsDataset):
-            return f"{pool}/{source.name}"
-    return pool
+    if not isinstance(root, Mountpoint):
+        return "", ""
+    dataset = graph.nodes.get(root.source)
+    if not isinstance(dataset, ZfsDataset):
+        return "", ""
+    pool = graph.nodes.get(dataset.pool)
+    if not isinstance(pool, ZfsPool):
+        return "", ""
+    return pool.name, f"{pool.name}/{dataset.name}"

--- a/tests/unit/test_plan_boot.py
+++ b/tests/unit/test_plan_boot.py
@@ -999,3 +999,42 @@ def test_bootctl_is_not_rebuilt_for_flags_it_already_has() -> None:
     recorder = Recorder()
     merge.apply(recorder)
     assert any("--noreplace" in one for one in recorder.in_target[0])
+
+
+def test_zfsbootmenu_configures_the_pool_the_root_is_on() -> None:
+    """The pool was whichever `ZfsPool` came first in the graph, and the root
+    dataset's leaf name was prefixed to it. A data pool beside the root pool
+    gave `zpool set bootfs=tank/ROOT/gentoo tank` — a dataset no pool has —
+    and the install stopped at the bootloader with everything else written.
+
+    The data pool is placed first here, because that is the order that changed
+    the answer while the layout stayed equivalent.
+    """
+    from gentoo_install.model.device import DeviceId, Existing
+    from gentoo_install.plan import bootloader as plan_bootloader
+    from gentoo_install.plan.bootloader import InstallZfsBootMenu
+
+    one = zfs_installation()
+    beside = [
+        Existing(id=DeviceId("datadisk"), selector="/dev/disk/by-id/virtio-data", wipe=True),
+        ZfsPool(id=DeviceId("tank"), vdevs=(DeviceId("datadisk"),), name="tank"),
+        *one.disk.graph.nodes.values(),
+    ]
+    two = replace(one, disk=replace(one.disk, graph=DeviceGraph.build(beside)))
+
+    installed = [
+        operation
+        for operation in plan_bootloader.build(two)
+        if isinstance(operation, InstallZfsBootMenu)
+    ]
+    assert len(installed) == 1, installed
+    assert installed[0].pool == "zpcala", installed[0].pool
+    assert installed[0].dataset == "zpcala/ROOT/gentoo/root", installed[0].dataset
+    # The same layout with one pool answers the same way, so the fix is not
+    # reading the second entry instead of the first.
+    alone = [
+        operation
+        for operation in plan_bootloader.build(one)
+        if isinstance(operation, InstallZfsBootMenu)
+    ]
+    assert (alone[0].pool, alone[0].dataset) == (installed[0].pool, installed[0].dataset)


### PR DESCRIPTION
`_pool_name` returned the first `ZfsPool` in graph order and `_root_dataset` prefixed that name to the root dataset's own. A layout with a data pool beside the root pool set `bootfs=tank/ROOT/gentoo` on `tank` — a dataset no pool has — and the install stopped at the bootloader with everything else already written. Reordering two equivalent `disk.devices` entries changed which pool was configured.

Both values now come from one edge: `disk.root` to its `Mountpoint`, to its `ZfsDataset`, to that dataset's `ZfsPool`.

Every ZFSBootMenu fixture has one pool, which is why nothing caught it; the test places a second pool first.