### PR TITLE
tests: retry a create the shared storage lock held off

### DIFF
--- a/tests/unit/test_proxmox.py
+++ b/tests/unit/test_proxmox.py
@@ -1075,3 +1075,41 @@ def test_every_cluster_guest_is_built_with_a_mark_of_its_own() -> None:
 
     source = inspect.getsource(cluster.install_one)
     assert "nonce=" in source, "the campaign has to mark the guests it builds"
+
+
+def test_a_create_held_off_by_the_storage_lock_is_tried_again() -> None:
+    """Thirteen guests built at once contend on `ceph-pve`, and one round lost
+    a fixture to `cfs-lock 'storage-ceph-pve' error: got lock request
+    timeout`. The lock belongs to another create and is gone in seconds; a
+    create that fails for any other reason still stops the run."""
+    from typing import Any
+
+    from tests.vm import proxmox
+    from tests.vm.proxmox import Api, Guest, GuestSpec, ProxmoxError
+
+    class Contended(Api):
+        def __init__(self, refusals: int, message: str) -> None:
+            self.refusals = refusals
+            self.message = message
+            self.attempts = 0
+
+        def call(self, method: str, path: str, **form: Any) -> Any:
+            if method == "POST" and path.endswith("/qemu"):
+                self.attempts += 1
+            return "UPID:x"
+
+        def wait(self, node: str, upid: str, patience: float = 1800.0) -> None:
+            if self.attempts <= self.refusals:
+                raise ProxmoxError(self.message)
+
+    lock = "ended with \"unable to create VM 9313 - cfs-lock 'storage-ceph-pve' error: got lock request timeout\""
+    proxmox.CREATE_PAUSE = 0.0
+    api = Contended(refusals=2, message=lock)
+    Guest(api=api, node="infra-node1", vmid=9300, spec=GuestSpec(name="x", iso="x")).create()
+    assert api.attempts == 3, api.attempts
+
+    # Anything else stops at once: a full storage is not a lock.
+    other = Contended(refusals=1, message="ended with 'no space left on device'")
+    with pytest.raises(ProxmoxError, match="no space"):
+        Guest(api=other, node="infra-node1", vmid=9300, spec=GuestSpec(name="x", iso="x")).create()
+    assert other.attempts == 1, other.attempts

--- a/tests/vm/proxmox.py
+++ b/tests/vm/proxmox.py
@@ -56,6 +56,12 @@ TAG: Final[str] = "gentoo-install-test"
 
 #: Where disks go. `local` is per node and holds the ISOs; `ceph-pve` is shared,
 #: so a guest can be built on whichever node has the memory.
+#: How many times a create is attempted when the shared storage lock is held,
+#: and how long between them. Thirteen guests built at once contend on
+#: `ceph-pve`; the lock is another create's, and it is gone in seconds.
+CREATE_TRIES: Final[int] = 4
+CREATE_PAUSE: Final[float] = 10.0
+
 DISK_STORAGE: Final[str] = "ceph-pve"
 ISO_STORAGE: Final[str] = "local"
 
@@ -361,7 +367,24 @@ class Guest:
         if self.spec.driver_iso:
             options["ide3"] = f"{ISO_STORAGE}:iso/{self.spec.driver_iso},media=cdrom"
         options["boot"] = "order=" + ("virtio0" if self.spec.boot_installed else "ide2")
-        self.api.wait(self.node, self.api.call("POST", f"/nodes/{self.node}/qemu", **options))
+        # Retried on a storage lock: thirteen guests built at once contend on
+        # `ceph-pve`, and one round lost a fixture to `cfs-lock
+        # 'storage-ceph-pve' error: got lock request timeout`. The lock is
+        # held by another create, not by anything wrong with this one.
+        last: ProxmoxError | None = None
+        for attempt in range(CREATE_TRIES):
+            try:
+                self.api.wait(
+                    self.node, self.api.call("POST", f"/nodes/{self.node}/qemu", **options)
+                )
+                return
+            except ProxmoxError as error:
+                if "lock request timeout" not in str(error):
+                    raise
+                last = error
+                time.sleep(CREATE_PAUSE * (attempt + 1))
+        assert last is not None
+        raise last
 
     def start(self) -> None:
         self.api.wait(


### PR DESCRIPTION
Round six lost `vm-unlock` at 0.4 minutes to `cfs-lock 'storage-ceph-pve' error: got lock request timeout`. Thirteen guests are built at once and their disks all land on the same shared storage; the lock belongs to another create and is gone in seconds.

Four attempts with a growing pause, and only for that message — a full storage or a bad option still stops the run on the first try.