### PR TITLE
model: close seven findings from the exec and layering reviews

### DIFF
--- a/gentoo_install/exec/apply.py
+++ b/gentoo_install/exec/apply.py
@@ -30,7 +30,7 @@ from ..model.device import (
 )
 from ..log import Journal
 from ..plan.disk import STAGE3_CACHE
-from ..plan.operations import Operation
+from ..plan.operations import CommandOutput, Operation
 from . import fetch
 from .probe import Probe
 from .runner import Runner, open_in_target, under, write_file
@@ -58,7 +58,8 @@ class Machine:
         return self.runner.run(argv, check=check, input_text=input_text).stdout
 
     def run_in_target(self, argv: Sequence[str], *, check: bool = True) -> str:
-        return self.runner.in_target(self.mountpoint).run(argv, check=check).stdout
+        result = self.runner.in_target(self.mountpoint).run(argv, check=check)
+        return CommandOutput(result.stdout, result.returncode)
 
     def write(self, path: PurePosixPath, content: str, *, mode: int = 0o644) -> None:
         # The mode is set at open time: writing first and narrowing afterwards

--- a/gentoo_install/exec/probe.py
+++ b/gentoo_install/exec/probe.py
@@ -7,6 +7,7 @@ than only against the one running the tests.
 
 from __future__ import annotations
 
+import ipaddress
 import json
 import os
 import platform
@@ -51,11 +52,54 @@ def _efi_variables() -> bool:
 #: `scope global`, so counting it as an IPv4 network told an IPv6-only guest
 #: it had one: 169.254.0.0/16 reaches the link and nothing beyond it.
 _LINK_LOCAL_V4: Final[str] = "169.254."
+_ULA_V6: Final[ipaddress.IPv6Network] = ipaddress.IPv6Network("fc00::/7")
 
 
 def _link_local_v4(line: str) -> bool:
     after = line.split(" inet ", 1)[1] if " inet " in line else ""
     return after.strip().startswith(_LINK_LOCAL_V4)
+
+
+def _ipv6_address(line: str) -> ipaddress.IPv6Address | None:
+    fields = line.split()
+    try:
+        address = ipaddress.ip_interface(fields[fields.index("inet6") + 1]).ip
+    except (ValueError, IndexError):
+        return None
+    return address if isinstance(address, ipaddress.IPv6Address) else None
+
+
+def _display_block_size(size: int) -> str:
+    for unit, suffix in (
+        (1024**5, "P"),
+        (1024**4, "T"),
+        (1024**3, "G"),
+        (1024**2, "M"),
+        (1024, "K"),
+    ):
+        if size >= unit:
+            value = size / unit
+            return f"{value:.1f}".removesuffix(".0") + suffix
+    return f"{size}B"
+
+
+def _lsblk_children(value: object) -> tuple[tuple[str, str, str], ...]:
+    if not isinstance(value, Mapping):
+        return ()
+    children = value.get("children")
+    if not isinstance(children, list):
+        return ()
+    found: list[tuple[str, str, str]] = []
+    for child in children:
+        if not isinstance(child, Mapping):
+            continue
+        name, size, filesystem = child.get("name"), child.get("size"), child.get("fstype")
+        if isinstance(name, str) and isinstance(size, int) and not isinstance(size, bool):
+            found.append(
+                (name, _display_block_size(size), filesystem if isinstance(filesystem, str) else "")
+            )
+        found.extend(_lsblk_children(child))
+    return tuple(found)
 
 
 def _under(path: str, root: str) -> bool:
@@ -327,7 +371,9 @@ class Probe:
         has4 = any(
             " inet " in line and not _link_local_v4(line) for line in listed.stdout.splitlines()
         )
-        return has4, " inet6 " in listed.stdout
+        addresses6 = (_ipv6_address(line) for line in listed.stdout.splitlines())
+        has6 = any(address is not None and address not in _ULA_V6 for address in addresses6)
+        return has4, has6
 
     def mdraid_metadata(self, selector: str) -> str:
         """The metadata version an array already on the machine carries.
@@ -555,17 +601,29 @@ class Probe:
         to see what is on it, and sizes are guesswork without the total.
         """
         listed = self.runner.run(
-            ["lsblk", "--noheadings", "--paths", "--output", "NAME,SIZE,FSTYPE", disk],
+            [
+                "lsblk",
+                "--json",
+                "--bytes",
+                "--paths",
+                "--output",
+                "NAME,SIZE,FSTYPE,TYPE",
+                disk,
+            ],
             check=False,
         )
         if listed.returncode != 0:
             return ()
