### PR TITLE
tests: make three checks able to fail

### DIFF
--- a/gentoo_install/plan/disk.py
+++ b/gentoo_install/plan/disk.py
@@ -712,12 +712,15 @@ def _teardown(graph: DeviceGraph) -> tuple[tuple[str, ...], ...]:
 
 
 def _disks_with_partitions(graph: DeviceGraph) -> tuple[DeviceId, ...]:
-    disks: list[DeviceId] = []
+    """Sorted, because nothing orders one disk's probe against another's and
+    graph order made the plan depend on how the devices happen to be written
+    in the configuration file."""
+    disks: set[DeviceId] = set()
     for partition in graph.of_type(Partition):
         table = graph[partition.table]
-        if isinstance(table, PartitionTable) and table.disk not in disks:
-            disks.append(table.disk)
-    return tuple(disks)
+        if isinstance(table, PartitionTable):
+            disks.add(table.disk)
+    return tuple(sorted(disks))
 
 
 def _operations_for(graph: DeviceGraph, node: Node) -> list[Operation]:

--- a/gentoo_install/plan/kernel.py
+++ b/gentoo_install/plan/kernel.py
@@ -812,8 +812,13 @@ def storage_packages(config: InstallConfig) -> tuple[str, ...]:
         tool = STACK_PACKAGES.get(module)
         if tool is not None and tool.atom not in wanted:
             wanted.append(tool.atom)
-    for filesystem in graph.of_type(Filesystem):
-        package = FILESYSTEM_PACKAGES[filesystem.kind]
+    # Sorted, unlike the dracut modules above whose order is a dependency
+    # order: these come from a set of filesystem kinds and reading them in
+    # graph order made the plan depend on how the devices happen to be written
+    # in the configuration file.
+    for package in sorted(
+        {FILESYSTEM_PACKAGES[one.kind] for one in graph.of_type(Filesystem)}
+    ):
         if package not in wanted:
             wanted.append(package)
     return tuple(wanted)

--- a/gentoo_install/plan/system.py
+++ b/gentoo_install/plan/system.py
@@ -1018,7 +1018,12 @@ def _zfs_services(config: InstallConfig) -> list[Operation]:
 def fstab_entries(config: InstallConfig) -> tuple[FstabEntry, ...]:
     graph = config.disk.graph
     entries: list[FstabEntry] = []
-    for mount in sorted(graph.of_type(Mountpoint), key=lambda node: len(node.path.parts)):
+    # Depth first so a nested mount follows its parent, then the path itself:
+    # `/efi` and `/home` are the same depth and reading them in graph order
+    # made fstab depend on how the devices happen to be written.
+    for mount in sorted(
+        graph.of_type(Mountpoint), key=lambda node: (len(node.path.parts), str(node.path))
+    ):
         source = graph[mount.source]
         if isinstance(source, ZfsDataset):
             # A dataset carries its mountpoint property; fstab would fight it.

--- a/tests/golden/btrfs-luks.txt
+++ b/tests/golden/btrfs-luks.txt
@@ -53,7 +53,7 @@
   set the console keymap to us and its font to default8x16
   set the hostname to gig
   give the target its own machine id
-  write /etc/fstab with entries for /, /home, /efi
+  write /etc/fstab with entries for /, /efi, /home
   treat the hardware clock as UTC
   write /etc/crypttab for root
   create user zakk in users, wheel, audio, video, render, usb, input with no password

--- a/tests/golden/test_golden.py
+++ b/tests/golden/test_golden.py
@@ -41,5 +41,26 @@ def test_every_fixture_has_a_golden_file() -> None:
 
 
 @pytest.mark.parametrize("name", fixtures())
