### PR TITLE
tests: record what the guest had when the network never came

### DIFF
--- a/tests/vm/cluster.py
+++ b/tests/vm/cluster.py
@@ -320,6 +320,16 @@ def wait_for_network(link: Reconnecting) -> None:
                 "dhcpcd -w -t 20 >/dev/null 2>&1; }; true",
                 timeout=90.0,
             )
+    # What the guest actually had, into the log this run leaves behind. Eight
+    # cluster guests failed here on one round and the log held nothing but
+    # `Could not connect to server`, so nothing said whether the medium never
+    # configured an interface or the cluster gave it no route.
+    for question in (
+        "ip -oneline address show",
+        "ip -4 route show default; ip -6 route show default",
+        "cat /etc/resolv.conf",
+    ):
+        link.run(question, timeout=60.0)
     raise ConsoleTimeout(f"the guest had no network after {NETWORK_PATIENCE:.0f}s")
 
 


### PR DESCRIPTION
`wait_for_network` raised after fifteen minutes and the log carried only the probe's own `Could not connect to server`. On a cluster whose guest network is intermittent that is not a diagnosis: it does not separate a medium that configured no interface from a cluster that handed out no route, and the round has to be repeated to find out.

The addresses, both default routes and the resolver go into the log before it gives up. Read from the guest, so it costs nothing on a run that succeeds.