### PR TITLE
tui: read the terminal again when the window grows

### DIFF
--- a/gentoo_install/tui/curses_screen.py
+++ b/gentoo_install/tui/curses_screen.py
@@ -58,7 +58,16 @@ class CursesScreen:
         self._window.refresh()
 
     def key(self) -> str:
-        return str(self._window.getkey())
+        pressed = str(self._window.getkey())
+        if pressed == "KEY_RESIZE":
+            # curses keeps the size it started with until it is told to look
+            # again, so `size()` kept answering 80x24 after the window grew
+            # and every list stayed the height it had when the menu opened.
+            # The widgets treat an unknown key as one to redraw on, which is
+            # what makes the new size take effect.
+            curses.update_lines_cols()
+            self._window.erase()
+        return pressed
 
 
 class Sized(Protocol):

--- a/tests/unit/test_tui_curses.py
+++ b/tests/unit/test_tui_curses.py
@@ -289,3 +289,86 @@ def test_a_form_message_does_not_push_the_done_row_off_the_screen() -> None:
     result = drive("\n\n\n\n", ACCOUNT)
     assert result.get("error") is None, result.get("error")
     assert result["values"] == ["", "", ""]
+
+
+#: Opens a screen and waits for the terminal to be resized, reporting the size
+#: it read before and after. `KEY_RESIZE` is what curses delivers; whether
+#: `getmaxyx` then answers the new size is the question.
+RESIZE = r"""
+import curses
+
+from gentoo_install.tui.curses_screen import CursesScreen
+
+
+def main(window):
+    import curses as c
+
+    screen = CursesScreen(window)
+    answer["before"] = list(screen.size())
+    pressed = ""
+    while pressed != "KEY_RESIZE":
+        try:
+            pressed = screen.key()
+        except c.error:
+            # `no input` while nothing has been typed: the resize arrives as a
+            # key, so this waits for one rather than treating it as a fault.
+            continue
+    answer["after"] = list(screen.size())
+
+
+curses.wrapper(main)
+"""
+
+
+def test_a_window_that_grows_is_read_again_rather_than_kept() -> None:
+    """curses keeps the size it started with until it is told to look again,
+    so a list stayed as tall as it was when the menu opened however large the
+    window became. Every widget reads `size()` on each redraw and treats an
+    unrecognised key as one to redraw on, so the screen only has to ask curses
+    to look.
+
+    Resized with `TIOCSWINSZ` against a real pty, the way a terminal emulator
+    does it.
+    """
+    import fcntl
+    import struct
+    import termios
+
+    read_end, write_end = os.pipe()
+    child, terminal = pty.fork()
+    if child == 0:  # pragma: no cover - the child never returns
+        os.close(read_end)
+        os.environ["TERM"] = "xterm"
+        os.environ["LINES"], os.environ["COLUMNS"] = str(SIZE[0]), str(SIZE[1])
+        sys.path.insert(0, str(REPOSITORY))
+        answer: dict[str, Any] = {}
+        try:
+            exec(compile(RESIZE, "<driver>", "exec"), {"answer": answer})
+        except BaseException as why:
+            answer["error"] = f"{type(why).__name__}: {why}"
+        os.write(write_end, json.dumps(answer).encode())
+        os.close(write_end)
+        os._exit(0)
+
+    os.close(write_end)
+    grown = (SIZE[0] + 20, SIZE[1] + 40)
+    fcntl.ioctl(terminal, termios.TIOCSWINSZ, struct.pack("HHHH", *SIZE, 0, 0))
+    time.sleep(1.0)
+    fcntl.ioctl(terminal, termios.TIOCSWINSZ, struct.pack("HHHH", *grown, 0, 0))
+    # A keystroke after it: curses reports the resize out of `getch`, so
+    # something has to arrive for it to be reported through.
+    time.sleep(0.3)
+    os.write(terminal, b"x")
+    said = b""
+    deadline = time.monotonic() + DEADLINE
+    while time.monotonic() < deadline:
+        chunk = os.read(read_end, 4096)
+        said += chunk
+        if not chunk:
+            break
+    os.close(read_end)
+    os.waitpid(child, 0)
+    result: dict[str, Any] = json.loads(said.decode() or "{}")
+    assert result.get("error") is None, result.get("error")
+    assert result["before"] == list(SIZE), result
+    assert result["after"] == list(grown), result

