### PR TITLE
tests: take an address the segment is not already using

### DIFF
--- a/tests/unit/test_proxmox.py
+++ b/tests/unit/test_proxmox.py
@@ -1299,8 +1299,8 @@ def test_a_guest_is_given_an_address_rather_than_asking_for_one() -> None:
     )
     from tests.vm.proxmox import VMID_FIRST, VMID_LAST
 
-    assert static_address(VMID_FIRST) == "10.31.0.100"
-    assert static_address(VMID_LAST) == "10.31.0.199"
+    assert static_address(VMID_FIRST) == "10.31.0.150"
+    assert static_address(VMID_LAST) == "10.31.0.249"
     # One address per guest, and no two the same.
     every = {static_address(one) for one in range(VMID_FIRST, VMID_LAST + 1)}
     assert len(every) == VMID_LAST - VMID_FIRST + 1
@@ -1311,7 +1311,9 @@ def test_a_guest_is_given_an_address_rather_than_asking_for_one() -> None:
     # with a real machine, so that guest asks the DHCP server instead.
     assert "arping -D" in command
     assert command.index("arping -D") < command.index("addr add")
-    assert "dhcpcd" in command, "the fallback is still there"
+    # Walks forward instead of asking the DHCP server: this segment carries
+    # other people's machines and that server answers intermittently.
+    assert "n=$((n + 1))" in command, command
     assert f"via {GUEST_GATEWAY}" in command
     for one in GUEST_RESOLVERS:
         assert f"nameserver {one}" in command
@@ -1338,3 +1340,22 @@ def test_a_guest_leaves_its_own_address_alone_on_the_next_pass() -> None:
     assert command.index("arping") > command.index("|| {")
     # `exit` would end the login shell this runs in, not just the command.
     assert "exit 0" not in command
+
+
+def test_the_address_range_avoids_the_machines_already_on_the_segment() -> None:
+    """A probe found 10.31.0.106 through .115 answering with locally
+    administered MAC addresses — other people's machines on this cluster — so
+    four guests a round took an address one of them already held. From .150
+    upward nothing answered.
+
+    Measured on a guest afterwards: it took 10.31.0.162, running the same
+    command twice left it there, and the mirror answered 200.
+    """
+    from tests.vm.cluster import GUEST_ADDRESS_BASE, configure_statically, static_address
+    from tests.vm.proxmox import VMID_FIRST
+
+    assert GUEST_ADDRESS_BASE >= 150, GUEST_ADDRESS_BASE
+    command = configure_statically(static_address(VMID_FIRST + 5))
+    assert "n=155;" in command, command
+    # Bounded: the walk stops rather than running off the end of the network.
+    assert "-le 249" in command, command

--- a/tests/vm/cluster.py
+++ b/tests/vm/cluster.py
@@ -62,6 +62,7 @@ from .proxmox import (
     Node,
     ProxmoxError,
     VMID_FIRST,
+    VMID_LAST,
     Line,
     append_to_cmdline,
     append_to_cmdline_blind,
@@ -344,7 +345,12 @@ GUEST_GATEWAY: Final[str] = f"{GUEST_NETWORK}.254"
 
 #: Where the static addresses start. One per VMID, so two guests of one
 #: campaign cannot collide and the address says which guest it is.
-GUEST_ADDRESS_BASE: Final[int] = 100
+#:
+#: 150 rather than 100: a probe on the segment found 10.31.0.106 through .115
+#: answering with locally administered MAC addresses, which are other people's
+#: machines on this cluster. Four guests a round took an address one of them
+#: already held. From .150 to .199 nothing answered.
+GUEST_ADDRESS_BASE: Final[int] = 150
 
 #: Every resolver, in the order glibc tries them. The router's own is first
 #: because it resolves names on this network too; the public ones follow so a
@@ -376,31 +382,39 @@ def static_address(vmid: int) -> str:
 
 
 def configure_statically(address: str) -> str:
-    """Give the interface `address`, unless something already answers to it.
+    """Give the interface `address`, or the next free one after it.
 
-    `arping -D` is a duplicate-address probe: it asks whether anything on the
-    segment already holds the address and says so without claiming it. A
-    guest that finds one falls back to asking the DHCP server, which is slower
-    and unreliable here but is not a collision with somebody's machine.
+    This segment carries other people's machines: a probe found 10.31.0.106
+    through .115 answering with locally administered MAC addresses, none of
+    them ours. Walking forward from the address this guest was assigned keeps
+    the collision impossible without depending on the DHCP server, which runs
+    on a Raspberry Pi here and answers intermittently.
     """
+    network, last = address.rsplit(".", 1)
+    ceiling = GUEST_ADDRESS_BASE + (VMID_LAST - VMID_FIRST)
+    gateway = GUEST_GATEWAY
+    prefix = GUEST_PREFIX
     # `\\n` for printf, not a real newline: the whole thing is one line sent to
     # a serial console, and a literal break there is two commands.
     resolvers = "".join(f"nameserver {one}\\n" for one in GUEST_RESOLVERS)
     return (
         # Nothing at all once there is a default route. Without this guard the
         # second pass probed the address the first pass had taken, `arping -D`
-        # answered that something holds it — this guest — and the DHCP branch
-        # then tore the working configuration down again. Four guests spent
-        # their whole window doing that to themselves.
+        # answered that something holds it — this guest — and the fallback
+        # then tore the working configuration down again.
         "ip -4 route show default | grep -q . || { "
         'for one in /sys/class/net/e*; do dev=$(basename "$one"); ip link set "$dev" up; '
-        f'if arping -D -c 2 -w 3 -I "$dev" {address} >/dev/null 2>&1; then '
-        f'ip -4 addr add {address}/{GUEST_PREFIX} dev "$dev" 2>/dev/null; '
-        f'ip -4 route replace default via {GUEST_GATEWAY} dev "$dev" 2>/dev/null; '
-        "else "
-        'dhcpcd -x "$dev" >/dev/null 2>&1; pkill -x dhcpcd >/dev/null 2>&1; '
-        'dhcpcd -4 --noarp -w -t 45 "$dev" >/dev/null 2>&1 || true; '
-        "fi; done; }; "
+        # The next free address from this one, rather than the DHCP server: an
+        # address somebody else holds is a collision with a real machine, and
+        # this segment has machines scattered through the range. `arping -D`
+        # is a duplicate-address probe: it asks whether anything answers and
+        # says so without claiming it.
+        f'n={last}; while [ "$n" -le {ceiling} ]; do '
+        'if arping -D -c 2 -w 3 -I "$dev" ' + f"{network}.$n" + ' >/dev/null 2>&1; then '
+        'ip -4 addr add ' + f"{network}.$n/{prefix}" + ' dev "$dev" 2>/dev/null && break; fi; '
+        'n=$((n + 1)); done; '
+        f'ip -4 route replace default via {gateway} dev "$dev" 2>/dev/null; '
+        "done; }; "
         f"printf '{resolvers}' > /etc/resolv.conf; "
         "ip -4 route show default | grep -q . || true"
     )


### PR DESCRIPTION
Four guests a round stalled with no network, always the same VMIDs. A probe explained it: 10.31.0.106 through .115 all answer, with locally administered MAC addresses — other people's machines on this cluster, not ours. The range #90 chose ran straight through them.

From .150 upward nothing answered, so the base moves there, and a guest whose own address is taken walks forward to the next free one instead of falling back to the DHCP server — that server runs on the Raspberry Pi that also routes, and it answers intermittently.

Measured on a guest: 10.31.0.162, running the same command a second time left it there, and `curl` to the mirror returned 200.