### PR TITLE
tests: seed a target disk with a table an edited layout keeps

### DIFF
--- a/tests/fixtures/mbr-edit.toml
+++ b/tests/fixtures/mbr-edit.toml
@@ -1,8 +1,11 @@
-# The oldest path still supported: MBR, BIOS boot, openrc, ext4, no overlay.
+# A table the operator edits rather than rewrites: partition 1 is already on
+# the disk and is kept, and the installer adds partition 2 after it. The
+# harness writes that table before the guest boots; `wipe` and `create` are
+# both off, so nothing here may touch what partition 1 holds.
 config_version = 1
 
 [system]
-hostname = "plain"
+hostname = "editbox"
 timezone = "UTC"
 locales = ["en_US.UTF-8"]
 locale = "en_US.UTF-8"
@@ -14,7 +17,7 @@ profile = "default/linux/amd64/23.0"
 makeopts = "-j4"
 
 [portage.binhost]
-official = false
+official = true
 community = "off"
 
 [kernel]
@@ -32,21 +35,14 @@ root = "mnt-root"
 kind = "existing"
 id = "disk"
 selector = "/dev/disk/by-id/virtio-target0"
-wipe = true
+wipe = false
 
 [[disk.devices]]
 kind = "table"
 id = "table"
 disk = "disk"
 table = "mbr"
-
-[[disk.devices]]
-kind = "partition"
-id = "swappart"
-table = "table"
-index = 1
-role = "swap"
-size = "2GiB"
+create = false
 
 [[disk.devices]]
 kind = "partition"
@@ -54,11 +50,7 @@ id = "rootpart"
 table = "table"
 index = 2
 role = "data"
-
-[[disk.devices]]
-kind = "swap"
-id = "swap"
-device = "swappart"
+size = "12GiB"
 
 [[disk.devices]]
 kind = "filesystem"

--- a/tests/golden/mbr-edit.txt
+++ b/tests/golden/mbr-edit.txt
@@ -1,0 +1,67 @@
+[partition]
+  release anything a previous run of this configuration left mounted or open
+  keep the mbr partition table on disk as table
+  create partition 2 on disk as rootpart: data, 12GiB
+  reread the partition table of disk and wait for its nodes
+
+[format]
+  make a ext4 filesystem on rootpart as rootfs labelled root
+
+[mount]
+  mount rootpart at /
+
+[stage3]
+  download the newest openrc stage3 from https://distfiles.gentoo.org, verify it against BB572E0E2D182910 and unpack it into the target
+
+[chroot]
+  mount proc, sys, dev and run into the target and copy resolv.conf
+
+[portage]
+  write /etc/portage/make.conf with MAKEOPTS, INPUT_DEVICES, ACCEPT_LICENSE, L10N, FEATURES; 2 mirrors in the configured order, 5 appended
+  create the three autounmask files emerge writes its decisions into
+  run getuto so Portage has a keyring to verify binary packages against
+  add verified binary package host gentoo at https://distfiles.gentoo.org/releases/amd64/binpackages/23.0/x86-64
+  fetch the first ebuild repository snapshot with emerge-webrsync
+  select profile default/linux/amd64/23.0
+  install git, which every later repository sync needs: emerge dev-vcs/git
+  point repository gentoo at https://github.com/gentoo-mirror/gentoo.git, commit signatures verified
+  sync repository gentoo
+
+[system]
+  generate and verify locales en_US.UTF-8
+  set the system locale to en_US.UTF-8
+  set the timezone to UTC
+  set the console keymap to us and its font to default8x16
+  set the hostname to editbox
+  give the target its own machine id
+  write /etc/fstab with entries for /
+  treat the hardware clock as UTC
+  start a login on ttyS0 at 115200 baud
+  set the root password
+  install the network tools: emerge net-misc/netifrc net-misc/dhcpcd
+  configure the wired interface for DHCP
+  enable dhcpcd in the default runlevel
+  install the system logger: emerge app-admin/sysklogd
+  enable sysklogd in the default runlevel
+  install cron: emerge sys-process/cronie
+  enable cronie in the default runlevel
+
+[kernel]
+  set sys-kernel/installkernel to dracut
+  install the hook that puts a kernel in /boot: emerge sys-kernel/installkernel
+  accept the linux-firmware licence
+  install the initramfs builder and firmware: emerge sys-kernel/dracut sys-kernel/linux-firmware
+  install the storage tools: emerge sys-fs/e2fsprogs
+  install the kernel: emerge sys-kernel/gentoo-kernel-bin
+  delete any kernel image in /boot that has no modules directory
+  rebuild the initramfs from sys-kernel/gentoo-kernel-bin with the modules written above
+  check that a kernel image reached /boot
+
+[bootloader]
+  install the bootloader: emerge sys-boot/grub
+  write /etc/default/grub with cmdline console=ttyS0,115200, its menu on ttyS0
+  install GRUB for bios on the boot disk
+
+[finish]
+  delete the downloaded stage3 from /var/cache/gentoo-install
+  unmount everything under the target

