### PR TITLE
model: refuse a remote unlock gateway of another family

### DIFF
--- a/gentoo_install/model/validate.py
+++ b/gentoo_install/model/validate.py
@@ -141,6 +141,15 @@ def _unlock_problems(config: InstallConfig) -> list[str]:
             ipaddress.ip_interface(value) if named == "address" else ipaddress.ip_address(value)
         except ValueError:
             problems.append(f"the remote unlock {named} {value!r} is not an address")
+    here, there = _family_of(unlock.address), _family_of(unlock.gateway)
+    if here and there and here != there:
+        # Both go into one dracut `ip=` stanza, so an IPv4 client with an IPv6
+        # gateway is a static interface that routes nowhere and the machine
+        # waiting for its passphrase can only be reached from the console.
+        problems.append(
+            f"the remote unlock address {unlock.address} is IPv{here} and its gateway "
+            f"{unlock.gateway} is IPv{there}, so the initramfs has no route"
+        )
     return problems
 
 

--- a/tests/unit/test_validate.py
+++ b/tests/unit/test_validate.py
@@ -246,3 +246,54 @@ def test_the_same_index_on_two_tables_is_a_working_layout() -> None:
         Mountpoint(id=i("mnt-home"), source=i("homefs"), path=PurePosixPath("/home")),
     ]
     validate(config([*ext4_on_gpt(), *second]))
+@pytest.mark.parametrize(
+    ("address", "gateway"),
+    [
+        pytest.param("192.0.2.10/24", "2001:db8::1", id="v4-address-v6-gateway"),
+        pytest.param("2001:db8::10/64", "192.0.2.1", id="v6-address-v4-gateway"),
+    ],
+)
+def test_a_remote_unlock_gateway_of_another_family_is_refused(
+    address: str, gateway: str
+) -> None:
+    """Both go into one dracut `ip=` stanza, so the initramfs is configured
+    with a client of one family and a gateway of the other and routes nowhere.
+    The machine waiting for its passphrase is then reachable only from the
+    console, which is the one thing remote unlock exists to avoid."""
+    from gentoo_install.model.config import KernelConfig, RemoteUnlock
+
+    installation = replace(
+        config(encrypted_root()),
+        system=replace(config().system, authorized_keys=("ssh-ed25519 AAAA test",)),
+        kernel=replace(
+            KernelConfig(),
+            remote_unlock=RemoteUnlock(
+                enabled=True, port=222, interface="eth0", address=address, gateway=gateway
+            ),
+        ),
+    )
+    with pytest.raises(ValidationFailed):
+        validate(installation)
+
+
+def test_a_remote_unlock_pair_of_one_family_is_a_working_configuration() -> None:
+    """The fixture ships an IPv4 pair, and an IPv6 pair is the same shape."""
+    from gentoo_install.model.config import KernelConfig, RemoteUnlock
+
+    for address, gateway in (("192.0.2.10/24", "192.0.2.1"), ("2001:db8::10/64", "2001:db8::1")):
+        validate(
+            replace(
+                config(encrypted_root()),
+                system=replace(config().system, authorized_keys=("ssh-ed25519 AAAA test",)),
+                kernel=replace(
+                    KernelConfig(),
+                    remote_unlock=RemoteUnlock(
+                        enabled=True,
+                        port=222,
+                        interface="eth0",
+                        address=address,
+                        gateway=gateway,
+                    ),
+                ),
+            )
+        )


### PR DESCRIPTION
`RemoteUnlock.address` and `gateway` were each checked for being an address and never against each other. Both go into one dracut `ip=` stanza — `ip=192.0.2.10::[2001:db8::1]:255.255.255.0::eth0:none` — so the initramfs comes up with a client of one family and a gateway of the other and routes nowhere. The machine waiting for its passphrase is then reachable only from the console, which is what remote unlock exists to avoid.

The installed system's own addresses already had this check; this is the same rule for the initramfs.