### PR TITLE
data: say in each catalog what the source says

### DIFF
--- a/gentoo_install/data/locale/ja.toml
+++ b/gentoo_install/data/locale/ja.toml
@@ -82,7 +82,7 @@
 
 # Bootloader and overlays
 "A ZFS root cannot boot from GRUB. Which bootloader?" = "ZFS ルートは GRUB では起動できません。どちらを使いますか？"
-"adds the gentoo-zh overlay, the only one that has it" = "gentoo-zh オーバーレイの追加が必要"
+"adds the gentoo-zh overlay, the only one that has it" = "これを提供する唯一の gentoo-zh オーバーレイを追加します"
 "no overlay, and the esp has to hold the kernel" = "オーバーレイ不要、カーネルは esp に配置"
 
 # Packages

--- a/gentoo_install/data/locale/ko.toml
+++ b/gentoo_install/data/locale/ko.toml
@@ -82,7 +82,7 @@
 
 # Bootloader and overlays
 "A ZFS root cannot boot from GRUB. Which bootloader?" = "ZFS 루트는 GRUB으로 부팅할 수 없습니다. 어느 것을 쓰시겠습니까?"
-"adds the gentoo-zh overlay, the only one that has it" = "gentoo-zh 오버레이 추가 필요"
+"adds the gentoo-zh overlay, the only one that has it" = "이것을 제공하는 유일한 gentoo-zh 오버레이를 추가합니다"
 "no overlay, and the esp has to hold the kernel" = "오버레이 불필요, 커널은 esp에 배치"
 
 # Packages
@@ -172,7 +172,7 @@
 "same as the console" = "콘솔과 동일"
 "i915 and xe, with the firmware they need" = "i915 와 xe, 필요한 펌웨어 포함"
 "GCN 1.2 and newer" = "GCN 1.2 이후"
-"AMD up to Sea Islands" = "Sea Islands 이전의 AMD"
+"AMD up to Sea Islands" = "Sea Islands 및 그 이전 세대의 AMD"
 "the in-kernel NVIDIA driver" = "커널 내장 NVIDIA 드라이버"
 "proprietary, widens ACCEPT_LICENSE, and blacklists nouveau itself" = "독점 드라이버. ACCEPT_LICENSE 를 넓히고 nouveau 를 스스로 차단합니다"
 "virtio-gpu, QXL and VMware, with fbdev left as the fallback" = "virtio-gpu, QXL, VMware. 대체 수단으로 fbdev 를 남깁니다"
@@ -410,7 +410,7 @@
 "an empty root password hash locks the account, so the installed system would boot with nothing that can log in" = "비어 있는 root 비밀번호 해시는 계정을 잠그므로, 설치된 시스템은 부팅해도 로그인할 방법이 없다"
 "the input method needs it in this session" = "이 세션의 입력기가 필요로 함"
 "via" = "경유"
-"{when} excludes {excludes}" = "{when}과(와) {excludes}은(는) 함께 쓸 수 없습니다"
+"{when} excludes {excludes}" = "{when}, {excludes}: 두 가지는 함께 쓸 수 없습니다"
 "root on ZFS" = "ZFS 상의 루트"
 "/boot on ZFS" = "/boot이 ZFS에 있음"
 "a root that is not a ZFS dataset" = "ZFS 데이터셋이 아닌 루트"

--- a/gentoo_install/data/locale/zh-CN.toml
+++ b/gentoo_install/data/locale/zh-CN.toml
@@ -238,7 +238,7 @@
 "SSH" = "SSH"
 "detected" = "已检测"
 "a snapshot from GENTOO_MIRRORS" = "从 GENTOO_MIRRORS 获取快照"
-"what emerge --sync has always done" = "emerge --sync 的默认方式"
+"what emerge --sync has always done" = "emerge --sync 一直以来采用的方式"
 "prebuilt" = "预先构建"
 "built here" = "本机构建"
 "built here, cjktty for CJK on the console, from gentoo-zh" = "本机构建，来自 gentoo-zh；cjktty 用于在控制台显示 CJK"

--- a/gentoo_install/data/locale/zh-TW.toml
+++ b/gentoo_install/data/locale/zh-TW.toml
@@ -238,7 +238,7 @@
 "SSH" = "SSH"
 "detected" = "已偵測"
 "a snapshot from GENTOO_MIRRORS" = "透過 GENTOO_MIRRORS 取得快照"
-"what emerge --sync has always done" = "emerge --sync 的預設方式"
+"what emerge --sync has always done" = "emerge --sync 一直以來採用的方式"
 "prebuilt" = "預先建置"
 "built here" = "本機建置"
 "built here, cjktty for CJK on the console, from gentoo-zh" = "本機建置，來自 gentoo-zh；cjktty 用於在主控台顯示 CJK"

--- a/tests/unit/test_i18n.py
+++ b/tests/unit/test_i18n.py
@@ -323,7 +323,7 @@ KEPT_IN_ENGLISH: frozenset[str] = frozenset(
 
 
 def test_the_panel_shows_no_untranslated_prose_under_a_chinese_catalog() -> None:
-    """`交換空間 a partition` and `-j1 (this machine)` reached the panel: the
+    """`a partition` and `(this machine)` reached a translated panel: the
     strings were built without `translate`, so the catalog completeness test
     never saw them — it collects what is passed to `translate` and these were
     not passed to anything."""
@@ -353,3 +353,27 @@ def test_the_panel_shows_no_untranslated_prose_under_a_chinese_catalog() -> None
             if unknown:
                 leaked.append(f"{row.key}: {shown!r}")
     assert not leaked, leaked
+
+
+def test_no_catalog_shows_a_particle_the_writer_had_not_chosen() -> None:
+    """Korean picks its subject and object particles by the sound of the word
+    before them, and the compatibility message printed both candidates in
+    brackets rather than one of them: the operator read a sentence with
+    `(wa)` and `(neun)` left in it.
+
+    A value interpolates a word the catalog cannot see, so the sentence has to
+    be one that needs no particle chosen at all.
+    """
+    import re
+    import tomllib
+    from pathlib import Path
+
+    # Codepoints, not literals: no file under tests/ holds a wide character.
+    # A Hangul syllable immediately before `(` is a particle candidate.
+    candidates = re.compile("[\uac00-\ud7a3]\\(")
+    for catalog in sorted(Path("gentoo_install/data/locale").glob("*.toml")):
+        said = tomllib.loads(catalog.read_text())["strings"]
+        for source, value in said.items():
+            if "{" not in source:
+                continue
+            assert not candidates.search(value), f"{catalog.name}: {source}"


### PR DESCRIPTION
Four translations state something the English does not.

`what emerge --sync has always done` reads as `emerge --sync 的預設方式` in both Chinese catalogs — the source says it is the long-standing behaviour, not the default. Japanese and Korean drop the reason from `adds the gentoo-zh overlay, the only one that has it`, so the operator is told to add an overlay and not why. Korean turns `AMD up to Sea Islands` into a range that excludes Sea Islands.

The fourth is visible on screen: Korean picks its particles by the sound of the preceding word, and `{when}과(와) {excludes}은(는)` printed both candidates around values the catalog cannot see. The sentence now needs no particle chosen. A test fails any interpolated Korean value that leaves a candidate in brackets.