### PR TITLE
tests: notice a worker that ended without reporting

### DIFF
--- a/tests/unit/test_harness.py
+++ b/tests/unit/test_harness.py
@@ -501,3 +501,23 @@ def test_a_guest_that_could_not_be_removed_keeps_its_slot() -> None:
     import inspect
 
     assert "not outcome.removed" in inspect.getsource(cluster.run)
+
+
+def test_a_worker_that_ends_without_reporting_becomes_an_error() -> None:
+    """`answer_once` puts an outcome on the queue for everything a Python
+    handler can see. A thread that ends any other way left its name in the
+    running set for ever and the schedule never finished: one round sat idle
+    for half an hour with an empty cluster and a job still queued."""
+    import inspect
+
+    from tests.vm import cluster
+
+    source = inspect.getsource(cluster.run)
+    assert "thread.is_alive()" in source, "the scheduler has to notice a dead worker"
+    assert "the worker ended without reporting" in source
+    # And the outcome it makes does not hand the node's slot back, because
+    # nothing proved the guest was removed.
+    gone = cluster.Outcome(
+        "x", cluster.Verdict.ERROR, 0.0, "the worker ended without reporting", removed=False
+    )
+    assert gone.removed is False

--- a/tests/vm/cluster.py
+++ b/tests/vm/cluster.py
@@ -690,6 +690,23 @@ def run(
                 if time.monotonic() - swept >= WATCH_EVERY:
                     _sweep(inflight)
                     swept = time.monotonic()
+                # A worker that ended without putting anything on the queue is
+                # a name that stays in `running` for ever, and the loop then
+                # never finishes: one round sat idle for half an hour with an
+                # empty cluster and a job still queued. `answer_once` catches
+                # everything a Python handler can see; this covers the rest.
+                for name, thread in list(running.items()):
+                    if thread.is_alive():
+                        continue
+                    done.put(
+                        Outcome(
+                            name,
+                            Verdict.ERROR,
+                            0.0,
+                            "the worker ended without reporting",
+                            removed=False,
+                        )
+                    )
                 continue
             finished.append(outcome)
             running.pop(outcome.name, None)


### PR DESCRIPTION
`answer_once` wraps the worker so every exception it can catch still puts an outcome on the queue. A thread that ends any other way — killed, or dying inside the interpreter's own teardown — left its name in `running` for ever, and the loop waits on `running` being empty: one round sat idle for half an hour with an empty cluster and a job still queued.

Each quiet poll now looks for a thread that has ended with nothing on the queue and puts an `ERROR` there itself. The outcome says `removed=False`, because nothing proved the guest was deleted, so the node keeps its slot.