### PR TITLE
plan: re-establish storage a resumed run cannot inherit

### DIFF
--- a/gentoo_install/plan/disk.py
+++ b/gentoo_install/plan/disk.py
@@ -301,7 +301,7 @@ class CreateLuks(Operation):
     name: str
 
     def describe(self) -> str:
-        return f"format {self.backing} as LUKS2 and open it as /dev/mapper/{self.name}"
+        return f"format {self.backing} as LUKS2"
 
     def apply(self, context: Context) -> None:
         path = context.device_path(self.backing)
@@ -319,7 +319,95 @@ class CreateLuks(Operation):
                 path,
             ]
         )
-        context.run(["cryptsetup", "open", "--type", "luks2", "--key-file", key, path, self.name])
+
+
+@dataclass(frozen=True, kw_only=True)
+class OpenLuks(Operation):
+    """Open a container that already exists, or leave an open one alone.
+
+    Separate from `CreateLuks` because the two outlive different things: the
+    header is on the disk and a resumed run must not write another, while the
+    mapping is process state that a failure cleanup or a reboot takes away.
+    Skipping both left `/dev/mapper/root` absent and every later stage
+    addressing a target that was never assembled.
+    """
+
+    stage: Stage = Stage.ARRAY
+    container: DeviceId
+    backing: DeviceId
+    name: str
+
+    def describe(self) -> str:
+        return f"open {self.backing} as /dev/mapper/{self.name}"
+
+    @property
+    def survives_a_reboot(self) -> bool:
+        return False
+
+    def apply(self, context: Context) -> None:
+        # `dmsetup ls` exits 0 with `No devices found` when there are none, so
+        # its output answers without a second exit code to read.
+        listed = context.run(["dmsetup", "ls", "--target", "crypt"])
+        if any(line.split() and line.split()[0] == self.name for line in listed.splitlines()):
+            return
+        context.run(
+            [
+                "cryptsetup", "open",
+                "--type", "luks2",
+                "--key-file", str(context.key_file(self.container)),
+                context.device_path(self.backing),
+                self.name,
+            ]
+        )
+
+
+@dataclass(frozen=True, kw_only=True)
+class AssembleMdRaid(Operation):
+    """Assemble an array that already exists, or leave a running one alone."""
+
+    stage: Stage = Stage.ARRAY
+    array: DeviceId
+    members: tuple[DeviceId, ...]
+    name: str
+
+    def describe(self) -> str:
+        return f"assemble /dev/md/{self.name} from {', '.join(self.members)}"
+
+    @property
+    def survives_a_reboot(self) -> bool:
+        return False
+
+    def apply(self, context: Context) -> None:
+        listed = context.run(["mdadm", "--detail", "--scan"])
+        if f"/dev/md/{self.name}" in listed:
+            return
+        context.run(
+            [
+                "mdadm",
+                "--assemble",
+                f"/dev/md/{self.name}",
+                *(context.device_path(member) for member in self.members),
+            ]
+        )
+
+
+@dataclass(frozen=True, kw_only=True)
+class ActivateVolumeGroup(Operation):
+    """Bring the group's volumes up. `vgchange` on an active group is a no-op."""
+
+    stage: Stage = Stage.ARRAY
+    group: DeviceId
+    name: str
+
+    def describe(self) -> str:
+        return f"activate volume group {self.name}"
+
+    @property
+    def survives_a_reboot(self) -> bool:
+        return False
+
+    def apply(self, context: Context) -> None:
+        context.run(["vgchange", "--activate", "y", self.name])
 
 
 @dataclass(frozen=True, kw_only=True)
@@ -496,6 +584,35 @@ class CreateZpool(Operation):
 
 
 @dataclass(frozen=True, kw_only=True)
+class ImportZpool(Operation):
+    """Import a pool that already exists, or leave an imported one alone.
+
+    The failure cleanup exports the pool, so a resumed run that skipped
+    `CreateZpool` had no pool at all and every dataset mount below it
+    addressed the live medium's own filesystem.
+    """
+
+    stage: Stage = Stage.ZFS
+    pool: DeviceId
+    name: str
+
+    def describe(self) -> str:
+        return f"import zpool {self.name} under {self.pool}"
+
+    @property
+    def survives_a_reboot(self) -> bool:
+        return False
+
+    def apply(self, context: Context) -> None:
+        # Listed rather than imported blindly: `zpool import` on a pool that
+        # is already imported fails, and its failure is not an answer here.
+        listed = context.run(["zpool", "list", "-H", "-o", "name"])
+        if self.name in listed.split():
+            return
+        context.run(["zpool", "import", "-N", "-f", "-R", str(context.target), self.name])
+
+
+@dataclass(frozen=True, kw_only=True)
 class CreateDataset(Operation):
     stage: Stage = Stage.ZFS
     dataset: DeviceId
@@ -566,6 +683,10 @@ class MountZfsDataset(Operation):
     mountpoint: DeviceId
     name: str
     path: PurePosixPath
+
+    @property
+    def survives_a_reboot(self) -> bool:
+        return False
 
     def describe(self) -> str:
         return f"mount dataset {self.name} at {self.path}"