-def test_planning_the_same_configuration_twice_gives_the_same_text(name: str) -> None:
-    assert plan_text(name) == plan_text(name)
+def test_the_order_devices_are_written_in_does_not_change_the_plan(name: str) -> None:
+    """Two equivalent inputs, not one input twice: comparing `plan_text(name)`
+    with itself passes for any deterministic implementation, including one
+    that returns an empty plan, and it holds nothing that could differ.
+
+    The device list's order is what an operator changes by editing a
+    configuration file, and the plan is derived from the graph rather than
+    from that order, so reversing it has to answer the same text.
+    """
+    from dataclasses import replace
+
+    from gentoo_install.model.device import DeviceGraph
+
+    installation = load(FIXTURES / f"{name}.toml")
+    backwards = replace(
+        installation,
+        disk=replace(
+            installation.disk,
+            graph=DeviceGraph.build(list(reversed(list(installation.disk.graph.nodes.values())))),
+        ),
+    )
+    catalog = load_catalog()
+    assert render(build(backwards, catalog)) == render(build(installation, catalog))

--- a/tests/golden/vm-btrfs.txt
+++ b/tests/golden/vm-btrfs.txt
@@ -41,7 +41,7 @@
   set the console keymap to us and its font to default8x16
   set the hostname to btrfsbox
   give the target its own machine id
-  write /etc/fstab with entries for /, /home, /efi
+  write /etc/fstab with entries for /, /efi, /home
   treat the hardware clock as UTC
   set the root password
   configure the wired interface for DHCP

--- a/tests/golden/vm-luks.txt
+++ b/tests/golden/vm-luks.txt
@@ -45,7 +45,7 @@
   set the console keymap to us and its font to default8x16
   set the hostname to cryptbox
   give the target its own machine id
-  write /etc/fstab with entries for /, /home, /efi
+  write /etc/fstab with entries for /, /efi, /home
   treat the hardware clock as UTC
   write /etc/crypttab for root
   set the root password

--- a/tests/golden/vm-unlock.txt
+++ b/tests/golden/vm-unlock.txt
@@ -45,7 +45,7 @@
   set the console keymap to us and its font to default8x16
   set the hostname to unlockbox
   give the target its own machine id
-  write /etc/fstab with entries for /, /home, /efi
+  write /etc/fstab with entries for /, /efi, /home
   treat the hardware clock as UTC
   write /etc/crypttab for root
   authorise 1 ssh key(s) for root

--- a/tests/unit/test_harness.py
+++ b/tests/unit/test_harness.py
@@ -24,6 +24,14 @@ def test_a_run_that_collected_no_exit_code_is_not_called_a_failure() -> None:
     assert verdict({}, None) == 0
 
 
+def test_a_run_that_installed_and_collected_no_exit_code_is_a_failure() -> None:
+    """The same `verdict` serves both modes, so an install whose archive lost
+    `install.rc` — or whose installer was killed before writing one — reported
+    success on a run that proves nothing finished."""
+    assert verdict({}, None, installed=True) == 1
+    assert verdict({"install.rc": b"0\n"}, None, installed=True) == 0
+
+
 def test_every_configuration_the_campaign_names_exists() -> None:
     """A stage naming a fixture that was renamed fails half an hour in, after
     the medium has booted, rather than at the first line."""

--- a/tests/unit/test_tui_app.py
+++ b/tests/unit/test_tui_app.py
@@ -1771,7 +1771,15 @@ def test_reopening_a_setting_and_accepting_keeps_what_it_held() -> None:
     # `Cron` flips where it stands, `Drive` reads `context.choice` rather than
     # the configuration, and `Bootloader` cannot keep a kind the layout forbids.
     flipped = {"Cron", "Drive", "Bootloader"}
+    # Four screens enter is not an answer to, named rather than caught: an
+    # `except Exception: continue` around the call meant every screen could
+    # raise on enter and this test still passed with an empty list.
+    # `Mirrors` and `SSH public keys` toggle entries and leave on cancel,
+    # `Partitions` is a table editor, and `Confirm erasing the drive` wants
+    # the disk name typed.
+    not_an_answer = {"Mirrors", "Partitions", "SSH public keys", "Confirm erasing the drive"}
     wrong: list[str] = []
+    opened: list[str] = []
     reachable = [
         one
         for group in settings.SETTINGS
@@ -1779,15 +1787,16 @@ def test_reopening_a_setting_and_accepting_keeps_what_it_held() -> None:
         if one.edit is not None and not one.rows
     ]
     for setting in reachable:
-        if setting.label in flipped:
+        if setting.label in flipped or setting.label in not_an_answer:
             continue
         edit = setting.edit
         assert edit is not None
