### PR TITLE
tests: cover the four paths reviewed5 found untested

### DIFF
--- a/tests/unit/test_exec.py
+++ b/tests/unit/test_exec.py
@@ -1381,3 +1381,101 @@ def test_an_empty_zoneinfo_tree_falls_back_too(tmp_path: Path) -> None:
     assert carried[0] == "UTC"
     assert all("/" in one for one in carried[1:])
     assert len(set(carried)) == len(carried), "no name twice"
+
+
+#: What `mdadm --detail --export` prints for a metadata 1.2 RAID1, captured on
+#: a guest of the official minimal medium on 2026-08-10. Kept whole rather than
+#: trimmed to the one line read: the parser has to find `MD_METADATA` among the
+#: `MD_DEVICE_dev_vda_ROLE` lines that follow it.
+MDADM_EXPORT: str = """MD_LEVEL=raid1
+MD_DEVICES=2
+MD_METADATA=1.2
+MD_UUID=ebc6c76d:09e453bb:dea4ce63:8df2da01
+MD_DEVNAME=sample
+MD_RESHAPE_ACTIVE=False
+MD_NAME=livecd:sample
+MD_DEVICE_dev_vda_ROLE=0
+MD_DEVICE_dev_vda_DEV=/dev/vda
+MD_DEVICE_dev_vdb_ROLE=1
+MD_DEVICE_dev_vdb_DEV=/dev/vdb
+"""
+
+#: What it prints for something that is not an array. The runner merges stderr
+#: into stdout, so this text arrives on stdout; it carries no `MD_METADATA`
+#: line, which is what makes the answer empty.
+MDADM_NOT_AN_ARRAY: str = "mdadm: /dev/vda does not appear to be an md device\n"
+
+
+def _probe_answering(tmp_path: Path, stdout: str, returncode: int) -> Probe:
+    class Answering(Runner):
+        def run(
+            self,
+            argv: Sequence[str],
+            *,
+            check: bool = True,
+            input_text: str | None = None,
+            timeout: float | None = None,
+        ) -> Result:
+            said = stdout if argv[0] == "mdadm" else ""
+            code = returncode if argv[0] == "mdadm" else 0
+            return Result(argv=tuple(argv), returncode=code, stdout=said, stderr="", seconds=0.0)
+
+    return Probe(runner=Answering(log=lambda line: None), work=tmp_path)
+
+
+def test_the_metadata_of_a_real_array_is_read_from_what_mdadm_prints(
+    tmp_path: Path,
+) -> None:
+    """Every test built `Existing(mdraid_metadata="1.2")` by hand, so the parse
+    and the exit-code check had never run. A reused RAID1 esp whose superblock
+    sits at the start meets no compatibility rule when this answers empty, and
+    firmware cannot read such a member."""
+    read = _probe_answering(tmp_path, MDADM_EXPORT, 0)
+    assert read.mdraid_metadata("/dev/md/sample") == "1.2"
+
+    # Not an array: nothing in what it printed names a metadata version.
+    plain = _probe_answering(tmp_path, MDADM_NOT_AN_ARRAY, 1)
+    assert plain.mdraid_metadata("/dev/vda") == ""
+
+
+def test_a_probed_array_reaches_the_rule_that_refuses_it(tmp_path: Path) -> None:
+    """`with_probed_facts` had no test at all, so the graph rebuild between the
+    probe and the validator was unexercised."""
+    from pathlib import PurePosixPath
+
+    from gentoo_install.exec.probe import with_probed_facts
+    from gentoo_install.model import compat
+    from gentoo_install.model.config import DiskConfig
+    from gentoo_install.model.device import (
+        DeviceGraph,
+        DeviceId,
+        Filesystem,
+        FilesystemType,
+        Mountpoint,
+    )
+
+    nodes = [
+        Existing(id=DeviceId("array"), selector="/dev/md/esp", wipe=False),
+        Filesystem(
+            id=DeviceId("espfs"),
+            device=DeviceId("array"),
+            kind=FilesystemType.VFAT,
+            create=False,
+        ),
+        Mountpoint(id=DeviceId("mnt-esp"), source=DeviceId("espfs"), path=PurePosixPath("/efi")),
+    ]
+    before = replace(
+        config(), disk=DiskConfig(graph=DeviceGraph.build(nodes), root=DeviceId("mnt-esp"))
+    )
+    assert not [one.mdraid_metadata for one in before.disk.graph.of_type(Existing) if one.mdraid_metadata]
+
+    after = with_probed_facts(before, _probe_answering(tmp_path, MDADM_EXPORT, 0))
+    said = [one.mdraid_metadata for one in after.disk.graph.of_type(Existing)]
+    assert said == ["1.2"], said
+    assert compat.Trait.ESP_MDRAID_SUPERBLOCK_AT_START in compat.traits_of(after)
+
+    # 1.0 keeps the superblock at the end, which firmware can read past.
+    older = with_probed_facts(
+        before, _probe_answering(tmp_path, MDADM_EXPORT.replace("1.2", "1.0"), 0)
+    )
+    assert compat.Trait.ESP_MDRAID_SUPERBLOCK_AT_START not in compat.traits_of(older)

--- a/tests/unit/test_plan_boot.py
+++ b/tests/unit/test_plan_boot.py
@@ -1038,3 +1038,59 @@ def test_zfsbootmenu_configures_the_pool_the_root_is_on() -> None:
         if isinstance(operation, InstallZfsBootMenu)
     ]
     assert (alone[0].pool, alone[0].dataset) == (installed[0].pool, installed[0].dataset)