@@ -755,12 +876,19 @@ def _operations_for(graph: DeviceGraph, node: Node) -> list[Operation]:
                 level=node.level,
                 metadata=node.metadata,
                 name=node.name,
-            )
+            ),
+            AssembleMdRaid(array=node.id, members=node.members, name=node.name),
         ]
     if isinstance(node, Luks):
-        return [CreateLuks(container=node.id, backing=node.backing, name=node.name)]
+        return [
+            CreateLuks(container=node.id, backing=node.backing, name=node.name),
+            OpenLuks(container=node.id, backing=node.backing, name=node.name),
+        ]
     if isinstance(node, VolumeGroup):
-        return [CreateVolumeGroup(group=node.id, members=node.members, name=node.name)]
+        return [
+            CreateVolumeGroup(group=node.id, members=node.members, name=node.name),
+            ActivateVolumeGroup(group=node.id, name=node.name),
+        ]
     if isinstance(node, LogicalVolume):
         group = _expect(graph, node.group, VolumeGroup)
         return [
@@ -790,7 +918,8 @@ def _operations_for(graph: DeviceGraph, node: Node) -> list[Operation]:
                 name=node.name,
                 topology=node.topology,
                 encrypted=node.encrypted,
-            )
+            ),
+            ImportZpool(pool=node.id, name=node.name),
         ]
     if isinstance(node, ZfsDataset):
         pool = _expect(graph, node.pool, ZfsPool)

--- a/gentoo_install/plan/portage.py
+++ b/gentoo_install/plan/portage.py
@@ -119,6 +119,13 @@ class PrepareChroot(Operation):
 
     stage: Stage = Stage.CHROOT
 
+    @property
+    def survives_a_reboot(self) -> bool:
+        # The failure cleanup unmounts the target recursively, this included,
+        # so a resumed run that skipped it ran every chroot command against
+        # the live medium's own /proc, /sys and /dev.
+        return False
+
     def describe(self) -> str:
         return "mount proc, sys, dev and run into the target and copy resolv.conf"
 

--- a/tests/golden/btrfs-luks.txt
+++ b/tests/golden/btrfs-luks.txt
@@ -7,7 +7,8 @@
   reread the partition table of disk and wait for its nodes
 
 [array]
-  format cryptroot as LUKS2 and open it as /dev/mapper/root
+  format cryptroot as LUKS2
+  open cryptroot as /dev/mapper/root
 
 [format]
   make a vfat filesystem on esp as espfs labelled ESP

--- a/tests/golden/vm-bios-luks.txt
+++ b/tests/golden/vm-bios-luks.txt
@@ -7,7 +7,8 @@
   reread the partition table of disk and wait for its nodes
 
 [array]
-  format rootpart as LUKS2 and open it as /dev/mapper/root
+  format rootpart as LUKS2
+  open rootpart as /dev/mapper/root
 
 [format]
   make swap on swappart as swap

--- a/tests/golden/vm-luks.txt
+++ b/tests/golden/vm-luks.txt
@@ -7,7 +7,8 @@
   reread the partition table of disk and wait for its nodes
 
 [array]
-  format cryptroot as LUKS2 and open it as /dev/mapper/root
+  format cryptroot as LUKS2
+  open cryptroot as /dev/mapper/root
 
 [format]
   make a vfat filesystem on esp as espfs labelled ESP

--- a/tests/golden/vm-lvm.txt
+++ b/tests/golden/vm-lvm.txt
@@ -8,6 +8,7 @@
 
 [array]
   create volume group vg0 as vg from pv
+  activate volume group vg0
   create logical volume vg0/root as lv-root: 16GiB
   create logical volume vg0/home as lv-home: the rest of the group
 

--- a/tests/golden/vm-mdraid.txt
+++ b/tests/golden/vm-mdraid.txt
@@ -12,6 +12,7 @@
 
 [array]
   create raid1 array /dev/md/root as array from member0, member1, metadata 1.2
+  assemble /dev/md/root from member0, member1
 
 [format]
   make a vfat filesystem on esp as espfs labelled ESP

--- a/tests/golden/vm-raidz.txt
+++ b/tests/golden/vm-raidz.txt
@@ -19,6 +19,7 @@
 
 [zfs]
   create zpool rpool as pool from poolpart, poolpart2, poolpart3 as a raidz1
+  import zpool rpool under pool
   create dataset rpool/ROOT/gentoo as ds-root, mountpoint /
 
 [mount]

--- a/tests/golden/vm-unlock.txt
+++ b/tests/golden/vm-unlock.txt
@@ -7,7 +7,8 @@
   reread the partition table of disk and wait for its nodes
 
 [array]
-  format cryptroot as LUKS2 and open it as /dev/mapper/root
+  format cryptroot as LUKS2
+  open cryptroot as /dev/mapper/root
 
 [format]
   make a vfat filesystem on esp as espfs labelled ESP

--- a/tests/golden/vm-zfs-encrypted.txt
+++ b/tests/golden/vm-zfs-encrypted.txt
@@ -11,6 +11,7 @@
 
 [zfs]
   create zpool rpool as pool from poolpart as a stripe with native encryption
