### PR TITLE
tui: translate the prose the panel builds itself

### DIFF
--- a/gentoo_install/data/locale/ja.toml
+++ b/gentoo_install/data/locale/ja.toml
@@ -168,6 +168,8 @@
 "Graphics" = "グラフィック"
 "Display manager" = "ディスプレイマネージャ"
 "none" = "なし"
+"measured" = "計測済み"
+"same as the console" = "コンソールと同じ"
 "i915 and xe, with the firmware they need" = "i915 と xe、必要なファームウェア込み"
 "GCN 1.2 and newer" = "GCN 1.2 以降"
 "AMD up to Sea Islands" = "Sea Islands までの AMD"

--- a/gentoo_install/data/locale/ko.toml
+++ b/gentoo_install/data/locale/ko.toml
@@ -168,6 +168,8 @@
 "Graphics" = "그래픽"
 "Display manager" = "디스플레이 관리자"
 "none" = "없음"
+"measured" = "측정됨"
+"same as the console" = "콘솔과 동일"
 "i915 and xe, with the firmware they need" = "i915 와 xe, 필요한 펌웨어 포함"
 "GCN 1.2 and newer" = "GCN 1.2 이후"
 "AMD up to Sea Islands" = "Sea Islands 이전의 AMD"

--- a/gentoo_install/data/locale/zh-CN.toml
+++ b/gentoo_install/data/locale/zh-CN.toml
@@ -168,6 +168,8 @@
 "Graphics" = "显卡"
 "Display manager" = "显示管理器"
 "none" = "无"
+"measured" = "已测速"
+"same as the console" = "同控制台"
 "i915 and xe, with the firmware they need" = "i915 与 xe，含所需固件"
 "GCN 1.2 and newer" = "GCN 1.2 及更新版本"
 "AMD up to Sea Islands" = "Sea Islands 及更早的 AMD GPU"

--- a/gentoo_install/data/locale/zh-TW.toml
+++ b/gentoo_install/data/locale/zh-TW.toml
@@ -168,6 +168,8 @@
 "Graphics" = "顯示卡"
 "Display manager" = "顯示管理器"
 "none" = "無"
+"measured" = "已測速"
+"same as the console" = "同主控台"
 "i915 and xe, with the firmware they need" = "i915 與 xe，含所需韌體"
 "GCN 1.2 and newer" = "GCN 1.2 及更新版本"
 "AMD up to Sea Islands" = "Sea Islands 及更早的 AMD GPU"

