### PR TITLE
tests: ask for an address on every pass, and spread the burst

### DIFF
--- a/tests/unit/test_proxmox.py
+++ b/tests/unit/test_proxmox.py
@@ -1251,6 +1251,31 @@ def test_the_dhcp_request_skips_the_arp_probe_and_waits_long_enough() -> None:
     from tests.vm.cluster import ASK_FOR_IPV4
 
     assert "--noarp" in ASK_FOR_IPV4, ASK_FOR_IPV4
-    assert "-t 90" in ASK_FOR_IPV4, ASK_FOR_IPV4
+    assert "-t 45" in ASK_FOR_IPV4, ASK_FOR_IPV4
     assert '"$dev"' in ASK_FOR_IPV4, "the interface has to be named"
     assert "ip -4 route show default" in ASK_FOR_IPV4, "and only when there is none"
+
+
+def test_the_guest_asks_for_an_address_on_every_pass() -> None:
+    """This network's DHCP server runs on a Raspberry Pi that also routes, and
+    it answers intermittently: the same node offered 10.31.0.201 on one
+    attempt and printed `soliciting a DHCP lease` then `timed out` on the
+    next, minutes apart. Asking once meant a guest that hit a quiet moment
+    spent its whole window with no address.
+
+    A daemon left by an earlier attempt is stopped first, because dhcpcd that
+    finds one running prints `sending commands to dhcpcd process` and returns
+    at once — which is why the log showed the marker pair with no delay.
+    """
+    import inspect
+
+    from tests.vm import cluster
+
+    assert "dhcpcd -x" in cluster.ASK_FOR_IPV4, cluster.ASK_FOR_IPV4
+    assert "--noarp" in cluster.ASK_FOR_IPV4
+    source = inspect.getsource(cluster.wait_for_network)
+    assert "if not asked:" not in source, "the request is no longer a one-shot"
+    assert source.count("ASK_FOR_IPV4") == 1
+    # And the burst is spread: thirteen leases inside one minute is what the
+    # server could not answer.
+    assert cluster.STAGGER >= 20.0, cluster.STAGGER

--- a/tests/vm/cluster.py
+++ b/tests/vm/cluster.py
@@ -138,7 +138,13 @@ WATCH_STRIKES: Final[int] = 3
 #: Between starting one guest and the next. They all reach for the same mirror
 #: in their first minute, and twelve starting together each failed the
 #: reachability check against a host that was answering.
-STAGGER: Final[float] = 8.0
+#:
+#: Twenty rather than eight, because the DHCP server on this network runs on a
+#: Raspberry Pi acting as the router, and thirteen guests asking for a lease
+#: inside one minute is what made it answer some and not others: the same node
+#: offered 10.31.0.201 on one attempt and printed `soliciting a DHCP lease`
+#: then `timed out` on the next, minutes apart.
+STAGGER: Final[float] = 20.0
 
 #: How long the schedule waits before looking at capacity again while jobs are
 #: still queued. A node's free memory lags what is actually running on it, so
@@ -337,7 +343,11 @@ ASK_FOR_IPV4: Final[str] = (
     # in `probing address 10.31.0.201/24` until dhcpcd gives up. Measured on
     # two nodes: `-w -t 25` timed out on both, `--noarp -w -t 90` leased
     # 10.31.0.203 and 10.31.0.201 with `default via 10.31.0.254`.
-    'dhcpcd -4 --noarp -w -t 90 "$dev" >/dev/null 2>&1 || true; done; }; '
+    # Any daemon from an earlier attempt is stopped first: dhcpcd that finds
+    # one running prints `sending commands to dhcpcd process` and returns at
+    # once, so every later attempt took no time and asked for nothing.
+    'dhcpcd -x "$dev" >/dev/null 2>&1; pkill -x dhcpcd >/dev/null 2>&1; '
+    'dhcpcd -4 --noarp -w -t 45 "$dev" >/dev/null 2>&1 || true; done; }; '
     "ip -4 route show default | grep -q . || true"
 )
 
@@ -383,10 +393,13 @@ def wait_for_network(link: Reconnecting) -> None:
         said = link.expect(rf"{NETWORK_UP}|{NETWORK_DONE}", timeout=180.0)
         if NETWORK_UP.encode() in said:
             return
-        if not asked:
-            asked = True
-            link.run(ASK_FOR_IPV4, timeout=120.0)
-            continue
+        # Every pass, not once: this cluster's DHCP server answers
+        # intermittently. One guest was offered 10.31.0.201 on one attempt and
+        # got `soliciting a DHCP lease` then `timed out` on the next, from the
+        # same node minutes apart. Asking once meant a guest that hit a quiet
+        # moment spent the whole window with no address at all.
+        link.run(ASK_FOR_IPV4, timeout=120.0)
+        asked = True
         time.sleep(NETWORK_PAUSE)
     # What the guest actually had, into the log this run leaves behind. Eight
     # cluster guests failed here on one round and the log held nothing but


### PR DESCRIPTION
The DHCP server on this network runs on a Raspberry Pi that also acts as the router, and it answers intermittently under load: the same node offered 10.31.0.201 on one attempt and printed `soliciting a DHCP lease` then `timed out` on the next, minutes apart. Asking once meant a guest that hit a quiet moment spent its whole fifteen-minute window with no address.

A daemon left behind by an earlier attempt compounded it: dhcpcd that finds one running prints `sending commands to dhcpcd process` and returns immediately, which is why the log showed `MARK_1_BEGIN` and `MARK_1_DONE` with no delay between them. Any running one is stopped first.

`STAGGER` goes from 8 to 20 seconds, so thirteen guests do not ask that Pi for a lease inside one minute.