### PR TITLE
tests: keep a node's slot while its guest is still there

### DIFF
--- a/tests/unit/test_harness.py
+++ b/tests/unit/test_harness.py
@@ -470,3 +470,34 @@ def test_a_run_that_collected_fewer_results_than_it_dispatched_fails(
 
     monkeypatch.setattr(cluster, "run", both)
     assert cluster.main(["vm-lvm", "vm-xfs"]) == 0
+
+
+def test_a_guest_that_could_not_be_removed_keeps_its_slot() -> None:
+    """`destroy()` failing printed a line and the scheduler handed the node's
+    slot back anyway. The memory is still allocated, so the next guest went
+    onto a node with no room for it and the hypervisor ended it."""
+    from dataclasses import replace
+
+    from tests.vm import cluster
+
+    ok = cluster.Outcome(name="x", verdict=cluster.Verdict.OK, seconds=1.0)
+    assert ok.removed is True, "a guest that was deleted returns its slot"
+
+    # The count a node is charged, before and after each outcome. `run` keeps
+    # this in a Counter and subtracts on an outcome whose guest is gone.
+    from collections import Counter
+
+    placed: Counter[str] = Counter({"infra-node1": 1})
+    for outcome, expected in (
+        (replace(ok, removed=True), 0),
+        (replace(ok, removed=False), 1),
+    ):
+        held: Counter[str] = Counter(placed)
+        if outcome.removed:
+            held["infra-node1"] -= 1
+        assert held["infra-node1"] == expected, outcome
+
+    # And the scheduler is what applies it: the guard names the field.
+    import inspect
+
+    assert "not outcome.removed" in inspect.getsource(cluster.run)

--- a/tests/vm/cluster.py
+++ b/tests/vm/cluster.py
@@ -173,6 +173,10 @@ class Outcome:
     seconds: float
     detail: str = ""
     log: Path | None = None
+    #: Whether the guest is gone from the cluster. False keeps the node's
+    #: slot held: the memory is still allocated, and handing it back put the
+    #: next guest onto a node that had no room for it.
+    removed: bool = True
 
 
 @dataclass
@@ -467,6 +471,12 @@ class Running:
     watch: Watchdog
 
 
+#: Jobs whose guest could not be removed. A node's memory is still allocated
+#: for one of these, so its slot is not handed back: doing that put the next
+#: guest onto a node with no room and the hypervisor ended it.
+LEFT_BEHIND: set[str] = set()
+
+
 def install_one(
     api: Api,
     node: str,
@@ -562,8 +572,10 @@ def install_one(
             guest.destroy()
         except ProxmoxError as error:
             # Said rather than raised: an undeleted guest holds a node's memory
-            # and the operator has to know, but the result already exists.
+            # and the operator has to know, but the result already exists. The
+            # slot stays held below, because the memory does.
             print(f"{job.name}: the guest was not removed: {error}", file=sys.stderr)
+            LEFT_BEHIND.add(job.name)
 
 
 def answer_once(
@@ -584,7 +596,8 @@ def answer_once(
     with an empty cluster and a job still queued.
     """
     try:
-        done.put(install_one(api, node, job, driver, workdir, inflight, vmid))
+        outcome = install_one(api, node, job, driver, workdir, inflight, vmid)
+        done.put(replace(outcome, removed=outcome.name not in LEFT_BEHIND))
     except BaseException as error:
         done.put(
             Outcome(job.name, Verdict.ERROR, 0.0, f"{type(error).__name__}: {error}"[:300])
@@ -681,6 +694,15 @@ def run(
             finished.append(outcome)
             running.pop(outcome.name, None)
             gone = where.pop(outcome.name, "")
+            if gone and not outcome.removed:
+                # The guest is still on that node holding its memory, so the
+                # slot is not free. Handing it back put the next guest onto a
+                # node with no room for it.
+                print(
+                    f"  {outcome.name} still holds a slot on {gone}",
+                    file=sys.stderr,
+                )
+                gone = ""
             if gone:
                 # The same unit it was taken in, or a node loses a slot for
                 # every heavy guest that finished on it.


### PR DESCRIPTION
A guest that could not be deleted printed `the guest was not removed` and the outcome carried nothing about it, so the scheduler subtracted the node's reservation and dispatched the next guest onto memory that was still allocated. That is how a node ends up over-committed and the hypervisor picks something to kill.

`Outcome` carries `removed`, the worker sets it from the cleanup that runs after the result is built, and the scheduler holds the slot and says which node is still carrying it.