-        screen = FakeScreen(keys=["\n"], lines=40, columns=120)
-        try:
-            answer = edit(screen, held, at)
-        except Exception:  # a screen this configuration cannot open
-            continue
+        # Enough for the longest of these: `User account` asks for a name and
+        # a password twice. A screen that wants more asks for a key the test
+        # did not supply and fails, which is what the caught exception hid.
+        screen = FakeScreen(keys=["\n"] * 8, lines=40, columns=120)
+        answer = edit(screen, held, at)
+        opened.append(setting.label)
         if not answer.chosen:
             continue
         # The row's own value, not the whole configuration: the locale screen
@@ -1796,6 +1805,7 @@ def test_reopening_a_setting_and_accepting_keeps_what_it_held() -> None:
         if setting.value(after, at) != setting.value(held, at):
             wrong.append(setting.label)
     assert not wrong, wrong
+    assert len(opened) > 5, opened
 
 
 def test_confirming_one_disk_does_not_authorise_a_second() -> None:

--- a/tests/vm/run.py
+++ b/tests/vm/run.py
@@ -535,7 +535,7 @@ def _perform(args: argparse.Namespace, medium: Medium, workdir: Path) -> int:
                 probe(console)
             power_off(console, vm)
 
-    return report(result_disk, keep=args.keep)
+    return report(result_disk, keep=args.keep, installed=bool(args.install and not args.dry_run))
 
 
 def power_off(console: SerialConsole, vm: Vm) -> None:
@@ -588,13 +588,13 @@ def _discard(targets: Sequence[Path], *, keep: bool) -> None:
 
 
 def report(
-    result_disk: Path, *, keep: bool, assertions: Path | None = None
+    result_disk: Path, *, keep: bool, assertions: Path | None = None, installed: bool = False
 ) -> int:
     results = read_disk(result_disk)
     for name in sorted(results):
         print(f"--- {name} ---")
         print(results[name].decode("utf-8", "replace").rstrip())
-    code = verdict(results, assertions)
+    code = verdict(results, assertions, installed=installed)
     if not keep:
         result_disk.unlink(missing_ok=True)
     return code
@@ -651,7 +651,9 @@ def _from_config(config: Path) -> list[tuple[str, str]]:
     return expected
 
 
-def verdict(results: dict[str, bytes], assertions: Path | None) -> int:
+def verdict(
+    results: dict[str, bytes], assertions: Path | None, *, installed: bool = False
+) -> int:
     """Turn everything the run left behind into one exit code."""
     code = check_expected(results, assertions) if assertions is not None else 0
     installer = results.get("install.rc", b"").decode("utf-8", "replace").strip()
@@ -659,6 +661,13 @@ def verdict(results: dict[str, bytes], assertions: Path | None) -> int:
     # a run that stopped at the bootloader printed its failure and exited 0.
     if installer not in ("", "0"):
         print(f"FAIL the installer exited {installer}", file=sys.stderr)
+        code = 1
+    if installed and installer == "":
+        # An absent code is an answer on a run that installed: the installer
+        # was killed before it wrote one, or the archive lost it. Either way
+        # nothing here says the install finished, and reporting success is how
+        # a run that never completed became a green verdict.
+        print("FAIL the run installed and collected no install.rc", file=sys.stderr)
         code = 1
     return code
 


### PR DESCRIPTION
Three checks passed whatever the code did.

`verdict` serves the probe and the install modes alike, so a run whose archive lost `install.rc` — or whose installer was killed before writing one — reported success. It now fails when a run that installed collected no exit code.

`test_reopening_a_setting_and_accepting_keeps_what_it_held` wrapped every screen call in `except Exception: continue`. Every screen could raise on enter and the list stayed empty. The four screens enter is not an answer to are named with the reason instead, and a deliberately broken `timezone_screen` now fails it.

`test_planning_the_same_configuration_twice_gives_the_same_text` compared a value with itself. Reversing the device list instead found three places reading graph order rather than the graph: the filesystem tool list, the partition table probes, and fstab entries of equal depth — `/efi` and `/home` swapped places in a file whose order decides mount order.