### PR TITLE
model: refuse mbr indexes parted will not honour

### DIFF
--- a/gentoo_install/model/validate.py
+++ b/gentoo_install/model/validate.py
@@ -26,6 +26,7 @@ from .device import (
     Node,
     Partition,
     PartitionTable,
+    TableType,
     ZfsPool,
     ZfsTopology,
 )
@@ -309,4 +310,26 @@ def _partition_index_problems(graph: DeviceGraph) -> list[str]:
         for index, count in sorted(Counter(indexes).items()):
             if count > 1:
                 problems.append(f"{count} partitions on {table.id} take index {index}")
+        problems += _mbr_index_problems(table, indexes)
     return problems
+
+
+def _mbr_index_problems(table: PartitionTable, indexes: list[int]) -> list[str]:
+    """Indexes `parted` will not honour on a table written from scratch.
+
+    `parted mkpart` takes no partition number: it assigns the lowest free one.
+    A new MBR table whose configuration asks for index 3 alone therefore gets
+    partition 1, `parted` reports success, and the executor waits for a node
+    ending in 3 that the kernel cannot expose — with the table and partition 1
+    already written. GPT is not affected: `sgdisk --new=N:...` is given the
+    number.
+    """
+    if table.table is not TableType.MBR or not table.create or not indexes:
+        return []
+    wanted = sorted(indexes)
+    if wanted != list(range(1, len(wanted) + 1)):
+        return [
+            f"{table.id} is a new mbr table and asks for indexes {wanted}; "
+            "parted assigns the lowest free number, so they have to be 1 upwards"
+        ]
+    return []

--- a/tests/unit/test_validate.py
+++ b/tests/unit/test_validate.py
@@ -7,7 +7,13 @@ import pytest
 
 from gentoo_install.errors import ValidationFailed
 from gentoo_install.model.config import InitSystem, InstallConfig
-from gentoo_install.model.device import Mountpoint, Node, Partition, PartitionRole
+from gentoo_install.model.device import (
+    Mountpoint,
+    Node,
+    Partition,
+    PartitionRole,
+    PartitionTable,
+)
 from gentoo_install.model.size import Size
 from gentoo_install.exec.config import load
 from gentoo_install.model.validate import validate
@@ -297,3 +303,46 @@ def test_a_remote_unlock_pair_of_one_family_is_a_working_configuration() -> None
                 ),
             )
         )
+
+
+def test_a_new_mbr_table_whose_indexes_parted_cannot_honour_is_refused() -> None:
+    """`parted mkpart` takes no partition number and assigns the lowest free
+    one, so a new MBR table asking for index 3 alone gets partition 1: parted
+    reports success and the executor waits for a node ending in 3 that the
+    kernel cannot expose, with the table and partition 1 already written.
+
+    Measured: `parted --script --align optimal <image> mkpart primary 1MiB
+    65MiB` on a fresh msdos label produced `1:1.00MiB:65.0MiB`.
+    """
+    from gentoo_install.model.device import TableType
+
+    nodes = [
+        node
+        for node in ext4_on_gpt()
+        if not isinstance(node, Partition) or node.id != i("esp")
+    ]
+    nodes = [
+        replace(node, table=TableType.MBR)
+        if isinstance(node, PartitionTable)
+        else replace(node, index=3)
+        if isinstance(node, Partition)
+        else node
+        for node in nodes
+    ]
+    nodes = [node for node in nodes if not isinstance(node, Mountpoint) or node.path != PurePosixPath("/efi")]
+    nodes = [node for node in nodes if node.id != i("espfs")]
+    with pytest.raises(ValidationFailed) as refused:
+        validate(config(nodes))
+    # Named, not merely refused: stripping the esp to reach an MBR layout
+    # gives this configuration other problems, and a test that only asks for
+    # `ValidationFailed` passes with the index rule removed.
+    assert "parted assigns the lowest free number" in str(refused.value), refused.value
+
+
+def test_an_mbr_table_numbered_from_one_is_a_working_layout() -> None:
+    """`ext4-bios.toml` is exactly this, and it installs."""
+    from pathlib import Path as _Path
+
+    from gentoo_install.exec.config import load as _load
+
+    validate(_load(_Path("tests/fixtures/ext4-bios.toml")))


### PR DESCRIPTION
`CreatePartition` keeps `self.index` and `parted mkpart` has no argument for it — it assigns the lowest free number. A new MBR table whose configuration asks for index 3 alone therefore gets partition 1, parted exits 0, and `_partition_path` waits for a node ending in 3 that the kernel cannot expose. The table and partition 1 are on the disk by then, and the esp path would run `parted set 3 esp on` against a number that does not exist.

Measured on a throwaway image: `mklabel msdos` then `mkpart primary 1MiB 65MiB` for a model index of 3 produced `1:1.00MiB:65.0MiB`.

GPT is untouched: `sgdisk --new=N:...` is given the number. The test asserts the message, not just that something was refused — stripping the esp to reach an MBR layout gives the configuration other problems, and a bare `pytest.raises` passed with the rule removed.