### PR TITLE
model: refuse partition sizes a table cannot hold

### DIFF
--- a/gentoo_install/model/manual.py
+++ b/gentoo_install/model/manual.py
@@ -379,6 +379,28 @@ def _array_nodes(array: Array, members: tuple[DeviceId, ...]) -> list[Node]:
     return nodes
 
 
+def _numbered(slices: list[Slice]) -> list[Slice]:
+    """The slices in the order the disk will number them.
+
+    The one with no size takes what is left, so it has to be last whatever
+    index the operator gave it: `suggest()` starts the root at 1 and an added
+    partition therefore sat behind a partition that runs to the last sector,
+    which `sgdisk` refuses after the table has been written.
+    """
+    kept = [one for one in slices if one.status is not SliceStatus.DELETE]
+    if any(one.status is not SliceStatus.CREATE for one in kept):
+        # An edited table: every number here is one the disk already gave out,
+        # and moving a kept partition's number renames somebody's filesystem.
+        return sorted(slices, key=lambda one: one.index)
+    ordered = sorted(
+        sorted(kept, key=lambda one: one.index), key=lambda one: one.size is None
+    )
+    renumbered: list[Slice] = []
+    for position, entry in enumerate(ordered, start=1):
+        renumbered.append(entry if entry.index == position else replace(entry, index=position))
+    return renumbered + [one for one in slices if one.status is SliceStatus.DELETE]
+
+
 def build(layout: Layout) -> tuple[DeviceGraph, DeviceId]:
     """The graph and the id of the mount point that is `/`.
 
@@ -397,7 +419,7 @@ def build(layout: Layout) -> tuple[DeviceGraph, DeviceId]:
     for position, disk in enumerate(layout.disks, start=1):
         prefix = f"disk{position}"
         nodes += _table_nodes(disk, prefix)
-        for entry in sorted(disk.slices, key=lambda one: one.index):
+        for entry in _numbered(disk.slices):
             if entry.status is SliceStatus.DELETE:
                 # Gone from the table above, so it carries nothing downstream.
                 continue

--- a/gentoo_install/model/validate.py
+++ b/gentoo_install/model/validate.py
@@ -311,6 +311,38 @@ def _partition_index_problems(graph: DeviceGraph) -> list[str]:
             if count > 1:
                 problems.append(f"{count} partitions on {table.id} take index {index}")
         problems += _mbr_index_problems(table, indexes)
+        problems += _partition_size_problems(graph, table)
+    return problems
+
+
+def _partition_size_problems(graph: DeviceGraph, table: PartitionTable) -> list[str]:
+    """Sizes the table cannot hold, found before `sgdisk --zap-all` runs.
+
+    A partition with no size takes what is left, so only the last one may have
+    none: an unsized partition 1 took the disk to its last usable sector and
+    `--new=2:0:+8M` then exited 4, with the operator's table already gone.
+    Zero is the same shape of failure one step earlier — `+0K` is refused —
+    and `Size(0)` stays a legal value everywhere else.
+    """
+    problems: list[str] = []
+    partitions = sorted(
+        (one for one in graph.of_type(Partition) if one.table == table.id),
+        key=lambda node: node.index,
+    )
+    for one in partitions:
+        if one.size is not None and one.size.bytes <= 0:
+            problems.append(f"partition {one.id} on {table.id} is {one.size}")
+    unsized = [one for one in partitions if one.size is None]
+    if len(unsized) > 1:
+        problems.append(
+            f"{len(unsized)} partitions on {table.id} take the rest of the disk; "
+            "only the last one can"
+        )
+    elif unsized and partitions and unsized[0].index != partitions[-1].index:
+        problems.append(
+            f"partition {unsized[0].id} takes the rest of {table.id} and is not "
+            "the last one, so nothing after it has room"
+        )
     return problems
 
 

--- a/tests/unit/test_plan.py
+++ b/tests/unit/test_plan.py
@@ -150,14 +150,22 @@ def test_a_zfs_root_produces_no_grub_operation() -> None:
 
 
 def test_bios_installs_no_efibootmgr() -> None:
-    nodes = ext4_on_gpt()
+    from gentoo_install.model.size import Size
+
+    # A bios-boot partition is a megabyte for GRUB's stage 1.5, and the root
+    # is what takes the rest: two partitions with no size describe a disk
+    # `sgdisk` refuses, because the first of them runs to the last sector.
+    nodes = [
+        replace(node, index=3) if isinstance(node, Partition) and node.id == i("rootpart") else node
+        for node in ext4_on_gpt()
+    ]
     nodes.append(
         Partition(
             id=i("bios"),
             table=i("table"),
-            index=3,
+            index=2,
             role=PartitionRole.BIOS_BOOT,
-            size=None,
+            size=Size.parse("2MiB"),
         )
     )
     on_bios = replace(

--- a/tests/unit/test_tui_partitions.py
+++ b/tests/unit/test_tui_partitions.py
@@ -1010,3 +1010,49 @@ def test_raid_and_the_pool_topology_are_visible_before_they_are_reachable() -> N
     assert "raid array member purpose" in drawn.last
     assert "Pool topology" in drawn.last
     assert "zfs pool member purpose" in drawn.last
+
+
+def test_a_partition_added_after_the_root_does_not_leave_it_in_the_middle() -> None:
+    """`suggest()` starts the root at index 1 with no size, so it takes the
+    rest of the disk. An operator adding a partition after it produced a table
+    whose partition 1 runs to the last sector and whose partition 3 has
+    nowhere to go, which `sgdisk` refuses once the table is written.
+
+    The one with no size is numbered last, whatever index it was given.
+    """
+    from gentoo_install.model.device import Partition
+
+    layout = manual.suggest("/dev/vda", Firmware.UEFI)
+    layout.disks[0].slices.append(
+        manual.Slice(
+            index=3,
+            role=PartitionRole.DATA,
+            size=Size.parse("20GiB"),
+            filesystem=FilesystemType.XFS,
+            mountpoint="/home",
+        )
+    )
+    graph, root = manual.build(layout)
+    numbered = sorted(graph.of_type(Partition), key=lambda one: one.index)
+    assert [one.size is None for one in numbered] == [False, False, True], [
+        (one.index, str(one.size)) for one in numbered
+    ]
+    validate(config_from(graph, root))
+
+
+def test_an_edited_table_keeps_the_numbers_the_disk_gave_out() -> None:
+    """Renumbering is for a table written from scratch. A kept partition's
+    number is the disk's, and moving it renames somebody's filesystem."""
+    from gentoo_install.model.device import Partition
+
+    status = manual.SliceStatus
+    layout = one_disk(slices=[
+        kept("/dev/vda1", FilesystemType.VFAT, "/efi"),
+        kept("/dev/vda2", FilesystemType.EXT4, "", status.DELETE),
+        manual.Slice(
+            index=3, role=PartitionRole.DATA, size=None,
+            filesystem=FilesystemType.EXT4, mountpoint="/",
+        ),
+    ])
+    graph, _ = manual.build(layout)
+    assert [one.index for one in graph.of_type(Partition)] == [3]

--- a/tests/unit/test_validate.py
+++ b/tests/unit/test_validate.py
@@ -346,3 +346,41 @@ def test_an_mbr_table_numbered_from_one_is_a_working_layout() -> None:
     from gentoo_install.exec.config import load as _load
 
     validate(_load(_Path("tests/fixtures/ext4-bios.toml")))
+
+
+@pytest.mark.parametrize(
+    ("what", "edited", "says"),
+    [
+        pytest.param(
+            "unsized-not-last",
+            {"esp": None, "rootpart": Size.parse("20GiB")},
+            "takes the rest of",
+            id="unsized-not-last",
+        ),
+        pytest.param("zero", {"esp": Size(0)}, "is 0B", id="zero"),
+    ],
+)
+def test_a_partition_size_the_table_cannot_hold_is_refused(
+    what: str, edited: dict[str, Size | None], says: str
+) -> None:
+    """Both are found after `sgdisk --zap-all` has taken the operator's table.
+
+    An unsized partition takes what is left, so an unsized partition 1 runs to
+    the last usable sector and `--new=2:0:+8M` exits 4. A zero-sized one is
+    refused one step earlier, as `+0K`.
+    """
+    nodes = [
+        replace(node, size=edited[str(node.id)])
+        if isinstance(node, Partition) and str(node.id) in edited
+        else node
+        for node in ext4_on_gpt()
+    ]
+    with pytest.raises(ValidationFailed) as refused:
+        validate(config(nodes))
+    assert says in str(refused.value), refused.value
+
+
+def test_the_last_partition_may_still_take_the_rest_of_the_disk() -> None:
+    """Every shipped layout does this, and it is the point of the rule that
+    only the last one may."""
+    validate(config(ext4_on_gpt()))


### PR DESCRIPTION
An unsized partition takes what is left, so only the last one may have none: an unsized partition 1 runs to the last usable sector and the next `--new` exits 4 — after `sgdisk --zap-all` has taken the operator's table. Zero is the same failure one step earlier, as `+0K`; `Size(0)` stays legal everywhere else.

The manual editor produced exactly that layout: `suggest()` starts the root at index 1 with no size, so an operator adding a partition left the root running to the end of the disk with a partition 3 that has nowhere to go. `manual.build` numbers the unsized slice last — only for a table written from scratch, because a kept partition's number is the disk's and moving it renames somebody's filesystem.