### PR TITLE
plan: retry a sync against a mirror that is mid-update

### DIFF
--- a/gentoo_install/plan/portage.py
+++ b/gentoo_install/plan/portage.py
@@ -7,6 +7,7 @@ before a key can be imported, an imported key stays untrusted until `lsign`, and
 
 from __future__ import annotations
 
+import time
 from dataclasses import dataclass
 from pathlib import PurePosixPath
 from typing import Final, Sequence
@@ -262,6 +263,13 @@ class WebrsyncRepository(Operation):
         context.run_in_target(["emerge-webrsync"])
 
 
+#: How many times a repository sync is attempted, and how long between them.
+#: A mirror rewriting its Manifests is the transient case; two more attempts a
+#: minute apart cover it without walking around a mismatch that is real.
+SYNC_TRIES: Final[int] = 3
+SYNC_PAUSE: Final[float] = 30.0
+
+
 @dataclass(frozen=True, kw_only=True)
 class SyncRepository(Operation):
     """A directory holding a copy that git did not create makes `emerge --sync`
@@ -276,8 +284,32 @@ class SyncRepository(Operation):
 
     def apply(self, context: Context) -> None:
         context.run_in_target(["rm", "--recursive", "--force", str(self.location)])
-        context.run_in_target(["emerge", "--sync", self.name])
+        self._sync(context)
         context.run_in_target(["chown", "--recursive", "portage:portage", str(self.location)])
+
+    def _sync(self, context: Context) -> None:
+        """`emerge --sync`, retried on a mirror that is mid-update.
+
+        Three of eight guests stopped in the same minute with `Manifest
+        mismatch for gui-apps/Manifest.gz __size__: expected: 5745, have:
+        5746`. Portage quarantined the download and refused, which is correct:
+        the snapshot it fetched was incomplete, not the tree corrupted. The
+        same command a minute later reads a whole one.
+
+        The same mirror, and a bounded number of times: a mismatch that is not
+        transient has to stop the install rather than be walked around.
+        """
+        last: CommandFailed | None = None
+        for attempt in range(SYNC_TRIES):
+            try:
+                context.run_in_target(["emerge", "--sync", self.name])
+                return
+            except CommandFailed as failed:
+                last = failed
+                if attempt + 1 < SYNC_TRIES:
+                    time.sleep(SYNC_PAUSE * (attempt + 1))
+        assert last is not None
+        raise last
 
 
 @dataclass(frozen=True, kw_only=True)

--- a/tests/unit/test_plan_portage.py
+++ b/tests/unit/test_plan_portage.py
@@ -527,3 +527,49 @@ def test_every_offered_region_resolves_a_stage3_source() -> None:
     for region in MirrorRegion:
         carrying = [one for one in mirrors.gentoo_sites(region) if one.releases]
         assert carrying, region
+
+
+def test_a_mirror_rewriting_its_manifests_is_retried_rather_than_fatal(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Three of eight cluster guests stopped in the same minute with `Manifest
+    mismatch for gui-apps/Manifest.gz __size__: expected: 5745, have: 5746`.
+    Portage quarantined an incomplete snapshot and refused, which is right;
+    stopping an install that had already partitioned the disks is not.
+    """
+    from typing import Sequence
+
+    from gentoo_install.errors import CommandFailed
+    from gentoo_install.plan import portage as plan_portage
+
+    from .recorder import Recorder
+
+    class Flaky(Recorder):
+        """Refuses the first `refusals` syncs the way a mirror mid-update does."""
+
+        refusals: int = 2
+        attempts: int = 0
+
+        def run_in_target(self, argv: Sequence[str], *, check: bool = True) -> str:
+            if tuple(argv[:2]) == ("emerge", "--sync"):
+                self.attempts += 1
+                if self.refusals:
+                    self.refusals -= 1
+                    raise CommandFailed("emerge --sync gentoo exited 1: Manifest mismatch")
+            return super().run_in_target(argv, check=check)
+
+    operation = plan_portage.SyncRepository(
+        name="gentoo", location=PurePosixPath("/var/db/repos/gentoo")
+    )
+    monkeypatch.setattr(plan_portage, "SYNC_PAUSE", 0.0)
+    recorder = Flaky()
+    operation.apply(recorder)
+    assert recorder.attempts == 3, recorder.attempts
+    synced = [one for one in recorder.in_target if tuple(one[:2]) == ("emerge", "--sync")]
+    assert len(synced) == 1, "the one that worked"
+
+    # Not walked around: a mismatch that keeps coming back stops the install.
+    stubborn = Flaky()
+    stubborn.refusals = plan_portage.SYNC_TRIES
+    with pytest.raises(CommandFailed):
+        operation.apply(stubborn)


### PR DESCRIPTION
Three of eight guests on today's cluster round stopped in the same minute: `Manifest mismatch for gui-apps/Manifest.gz __size__: expected: 5745, have: 5746`, all against the same Chinese mirror. Portage quarantined the download and refused, which is correct — the snapshot it fetched was incomplete, not the tree corrupted — and the same command a minute later reads a whole one.

`SyncRepository` now attempts it three times against the same mirror with a growing pause. The same mirror on purpose: switching would walk around a mismatch that is real. This is not the stage3 rule, which `docs/design.md` states is never retried — a bad signature means the bytes cannot be trusted, not that they are incomplete.