### PR TITLE
tui: open every menu on the value it holds

### DIFF
--- a/gentoo_install/tui/screens.py
+++ b/gentoo_install/tui/screens.py
@@ -1375,7 +1375,10 @@ def desktop_screen(screen: Screen, config: InstallConfig, context: Context) -> A
         for name in sorted(desktop_profiles(context.groups))
     ]
     menu: Menu[str] = Menu(
-        title=translate("Desktop and applications"), items=items, footer=footer(translate)
+        title=translate("Desktop and applications"),
+        items=items,
+        current=config.packages.desktop,
+        footer=footer(translate),
     )
     answer = menu.run(screen)
     if not answer.chosen:
@@ -1950,7 +1953,12 @@ def swap_screen(screen: Screen, config: InstallConfig, context: Context) -> Answ
         Item(label="4GiB", value="4GiB", detail=translate("a partition")),
         Item(label="8GiB", value="8GiB", detail=translate("a partition")),
     ]
-    menu: Menu[str] = Menu(title=translate("Swap"), items=items, footer=footer(translate))
+    menu: Menu[str] = Menu(
+        title=translate("Swap"),
+        items=items,
+        current=str(context.choice.swap) if context.choice.swap else "",
+        footer=footer(translate),
+    )
     answer = menu.run(screen)
     if not answer.chosen:
         return Answer(answer.outcome)
@@ -1990,7 +1998,10 @@ def zram_screen(screen: Screen, config: InstallConfig, context: Context) -> Answ
         _say(screen, context, translate("this machine reports no memory to share"))
         return Answer(Outcome.BACK)
     menu: Menu[Size | None] = Menu(
-        title=translate("zram"), items=items, footer=footer(translate)
+        title=translate("zram"),
+        items=items,
+        current=config.system.zram,
+        footer=footer(translate),
     )
     answer = menu.run(screen)
     if not answer.chosen:
@@ -2040,6 +2051,7 @@ def build_in_ram_screen(
     menu: Menu[Size | None] = Menu(
         title=translate("Build in RAM"),
         items=items,
+        current=config.portage.build_in_ram,
         footer=footer(translate),
     )
     answer = menu.run(screen)
@@ -2363,7 +2375,10 @@ def table_screen(screen: Screen, config: InstallConfig, context: Context) -> Ans
     translate = context.translate
     items = [Item(label=table.value, value=table) for table in TableType]
     menu: Menu[TableType] = Menu(
-        title=translate("Partition table"), items=items, footer=footer(translate)
+        title=translate("Partition table"),
+        items=items,
+        current=context.choice.table,
+        footer=footer(translate),
     )
     answer = menu.run(screen)
     if not answer.chosen:
@@ -3566,7 +3581,10 @@ def license_screen(screen: Screen, config: InstallConfig, context: Context) -> A
         Item(label=value, value=value, detail=translate(reason)) for value, reason in LICENSES
     ]
     menu: Menu[str] = Menu(
-        title=translate("Licenses to accept"), items=items, footer=footer(translate)
+        title=translate("Licenses to accept"),
+        items=items,
+        current=" ".join(config.portage.accept_license),
+        footer=footer(translate),
     )
     answer = menu.run(screen)
     if not answer.chosen:
@@ -3647,7 +3665,10 @@ def compile_flags_screen(
         Item(label=translate("Type them"), value=""),
     ]
     menu: Menu[str] = Menu(
-        title=translate("Compiler flags"), items=items, footer=footer(translate)
+        title=translate("Compiler flags"),
+        items=items,
+        current=config.portage.common_flags,
+        footer=footer(translate),
     )
     answer = menu.run(screen)
     if not answer.chosen:

--- a/tests/unit/test_every_row.py
+++ b/tests/unit/test_every_row.py
@@ -258,3 +258,53 @@ def test_reopening_encryption_keeps_the_container_and_its_passphrase() -> None:
         off,
     )
     assert off.choice.passphrase_file == ""
+
+
+#: Rows that answer by flipping rather than by offering a list. Reopening one
+#: and pressing enter flips it again, which is what it is for.
+FLIPPED: frozenset[str] = frozenset({"cron"})
+
+
+def test_no_row_loses_its_value_when_it_is_opened_again() -> None:
+    """Change a row to something other than its first entry, open it again and
+    press enter: the value it shows has to be the one that was chosen.
+
+    Two rows changed a setting the operator only opened to read — `Root login
+    over SSH` widened root's access and `Encryption` removed the container —
+    and six more read their first entry back. Each menu was missing `current`,
+    and no test drove a row twice, so none of them could be seen.
+    """
+    at = context()
+    at.columns = 100
+    base = config(ext4_on_gpt())
+    wrong: list[str] = []
+    walked = 0
+    for row in openable():
+        if row.key in FLIPPED:
+            continue
+        assert row.edit is not None
+        try:
+            first = row.edit(
+                FakeScreen(keys=["KEY_DOWN", "\n", *(["\n"] * 6)], lines=40, columns=100),
+                base,
+                at,
+            )
+        except AssertionError:
+            continue  # A screen enter is not an answer to; `LEAVE` covers those.
+        if first.outcome is not Outcome.CHOSE:
+            continue
+        changed = first.unwrap()
+        chose = row.value(changed, at)
+        if chose == row.value(base, at):
+            continue  # The row has one entry, or the second is what it held.
+        try:
+            again = row.edit(FakeScreen(keys=["\n"] * 8, lines=40, columns=100), changed, at)
+        except AssertionError:
+            continue
+        if again.outcome is not Outcome.CHOSE:
+            continue
+        walked += 1
+        if row.value(again.unwrap(), at) != chose:
+            wrong.append(f"{row.key}: chose {chose!r}, reopened as {row.value(again.unwrap(), at)!r}")
+    assert not wrong, wrong
+    assert walked > 10, walked

--- a/tests/unit/test_tui_app.py
+++ b/tests/unit/test_tui_app.py
@@ -1038,10 +1038,12 @@ def test_a_swap_partition_and_zram_are_two_rows_and_not_alternatives() -> None:
     assert both.system.zram is not None
     assert both.disk.graph.of_type(Swap), "choosing zram removed the partition"
 
-    off = screens.zram_screen(FakeScreen(keys=["\n"], lines=24), both, at).unwrap()
+    # `off` and `none` are one row up from where the cursor starts: each menu
+    # opens on the value it holds, so enter alone keeps it.
+    off = screens.zram_screen(FakeScreen(keys=["KEY_UP", "\n"], lines=24), both, at).unwrap()
     assert off.system.zram is None and off.disk.graph.of_type(Swap)
 
-    none = screens.swap_screen(FakeScreen(keys=["\n"]), off, at).unwrap()
+    none = screens.swap_screen(FakeScreen(keys=["KEY_UP", "\n"]), off, at).unwrap()
     assert not none.disk.graph.of_type(Swap)
 
 


### PR DESCRIPTION
Sixty-five menus, sixteen with `current`. A walk that changes each row to something other than its first entry, opens it again and presses enter named eight rows that came back with the wrong value: two of them were security-relevant and landed in #60, and these six are the rest — the partition table went back to GPT, swap and zram to off, compiler flags to the stage3 default, licenses to `@FREE`, and the desktop to none.

The walk is the test. It drives forty-seven rows, skips the one that answers by flipping, and fails on any row whose reopened value is not what was chosen — so a menu added without `current` fails here rather than on an operator's machine.

Two existing tests moved a keypress: each menu now opens on what it holds, so the first entry is one row up.