### PR TITLE
tests: count every job the campaign dispatched

### DIFF
--- a/tests/unit/test_harness.py
+++ b/tests/unit/test_harness.py
@@ -429,3 +429,44 @@ def test_every_fixture_has_a_boot_check_that_can_fail() -> None:
         empty = [one for one, _, value in checks if not value]
         assert not empty, f"{fixture.name}: {empty}"
         assert len(checks) >= 4, f"{fixture.name}: {checks}"
+
+
+def test_a_fixture_named_twice_is_refused_before_any_guest_is_built() -> None:
+    """Every map in the schedule is keyed by job name, so the second guest
+    overwrote the first's bookkeeping: one outcome ended the loop while the
+    other was still running, `1/1 passed` was printed for two jobs, and the
+    second guest could outlive the process."""
+    from tests.vm.cluster import main
+
+    assert main(["vm-lvm", "vm-lvm"]) == 1
+
+
+def test_a_run_that_collected_fewer_results_than_it_dispatched_fails(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A worker that died without answering left its job with no outcome, and
+    the verdict compared passes against the outcomes that arrived rather than
+    against the jobs that were asked for: two dispatched, one returned, `1/1
+    passed` and exit 0."""
+    from typing import Any
+
+    from tests.vm import cluster
+
+    def one_result(jobs: list[Any], *args: Any, **kwargs: Any) -> list[cluster.Outcome]:
+        return [
+            cluster.Outcome(
+                name=jobs[0].name, verdict=cluster.Verdict.OK, seconds=1.0, detail=""
+            )
+        ]
+
+    monkeypatch.setattr(cluster, "run", one_result)
+    assert cluster.main(["vm-lvm", "vm-xfs"]) == 1
+    # And the ordinary case still passes, so this is not failing on everything.
+    def both(jobs: list[Any], *args: Any, **kwargs: Any) -> list[cluster.Outcome]:
+        return [
+            cluster.Outcome(name=one.name, verdict=cluster.Verdict.OK, seconds=1.0, detail="")
+            for one in jobs
+        ]
+
+    monkeypatch.setattr(cluster, "run", both)
+    assert cluster.main(["vm-lvm", "vm-xfs"]) == 0

--- a/tests/vm/cluster.py
+++ b/tests/vm/cluster.py
@@ -1088,8 +1088,18 @@ def main(argv: list[str] | None = None) -> int:
     )
     args = parser.parse_args(argv)
 
+    repeated = sorted({one for one in args.fixtures if args.fixtures.count(one) > 1})
+    if repeated:
+        # Refused rather than deduplicated: every map below is keyed by name,
+        # so the second guest overwrote the first's bookkeeping, one result
+        # ended the loop while the other was still running, and `1/1 passed`
+        # was printed for two jobs.
+        print(f"named more than once: {repeated}", file=sys.stderr)
+        return 1
+
+    jobs = fixtures(args.fixtures)
     outcomes = run(
-        fixtures(args.fixtures),
+        jobs,
         args.workdir,
         args.limit,
         int(time.time()),
@@ -1097,11 +1107,17 @@ def main(argv: list[str] | None = None) -> int:
         Sync(args.sync),
     )
     passed = [one for one in outcomes if one.verdict is Verdict.OK]
-    print(f"\n{len(passed)}/{len(outcomes)} passed")
+    print(f"\n{len(passed)}/{len(jobs)} passed")
     for one in outcomes:
         if one.verdict is not Verdict.OK:
             print(f"  {one.verdict.value} {one.name}: {one.detail} ({one.log})")
-    return 0 if len(passed) == len(outcomes) else 1
+    # Against what was asked for, not against what came back: a worker that
+    # died without answering left its job with no outcome at all, and a run
+    # that collected fewer results than it dispatched still exited 0.
+    missing = sorted({one.name for one in jobs} - {one.name for one in outcomes})
+    for name in missing:
+        print(f"  no result {name}", file=sys.stderr)
+    return 0 if len(passed) == len(jobs) else 1
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
`running`, `where` and `inflight` are all keyed by job name. A fixture named twice therefore had the second guest overwrite the first's bookkeeping: one outcome removed the only entry, the loop ended while the other was still installing, and `1/1 passed` was printed for two jobs — the second guest outliving the process that made it. Naming one twice is refused before a guest is built.

The verdict compared passes against the outcomes that came back rather than the jobs that went out, so a worker dying without answering was invisible. It compares against the jobs now and names any that returned nothing.