### PR TITLE
plan: refresh the release key from a keyserver that answers

### DIFF
--- a/gentoo_install/plan/portage.py
+++ b/gentoo_install/plan/portage.py
@@ -249,6 +249,14 @@ class ConfigureRepository(Operation):
         )
 
 
+#: Where gemato refreshes the release key from before it checks the snapshot
+#: signature. Not the default `keys.gentoo.org`: a guest on the Proxmox
+#: cluster resolved it to 85.143.112.91 and then reached nothing there, while
+#: `keys.openpgp.org` answered 200 and serves the same key by fingerprint.
+#: The key and the signature are unchanged; only the refresh moves.
+KEY_SERVER: Final[str] = "hkps://keys.openpgp.org"
+
+
 @dataclass(frozen=True, kw_only=True)
 class WebrsyncRepository(Operation):
     """The first sync cannot be a git sync: a stage3 has no `dev-vcs/git`, and
@@ -260,7 +268,16 @@ class WebrsyncRepository(Operation):
         return "fetch the first ebuild repository snapshot with emerge-webrsync"
 
     def apply(self, context: Context) -> None:
-        context.run_in_target(["emerge-webrsync"])
+        # `emerge-webrsync` verifies the snapshot with gemato, which refreshes
+        # the release key before checking the signature. Its default keyserver
+        # is unreachable on some networks: a cluster guest resolved
+        # `keys.gentoo.org` to 85.143.112.91 and then got nothing from it,
+        # so every install stopped at `No keyserver available`. Pointing the
+        # refresh at a keyserver that answers changes where the same key comes
+        # from and verifies exactly as before.
+        context.run_in_target(
+            ["env", f"PORTAGE_GPG_KEY_SERVER={KEY_SERVER}", "emerge-webrsync"]
+        )
 
 
 #: How many times a repository sync is attempted, and how long between them.

--- a/tests/unit/test_plan_portage.py
+++ b/tests/unit/test_plan_portage.py
@@ -610,3 +610,27 @@ def test_the_stage3_matches_the_profile_and_not_only_the_init_system() -> None:
             system=replaced(base.system, init=init),
         )
         assert variant_of(installation) == variant, profile
+
+
+def test_the_first_snapshot_is_verified_against_a_reachable_keyserver() -> None:
+    """`emerge-webrsync` verifies the snapshot with gemato, which refreshes the
+    release key first. Its default keyserver answers nothing on some networks:
+    a cluster guest resolved `keys.gentoo.org` to 85.143.112.91 and then got
+    no connection at all, so every install stopped at `gpg: keyserver refresh
+    failed: No keyserver available` before a single package was merged.
+
+    The key and the signature are unchanged; only where the refresh reads the
+    key from moves, so this is not a weakening of the check.
+    """
+    from gentoo_install.plan import portage as plan_portage
+
+    from .recorder import Recorder
+
+    recorder = Recorder()
+    plan_portage.WebrsyncRepository().apply(recorder)
+    ran = recorder.in_target[-1]
+    assert ran[-1] == "emerge-webrsync", ran
+    assert f"PORTAGE_GPG_KEY_SERVER={plan_portage.KEY_SERVER}" in ran, ran
+    assert plan_portage.KEY_SERVER.startswith("hkps://"), plan_portage.KEY_SERVER
+    # Not the default: naming the same one it already uses fixes nothing.
+    assert "keys.gentoo.org" not in plan_portage.KEY_SERVER


### PR DESCRIPTION
`emerge-webrsync` verifies the snapshot with gemato, which refreshes the release key before checking the signature. On the cluster's network that refresh reaches nothing: a probe guest resolved `keys.gentoo.org` to 85.143.112.91, then `curl` returned 000 and `gpg --recv-keys` hung until it was killed. Every install stopped at `gpg: keyserver refresh failed: No keyserver available` before a package was merged.

`keys.openpgp.org` answered 200 from the same guest and serves the release key by fingerprint — `/vks/v1/by-fingerprint/13EBBDBEDE7A12775DFDB1BABB572E0E2D182910` returns 200. `emerge-webrsync` passes `PORTAGE_GPG_KEY_SERVER` through to gemato's `--keyserver`.

The key, the signature and the check are unchanged; only where the refresh reads the key from moves. Nothing is skipped.