### PR TITLE
tests: give a guest that compiles a whole node

### DIFF
--- a/tests/unit/test_proxmox.py
+++ b/tests/unit/test_proxmox.py
@@ -861,3 +861,48 @@ def test_a_connection_reset_is_a_dropped_console_and_not_a_dead_run() -> None:
     after, why = framed.closed, framed.why_closed
     assert (before, after) == (False, True), "a reset has to look like a closed connection"
     assert "reset" in why.lower(), why
+
+
+def test_a_guest_that_compiles_is_given_a_whole_node() -> None:
+    """Every guest got two cores and four gibibytes, so an hour of `emerge`
+    ran with the same share as a six-minute binary-package install and the
+    cluster sat idle beside a deep queue. What makes a run long is compiling,
+    and the configuration is what says whether it does."""
+    from tests.vm.cluster import GUEST_CORES, GUEST_MEMORY_MIB, HEAVY_CORES, HEAVY_MEMORY_MIB
+    from tests.vm.cluster import fixtures as cluster_fixtures
+
+    weights = {one.name: one for one in cluster_fixtures(
+        ["vm-binpkg", "vm-zfs", "vm-desktop", "vm-gnome", "ext4-bios"]
+    )}
+    for name in ("vm-desktop", "vm-gnome", "ext4-bios"):
+        job = weights[name]
+        assert job.heavy, name
+        assert (job.cores, job.memory_mib) == (HEAVY_CORES, HEAVY_MEMORY_MIB), name
+    for name in ("vm-binpkg", "vm-zfs"):
+        job = weights[name]
+        assert not job.heavy, name
+        assert (job.cores, job.memory_mib) == (GUEST_CORES, GUEST_MEMORY_MIB), name
+
+
+def test_a_node_with_one_light_slot_left_is_not_given_a_heavy_guest() -> None:
+    """A heavy guest asks for twice the memory, so a slot list built from the
+    light size does not answer for it."""
+    from tests.vm.cluster import GUEST_MEMORY_MIB, NODE_HEADROOM_BYTES, room_for
+    from tests.vm.cluster import fixtures as cluster_fixtures
+    from tests.vm.proxmox import Node
+
+    light, heavy = cluster_fixtures(["vm-binpkg", "vm-desktop"])
+    one_slot = Node(
+        name="infra-node1",
+        free_bytes=NODE_HEADROOM_BYTES + GUEST_MEMORY_MIB * 1024**2,
+        cores=4,
+    )
+    assert room_for(one_slot, light)
+    assert not room_for(one_slot, heavy)
+
+    two_slots = Node(
+        name="infra-node2",
+        free_bytes=NODE_HEADROOM_BYTES + 2 * GUEST_MEMORY_MIB * 1024**2,
+        cores=4,
+    )
+    assert room_for(two_slots, heavy)

--- a/tests/vm/cluster.py
+++ b/tests/vm/cluster.py
@@ -107,6 +107,14 @@ GUEST_MEMORY_MIB: Final[int] = 4096
 GUEST_CORES: Final[int] = 2
 TARGET_GIB: Final[int] = 40
 
+#: What a guest that compiles is given instead. A source kernel or a desktop
+#: is an hour of `emerge` where a binary-package fixture is six minutes, and
+#: giving both the same two cores left the cluster idle while the queue was
+#: deep. A node has four cores, so a heavy guest takes all of them and the
+#: node carries one; the memory is what `MAKEOPTS -j4` needs to link.
+HEAVY_MEMORY_MIB: Final[int] = 8192
+HEAVY_CORES: Final[int] = 4
+
 #: Left free on every node whatever else is scheduled. A node with nothing
 #: spare stops answering, and this cluster runs other people's machines.
 NODE_HEADROOM_BYTES: Final[int] = 2 * 1024**3
@@ -167,6 +175,17 @@ class Job:
     iso: str = DEFAULT_ISO
     uefi: bool = True
     disks: int = 1
+    #: Read from the fixture rather than listed beside it: what makes a run
+    #: long is compiling, and the configuration is what says whether it does.
+    heavy: bool = False
+
+    @property
+    def memory_mib(self) -> int:
+        return HEAVY_MEMORY_MIB if self.heavy else GUEST_MEMORY_MIB
+
+    @property
+    def cores(self) -> int:
+        return HEAVY_CORES if self.heavy else GUEST_CORES
 
 
 #: Below this, over a whole ten-minute look, the guest is not working: a
@@ -411,6 +430,18 @@ def free_slots(api: Api, placed: Mapping[str, int] | None = None) -> list[Node]:
     return slots
 
 
