### PR TITLE
tui: open the ssh and encryption rows on the value they hold

### DIFF
--- a/gentoo_install/tui/screens.py
+++ b/gentoo_install/tui/screens.py
@@ -1847,9 +1847,14 @@ def encryption_screen(screen: Screen, config: InstallConfig, context: Context) -
         # over a graph with no container in it at all.
         _say(screen, context, translate("Encryption is a field of each partition, under Partitions."))
         return Answer(Outcome.BACK)
+    encrypted = bool(context.choice.passphrase_file)
     wanted = Confirm(
         **answers(translate),
-        title=translate("Encrypt the root filesystem?"), footer=footer(translate)
+        title=translate("Encrypt the root filesystem?"),
+        # Without this the cursor starts on `No`, so reopening the row and
+        # pressing enter removed the container and the passphrase with it.
+        current=encrypted,
+        footer=footer(translate),
     ).run(screen)
     if not wanted.chosen:
         return Answer(wanted.outcome)
@@ -1858,6 +1863,10 @@ def encryption_screen(screen: Screen, config: InstallConfig, context: Context) -
         return Answer(Outcome.CHOSE, _rebuild(config, context))
     staged = _ask_passphrase(screen, context)
     if not staged:
+        # The key that is already staged, not an empty one: cancelling the
+        # field is declining to change the passphrase, not declining to have
+        # one, and clearing it here turned an encrypted layout into a plain
+        # one on the way out.
         return Answer(Outcome.BACK)
     context.choice = replace(context.choice, passphrase_file=staged)
     return Answer(Outcome.CHOSE, _rebuild(config, context))
@@ -4001,6 +4010,10 @@ def root_login_screen(
                 detail=translate("reach root through a sudo user"),
             ),
         ],
+        # Without this the cursor starts on `allowed`, so reopening the row
+        # and pressing enter widened root's access over ssh on a machine that
+        # had refused it.
+        current=config.system.sshd_root_login,
         footer=footer(translate),
     )
     answer = menu.run(screen)

--- a/tests/unit/test_every_row.py
+++ b/tests/unit/test_every_row.py
@@ -205,3 +205,56 @@ def test_the_timezone_screen_offers_cities_behind_a_region() -> None:
     row.edit(screen, config(ext4_on_gpt()), at)
     cities = [line for line in screen.frames[1] if line.strip()]
     assert len(cities) > 5, cities
+
+
+def test_reopening_root_login_over_ssh_does_not_widen_it() -> None:
+    """The cursor started on `allowed`, so an operator who had refused root
+    over ssh and opened the row again to read it widened root's access by
+    pressing enter. The shared reopening test set this to `True`, which is the
+    first item, so it could not see the difference."""
+    at = context()
+    at.columns = 100
+    refused = replace(
+        config(ext4_on_gpt()),
+        system=replace(config(ext4_on_gpt()).system, sshd=True, sshd_root_login=False),
+    )
+    row = next(one for one in every_row() if one.key == "rootlogin")
+    assert row.edit is not None
+    answer = row.edit(FakeScreen(keys=["\n"] * 4, lines=40, columns=100), refused, at)
+    assert answer.outcome is Outcome.CHOSE
+    assert answer.unwrap().system.sshd_root_login is False
+
+
+def test_reopening_encryption_keeps_the_container_and_its_passphrase() -> None:
+    """The cursor started on `No`, so reopening the row and pressing enter
+    removed the LUKS container and cleared the staged passphrase. Cancelling
+    the passphrase field is declining to change it, not declining to have one.
+    """
+    from .layouts import encrypted_root
+
+    row = next(one for one in every_row() if one.key == "encryption")
+    assert row.edit is not None
+
+    at = context()
+    at.columns = 100
+    at.choice = replace(at.choice, passphrase_file="/run/keys/root")
+    # Enter accepts `still encrypted`, escape declines to retype the key.
+    row.edit(
+        FakeScreen(keys=["\n", "\x1b", "\x1b"], lines=40, columns=100),
+        config(encrypted_root()),
+        at,
+    )
+    assert at.choice.passphrase_file == "/run/keys/root"
+
+    # Choosing no still turns it off: this is a default, not a refusal. The
+    # items are `No` then `Yes`, and the cursor now starts on `Yes`, so `No`
+    # is one row up.
+    off = context()
+    off.columns = 100
+    off.choice = replace(off.choice, passphrase_file="/run/keys/root")
+    row.edit(
+        FakeScreen(keys=["KEY_UP", "\n"], lines=40, columns=100),
+        config(encrypted_root()),
+        off,
+    )
+    assert off.choice.passphrase_file == ""

--- a/tests/unit/test_tui_app.py
+++ b/tests/unit/test_tui_app.py
@@ -371,9 +371,11 @@ def test_every_catalog_translates_the_passphrase_hint() -> None:
 
 
 def test_declining_encryption_clears_the_passphrase() -> None:
+    """`No` is one row up from where the cursor now starts: an encrypted
+    layout opens on `Yes`, so pressing enter keeps what it had."""
     at = context()
     at.choice = replace(at.choice, passphrase_file="/run/keys/old")
-    screens.encryption_screen(FakeScreen(keys=["\n"]), config(), at)
+    screens.encryption_screen(FakeScreen(keys=["KEY_UP", "\n"]), config(), at)
     assert at.choice.passphrase_file == ""
 
 


### PR DESCRIPTION
Two rows drew their first item under the cursor whatever the configuration held, so an operator opening the row to read it and pressing enter changed it.

`Root login over SSH` moved `refused` to `allowed`. `Encryption` moved `on` to `off`, removing the LUKS container and clearing the staged passphrase; cancelling the passphrase field afterwards now means declining to change the key, not declining to have one.

Both reproduced against the real screens before the fix. The shared reopening test could not see either: it sets `sshd_root_login` to `True`, which is the first item, and builds an unencrypted layout.