### PR TITLE
tests: treat a broken pipe as a dropped console

### DIFF
--- a/tests/unit/test_proxmox.py
+++ b/tests/unit/test_proxmox.py
@@ -906,3 +906,32 @@ def test_a_node_with_one_light_slot_left_is_not_given_a_heavy_guest() -> None:
         cores=4,
     )
     assert room_for(two_slots, heavy)
+
+
+def test_a_broken_pipe_is_a_dropped_console_and_not_a_dead_run() -> None:
+    """The read side was fixed and the write side was not, so three guests
+    were recorded `ERROR ... [Errno 32] Broken pipe` at sixteen minutes with
+    their installs running."""
+    from tests.vm.websocket import WebSocket
+
+    class Broken:
+        def recv(self, size: int) -> bytes:
+            return b""
+
+        def sendall(self, data: bytes) -> None:
+            raise BrokenPipeError(32, "Broken pipe")
+
+        def close(self) -> None:
+            return None
+
+        def settimeout(self, seconds: float | None) -> None:
+            return None
+
+    framed = WebSocket(Broken())
+    before = framed.closed
+    framed.send(b"hello")
+    after, why = framed.closed, framed.why_closed
+    assert (before, after) == (False, True), "a broken pipe has to look like a closed connection"
+    assert "pipe" in why.lower(), why
+    # A second write on a closed connection is not an error either.
+    framed.send(b"again")

--- a/tests/vm/websocket.py
+++ b/tests/vm/websocket.py
@@ -130,7 +130,18 @@ class WebSocket:
         self._sock.settimeout(seconds)
 
     def send(self, payload: bytes, opcode: int = _BINARY) -> None:
-        self._sock.sendall(_client_frame(payload, opcode))
+        if self._closed:
+            return
+        try:
+            self._sock.sendall(_client_frame(payload, opcode))
+        except OSError as error:
+            # Closed rather than raised, as on the read side: three cluster
+            # guests were recorded `ERROR ... [Errno 32] Broken pipe` at
+            # sixteen minutes with their installs running, because a write to
+            # a connection the far end had dropped went past every
+            # `except ConsoleClosed` above.
+            self._closed = True
+            self._why = f"the connection broke: {error}"
 
     def read(self) -> bytes:
         """Payload from whatever whole frames have arrived, possibly empty.


### PR DESCRIPTION
#58 closed the connection on a read that fails and left `send` raising. Today's round recorded `ERROR vm-binpkg 18.4m [Errno 32] Broken pipe` for three guests whose installs were running: a write to a connection the far end had dropped went past every `except ConsoleClosed`.

Writing to an already closed connection is not an error either — the reader above reopens it.