### PR TITLE
tests: leave a guest's own address alone on the next pass

### DIFF
--- a/tests/unit/test_proxmox.py
+++ b/tests/unit/test_proxmox.py
@@ -1315,3 +1315,26 @@ def test_a_guest_is_given_an_address_rather_than_asking_for_one() -> None:
     assert f"via {GUEST_GATEWAY}" in command
     for one in GUEST_RESOLVERS:
         assert f"nameserver {one}" in command
+
+
+def test_a_guest_leaves_its_own_address_alone_on_the_next_pass() -> None:
+    """The request runs on every pass, so the second one probed the address
+    the first had taken: `arping -D` answered that something holds it — this
+    guest — and the DHCP branch then tore the working configuration down.
+    Four guests spent their whole window doing that to themselves.
+
+    Measured from a probe on the segment: 10.31.0.101, .105, .106, .110, .111
+    and .120 all answered as taken, and every one of them was a guest of the
+    round that was running.
+    """
+    import subprocess
+
+    from tests.vm.cluster import configure_statically
+
+    command = configure_statically("10.31.0.113")
+    assert subprocess.run(["bash", "-n", "-c", command], capture_output=True).returncode == 0
+    # The guard comes first, and nothing else runs when a route is already there.
+    assert command.startswith("ip -4 route show default | grep -q . || {"), command[:80]
+    assert command.index("arping") > command.index("|| {")
+    # `exit` would end the login shell this runs in, not just the command.
+    assert "exit 0" not in command

--- a/tests/vm/cluster.py
+++ b/tests/vm/cluster.py
@@ -387,6 +387,12 @@ def configure_statically(address: str) -> str:
     # a serial console, and a literal break there is two commands.
     resolvers = "".join(f"nameserver {one}\\n" for one in GUEST_RESOLVERS)
     return (
+        # Nothing at all once there is a default route. Without this guard the
+        # second pass probed the address the first pass had taken, `arping -D`
+        # answered that something holds it — this guest — and the DHCP branch
+        # then tore the working configuration down again. Four guests spent
+        # their whole window doing that to themselves.
+        "ip -4 route show default | grep -q . || { "
         'for one in /sys/class/net/e*; do dev=$(basename "$one"); ip link set "$dev" up; '
         f'if arping -D -c 2 -w 3 -I "$dev" {address} >/dev/null 2>&1; then '
         f'ip -4 addr add {address}/{GUEST_PREFIX} dev "$dev" 2>/dev/null; '
@@ -394,7 +400,7 @@ def configure_statically(address: str) -> str:
         "else "
         'dhcpcd -x "$dev" >/dev/null 2>&1; pkill -x dhcpcd >/dev/null 2>&1; '
         'dhcpcd -4 --noarp -w -t 45 "$dev" >/dev/null 2>&1 || true; '
-        "fi; done; "
+        "fi; done; }; "
         f"printf '{resolvers}' > /etc/resolv.conf; "
         "ip -4 route show default | grep -q . || true"
     )


### PR DESCRIPTION
#90 asks for the address on every pass, which is right for the DHCP fallback and wrong for the static path: the second pass probes the address the first one took, `arping -D` reports that something on the segment holds it — this guest — and the else branch runs `dhcpcd -x` and tears the working configuration down again. Four guests of twelve spent their whole window doing that to themselves.

A probe guest confirmed it: 10.31.0.101, .105, .106, .110, .111 and .120 all answered as taken, and each was a guest of the round that was running.

The command now does nothing at all once there is a default route. Not `exit 0` — that would end the login shell it runs in.