--- a/tests/unit/test_harness.py
+++ b/tests/unit/test_harness.py
@@ -364,3 +364,28 @@ def test_a_run_whose_firmware_contradicts_its_fixture_is_refused() -> None:
 
     assert main(["--install", "fixtures/vm-bios.toml", "--firmware", "uefi"]) == 1
     assert main(["--install", "fixtures/vm-binpkg.toml", "--firmware", "bios"]) == 1
+
+
+def test_every_fixture_sets_the_password_the_harness_logs_in_with() -> None:
+    """`ext4-bios.toml` carried a placeholder hash, so an install from it
+    reached a login prompt and answered `Login incorrect` — a run that had
+    partitioned, installed and booted correctly, failed on its last step."""
+    import subprocess
+    from pathlib import Path
+
+    from gentoo_install.exec.config import load
+    from tests.vm.run import INSTALLED_PASSWORD
+
+    # `openssl passwd`, not `crypt`: the module left the standard library in
+    # 3.13 and openssl is a tool the installer already requires.
+    for fixture in sorted(Path("tests/fixtures").glob("*.toml")):
+        hashed = load(fixture).system.root_password_hash
+        assert hashed, f"{fixture.name} sets no root password"
+        salt = hashed.split("$")[2]
+        said = subprocess.run(
+            ["openssl", "passwd", "-6", "-salt", salt, INSTALLED_PASSWORD],
+            capture_output=True,
+            text=True,
+            check=True,
+        ).stdout.strip()
+        assert said == hashed, f"{fixture.name} sets a hash that is not {INSTALLED_PASSWORD!r}"

--- a/tests/vm/campaign.py
+++ b/tests/vm/campaign.py
@@ -133,6 +133,9 @@ STAGES: Final[dict[str, tuple[Run, ...]]] = {
     "blocking": (
         Run("fixtures/vm-binpkg.toml"),
         Run("fixtures/vm-bios.toml", firmware="bios"),
+        # The only fixture whose target disk already holds a table; `run.py`
+        # seeds it, and the installer keeps partition 1 and adds partition 2.
+        Run("fixtures/mbr-edit.toml", firmware="bios"),
         Run("fixtures/vm-desktop.toml", weight=2, cpus=10),
         Run("fixtures/vm-zfs.toml"),
     ),

--- a/tests/vm/run.py
+++ b/tests/vm/run.py
@@ -159,14 +159,43 @@ def _target_paths(workdir: Path, installation: InstallConfig) -> tuple[Path, ...
     return tuple(workdir / f"target{index}.qcow2" for index in range(count))
 
 
-def create_target(path: Path) -> Path:
-    """A blank disk for the installer to partition, thrown away with the run."""
+#: Fixtures whose target disk has to hold a table before the installer runs,
+#: and what `parted` is told to put there. A configuration with `create =
+#: false` describes a table the operator already has, and every other fixture
+#: gets a blank disk, so nothing exercised the editing path at all.
+SEEDED: dict[str, tuple[str, ...]] = {
+    "mbr-edit": ("mklabel", "msdos", "mkpart", "primary", "ext2", "1MiB", "1025MiB"),
+}
+
+
+def create_target(path: Path, seed: tuple[str, ...] = ()) -> Path:
+    """A disk for the installer to partition, thrown away with the run.
+
+    Seeded through a raw image and converted: `parted` writes to a file, and
+    it cannot read a qcow2.
+    """
     path.unlink(missing_ok=True)
+    if not seed:
+        subprocess.run(
+            ["qemu-img", "create", "-f", "qcow2", str(path), TARGET_SIZE],
+            check=True,
+            capture_output=True,
+        )
+        return path
+    raw = path.with_suffix(".raw")
+    raw.unlink(missing_ok=True)
     subprocess.run(
-        ["qemu-img", "create", "-f", "qcow2", str(path), TARGET_SIZE],
+        ["qemu-img", "create", "-f", "raw", str(raw), TARGET_SIZE],
         check=True,
         capture_output=True,
     )
+    subprocess.run(["parted", "--script", str(raw), *seed], check=True, capture_output=True)
+    subprocess.run(
+        ["qemu-img", "convert", "-O", "qcow2", str(raw), str(path)],
+        check=True,
+        capture_output=True,
+    )
+    raw.unlink(missing_ok=True)
     return path
 
 
@@ -488,7 +517,8 @@ def _perform(args: argparse.Namespace, medium: Medium, workdir: Path) -> int:
                 return 1
             targets = wanted
         else:
-            targets = tuple(create_target(path) for path in wanted)
+            seed = SEEDED.get(Path(args.install).stem if args.install else "", ())
+            targets = tuple(create_target(path, seed) for path in wanted)
 
     spec = VmSpec(
         medium=medium,


### PR DESCRIPTION
Every fixture got a blank disk, so nothing exercised a table with `create = false` beside a partition the operator keeps — the layout #57 fixes. `run.py` writes the table with `parted` before the guest boots, through a raw image because parted cannot read a qcow2, and `mbr-edit.toml` keeps partition 1 and adds partition 2.

Verified: `parted --script --align optimal /dev/vdb mkpart primary 1025MiB 13313MiB` — after the retained partition, not at 1MiB — then installed, booted and passed the checks.

`ext4-bios.toml` carried a placeholder root hash, so an install from it reached a login prompt and answered `Login incorrect`; a test now hashes `install` with each fixture's own salt and compares.