### PR TITLE
tests: prove a guest is ours before removing it

### DIFF
--- a/tests/unit/test_proxmox.py
+++ b/tests/unit/test_proxmox.py
@@ -1011,3 +1011,67 @@ def test_a_command_is_delivered_after_the_console_was_dropped() -> None:
     # `reopen` sends an empty line first, to make the shell draw a prompt.
     assert opened[1].sent == ["", "probe me"]
     assert opened[0].sent == [], "nothing goes into the dropped one"
+
+
+def test_removing_a_guest_needs_the_range_the_tag_and_this_run_s_own_mark() -> None:
+    """The tag is ours to write, so it is not evidence on its own: a machine
+    outside the range that carries it would have been deleted, and two
+    campaigns that picked the same free VMID in the same second could each
+    delete the other's guest.
+
+    This token administers a cluster running other people's work.
+    """
+    from typing import Any
+
+    from tests.vm.proxmox import TAG, VMID_FIRST, Api, Guest, GuestSpec, ProxmoxError
+
+    class Answering(Api):
+        def __init__(self, tags: str) -> None:
+            self.tags = tags
+            self.deleted: list[int] = []
+
+        def call(self, method: str, path: str, **form: Any) -> Any:
+            if method == "GET" and path.endswith("/config"):
+                return {"tags": self.tags}
+            if method == "DELETE":
+                self.deleted.append(int(path.rsplit("/", 1)[1]))
+            return "UPID:x"
+
+        def wait(self, node: str, upid: str, patience: float = 1800.0) -> None:
+            return None
+
+    def guest(api: Api, vmid: int, nonce: str) -> Guest:
+        return Guest(
+            api=api,
+            node="infra-node1",
+            vmid=vmid,
+            spec=GuestSpec(name="x", iso="x", nonce=nonce),
+        )
+
+    # Outside the range, however it is tagged.
+    api = Answering(f"{TAG};gi-abc")
+    with pytest.raises(ProxmoxError, match="outside"):
+        guest(api, 9002, "gi-abc").destroy()
+    assert api.deleted == []
+
+    # In range and tagged, but built by another run.
+    api = Answering(f"{TAG};gi-someone-else")
+    with pytest.raises(ProxmoxError, match="not the guest this run built"):
+        guest(api, VMID_FIRST, "gi-abc").destroy()
+    assert api.deleted == []
+
+    # In range, tagged, and ours.
+    api = Answering(f"{TAG};gi-abc")
+    guest(api, VMID_FIRST, "gi-abc").destroy()
+    assert api.deleted == [VMID_FIRST]
+
+
+def test_every_cluster_guest_is_built_with_a_mark_of_its_own() -> None:
+    """A guest with no nonce falls back to the tag alone, which is the state
+    this rule exists to leave behind."""
+    import inspect
+
+    from tests.vm import cluster
+
+    source = inspect.getsource(cluster.install_one)
+    assert "nonce=" in source, "the campaign has to mark the guests it builds"

--- a/tests/vm/cluster.py
+++ b/tests/vm/cluster.py
@@ -21,6 +21,7 @@ import queue
 import sys
 import threading
 import time
+import uuid
 import urllib.request
 from dataclasses import dataclass, field, replace
 from enum import Enum
@@ -491,6 +492,9 @@ def install_one(
             target_gib=tuple(TARGET_GIB for _ in range(job.disks)),
             uefi=job.uefi,
             driver_iso=driver,
+            # This run's own mark, so a second campaign that picked the same
+            # free VMID cannot delete the guest this one built.
+            nonce=f"gi-{uuid.uuid4().hex[:12]}",
         ),
     )
     watch = Watchdog(log=log, counters=lambda: guest.transferred())

--- a/tests/vm/proxmox.py
+++ b/tests/vm/proxmox.py
@@ -302,6 +302,10 @@ class GuestSpec:
     #: Boot the installed disk instead of the medium. The medium stays attached
     #: so a failed boot can be looked at without rebuilding the guest.
     boot_installed: bool = False
+    #: Written beside the tag and required before this guest is removed. Two
+    #: campaigns can pick the same free VMID in the same second, and the tag
+    #: alone then let each of them delete the other's machine.
+    nonce: str = ""
 
 
 @dataclass
@@ -339,7 +343,7 @@ class Guest:
             # page cache. Without it four guests hold their whole allocation.
             "balloon": self.spec.memory_mib,
             "agent": 0,
-            "tags": TAG,
+            "tags": f"{TAG};{self.spec.nonce}" if self.spec.nonce else TAG,
         }
         if self.spec.uefi:
             options["bios"] = "ovmf"
@@ -474,10 +478,25 @@ class Guest:
         other people's work, and a VMID is not proof of ownership: the range
         this harness allocates from already held a production template.
         """
+        if not VMID_FIRST <= self.vmid <= VMID_LAST:
+            # The tag is ours to write, so a machine outside the range that
+            # carries it is not evidence: the range is the second guard, and
+            # `9002` in this cluster is `prod-debian-12-server-template`.
+            raise ProxmoxError(
+                f"vm {self.vmid} is outside {VMID_FIRST}-{VMID_LAST}; refusing to remove it"
+            )
         config = self.api.call("GET", f"/nodes/{self.node}/qemu/{self.vmid}/config")
-        if TAG not in str(config.get("tags", "")).split(";"):
+        tags = str(config.get("tags", "")).split(";")
+        if TAG not in tags:
             raise ProxmoxError(
                 f"vm {self.vmid} on {self.node} is not tagged {TAG!r}; refusing to remove it"
+            )
+        if self.spec.nonce and self.spec.nonce not in tags:
+            # Somebody else's guest at the VMID this one wanted: two campaigns
+            # asking the cluster in the same second both read it as free.
+            raise ProxmoxError(
+                f"vm {self.vmid} on {self.node} is not the guest this run built; "
+                "refusing to remove it"
             )
         self.stop()
         try:


### PR DESCRIPTION
`destroy()` checked the tag and nothing else. The tag is written by this harness, so it proves nothing about a machine that already carried it, and the VMID range — the guard the comment names — was never enforced: `9002` in this cluster is `prod-debian-12-server-template`.

Three conditions now: the VMID inside 9300-9399, the tag, and a nonce this run wrote at creation. Two campaigns asking the cluster in the same second both read the same VMID as free, and each could then delete the other's guest; the nonce is what separates them.

This token holds all 42 privileges on a cluster running 79 machines that belong to somebody's infrastructure.