### PR TITLE
tests: skip the ARP probe and wait long enough for a lease

### DIFF
--- a/tests/unit/test_proxmox.py
+++ b/tests/unit/test_proxmox.py
@@ -1236,3 +1236,21 @@ def test_slots_are_offered_one_node_at_a_time() -> None:
 
     order = [one.name for one in free_slots(Cluster())]
     assert order == ["a", "b", "c", "a", "c", "a"], order
+
+
+def test_the_dhcp_request_skips_the_arp_probe_and_waits_long_enough() -> None:
+    """The server offers an address within a second and the handshake then
+    stalls in `probing address 10.31.0.201/24` until dhcpcd gives up, so a
+    guest that had been offered a lease still came up with nothing. Measured
+    on two nodes: `-w -t 25` timed out on both, `--noarp -w -t 90` leased
+    10.31.0.203 and 10.31.0.201 with `default via 10.31.0.254`.
+
+    The interface is named, too: a bare `dhcpcd -4 -w` returned at once when
+    one was already running, so the wait was never taken.
+    """
+    from tests.vm.cluster import ASK_FOR_IPV4
+
+    assert "--noarp" in ASK_FOR_IPV4, ASK_FOR_IPV4
+    assert "-t 90" in ASK_FOR_IPV4, ASK_FOR_IPV4
+    assert '"$dev"' in ASK_FOR_IPV4, "the interface has to be named"
+    assert "ip -4 route show default" in ASK_FOR_IPV4, "and only when there is none"

--- a/tests/vm/cluster.py
+++ b/tests/vm/cluster.py
@@ -330,8 +330,15 @@ NETWORK_PROBE: Final[str] = (
 #: already, so a medium whose own manager configured one is left alone.
 ASK_FOR_IPV4: Final[str] = (
     "ip -4 route show default | grep -q . || { "
-    'for one in /sys/class/net/e*; do ip link set "$(basename "$one")" up; done; '
-    "dhcpcd -4 -w -t 25 >/dev/null 2>&1; }; true"
+    'for one in /sys/class/net/e*; do dev=$(basename "$one"); ip link set "$dev" up; '
+    # Named, and with the ARP probe skipped. A bare `dhcpcd -4 -w` returned at
+    # once when one was already running, so the wait was never taken; and the
+    # server offers an address within a second while the handshake then stalls
+    # in `probing address 10.31.0.201/24` until dhcpcd gives up. Measured on
+    # two nodes: `-w -t 25` timed out on both, `--noarp -w -t 90` leased
+    # 10.31.0.203 and 10.31.0.201 with `default via 10.31.0.254`.
+    'dhcpcd -4 --noarp -w -t 90 "$dev" >/dev/null 2>&1 || true; done; }; '
+    "ip -4 route show default | grep -q . || true"
 )
 
 


### PR DESCRIPTION
#81 asked for an address and the guests still came up without one. Two things were wrong with the command.

A bare `dhcpcd -4 -w` returned immediately when one was already running, so the wait was never taken — the log shows `MARK_1_BEGIN` and `MARK_1_DONE` with nothing between them and no delay at all. The interface is named now.

And the handshake itself stalls: the server offers an address within a second, then dhcpcd sits in `probing address 10.31.0.201/24` until it gives up. Measured on two nodes — `-w -t 25` timed out on both, `--noarp -w -t 90` leased 10.31.0.203 and 10.31.0.201 with `default via 10.31.0.254` and `curl` then answered.