### PR TITLE
plan: place a partition added to an edited table in free space

### DIFF
--- a/gentoo_install/exec/probe.py
+++ b/gentoo_install/exec/probe.py
@@ -19,7 +19,7 @@ from typing import ClassVar, Final, Iterable, Mapping
 
 from ..errors import CommandFailed, DeviceNotFound
 from ..model.config import InstallConfig
-from ..model.device import DeviceGraph, DeviceId, Existing
+from ..model.device import DeviceGraph, DeviceId, Existing, Extent, PartitionTable
 from .runner import Runner
 
 EFI_MARKER: Final[Path] = Path("/sys/firmware/efi")
@@ -350,6 +350,32 @@ class Probe:
             if name.strip() == "MD_METADATA" and value.strip():
                 return value.strip()
         return ""
+
+    def free_extents(self, disk: str) -> tuple[Extent, ...]:
+        """Where the disk has no partition now, in bytes.
+
+        `parted --machine ... unit B print free` prints one line per extent,
+        occupied and free alike, and marks the free ones in its filesystem
+        field. The number field repeats on those lines and means nothing, so
+        the marker is what they are read by.
+        """
+        listed = self.runner.run(
+            ["parted", "--machine", "--script", disk, "unit", "B", "print", "free"],
+            check=False,
+        )
+        if listed.returncode != 0:
+            raise DeviceNotFound(f"parted could not read the table of {disk}")
+        found: list[Extent] = []
+        for line in listed.stdout.splitlines():
+            fields = line.strip().rstrip(";").split(":")
+            if len(fields) < 5 or fields[4] != "free":
+                continue
+            try:
+                start, end = int(fields[1].rstrip("B")), int(fields[2].rstrip("B"))
+            except ValueError:
+                continue
+            found.append(Extent(start=start, end=end))
+        return tuple(found)
 
     def passphrase(self, source: str) -> tuple[str, str]:
         """What a passphrase file holds, and why it could not be read.
@@ -773,15 +799,38 @@ def with_probed_facts(config: InstallConfig, probe: Probe) -> InstallConfig:
     """
     graph = config.disk.graph
     reused = [one for one in graph.of_type(Existing) if not one.mdraid_metadata]
-    if not reused:
-        return config
     known = {one.id: probe.mdraid_metadata(one.selector) for one in reused}
-    if not any(known.values()):
+    free = _free_extents(graph, probe)
+    if not any(known.values()) and not free:
         return config
     nodes = [
         replace(one, mdraid_metadata=known[one.id])
         if isinstance(one, Existing) and known.get(one.id)
+        else replace(one, free_extents=free[one.id])
+        if isinstance(one, PartitionTable) and one.id in free
         else one
         for one in graph.nodes.values()
     ]
     return replace(config, disk=replace(config.disk, graph=DeviceGraph.build(nodes)))
+
+
+def _free_extents(graph: DeviceGraph, probe: Probe) -> dict[DeviceId, tuple[Extent, ...]]:
+    """Where each edited table has room, read from the disk it is on.
+
+    Only tables the plan does not write from scratch: a new table's whole disk
+    is free, and `sgdisk --new=N:0` finds the room itself on GPT. An MBR
+    partition is given an explicit start, computed from the model's own
+    partitions alone, so an added one landed at 1MiB on top of a retained one.
+    """
+    found: dict[DeviceId, tuple[Extent, ...]] = {}
+    for table in graph.of_type(PartitionTable):
+        if table.create or table.free_extents:
+            continue
+        disk = graph.nodes.get(table.disk)
+        if not isinstance(disk, Existing):
+            continue
+        try:
+            found[table.id] = probe.free_extents(probe.resolve(disk.id, disk.selector))
+        except DeviceNotFound:
+            continue
+    return found

--- a/gentoo_install/model/device.py
+++ b/gentoo_install/model/device.py
@@ -119,6 +119,18 @@ class Existing(Node):
 
 
 @dataclass(frozen=True)
+class Extent:
+    """A byte range on a disk, `end` inclusive, as `parted` reports one."""
+
+    start: int
+    end: int
+
+    @property
+    def size(self) -> int:
+        return self.end - self.start + 1
+
+
+@dataclass(frozen=True)
 class PartitionTable(Node):
     disk: DeviceId
     table: TableType
@@ -130,6 +142,12 @@ class PartitionTable(Node):
     #: is an edit to the table, so it belongs to the table and not to a node of
     #: its own: the partition it names stops existing.
     remove: tuple[int, ...] = ()