+def room_for(node: Node, job: Job, placed: Mapping[str, int] | None = None) -> bool:
+    """Whether this node can carry this job now.
+
+    A heavy guest asks for twice the memory, so a slot list built from the
+    light size does not answer for it: eight of them were dispatched onto
+    nodes with room for four and the last four were killed by the hypervisor.
+    """
+    held = (placed or {}).get(node.name, 0) * GUEST_MEMORY_MIB * 1024**2
+    room = node.free_bytes - NODE_HEADROOM_BYTES - held
+    return room >= job.memory_mib * 1024**2
+
+
 class Stoppable(Protocol):
     """All the sweep needs of a guest. Stopping is what wakes the worker that
     is blocked reading its console; deleting is the worker's own job, and a
@@ -447,8 +478,8 @@ def install_one(
         spec=GuestSpec(
             name=f"gi-{job.name}"[:63],
             iso=job.iso,
-            memory_mib=GUEST_MEMORY_MIB,
-            cores=GUEST_CORES,
+            memory_mib=job.memory_mib,
+            cores=job.cores,
             target_gib=tuple(TARGET_GIB for _ in range(job.disks)),
             uefi=job.uefi,
             driver_iso=driver,
@@ -592,12 +623,24 @@ def run(
             if limit:
                 slots = slots[: max(0, limit - len(running))]
             while waiting and slots:
+                # The first job this node has room for, not the first job:
+                # a heavy guest wants twice the memory, and taking it from a
+                # node with one light slot left is how the hypervisor came to
+                # kill it. A light job behind it still goes now.
+                index = next(
+                    (at for at, one in enumerate(waiting) if room_for(slots[0], one, placed)),
+                    None,
+                )
+                if index is None:
+                    break
                 node = slots.pop(0)
                 if node.name not in prepared:
                     prepare(api, node.name, medium, urls, driver_path, driver)
                     prepared.add(node.name)
-                job = waiting.pop(0)
-                placed[node.name] += 1
+                job = waiting.pop(index)
+                # Two light slots for a heavy guest, so the arithmetic below
+                # keeps counting in one unit.
+                placed[node.name] += 2 if job.heavy else 1
                 where[job.name] = node.name
                 if job.iso == DEFAULT_ISO:
                     job = replace(job, iso=medium)
@@ -627,7 +670,10 @@ def run(
             running.pop(outcome.name, None)
             gone = where.pop(outcome.name, "")
             if gone:
-                placed[gone] -= 1
+                # The same unit it was taken in, or a node loses a slot for
+                # every heavy guest that finished on it.
+                weight = next((2 if one.heavy else 1 for one in jobs if one.name == outcome.name), 1)
+                placed[gone] -= weight
             print(
                 f"{outcome.verdict.value:6} {outcome.name:34} {outcome.seconds / 60:5.1f}m "
                 f"{outcome.detail}",
@@ -928,6 +974,15 @@ def _sweep(inflight: dict[str, Running]) -> None:
             print(f"{name}: the stuck guest would not stop: {error}", file=sys.stderr)
 
 
+def _compiles(config: InstallConfig) -> bool:
+    """Whether this configuration spends an hour in `emerge` rather than six
+    minutes: a kernel built from source, a desktop, or no binary host at all.
+    """
+    if config.kernel.source.value.endswith("-bin"):
+        return bool(config.packages.desktop) or not config.portage.binhost.official
+    return True
+
+
 def fixtures(names: list[str]) -> list[Job]:
     found: list[Job] = []
     for name in names:
@@ -941,6 +996,7 @@ def fixtures(names: list[str]) -> list[Job]:
                 fixture=path,
                 uefi=config.bootloader.firmware.value != "bios",
                 disks=max(1, len(config.disk.graph.of_type(Existing))),
+                heavy=_compiles(config),
             )
         )
     return found


### PR DESCRIPTION
`GUEST_MEMORY_MIB` and `GUEST_CORES` were constants, so `vm-desktop` and `ext4-bios` — an hour of `emerge` each — ran with the same two cores as `vm-binpkg`, which finishes in six minutes. Nodes stayed half idle while the queue was twelve deep.

A job reads its weight from the fixture rather than from a list beside it: a source kernel, a desktop, or no binary host means it compiles. Those get all four of a node's cores and eight gibibytes; everything else is unchanged.

The scheduler picks the first queued job the node has room for instead of the first job, so a heavy guest is not placed on a node with one light slot left and a light job behind it still goes now. Slots are taken and returned in the same unit.