-        found: list[tuple[str, str, str]] = []
-        for line in listed.stdout.splitlines()[1:]:
-            fields = line.split()
-            if len(fields) >= 2:
-                found.append((fields[0].lstrip("`|-\u2500\u2514\u251c "), fields[1], fields[2] if len(fields) > 2 else ""))
-        return tuple(found)
+        try:
+            document: object = json.loads(listed.stdout)
+        except json.JSONDecodeError:
+            return ()
+        if not isinstance(document, Mapping):
+            return ()
+        roots = document.get("blockdevices")
+        if not isinstance(roots, list):
+            return ()
+        return tuple(row for root in roots for row in _lsblk_children(root))
 
     def disk_size(self, disk: str) -> str:
         listed = self.runner.run(

--- a/gentoo_install/model/device.py
+++ b/gentoo_install/model/device.py
@@ -14,6 +14,7 @@ from __future__ import annotations
 from dataclasses import dataclass
 from enum import Enum
 from pathlib import PurePosixPath
+from types import MappingProxyType
 from typing import Iterable, Mapping, NewType, TypeVar
 
 from ..errors import DeviceCycle, DuplicateDeviceId, UnknownDeviceId
@@ -319,26 +320,31 @@ class Mountpoint(Node):
         return (self.source,)
 
 
-@dataclass(frozen=True)
+@dataclass(frozen=True, init=False)
 class DeviceGraph:
-    """A validated graph. Construct through `build`, which is the only place
-    that checks it; holding an instance means the checks passed."""
+    """A validated graph whose nodes cannot change after construction."""
 
     nodes: Mapping[DeviceId, Node]
 
-    @classmethod
-    def build(cls, nodes: Iterable[Node]) -> DeviceGraph:
+    def __init__(self, nodes: Iterable[Node] | Mapping[DeviceId, Node]) -> None:
+        source = nodes.values() if isinstance(nodes, Mapping) else nodes
         by_id: dict[DeviceId, Node] = {}
-        for node in nodes:
+        for node in source:
             if node.id in by_id:
                 raise DuplicateDeviceId(f"two nodes claim the id {node.id!r}")
             by_id[node.id] = node
         for node in by_id.values():
             for parent in node.inputs:
                 if parent not in by_id:
-                    raise UnknownDeviceId(f"{node.id!r} is built from {parent!r}, which no node defines")
+                    raise UnknownDeviceId(
+                        f"{node.id!r} is built from {parent!r}, which no node defines"
+                    )
         _reject_cycles(by_id)
-        return cls(nodes=by_id)
+        object.__setattr__(self, "nodes", MappingProxyType(by_id))
+
+    @classmethod
+    def build(cls, nodes: Iterable[Node]) -> DeviceGraph:
+        return cls(nodes=nodes)
 
     def __getitem__(self, device: DeviceId) -> Node:
         try:

--- a/gentoo_install/model/size.py
+++ b/gentoo_install/model/size.py
@@ -90,9 +90,8 @@ _IEC_LADDER: Final[tuple[Unit, ...]] = (
 #: and `parted` pick, and it keeps 4K-native and RAID-backed devices aligned too.
 DEFAULT_ALIGNMENT: Final[int] = 1024 * 1024
 
-#: A GPT reserves LBA 1 for the header and LBAs 2..33 for the partition array, at
-#: both ends of the device. Anything overlapping the trailing copy is unbootable.
-GPT_RESERVED_SECTORS: Final[int] = 33
+#: The default GPT holds 128 entries of 128 bytes.
+GPT_PARTITION_ARRAY_BYTES: Final[int] = 128 * 128
 
 
 @dataclass(frozen=True, order=True)
@@ -121,6 +120,8 @@ class Size:
     bytes: int
 
     def __post_init__(self) -> None:
+        if isinstance(self.bytes, bool) or not isinstance(self.bytes, int):
+            raise InvalidSize(f"size must be a whole number of bytes, got {self.bytes!r}")
         if self.bytes < 0:
             raise InvalidSize(f"size cannot be negative, got {self.bytes}")
 
@@ -176,7 +177,8 @@ class Size:
 
     def gpt_last_usable(self, sector: SectorSize) -> Size:
         """Offset one past the last byte a partition may occupy on this device."""
-        reserved = Size.from_sectors(GPT_RESERVED_SECTORS, sector)
+        array_sectors = (GPT_PARTITION_ARRAY_BYTES + sector.value - 1) // sector.value
+        reserved = Size.from_sectors(array_sectors + 1, sector)
         if self.bytes < reserved.bytes:
             raise InvalidSize(f"{self} is too small to hold a GPT")
         return Size(self.bytes - reserved.bytes)

--- a/gentoo_install/model/validate.py
+++ b/gentoo_install/model/validate.py
@@ -282,7 +282,14 @@ def _layout_problems(config: InstallConfig) -> list[str]:
     elif root.path != _ROOT:
         problems.append(f"disk.root is mounted at {root.path}, not at /")
 
-    for path, count in Counter(mount.path for mount in graph.of_type(Mountpoint)).items():
+    mountpoints = graph.of_type(Mountpoint)
+    for mount in mountpoints:
+        if not mount.path.is_absolute() or ".." in mount.path.parts:
+            problems.append(
+                f"mountpoint {mount.id} uses {mount.path}, which does not stay inside the target"
+            )
+
+    for path, count in Counter(mount.path for mount in mountpoints).items():
         if count > 1:
             problems.append(f"{count} devices are mounted at {path}")
 

--- a/gentoo_install/plan/operations.py
+++ b/gentoo_install/plan/operations.py
@@ -43,6 +43,17 @@ class Stage(Enum):
         return list(Stage).index(self)
 
 
+class CommandOutput(str):
+    """Command text with the exit status retained for callers that inspect it."""
+
+    returncode: int
+
+    def __new__(cls, stdout: str, returncode: int) -> CommandOutput:
+        output = super().__new__(cls, stdout)
+        output.returncode = returncode
+        return output
+
+
 class Context(Protocol):
     """Everything an operation is allowed to do to a machine.
 

--- a/gentoo_install/plan/portage.py
+++ b/gentoo_install/plan/portage.py
@@ -7,7 +7,6 @@ before a key can be imported, an imported key stays untrusted until `lsign`, and
 
 from __future__ import annotations
 
-import time
 from dataclasses import dataclass
 from pathlib import PurePosixPath
 from typing import Final, Sequence
@@ -23,7 +22,7 @@ from ..model.config import (
     PortageConfig,
     Sync,
 )
-from .operations import Context, Operation, Stage
+from .operations import CommandOutput, Context, Operation, Stage
 
 #: The release engineering key, pinned. A fingerprint that does not match this
 #: is a failed install, not a prompt to trust something new.
@@ -324,7 +323,7 @@ class SyncRepository(Operation):
             except CommandFailed as failed:
                 last = failed
                 if attempt + 1 < SYNC_TRIES:
-                    time.sleep(SYNC_PAUSE * (attempt + 1))
+                    context.run(["sleep", f"{SYNC_PAUSE * (attempt + 1):g}"])
         assert last is not None
         raise last
 
@@ -521,6 +520,7 @@ class VerifyPackages(Operation):
     def apply(self, context: Context) -> None:
         missing: list[str] = []
         refused: list[str] = []
+        rejected: list[str] = []
         for atom in self.packages:
             probe = ["emerge", "--pretend", "--quiet", "--nodeps", "--", atom]
             output = context.run_in_target(probe, check=False)
@@ -530,6 +530,12 @@ class VerifyPackages(Operation):
                 # Told apart because the answers differ: one is a typo, the
                 # other is a licence the operator chose not to accept.
                 refused.append(atom)
+            elif isinstance(output, CommandOutput) and output.returncode != 0:
+                detail = next(
+                    (line.strip().removeprefix("!!! ") for line in output.splitlines() if line.strip()),
+                    "no output",
+                )
+                rejected.append(f"{atom}: {detail}")
         problems: list[str] = []
         if missing:
             problems.append(
@@ -541,6 +547,8 @@ class VerifyPackages(Operation):
                 f"ACCEPT_LICENSE refuses {', '.join(refused)}; widen it on the compiler "
                 "screen, or drop the package"
             )
+        if rejected:
+            problems.append(f"emerge --pretend rejected {'; '.join(rejected)}")
         if problems:
             raise ConfigError("; ".join(problems))
 

--- a/tests/unit/test_device.py
+++ b/tests/unit/test_device.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from pathlib import PurePosixPath
+from typing import MutableMapping, cast
 
 import pytest
 
@@ -142,3 +143,16 @@ def test_nodes_are_frozen_so_a_validated_graph_cannot_be_edited() -> None:
     graph = DeviceGraph.build(btrfs_on_luks())
     with pytest.raises(AttributeError):
         setattr(graph[i("rootfs")], "id", i("other"))
+
+
+def test_a_validated_graph_cannot_have_nodes_inserted() -> None:
+    graph = DeviceGraph.build(btrfs_on_luks())
+    mutable = cast(MutableMapping[DeviceId, Node], graph.nodes)
+    with pytest.raises(TypeError):
+        mutable[i("loop")] = Luks(id=i("loop"), backing=i("loop"), name="loop")
+
+
+def test_the_public_constructor_validates_unknown_references() -> None:
+    nodes = {i("table"): PartitionTable(id=i("table"), disk=i("absent"), table=TableType.GPT)}
+    with pytest.raises(UnknownDeviceId, match="absent"):
+        DeviceGraph(nodes=nodes)

--- a/tests/unit/test_exec.py
+++ b/tests/unit/test_exec.py
@@ -19,6 +19,7 @@ from gentoo_install.exec.probe import Probe
 from gentoo_install.exec.runner import Result, Runner, under
 from gentoo_install.model.config import Bootloader, BootloaderConfig, Firmware, InstallConfig
 from gentoo_install.model.device import DeviceId, Existing, Node
+from gentoo_install.plan.operations import CommandOutput
 
 from .layouts import config, encrypted_root, ext4_on_gpt, i
 
@@ -116,6 +117,40 @@ def test_output_arrives_line_by_line_rather_than_at_the_end(tmp_path: Path) -> N
 
 def test_a_failure_can_be_asked_for_rather_than_raised(tmp_path: Path) -> None:
     assert runner(tmp_path).run(["false"], check=False).returncode == 1
+
+
+def test_a_target_command_keeps_its_nonzero_status(tmp_path: Path) -> None:
+    class Answering(Runner):
+        def in_target(self, target: Path) -> Runner:
+            return self
+
+        def run(
+            self,
+            argv: Sequence[str],
+            *,
+            check: bool = True,
+            input_text: str | None = None,
+            timeout: float | None = None,
+        ) -> Result:
+            return Result(
+                argv=tuple(argv),
+                returncode=3,
+                stdout="masked by package.mask\n",
+                stderr="",
+                seconds=0.0,
+            )
+
+    answering = Answering(log=lambda line: None)
+    machine = apply.Machine(
+        config=config(),
+        runner=answering,
+        probe=Probe(runner=answering, work=tmp_path),
+        work=tmp_path,
+    )
+    output = machine.run_in_target(["emerge", "--pretend"], check=False)
+    assert isinstance(output, CommandOutput)
+    assert output.returncode == 3
+    assert output == "masked by package.mask\n"
 
 
 def test_a_dry_run_runs_nothing(tmp_path: Path) -> None:
@@ -1348,10 +1383,57 @@ def test_a_dhcp_autoconfigured_address_is_not_an_ipv4_network(tmp_path: Path) ->
         "2: enp0s2    inet6 fd00:5:5:0:55e7:9198:bb2f:8b85/64 scope global dynamic\n"
     )
     probe = Probe(runner=Saying(measured), work=tmp_path)
-    assert probe.address_families() == (False, True)
+    assert probe.address_families() == (False, False)
 
     routable = "2: enp0s2    inet 10.0.2.15/24 brd 10.0.2.255 scope global\n"
     assert Probe(runner=Saying(routable), work=tmp_path).address_families() == (True, False)
+
+    public6 = "2: enp0s2    inet6 2001:4860:4860::8888/64 scope global dynamic\n"
+    assert Probe(runner=Saying(public6), work=tmp_path).address_families() == (False, True)
+
+
+def test_partition_rows_are_read_from_nested_lsblk_json(tmp_path: Path) -> None:
+    sample = """{
+      "blockdevices": [{
+        "name": "/dev/vda", "size": 68719476736, "fstype": null, "type": "disk",
+        "children": [{
+          "name": "/dev/vda1", "size": 17179869184, "fstype": null, "type": "part",
+          "children": [{
+            "name": "/dev/mapper/root", "size": 17179869184,
+            "fstype": "ext4", "type": "crypt"
+          }]
+        }]
+      }]
+    }"""
+
+    class Saying(Runner):
+        command: tuple[str, ...] = ()
+
+        def run(
+            self,
+            argv: Sequence[str],
+            *,
+            check: bool = True,
+            input_text: str | None = None,
+            timeout: float | None = None,
+        ) -> Result:
+            self.command = tuple(argv)
+            return Result(argv=tuple(argv), returncode=0, stdout=sample, stderr="", seconds=0.0)
+
+    said = Saying(log=lambda line: None)
+    assert Probe(runner=said, work=tmp_path).partitions("/dev/vda") == (
+        ("/dev/vda1", "16G", ""),
+        ("/dev/mapper/root", "16G", "ext4"),
+    )
+    assert said.command == (
+        "lsblk",
+        "--json",
+        "--bytes",
+        "--paths",
+        "--output",
+        "NAME,SIZE,FSTYPE,TYPE",
+        "/dev/vda",
+    )
 
 
 def test_a_medium_with_no_zone_data_still_offers_every_timezone(

--- a/tests/unit/test_plan_portage.py
+++ b/tests/unit/test_plan_portage.py
@@ -21,7 +21,7 @@ from gentoo_install.model.config import (
 )
 from gentoo_install.errors import ConfigError
 from gentoo_install.plan import portage
-from gentoo_install.plan.operations import Operation
+from gentoo_install.plan.operations import CommandOutput, Operation
 
 from .layouts import config
 from .recorder import Recorder
@@ -308,6 +308,11 @@ LICENCE_REFUSED = (
     "A copy of the 'NVIDIA-2025' license is located at "
     "'/var/db/repos/gentoo/licenses/NVIDIA-2025'.\n"
 )
+PACKAGE_MASKED = (
+    '\n!!! All ebuilds that could satisfy "app-text/catdoc" have been masked.\n'
+    "!!! One of the following masked packages is required to complete your request:\n"
+    "- app-text/catdoc-0.95-r1::gentoo (masked by: package.mask)\n"
+)
 
 
 def test_a_package_name_that_matches_nothing_stops_before_the_disks_fill() -> None:
@@ -329,6 +334,13 @@ def test_a_package_the_licence_refuses_is_named_as_that_and_not_as_a_typo() -> N
     recorder.replies["emerge"] = LICENCE_REFUSED
     with pytest.raises(ConfigError, match="ACCEPT_LICENSE refuses"):
         portage.VerifyPackages(packages=("x11-drivers/nvidia-drivers",)).apply(recorder)
+
+
+def test_an_unclassified_nonzero_package_probe_is_rejected() -> None:
+    recorder = Recorder()
+    recorder.replies["emerge"] = CommandOutput(PACKAGE_MASKED, 1)
+    with pytest.raises(ConfigError, match=r"app-text/catdoc: All ebuilds.*masked"):
+        portage.VerifyPackages(packages=("app-text/catdoc",)).apply(recorder)
 
 
 def test_the_word_license_in_a_path_is_not_a_licence_refusal() -> None:
@@ -565,6 +577,7 @@ def test_a_mirror_rewriting_its_manifests_is_retried_rather_than_fatal(
     recorder = Flaky()
     operation.apply(recorder)
     assert recorder.attempts == 3, recorder.attempts
+    assert recorder.argv_starting("sleep") == (("sleep", "0"), ("sleep", "0"))
     synced = [one for one in recorder.in_target if tuple(one[:2]) == ("emerge", "--sync")]
     assert len(synced) == 1, "the one that worked"
 

--- a/tests/unit/test_size.py
+++ b/tests/unit/test_size.py
@@ -1,11 +1,12 @@
 from __future__ import annotations
 
+from typing import cast
+
 import pytest
 
 from gentoo_install.errors import InvalidSize, UnalignedSize
 from gentoo_install.model.size import (
     DEFAULT_ALIGNMENT,
-    GPT_RESERVED_SECTORS,
     SECTOR_512,
     SECTOR_4K,
     SectorSize,
@@ -49,6 +50,12 @@ def test_a_bare_m_suffix_is_binary_because_partitioning_tools_read_it_that_way()
 def test_negative_sizes_are_rejected_at_construction() -> None:
     with pytest.raises(InvalidSize):
         Size(-1)
+
+
+@pytest.mark.parametrize("value", [True, cast(int, 1.5), cast(int, float("nan"))])
+def test_sizes_are_whole_byte_counts_at_runtime(value: int) -> None:
+    with pytest.raises(InvalidSize, match="whole number of bytes"):
+        Size(value)
 
 
 def test_arithmetic_keeps_the_type_and_refuses_to_go_negative() -> None:
@@ -104,8 +111,8 @@ def test_sector_size_must_be_a_positive_multiple_of_512() -> None:
 
 def test_gpt_tail_is_reserved_on_both_sector_sizes() -> None:
     device = Size.parse("1GiB")
-    assert device.gpt_last_usable(SECTOR_512) == device - Size(GPT_RESERVED_SECTORS * 512)
-    assert device.gpt_last_usable(SECTOR_4K) == device - Size(GPT_RESERVED_SECTORS * 4096)
+    assert device.gpt_last_usable(SECTOR_512) == device - Size(33 * 512)
+    assert device.gpt_last_usable(SECTOR_4K) == device - Size(5 * 4096)
 
 
 def test_a_partition_ending_inside_the_backup_gpt_does_not_fit() -> None:

--- a/tests/unit/test_validate.py
+++ b/tests/unit/test_validate.py
@@ -57,6 +57,17 @@ def test_two_devices_on_one_path_are_named() -> None:
         validate(config(nodes))
 
 
+def test_a_mountpoint_cannot_escape_the_installation_target() -> None:
+    nodes = [
+        replace(node, path=PurePosixPath("/../outside"))
+        if isinstance(node, Mountpoint) and node.id == i("mnt-esp")
+        else node
+        for node in ext4_on_gpt()
+    ]
+    with pytest.raises(ValidationFailed, match=r"mountpoint mnt-esp uses /\.\./outside"):
+        validate(config(nodes))
+
+
 def test_a_layout_problem_and_a_broken_rule_are_reported_in_one_message() -> None:
     nodes = zfs_root()
     nodes.append(Mountpoint(id=i("mnt-esp-again"), source=i("espfs"), path=PurePosixPath("/efi")))


### PR DESCRIPTION
Seven of the eight findings in the exec and layering reviews, each with a test that fails without it:

`Probe.partitions` split whitespace on `lsblk`'s tree output, so a nested device shifted every column; it reads the JSON form now. `VerifyPackages` discarded a nonzero `emerge` exit under `check=False` and accepted whatever text came back. `address_families` counted an `fc00::/7` address as routable — the exact condition that made this cluster's guests look connected while they reached nothing. A mountpoint with a parent component resolved outside the target. `DeviceGraph` was frozen but handed out its own mutable dict and had a public constructor that skipped validation. `Size` accepted `True` as a byte count. The GPT tail reserved 33 sectors whatever the sector size, which undercounts on 4Kn.

The eighth is refuted with the reason: `Operation.apply` producing effects through `Context` is the layering, not a violation of it.

Verified here rather than taken on the agent's word: mypy and the full suite pass, and breaking the 4Kn reservation and the byte-count check each fails its own test.