### PR TITLE
tests: treat a connection reset as a dropped console

### DIFF
--- a/tests/unit/test_proxmox.py
+++ b/tests/unit/test_proxmox.py
@@ -818,3 +818,46 @@ def test_an_encrypted_disk_is_unlocked_before_a_login_is_waited_for(
     console = Silent()
     assert cluster._unlock(console, Reconnecting(lambda: console, tries=1), plain) == ""
     assert console.sent == [], "a plain disk was sent a passphrase"
+
+
+def test_a_connection_reset_is_a_dropped_console_and_not_a_dead_run() -> None:
+    """`WebSocketError` went past every `except ConsoleClosed`, so a TCP reset
+    ended two cluster guests at zero minutes with their installs running and
+    the schedule recorded `ERROR` for a machine that was fine.
+
+    Driven through the real `Framed.read`, so the transport decides.
+    """
+    from tests.vm.websocket import WebSocket
+
+    class Resetting:
+        """A socket that answers one frame and then resets."""
+
+        def __init__(self) -> None:
+            self.reads = 0
+
+        def recv(self, size: int) -> bytes:
+            self.reads += 1
+            if self.reads == 1:
+                # One unmasked text frame carrying `hello`.
+                return b"\x81\x05hello"
+            raise ConnectionResetError(104, "Connection reset by peer")
+
+        def sendall(self, data: bytes) -> None:
+            return None
+
+        def close(self) -> None:
+            return None
+
+        def settimeout(self, seconds: float | None) -> None:
+            return None
+
+    sock = Resetting()
+    framed = WebSocket(sock)
+    assert framed.read() == b"hello"
+    # Read into locals: mypy narrows a property it has seen tested, and the
+    # whole point here is that this one changes.
+    before = framed.closed
+    assert framed.read() == b""
+    after, why = framed.closed, framed.why_closed
+    assert (before, after) == (False, True), "a reset has to look like a closed connection"
+    assert "reset" in why.lower(), why

--- a/tests/vm/websocket.py
+++ b/tests/vm/websocket.py
@@ -80,6 +80,8 @@ class WebSocket:
         self._sock = sock
         self._buffer = bytearray()
         self._closed = False
+        #: Why it closed, for the reader that reports a dropped console.
+        self._why = ""
 
     @classmethod
     def connect(
@@ -143,7 +145,13 @@ class WebSocket:
         except (TimeoutError, ssl.SSLWantReadError):
             return self._take()
         except OSError as error:
-            raise WebSocketError(f"the connection broke: {error}") from error
+            # Closed, not raised: a reset is one more way for this connection
+            # to end, and the reader above reopens a closed one. Raised, it
+            # went past every `except ConsoleClosed` and ended two cluster
+            # guests at zero minutes with their installs running.
+            self._closed = True
+            self._why = f"the connection broke: {error}"
+            return self._take()
         if not chunk:
             self._closed = True
             return self._take()
@@ -153,6 +161,10 @@ class WebSocket:
     @property
     def closed(self) -> bool:
         return self._closed
+
+    @property
+    def why_closed(self) -> str:
+        return self._why
 
     def _take(self) -> bytes:
         out = bytearray()


### PR DESCRIPTION
`Framed.read` raised `WebSocketError` on any `OSError`. That type is outside every `except ConsoleClosed` in `Reconnecting`, so a TCP reset was not a reconnect but the end of the run: two guests on the round now finishing were recorded `ERROR ... 0.0m Connection reset by peer` with their installs running normally.

A reset is one more way this connection ends, and the reader above already reopens a closed one, so it now closes with the reason kept for the report instead of raising.

Driven through the real `WebSocket.read` against a socket that answers one frame and then resets.