+    #: Where the disk has no partition now, in bytes, filled in by the probe
+    #: before validation. Empty for a table written from scratch, and empty in
+    #: a configuration file: the model cannot read a partition table, and
+    #: without this an added partition on an edited table was placed at 1MiB
+    #: on top of one the operator kept.
+    free_extents: tuple[Extent, ...] = ()
 
     @property
     def inputs(self) -> tuple[DeviceId, ...]:

--- a/gentoo_install/plan/disk.py
+++ b/gentoo_install/plan/disk.py
@@ -970,11 +970,20 @@ def _dataset_mountpoint(graph: DeviceGraph, dataset: DeviceId) -> PurePosixPath 
 
 
 def _start_of(graph: DeviceGraph, partition: Partition) -> Size:
-    """Where an MBR partition begins: after every partition with a lower index.
+    """Where an MBR partition begins.
 
-    A partition with no size takes the rest of the disk, so anything after it has
-    no start to compute; `validate.py` rejects that layout.
+    On a table written from scratch, after every partition with a lower index.
+    A partition with no size takes the rest of the disk, so anything after it
+    has no start to compute; `validate.py` rejects that layout.
+
+    On a table the operator edits, after the partitions the disk already has:
+    those are not model nodes and summing the model's own gave 1MiB, which
+    `parted` refused with `the closest location we can manage is 1048kB` after
+    the removals in the same plan had already been committed.
     """
+    table = graph[partition.table]
+    if isinstance(table, PartitionTable) and table.free_extents:
+        return _into_free_space(graph, table, partition)
     start = FIRST_OFFSET
     for sibling in sorted(graph.of_type(Partition), key=lambda node: node.index):
         if sibling.table != partition.table or sibling.index >= partition.index:
@@ -983,6 +992,36 @@ def _start_of(graph: DeviceGraph, partition: Partition) -> Size:
             return start
         start = (start + sibling.size).align_up()
     return start
+
+
+def _into_free_space(graph: DeviceGraph, table: PartitionTable, partition: Partition) -> Size:
+    """The first free extent with room for this partition and the ones before it.
+
+    Every added partition of one table is placed in extent order, so two of
+    them do not both take the start of the same gap.
+    """
+    added = [
+        one
+        for one in sorted(graph.of_type(Partition), key=lambda node: node.index)
+        if one.table == table.id
+    ]
+    cursor = {extent.start: Size(extent.start).align_up() for extent in table.free_extents}
+    for one in added:
+        for extent in table.free_extents:
+            at = cursor[extent.start]
+            wanted = one.size.bytes if one.size is not None else 0
+            if at.bytes + wanted > extent.end + 1:
+                continue
+            if one.id == partition.id:
+                return at
+            cursor[extent.start] = (at + one.size).align_up() if one.size else at
+            break
+        else:
+            if one.id == partition.id:
+                raise InvalidLayout(
+                    f"{partition.id} does not fit any free extent of {table.id}"
+                )
+    raise InvalidLayout(f"{partition.id} does not fit any free extent of {table.id}")
 
 
 def _expect(graph: DeviceGraph, device: DeviceId, kind: type[T]) -> T:

--- a/tests/unit/test_plan_disk.py
+++ b/tests/unit/test_plan_disk.py
@@ -5,10 +5,14 @@ from pathlib import Path, PurePosixPath
 
 import pytest
 
+from typing import Sequence
+
 from gentoo_install.errors import InvalidLayout
 from gentoo_install.model.device import (
     DeviceGraph,
+    DeviceId,
     Existing,
+    Extent,
     Filesystem,
     FilesystemType,
     LogicalVolume,
@@ -474,3 +478,100 @@ def test_a_dataset_already_mounted_is_left_alone() -> None:
     already.replies["zfs"] = "yes\n"
     told.apply(already)
     assert not any(one[:2] == ("zfs", "mount") for one in already.commands)
+
+
+#: What `parted --machine --script <disk> unit B print free` printed for a
+#: 4 GiB MBR image holding one 1 GiB partition at 1MiB, captured on this
+#: machine. Kept whole: the free lines repeat the number `1`, so the marker in
+#: the fifth field is what they have to be read by.
+PARTED_PRINT_FREE: str = """BYT;
+/home/zakk/.cache/mbrtest/disk.img:4294967296B:file:512:512:msdos::;
+1:16384B:1048575B:1032192B:free;
+1:1048576B:1074790399B:1073741824B:::;
+1:1074790400B:4294967295B:3220176896B:free;
+"""
+
+
+def _edited_mbr(free: tuple[Extent, ...], size: Size | None = None) -> DeviceGraph:
+    """One retained partition on the disk, one added by the configuration."""
+    from pathlib import PurePosixPath
+
+    return DeviceGraph.build(
+        [
+            Existing(id=DeviceId("d"), selector="/dev/null", wipe=False),
+            PartitionTable(
+                id=DeviceId("t"),
+                disk=DeviceId("d"),
+                table=TableType.MBR,
+                create=False,
+                free_extents=free,
+            ),
+            Partition(
+                id=DeviceId("new"),
+                table=DeviceId("t"),
+                index=2,
+                role=PartitionRole.DATA,
+                size=size if size is not None else Size(1024**3),
+            ),
+            Filesystem(id=DeviceId("fs"), device=DeviceId("new"), kind=FilesystemType.EXT4),
+            Mountpoint(id=DeviceId("m"), source=DeviceId("fs"), path=PurePosixPath("/")),
+        ]
+    )
+
+
+def test_a_partition_added_to_an_edited_mbr_goes_after_the_ones_on_the_disk() -> None:
+    """A retained partition is not a model node, so summing the model's own
+    gave 1MiB and `parted` answered `the closest location we can manage is
+    1048kB to 1048kB` — after the removals in the same plan had already been
+    committed."""
+    from gentoo_install.exec.probe import Probe
+    from gentoo_install.exec.runner import Result, Runner
+    from gentoo_install.plan.disk import _start_of
+
+    class Answering(Runner):
+        def run(
+            self,
+            argv: Sequence[str],
+            *,
+            check: bool = True,
+            input_text: str | None = None,
+            timeout: float | None = None,
+        ) -> Result:
+            said = PARTED_PRINT_FREE if argv[0] == "parted" else ""
+            return Result(argv=tuple(argv), returncode=0, stdout=said, stderr="", seconds=0.0)
+
+    read = Probe(runner=Answering(log=lambda line: None), work=Path("/tmp"))
+    free = read.free_extents("/dev/null")
+    assert free == (Extent(start=16384, end=1048575), Extent(start=1074790400, end=4294967295)), free
+
+    graph = _edited_mbr(free)
+    added = next(one for one in graph.of_type(Partition) if one.id == DeviceId("new"))
+    start = _start_of(graph, added)
+    # The retained partition ends at 1074790399, so anything at or below it
+    # overlaps what the operator kept.
+    assert start.bytes > 1074790399, start
+    assert start.is_aligned(), start
+
+
+def test_a_partition_that_fits_no_free_extent_is_refused_before_anything_runs() -> None:
+    """Refused while the table is unchanged: the removals of the same plan run
+    first and stay committed when a later creation fails."""
+    from gentoo_install.errors import InvalidLayout
+    from gentoo_install.plan.disk import _start_of
+
+    graph = _edited_mbr((Extent(start=1048576, end=2097151),), size=Size(4 * 1024**3))
+    added = next(one for one in graph.of_type(Partition) if one.id == DeviceId("new"))
+    with pytest.raises(InvalidLayout):
+        _start_of(graph, added)
+
+
+def test_a_table_written_from_scratch_still_starts_at_the_first_offset() -> None:
+    """`free_extents` is empty for a new table, and `sgdisk --new=N:0` finds
+    the room itself on GPT, so nothing about that path changes."""
+    from gentoo_install.plan.disk import FIRST_OFFSET, _start_of
+
+    graph = DeviceGraph.build(ext4_on_gpt())
+    first = next(
+        one for one in graph.of_type(Partition) if one.index == 1
+    )
+    assert _start_of(graph, first) == FIRST_OFFSET


### PR DESCRIPTION
`_start_of` summed the model's own `Partition` siblings. A partition the operator keeps is not a model node, so a partition added to a table with `create = false` was computed at 1MiB, on top of the retained one: `parted` answered `Error: You requested a partition from 1049kB to 17.8MB. The closest location we can manage is 1048kB to 1048kB` — and the removals in the same plan had already been written.

`Probe.free_extents` reads `parted --machine --script <disk> unit B print free`, which prints occupied and free ranges alike and marks the free ones in its fifth field; the number field repeats on those lines and means nothing, so the marker is what they are read by. `with_probed_facts` fills `PartitionTable.free_extents` before validation, the way it already fills `mdraid_metadata`, and the plan places each added partition in the first extent with room. Nothing fits, nothing runs: `InvalidLayout` before the first removal.

GPT is untouched — `sgdisk --new=N:0` finds the room itself. The sample in the test is real parted output from a 4 GiB image made on this machine.

Unverified: no VM run has exercised an edited MBR table yet; no fixture describes one.