### PR TITLE
tests: refuse a run whose firmware contradicts its fixture

### DIFF
--- a/tests/unit/test_harness.py
+++ b/tests/unit/test_harness.py
@@ -333,3 +333,26 @@ def test_the_guest_offers_a_monitor_socket() -> None:
     argv = Vm(spec)._argv()
     assert "-monitor" in argv
     assert "none" not in argv[argv.index("-monitor") + 1]
+
+
+def test_the_campaign_gives_every_run_the_firmware_its_fixture_installs_for() -> None:
+    """A BIOS layout booted with UEFI firmware reaches the EDK2 shell, and the
+    run spends forty minutes installing before it fails at `never matched
+    'login:'` with `Shell>` in the log."""
+    from pathlib import Path
+
+    from gentoo_install.exec.config import load
+    from tests.vm.campaign import STAGES
+
+    for runs in STAGES.values():
+        for run in runs:
+            wanted = load(Path("tests") / run.config).bootloader.firmware.value
+            assert run.firmware == wanted, f"{run.config} installs for {wanted}"
+
+
+def test_a_run_whose_firmware_contradicts_its_fixture_is_refused() -> None:
+    """Refused before the medium boots, not after the install."""
+    from tests.vm.run import main
+
+    assert main(["--install", "fixtures/vm-bios.toml", "--firmware", "uefi"]) == 1
+    assert main(["--install", "fixtures/vm-binpkg.toml", "--firmware", "bios"]) == 1

--- a/tests/vm/run.py
+++ b/tests/vm/run.py
@@ -437,6 +437,18 @@ def main(argv: list[str] | None = None) -> int:
     if args.boot_installed and not args.install:
         print("--boot-installed needs the same --install argument as the run it checks", file=sys.stderr)
         return 1
+    if args.install:
+        wanted = load(REPOSITORY / "tests" / args.install).bootloader.firmware.value
+        if wanted != args.firmware:
+            # Refused here rather than after the install: a BIOS layout booted
+            # with UEFI firmware reaches the EDK2 shell, and the run spends
+            # forty minutes installing before it fails at `never matched
+            # 'login:'` with a `Shell>` prompt in the log.
+            print(
+                f"{args.install} installs for {wanted} and --firmware says {args.firmware}",
+                file=sys.stderr,
+            )
+            return 1
     variant = Path(args.install).stem if args.install else "probe"
     workdir = WORKROOT / f"{medium.name}-{args.firmware}-{variant}"
     workdir.mkdir(parents=True, exist_ok=True)


### PR DESCRIPTION
`--firmware` defaults to uefi and the fixture already states which it installs for. A BIOS layout booted with UEFI firmware reaches the EDK2 shell: the run installs for forty minutes and then fails at `never matched 'login:'` with a `Shell>` prompt in the log, which reads like an install defect and is not one. Measured today on `vm-bios.toml`.

Refused before the medium boots. A second test asserts every `Run` in `campaign.py` already names the firmware its fixture installs for, so the pairing cannot drift.