### PR TITLE
model: put USTC and NJU ahead of tuna

### DIFF
--- a/gentoo_install/model/mirrors.py
+++ b/gentoo_install/model/mirrors.py
@@ -50,6 +50,28 @@ class Site:
 #: to every host, because the paths do not follow one: USTC serves git at
 #: `/gentoo.git` and rsync from another hostname entirely.
 GENTOO_SITES: Final[tuple[Site, ...]] = (
+    # USTC first, then NJU. On 2026-08-10 the rsync tree at tuna served a
+    # snapshot its own signed Manifest did not match — `metadata/Manifest.gz
+    # expected 23353, have 23355` — and it stayed that way across three
+    # attempts an hour apart, so three cluster guests stopped an hour into
+    # their installs. The order is what an operator gets by default.
+    Site(
+        "ustc", "USTC", "Hefei",
+        "https://mirrors.ustc.edu.cn/gentoo",
+        "https://mirrors.ustc.edu.cn/gentoo.git",
+        "rsync://rsync.mirrors.ustc.edu.cn/gentoo-portage",
+    ),
+    Site(
+        "nju", "Nanjing University", "Nanjing",
+        "https://mirrors.nju.edu.cn/gentoo",
+        "https://mirrors.nju.edu.cn/git/gentoo-portage.git",
+    ),
+    Site(
+        "bfsu", "BFSU", "Beijing",
+        "https://mirrors.bfsu.edu.cn/gentoo",
+        "https://mirrors.bfsu.edu.cn/git/gentoo-portage.git",
+        "rsync://mirrors.bfsu.edu.cn/gentoo-portage",
+    ),
     # No git column: `/git/gentoo-portage.git`, `/git/gentoo.git` and
     # `/gentoo-portage.git` were each asked and none of them answered. A sync
     # method falls back to a site that has it rather than to a dead address.
@@ -59,25 +81,8 @@ GENTOO_SITES: Final[tuple[Site, ...]] = (
         rsync="rsync://mirrors.tuna.tsinghua.edu.cn/gentoo-portage",
     ),
     Site(
-        "bfsu", "BFSU", "Beijing",
-        "https://mirrors.bfsu.edu.cn/gentoo",
-        "https://mirrors.bfsu.edu.cn/git/gentoo-portage.git",
-        "rsync://mirrors.bfsu.edu.cn/gentoo-portage",
-    ),
-    Site(
-        "ustc", "USTC", "Hefei",
-        "https://mirrors.ustc.edu.cn/gentoo",
-        "https://mirrors.ustc.edu.cn/gentoo.git",
-        "rsync://rsync.mirrors.ustc.edu.cn/gentoo-portage",
-    ),
-    Site(
         "zju", "Zhejiang University", "Hangzhou",
         "https://mirrors.zju.edu.cn/gentoo",
-    ),
-    Site(
-        "nju", "Nanjing University", "Nanjing",
-        "https://mirrors.nju.edu.cn/gentoo",
-        "https://mirrors.nju.edu.cn/git/gentoo-portage.git",
     ),
     Site(
         "sdu", "Shandong University", "Qingdao",

--- a/tests/unit/test_mirrors.py
+++ b/tests/unit/test_mirrors.py
@@ -69,3 +69,20 @@ def test_every_gentoozh_site_is_appended_with_the_chosen_one_first() -> None:
     assert mirrors.gentoozh_distfiles(GentooZhMirror.UPSTREAM)[0] == (
         "https://distfiles.gentoozh.org"
     )
+
+
+def test_the_chinese_default_is_ustc_and_not_tuna() -> None:
+    """On 2026-08-10 the rsync tree at tuna served a snapshot its own signed
+    Manifest did not match — `metadata/Manifest.gz expected 23353, have
+    23355` — and stayed that way across three attempts an hour apart, so three
+    cluster guests stopped an hour into their installs with
+    `emerge --sync gentoo exited 1`.
+
+    The order here is what an operator gets without choosing, so it names the
+    two that were serving a consistent tree.
+    """
+    from gentoo_install.model.mirrors import GENTOO_SITES
+
+    names = [one.key for one in GENTOO_SITES]
+    assert names[:2] == ["ustc", "nju"], names[:4]
+    assert names.index("tuna") > names.index("ustc"), names


### PR DESCRIPTION
The rsync tree at `mirrors.tuna.tsinghua.edu.cn` served a snapshot its own signed Manifest did not match — `metadata/Manifest.gz __size__: expected: 23353, have: 23355` — and stayed that way across three attempts an hour apart. Three cluster guests today stopped with `emerge --sync gentoo exited 1` after nineteen to thirty-six minutes of installing, and the retry added in #59 ran all three times against the same answer.

`GENTOO_SITES` order is what an operator gets without choosing one, so it now starts with the two that were serving a consistent tree. tuna stays on the list.