--- a/tests/vm/tui.py
+++ b/tests/vm/tui.py
@@ -1,0 +1,164 @@
+"""Walk the menu in a real terminal, on the medium it ships on.
+
+`tests/unit/` drives the screens through `FakeScreen`, which answers a key and
+records the lines a screen asked to draw. That found nothing an operator met:
+the timezone screen offering `UTC` alone, the root password row disagreeing
+with the Install row, and eight rows that read their first entry back were all
+reported from a machine or from reading the code. What `FakeScreen` cannot
+show is what curses actually puts on an 80-column console, so this boots the
+medium, starts the menu on the serial port and reads the screen back.
+
+    python3 -m tests.vm.tui
+    python3 -m tests.vm.tui --lang zh-TW --keep
+"""
+
+from __future__ import annotations
+
+import argparse
+import re
+import sys
+import time
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Final
+
+from .console import SerialConsole
+from .driver import build as build_driver
+from .media import MEDIA
+from .qemu import Firmware, Vm, VmSpec
+
+WORKROOT: Final[Path] = Path.home() / "code/gentoo-install/lab/vm/tui"
+
+#: The console the menu is drawn on. Eighty by twenty-four is what the medium
+#: gives over a serial port and the smallest the interface supports, so a row
+#: that only fits a wider terminal is a defect an operator meets first.
+COLUMNS: Final[int] = 80
+LINES: Final[int] = 24
+
+#: How long a redraw is collected for. curses writes a screen in many small
+#: writes, and reading for less than this catches half of one.
+REDRAW_SECONDS: Final[float] = 2.0
+
+_ANSI: Final[re.Pattern[bytes]] = re.compile(rb"\x1b\[[0-9;?]*[A-Za-z]|\x1b[()][A-B]|\x1b[=>]")
+
+
+def rendered(said: bytes) -> list[str]:
+    """The lines a screen left, with the escape codes taken out."""
+    text = _ANSI.sub(b"", said).decode("utf-8", "replace")
+    return [line.rstrip() for line in text.replace("\r\n", "\n").split("\n")]
+
+
+@dataclass
+class Finding:
+    where: str
+    what: str
+
+
+@dataclass
+class Walk:
+    """What the walk saw, and what was wrong with it."""
+
+    screens: int = 0
+    findings: list[Finding] = field(default_factory=list)
+
+    def note(self, where: str, what: str) -> None:
+        self.findings.append(Finding(where=where, what=what))
+
+
+#: What `width()` counts as two cells. A menu drawn with a wide character on a
+#: console with no CJK font still occupies two columns, so the check is on the
+#: cells rather than on the glyphs.
+def cells(line: str) -> int:
+    from gentoo_install.i18n import width
+
+    return width(line)
+
+
+def _open_menu(console: SerialConsole, lang: str) -> None:
+    console.run("mkdir -p /mnt/driver")
+    console.run("mountpoint -q /mnt/driver || mount -o ro /dev/sr1 /mnt/driver")
+    console.run("mkdir -p /tmp/driver && tar xzf /mnt/driver/driver.tar.gz -C /tmp/driver")
+    console.run(f"stty rows {LINES} cols {COLUMNS}")
+    # `TERM` explicitly: a serial getty leaves it unset and curses then refuses
+    # to start, which reads as the installer crashing.
+    console.send_raw(
+        f"cd /tmp/driver && TERM=vt220 LINES={LINES} COLUMNS={COLUMNS} "
+        f"python3 -m gentoo_install --lang {lang}\n"
+    )
+
+
+def walk(console: SerialConsole, lang: str) -> Walk:
+    """Open every row of the menu and read what the terminal shows."""
+    seen = Walk()
+    _open_menu(console, lang)
+    # The shell echoes the launch line and it is longer than the console is
+    # wide, so it is read and discarded before the first screen is measured.
+    time.sleep(8.0)
+    console.snapshot(REDRAW_SECONDS)
+    console.send_raw("\x1b[B")
+    time.sleep(0.5)
+    console.send_raw("\x1b[A")
+    time.sleep(0.5)
+    for step in range(_ROWS):
+        drawn = rendered(console.snapshot(REDRAW_SECONDS))
+        body = [line for line in drawn if line.strip()]
+        if not body:
+            seen.note(f"row {step}", "the row drew nothing")
+        else:
+            seen.screens += 1
+            for line in body:
+                if cells(line) > COLUMNS:
+                    seen.note(f"row {step}", f"{cells(line)} cells: {line!r}")
+        # Enter opens the row, then escape leaves it, then down moves on.
+        console.send_raw("\r")
+        time.sleep(1.0)
+        opened = rendered(console.snapshot(REDRAW_SECONDS))
+        for line in opened:
+            if cells(line) > COLUMNS:
+                seen.note(f"row {step} opened", f"{cells(line)} cells: {line!r}")
+        console.send_raw("\x1b")
+        time.sleep(0.5)
+        console.send_raw("\x1b[B")
+        time.sleep(0.3)
+    return seen
+
+
+#: How many rows are walked. Read from the menu rather than guessed would need
+#: the model here; the panel has fewer than this and the extra presses land on
+#: the last row, which is harmless and keeps the walk from ending early.
+_ROWS: Final[int] = 20
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--medium", default="official-minimal", choices=sorted(MEDIA))
+    parser.add_argument("--lang", default="en", help="the interface language to walk")
+    parser.add_argument("--workdir", type=Path, default=WORKROOT)
+    parser.add_argument("--keep", action="store_true", help="keep the run directory")
+    args = parser.parse_args(argv)
+
+    workdir = args.workdir / f"{args.medium}-{args.lang}"
+    workdir.mkdir(parents=True, exist_ok=True)
+    medium = MEDIA[args.medium]
+    driver_iso = build_driver(workdir / "driver.iso", packed=True)
+    spec = VmSpec(
+        medium=medium,
+        workdir=workdir,
+        firmware=Firmware.UEFI,
+        memory="2G",
+        cpus=2,
+        driver_iso=driver_iso,
+    )
+    with Vm(spec) as machine:
+        with SerialConsole.connect(machine.serial_socket, machine.serial_log) as console:
+            console.expect(medium.root_prompt, timeout=600.0)
+            seen = walk(console, args.lang)
+
+    print(f"{seen.screens} screens drawn, {len(seen.findings)} findings", flush=True)
+    for one in seen.findings:
+        print(f"  {one.where}: {one.what}", flush=True)
+    return 1 if seen.findings else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
curses keeps the size it started with until it is told to look again, so `size()` answered the old height after the window grew and every list stayed as tall as it was when the menu opened. The widgets already read `size()` on each redraw and treat an unrecognised key as one to redraw on, so the screen only has to ask curses to look. Driven against a real pty resized with `TIOCSWINSZ`.

`tests/vm/tui.py` walks the menu in a real terminal on the medium it ships on: it boots the guest, starts the menu on the serial port, opens every row and reads the screen back, failing any line wider than the console. `FakeScreen` records what a screen asked to draw; this records what curses put there. Both languages walked clean at 80x24 today — twenty screens, no line over eighty cells.