### PR TITLE
tests: check what the fixture asked for, not that it booted

### DIFF
--- a/tests/unit/test_harness.py
+++ b/tests/unit/test_harness.py
@@ -389,3 +389,43 @@ def test_every_fixture_sets_the_password_the_harness_logs_in_with() -> None:
             check=True,
         ).stdout.strip()
         assert said == hashed, f"{fixture.name} sets a hash that is not {INSTALLED_PASSWORD!r}"
+
+
+def test_the_boot_check_asks_what_the_fixture_asked_for() -> None:
+    """`hostname` and `kernel` carried an empty expectation, and `mounts` only
+    looked for `/`, so a guest that came up with the wrong hostname, the wrong
+    root filesystem or the wrong locale passed every check and the run was
+    recorded `ok`. That is success with the wrong result, which no assertion
+    in this repository could see."""
+    from pathlib import Path
+
+    from gentoo_install.exec.config import load
+    from tests.vm.cluster import _asked_for
+
+    wanted = {
+        "vm-xfs": ("xfsbox", "xfs", "systemd", "en_US.UTF-8"),
+        "vm-btrfs": ("btrfsbox", "btrfs", "systemd", "zh_TW.UTF-8"),
+        "vm-zfs": ("zfsbox", "zfs", "systemd", "en_US.UTF-8"),
+        "vm-openrc-desktop": ("openrcdesk", "ext4", "openrc", "en_US.UTF-8"),
+    }
+    for name, (host, filesystem, init, locale) in wanted.items():
+        said = {one: value for one, _, value in _asked_for(load(Path("tests/fixtures") / f"{name}.toml"))}
+        assert said["hostname"] == host, name
+        assert said["root filesystem"] == filesystem, name
+        assert said["init"] == init, name
+        assert said["locale"] == f"LANG={locale}", name
+
+
+def test_every_fixture_has_a_boot_check_that_can_fail() -> None:
+    """A fixture whose checks are all empty strings is one the boot pass
+    cannot fail, which is how the empty ones went unnoticed."""
+    from pathlib import Path
+
+    from gentoo_install.exec.config import load
+    from tests.vm.cluster import _asked_for
+
+    for fixture in sorted(Path("tests/fixtures").glob("*.toml")):
+        checks = _asked_for(load(fixture))
+        empty = [one for one, _, value in checks if not value]
+        assert not empty, f"{fixture.name}: {empty}"
+        assert len(checks) >= 4, f"{fixture.name}: {checks}"

--- a/tests/vm/cluster.py
+++ b/tests/vm/cluster.py
@@ -30,8 +30,16 @@ from collections.abc import Callable, Mapping
 from typing import Final, Protocol
 
 from gentoo_install.model.config import Firmware as BootFirmware
-from gentoo_install.model.config import InstallConfig
-from gentoo_install.model.device import Existing, Luks, ZfsPool
+from gentoo_install.model.config import InitSystem, InstallConfig
+from gentoo_install.model.device import (
+    Existing,
+    Filesystem,
+    Luks,
+    Mountpoint,
+    Subvolume,
+    ZfsDataset,
+    ZfsPool,
+)
 from gentoo_install.model.config import MirrorRegion, Sync
 from gentoo_install.exec.config import load
 from gentoo_install.model.serialise import to_toml
@@ -856,12 +864,47 @@ INSTALLED_PASSWORD: Final[str] = "install"
 #: One table, so a check cannot be added without saying what would fail it.
 INSIDE: Final[tuple[tuple[str, str, str], ...]] = (
     ("os-release", "cat /etc/os-release", "Gentoo"),
-    ("mounts", "findmnt --noheadings --list --output TARGET,SOURCE,FSTYPE", "/"),
     ("fstab", "cat /etc/fstab", "UUID="),
-    ("hostname", "cat /etc/hostname 2>/dev/null || cat /etc/conf.d/hostname", ""),
-    ("locale", "locale", "LANG="),
-    ("kernel", "uname -r", ""),
 )
+
+
+def _asked_for(installation: InstallConfig) -> list[tuple[str, str, str]]:
+    """What this particular configuration should have produced.
+
+    Derived from the model rather than written out once for every fixture:
+    `hostname` and `kernel` carried an empty expectation, so a guest with the
+    wrong hostname, the wrong root filesystem or the wrong locale passed every
+    check, and a run that installed the wrong system was recorded as `ok`.
+    """
+    graph = installation.disk.graph
+    root = graph.nodes.get(installation.disk.root)
+    source = graph.nodes.get(root.source) if isinstance(root, Mountpoint) else None
+    checks = [
+        ("locale", "locale", f"LANG={installation.system.locale}"),
+        ("hostname", "hostname", installation.system.hostname),
+    ]
+    if isinstance(source, Filesystem):
+        # The type as `findmnt` names it, on the row for `/`: an xfs root that
+        # came up as ext4 is an install that went wrong quietly.
+        checks.append(
+            (
+                "root filesystem",
+                "findmnt --noheadings --output FSTYPE /",
+                source.kind.value,
+            )
+        )
+    elif isinstance(source, Subvolume):
+        checks.append(("root filesystem", "findmnt --noheadings --output FSTYPE /", "btrfs"))
+    elif isinstance(source, ZfsDataset):
+        checks.append(("root filesystem", "findmnt --noheadings --output FSTYPE /", "zfs"))
+    checks.append(
+        (
+            "init",
+            "ls -l /sbin/init",
+            "systemd" if installation.system.init is InitSystem.SYSTEMD else "openrc",
+        )
+    )
+    return checks
 
 
 #: How long SeaBIOS and GRUB take to reach the cryptomount prompt. Nothing on
@@ -942,7 +985,7 @@ def boot_and_check(
     except (ConsoleTimeout, ConsoleClosed) as error:
         return f"root could not log into the installed system: {error}"[:200]
 
-    for name, command, wanted in INSIDE:
+    for name, command, wanted in (*INSIDE, *_asked_for(installation)):
         said = link.expect_output(command, timeout=120.0)
         if wanted and wanted.encode() not in said:
             return f"{name}: the installed system does not say {wanted!r}"


### PR DESCRIPTION
The `INSIDE` table gave `hostname` and `kernel` an empty expectation, so neither was checked at all, and `mounts` only looked for `/` in `findmnt` output. A guest that came up with the wrong hostname, the wrong root filesystem, the wrong init or the wrong locale passed every check and the run was recorded `ok` — success with the wrong result, which is the class no assertion here could see.

The checks are now derived from the fixture's own `InstallConfig`, the way the local runner already derives its own: the hostname it set, the locale it chose, the filesystem `findmnt` should name on `/`, and which init `/sbin/init` points at. A test asserts no fixture ends up with an empty expectation, which is how the two empty ones went unnoticed.