### PR TITLE
readme: state what the five files can prove

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -2,7 +2,9 @@
 
 # gentoo-install
 
-gentoo-install は、互換性のある Linux ライブ環境上で amd64 アーキテクチャの Gentoo システムをインストールできるシステムインストーラです。インストール内容は、対話式メニューまたは TOML 設定ファイルで設定できます。プログラムのインターフェイスは、英語、繁体字中国語、簡体字中国語、日本語、韓国語に対応しています。
+<!-- fact: identity -->
+
+gentoo-install は、認識対象の Linux ライブ環境上で amd64 アーキテクチャの Gentoo システムをインストールするシステムインストーラです。インストール内容は、対話式メニューまたは TOML 設定ファイルで指定できます。プログラムのインターフェイスは、英語、繁体字中国語、簡体字中国語、日本語、韓国語に対応しています。
 
 ![インストール内容の各項目を表示するメニュー](screenshot.png)
 
@@ -10,39 +12,79 @@ gentoo-install は、互換性のある Linux ライブ環境上で amd64 アー
 
 ## 機能
 
-**ストレージ** デバイスグラフは、GPT と MBR のパーティションテーブル、Ext2/3/4、XFS、F2FS、VFAT、および subvolume を含む Btrfs などのファイルシステム、swap、zram、LUKS2 暗号化、LVM、mdraid に対応しています。パーティション管理では、既存のパーティションテーブルを保持し、各パーティションに対して保持、フォーマット、削除のいずれかを個別に指定できます。
+<!-- fact: capability-scope -->
+
+検証状況により狭い範囲が示されている場合を除き、以下の経路は実装済みであり、自動化された単体テストまたは plan テストで検査されています。
+
+<!-- fact: storage-device-graph -->
+
+**ストレージ** デバイスグラフは、GPT と MBR のパーティションテーブル、ext2、ext3、ext4、xfs、f2fs、vfat、subvolume を含む btrfs、swap、LUKS2 暗号化、LVM、mdraid を扱います。既存のパーティションテーブルを保持し、各パーティションに対して保持、フォーマット、削除のいずれかを個別に指定できます。
+
+<!-- fact: zram-system -->
+
+システム設定では、デバイスグラフおよび swap パーティションとは別に zram を設定できます。
+
+<!-- fact: boot-system -->
 
 **起動とシステム** インストーラでは、ブートローダーとして GRUB または systemd-boot を選択できます。GRUB は UEFI と BIOS に対応し、systemd-boot は UEFI に対応しています。また、systemd または OpenRC、dracut、locale、キーボードレイアウト、タイムゾーン、ホスト名、DNS、静的アドレス、選択したネットワークマネージャを設定できます。
 
+<!-- fact: desktop-language -->
+
 **デスクトップと言語対応** GNOME、KDE Plasma、Xfce を選択し、GDM、SDDM、LightDM のいずれかと組み合わせられます。グラフィックス設定は AMD、Intel、NVIDIA、仮想マシンに対応しています。パッケージカタログには Fcitx 5、Rime、Anthy、Mozc、Hangul、CJK フォントが含まれます。gentoo-zh が提供するパッチ適用済みカーネルは、Linux テキストコンソールに中国語、日本語、韓国語を表示できます。
 
-**Portage** 設定項目には、profile、`MAKEOPTS`、`USE`、`ACCEPT_KEYWORDS`、`L10N`、ミラー、リポジトリ同期方式が含まれます。gentoo-zh と gig の overlay は明示的に有効にする必要があります。公式と gentoo-zh のバイナリパッケージ取得元は、それぞれ独立した設定と鍵を使用します。
+<!-- fact: portage -->
+
+**Portage** 設定項目には、profile、`MAKEOPTS`、`USE`、`ACCEPT_KEYWORDS`、`L10N`、ミラー、リポジトリ同期方式が含まれます。gentoo-zh と gig の overlay は個別に選択できます。インターフェイス言語として `zh-TW`、`zh-CN`、`ja`、`ko` のいずれかを選択すると、gentoo-zh のパッチ適用済みバイナリカーネルとその overlay も選択されます。`en` を選択した場合は自動的に選択されません。公式と gentoo-zh のバイナリパッケージ取得元は、それぞれ独立した設定と鍵を使用します。
+
+<!-- fact: plan-records -->
 
 **計画と記録** dry run と実際のインストールは同じ一連の操作を使用します。`install.log` はコマンド出力を記録し、`install.jsonl` は操作、パッケージの取得元、バイナリパッケージのフォールバック理由を記録します。メニューは機密情報を除去した設定を `paste.gentoozh.org` にアップロードし、アップロード先ページのアドレスをテキストと QR コードで表示できます。
 
 ## 検証状況
 
-記録済みの最新エンドツーエンド検証ベースラインは、一部の UEFI と BIOS インストール、systemd、OpenRC、Ext4、Btrfs、XFS、LUKS2、LVM、mdraid、Plasma、公式 binhost を対象としています。有効な記録はそれぞれインストーラのリビジョンを明示し、インストール済みシステムが正常に起動した後に初めて検証の根拠として扱われます。
+<!-- fact: verification-history -->
 
-現在のリビジョンでは、ZFS と ZFSBootMenu、initramfs の SSH リモート解錠、greetd のデスクトップセッション、GNOME 以外での ibus は、このベースラインに含まれていません。既定以外の 6 種類のライブメディアからのインストールと、binhost 障害時のフォールバック経路もベースラインに含まれていません。`tests/fixtures/` のファイルは設定モデルのみを検証します。ファイルが存在していても、対応する組み合わせがエンドツーエンド検証に合格したことを意味しません。
+過去のエンドツーエンド記録では、amd64 Gentoo minimal ISO と、インストーラリビジョン `a71f91b4735469bae8ec76af170201acb967a5fe` および `f7257793f95df4b21ebf2ac6a775a343f6205f1b` が使用されました。これらの記録は、一部の UEFI と BIOS インストール、systemd、OpenRC、ext4、btrfs、xfs、LUKS2、LVM、mdraid、Plasma、公式 binhost を対象としていましたが、その後のインストール経路の変更により、現在は過去の根拠としてのみ扱われます。
+
+<!-- fact: verification-current -->
+
+現在のインストーラリビジョンを検証する、リビジョン付きのエンドツーエンド実行記録はありません。このため、上記のストレージ、起動、デスクトップ、ライブメディア、binhost のすべての組み合わせは、現在のリビジョンではエンドツーエンド未検証です。ext2 と ext3 には、各設定に対する自動テストもありません。`tests/fixtures/` のファイルは設定モデルのみを検証し、対応する組み合わせのインストールと起動を証明するものではありません。
+
+<!-- fact: verification-network -->
+
+IPv4 のみ、IPv6 のみ、デュアルスタックの VM 検査は、ディスクへアクセスする前に終了します。この検査は、アドレスファミリの検出、`bootstrap.sh --missing-commands`、stage3 pointer の取得だけを確認します。stage3 のダウンロード、リポジトリ同期、binhost へのアクセス、パッケージのインストール、ターゲットシステムの起動は検証しません。
 
 ## 要件
 
+<!-- fact: requirements-runtime -->
+
 実際のインストールには root 権限、amd64 アーキテクチャ、Python 3.11 以降が必要です。設定ファイルを使用する dry run には root 権限が必要ありません。インストーラには Python 標準ライブラリ以外の実行時依存関係がありません。
 
-メニューは各バージョンを `packages.gentoo.org` から読み取るため、このサイトへの接続が必要です。設定ファイルからのインストールでは、代わりにその設定が指定するミラーへの接続が必要になります。`--missing-commands` と `--config FILE --dry-run` はいずれも接続を必要としません。カーネルバージョンと `sys-fs/zfs` が対応する最大カーネルバージョンは実行時に読み取られます。
+<!-- fact: requirements-version-sources -->
 
-IPv4 のみ、IPv6 のみ、デュアルスタックのいずれのネットワークにも対応します。現在のアドレスファミリで到達できないミラーはメニューが拒否します。
+メニューは、Gentoo メインツリーのパッケージバージョンを `packages.gentoo.org` から、gentoo-zh のパッチ適用済みカーネルのバージョンを `api.github.com/repos/gentoo-zh/overlay/contents` から読み取ります。`sys-fs/zfs` が受け入れる最大カーネルバージョンは `gitweb.gentoo.org` から読み取ります。設定ファイルからのインストールでは、その設定が指定するミラーへの接続が必要です。`--missing-commands` と `--config FILE --dry-run` は、これらのバージョン取得先への接続を必要としません。
 
-`bootstrap.sh` は `/etc/os-release` を読み、不足しているコマンドを報告し、候補となるパッケージマネージャのコマンドを表示します。Debian と Ubuntu、Arch、openSUSE、Fedora、RHEL と CentOS、Gentoo、Alpine など、複数のディストリビューション系統を識別できます。表示されたコマンドは実行前に確認する必要があります。
+<!-- fact: requirements-network-filter -->
+
+検出されたアドレスファミリが、ミラーで利用可能と宣言された IPv4 または IPv6 のいずれにも一致しない場合、メニューはそのミラーを拒否します。
+
+<!-- fact: requirements-bootstrap -->
+
+`bootstrap.sh` は `/etc/os-release` を読み、不足しているコマンドを報告し、候補となるパッケージマネージャのコマンドを表示します。識別するディストリビューション系統は、Debian と Ubuntu、Arch、openSUSE、Fedora、RHEL と CentOS、Gentoo、Alpine です。表示されたコマンドは実行前に確認する必要があります。
 
 ## 安全上の注意
 
+<!-- fact: safety-destructive -->
+
 実際のインストールでは、選択したディスクに書き込みます。設定ファイルを使用して実行する場合、ディスク消去の確認は再度行われません。`wipe = true`、パーティションの削除、ファイルシステムの作成は既存データを破壊する可能性があります。
 
-実際のインストール前に、dry-run の出力でディスクセレクタとすべての破壊的操作を確認する必要があります。`/dev/sda` のような名前より、安定した `/dev/disk/by-id/` セレクタが望ましいです。誤操作によるデータ損失を防ぐため、保持する必要があるデータのバックアップは必須です。
+<!-- fact: safety-review-backup -->
+
+実際のインストール前に、dry-run の出力でディスクセレクタとすべての破壊的操作を確認する必要があります。`/dev/sda` のような名前より、安定した `/dev/disk/by-id/` セレクタが望ましいです。保持する必要があるデータには、選択したディスクとは別のバックアップが必要です。
 
 ## インストール
+
+<!-- fact: install-download -->
 
 次のコマンドを使用すると、現在の `master` アーカイブをダウンロードしてメニューを開けます。
 
