### PR TITLE
plan: fetch the stage3 the chosen profile is built for

### DIFF
--- a/gentoo_install/plan/portage.py
+++ b/gentoo_install/plan/portage.py
@@ -790,5 +790,28 @@ def _l10n(config: InstallConfig) -> tuple[str, ...]:
     return tuple(tags)
 
 
+#: The stage3 Gentoo publishes for each profile target, by the profile path
+#: segment that names it. Order matters: `no-multilib` is checked before the
+#: plain base, and `desktop` covers `desktop/plasma` and `desktop/gnome`, for
+#: which Gentoo publishes no stage3 of their own.
+STAGE3_BY_PROFILE: tuple[tuple[str, str], ...] = (
+    ("/no-multilib", "nomultilib"),
+    ("/desktop", "desktop"),
+)
+
+
 def variant_of(config: InstallConfig) -> str:
-    return "systemd" if config.system.init is InitSystem.SYSTEMD else "openrc"
+    """The stage3 that matches the chosen profile and init system.
+
+    `eselect profile set` is all the installer runs, and a profile switch
+    removes nothing: a no-multilib profile on a multilib stage3 keeps every
+    32-bit ABI and package the tarball came with, which is not the complete
+    64-bit environment the option offers. Gentoo publishes a tarball built
+    for each of these targets, so the right one is fetched instead.
+    """
+    init = "systemd" if config.system.init is InitSystem.SYSTEMD else "openrc"
+    profile = config.portage.profile
+    for segment, target in STAGE3_BY_PROFILE:
+        if segment in profile:
+            return f"{target}-{init}"
+    return init

--- a/tests/golden/btrfs-luks.txt
+++ b/tests/golden/btrfs-luks.txt
@@ -22,7 +22,7 @@
   mount root-luks at /home with compress=zstd:1,subvol=@home
 
 [stage3]
-  download the newest systemd stage3 from https://mirrors.tuna.tsinghua.edu.cn/gentoo, verify it against BB572E0E2D182910 and unpack it into the target
+  download the newest desktop-systemd stage3 from https://mirrors.tuna.tsinghua.edu.cn/gentoo, verify it against BB572E0E2D182910 and unpack it into the target
 
 [chroot]
   mount proc, sys, dev and run into the target and copy resolv.conf

--- a/tests/golden/vm-desktop.txt
+++ b/tests/golden/vm-desktop.txt
@@ -15,7 +15,7 @@
   mount esp at /efi with umask=0077
 
 [stage3]
-  download the newest systemd stage3 from https://distfiles.gentoo.org, verify it against BB572E0E2D182910 and unpack it into the target
+  download the newest desktop-systemd stage3 from https://distfiles.gentoo.org, verify it against BB572E0E2D182910 and unpack it into the target
 
 [chroot]
   mount proc, sys, dev and run into the target and copy resolv.conf

--- a/tests/golden/vm-gnome.txt
+++ b/tests/golden/vm-gnome.txt
@@ -15,7 +15,7 @@
   mount esp at /efi with umask=0077
 
 [stage3]
-  download the newest systemd stage3 from https://distfiles.gentoo.org, verify it against BB572E0E2D182910 and unpack it into the target
+  download the newest desktop-systemd stage3 from https://distfiles.gentoo.org, verify it against BB572E0E2D182910 and unpack it into the target
 
 [chroot]
   mount proc, sys, dev and run into the target and copy resolv.conf

--- a/tests/golden/vm-openrc-desktop.txt
+++ b/tests/golden/vm-openrc-desktop.txt
@@ -15,7 +15,7 @@
   mount esp at /efi with umask=0077
 
 [stage3]
-  download the newest openrc stage3 from https://distfiles.gentoo.org, verify it against BB572E0E2D182910 and unpack it into the target
+  download the newest desktop-openrc stage3 from https://distfiles.gentoo.org, verify it against BB572E0E2D182910 and unpack it into the target
 
 [chroot]
   mount proc, sys, dev and run into the target and copy resolv.conf

--- a/tests/unit/test_plan_portage.py
+++ b/tests/unit/test_plan_portage.py
@@ -573,3 +573,40 @@ def test_a_mirror_rewriting_its_manifests_is_retried_rather_than_fatal(
     stubborn.refusals = plan_portage.SYNC_TRIES
     with pytest.raises(CommandFailed):
         operation.apply(stubborn)
+def test_the_stage3_matches_the_profile_and_not_only_the_init_system() -> None:
+    """`eselect profile set` is all the installer runs, and a profile switch
+    removes nothing: a no-multilib profile on a multilib stage3 keeps every
+    32-bit ABI and package the tarball came with, so what the option calls a
+    complete 64-bit environment is not one.
+
+    Every profile the menu offers, and the tarball Gentoo publishes for it.
+    """
+    from dataclasses import replace as replaced
+
+    from gentoo_install.model.config import InitSystem
+    from gentoo_install.plan.portage import variant_of
+    from gentoo_install.tui.screens import PROFILES
+
+    wanted = {
+        "default/linux/amd64/23.0": "openrc",
+        "default/linux/amd64/23.0/systemd": "systemd",
+        "default/linux/amd64/23.0/desktop": "desktop-openrc",
+        "default/linux/amd64/23.0/desktop/systemd": "desktop-systemd",
+        "default/linux/amd64/23.0/desktop/plasma": "desktop-openrc",
+        "default/linux/amd64/23.0/desktop/plasma/systemd": "desktop-systemd",
+        "default/linux/amd64/23.0/desktop/gnome": "desktop-openrc",
+        "default/linux/amd64/23.0/desktop/gnome/systemd": "desktop-systemd",
+        "default/linux/amd64/23.0/no-multilib": "nomultilib-openrc",
+        "default/linux/amd64/23.0/no-multilib/systemd": "nomultilib-systemd",
+    }
+    assert set(wanted) == set(PROFILES), "a profile was added with no stage3 named for it"
+
+    base = config()
+    for profile, variant in wanted.items():
+        init = InitSystem.SYSTEMD if profile.endswith("systemd") else InitSystem.OPENRC
+        installation = replaced(
+            base,
+            portage=replaced(base.portage, profile=profile),
+            system=replaced(base.system, init=init),
+        )
+        assert variant_of(installation) == variant, profile


### PR DESCRIPTION
`variant_of` read the init system alone, so every profile got the plain tarball. `eselect profile set` is all the installer runs and a profile switch removes nothing: a no-multilib profile on a multilib stage3 keeps every 32-bit ABI and package the tarball came with, which is not the complete 64-bit environment that option offers. The desktop targets were the same shape — the stage3's packages were never rebuilt for the profile's USE.

Gentoo publishes `desktop-{openrc,systemd}` and `nomultilib-{openrc,systemd}` beside the plain pair; all six pointer files answered 200 today. `desktop/plasma` and `desktop/gnome` take the desktop tarball, which is the closest Gentoo publishes.

A test pairs every entry of `PROFILES` with its tarball and fails when a profile is added without one.

Unverified: no desktop VM run has gone behind this yet, and the four fixtures whose golden text changed are the evidence so far.