+  import zpool rpool under pool
   create dataset rpool/ROOT/gentoo as ds-root, mountpoint /
 
 [mount]

--- a/tests/golden/vm-zfs-mirror.txt
+++ b/tests/golden/vm-zfs-mirror.txt
@@ -15,6 +15,7 @@
 
 [zfs]
   create zpool rpool as pool from poolpart, poolpart2 as a mirror
+  import zpool rpool under pool
   create dataset rpool/ROOT/gentoo as ds-root, mountpoint /
 
 [mount]

--- a/tests/golden/vm-zfs.txt
+++ b/tests/golden/vm-zfs.txt
@@ -11,6 +11,7 @@
 
 [zfs]
   create zpool rpool as pool from poolpart as a stripe
+  import zpool rpool under pool
   create dataset rpool/ROOT/gentoo as ds-root, mountpoint /
 
 [mount]

--- a/tests/golden/zfs-zbm.txt
+++ b/tests/golden/zfs-zbm.txt
@@ -11,6 +11,7 @@
 
 [zfs]
   create zpool zpcala as pool from poolpart as a stripe with native encryption
+  import zpool zpcala under pool
   create dataset zpcala/ROOT/gentoo/home as ds-home, mountpoint /home
   create dataset zpcala/ROOT/gentoo/root as ds-root, mountpoint /
 

--- a/tests/unit/test_resume.py
+++ b/tests/unit/test_resume.py
@@ -7,6 +7,8 @@ Starting again from the beginning throws all of that away.
 
 from __future__ import annotations
 
+import pytest
+
 from dataclasses import dataclass
 from pathlib import Path, PurePosixPath
 
@@ -284,3 +286,54 @@ def test_an_emerge_after_a_resume_still_builds_from_source(tmp_path: Path) -> No
     Emerge(packages=("app-editors/nano",), summary="editor", binary_packages=True).apply(recorder)
     merged = " ".join(" ".join(one) for one in recorder.in_target)
     assert "--usepkg=n" in merged and "--getbinpkg=n" in merged, merged
+
+
+#: Every fixture with storage a reboot takes down, and the operation that has
+#: to put it back. One table, so a storage kind cannot be added with a
+#: creation step and no activation step.
+REESTABLISHED: tuple[tuple[str, str], ...] = (
+    ("vm-luks", "OpenLuks"),
+    ("vm-mdraid", "AssembleMdRaid"),
+    ("vm-lvm", "ActivateVolumeGroup"),
+    ("vm-zfs", "ImportZpool"),
+)
+
+
+@pytest.mark.parametrize(("fixture", "operation"), REESTABLISHED, ids=lambda one: str(one))
+def test_a_resumed_run_re_establishes_what_a_reboot_takes_away(
+    fixture: str, operation: str
+) -> None:
+    """The failure cleanup unmounts the target and exports the pool, so a
+    resume that skipped the creation had no container, no array, no volume
+    group and no pool: `/mnt/gentoo` was the live medium's own directory and
+    every chroot command ran against the installing system.
+
+    The creation stays skippable — it wrote a header the disk still has — and
+    the activation beside it does not.
+    """
+    from pathlib import Path
+
+    from gentoo_install.data import load_catalog
+    from gentoo_install.exec.config import load
+    from gentoo_install.plan import build as plan
+
+    operations = plan.build(load(Path("tests/fixtures") / f"{fixture}.toml"), load_catalog())
+    by_name = {type(one).__name__: one for one in operations}
+    assert operation in by_name, sorted(by_name)
+    assert by_name[operation].survives_a_reboot is False
+    assert by_name["PrepareChroot"].survives_a_reboot is False
+
+
+def test_every_kind_of_storage_that_needs_activation_has_a_fixture_here() -> None:
+    """An activation operation with no fixture in the table above is one
+    nothing proves, and it reads as covered."""
+    from gentoo_install.plan import disk as plan_disk
+
+    named = {name for _, name in REESTABLISHED}
+    defined = {
+        name
+        for name in dir(plan_disk)
+        if name.startswith(("Open", "Assemble", "Activate", "Import"))
+        and isinstance(getattr(plan_disk, name), type)
+    }
+    assert defined - named == set(), defined - named


### PR DESCRIPTION
Every creation was journal-skippable and nothing else brought the storage back. The failure cleanup unmounts the target recursively and exports the pool, so `--resume` skipped `CreateZpool`, `MountZfsDataset` and `PrepareChroot`, `/mnt/gentoo` was the live medium's own directory, and each chroot command ran against the installing system.

Each storage kind is now two operations. The creation wrote a header the disk still has and stays skippable; the activation beside it never is, and is idempotent — `dmsetup ls`, `mdadm --detail --scan` and `zpool list` are read for what is already up, and `vgchange --activate y` is a no-op on an active group. `MountZfsDataset` and `PrepareChroot` join `Mount` in never being skipped.

Unverified: this needs `tests/vm/run.py --interrupt`, which is queued behind the round now running.