@@ -52,7 +94,11 @@ cd gentoo-install-master
 ./bootstrap.sh
 ```
 
+<!-- fact: install-terminal -->
+
 メニューには、80 列 24 行以上の対話型端末が必要です。インストーラは起動時にインターフェイス言語の選択を一度求めます。`--lang ja` を使用すると、日本語を直接選択できます。
+
+<!-- fact: install-config-workflow -->
 
 メニューでは、設定を `my-install.toml` という設定ファイルに保存して終了できます。次の設定ファイルによる操作手順では、最初に完全な設定計画を表示し、その後に実際のインストールを実行します。
 
@@ -63,9 +109,13 @@ cd gentoo-install-master
 ./bootstrap.sh --config my-install.toml --no-shell   # 同じ実行で、root シェルの確認をしません
 ```
 
+<!-- fact: install-root-shell -->
+
 対話型インストールでは、成功時と失敗時のどちらでも、アンマウント前にターゲットシステム内で root シェルを開く選択肢が提示されます。`--no-shell` を使用すると、この確認を省略できます。
 
 ## 中断した実行の再開
+
+<!-- fact: resume-behavior -->
 
 `--resume` は、ジャーナルで完了済みと記録された操作を省略します。
 
@@ -73,24 +123,38 @@ cd gentoo-install-master
 ./bootstrap.sh --config my-install.toml --resume
 ```
 
+<!-- fact: resume-limits -->
+
 再開は同じライブセッション、同じインストーラーリビジョン、同じ設定ファイルに限られます。既定のジャーナルは `/run/gentoo-install/install.jsonl` にあるため、再起動後には残りません。ジャーナルの各項目には、その操作のクラスのソースとその操作が持つフィールドのダイジェストが記録されるため、クラスまたはフィールドが変更された操作は省略されずに再度実行されます。共有のヘルパーや定数の変更はそのダイジェストの範囲外であり、設定全体のダイジェストも記録されないため、リビジョンや設定ファイルをまたぐ再開はサポートされません。
 
 ## 設定ファイル
 
+<!-- fact: config-model -->
+
 設定ファイルは TOML 形式です。トップレベルの `config_version` フィールドがスキーマバージョンを指定します。ストレージはデバイスグラフで表します。各デバイスは `id` を持ち、ほかのデバイスを `id` で参照します。セレクタは実際のインストール時にのみ解決されます。
 
+<!-- fact: config-fixtures -->
+
 [`tests/fixtures/vm-binpkg.toml`](tests/fixtures/vm-binpkg.toml) は、UEFI と Ext4 を使用する完全なスキーマ参照です。ほかの [`tests/fixtures/`](tests/fixtures/) ファイルは BIOS、LUKS2、LVM、mdraid、ZFS、Btrfs subvolume、デスクトップを扱います。これらのファイルには仮想マシン用のディスクセレクタとテスト用パスワードが含まれているため、内容を変更せずに実機のインストールに使用してはなりません。
+
+<!-- fact: config-dry-run -->
 
 解析と計画ではストレージハードウェアを調査しないため、ターゲットディスクがないマシンでも `--dry-run` で設定を確認できます。
 
 ## バイナリパッケージ
 
-バイナリパッケージは任意の機能です。無効にしてもソースからビルドできます。公式 binhost と gentoo-zh binhost は別々の選択肢であり、それぞれ異なる信頼設定を使用します。現在のエンドツーエンド検証ベースラインは、binhost に接続できない場合、署名がない場合、鍵が信頼されていない場合を対象としていないため、これらのフォールバック経路は検証状況に引き続き記載されています。
+<!-- fact: binary-packages -->
+
+バイナリパッケージは任意の機能です。無効にしてもソースからビルドできます。公式 binhost と gentoo-zh binhost は別々の選択肢であり、それぞれ異なる信頼設定を使用します。binhost に接続できない場合、署名がない場合、鍵が信頼されていない場合を対象とする現在のエンドツーエンド根拠はないため、これらのフォールバック経路は検証状況に引き続き記載されています。
 
 ## 終了コード
 
-`0` は完了、`1` は設定エラー、`2` は preflight の失敗、`3` は完全性検証の失敗、`4` は外部コマンドの失敗、`5` は操作者による中止を意味します。
+<!-- fact: exit-codes -->
+
+Python CLI が引数を正常に解析した後は、`0` は完了、`1` は設定エラー、`2` は preflight の失敗、`3` は完全性検証の失敗、`4` は外部コマンドの失敗、`5` は操作者による中止を意味します。それ以前では、無効な引数に対して `argparse` が `2` を使用します。`bootstrap.sh` は、Python のバージョン不足、コマンド不足、権限不足といったランチャーの失敗に `1` を使用します。
 
 ## 開発への参加
+
+<!-- fact: contributing -->
 
 [CONTRIBUTING.md](CONTRIBUTING.md) では、開発環境、アーキテクチャ、必要な検査について説明しています。

--- a/README.ko.md
+++ b/README.ko.md
@@ -2,7 +2,9 @@
 
 # gentoo-install
 
-gentoo-install은 호환되는 Linux 라이브 환경에서 amd64 아키텍처의 Gentoo 시스템을 설치할 수 있는 시스템 설치 도구다. 설치 내용은 대화형 메뉴 또는 TOML 설정 파일로 구성할 수 있다. 프로그램 인터페이스는 영어, 번체 중국어, 간체 중국어, 일본어, 한국어를 지원한다.
+<!-- fact: identity -->
+
+gentoo-install은 인식 대상 Linux 라이브 환경에서 amd64 아키텍처의 Gentoo 시스템을 설치하는 시스템 설치 도구다. 설치 내용은 대화형 메뉴 또는 TOML 설정 파일로 지정할 수 있다. 프로그램 인터페이스는 영어, 번체 중국어, 간체 중국어, 일본어, 한국어를 제공한다.
 
 ![설치 과정의 선택 항목을 보여 주는 메뉴](screenshot.png)
 
@@ -10,39 +12,79 @@ gentoo-install은 호환되는 Linux 라이브 환경에서 amd64 아키텍처�
 
 ## 기능
 
-**저장 장치** 장치 그래프는 GPT와 MBR 파티션 테이블, Ext2/3/4, XFS, F2FS, VFAT와 subvolume을 포함하는 Btrfs 등의 파일 시스템, swap, zram, LUKS2 암호화, LVM, mdraid를 지원한다. 파티션을 관리할 때 기존 파티션 테이블을 유지할 수 있으며, 각 파티션에 유지, 포맷, 삭제 작업을 각각 지정할 수 있다.
+<!-- fact: capability-scope -->
+
+검증 상태에서 더 좁은 범위를 밝힌 경우를 제외하면 아래 경로는 구현되어 있으며 자동화된 단위 테스트 또는 plan 테스트로 검사된다.
+
+<!-- fact: storage-device-graph -->
+
+**저장 장치** 장치 그래프는 GPT와 MBR 파티션 테이블, ext2, ext3, ext4, xfs, f2fs, vfat, subvolume을 포함하는 btrfs, swap, LUKS2 암호화, LVM, mdraid를 다룬다. 기존 파티션 테이블을 유지할 수 있으며 각 파티션에 유지, 포맷, 삭제 작업을 각각 지정할 수 있다.
+
+<!-- fact: zram-system -->
+
+시스템 설정은 장치 그래프와 swap 파티션과 별도로 zram을 구성할 수 있다.
+
+<!-- fact: boot-system -->
 
 **부팅 및 시스템** 설치 도구에서는 GRUB과 systemd-boot 부트로더를 선택할 수 있다. GRUB은 UEFI와 BIOS를 지원하고 systemd-boot는 UEFI를 지원한다. 설치 도구는 systemd 또는 OpenRC, dracut, locale, 키보드 배열, 시간대, 호스트 이름, DNS, 고정 주소, 선택한 네트워크 관리자를 설정할 수도 있다.
 
+<!-- fact: desktop-language -->
+
 **데스크톱 및 언어 지원** 설치 도구에서는 GNOME, KDE Plasma, Xfce를 선택하고 GDM, SDDM, LightDM 중 하나와 조합할 수 있다. 그래픽 설정은 AMD, Intel, NVIDIA, 가상 머신을 지원한다. 패키지 카탈로그에는 Fcitx 5, Rime, Anthy, Mozc, Hangul, CJK 글꼴이 포함된다. gentoo-zh에서 제공하는 패치된 커널은 Linux 텍스트 콘솔에 중국어, 일본어, 한국어를 표시할 수 있다.
 
-**Portage** 설정 항목에는 profile, `MAKEOPTS`, `USE`, `ACCEPT_KEYWORDS`, `L10N`, 미러, 저장소 동기화 방식이 포함된다. gentoo-zh와 gig overlay는 명시적으로 활성화해야 한다. 공식 바이너리 패키지 소스와 gentoo-zh 바이너리 패키지 소스는 각각 독립된 설정과 키를 사용한다.
+<!-- fact: portage -->
+
+**Portage** 설정 항목에는 profile, `MAKEOPTS`, `USE`, `ACCEPT_KEYWORDS`, `L10N`, 미러, 저장소 동기화 방식이 포함된다. gentoo-zh와 gig overlay는 각각 선택할 수 있다. 인터페이스 언어로 `zh-TW`, `zh-CN`, `ja`, `ko` 중 하나를 선택하면 gentoo-zh의 패치된 바이너리 커널과 해당 overlay도 선택된다. `en`을 선택하면 자동으로 선택되지 않는다. 공식 바이너리 패키지 소스와 gentoo-zh 바이너리 패키지 소스는 각각 독립된 설정과 키를 사용한다.
+
+<!-- fact: plan-records -->
 
 **계획 및 기록** dry run과 실제 설치는 동일한 일련의 작업을 사용한다. `install.log`는 명령 출력을 기록하고, `install.jsonl`은 작업, 패키지 소스, 바이너리 패키지에서 소스 빌드로 전환한 사유를 기록한다. 메뉴는 민감한 정보를 제거한 설정을 `paste.gentoozh.org`에 업로드하고, 업로드된 페이지의 주소를 텍스트와 QR 코드로 표시할 수 있다.
 
 ## 검증 상태
 
-기록된 최신 엔드투엔드 검증 기준은 일부 UEFI와 BIOS 설치, systemd, OpenRC, Ext4, Btrfs, XFS, LUKS2, LVM, mdraid, Plasma, 공식 binhost를 포함한다. 유효한 각 기록에는 설치 도구의 리비전이 명시되며, 설치된 시스템이 정상적으로 부팅된 후에만 증거로 인정된다.
+<!-- fact: verification-history -->
 
-현재 리비전의 기준에는 ZFS와 ZFSBootMenu, initramfs의 SSH 원격 잠금 해제, greetd 데스크톱 세션, GNOME 이외 환경의 ibus가 포함되지 않는다. 기본값이 아닌 여섯 종류의 라이브 미디어를 사용한 설치와 binhost 실패 시 소스 빌드로 전환하는 경로도 해당 기준에 포함되지 않는다. `tests/fixtures/`의 파일은 설정 모델만 검증하며, 파일이 존재한다고 해서 해당 조합이 엔드투엔드 검증을 통과한 것은 아니다.
+과거 엔드투엔드 기록은 amd64 Gentoo minimal ISO와 설치 도구 리비전 `a71f91b4735469bae8ec76af170201acb967a5fe` 및 `f7257793f95df4b21ebf2ac6a775a343f6205f1b`를 사용했다. 해당 기록은 일부 UEFI와 BIOS 설치, systemd, OpenRC, ext4, btrfs, xfs, LUKS2, LVM, mdraid, Plasma, 공식 binhost를 다뤘지만 이후 설치 경로가 변경되어 현재는 과거 증거로만 인정된다.
+
+<!-- fact: verification-current -->
+
+현재 설치 도구 리비전을 검증하는 리비전 표기 엔드투엔드 실행 기록은 없다. 따라서 위에서 설명한 모든 저장 장치, 부팅, 데스크톱, 라이브 미디어, binhost 조합은 현재 리비전에서 엔드투엔드 검증을 거치지 않았다. ext2와 ext3에는 해당 설정을 다루는 자동화 테스트도 없다. `tests/fixtures/`의 파일은 설정 모델만 검증하며 해당 조합의 설치와 부팅을 입증하지 않는다.
+
+<!-- fact: verification-network -->
+
+IPv4 전용, IPv6 전용, 듀얼 스택 VM 검사는 디스크에 접근하기 전에 끝난다. 이 검사는 주소 계열 감지, `bootstrap.sh --missing-commands`, stage3 pointer 가져오기만 확인한다. stage3 다운로드, 저장소 동기화, binhost 접근, 패키지 설치, 대상 시스템 부팅은 검증하지 않는다.
 
 ## 요구 사항
 
+<!-- fact: requirements-runtime -->
+
 실제 설치에는 root 권한, amd64 아키텍처, Python 3.11 이상이 필요하다. 설정 파일로 dry run을 수행할 때는 root 권한이 필요하지 않다. 설치 도구에는 타사 Python 런타임 의존성이 없다.
 
-메뉴는 모든 버전을 `packages.gentoo.org`에서 읽으므로 이 사이트에 연결할 수 있어야 한다. 설정 파일로 설치할 때는 대신 그 설정이 지정한 미러에 연결할 수 있어야 하며, `--missing-commands`와 `--config FILE --dry-run`은 둘 다 연결을 요구하지 않는다. 커널 버전과 `sys-fs/zfs`가 지원하는 최대 커널 버전은 실행 시점에 조회한다.
+<!-- fact: requirements-version-sources -->
 
-IPv4 전용, IPv6 전용, 듀얼 스택 네트워크를 모두 지원한다. 현재 주소 계열로 접근할 수 없는 미러는 메뉴가 거부한다.
+메뉴는 Gentoo 메인 트리 패키지 버전을 `packages.gentoo.org`에서 읽고 gentoo-zh 패치 커널 버전을 `api.github.com/repos/gentoo-zh/overlay/contents`에서 읽는다. `sys-fs/zfs`가 허용하는 최대 커널 버전은 `gitweb.gentoo.org`에서 읽는다. 설정 파일로 설치할 때는 해당 설정이 지정한 미러에 연결해야 한다. `--missing-commands`와 `--config FILE --dry-run`은 이 버전 제공 지점에 연결하지 않는다.
 
-`bootstrap.sh`는 `/etc/os-release`를 읽고, 누락된 명령을 보고하며, 후보 패키지 관리자 명령을 표시한다. Debian과 Ubuntu, Arch, openSUSE, Fedora, RHEL과 CentOS, Gentoo, Alpine을 비롯한 여러 배포판 계열을 인식한다. 표시된 명령은 실행하기 전에 확인해야 한다.
+<!-- fact: requirements-network-filter -->
+
+감지된 주소 계열이 미러에서 사용 가능하다고 선언된 IPv4 또는 IPv6와 모두 일치하지 않으면 메뉴가 해당 미러를 거부한다.
+
+<!-- fact: requirements-bootstrap -->
+
+`bootstrap.sh`는 `/etc/os-release`를 읽고, 누락된 명령을 보고하며, 후보 패키지 관리자 명령을 표시한다. 인식하는 배포판 계열은 Debian과 Ubuntu, Arch, openSUSE, Fedora, RHEL과 CentOS, Gentoo, Alpine이다. 표시된 명령은 실행하기 전에 확인해야 한다.
 
 ## 안전
 
+<!-- fact: safety-destructive -->
+
 실제 설치는 선택한 디스크에 데이터를 기록한다. 설정 파일로 실행할 때는 디스크 삭제 여부를 다시 확인하지 않는다. `wipe = true`, 파티션 삭제, 파일 시스템 생성은 기존 데이터를 파괴할 수 있다.
 
-실제 설치 전에 dry-run 출력에서 디스크 선택자와 모든 파괴적 작업을 확인해야 한다. `/dev/sda` 같은 이름보다 안정적인 `/dev/disk/by-id/` 선택자가 더 적합하다. 잘못된 조작으로 인한 데이터 손실을 방지하려면 보존해야 하는 데이터를 반드시 백업해야 한다.
+<!-- fact: safety-review-backup -->
+
+실제 설치 전에 dry-run 출력에서 디스크 선택자와 모든 파괴적 작업을 확인해야 한다. `/dev/sda` 같은 이름보다 안정적인 `/dev/disk/by-id/` 선택자가 더 적합하다. 보존해야 하는 데이터는 선택한 디스크와 분리된 위치에 별도 백업이 있어야 한다.
 
 ## 설치
+
+<!-- fact: install-download -->
 
 다음 명령을 사용하여 현재 `master` 아카이브를 다운로드하고 메뉴를 열 수 있다.
 
@@ -52,7 +94,11 @@ cd gentoo-install-master
 ./bootstrap.sh
 ```
 
