### PR TITLE
readme: name the two install commands as alternatives

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -58,8 +58,9 @@ cd gentoo-install-master
 
 ```sh
 ./bootstrap.sh --config my-install.toml --dry-run
+# 続いて次のいずれか一方を実行します。どちらも選択したディスクに書き込みます。
 ./bootstrap.sh --config my-install.toml
-./bootstrap.sh --config my-install.toml --no-shell   # root シェルを開くかどうかは確認しません
+./bootstrap.sh --config my-install.toml --no-shell   # 同じ実行で、root シェルの確認をしません
 ```
 
 対話型インストールでは、成功時と失敗時のどちらでも、アンマウント前にターゲットシステム内で root シェルを開く選択肢が提示されます。`--no-shell` を使用すると、この確認を省略できます。

--- a/README.ko.md
+++ b/README.ko.md
@@ -58,8 +58,9 @@ cd gentoo-install-master
 
 ```sh
 ./bootstrap.sh --config my-install.toml --dry-run
+# 이어서 아래 두 줄 가운데 하나만 실행한다. 둘 다 선택한 디스크에 쓴다.
 ./bootstrap.sh --config my-install.toml
-./bootstrap.sh --config my-install.toml --no-shell   # root 셸을 열지 여부를 묻지 않는다
+./bootstrap.sh --config my-install.toml --no-shell   # 같은 실행이며 root 셸을 묻지 않는다
 ```
 
 대화형 설치에서는 성공하거나 실패한 경우 모두 마운트를 해제하기 전에 대상 시스템 안에서 root 셸을 여는 선택지를 제공한다. `--no-shell`을 사용하면 이 확인을 생략할 수 있다.

--- a/README.md
+++ b/README.md
@@ -58,8 +58,9 @@ The menu can save its answers as `my-install.toml` and exit. The configuration-f
 
 ```sh
 ./bootstrap.sh --config my-install.toml --dry-run
+# Then one of the two below. Each writes the selected disks.
 ./bootstrap.sh --config my-install.toml
-./bootstrap.sh --config my-install.toml --no-shell   # suppress the root-shell prompt
+./bootstrap.sh --config my-install.toml --no-shell   # the same run, without the root-shell prompt
 ```
 
 Before unmounting, an interactive run offers a root shell in the target after either success or failure. `--no-shell` suppresses that question.

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -58,8 +58,9 @@ cd gentoo-install-master
 
 ```sh
 ./bootstrap.sh --config my-install.toml --dry-run
+# 接着择一执行下列其中一行。两者都会写入所选磁盘。
 ./bootstrap.sh --config my-install.toml
-./bootstrap.sh --config my-install.toml --no-shell   # 不询问是否打开 root shell
+./bootstrap.sh --config my-install.toml --no-shell   # 同一次安装，不询问是否打开 root shell
 ```
 
 交互式安装无论成功或失败，都会在卸载前提供在目标系统内打开 root shell 的选项。可使用`--no-shell` 跳过这项确认。

--- a/README.zh-TW.md
+++ b/README.zh-TW.md
@@ -58,8 +58,9 @@ cd gentoo-install-master
 
 ```sh
 ./bootstrap.sh --config my-install.toml --dry-run
+# 接著擇一執行下列其中一行。兩者都會寫入所選磁碟。
 ./bootstrap.sh --config my-install.toml
-./bootstrap.sh --config my-install.toml --no-shell   # 不詢問是否開啟 root shell
+./bootstrap.sh --config my-install.toml --no-shell   # 同一次安裝，不詢問是否開啟 root shell
 ```
 
 互動式安裝無論成功或失敗，都會在卸載前提供於目標系統內開啟 root shell 的選項。`--no-shell` 可略過這項確認。


### PR DESCRIPTION
The configuration workflow read as four steps: save, dry run, install, install with `--no-shell`. Only `--dry-run` decides whether the disks are written — `--no-shell` suppresses the closing root-shell question and nothing else — so a reader following the block installs onto the selected disks twice.

The two are now marked as one or the other, in all five files, with the line saying that each writes the disks.