+
+
+def test_the_dropbear_port_written_is_the_port_the_configuration_asked_for() -> None:
+    """`render()` calls `describe()` alone, so the golden file fixed the text
+    `port 2222` while nothing ever ran `apply()` with a port other than the
+    default. A `ConfigureRemoteUnlock` that wrote 222 whatever it was given
+    would have passed both, and `vm-unlock` would install an initramfs
+    listening on a port the operator was told to avoid.
+    """
+    from pathlib import Path
+
+    from gentoo_install.exec.config import load
+    from gentoo_install.plan import kernel as plan_kernel
+
+    from .recorder import Recorder
+
+    installation = load(Path("tests/fixtures/vm-unlock.toml"))
+    asked = installation.kernel.remote_unlock.port
+    assert asked != 222, "the fixture has to differ from the default to prove anything"
+
+    recorder = Recorder()
+    ran = 0
+    for operation in plan_kernel.build(installation):
+        if isinstance(operation, plan_kernel.ConfigureRemoteUnlock):
+            operation.apply(recorder)
+            ran += 1
+    assert ran == 1, "the fixture enables remote unlock, so exactly one is planned"
+    written = recorder.files[PurePosixPath("/etc/dracut.conf.d/crypt-ssh.conf")]
+    assert f'dropbear_port="{asked}"' in written, written
+
+
+def test_pinning_a_kernel_version_writes_the_keyword_file_it_describes() -> None:
+    """No fixture sets `kernel.version`, so `AcceptKernelVersion.apply()` had
+    never run: a wrong atom, version, filename or a missing `~amd64` showed
+    the right text in a dry run and stopped a real install after the disks
+    were partitioned, with the pinned kernel still keyword-masked."""
+    from dataclasses import replace as replaced
+
+    from gentoo_install.plan import kernel as plan_kernel
+
+    from .recorder import Recorder
+
+    installation = replaced(config(), kernel=replaced(config().kernel, version="6.12.4"))
+    recorder = Recorder()
+    accepted = [
+        one
+        for one in plan_kernel.build(installation)
+        if isinstance(one, plan_kernel.AcceptKernelVersion)
+    ]
+    assert len(accepted) == 1, accepted
+    accepted[0].apply(recorder)
+    written = recorder.files[
+        PurePosixPath("/etc/portage/package.accept_keywords/kernel-version")
+    ]
+    assert written == f"={accepted[0].package}-6.12.4 ~amd64\n", written
+    assert accepted[0].package.startswith("sys-kernel/"), accepted[0].package

--- a/tests/unit/test_random_configurations.py
+++ b/tests/unit/test_random_configurations.py
@@ -160,13 +160,31 @@ def a_configuration() -> InstallConfig:
 
 @pytest.mark.parametrize("seed", range(300))
 def test_a_random_configuration_is_planned_or_refused_and_never_crashes(seed: int) -> None:
+    """Refusing is `validate`'s job alone.
+
+    Both calls sat in one `try` and any `GentooInstallError` counted as a
+    refusal, so a `build()` that raised `InvalidLayout` for every valid ZFS,
+    LUKS or mdraid configuration was recorded as the rules working, and the
+    ext4 seeds carried the hit count on their own.
+    """
+    from gentoo_install.plan.packages import driver_conflict, framework_conflict
+
     random.seed(seed)
     catalog = load_catalog()
+    wanted = a_configuration()
     try:
-        wanted = a_configuration()
         validate(wanted)
-        operations = build(wanted, catalog)
     except GentooInstallError:
+        return
+    try:
+        operations = build(wanted, catalog)
+    except GentooInstallError as refused:
+        # `build` may refuse two catalog rules `validate` cannot see: they read
+        # the package catalog, and the model layer does not. Any other refusal
+        # of a configuration that validated is the finding, and one `try`
+        # around both calls hid it.
+        named = framework_conflict(wanted, catalog) or driver_conflict(wanted, catalog)
+        assert named and named == str(refused), refused
         return
     assert operations, "a configuration that validated produced no operations"
 
@@ -181,8 +199,8 @@ def test_the_seeds_reach_the_plan_often_enough_to_mean_anything() -> None:
     planned = 0
     for seed in range(300):
         random.seed(seed)
+        wanted = a_configuration()
         try:
-            wanted = a_configuration()
             validate(wanted)
             build(wanted, catalog)
         except GentooInstallError:


### PR DESCRIPTION
`ConfigureRemoteUnlock.apply()` had only ever run with the default port, so the golden file fixed the text `port 2222` while an implementation writing 222 whatever it was given passed both. `AcceptKernelVersion.apply()` had never run at all — no fixture sets `kernel.version` — so a wrong atom, filename or a missing `~amd64` showed correct text in a dry run and stopped a real install with the pinned kernel still masked.

`Probe.mdraid_metadata` and `with_probed_facts` had no test: every case built `Existing(mdraid_metadata="1.2")` by hand. The sample is real output captured on a guest today, kept whole so the parse has to find `MD_METADATA` among the `MD_DEVICE_*` lines after it.

The random-configuration test held `validate` and `build` in one `try`, so a `build` refusing every valid ZFS, LUKS or mdraid configuration counted as the rules working. A plan-layer refusal now has to name the catalog rule that explains it — those two rules read the package catalog, which the model layer cannot see, so refusing there is the design and not a defect.