+<!-- fact: install-terminal -->
+
 메뉴에는 80열 24행 이상의 대화형 터미널이 필요하다. 설치 도구는 시작할 때 인터페이스 언어를 한 번 묻는다. `--lang ko`를 사용하면 한국어를 바로 선택할 수 있다.
+
+<!-- fact: install-config-workflow -->
 
 메뉴는 설정을 `my-install.toml`이라는 설정 파일로 저장한 뒤 종료할 수 있다. 다음 설정 파일 작업 절차에서는 전체 설정 계획을 먼저 표시한 다음 실제 설치를 수행한다.
 
@@ -63,9 +109,13 @@ cd gentoo-install-master
 ./bootstrap.sh --config my-install.toml --no-shell   # 같은 실행이며 root 셸을 묻지 않는다
 ```
 
+<!-- fact: install-root-shell -->
+
 대화형 설치에서는 성공하거나 실패한 경우 모두 마운트를 해제하기 전에 대상 시스템 안에서 root 셸을 여는 선택지를 제공한다. `--no-shell`을 사용하면 이 확인을 생략할 수 있다.
 
 ## 중단된 실행 재개
+
+<!-- fact: resume-behavior -->
 
 `--resume`은 저널에서 완료된 것으로 기록된 작업을 건너뛴다.
 
@@ -73,24 +123,38 @@ cd gentoo-install-master
 ./bootstrap.sh --config my-install.toml --resume
 ```
 
+<!-- fact: resume-limits -->
+
 재개는 동일한 라이브 세션, 동일한 설치 프로그램 리비전, 동일한 설정 파일로 제한된다. 기본 저널은 `/run/gentoo-install/install.jsonl`에 있으므로 재부팅 후에는 남아 있지 않는다. 저널의 각 항목은 해당 작업 클래스의 소스와 해당 작업 자체의 필드에 대한 다이제스트를 기록하므로, 클래스나 필드가 변경된 작업은 건너뛰지 않고 다시 수행된다. 공용 헬퍼나 상수의 변경은 그 다이제스트의 범위 밖이며 저널은 설정 전체의 다이제스트도 기록하지 않으므로, 리비전이나 설정 파일을 넘나드는 재개는 지원되지 않는다.
 
 ## 설정 파일
 
+<!-- fact: config-model -->
+
 설정 파일은 TOML 형식이다. 최상위 `config_version` 필드가 스키마 버전을 지정한다. 저장 장치는 장치 그래프로 표현된다. 각 장치에는 `id`가 있으며, 장치는 다른 장치를 `id`로 참조한다. 선택자는 실제 설치 중에만 해석된다.
 
+<!-- fact: config-fixtures -->
+
 [`tests/fixtures/vm-binpkg.toml`](tests/fixtures/vm-binpkg.toml)은 UEFI와 Ext4 구성을 모두 포함한 완전한 스키마 참조 파일이다. [`tests/fixtures/`](tests/fixtures/)의 다른 파일은 BIOS, LUKS2, LVM, mdraid, ZFS, Btrfs subvolume, 데스크톱을 다룬다. 이 설정 파일들에는 가상 머신 디스크 선택자와 테스트용 암호가 포함되어 있으므로, 내용을 수정하지 않은 채 실제 머신 설치에 사용해서는 안 된다.
+
+<!-- fact: config-dry-run -->
 
 구문 분석과 계획 단계에서는 저장 장치 하드웨어를 조사하지 않으므로 대상 디스크가 없는 머신에서도 `--dry-run`으로 설정을 확인할 수 있다.
 
 ## 바이너리 패키지
 
-바이너리 패키지는 선택 사항이다. 비활성화해도 소스에서 빌드할 수 있다. 공식 binhost와 gentoo-zh binhost는 별도의 선택 사항이며 각각 독립된 신뢰 설정을 사용한다. 현재 엔드투엔드 검증 기준은 binhost에 연결할 수 없거나 서명이 없거나 키를 신뢰할 수 없는 경우를 다루지 않는다. 따라서 binhost 실패 시 소스 빌드로 전환하는 경로는 검증 상태의 미검증 항목으로 남아 있다.
+<!-- fact: binary-packages -->
+
+바이너리 패키지는 선택 사항이다. 비활성화해도 소스에서 빌드할 수 있다. 공식 binhost와 gentoo-zh binhost는 별도의 선택 사항이며 각각 독립된 신뢰 설정을 사용한다. binhost에 연결할 수 없거나 서명이 없거나 키를 신뢰할 수 없는 경우를 다루는 현재 엔드투엔드 증거는 없다. 따라서 binhost 실패 시 소스 빌드로 전환하는 경로는 검증 상태의 미검증 항목으로 남아 있다.
 
 ## 종료 코드
 
-`0`은 완료, `1`은 설정 오류, `2`는 preflight 실패, `3`은 무결성 검증 실패, `4`는 외부 명령 실패, `5`는 운영자 중단을 의미한다.
+<!-- fact: exit-codes -->
+
+Python CLI가 인수를 정상적으로 해석한 뒤에는 `0`은 완료, `1`은 설정 오류, `2`는 preflight 실패, `3`은 무결성 검증 실패, `4`는 외부 명령 실패, `5`는 운영자 중단을 의미한다. 그 전에는 잘못된 인수에 대해 `argparse`가 `2`를 사용한다. `bootstrap.sh`는 Python 버전 부족, 명령 누락, 권한 부족과 같은 실행기 실패에 `1`을 사용한다.
 
 ## 기여
