### PR TITLE
tests: answer the keymap question the medium asks

### DIFF
--- a/tests/unit/test_proxmox.py
+++ b/tests/unit/test_proxmox.py
@@ -1141,3 +1141,67 @@ def test_a_guest_is_asked_for_an_address_on_the_first_pass() -> None:
     source = inspect.getsource(cluster.wait_for_network)
     assert "NETWORK_PATIENCE / 2" not in source, "the request is not delayed any more"
     assert "ASK_FOR_IPV4" in source
+
+
+def test_the_keymap_question_is_answered_rather_than_waited_out() -> None:
+    """The official minimal medium asks `Load keymap (Enter for default):` and
+    waits for a key. Nothing answered it: two guests on one round sat there
+    while the run spent its patience waiting for a prompt that was one
+    keystroke away."""
+    from tests.vm.cluster import Reconnecting, reach_prompt
+
+    class Asking:
+        """Asks once, then gives a prompt."""
+
+        def __init__(self) -> None:
+            self.sent: list[str] = []
+            self.asked = False
+
+        def send(self, line: str) -> None:
+            self.sent.append(line)
+
+        def send_raw(self, keys: str) -> None:
+            self.sent.append(keys)
+
+        def snapshot(self, seconds: float) -> bytes:
+            return b""
+
+        def expect(self, pattern: str, timeout: float) -> bytes:
+            if not self.asked:
+                self.asked = True
+                return b"Load keymap (Enter for default): "
+            return b"livecd ~ # "
+
+        @property
+        def closed(self) -> bool:
+            return False
+
+    console = Asking()
+    reach_prompt(Reconnecting(lambda: console, tries=1), patience=30.0)
+    assert console.sent == [""], console.sent
+
+    class Ready:
+        """Gives a prompt straight away, and must not be sent anything."""
+
+        def __init__(self) -> None:
+            self.sent: list[str] = []
+
+        def send(self, line: str) -> None:
+            self.sent.append(line)
+
+        def send_raw(self, keys: str) -> None:
+            self.sent.append(keys)
+
+        def snapshot(self, seconds: float) -> bytes:
+            return b""
+
+        def expect(self, pattern: str, timeout: float) -> bytes:
+            return b"livecd ~ # "
+
+        @property
+        def closed(self) -> bool:
+            return False
+
+    quiet = Ready()
+    reach_prompt(Reconnecting(lambda: quiet, tries=1), patience=30.0)
+    assert quiet.sent == [], quiet.sent

--- a/tests/vm/cluster.py
+++ b/tests/vm/cluster.py
@@ -18,6 +18,7 @@ from __future__ import annotations
 import argparse
 import itertools
 import queue
+import re
 import sys
 import threading
 import time
@@ -334,6 +335,32 @@ ASK_FOR_IPV4: Final[str] = (
 )
 
 
+#: What the official minimal medium asks before it hands over a shell, and
+#: what answers it. Nothing answered: two guests on one round sat at `Load
+#: keymap (Enter for default):` while the run spent its patience waiting for a
+#: prompt that was one keystroke away.
+KEYMAP_QUESTION: Final[str] = r"Load keymap|keymap \(Enter for default\)"
+
+#: How long the medium is given to reach a shell, question or no question.
+PROMPT_PATIENCE: Final[float] = 900.0
+
+
+def reach_prompt(link: Reconnecting, patience: float = PROMPT_PATIENCE) -> None:
+    """Wait for a root prompt, answering the medium's questions on the way."""
+    deadline = time.monotonic() + patience
+    while time.monotonic() < deadline:
+        said = link.expect(
+            rf"livecd .*#|localhost .*#|{KEYMAP_QUESTION}",
+            timeout=max(30.0, deadline - time.monotonic()),
+        )
+        if not re.search(KEYMAP_QUESTION.encode(), said):
+            return  # The prompt matched, which is what this waits for.
+        # The default is what every fixture wants, and the question waits for
+        # a key rather than answering itself.
+        link.send("")
+    raise ConsoleTimeout(f"the medium did not reach a shell in {patience:.0f}s")
+
+
 def wait_for_network(link: Reconnecting) -> None:
     """Configure the guest's interface, then wait until it can reach a mirror.
 
@@ -529,7 +556,7 @@ def install_one(
             # read. The keys go through the API and the kernel appearing on
             # the console is what says the edit landed.
             append_to_cmdline_blind(guest, link, EXTRA_CMDLINE)
-        link.expect(r"livecd .*#|localhost .*#", timeout=900.0)
+        reach_prompt(link)
         # The guest's own resolver is left alone. A local run pins one because
         # slirp reads the host's `/etc/resolv.conf` once at startup; the
         # cluster hands out a real configuration, and it is IPv6 with DNS64.


### PR DESCRIPTION
The official minimal medium asks `Load keymap (Enter for default):` and waits for a key. The cluster path waited for a root prompt and nothing answered, so two guests on the round now running sat at that question while their patience ran down.

`reach_prompt` waits for either and presses enter when it is the question. A medium that gives a prompt straight away is sent nothing.