### PR TITLE
tests: offer slots one node at a time

### DIFF
--- a/tests/unit/test_proxmox.py
+++ b/tests/unit/test_proxmox.py
@@ -1205,3 +1205,31 @@ def test_the_keymap_question_is_answered_rather_than_waited_out() -> None:
     quiet = Ready()
     reach_prompt(Reconnecting(lambda: quiet, tries=1), patience=30.0)
     assert quiet.sent == [], quiet.sent
+
+
+def test_slots_are_offered_one_node_at_a_time() -> None:
+    """A node's whole share came before the next node was touched, so five
+    guests went onto `infra-node5` and left the other five idle: one node
+    carried every build, and its four cores and the shared storage lock were
+    contended by all of them."""
+    from typing import Any
+
+    from tests.vm.cluster import GUEST_MEMORY_MIB, NODE_HEADROOM_BYTES, free_slots
+    from tests.vm.proxmox import Api, Node
+
+    def node(name: str, guests: int) -> Node:
+        return Node(
+            name=name,
+            free_bytes=NODE_HEADROOM_BYTES + guests * GUEST_MEMORY_MIB * 1024**2,
+            cores=4,
+        )
+
+    class Cluster(Api):
+        def __init__(self) -> None:
+            pass
+
+        def nodes(self) -> list[Node]:
+            return [node("a", 3), node("b", 1), node("c", 2)]
+
+    order = [one.name for one in free_slots(Cluster())]
+    assert order == ["a", "b", "c", "a", "c", "a"], order

--- a/tests/unit/test_proxmox.py
+++ b/tests/unit/test_proxmox.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import shlex
+from collections import Counter
 import struct
 import urllib.request
 from pathlib import Path
@@ -385,7 +386,9 @@ def test_a_node_offers_a_slot_for_every_guest_it_can_hold() -> None:
             ]
 
     names = [node.name for node in free_slots(Counted(host="nowhere.invalid"))]
-    assert names == ["big", "big", "big", "one"]
+    # Counted, not ordered: the order is round robin so that one node does not
+    # carry every build, and that rule has a test of its own.
+    assert Counter(names) == Counter({"big": 3, "one": 1}), names
     assert "none" not in names, "the headroom is left free on every node"
 
 

--- a/tests/vm/cluster.py
+++ b/tests/vm/cluster.py
@@ -465,10 +465,19 @@ def free_slots(api: Api, placed: Mapping[str, int] | None = None) -> list[Node]:
     """
     need = GUEST_MEMORY_MIB * 1024**2
     held = placed or {}
-    slots: list[Node] = []
+    per_node: list[list[Node]] = []
     for node in api.nodes():
         room = node.free_bytes - NODE_HEADROOM_BYTES - held.get(node.name, 0) * need
-        slots += [node] * max(0, int(room // need))
+        per_node.append([node] * max(0, int(room // need)))
+    # One from each node in turn, rather than a node's whole share before the
+    # next one is touched: five guests went onto `infra-node5` and left the
+    # other five idle, so one node carried every build while the shared
+    # storage lock and its four cores were contended by all of them.
+    slots: list[Node] = []
+    for index in range(max((len(one) for one in per_node), default=0)):
+        for one in per_node:
+            if index < len(one):
+                slots.append(one[index])
     return slots
 
 


### PR DESCRIPTION
`free_slots` appended a node's whole share before moving to the next, and the scheduler takes them in order, so the last round put five guests on `infra-node5` and left five nodes idle. One node's four cores and the `ceph-pve` lock were then contended by every build on it, which is where `cfs-lock ... got lock request timeout` came from.

Round robin: one slot from each node in turn until each node's share is used up. The existing test asserted the order rather than the count, so it now compares counts and the order has a test of its own.