+
+<!-- fact: contributing -->
 
 개발 환경, 아키텍처, 필수 검사는 [CONTRIBUTING.md](CONTRIBUTING.md)에 설명되어 있다.

--- a/README.md
+++ b/README.md
@@ -2,7 +2,9 @@ English | [正體中文](README.zh-TW.md) | [简体中文](README.zh-CN.md) | [�
 
 # gentoo-install
 
-gentoo-install is an installer that installs an amd64 Gentoo system from a supported Linux live environment. An interactive menu or a TOML configuration file specifies the installation. The interface is available in English, Traditional Chinese, Simplified Chinese, Japanese and Korean.
+<!-- fact: identity -->
+
+gentoo-install is an installer that installs an amd64 Gentoo system from a recognized Linux live environment. An interactive menu or a TOML configuration file specifies the installation. The interface is available in English, Traditional Chinese, Simplified Chinese, Japanese and Korean.
 
 ![The menu showing the installation decisions](screenshot.png)
 
@@ -10,39 +12,79 @@ gentoo-install is an installer that installs an amd64 Gentoo system from a suppo
 
 ## Capabilities
 
-**Storage.** The device graph supports GPT and MBR; ext2/3/4, btrfs subvolumes, xfs, f2fs and vfat; swap and zram; and LUKS2, LVM and mdraid. Existing partition tables can be retained, with a separate keep, format or delete decision for each partition.
+<!-- fact: capability-scope -->
+
+The paths below are implemented and have automated unit or plan coverage unless the verification status identifies a narrower boundary.
+
+<!-- fact: storage-device-graph -->
+
+**Storage.** The device graph covers GPT and MBR; ext2, ext3, ext4, btrfs subvolumes, xfs, f2fs and vfat; swap; and LUKS2, LVM and mdraid. Existing partition tables can be retained, with a separate keep, format or delete decision for each partition.
+
+<!-- fact: zram-system -->
+
+The system configuration can configure zram independently of the device graph and swap partitions.
+
+<!-- fact: boot-system -->
 
 **Boot and system.** GRUB supports UEFI and BIOS, and systemd-boot supports UEFI. The installer configures systemd or OpenRC, dracut, locale, keyboard layout, timezone, hostname, DNS, static addresses and the selected network manager.
 
+<!-- fact: desktop-language -->
+
 **Desktop and language support.** GNOME, KDE Plasma and Xfce are available with gdm, sddm or lightdm. Graphics settings cover AMD, Intel, NVIDIA and virtual machines. The package catalog includes fcitx5, Rime, Anthy, Mozc, Hangul and CJK fonts. Patched kernels from gentoo-zh can render Chinese, Japanese and Korean on the Linux text console.
 
-**Portage.** The configuration covers the profile, `MAKEOPTS`, `USE`, `ACCEPT_KEYWORDS`, `L10N`, mirrors and repository synchronization. The gentoo-zh and gig overlays are opt-in. Official and gentoo-zh binary package sources have separate settings and keys.
+<!-- fact: portage -->
+
+**Portage.** The configuration covers the profile, `MAKEOPTS`, `USE`, `ACCEPT_KEYWORDS`, `L10N`, mirrors and repository synchronization. The gentoo-zh and gig overlays can be selected independently. Selecting `zh-TW`, `zh-CN`, `ja` or `ko` as the interface language also selects the gentoo-zh patched binary kernel and its overlay; selecting `en` does not. Official and gentoo-zh binary package sources have separate settings and keys.
+
+<!-- fact: plan-records -->
 
 **Plan and records.** A dry run and a real installation use the same operation plan. `install.log` records command output, and `install.jsonl` records operations, package sources and binary-package degradation reasons. The menu can upload a redacted configuration to `paste.gentoozh.org` and display the resulting page address as text and as a QR code.
 
 ## Verification status
 
-The last recorded end-to-end baseline covers selected UEFI and BIOS installations, systemd and OpenRC, ext4, btrfs, xfs, LUKS2, LVM, mdraid, Plasma and the official binhost. Each recorded run names its installer revision and boots the installed system before it counts as evidence.
+<!-- fact: verification-history -->
 
-ZFS and ZFSBootMenu, initramfs SSH unlock, greetd desktop sessions and ibus outside GNOME are not part of that baseline at the current revision. Installation from the six non-default live media and binary-host failure fallback are also outside the baseline. Files under `tests/fixtures/` exercise the configuration model; their presence does not by itself establish end-to-end support.
+Historical end-to-end records used the amd64 Gentoo minimal ISO at installer revisions `a71f91b4735469bae8ec76af170201acb967a5fe` and `f7257793f95df4b21ebf2ac6a775a343f6205f1b`. Those records covered selected UEFI and BIOS installations, systemd and OpenRC, ext4, btrfs, xfs, LUKS2, LVM, mdraid, Plasma and the official binhost, but later installation-path changes made them historical evidence only.
+
+<!-- fact: verification-current -->
+
+No revision-tagged end-to-end run currently verifies the current installer revision. Every implemented installation-and-boot combination is therefore currently unverified end to end, including all storage, boot, desktop, live-medium and binhost combinations described above. ext2 and ext3 additionally have no focused automated configuration test. Files under `tests/fixtures/` exercise the configuration model; their presence does not establish an end-to-end installation and boot result.
+
+<!-- fact: verification-network -->
+
+The IPv4-only, IPv6-only and dual-stack VM check stops before disk access. It checks address-family detection, `bootstrap.sh --missing-commands` and stage3 pointer retrieval; it does not verify stage3 download, repository synchronization, binhost access, package installation or a booted target system on those network modes.
 
 ## Requirements
 
+<!-- fact: requirements-runtime -->
+
 A real installation requires root privileges, an amd64 target and Python 3.11 or newer. A configuration-file dry run does not require root privileges. The installer has no third-party Python runtime dependency.
 
-The menu reads every version from `packages.gentoo.org` and requires network access to it. An installation from a configuration file requires the mirror that configuration names instead; `--missing-commands` and `--config FILE --dry-run` require neither. Kernel versions and the maximum kernel version supported by `sys-fs/zfs` are read at run time.
+<!-- fact: requirements-version-sources -->
 
-IPv4-only, IPv6-only and dual-stack networks are all supported; the menu refuses a mirror the machine's address family cannot reach.
+The menu reads Gentoo main-tree package versions from `packages.gentoo.org` and gentoo-zh patched-kernel versions from `api.github.com/repos/gentoo-zh/overlay/contents`. It reads the maximum kernel version accepted by `sys-fs/zfs` from `gitweb.gentoo.org`. An installation from a configuration file requires the mirror that configuration names instead; `--missing-commands` and `--config FILE --dry-run` require none of these version endpoints.
+
+<!-- fact: requirements-network-filter -->
+
+The menu rejects a mirror when none of the detected address families match the mirror's declared IPv4 or IPv6 availability.
+
+<!-- fact: requirements-bootstrap -->
 
 `bootstrap.sh` reads `/etc/os-release`, reports missing commands and prints a candidate package-manager command. It recognizes these distribution families: Debian and Ubuntu; Arch; openSUSE; Fedora, RHEL and CentOS; Gentoo; and Alpine. The printed command must be reviewed before it is run.
 
 ## Safety
 
+<!-- fact: safety-destructive -->
+
 A real run writes to the selected disks. A configuration-file run starts without a second erase confirmation; `wipe = true`, partition deletion and filesystem creation can destroy existing data.
+
+<!-- fact: safety-review-backup -->
 
 Before a real run, the disk selectors and every destructive operation must be checked in the dry-run output. Stable `/dev/disk/by-id/` selectors are preferable to names such as `/dev/sda`, and required data must have a separate backup.
 
 ## Installation
+
+<!-- fact: install-download -->
 
 The following commands download the current `master` archive and open the menu:
 
@@ -52,7 +94,11 @@ cd gentoo-install-master
 ./bootstrap.sh
 ```
 
+<!-- fact: install-terminal -->
+
 The menu requires an interactive terminal of at least 80x24 cells. It asks for the interface language once; `--lang en` selects English without that question.
+
+<!-- fact: install-config-workflow -->
 
 The menu can save its answers as `my-install.toml` and exit. The configuration-file workflow below prints the complete plan before the real run:
 
@@ -63,9 +109,13 @@ The menu can save its answers as `my-install.toml` and exit. The configuration-f
 ./bootstrap.sh --config my-install.toml --no-shell   # the same run, without the root-shell prompt
 ```
 
+<!-- fact: install-root-shell -->
+
 Before unmounting, an interactive run offers a root shell in the target after either success or failure. `--no-shell` suppresses that question.
 
 ## Resuming an interrupted run
+
+<!-- fact: resume-behavior -->
 
 `--resume` skips operations recorded as complete in the journal:
 
@@ -73,24 +123,38 @@ Before unmounting, an interactive run offers a root shell in the target after ei
 ./bootstrap.sh --config my-install.toml --resume
 ```
 
+<!-- fact: resume-limits -->
+
 Resume is limited to the same live session, the same installer revision and the same configuration file. The default journal is `/run/gentoo-install/install.jsonl`, so it does not survive a reboot. Each entry records a digest of that operation's own class source and of its own field values, so an operation whose class or fields changed is performed again rather than skipped. A change to a shared helper or constant is outside that digest, and the journal carries no digest of the configuration as a whole, so resuming across a different revision or configuration is not supported.
 
 ## Configuration files
 
+<!-- fact: config-model -->
+
 Configuration files use TOML. The top-level `config_version` field selects the schema version. Storage is a device graph: every device has an `id`, devices refer to other devices by `id`, and selectors are resolved only during a real run.
 
+<!-- fact: config-fixtures -->
+
 [`tests/fixtures/vm-binpkg.toml`](tests/fixtures/vm-binpkg.toml) is a complete UEFI and ext4 schema reference. Other files under [`tests/fixtures/`](tests/fixtures/) cover BIOS, LUKS2, LVM, mdraid, ZFS, btrfs subvolumes and desktops. They contain virtual-machine disk selectors and test credentials, so they must not be installed unchanged on a real machine.
+
+<!-- fact: config-dry-run -->
 
 Parsing and planning do not probe storage hardware. A machine without the target disk can therefore check a configuration with `--dry-run`.
 
 ## Binary packages
 
-Binary packages are optional. Disabling them keeps source builds available. The official binhost and the gentoo-zh binhost are separate options with separate trust configuration. The current end-to-end baseline does not cover an unreachable binhost, a missing signature or an untrusted key, so those degradation paths remain listed under verification status.
+<!-- fact: binary-packages -->
+
+Binary packages are optional. Disabling them keeps source builds available. The official binhost and the gentoo-zh binhost are separate options with separate trust configuration. No current end-to-end evidence covers an unreachable binhost, a missing signature or an untrusted key, so those degradation paths remain listed under verification status.
 
 ## Exit codes
 
-`0` means completed, `1` means configuration error, `2` means preflight failure, `3` means integrity failure, `4` means external-command failure and `5` means operator abort.
+<!-- fact: exit-codes -->
+
+After the Python CLI successfully parses its arguments, `0` means completed, `1` means configuration error, `2` means preflight failure, `3` means integrity failure, `4` means external-command failure and `5` means operator abort. Before that point, `argparse` uses `2` for invalid arguments, while `bootstrap.sh` uses `1` for launcher failures such as an insufficient Python version, missing commands or insufficient privileges.
 
 ## Contributing
+
+<!-- fact: contributing -->
 
 [CONTRIBUTING.md](CONTRIBUTING.md) describes the development setup, architecture and required checks.

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -2,7 +2,9 @@
 
 # gentoo-install
 
-gentoo-install 是一个系统安装程序，支持在兼容的 Linux Live 环境中安装 amd64 架构的 Gentoo 系统。可通过交互式菜单或 TOML 配置文件定制安装内容。程序界面支持英文、繁体中文、简体中文、日文和韩文语言。
+<!-- fact: identity -->
+
+gentoo-install 是一个系统安装程序，用于在能识别的 Linux live 环境中安装 amd64 架构的 Gentoo 系统。安装内容由交互式菜单或 TOML 配置文件指定。程序界面提供英文、繁体中文、简体中文、日文和韩文。
 
 ![显示各项安装决定的菜单](screenshot.png)
 
@@ -10,39 +12,79 @@ gentoo-install 是一个系统安装程序，支持在兼容的 Linux Live 环�
 
 ## 功能
 
-**存储设备** 设备图支持 GPT 和 MBR 分区表，支持 Ext2/3/4、XFS、F2FS、VFAT 以及包含 子卷 的 Btrfs 等文件系统，支持 swap、zram、LUKS2 加密、LVM 和 mdraid。在进行分区管理时可以保留现有分区表，还可以为每个分区分别指定保留、格式化或删除操作。
+<!-- fact: capability-scope -->
+
+除非验证状态另行说明更窄的范围，以下路径均已实现，并有自动化单元测试或 plan 测试。
+
+<!-- fact: storage-device-graph -->
+
+**存储设备** 设备图涵盖 GPT 和 MBR 分区表、ext2、ext3、ext4、xfs、f2fs、vfat、包含 subvolume 的 btrfs、swap、LUKS2 加密、LVM 和 mdraid。现有分区表可以保留，每个分区可以分别指定保留、格式化或删除操作。
+
+<!-- fact: zram-system -->
+
+系统配置可以在设备图和 swap 分区之外单独配置 zram。
+
+<!-- fact: boot-system -->
 
 **引导与系统** 安装程序支持选择 GRUB、systemd-boot 引导程序，其中 GRUB 支持 UEFI 和 BIOS，systemd-boot 支持 UEFI。还可配置 systemd 或 OpenRC、dracut、locale、键盘布局、时区、主机名、DNS、静态地址和所选的网络管理程序。
 
-**桌面与语言支持** 支持选择 GNOME、KDE Plasma 和 Xfce ，并可搭配 GDM、SDDM 或 LightDM。图形设置方面涵盖 AMD、Intel、NVIDIA 和虚拟机。软件包目录包含 Fcitx 5、Rime、Anthy、Mozc、Hangul 和 CJK 字体。gentoo-zh 提供的补丁内核可在 Linux 文本控制台显示中文、日文和韩文。
+<!-- fact: desktop-language -->
 
-**Portage** 配置项包括 profile、`MAKEOPTS`、`USE`、`ACCEPT_KEYWORDS`、`L10N`、镜像和仓库同步方式。gentoo-zh 和 gig overlay 必须明确启用。官方与 gentoo-zh 的二进制软件包来源分别使用独立的设置和密钥。
+**桌面与语言支持** 桌面可以选择 GNOME、KDE Plasma 和 Xfce，并搭配 GDM、SDDM 或 LightDM。图形设置涵盖 AMD、Intel、NVIDIA 和虚拟机。软件包目录包含 Fcitx 5、Rime、Anthy、Mozc、Hangul 和 CJK 字体。gentoo-zh 提供的补丁内核可在 Linux 文本控制台显示中文、日文和韩文。
 
-**计划与记录** dry run 和实际安装使用同一份操作序列。日志`install.log` 将记录命令输出，`install.jsonl` 记录操作、软件包来源和二进制软件包降级原因。菜单可将移除敏感信息的配置上传至 `paste.gentoozh.org`，并以文本和 QR 码显示上传页面的网址。
+<!-- fact: portage -->
+
+**Portage** 配置项包括 profile、`MAKEOPTS`、`USE`、`ACCEPT_KEYWORDS`、`L10N`、镜像和仓库同步方式。gentoo-zh 和 gig overlay 可以分别选择。界面语言选择 `zh-TW`、`zh-CN`、`ja` 或 `ko` 时，也会选择 gentoo-zh 的补丁二进制内核及其 overlay；选择 `en` 时不会自动选择。官方与 gentoo-zh 的二进制软件包来源分别使用独立的设置和密钥。
+
+<!-- fact: plan-records -->
+
+**计划与记录** dry run 和实际安装使用同一份操作序列。日志 `install.log` 记录命令输出，`install.jsonl` 记录操作、软件包来源和二进制软件包降级原因。菜单可将移除敏感信息的配置上传至 `paste.gentoozh.org`，并以文本和 QR 码显示上传页面的网址。
 
 ## 验证状态
 
-最近一份有记录的端到端基准覆盖部分 UEFI 和 BIOS 安装、systemd、OpenRC、Ext4、Btrfs、XFS、LUKS2、LVM、mdraid、Plasma 和官方 binhost。每份有效记录都会标明安装程序修订版，并在安装完成的系统成功引导后才列为证据。
+<!-- fact: verification-history -->
 
-当前修订版的基准尚未覆盖 ZFS 与 ZFSBootMenu、initramfs 的 SSH 远程解锁、greetd 桌面会话，以及 GNOME 以外的 ibus。从六种非默认 live 介质安装和 binhost 失败后的降级路径也未纳入。`tests/fixtures/` 下的文件只验证配置模型；文件存在并不表示对应组合已通过端到端验证。
+历史端到端记录使用 amd64 Gentoo minimal ISO，安装程序修订版为 `a71f91b4735469bae8ec76af170201acb967a5fe` 和 `f7257793f95df4b21ebf2ac6a775a343f6205f1b`。这些记录覆盖部分 UEFI 和 BIOS 安装、systemd、OpenRC、ext4、btrfs、xfs、LUKS2、LVM 和 mdraid，也覆盖 Plasma 和官方 binhost。后续安装路径变更使其只能作为历史证据。
+
+<!-- fact: verification-current -->
+
+目前没有带修订版标记的端到端运行可以验证当前安装程序修订版。因此，上述所有存储、引导、桌面、live 介质和 binhost 组合目前都尚未完成端到端验证。ext2 和 ext3 也没有针对其配置的自动化测试。`tests/fixtures/` 下的文件只验证配置模型；文件存在并不表示对应组合已完成端到端安装和引导验证。
+
+<!-- fact: verification-network -->
+
+纯 IPv4、纯 IPv6 和双栈的 VM 检查会在访问磁盘前结束。该检查只验证地址族检测、`bootstrap.sh --missing-commands` 和 stage3 pointer 读取，不验证 stage3 下载、仓库同步、binhost 访问、软件包安装或目标系统引导。
 
 ## 要求
 
+<!-- fact: requirements-runtime -->
+
 实际安装需要 root 权限、amd64 架构和 Python 3.11 或更高版本。使用配置文件执行 dry run 不需要 root 权限。安装程序没有第三方 Python 运行时依赖项。
 
-菜单从 `packages.gentoo.org` 读取每个版本，因此需要连接该站点。使用配置文件安装时需要连接的是该配置指定的镜像；`--missing-commands` 和 `--config FILE --dry-run` 两者都不需要。内核版本和 `sys-fs/zfs` 支持的最高内核版本会在运行时读取。
+<!-- fact: requirements-version-sources -->
 
-支持纯 IPv4、纯 IPv6 与双栈网络；菜单会拒绝当前地址族无法访问的镜像。
+菜单从 `packages.gentoo.org` 读取 Gentoo 主仓库的软件包版本，并从 `api.github.com/repos/gentoo-zh/overlay/contents` 读取 gentoo-zh 补丁内核版本。`sys-fs/zfs` 接受的最高内核版本从 `gitweb.gentoo.org` 读取。使用配置文件安装时需要连接的是该配置指定的镜像；`--missing-commands` 和 `--config FILE --dry-run` 都不需要这些版本端点。
 
-`bootstrap.sh` 会读取 `/etc/os-release`、报告缺少的命令，并显示候选的软件包管理器命令。它可识别多个发行版系列，包括 Debian 和 Ubuntu、Arch、openSUSE、Fedora、RHEL 和 CentOS、Gentoo，以及 Alpine。显示的命令必须在执行前核对。
+<!-- fact: requirements-network-filter -->
+
+检测到的地址族与镜像声明的 IPv4 或 IPv6 可用性均不匹配时，菜单会拒绝该镜像。
+
+<!-- fact: requirements-bootstrap -->
+
+`bootstrap.sh` 会读取 `/etc/os-release`、报告缺少的命令，并显示候选的软件包管理器命令。它可识别以下发行版系列：Debian 和 Ubuntu、Arch、openSUSE、Fedora、RHEL 和 CentOS、Gentoo、Alpine。显示的命令必须在执行前核对。
 
 ## 安全事项
 
-实际安装会写入所选磁盘。请注意，使用配置文件运行时不会再次要求确认擦除磁盘；`wipe = true`、删除分区和创建文件系统都可能破坏现有数据。
+<!-- fact: safety-destructive -->
 
-实际安装前，必须在 dry-run 输出中核对磁盘选择器和每项破坏性操作。稳定的 `/dev/disk/by-id/` 选择器优于 `/dev/sda` 之类的名称；为避免因误操作导致的数据丢失，请务必备份好需要保留的数据。
+实际安装会写入所选磁盘。使用配置文件运行时不会再次要求确认擦除磁盘；`wipe = true`、删除分区和创建文件系统都可能破坏现有数据。
+
+<!-- fact: safety-review-backup -->
+
+实际安装前，必须在 dry-run 输出中核对磁盘选择器和每项破坏性操作。稳定的 `/dev/disk/by-id/` 选择器优于 `/dev/sda` 之类的名称；需要保留的数据必须另有一份独立于所选磁盘的备份。
 
 ## 安装
+
+<!-- fact: install-download -->
 
 可使用以下命令下载当前的 `master` 归档文件并打开菜单：
 
@@ -52,9 +94,13 @@ cd gentoo-install-master
 ./bootstrap.sh
 ```
 
-菜单需要至少 80 列、24 行的交互式终端。安装程序启动时会询问一次界面语言；使用`--lang zh-CN` 可直接选择简体中文。
+<!-- fact: install-terminal -->
 
-菜单可将配置保存为 `my-install.toml` 配置文件后退出。以下配置文件操作流程会先显示完整的配置计划，再执行实际安装：
+菜单需要至少 80 列、24 行的交互式终端。安装程序启动时会询问一次界面语言；使用 `--lang zh-CN` 可直接选择简体中文。
+
+<!-- fact: install-config-workflow -->
+
+菜单可将配置保存为 `my-install.toml` 后退出。以下配置文件操作流程会先显示完整的配置计划，再执行实际安装：
 
 ```sh
 ./bootstrap.sh --config my-install.toml --dry-run
@@ -63,9 +109,13 @@ cd gentoo-install-master
 ./bootstrap.sh --config my-install.toml --no-shell   # 同一次安装，不询问是否打开 root shell
 ```
 
-交互式安装无论成功或失败，都会在卸载前提供在目标系统内打开 root shell 的选项。可使用`--no-shell` 跳过这项确认。
+<!-- fact: install-root-shell -->
+
+交互式安装无论成功或失败，都会在卸载前提供在目标系统内打开 root shell 的选项。使用 `--no-shell` 可以跳过这项确认。
 
 ## 从中断处继续
+
+<!-- fact: resume-behavior -->
 
 `--resume` 会跳过日志中标记为完成的操作：
 
@@ -73,24 +123,38 @@ cd gentoo-install-master
 ./bootstrap.sh --config my-install.toml --resume
 ```
 
-继续执行仅限同一个 Live 会话、同一个安装器修订版与同一份配置文件。默认日志位于 `/run/gentoo-install/install.jsonl`，重新启动后不会保留。日志的每一条记录该操作类的源代码与该操作自身字段的摘要，因此类或字段更改过的操作会重新执行而不是跳过。共用辅助函数或常量的更改不在该摘要覆盖范围内，日志也不记录整份配置的摘要，因此跨修订版或跨配置文件的续装不受支持。
+<!-- fact: resume-limits -->
+
+继续执行仅限同一个 live 会话、同一个安装程序修订版与同一份配置文件。默认日志位于 `/run/gentoo-install/install.jsonl`，重新启动后不会保留。日志的每一条记录包含该操作类的源代码与该操作自身字段的摘要，因此类或字段更改过的操作会重新执行而不是跳过。共用辅助函数或常量的更改不在该摘要覆盖范围内，日志也不记录整份配置的摘要，因此跨修订版或跨配置文件的续装不受支持。
 
 ## 配置文件
 
+<!-- fact: config-model -->
+
 配置文件使用 TOML。顶层 `config_version` 字段指定结构版本。存储设备以设备图表示：每个设备都有 `id`，设备通过其他设备的 `id` 建立引用，选择器仅在实际安装时解析。
 
-[`tests/fixtures/vm-binpkg.toml`](tests/fixtures/vm-binpkg.toml) 是完整的 UEFI 和 Ext4 结构参考。其他 [`tests/fixtures/`](tests/fixtures/) 文件覆盖 BIOS、LUKS2、LVM、mdraid、ZFS、Btrfs 子卷 和桌面。这些文件使用虚拟机磁盘选择器和测试密码，不得原样用于实际机器的安装。
+<!-- fact: config-fixtures -->
+
+[`tests/fixtures/vm-binpkg.toml`](tests/fixtures/vm-binpkg.toml) 是完整的 UEFI 和 ext4 结构参考。其他 [`tests/fixtures/`](tests/fixtures/) 文件覆盖 BIOS、LUKS2、LVM、mdraid、ZFS、btrfs subvolume 和桌面。这些文件使用虚拟机磁盘选择器和测试密码，不得原样用于实际机器的安装。
+
+<!-- fact: config-dry-run -->
 
 解析与计划阶段不会探测存储硬件，因此没有目标磁盘的机器也能通过 `--dry-run` 检查配置。
 
 ## 二进制软件包
 
-二进制软件包属于可选功能。关闭后仍可从源代码构建。官方 binhost 和 gentoo-zh binhost 是两个独立选项，并使用不同的信任配置。当前端到端基准尚未覆盖 binhost 无法连接、缺少签名或密钥不受信任的情况，因此这些降级路径仍列在验证状态中。
+<!-- fact: binary-packages -->
+
+二进制软件包属于可选功能。关闭后仍可从源代码构建。官方 binhost 和 gentoo-zh binhost 是两个独立选项，并使用不同的信任配置。目前没有端到端证据覆盖 binhost 无法连接、缺少签名或密钥不受信任的情况，因此这些降级路径仍列在验证状态中。
 
 ## 退出码
 
-`0` 表示完成，`1` 表示配置错误，`2` 表示 preflight 失败，`3` 表示完整性验证失败，`4` 表示外部命令失败，`5` 表示操作者中止。
+<!-- fact: exit-codes -->
+
+Python CLI 成功解析参数后，以下退出码对照才适用。`0` 表示完成，`1` 表示配置错误，`2` 表示 preflight 失败。`3` 表示完整性验证失败，`4` 表示外部命令失败，`5` 表示操作者中止。在此之前，`argparse` 以 `2` 表示无效参数。`bootstrap.sh` 则以 `1` 表示 Python 版本不足、缺少命令或权限不足等启动程序失败。
 
 ## 参与开发
+
+<!-- fact: contributing -->
 
 [CONTRIBUTING.md](CONTRIBUTING.md) 介绍开发环境、架构和必要检查。

--- a/README.zh-TW.md
+++ b/README.zh-TW.md
@@ -2,7 +2,9 @@
 
 # gentoo-install
 
-gentoo-install 是一套系統安裝器，可在相容的 Linux live 環境中安裝 amd64 架構的 Gentoo 系統。安裝內容以互動式選單或 TOML 設定檔指定。介面提供英文、正體中文、簡體中文、日文與韓文。
+<!-- fact: identity -->
+
+gentoo-install 是一套系統安裝器，可在能辨識的 Linux live 環境中安裝 amd64 架構的 Gentoo 系統。安裝內容以互動式選單或 TOML 設定檔指定。介面提供英文、正體中文、簡體中文、日文與韓文。
 
 ![顯示各項安裝決定的選單](screenshot.png)
 
@@ -10,39 +12,79 @@ gentoo-install 是一套系統安裝器，可在相容的 Linux live 環境中�
 
 ## 功能
 
-**儲存裝置** 裝置圖支援 GPT 與 MBR 分割表。檔案系統支援 ext2/3/4、xfs、f2fs、vfat 以及含 subvolume 的 btrfs，另有 swap、zram、LUKS2 加密、LVM 與 mdraid。既有分割表可以保留，每個分割區可分別指定保留、格式化或刪除。
+<!-- fact: capability-scope -->
+
+除非驗證狀態另行指出較窄的範圍，以下路徑均已實作，並有自動化單元測試或 plan 測試。
+
+<!-- fact: storage-device-graph -->
+
+**儲存裝置** 裝置圖涵蓋 GPT 與 MBR 分割表、ext2、ext3、ext4、xfs、f2fs、vfat、含 subvolume 的 btrfs、swap、LUKS2 加密、LVM 與 mdraid。既有分割表可以保留，每個分割區可分別指定保留、格式化或刪除。
+
+<!-- fact: zram-system -->
+
+系統設定可在裝置圖與 swap 分割區之外，獨立設定 zram。
+
+<!-- fact: boot-system -->
 
 **開機與系統** 開機載入器可選 GRUB 或 systemd-boot，其中 GRUB 支援 UEFI 與 BIOS，systemd-boot 支援 UEFI。安裝器另可設定 systemd 或 OpenRC、dracut、locale、鍵盤配置、時區、主機名稱、DNS、靜態位址與所選的網路管理程式。
 
+<!-- fact: desktop-language -->
+
 **桌面與語言支援** 桌面可選 GNOME、KDE Plasma 與 Xfce，並搭配 gdm、sddm 或 lightdm。圖形設定涵蓋 AMD、Intel、NVIDIA 與虛擬機。套件目錄包含 fcitx5、Rime、Anthy、Mozc、Hangul 與 CJK 字型。gentoo-zh 提供的修補核心可在 Linux 文字主控台顯示中文、日文與韓文。
 
-**Portage** 設定項目包含 profile、`MAKEOPTS`、`USE`、`ACCEPT_KEYWORDS`、`L10N`、鏡像與儲存庫同步方式。gentoo-zh 與 gig overlay 必須明確啟用。官方與 gentoo-zh 的二進位套件來源各有獨立設定與金鑰。
+<!-- fact: portage -->
+
+**Portage** 設定項目包含 profile、`MAKEOPTS`、`USE`、`ACCEPT_KEYWORDS`、`L10N`、鏡像與儲存庫同步方式。gentoo-zh 與 gig overlay 可分別選取。介面語言選為 `zh-TW`、`zh-CN`、`ja` 或 `ko` 時，也會選取 gentoo-zh 的修補版二進位核心及其 overlay；選為 `en` 時不會自動選取。官方與 gentoo-zh 的二進位套件來源各有獨立設定與金鑰。
+
+<!-- fact: plan-records -->
 
 **計畫與記錄** dry run 與實際安裝使用同一份操作序列。記錄方面，`install.log` 記錄指令輸出，`install.jsonl` 記錄操作、套件來源與二進位套件降級原因。選單可將移除敏感資料的設定上傳至 `paste.gentoozh.org`，並以文字與 QR 碼顯示上傳頁面的網址。
 
 ## 驗證狀態
 
-最近一份有記錄的端到端基準涵蓋部分 UEFI 與 BIOS 安裝、systemd、OpenRC、ext4、btrfs、xfs、LUKS2、LVM、mdraid、Plasma 與官方 binhost。每份有效記錄都會標明安裝器修訂版，並在裝好的系統成功開機後才列為實據。
+<!-- fact: verification-history -->
 
-現行修訂的基準尚未涵蓋 ZFS 與 ZFSBootMenu、initramfs 的 SSH 遠端解鎖、greetd 桌面工作階段，以及 GNOME 以外的 ibus。從六種非預設 live 媒介安裝與 binhost 失敗後的降級路徑也未納入。`tests/fixtures/` 下的檔案只驗證設定模型；檔案存在不代表對應組合已通過端到端驗證。
+歷史端到端記錄使用 amd64 Gentoo minimal ISO，安裝器修訂版為 `a71f91b4735469bae8ec76af170201acb967a5fe` 與 `f7257793f95df4b21ebf2ac6a775a343f6205f1b`。這些記錄涵蓋部分 UEFI 與 BIOS 安裝、systemd、OpenRC、ext4、btrfs、xfs、LUKS2、LVM 與 mdraid，也涵蓋 Plasma 與官方 binhost。後續安裝路徑變更使其只能作為歷史實據。
+
+<!-- fact: verification-current -->
+
+目前沒有具修訂版標記的端到端執行可驗證現行安裝器修訂版。因此，上述所有儲存裝置、開機、桌面、live 媒介與 binhost 組合目前都尚未完成端到端驗證。ext2 與 ext3 也沒有針對其設定的自動化測試。`tests/fixtures/` 下的檔案只驗證設定模型；檔案存在不代表對應組合已完成端到端安裝與開機驗證。
+
+<!-- fact: verification-network -->
+
+純 IPv4、純 IPv6 與雙堆疊的 VM 檢查會在存取磁碟前結束。該檢查只驗證位址家族偵測、`bootstrap.sh --missing-commands` 與 stage3 pointer 讀取，不驗證 stage3 下載、儲存庫同步、binhost 存取、套件安裝或目標系統開機。
 
 ## 需求
 
+<!-- fact: requirements-runtime -->
+
 實際安裝需要 root 權限、amd64 目標與 Python 3.11 以上版本。使用設定檔執行 dry run 不需要 root 權限。安裝器沒有第三方 Python 執行期相依套件。
 
-選單從 `packages.gentoo.org` 讀取每個版本，因此需要連線至該站台。以設定檔安裝時需要連線的是該設定指定的鏡像；`--missing-commands` 與 `--config FILE --dry-run` 兩者都不需要。核心版本與 `sys-fs/zfs` 支援的最高核心版本會在執行時讀取。
+<!-- fact: requirements-version-sources -->
 
-支援純 IPv4、純 IPv6 與雙堆疊網路；選單會拒絕目前位址家族無法連線的鏡像。
+選單從 `packages.gentoo.org` 讀取 Gentoo 主儲存庫的套件版本，並從 `api.github.com/repos/gentoo-zh/overlay/contents` 讀取 gentoo-zh 修補核心的版本。`sys-fs/zfs` 接受的最高核心版本從 `gitweb.gentoo.org` 讀取。以設定檔安裝時需要連線的是該設定指定的鏡像；`--missing-commands` 與 `--config FILE --dry-run` 都不需要這些版本端點。
 
-`bootstrap.sh` 會讀取 `/etc/os-release`、回報缺少的指令，並印出候選的套件管理器指令。它可辨識多個發行版系列，包括 Debian 與 Ubuntu、Arch、openSUSE、Fedora、RHEL 與 CentOS、Gentoo，以及 Alpine。印出的指令必須在執行前核對。
+<!-- fact: requirements-network-filter -->
+
+偵測到的位址家族與鏡像宣告的 IPv4 或 IPv6 可用性均不相符時，選單會拒絕該鏡像。
+
+<!-- fact: requirements-bootstrap -->
+
+`bootstrap.sh` 會讀取 `/etc/os-release`、回報缺少的指令，並印出候選的套件管理器指令。它可辨識下列發行版系列：Debian 與 Ubuntu、Arch、openSUSE、Fedora、RHEL 與 CentOS、Gentoo、Alpine。印出的指令必須在執行前核對。
 
 ## 安全事項
 
+<!-- fact: safety-destructive -->
+
 實際安裝會寫入所選磁碟。使用設定檔執行時不會再次要求確認清除磁碟；`wipe = true`、刪除分割區與建立檔案系統都可能毀損既有資料。
+
+<!-- fact: safety-review-backup -->
 
 實際安裝前，必須在 dry-run 輸出中核對磁碟選擇器與每項破壞性操作。穩定的 `/dev/disk/by-id/` 選擇器優於 `/dev/sda` 之類的名稱；需要保留的資料必須另有備份。
 
 ## 安裝
+
+<!-- fact: install-download -->
 
 下列指令會下載目前的 `master` 封存檔並開啟選單：
 
@@ -52,7 +94,11 @@ cd gentoo-install-master
 ./bootstrap.sh
 ```
 
+<!-- fact: install-terminal -->
+
 選單需要至少 80 欄、24 列的互動式終端機。安裝器啟動時會詢問一次介面語言；`--lang zh-TW` 可直接選用正體中文。
+
+<!-- fact: install-config-workflow -->
 
 選單可將答案儲存為 `my-install.toml` 後離開。下列設定檔操作流程會先印出完整計畫，再執行實際安裝：
 
@@ -63,9 +109,13 @@ cd gentoo-install-master
 ./bootstrap.sh --config my-install.toml --no-shell   # 同一次安裝，不詢問是否開啟 root shell
 ```
 
+<!-- fact: install-root-shell -->
+
 互動式安裝無論成功或失敗，都會在卸載前提供於目標系統內開啟 root shell 的選項。`--no-shell` 可略過這項確認。
 
 ## 從中斷處繼續
+
+<!-- fact: resume-behavior -->
 
 `--resume` 會略過日誌中記為完成的操作：
 
@@ -73,24 +123,38 @@ cd gentoo-install-master
 ./bootstrap.sh --config my-install.toml --resume
 ```
 
+<!-- fact: resume-limits -->
+
 繼續執行僅限同一個 live 工作階段、同一個安裝器修訂版與同一份設定檔。預設日誌位於 `/run/gentoo-install/install.jsonl`，重新開機後不會保留。日誌的每一筆記錄該操作類別原始碼與該操作自身欄位的摘要，因此類別或欄位變更過的操作會重新執行而不是略過。共用輔助函式或常數的變更不在該摘要涵蓋範圍內，日誌也不記錄整份設定的摘要，因此跨修訂版或跨設定檔的續裝不受支援。
 
 ## 設定檔
 
+<!-- fact: config-model -->
+
 設定檔使用 TOML。頂層的 `config_version` 欄位指定結構版本。儲存裝置以裝置圖表示：每個裝置都有 `id`，裝置以其他裝置的 `id` 建立引用，選擇器只在實際安裝時解析。
 
+<!-- fact: config-fixtures -->
+
 [`tests/fixtures/vm-binpkg.toml`](tests/fixtures/vm-binpkg.toml) 是完整的 UEFI 與 ext4 結構參考。其他 [`tests/fixtures/`](tests/fixtures/) 檔案涵蓋 BIOS、LUKS2、LVM、mdraid、ZFS、btrfs subvolume 與桌面。這些檔案使用虛擬機磁碟選擇器與測試密碼，不得原樣用於實機安裝。
+
+<!-- fact: config-dry-run -->
 
 解析與計畫階段不會探測儲存硬體，因此沒有目標磁碟的機器也能以 `--dry-run` 檢查設定。
 
 ## 二進位套件
 
-二進位套件為選用功能。關閉後仍可從原始碼建置。官方 binhost 與 gentoo-zh binhost 是兩個獨立選項，並使用不同的信任設定。現行端到端基準未涵蓋 binhost 無法連線、缺少簽章或金鑰不受信任的情況，因此這些降級路徑仍列在驗證狀態中。
+<!-- fact: binary-packages -->
+
+二進位套件為選用功能。關閉後仍可從原始碼建置。官方 binhost 與 gentoo-zh binhost 是兩個獨立選項，並使用不同的信任設定。目前沒有端到端實據涵蓋 binhost 無法連線、缺少簽章或金鑰不受信任的情況，因此這些降級路徑仍列在驗證狀態中。
 
 ## 退出碼
 
-`0` 表示完成，`1` 表示設定錯誤，`2` 表示 preflight 失敗，`3` 表示完整性驗證失敗，`4` 表示外部指令失敗，`5` 表示操作者中止。
+<!-- fact: exit-codes -->
+
+Python CLI 成功解析參數後，以下退出碼對照才適用。`0` 表示完成，`1` 表示設定錯誤，`2` 表示 preflight 失敗。`3` 表示完整性驗證失敗，`4` 表示外部指令失敗，`5` 表示操作者中止。在此之前，`argparse` 以 `2` 表示無效參數。`bootstrap.sh` 則以 `1` 表示 Python 版本不足、缺少指令或權限不足等啟動器失敗。
 
 ## 參與開發
+
+<!-- fact: contributing -->
 
 [CONTRIBUTING.md](CONTRIBUTING.md) 說明開發環境、架構與必要檢查。

--- a/tests/unit/test_readme.py
+++ b/tests/unit/test_readme.py
@@ -6,6 +6,7 @@ is invisible to a reader who reads only one of them.
 
 from __future__ import annotations
 
+import re
 from pathlib import Path
 
 ROOT = Path(__file__).resolve().parents[2]
@@ -26,6 +27,69 @@ SWITCHER = tuple(READMES)
 #: Both pictures, in both files, at the top. A README that lost one of them
 #: still reads as complete.
 PICTURES = ("screenshot.png", "cjk-console.png")
+
+SECTIONS = {
+    "README.md": (
+        "Capabilities", "Verification status", "Requirements", "Safety", "Installation",
+        "Resuming an interrupted run", "Configuration files", "Binary packages", "Exit codes",
+        "Contributing",
+    ),
+    "README.zh-TW.md": (
+        "\u529f\u80fd", "\u9a57\u8b49\u72c0\u614b", "\u9700\u6c42", "\u5b89\u5168\u4e8b\u9805",
+        "\u5b89\u88dd", "\u5f9e\u4e2d\u65b7\u8655\u7e7c\u7e8c", "\u8a2d\u5b9a\u6a94",
+        "\u4e8c\u9032\u4f4d\u5957\u4ef6", "\u9000\u51fa\u78bc", "\u53c3\u8207\u958b\u767c",
+    ),
+    "README.zh-CN.md": (
+        "\u529f\u80fd", "\u9a8c\u8bc1\u72b6\u6001", "\u8981\u6c42", "\u5b89\u5168\u4e8b\u9879",
+        "\u5b89\u88c5", "\u4ece\u4e2d\u65ad\u5904\u7ee7\u7eed", "\u914d\u7f6e\u6587\u4ef6",
+        "\u4e8c\u8fdb\u5236\u8f6f\u4ef6\u5305", "\u9000\u51fa\u7801", "\u53c2\u4e0e\u5f00\u53d1",
+    ),
+    "README.ja.md": (
+        "\u6a5f\u80fd", "\u691c\u8a3c\u72b6\u6cc1", "\u8981\u4ef6", "\u5b89\u5168\u4e0a\u306e\u6ce8\u610f",
+        "\u30a4\u30f3\u30b9\u30c8\u30fc\u30eb", "\u4e2d\u65ad\u3057\u305f\u5b9f\u884c\u306e\u518d\u958b",
+        "\u8a2d\u5b9a\u30d5\u30a1\u30a4\u30eb", "\u30d0\u30a4\u30ca\u30ea\u30d1\u30c3\u30b1\u30fc\u30b8",
+        "\u7d42\u4e86\u30b3\u30fc\u30c9", "\u958b\u767a\u3078\u306e\u53c2\u52a0",
+    ),
+    "README.ko.md": (
+        "\uae30\ub2a5", "\uac80\uc99d \uc0c1\ud0dc", "\uc694\uad6c \uc0ac\ud56d", "\uc548\uc804",
+        "\uc124\uce58", "\uc911\ub2e8\ub41c \uc2e4\ud589 \uc7ac\uac1c", "\uc124\uc815 \ud30c\uc77c",
+        "\ubc14\uc774\ub108\ub9ac \ud328\ud0a4\uc9c0", "\uc885\ub8cc \ucf54\ub4dc", "\uae30\uc5ec",
+    ),
+}
+
+FACT_UNITS = (
+    "identity", "capability-scope", "storage-device-graph", "zram-system", "boot-system",
+    "desktop-language", "portage", "plan-records", "verification-history",
+    "verification-current", "verification-network", "requirements-runtime",
+    "requirements-version-sources", "requirements-network-filter", "requirements-bootstrap",
+    "safety-destructive", "safety-review-backup", "install-download", "install-terminal",
+    "install-config-workflow", "install-root-shell", "resume-behavior", "resume-limits",
+    "config-model", "config-fixtures", "config-dry-run", "binary-packages", "exit-codes",
+    "contributing",
+)
+
+SECOND_PERSON = {
+    "en": re.compile(r"\b(?:you|your|yours)\b", re.IGNORECASE),
+    "zh-TW": re.compile(r"[\u4f60\u59b3\u60a8]|\u8acb"),
+    "zh-CN": re.compile(r"[\u4f60\u60a8]|\u8bf7"),
+    "ja": re.compile(r"\u3042\u306a\u305f|\u304f\u3060\u3055\u3044"),
+    "ko": re.compile(r"\ub2f9\uc2e0|\ud558\uc138\uc694|\ud558\uc2ed\uc2dc\uc624"),
+}
+
+
+def readme(name: str) -> str:
+    return (ROOT / name).read_text()
+
+
+def fact_bodies(name: str) -> dict[str, str]:
+    found: dict[str, str] = {}
+    for match in re.finditer(
+        r"<!-- fact: ([a-z0-9-]+) -->\n\n(.*?)(?=\n\n<!-- fact:|\n\n## |\Z)",
+        readme(name),
+        re.S,
+    ):
+        found[match.group(1)] = match.group(2).strip()
+    return found
 
 
 def test_every_readme_exists_and_links_to_all_the_others() -> None:
@@ -53,14 +117,95 @@ def test_both_pictures_are_in_every_readme_and_on_disk() -> None:
             assert f"({picture})" in said, f"{name} is missing {picture}"
 
 
-def test_every_readme_carries_the_same_sections() -> None:
-    """The headings are translated, so the count is what can be compared: a
-    section added to one file and not the rest is the usual way they diverge."""
-    counts = {
-        name: sum(1 for line in (ROOT / name).read_text().splitlines() if line.startswith("## "))
-        for name in READMES
+def test_every_readme_carries_the_complete_ordered_sections() -> None:
+    for name, expected in SECTIONS.items():
+        assert tuple(re.findall(r"^## (.+)$", readme(name), re.M)) == expected, name
+
+
+def test_every_readme_carries_the_same_nonempty_factual_units() -> None:
+    for name in READMES:
+        bodies = fact_bodies(name)
+        assert tuple(bodies) == FACT_UNITS, name
+        assert all(bodies.values()), name
+
+
+def test_reviewed_cross_locale_claims_stay_attached_to_their_factual_units() -> None:
+    common = {
+        "verification-history": (
+            "amd64", "Gentoo minimal ISO", "a71f91b4735469bae8ec76af170201acb967a5fe",
+            "f7257793f95df4b21ebf2ac6a775a343f6205f1b",
+        ),
+        "verification-current": ("ext2", "ext3", "tests/fixtures/"),
+        "verification-network": ("IPv4", "IPv6", "bootstrap.sh --missing-commands", "stage3"),
+        "requirements-version-sources": (
+            "packages.gentoo.org", "api.github.com/repos/gentoo-zh/overlay/contents",
+            "gitweb.gentoo.org",
+        ),
+        "portage": ("zh-TW", "zh-CN", "ja", "ko", "en", "gentoo-zh"),
+        "exit-codes": ("argparse", "bootstrap.sh", "`1`", "`2`"),
     }
-    assert len(set(counts.values())) == 1, counts
+    backups = {
+        "README.md": "separate backup",
+        "README.zh-TW.md": "\u53e6\u6709\u5099\u4efd",
+        "README.zh-CN.md": "\u72ec\u7acb\u4e8e\u6240\u9009\u78c1\u76d8\u7684\u5907\u4efd",
+        "README.ja.md": "\u9078\u629e\u3057\u305f\u30c7\u30a3\u30b9\u30af\u3068\u306f\u5225\u306e\u30d0\u30c3\u30af\u30a2\u30c3\u30d7",
+        "README.ko.md": "\uc120\ud0dd\ud55c \ub514\uc2a4\ud06c\uc640 \ubd84\ub9ac\ub41c \uc704\uce58\uc5d0 \ubcc4\ub3c4 \ubc31\uc5c5",
+    }
+    install_alternatives = {
+        "README.md": "one of the two",
+        "README.zh-TW.md": "\u64c7\u4e00",
+        "README.zh-CN.md": "\u62e9\u4e00",
+        "README.ja.md": "\u3044\u305a\u308c\u304b\u4e00\u65b9",
+        "README.ko.md": "\ud558\ub098\ub9cc",
+    }
+    resume_identity = {
+        "README.md": "same installer revision and the same configuration file",
+        "README.zh-TW.md": "\u540c\u4e00\u500b\u5b89\u88dd\u5668\u4fee\u8a02\u7248\u8207\u540c\u4e00\u4efd\u8a2d\u5b9a\u6a94",
+        "README.zh-CN.md": "\u540c\u4e00\u4e2a\u5b89\u88c5\u7a0b\u5e8f\u4fee\u8ba2\u7248\u4e0e\u540c\u4e00\u4efd\u914d\u7f6e\u6587\u4ef6",
+        "README.ja.md": "\u540c\u3058\u30a4\u30f3\u30b9\u30c8\u30fc\u30e9\u30fc\u30ea\u30d3\u30b8\u30e7\u30f3\u3001\u540c\u3058\u8a2d\u5b9a\u30d5\u30a1\u30a4\u30eb",
+        "README.ko.md": "\ub3d9\uc77c\ud55c \uc124\uce58 \ud504\ub85c\uadf8\ub7a8 \ub9ac\ube44\uc804, \ub3d9\uc77c\ud55c \uc124\uc815 \ud30c\uc77c",
+    }
+    resume_digest_limit = {
+        "README.md": "shared helper or constant",
+        "README.zh-TW.md": "\u5171\u7528\u8f14\u52a9\u51fd\u5f0f\u6216\u5e38\u6578",
+        "README.zh-CN.md": "\u5171\u7528\u8f85\u52a9\u51fd\u6570\u6216\u5e38\u91cf",
+        "README.ja.md": "\u5171\u6709\u306e\u30d8\u30eb\u30d1\u30fc\u3084\u5b9a\u6570",
+        "README.ko.md": "\uacf5\uc6a9 \ud5ec\ud37c\ub098 \uc0c1\uc218",
+    }
+    for name in READMES:
+        bodies = fact_bodies(name)
+        for unit, tokens in common.items():
+            assert all(token in bodies[unit] for token in tokens), (name, unit)
+        assert backups[name] in bodies["safety-review-backup"], name
+        assert install_alternatives[name] in bodies["install-config-workflow"], name
+        assert resume_identity[name] in bodies["resume-limits"], name
+        assert resume_digest_limit[name] in bodies["resume-limits"], name
+        assert "zram" not in bodies["storage-device-graph"], name
+        assert "zram" in bodies["zram-system"], name
+
+
+def test_translated_closed_lists_have_no_open_ended_marker() -> None:
+    banned = {
+        "README.zh-CN.md": ("\u7b49", "\u5305\u62ec"),
+        "README.ja.md": ("\u306a\u3069",),
+        "README.ko.md": ("\ub4f1\uc758", "\ube44\ub86f\ud55c"),
+    }
+    for name, markers in banned.items():
+        bodies = fact_bodies(name)
+        scope = bodies["storage-device-graph"] + bodies["requirements-bootstrap"]
+        assert all(marker not in scope for marker in markers), name
+
+
+def test_simplified_chinese_keeps_required_inline_spacing() -> None:
+    banned = (
+        "\u5305\u542b \u5b50\u5377 \u7684",
+        "Xfce \uff0c",
+        "\u65e5\u5fd7`install.log`",
+        "\u4f7f\u7528`--lang",
+        "\u4f7f\u7528`--no-shell`",
+    )
+    said = readme("README.zh-CN.md")
+    assert all(fragment not in said for fragment in banned)
 
 
 def test_every_configuration_a_readme_prints_can_produce_a_plan() -> None:
@@ -113,12 +258,18 @@ def test_the_shell_commands_are_the_same_in_every_translation() -> None:
 def test_no_readme_addresses_the_reader_in_the_second_person() -> None:
     """The whole set is written about the installer and the operator, and one
     locale slipping into instructions to `you` reads as a different document."""
-    import re
+    for name, locale in READMES.items():
+        for number, line in enumerate(readme(name).splitlines(), 1):
+            assert not SECOND_PERSON[locale].search(line), f"{name}:{number}"
 
-    banned = re.compile(r"\b(you|your|yours)\b", re.IGNORECASE)
-    for name in READMES:
-        for number, line in enumerate((ROOT / name).read_text().splitlines(), 1):
-            assert not banned.search(line), f"{name}:{number}"
+
+def test_every_documented_long_option_exists_in_cli_help() -> None:
+    from gentoo_install.cli import parser
+
+    documented = set(re.findall(r"--[a-z][a-z-]*", readme("README.md")))
+    cli_help = parser().format_help()
+    assert documented
+    assert all(option in cli_help for option in documented), documented
 
 
 def test_the_readme_set_holds_no_contributor_instructions() -> None:


### PR DESCRIPTION
Thirteen findings across the five READMEs, from an independent review.

The verification section named a scope the repository has no current evidence for: every installation-and-boot combination is now marked unverified against this revision, with the medium and revision of the historical runs stated separately. ext2 and ext3 stay listed as implemented and are marked as having no focused test and no boot log. The IPv4, IPv6 and dual-stack claim is narrowed to the three things that were actually measured — address detection, launcher startup, stage3 pointer retrieval — none of which is a completed install.

The exit-code table is scoped to the Python CLI after argument parsing, since argparse and the launcher answer differently. Three translations had dropped the requirement to keep a backup separate from the selected disk; two had turned closed lists into open ranges; the Simplified file had five spacing defects.

`test_readme.py` now enforces the ordered section set, 29 ordered factual units shared by all five, and the locale-specific second-person rules. Verified here: mypy, the suite, and both Chinese readme lints pass, and removing the backup sentence from one file fails two tests.