### PR TITLE
tests: ask the guest network for an address on the first pass

### DIFF
--- a/tests/unit/test_proxmox.py
+++ b/tests/unit/test_proxmox.py
@@ -684,31 +684,31 @@ def test_every_question_asked_inside_names_what_would_fail_it() -> None:
         assert wanted, f"{name} compares against nothing"
 
 
-def test_the_link_is_left_alone_until_the_medium_has_had_its_chance() -> None:
-    """The medium runs NetworkManager, and an interface raised from outside it
-    is one NetworkManager then leaves alone: `ip link set up` at the start was
-    enough to stop it configuring the guest, and `curl` answered `Could not
-    connect to server` in ten milliseconds where before it had reached the
-    mirror. A medium with no manager still needs the ask, so it happens late
-    and once."""
+def test_the_probe_runs_before_the_guest_is_touched() -> None:
+    """An interface raised from outside NetworkManager is one it then leaves
+    alone: `ip link set up` before the medium had its chance stopped it
+    configuring the guest, and `curl` answered `Could not connect to server`
+    in ten milliseconds where before it had reached the mirror.
+
+    So the probe goes first and the request follows immediately after it comes
+    back empty — not after half the patience, which is what left seventeen of
+    twenty-four guests waiting for an address nothing would hand them. The
+    request is guarded on there being no IPv4 default route, so a medium whose
+    own manager configured one is still left alone.
+    """
     import inspect
 
     from tests.vm import cluster
 
-    # Comments name the same commands, so only the code is read: the first
-    # mention of `ip link set` in this function is the sentence explaining why
-    # it is not done first.
     code = [
         line
         for line in inspect.getsource(cluster.wait_for_network).splitlines()
         if line.strip() and not line.strip().startswith("#")
     ]
-    polled = next(at for at, line in enumerate(code) if "NETWORK_PROBE" in line)
-    raised = next(at for at, line in enumerate(code) if "ip link set" in line)
-    assert polled < raised, "poll first; touch the link only if nothing happens"
-    whole = "\n".join(code)
-    assert "NetworkManager" in whole, "and never when the medium has a manager"
-    assert "asked = True" in whole, "once, not on every pass"
+    probe = next(at for at, line in enumerate(code) if "NETWORK_PROBE" in line)
+    ask = next(at for at, line in enumerate(code) if "ASK_FOR_IPV4" in line)
+    assert probe < ask, "the medium gets its chance before anything is raised"
+    assert "ip -4 route show default" in cluster.ASK_FOR_IPV4
 
 
 def test_no_marker_appears_in_the_command_that_prints_it() -> None:
@@ -1115,3 +1115,29 @@ def test_a_create_held_off_by_the_storage_lock_is_tried_again(
     with pytest.raises(ProxmoxError, match="no space"):
         Guest(api=other, node="infra-node1", vmid=9300, spec=GuestSpec(name="x", iso="x")).create()
     assert other.attempts == 1, other.attempts
+
+
+def test_a_guest_is_asked_for_an_address_on_the_first_pass() -> None:
+    """This cluster's guest network carries a ULA IPv6 prefix advertised by
+    something that is not the hypervisor and offers no way out of itself. The
+    addresses that reach a mirror come from DHCPv4, and nothing asked for one
+    until half the patience had gone — and then only when NetworkManager was
+    absent. Seventeen of twenty-four guests in one round waited out the whole
+    fifteen minutes for an address nothing was going to hand them.
+
+    Measured: `dhcpcd -4 ens18` answered `leased 10.31.0.230` with `default
+    via 10.31.0.254`, and `curl` returned 200 immediately after.
+    """
+    import inspect
+
+    from tests.vm import cluster
+
+    assert "dhcpcd -4" in cluster.ASK_FOR_IPV4, cluster.ASK_FOR_IPV4
+    # Only when there is none: a medium whose own manager configured a route
+    # is left alone, which is what stopped the ones that do have a manager.
+    assert "ip -4 route show default" in cluster.ASK_FOR_IPV4
+    assert "NetworkManager" not in cluster.ASK_FOR_IPV4, "the manager is not the question"
+
+    source = inspect.getsource(cluster.wait_for_network)
+    assert "NETWORK_PATIENCE / 2" not in source, "the request is not delayed any more"
+    assert "ASK_FOR_IPV4" in source

--- a/tests/vm/cluster.py
+++ b/tests/vm/cluster.py
@@ -317,21 +317,31 @@ NETWORK_PROBE: Final[str] = (
 )
 
 
+#: What gets the guest an address on this cluster. Its network carries a ULA
+#: IPv6 prefix advertised by something that is not the hypervisor and offers no
+#: way out of itself, and the addresses that reach a mirror come from DHCPv4:
+#: `dhcpcd -4` answered `leased 10.31.0.230` and `default via 10.31.0.254`, and
+#: `curl` then returned 200 where it had timed out for fifteen minutes.
+#:
+#: Asked for on the first pass, not after half the patience: seventeen of
+#: twenty-four guests in one round waited out the whole window for an address
+#: nothing was going to hand them. Only when there is no IPv4 default route
+#: already, so a medium whose own manager configured one is left alone.
+ASK_FOR_IPV4: Final[str] = (
+    "ip -4 route show default | grep -q . || { "
+    'for one in /sys/class/net/e*; do ip link set "$(basename "$one")" up; done; '
+    "dhcpcd -4 -w -t 25 >/dev/null 2>&1; }; true"
+)
+
+
 def wait_for_network(link: Reconnecting) -> None:
     """Configure the guest's interface, then wait until it can reach a mirror.
 
-    Waiting alone was not enough, and measuring said why: a fresh guest has no
-    global address at all, `curl -4` and `curl -6` both answer nothing, and
-    `ip address show scope global` prints an empty list. The medium boots with
-    `nodhcp` and leaves the link unconfigured, so something has to ask — which
-    is what an operator does before installing. The runs that used to succeed
-    were the ones where something else had configured it in time.
+    The medium boots with `nodhcp` and leaves the link unconfigured, so
+    something has to ask, which is what an operator does before installing.
+    The probe goes first in case the medium's own manager got there, and the
+    request follows immediately when it did not.
     """
-    # Nothing is touched at first. The medium runs NetworkManager, and an
-    # interface raised from outside it is one NetworkManager then leaves
-    # alone: `ip link set up` here was enough to stop it configuring the
-    # guest, and `curl` answered `Could not connect to server` in ten
-    # milliseconds where before it had reached the mirror.
     deadline = time.monotonic() + NETWORK_PATIENCE
     asked = False
     while time.monotonic() < deadline:
@@ -339,19 +349,11 @@ def wait_for_network(link: Reconnecting) -> None:
         said = link.expect(rf"{NETWORK_UP}|{NETWORK_DONE}", timeout=180.0)
         if NETWORK_UP.encode() in said:
             return
-        time.sleep(NETWORK_PAUSE)
-        if time.monotonic() > deadline - NETWORK_PATIENCE / 2 and not asked:
-            # Half the patience gone and still nothing, so the medium has no
-            # manager of its own: raise the link and ask for an address. Once,
-            # and late, because doing it first is what stopped the mediums
-            # that do have one.
+        if not asked:
             asked = True
-            link.run(
-                "pgrep -x NetworkManager >/dev/null || { "
-                'for one in /sys/class/net/e*; do ip link set "$(basename $one)" up; done; '
-                "dhcpcd -w -t 20 >/dev/null 2>&1; }; true",
-                timeout=90.0,
-            )
+            link.run(ASK_FOR_IPV4, timeout=120.0)
+            continue
+        time.sleep(NETWORK_PAUSE)
     # What the guest actually had, into the log this run leaves behind. Eight
     # cluster guests failed here on one round and the log held nothing but
     # `Could not connect to server`, so nothing said whether the medium never


### PR DESCRIPTION
Seventeen of twenty-four guests in one round failed with `the guest had no network after 900s`, and the cluster was not the reason.

Measured on a probe guest: the only address it comes up with is on `fd72:f02a:f19a::/64`, advertised by a device on the segment that is not the hypervisor — PVE has no IPv6 — and that prefix has no default route and no egress even when one is added by hand. `dhcpcd -4 ens18` answered `leased 10.31.0.230` with `default via 10.31.0.254`, and `curl` returned 200 straight after. The guests that used to reach a mirror were the ones that got a DHCPv4 lease.

The old code waited out half the patience before asking, and then only when `pgrep -x NetworkManager` found nothing — which on the official minimal medium it does not, so it never asked at all. The probe still runs first, because raising a link before the medium's own manager has had its chance is what stopped it configuring the guest; the request follows the moment the probe comes back empty, and only when there is no IPv4 default route already.