--- a/gentoo_install/tui/settings.py
+++ b/gentoo_install/tui/settings.py
@@ -211,7 +211,9 @@ def _summary(rows: tuple[Setting, ...]) -> Callable[[InstallConfig, Context], st
 def _swap(config: InstallConfig, context: Context) -> str:
     from ..model.device import Swap
 
-    return "a partition" if config.disk.graph.of_type(Swap) else context.translate("none")
+    if config.disk.graph.of_type(Swap):
+        return context.translate("a partition")
+    return context.translate("none")
 
 
 def _zram(config: InstallConfig, context: Context) -> str:
@@ -315,7 +317,10 @@ def _unlock_keymap(config: InstallConfig, context: Context) -> str:
     if not graph.of_type(Luks) and not config.kernel.remote_unlock.enabled:
         return context.translate("nothing is unlocked at boot")
     chosen = config.system.keymap_initramfs
-    return chosen if chosen else f"{config.system.keymap} (same as the console)"
+    if chosen:
+        return chosen
+    same = context.translate("same as the console")
+    return f"{config.system.keymap} ({same})"
 
 
 def _address(config: InstallConfig, context: Context) -> str:
@@ -364,7 +369,7 @@ def _mirror(config: InstallConfig, context: Context) -> str:
     if not chosen.site:
         return UNSET
     overlays = [overlay.name for overlay in config.portage.overlays]
-    measured = ", measured" if chosen.speed_test else ""
+    measured = f", {context.translate('measured')}" if chosen.speed_test else ""
     return f"{chosen.site}{measured}" + (f", {', '.join(overlays)}" if overlays else "")
 
 
@@ -510,7 +515,9 @@ def _license(config: InstallConfig, context: Context) -> str:
 
 
 def _makeopts(config: InstallConfig, context: Context) -> str:
-    return config.portage.makeopts or f"-j{context.cores} (this machine)"
+    if config.portage.makeopts:
+        return config.portage.makeopts
+    return f"-j{context.cores} ({context.translate('this machine')})"
 
 
 def _cflags(config: InstallConfig, context: Context) -> str:

--- a/tests/unit/test_i18n.py
+++ b/tests/unit/test_i18n.py
@@ -300,3 +300,56 @@ def test_no_setting_row_shows_an_untranslated_english_word() -> None:
                 if word.lower() in prose:
                     offenders.append(f"line {node.lineno}: {piece.value!r}")
     assert not offenders, offenders
+
+
+#: Words a translated panel may still show: identifiers the ecosystem uses,
+#: package atoms, device names and command flags. Everything else in a row's
+#: value is prose, and prose belongs in the catalog.
+KEPT_IN_ENGLISH: frozenset[str] = frozenset(
+    {
+        "gentoo", "grub", "efi", "uefi", "bios", "zfs", "luks", "lvm", "mdraid", "utf",
+        "btrfs", "ext", "xfs", "vfat", "f2fs", "swap", "dhcp", "ssh", "sshd", "gpt", "mbr",
+        "zram", "openrc", "systemd", "dracut", "journald", "pipe", "native", "free",
+        "binary", "redistributable", "fcitx", "rime", "anthy", "mozc", "hangul", "ibus",
+        "plasma", "gnome", "xfce", "sddm", "gdm", "lightdm", "greetd", "amd", "intel",
+        "nvidia", "nouveau", "none", "true", "false", "auto", "cronie", "tmpfs", "dist",
+        "stage", "bin", "cjk", "default", "console", "linux", "amd64", "desktop",
+        "multilib", "virtio", "target", "disk", "whole", "builtin", "profile", "kernel",
+        "sys", "asia", "utc", "taipei", "shanghai", "tokyo", "seoul", "zfsbootmenu",
+        "networkmanager", "iwd", "wpa", "supplicant", "guru", "gig", "rsync", "git",
+        "webrsync", "official", "community", "off", "cpu", "flags", "ram",
+    }
+)
+
+
+def test_the_panel_shows_no_untranslated_prose_under_a_chinese_catalog() -> None:
+    """`交換空間 a partition` and `-j1 (this machine)` reached the panel: the
+    strings were built without `translate`, so the catalog completeness test
+    never saw them — it collects what is passed to `translate` and these were
+    not passed to anything."""
+    import re
+    from dataclasses import replace as replaced
+
+    from gentoo_install.i18n import Catalog
+    from gentoo_install.tui import settings as tui_settings
+
+    from .layouts import config, ext4_on_gpt
+    from .test_tui_app import context
+
+    at = context()
+    at.translate = Catalog("zh-TW")
+    at.columns = 100
+    base = config(ext4_on_gpt())
+    base = replaced(base, portage=replaced(base.portage, makeopts=""))
+
+    word = re.compile(r"[A-Za-z]{4,}")
+    leaked: list[str] = []
+    for group in tui_settings.SETTINGS:
+        for row in group.rows or (group,):
+            shown = str(row.value(base, at))
+            unknown = [
+                one for one in word.findall(shown) if one.lower() not in KEPT_IN_ENGLISH
+            ]
+            if unknown:
+                leaked.append(f"{row.key}: {shown!r}")
+    assert not leaked, leaked


### PR DESCRIPTION
Four row values were built as f-strings and never reached `translate`, so a Chinese, Japanese or Korean panel drew English inside them: `交換空間 a partition`, `us (same as the console)`, `, measured` beside a mirror, and `-j1 (this machine)` on every compiler row.

The catalog completeness test collects the literals passed to `translate`, so a string passed to nothing was invisible to it. The new test draws every row under the zh-TW catalog and fails on any English word that is not an identifier — package atoms, device names, filesystem names and command flags stay as they are, and the table says which.

Two catalog entries are new; the other two were already there.