### PR TITLE
tests: close sixteen findings from the harness review

### DIFF
--- a/tests/unit/test_harness.py
+++ b/tests/unit/test_harness.py
@@ -455,7 +455,11 @@ def test_a_run_that_collected_fewer_results_than_it_dispatched_fails(
     def one_result(jobs: list[Any], *args: Any, **kwargs: Any) -> list[cluster.Outcome]:
         return [
             cluster.Outcome(
-                name=jobs[0].name, verdict=cluster.Verdict.OK, seconds=1.0, detail=""
+                name=jobs[0].name,
+                verdict=cluster.Verdict.OK,
+                seconds=1.0,
+                detail="",
+                revision="revision-a",
             )
         ]
 
@@ -464,7 +468,13 @@ def test_a_run_that_collected_fewer_results_than_it_dispatched_fails(
     # And the ordinary case still passes, so this is not failing on everything.
     def both(jobs: list[Any], *args: Any, **kwargs: Any) -> list[cluster.Outcome]:
         return [
-            cluster.Outcome(name=one.name, verdict=cluster.Verdict.OK, seconds=1.0, detail="")
+            cluster.Outcome(
+                name=one.name,
+                verdict=cluster.Verdict.OK,
+                seconds=1.0,
+                detail="",
+                revision="revision-a",
+            )
             for one in jobs
         ]
 
@@ -521,3 +531,325 @@ def test_a_worker_that_ends_without_reporting_becomes_an_error() -> None:
         "x", cluster.Verdict.ERROR, 0.0, "the worker ended without reporting", removed=False
     )
     assert gone.removed is False
+
+
+def test_unknown_telemetry_does_not_make_a_quiet_guest_stuck(tmp_path: Path) -> None:
+    """Three failed API reads were treated as three proofs that counters were flat."""
+    from tests.vm.cluster import WATCH_STRIKES, Watchdog
+
+    log = tmp_path / "quiet.log"
+    log.write_bytes(b"")
+    answers: list[int | None] = [None] * WATCH_STRIKES + [10] * (WATCH_STRIKES + 1)
+    watch = Watchdog(log, lambda: answers.pop(0))
+    unknown = [watch.moved() for _ in range(WATCH_STRIKES)]
+    assert unknown == [True] * WATCH_STRIKES
+    assert watch.strikes == 0 and not watch.stuck
+    [watch.moved() for _ in range(WATCH_STRIKES + 1)]
+    assert watch.stuck, "known flat counters must still trip the watchdog"
+
+
+def test_preinstall_console_timeout_is_an_error_with_its_phase(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A live-medium timeout was recorded as an installer FAIL."""
+    from typing import Any
+
+    from tests.vm import cluster
+    from tests.vm.console import ConsoleTimeout
+    from tests.vm.proxmox import Api
+
+    class FakeGuest:
+        def __init__(self, *args: object, **kwargs: object) -> None:
+            # `wait_for_network` derives this guest's static address from it.
+            self.vmid = 9300
+
+        def create(self) -> None:
+            return None
+
+        def start(self) -> None:
+            return None
+
+        def reset(self) -> None:
+            return None
+
+        def transferred(self) -> int:
+            return 0
+
+        def destroy(self) -> None:
+            return None
+
+    class Link:
+        console: Any = object()
+
+        def run(self, command: str, timeout: float = 120.0) -> None:
+            return None
+
+        def wait_for(self, command: str, timeout: float) -> None:
+            return None
+
+    class Links:
+        @classmethod
+        def to(cls, guest: object, log: Path) -> Link:
+            return Link()
+
+    def timeout(*args: object, **kwargs: object) -> None:
+        raise ConsoleTimeout("no live prompt")
+
+    monkeypatch.setattr(cluster, "Guest", FakeGuest)
+    monkeypatch.setattr(cluster, "Reconnecting", Links)
+    monkeypatch.setattr(cluster, "append_to_cmdline", timeout)
+    job = cluster.Job("vm-lvm", Path("tests/fixtures/vm-lvm.toml"))
+    outcome = cluster.install_one(
+        Api(host="nowhere.invalid"),
+        "node",
+        job,
+        "driver.iso",
+        tmp_path,
+        vmid=9300,
+        nonce="gi-phase",
+        revision="revision-a",
+    )
+    assert (outcome.verdict, outcome.phase) == (
+        cluster.Verdict.ERROR,
+        cluster.Phase.BOOT_LIVE,
+    )
+
+    monkeypatch.setattr(cluster, "append_to_cmdline", lambda *args: None)
+    monkeypatch.setattr(cluster, "reach_prompt", lambda *args: None)
+    monkeypatch.setattr(cluster, "wait_for_network", lambda *args: None)
+    monkeypatch.setattr(cluster, "stage_passphrases", lambda *args: None)
+    monkeypatch.setattr(cluster, "collect", lambda *args: {"install.rc": b"1"})
+    outcome = cluster.install_one(
+        Api(host="nowhere.invalid"),
+        "node",
+        job,
+        "driver.iso",
+        tmp_path,
+        vmid=9300,
+        nonce="gi-phase",
+        revision="revision-a",
+    )
+    assert (outcome.verdict, outcome.phase) == (
+        cluster.Verdict.FAIL,
+        cluster.Phase.INSTALL,
+    )
+
+
+def test_driver_identity_changes_with_the_packaged_bytes(tmp_path: Path) -> None:
+    """Outcomes named only a commit even when the packaged dirty tree changed."""
+    from tests.vm.cluster import revision_identity
+    from tests.vm.driver import remote_name
+
+    driver = tmp_path / "driver.iso"
+    driver.write_bytes(b"first fixture tree")
+    first = revision_identity(driver), remote_name(driver)
+    driver.write_bytes(b"second fixture tree")
+    second = revision_identity(driver), remote_name(driver)
+    assert first != second
+
+
+def test_a_revisionless_success_is_not_counted_as_passed(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A green outcome with no installer identity proves no revision."""
+    from typing import Any
+
+    from tests.vm import cluster
+
+    def revisionless(*args: Any, **kwargs: Any) -> list[cluster.Outcome]:
+        return [cluster.Outcome("vm-lvm", cluster.Verdict.OK, 1.0)]
+
+    monkeypatch.setattr(cluster, "run", revisionless)
+    assert cluster.main(["vm-lvm"]) == 1
+
+    def dirty(*args: Any, **kwargs: Any) -> list[cluster.Outcome]:
+        return [
+            cluster.Outcome(
+                "vm-lvm",
+                cluster.Verdict.OK,
+                1.0,
+                revision="abc dirty=1 driver-sha256=def",
+            )
+        ]
+
+    monkeypatch.setattr(cluster, "run", dirty)
+    assert cluster.main(["vm-lvm"]) == 1
+
+
+def test_negative_cluster_limit_is_refused_before_building() -> None:
+    """A negative limit sliced every slot away and waited forever."""
+    from tests.vm.cluster import main
+
+    with pytest.raises(SystemExit):
+        main(["vm-lvm", "--limit", "-1"])
+
+
+def test_zero_cluster_capacity_returns_an_error_after_a_deadline(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A nonempty waiting queue with no running workers blocked on an empty queue forever."""
+    from typing import Any
+    import time as clock
+
+    from tests.vm import cluster, workdir
+
+    lab = tmp_path / "lab"
+    run_dir = lab / "cluster"
+    lab.mkdir()
+    monkeypatch.setattr(workdir, "LAB_ROOT", lab)
+
+    class Empty:
+        def ours(self) -> list[tuple[str, int]]:
+            return []
+
+        def nodes(self) -> list[Any]:
+            return []
+
+        def remove_iso(self, node: str, name: str) -> str:
+            return ""
+
+    now = [0.0]
+    monkeypatch.setattr(cluster, "Api", lambda: Empty())
+    monkeypatch.setattr(cluster, "rewrite_fixtures", lambda jobs, into, region, sync: into)
+
+    def build(path: Path, **kwargs: object) -> Path:
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_bytes(b"driver")
+        return path
+
+    monkeypatch.setattr(cluster, "build_driver", build)
+    monkeypatch.setattr(
+        cluster,
+        "current_minimal",
+        lambda path: ("minimal-deadbeef.iso", ("https://invalid/iso",), "0" * 128),
+    )
+    monkeypatch.setattr(clock, "monotonic", lambda: now[0])
+    monkeypatch.setattr(clock, "sleep", lambda seconds: now.__setitem__(0, now[0] + seconds))
+    outcome = cluster.run(
+        [cluster.Job("vm-lvm", Path("tests/fixtures/vm-lvm.toml"))], run_dir
+    )
+    assert len(outcome) == 1
+    assert outcome[0].verdict is cluster.Verdict.ERROR
+    assert outcome[0].phase is cluster.Phase.SCHEDULE
+    assert now[0] == cluster.CAPACITY_PATIENCE
+
+
+def test_reconcile_removes_only_an_expired_locally_leased_guest(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The unused cluster listing could neither recover an orphan nor distinguish campaigns."""
+    from typing import Any
+
+    from tests.vm import cluster
+    from tests.vm.proxmox import ProxmoxNotFound, TAG
+
+    expired = cluster.Lease("node", 9300, "gi-expired", 10)
+    live = cluster.Lease("node", 9302, "gi-live", 20)
+    expired_path = cluster._write_lease(tmp_path, expired)
+    live_path = cluster._write_lease(tmp_path, live)
+    cluster._write_lease(tmp_path, cluster.Lease("node", 9002, "gi-outside", 10))
+
+    from tests.vm.proxmox import Api
+
+    class Leased(Api):
+        def __init__(self) -> None:
+            self.absent = False
+            self.deleted: list[int] = []
+
+        def ours(self) -> list[tuple[str, int]]:
+            return [("node", 9300), ("node", 9301), ("node", 9302)]
+
+        def call(self, method: str, path: str, **form: Any) -> Any:
+            vmid = int(path.split("/qemu/", 1)[1].split("/", 1)[0])
+            if path.endswith("/config"):
+                if self.absent:
+                    raise ProxmoxNotFound("gone")
+                return {"tags": f"{TAG};gi-expired"}
+            if path.endswith("/status/current"):
+                return {"status": "stopped"}
+            if method == "DELETE":
+                self.deleted.append(vmid)
+                self.absent = True
+                return "UPID:node:delete"
+            raise AssertionError((method, path))
+
+        def wait(self, node: str, upid: str, patience: float = 1800.0) -> None:
+            return None
+
+    api = Leased()
+    monkeypatch.setattr(cluster, "_pid_alive", lambda pid: pid == 20)
+    cluster.reconcile(api, tmp_path)
+    assert api.deleted == [9300]
+    assert not expired_path.exists()
+    assert live_path.exists()
+    assert not any(vmid == 9301 for vmid in api.deleted)
+
+
+def test_workdirs_are_confined_before_any_vm_artifact_is_written(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Repository paths, traversal and an escaping symlink reached mkdir and rmtree."""
+    from tests.vm import cluster, netcheck, tui, workdir
+
+    lab = tmp_path / "lab"
+    inside = lab / "inside"
+    outside = tmp_path / "outside"
+    inside.mkdir(parents=True)
+    outside.mkdir()
+    escape = lab / "escape"
+    escape.symlink_to(outside, target_is_directory=True)
+    inward = lab / "inward"
+    inward.symlink_to(inside, target_is_directory=True)
+    monkeypatch.setattr(workdir, "LAB_ROOT", lab)
+
+    assert workdir.confined(inward) == inside.resolve()
+    for path in (outside, escape, lab / ".." / "outside", Path.cwd()):
+        with pytest.raises(workdir.WorkdirError):
+            workdir.confined(path)
+
+    monkeypatch.setattr(cluster, "Api", lambda: pytest.fail("cluster API contacted"))
+    with pytest.raises(workdir.WorkdirError):
+        cluster.run([], escape)
+    with pytest.raises(workdir.WorkdirError):
+        netcheck.run("ipv4", escape)
+    assert tui.main(["--workdir", str(escape)]) == 1
+    assert tui.main(
+        ["--workdir", str(inside), "--lang", "../../../../../../outside"]
+    ) == 1
+
+
+def test_parallel_driver_builds_do_not_share_staging(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Each build deleted the other build's fixed `driver` staging directory."""
+    from concurrent.futures import ThreadPoolExecutor
+    from typing import Any
+    import shutil
+    import threading
+
+    from tests.vm import driver
+
+    first_fixtures = tmp_path / "first-fixtures"
+    second_fixtures = tmp_path / "second-fixtures"
+    first_fixtures.mkdir()
+    second_fixtures.mkdir()
+    (first_fixtures / "one.toml").write_text("one = true\n")
+    (second_fixtures / "two.toml").write_text("two = true\n")
+    barrier = threading.Barrier(2)
+    original = shutil.copytree
+
+    def synchronized(source: Path, target: Path, *args: Any, **kwargs: Any) -> Any:
+        result = original(source, target, *args, **kwargs)
+        if Path(source).name == "gentoo_install":
+            barrier.wait(timeout=10.0)
+        return result
+
+    monkeypatch.setattr(shutil, "copytree", synchronized)
+    with ThreadPoolExecutor(max_workers=2) as pool:
+        futures = [
+            pool.submit(driver.build, tmp_path / "first.iso", True, first_fixtures),
+            pool.submit(driver.build, tmp_path / "second.iso", True, second_fixtures),
+        ]
+        built = [future.result(timeout=30.0) for future in futures]
+    assert all(path.is_file() for path in built)
+    assert driver.remote_name(built[0]) != driver.remote_name(built[1])

--- a/tests/unit/test_proxmox.py
+++ b/tests/unit/test_proxmox.py
@@ -4,7 +4,11 @@ from __future__ import annotations
 
 import shlex
 from collections import Counter
+from email.message import Message
+import io
 import struct
+import urllib.error
+import urllib.response
 import urllib.request
 from pathlib import Path
 from typing import Any
@@ -12,8 +16,18 @@ from typing import Any
 import pytest
 
 from tests.vm import proxmox
-from tests.vm.proxmox import TAG, Api, Guest, GuestSpec, ProxmoxError, _line_of_linux
-from tests.vm.websocket import WebSocket, _client_frame
+from tests.vm.proxmox import (
+    TAG,
+    Api,
+    CreateConflict,
+    Guest,
+    GuestSpec,
+    ProxmoxError,
+    ProxmoxNotFound,
+    _RejectRedirect,
+    _line_of_linux,
+)
+from tests.vm.websocket import WebSocket, WebSocketError, _client_frame
 
 #: One editor screen as GRUB drew it on the serial console, captured from the
 #: Gentoo minimal ISO. `search` sits between `setparams` and `linux`, which is
@@ -53,9 +67,15 @@ class _Recording(Api):
         super().__init__(host="nowhere.invalid")
         self.answers = answers
         self.asked: list[tuple[str, str]] = []
+        self.removed: set[int] = set()
 
     def call(self, method: str, path: str, **form: Any) -> Any:
         self.asked.append((method, path))
+        vmid = int(path.split("/qemu/", 1)[1].split("/", 1)[0]) if "/qemu/" in path else -1
+        if method == "GET" and path.endswith("/config") and vmid in self.removed:
+            raise ProxmoxNotFound("the guest does not exist")
+        if method == "DELETE":
+            self.removed.add(vmid)
         for key, value in self.answers.items():
             if key in path:
                 return value
@@ -76,8 +96,13 @@ def test_a_guest_without_the_tag_is_not_deleted() -> None:
 
 
 def test_a_tagged_guest_is_deleted() -> None:
-    api = _Recording({"config": {"name": "gi-run", "tags": TAG}})
-    guest = Guest(api=api, node="infra-node4", vmid=9300, spec=GuestSpec(name="x", iso="x"))
+    api = _Recording({"config": {"name": "gi-run", "tags": f"{TAG};gi-one"}})
+    guest = Guest(
+        api=api,
+        node="infra-node4",
+        vmid=9300,
+        spec=GuestSpec(name="x", iso="x", nonce="gi-one"),
+    )
     guest.destroy()
     assert ("DELETE", "/nodes/infra-node4/qemu/9300") in api.asked
 
@@ -126,8 +151,8 @@ def test_a_delete_carries_its_parameters_in_the_url(monkeypatch: pytest.MonkeyPa
         seen["body"] = request.data
         return Answer()
 
-    monkeypatch.setattr(urllib.request, "urlopen", fake_open)
     api = Api(host="nowhere.invalid")
+    monkeypatch.setattr(api._opener, "open", fake_open)
     api.call("DELETE", "/nodes/n/qemu/9300", purge=1)
     removed = (seen["url"], seen["body"])
     api.call("POST", "/nodes/n/qemu", vmid=9300)
@@ -135,6 +160,30 @@ def test_a_delete_carries_its_parameters_in_the_url(monkeypatch: pytest.MonkeyPa
 
     assert removed == ("https://nowhere.invalid/api2/json/nodes/n/qemu/9300?purge=1", None)
     assert created == ("https://nowhere.invalid/api2/json/nodes/n/qemu", b"vmid=9300")
+
+
+def test_an_api_redirect_cannot_create_a_second_authorized_request() -> None:
+    """A 302 to another origin inherited the cluster administrator token."""
+    seen: list[tuple[str, str | None]] = []
+
+    class Redirecting(urllib.request.HTTPSHandler):
+        def https_open(self, request: urllib.request.Request) -> Any:
+            seen.append((request.full_url, request.get_header("Authorization")))
+            headers = Message()
+            headers.add_header("Location", "https://example.invalid/stolen")
+            response = urllib.response.addinfourl(
+                io.BytesIO(), headers, request.full_url, code=302
+            )
+            setattr(response, "msg", "Found")
+            return response
+
+    api = Api(host="nowhere.invalid")
+    api._opener = urllib.request.build_opener(Redirecting(), _RejectRedirect())
+    with pytest.raises(ProxmoxError, match="302"):
+        api.call("GET", "/nodes")
+    assert len(seen) == 1
+    assert seen[0][0].startswith("https://nowhere.invalid/")
+    assert seen[0][1] is not None
 
 
 def test_the_console_channel_frames_input_the_way_proxmox_reads_it() -> None:
@@ -193,6 +242,118 @@ def test_a_client_frame_is_masked() -> None:
     assert frame[1] & 0x80, "the mask bit has to be set"
     mask = frame[2:6]
     assert bytes(b ^ mask[n % 4] for n, b in enumerate(frame[6:])) == b"hi"
+
+
+class _FramedStream:
+    def __init__(self, chunks: list[bytes]) -> None:
+        self.chunks = chunks
+        self.sent: list[bytes] = []
+        self.closed = False
+
+    def recv(self, size: int, /) -> bytes:
+        return self.chunks.pop(0) if self.chunks else b""
+
+    def sendall(self, data: bytes, /) -> None:
+        self.sent.append(data)
+
+    def close(self) -> None:
+        self.closed = True
+
+    def settimeout(self, seconds: float | None, /) -> None:
+        return None
+
+
+def _client_payload(frame: bytes) -> tuple[int, bytes]:
+    size = frame[1] & 0x7F
+    assert size < 126
+    mask = frame[2:6]
+    payload = bytes(byte ^ mask[index % 4] for index, byte in enumerate(frame[6:]))
+    return frame[0] & 0x0F, payload
+
+
+def test_a_fragmented_message_survives_an_interleaved_ping() -> None:
+    """The continuation payload was discarded after the first fragment."""
+    stream = _FramedStream([b"\x02\x02ab\x89\x01P\x80\x02cd"])
+    socket = WebSocket(stream)
+    assert socket.read() == b"abcd"
+    assert [_client_payload(one) for one in stream.sent] == [(0xA, b"P")]
+
+
+def test_a_received_close_is_answered_once_and_closes_the_transport() -> None:
+    """The peer waited for a close reply while the client left the socket open."""
+    payload = struct.pack("!H", 1000)
+    stream = _FramedStream([bytes((0x88, len(payload))) + payload])
+    socket = WebSocket(stream)
+    assert socket.read() == b""
+    assert [_client_payload(one) for one in stream.sent] == [(0x8, payload)]
+    assert stream.closed and socket.closed
+
+
+def test_an_oversized_declared_frame_is_refused_before_its_payload_arrives() -> None:
+    """A declared 2^40-byte frame otherwise grew the receive buffer without a bound."""
+    stream = _FramedStream([b"\x82\x7f" + struct.pack("!Q", 1 << 40)])
+    with pytest.raises(WebSocketError, match="declares"):
+        WebSocket(stream).read()
+    assert stream.closed
+
+
+def test_the_handshake_accept_must_match_the_key_that_was_sent(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Any status line containing 101 was accepted without proving the upgrade."""
+    import base64
+    import hashlib
+    import os
+    import socket as socket_module
+    import ssl
+    from typing import cast
+
+    from tests.vm import websocket
+
+    key_bytes = b"0123456789abcdef"
+    key = base64.b64encode(key_bytes)
+    accept = base64.b64encode(
+        hashlib.sha1(key + b"258EAFA5-E914-47DA-95CA-C5AB0DC85B11").digest()
+    )
+
+    class Handshake(_FramedStream):
+        pass
+
+    class Context:
+        def __init__(self, reply: bytes) -> None:
+            self.reply = reply
+            self.secure: Handshake | None = None
+
+        def wrap_socket(self, raw: Any, server_hostname: str) -> Any:
+            self.secure = Handshake([self.reply])
+            return self.secure
+
+    class Raw:
+        def __init__(self) -> None:
+            self.closed = False
+
+        def close(self) -> None:
+            self.closed = True
+
+    prefix = (
+        b"HTTP/1.1 101 Switching Protocols\r\n"
+        b"Upgrade: websocket\r\nConnection: Upgrade\r\n"
+        b"Sec-WebSocket-Protocol: binary\r\nSec-WebSocket-Accept: "
+    )
+    monkeypatch.setattr(os, "urandom", lambda size: key_bytes)
+    monkeypatch.setattr(socket_module, "create_connection", lambda *args, **kwargs: Raw())
+
+    valid = Context(prefix + accept + b"\r\n\r\n")
+    assert WebSocket.connect(
+        "pve.invalid", "/console", {}, context=cast(ssl.SSLContext, valid)
+    ).closed is False
+
+    invalid = Context(prefix + b"wrong\r\n\r\n")
+    with pytest.raises(WebSocketError, match="accept"):
+        WebSocket.connect(
+            "pve.invalid", "/console", {}, context=cast(ssl.SSLContext, invalid)
+        )
+    assert invalid.secure is not None and invalid.secure.closed
 
 
 def _archive(files: dict[str, bytes]) -> str:
@@ -1035,7 +1196,11 @@ def test_removing_a_guest_needs_the_range_the_tag_and_this_run_s_own_mark() -> N
 
         def call(self, method: str, path: str, **form: Any) -> Any:
             if method == "GET" and path.endswith("/config"):
+                if self.deleted:
+                    raise ProxmoxNotFound("the guest does not exist")
                 return {"tags": self.tags}
+            if method == "GET" and path.endswith("/status/current"):
+                return {"status": "stopped"}
             if method == "DELETE":
                 self.deleted.append(int(path.rsplit("/", 1)[1]))
             return "UPID:x"
@@ -1118,6 +1283,269 @@ def test_a_create_held_off_by_the_storage_lock_is_tried_again(
     with pytest.raises(ProxmoxError, match="no space"):
         Guest(api=other, node="infra-node1", vmid=9300, spec=GuestSpec(name="x", iso="x")).create()
     assert other.attempts == 1, other.attempts
+
+
+def test_a_create_conflict_never_cleans_up_the_conflicting_vmid() -> None:
+    """Cleanup used the requested VMID even though create proved another guest owned it."""
+
+    class Conflicting(Api):
+        def __init__(self) -> None:
+            self.asked: list[tuple[str, str]] = []
+
+        def call(self, method: str, path: str, **form: Any) -> Any:
+            self.asked.append((method, path))
+            raise ProxmoxError("VM 9300 already exists on node 'other'")
+
+    api = Conflicting()
+    guest = Guest(
+        api,
+        "infra-node1",
+        9300,
+        GuestSpec(name="x", iso="x", nonce="gi-conflict"),
+    )
+    with pytest.raises(CreateConflict):
+        guest.create()
+    guest.destroy()
+    assert api.asked == [("POST", "/nodes/infra-node1/qemu")]
+
+
+def test_transient_task_status_failures_do_not_abort_a_completed_task(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Two temporary 502 responses discarded a task that later reported OK."""
+    answers: list[Any] = [
+        ProxmoxError("GET status answered 502 Bad Gateway"),
+        ProxmoxError("GET status answered 502 Bad Gateway"),
+        {"status": "stopped", "exitstatus": "OK"},
+    ]
+
+    class Tasks(Api):
+        def __init__(self) -> None:
+            pass
+
+        def call(self, method: str, path: str, **form: Any) -> Any:
+            answer = answers.pop(0)
+            if isinstance(answer, Exception):
+                raise answer
+            return answer
+
+    import time as clock
+
+    monkeypatch.setattr(clock, "sleep", lambda seconds: None)
+    Tasks().wait("wrong-node", "UPID:right-node:task", patience=10.0)
+    assert not answers
+
+
+def test_install_media_download_carries_the_signed_sha512() -> None:
+    """A replaced ISO was accepted because the node received no checksum."""
+
+    class Downloads(Api):
+        def __init__(self) -> None:
+            self.form: dict[str, Any] = {}
+
+        def isos(self, node: str) -> list[str]:
+            return []
+
+        def call(self, method: str, path: str, **form: Any) -> Any:
+            self.form = form
+            return "UPID:node:download"
+
+        def wait(self, node: str, upid: str, patience: float = 1800.0) -> None:
+            return None
+
+    api = Downloads()
+    sha512 = "a" * 128
+    api.fetch_iso("node", "https://mirror.invalid/install.iso", "install-a.iso", sha512)
+    assert api.form["checksum"] == sha512
+    assert api.form["checksum-algorithm"] == "sha512"
+
+
+def test_install_media_cache_name_contains_its_signed_digest() -> None:
+    """Two different images with one upstream filename otherwise reused one remote ISO."""
+    from tests.vm.cluster import _medium_name
+
+    first = _medium_name("install-amd64-minimal.iso", "a" * 128)
+    second = _medium_name("install-amd64-minimal.iso", "b" * 128)
+    assert first != second
+    assert first.endswith(".iso") and second.endswith(".iso")
+
+
+def test_an_existing_install_iso_needs_its_matching_verification_record(
+    tmp_path: Path,
+) -> None:
+    """A same-name remote ISO was reused without evidence that its bytes were checked."""
+    from tests.vm.cluster import prepare
+    from tests.vm.driver import digest as driver_digest
+
+    class Existing(Api):
+        def __init__(self) -> None:
+            pass
+
+        def isos(self, node: str) -> list[str]:
+            return ["minimal-a.iso", "driver.iso"]
+
+        def upload_iso(self, node: str, path: Path, name: str) -> str:
+            return name
+
+    api = Existing()
+    driver = tmp_path / "driver.iso"
+    driver.write_bytes(b"driver")
+    with pytest.raises(ProxmoxError, match="signed SHA-512 record"):
+        prepare(
+            api,
+            "node",
+            "minimal-a.iso",
+            ("https://mirror.invalid/install.iso",),
+            "a" * 128,
+            tmp_path / "trust",
+            driver,
+            "driver.iso",
+        )
+
+    stamp = tmp_path / "trust" / "remote" / "node" / "minimal-a.iso.sha512"
+    stamp.parent.mkdir(parents=True)
+    stamp.write_text("a" * 128)
+    with pytest.raises(ProxmoxError, match="driver SHA-256 record"):
+        prepare(
+            api,
+            "node",
+            "minimal-a.iso",
+            ("https://mirror.invalid/install.iso",),
+            "a" * 128,
+            tmp_path / "trust",
+            driver,
+            "driver.iso",
+        )
+    driver_stamp = tmp_path / "trust" / "remote" / "node" / "driver.iso.sha256"
+    driver_stamp.write_text(driver_digest(driver))
+    prepare(
+        api,
+        "node",
+        "minimal-a.iso",
+        ("https://mirror.invalid/install.iso",),
+        "a" * 128,
+        tmp_path / "trust",
+        driver,
+        "driver.iso",
+    )
+
+
+def test_an_invalid_install_media_digest_signature_is_refused(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """An unsigned checksum would let a mirror replace both ISO and digest."""
+    import subprocess
+
+    from tests.vm import cluster
+
+    digests = tmp_path / "install.iso.DIGESTS"
+    key = tmp_path / "release.gpg"
+    digests.write_text(f"# SHA512 HASH\n{'a' * 128}  install.iso\n")
+    key.write_bytes(b"key")
+    answers = iter(
+        [
+            subprocess.CompletedProcess([], 0, "", ""),
+            subprocess.CompletedProcess([], 0, "gpg: good-looking text without status", ""),
+        ]
+    )
+    monkeypatch.setattr(subprocess, "run", lambda *args, **kwargs: next(answers))
+    with pytest.raises(ProxmoxError, match="does not verify"):
+        cluster.verify_release_signature(digests, key, tmp_path / "gnupg")
+
+
+def test_cleanup_retries_unknown_stop_and_delete_until_the_guest_is_absent(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A lost stop reply and one failed delete left a running guest behind."""
+
+    class Uncertain(Api):
+        def __init__(self) -> None:
+            self.running = True
+            self.absent = False
+            self.stops = 0
+            self.deletes = 0
+
+        def call(self, method: str, path: str, **form: Any) -> Any:
+            if path.endswith("/config"):
+                if self.absent:
+                    raise ProxmoxNotFound("the guest does not exist")
+                return {"tags": f"{TAG};gi-owned"}
+            if path.endswith("/status/current"):
+                return {"status": "running" if self.running else "stopped"}
+            if path.endswith("/status/stop"):
+                self.stops += 1
+                self.running = False
+                return "UPID:node:stop"
+            if method == "DELETE":
+                self.deletes += 1
+                if self.deletes == 1:
+                    raise ProxmoxError("DELETE answered 503 storage busy")
+                self.absent = True
+                return "UPID:node:delete"
+            raise AssertionError((method, path))
+
+        def wait(self, node: str, upid: str, patience: float = 1800.0) -> None:
+            if upid.endswith(":stop") and self.stops == 1:
+                raise ProxmoxError("task status did not answer")
+
+    import time as clock
+
+    monkeypatch.setattr(clock, "sleep", lambda seconds: None)
+    api = Uncertain()
+    Guest(
+        api,
+        "node",
+        9300,
+        GuestSpec(name="x", iso="x", nonce="gi-owned"),
+    ).destroy(patience=10.0)
+    assert api.stops == 1
+    assert api.deletes == 2
+    assert api.absent
+
+
+def test_a_console_uses_the_cookie_returned_with_its_own_ticket(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Another worker replaced the shared affinity cookie between ticket and connect."""
+    captured: dict[str, str] = {}
+
+    class Tickets(Api):
+        def __init__(self) -> None:
+            self.host = "pve.invalid"
+            self.affinity = "cookie-before"
+
+        def call_with_affinity(self, method: str, path: str, **form: Any) -> tuple[Any, str]:
+            self.affinity = "INGRESSCOOKIE=worker-b"
+            return {"port": 1, "ticket": "ticket-a", "user": "root@pam"}, "INGRESSCOOKIE=worker-a"
+
+    class Framed:
+        closed = False
+
+        def settimeout(self, seconds: float | None) -> None:
+            return None
+
+        def send(self, payload: bytes, opcode: int = 0x2) -> None:
+            return None
+
+        def read(self) -> bytes:
+            return b""
+
+        def close(self) -> None:
+            return None
+
+    def connect(
+        host: str,
+        path: str,
+        headers: dict[str, str],
+        **kwargs: Any,
+    ) -> Framed:
+        captured.update(headers)
+        return Framed()
+
+    monkeypatch.setattr(WebSocket, "connect", connect)
+    monkeypatch.setattr(proxmox, "_secret", lambda: "secret")
+    proxmox.ConsoleChannel.open(Tickets(), "node", 9300, tries=1)
+    assert captured["Cookie"] == "INGRESSCOOKIE=worker-a"
 
 
 def test_a_guest_is_asked_for_an_address_on_the_first_pass() -> None:

--- a/tests/vm/cluster.py
+++ b/tests/vm/cluster.py
@@ -17,8 +17,11 @@ from __future__ import annotations
 
 import argparse
 import itertools
+import json
+import os
 import queue
 import re
+import subprocess
 import sys
 import threading
 import time
@@ -53,7 +56,7 @@ from .console import (
     ConsoleTimeout,
     SerialConsole,
 )
-from .driver import build as build_driver
+from .driver import build as build_driver, digest as driver_digest, remote_name
 from .monitor import keys_for
 from .proxmox import (
     Api,
@@ -68,6 +71,7 @@ from .proxmox import (
     append_to_cmdline_blind,
 )
 from .results import CONSOLE_CLOSE, ResultError, console_command, read_console
+from .workdir import WorkdirError, confined
 
 REPOSITORY: Final[Path] = Path(__file__).resolve().parents[2]
 WORKROOT: Final[Path] = Path.home() / "code/gentoo-install/lab/vm/cluster"
@@ -105,6 +109,10 @@ MINIMAL_POINTER: Final[str] = "latest-install-amd64-minimal.txt"
 #: Filled in from the pointer file when a run starts. The placeholder is what a
 #: `Job` carries until then, so a fixture can still name a medium of its own.
 DEFAULT_ISO: Final[str] = "minimal"
+
+RELENG_FINGERPRINT: Final[str] = "13EBBDBEDE7A12775DFDB1BABB572E0E2D182910"
+RELEASE_KEY: Final[Path] = Path("/usr/share/openpgp-keys/gentoo-release.asc")
+RELEASE_KEYRING: Final[str] = "https://qa-reports.gentoo.org/output/service-keys.gpg"
 
 #: Kernel parameters the medium's own GRUB entry lacks. Without the console the
 #: kernel says nothing on the serial port and every run reads as hung.
@@ -163,6 +171,9 @@ RUN_CEILING: Final[float] = 3 * 3600.0
 #: builds the initramfs cache and, on openrc, runs every service in order.
 BOOT_PATIENCE: Final[float] = 600.0
 
+#: A cluster with no room must produce a result rather than poll for ever.
+CAPACITY_PATIENCE: Final[float] = 120.0
+
 
 class Verdict(Enum):
     """How one guest ended. `STUCK` is separate from `FAIL` on purpose: a
@@ -173,6 +184,16 @@ class Verdict(Enum):
     FAIL = "FAIL"
     STUCK = "STUCK"
     ERROR = "ERROR"
+
+
+class Phase(Enum):
+    """The operation that produced an outcome."""
+
+    SCHEDULE = "schedule"
+    CREATE = "create"
+    BOOT_LIVE = "boot-live"
+    INSTALL = "install"
+    BOOT_INSTALLED = "boot-installed"
 
 
 @dataclass
@@ -186,6 +207,8 @@ class Outcome:
     #: slot held: the memory is still allocated, and handing it back put the
     #: next guest onto a node that had no room for it.
     removed: bool = True
+    phase: Phase = Phase.SCHEDULE
+    revision: str = ""
 
 
 @dataclass
@@ -227,7 +250,7 @@ class Watchdog:
     """
 
     log: Path
-    counters: Callable[[], int]
+    counters: Callable[[], int | None]
     strikes: int = 0
     _seen: int = field(default=0, init=False)
     _moved: int = field(default=0, init=False)
@@ -236,8 +259,12 @@ class Watchdog:
         size = self.log.stat().st_size if self.log.exists() else 0
         traffic = self.counters()
         talking = size > self._seen
-        working = traffic - self._moved >= QUIET_BYTES
         self._seen = max(self._seen, size)
+        if traffic is None:
+            if talking:
+                self.strikes = 0
+            return True
+        working = traffic - self._moved >= QUIET_BYTES
         self._moved = max(self._moved, traffic)
         if talking or working:
             self.strikes = 0
@@ -250,8 +277,81 @@ class Watchdog:
         return self.strikes >= WATCH_STRIKES
 
 
-def current_minimal() -> tuple[str, tuple[str, ...]]:
-    """The current minimal ISO's name and every URL that serves it."""
+def _download(url: str, target: Path) -> None:
+    try:
+        with urllib.request.urlopen(url, timeout=30.0) as answer:
+            target.write_bytes(answer.read())
+    except OSError as error:
+        raise ProxmoxError(f"{url} did not answer: {error}") from error
+
+
+def _signing_key(status: str) -> str | None:
+    for line in status.splitlines():
+        fields = line.split()
+        if len(fields) >= 3 and fields[:2] == ["[GNUPG:]", "VALIDSIG"]:
+            return fields[-1]
+    return None
+
+
+def verify_release_signature(digests: Path, key: Path, home: Path) -> None:
+    """Verify Gentoo's digest signature against the pinned primary key."""
+    home.mkdir(mode=0o700, parents=True, exist_ok=True)
+    imported = subprocess.run(
+        ["gpg", "--batch", "--homedir", str(home), "--import", str(key)],
+        capture_output=True,
+        text=True,
+    )
+    if imported.returncode != 0:
+        raise ProxmoxError(f"the Gentoo release key could not be imported: {imported.stderr[:200]}")
+    verified = subprocess.run(
+        [
+            "gpg",
+            "--batch",
+            "--homedir",
+            str(home),
+            "--status-fd",
+            "1",
+            "--verify",
+            str(digests),
+        ],
+        capture_output=True,
+        text=True,
+    )
+    signed = _signing_key(verified.stdout)
+    if verified.returncode != 0 or signed is None:
+        raise ProxmoxError(f"the signature on {digests.name} does not verify")
+    if signed.upper() != RELENG_FINGERPRINT:
+        raise ProxmoxError(
+            f"{digests.name} is signed by {signed}, not the pinned {RELENG_FINGERPRINT}"
+        )
+
+
+def _expected_sha512(digests: Path, name: str) -> str:
+    rows = digests.read_text().splitlines()
+    for index, row in enumerate(rows):
+        if row.strip().upper().startswith("# SHA512"):
+            for candidate in rows[index + 1 :]:
+                fields = candidate.split()
+                if len(fields) == 2 and Path(fields[1]).name == name:
+                    digest = fields[0].lower()
+                    if re.fullmatch(r"[0-9a-f]{128}", digest):
+                        return digest
+    raise ProxmoxError(f"{digests.name} has no SHA512 line for {name}")
+
+
+def _medium_name(name: str, sha512: str) -> str:
+    return f"{Path(name).stem}-{sha512[:20]}.iso"
+
+
+def current_minimal(workdir: Path) -> tuple[str, tuple[str, ...], str]:
+    """The verified current minimal ISO, its mirrors and signed SHA-512."""
+    trust = workdir / "medium-trust"
+    trust.mkdir(parents=True, exist_ok=True)
+    key = RELEASE_KEY
+    if not key.is_file():
+        key = trust / "service-keys.gpg"
+        if not key.is_file():
+            _download(RELEASE_KEYRING, key)
     for mirror in MIRRORS:
         pointer = f"{mirror}/{AUTOBUILDS}/{MINIMAL_POINTER}"
         try:
@@ -262,14 +362,32 @@ def current_minimal() -> tuple[str, tuple[str, ...]]:
         for line in said.splitlines():
             first = line.strip().split(" ")[0]
             if first.endswith(".iso"):
-                return first.rsplit("/", 1)[-1], tuple(
-                    f"{one}/{AUTOBUILDS}/{first}" for one in MIRRORS
-                )
+                original = first.rsplit("/", 1)[-1]
+                digests = trust / f"{original}.DIGESTS"
+                last = ""
+                for source in MIRRORS:
+                    try:
+                        _download(f"{source}/{AUTOBUILDS}/{first}.DIGESTS", digests)
+                        verify_release_signature(digests, key, trust / "gnupg")
+                        sha512 = _expected_sha512(digests, original)
+                        return _medium_name(original, sha512), tuple(
+                            f"{one}/{AUTOBUILDS}/{first}" for one in MIRRORS
+                        ), sha512
+                    except ProxmoxError as error:
+                        last = str(error)
+                raise ProxmoxError(f"no mirror served trusted digests for {original}: {last}")
     raise SystemExit("no mirror named an install medium")
 
 
 def prepare(
-    api: Api, node: str, medium: str, urls: tuple[str, ...], driver_path: Path, driver: str
+    api: Api,
+    node: str,
+    medium: str,
+    urls: tuple[str, ...],
+    sha512: str,
+    trust: Path,
+    driver_path: Path,
+    driver: str,
 ) -> None:
     """Put the medium and the driver CD on one node's `local` storage.
 
@@ -277,18 +395,43 @@ def prepare(
     is refused with `volume 'local:iso/...' does not exist`, which is what the
     first cluster run hit.
     """
-    if medium not in api.isos(node):
+    stamp = trust / "remote" / node / f"{medium}.sha512"
+    if medium in api.isos(node):
+        try:
+            recorded = stamp.read_text().strip()
+        except OSError:
+            recorded = ""
+        if recorded != sha512:
+            raise ProxmoxError(
+                f"{medium} already exists on {node} without its signed SHA-512 record"
+            )
+    else:
         last = ""
         for url in urls:
             try:
-                api.fetch_iso(node, url, medium)
+                api.fetch_iso(node, url, medium, sha512)
                 break
             except ProxmoxError as error:
                 last = str(error)
         else:
             raise ProxmoxError(f"no mirror served {medium} to {node}: {last}")
-    if driver not in api.isos(node):
+        stamp.parent.mkdir(parents=True, exist_ok=True)
+        stamp.write_text(sha512)
+    driver_sha256 = driver_digest(driver_path)
+    driver_stamp = trust / "remote" / node / f"{driver}.sha256"
+    if driver in api.isos(node):
+        try:
+            recorded_driver = driver_stamp.read_text().strip()
+        except OSError:
+            recorded_driver = ""
+        if recorded_driver != driver_sha256:
+            raise ProxmoxError(
+                f"{driver} already exists on {node} without its driver SHA-256 record"
+            )
+    else:
         api.upload_iso(node, driver_path, driver)
+        driver_stamp.parent.mkdir(parents=True, exist_ok=True)
+        driver_stamp.write_text(driver_sha256)
 
 
 
@@ -539,6 +682,100 @@ def rewrite_fixtures(
     return into
 
 
+@dataclass(frozen=True)
+class Lease:
+    node: str
+    vmid: int
+    nonce: str
+    pid: int
+
+
+def _lease_path(workdir: Path, lease: Lease) -> Path:
+    return workdir / "leases" / f"{lease.vmid}-{lease.nonce}.json"
+
+
+def _write_lease(workdir: Path, lease: Lease) -> Path:
+    path = _lease_path(workdir, lease)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    temporary = path.with_suffix(".new")
+    temporary.write_text(json.dumps(lease.__dict__, sort_keys=True))
+    temporary.replace(path)
+    return path
+
+
+def _read_lease(path: Path) -> Lease | None:
+    try:
+        raw = json.loads(path.read_text())
+        if not isinstance(raw, dict):
+            return None
+        node = raw.get("node")
+        vmid = raw.get("vmid")
+        nonce = raw.get("nonce")
+        pid = raw.get("pid")
+        if not isinstance(node, str) or not isinstance(vmid, int):
+            return None
+        if not isinstance(nonce, str) or not nonce or not isinstance(pid, int):
+            return None
+        return Lease(node, vmid, nonce, pid)
+    except (OSError, ValueError):
+        return None
+
+
+def _pid_alive(pid: int) -> bool:
+    if pid <= 0:
+        return False
+    try:
+        os.kill(pid, 0)
+    except ProcessLookupError:
+        return False
+    except PermissionError:
+        return True
+    return True
+
+
+def reconcile(api: Api, workdir: Path) -> None:
+    """Remove expired guests only when a local lease supplies their nonce."""
+    owned = set(api.ours())
+    directory = workdir / "leases"
+    for path in sorted(directory.glob("*.json")):
+        lease = _read_lease(path)
+        if lease is None or _pid_alive(lease.pid):
+            continue
+        if (lease.node, lease.vmid) not in owned:
+            continue
+        guest = Guest(
+            api,
+            lease.node,
+            lease.vmid,
+            GuestSpec(name="expired-lease", iso="", nonce=lease.nonce),
+        )
+        guest.destroy()
+        path.unlink()
+
+
+def revision_identity(driver: Path) -> str:
+    """Git state and exact driver bytes represented by a campaign outcome."""
+
+    def ask(argv: list[str]) -> str:
+        try:
+            result = subprocess.run(
+                argv, cwd=REPOSITORY, capture_output=True, text=True
+            )
+        except OSError:
+            return ""
+        return result.stdout.strip() if result.returncode == 0 else ""
+
+    described = ask(["git", "describe", "--always", "--dirty"]) or "unknown"
+    changed = len(ask(["git", "status", "--short"]).splitlines())
+    return f"{described} dirty={changed} driver-sha256={driver_digest(driver)}"
+
+
+def trusted_revision(identity: str) -> bool:
+    """Whether an outcome identifies a clean tree or an explicit test identity."""
+    dirty = re.search(r"(?:^| )dirty=(\d+)(?: |$)", identity)
+    return bool(identity) and (dirty is None or dirty.group(1) == "0")
+
+
 def free_slots(api: Api, placed: Mapping[str, int] | None = None) -> list[Node]:
     """One entry per guest the cluster can still hold, most free node first.
 
@@ -612,6 +849,8 @@ def install_one(
     workdir: Path,
     inflight: dict[str, Running] | None = None,
     vmid: int = 0,
+    nonce: str = "",
+    revision: str = "",
 ) -> Outcome:
     """Build a guest, install into it, read the result, delete the guest."""
     started = time.monotonic()
@@ -631,16 +870,18 @@ def install_one(
             driver_iso=driver,
             # This run's own mark, so a second campaign that picked the same
             # free VMID cannot delete the guest this one built.
-            nonce=f"gi-{uuid.uuid4().hex[:12]}",
+            nonce=nonce or f"gi-{uuid.uuid4().hex[:12]}",
         ),
     )
+    phase = Phase.CREATE
     watch = Watchdog(log=log, counters=lambda: guest.transferred())
     if inflight is not None:
         inflight[job.name] = Running(guest=guest, watch=watch)
     try:
         guest.create()
         guest.start()
-        log.write_bytes(b"")
+        phase = Phase.BOOT_LIVE
+        log.write_text(f"installer revision: {revision}\n")
         link = Reconnecting.to(guest, log)
         console = link.console
         # Reset with the console attached: termproxy forwards only what arrives
@@ -670,6 +911,7 @@ def install_one(
         # tell a slow mirror from a dead guest.
         # `wait_for`, not `run`: a console dropped mid-install is reopened and
         # listened to again, never handed the command a second time.
+        phase = Phase.INSTALL
         link.wait_for(
             f"{{ sh /mnt/driver/install.sh --config fixtures/{job.fixture.name}; "
             f"echo $? > {RESULT_DIR}/install.rc; }} 2>&1 | tee {RESULT_DIR}/install.txt",
@@ -678,20 +920,59 @@ def install_one(
         files = collect(guest, link, log)
         code = files.get("install.rc", b"").strip()
         if code != b"0":
-            return Outcome(job.name, Verdict.FAIL, time.monotonic() - started,
-                           f"the installer exited {code!r}", log)
+            return Outcome(
+                job.name,
+                Verdict.FAIL,
+                time.monotonic() - started,
+                f"the installer exited {code!r}",
+                log,
+                phase=phase,
+                revision=revision,
+            )
         # The install finishing is half the question. The other half is whether
         # the machine it produced comes up and carries what was asked for, and
         # nothing in the log above can answer that.
+        phase = Phase.BOOT_INSTALLED
         wrong = boot_and_check(guest, link, log, load(job.fixture))
         if wrong:
-            return Outcome(job.name, Verdict.FAIL, time.monotonic() - started, wrong, log)
-        return Outcome(job.name, Verdict.OK, time.monotonic() - started, log=log)
+            return Outcome(
+                job.name,
+                Verdict.FAIL,
+                time.monotonic() - started,
+                wrong,
+                log,
+                phase=phase,
+                revision=revision,
+            )
+        return Outcome(
+            job.name,
+            Verdict.OK,
+            time.monotonic() - started,
+            log=log,
+            phase=phase,
+            revision=revision,
+        )
     except (ConsoleTimeout, ConsoleClosed) as error:
-        verdict = Verdict.STUCK if watch.stuck else Verdict.FAIL
-        return Outcome(job.name, verdict, time.monotonic() - started, str(error)[:300], log)
+        verdict = Verdict.STUCK if watch.stuck else Verdict.ERROR
+        return Outcome(
+            job.name,
+            verdict,
+            time.monotonic() - started,
+            str(error)[:300],
+            log,
+            phase=phase,
+            revision=revision,
+        )
     except (ProxmoxError, ResultError, OSError) as error:
-        return Outcome(job.name, Verdict.ERROR, time.monotonic() - started, str(error)[:300], log)
+        return Outcome(
+            job.name,
+            Verdict.ERROR,
+            time.monotonic() - started,
+            str(error)[:300],
+            log,
+            phase=phase,
+            revision=revision,
+        )
     finally:
         if inflight is not None:
             inflight.pop(job.name, None)
@@ -714,6 +995,9 @@ def answer_once(
     workdir: Path,
     inflight: dict[str, Running],
     vmid: int = 0,
+    nonce: str = "",
+    lease_path: Path | None = None,
+    revision: str = "",
 ) -> None:
     """Run one job and put exactly one outcome on the queue, whatever happens.
 
@@ -723,11 +1007,23 @@ def answer_once(
     with an empty cluster and a job still queued.
     """
     try:
-        outcome = install_one(api, node, job, driver, workdir, inflight, vmid)
-        done.put(replace(outcome, removed=outcome.name not in LEFT_BEHIND))
+        outcome = install_one(
+            api, node, job, driver, workdir, inflight, vmid, nonce, revision
+        )
+        outcome = replace(outcome, removed=outcome.name not in LEFT_BEHIND)
+        if outcome.removed and lease_path is not None:
+            lease_path.unlink(missing_ok=True)
+        done.put(outcome)
     except BaseException as error:
         done.put(
-            Outcome(job.name, Verdict.ERROR, 0.0, f"{type(error).__name__}: {error}"[:300])
+            Outcome(
+                job.name,
+                Verdict.ERROR,
+                0.0,
+                f"{type(error).__name__}: {error}"[:300],
+                removed=False,
+                revision=revision,
+            )
         )
 
 
@@ -743,16 +1039,19 @@ def run(
 
     `limit` caps how many run at once; zero asks the cluster what fits.
     """
+    workdir = confined(workdir)
     api = Api()
     workdir.mkdir(parents=True, exist_ok=True)
+    reconcile(api, workdir)
     # Packed: the ingress refuses the 1.4 MiB loose-file CD with `413`.
     driver_path = build_driver(
         workdir / "driver.iso",
         packed=True,
         fixtures=rewrite_fixtures(jobs, workdir / "fixtures", region, sync),
     )
-    driver = f"gi-driver-{stamp}.iso"
-    medium, urls = current_minimal()
+    revision = revision_identity(driver_path)
+    driver = remote_name(driver_path)
+    medium, urls, medium_sha512 = current_minimal(workdir)
     prepared: set[str] = set()
     done: queue.Queue[Outcome] = queue.Queue()
     waiting = list(jobs)
@@ -768,12 +1067,35 @@ def run(
     handed: set[int] = set()
     placed: Counter[str] = Counter()
     swept = time.monotonic()
+    capacity_since: float | None = None
 
     try:
         while waiting or running:
             slots = free_slots(api, placed)
             if limit:
                 slots = slots[: max(0, limit - len(running))]
+            if waiting and not running and not slots:
+                now = time.monotonic()
+                if capacity_since is None:
+                    capacity_since = now
+                waited = now - capacity_since
+                if waited >= CAPACITY_PATIENCE:
+                    for job in waiting:
+                        finished.append(
+                            Outcome(
+                                job.name,
+                                Verdict.ERROR,
+                                waited,
+                                f"the cluster had no capacity for {waited:.0f}s",
+                                phase=Phase.SCHEDULE,
+                                revision=revision,
+                            )
+                        )
+                    waiting.clear()
+                    break
+                time.sleep(min(POLL_WHILE_QUEUED, CAPACITY_PATIENCE - waited))
+                continue
+            capacity_since = None
             while waiting and slots:
                 # The first job this node has room for, not the first job:
                 # a heavy guest wants twice the memory, and taking it from a
@@ -787,7 +1109,16 @@ def run(
                     break
                 node = slots.pop(0)
                 if node.name not in prepared:
-                    prepare(api, node.name, medium, urls, driver_path, driver)
+                    prepare(
+                        api,
+                        node.name,
+                        medium,
+                        urls,
+                        medium_sha512,
+                        workdir / "medium-trust",
+                        driver_path,
+                        driver,
+                    )
                     prepared.add(node.name)
                 job = waiting.pop(index)
                 # Two light slots for a heavy guest, so the arithmetic below
@@ -798,9 +1129,25 @@ def run(
                     job = replace(job, iso=medium)
                 vmid = api.free_vmid(frozenset(handed))
                 handed.add(vmid)
+                nonce = f"gi-{uuid.uuid4().hex[:12]}"
+                lease = _write_lease(
+                    workdir, Lease(node.name, vmid, nonce, os.getpid())
+                )
                 thread = threading.Thread(
                     target=answer_once,
-                    args=(done, api, node.name, job, driver, workdir, inflight, vmid),
+                    args=(
+                        done,
+                        api,
+                        node.name,
+                        job,
+                        driver,
+                        workdir,
+                        inflight,
+                        vmid,
+                        nonce,
+                        lease,
+                        revision,
+                    ),
                     daemon=True,
                 )
                 running[job.name] = thread
@@ -832,6 +1179,7 @@ def run(
                             0.0,
                             "the worker ended without reporting",
                             removed=False,
+                            revision=revision,
                         )
                     )
                 continue
@@ -1242,7 +1590,13 @@ def fixtures(names: list[str]) -> list[Job]:
 def main(argv: list[str] | None = None) -> int:
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("fixtures", nargs="+", help="fixture names, without .toml")
-    parser.add_argument("--limit", type=int, default=0, help="how many guests at once")
+    def nonnegative(value: str) -> int:
+        limit = int(value)
+        if limit < 0:
+            raise argparse.ArgumentTypeError("--limit cannot be negative")
+        return limit
+
+    parser.add_argument("--limit", type=nonnegative, default=0, help="how many guests at once")
     parser.add_argument("--workdir", type=Path, default=WORKROOT)
     parser.add_argument(
         "--region",
@@ -1258,6 +1612,12 @@ def main(argv: list[str] | None = None) -> int:
     )
     args = parser.parse_args(argv)
 
+    try:
+        workdir = confined(args.workdir)
+    except WorkdirError as error:
+        print(error, file=sys.stderr)
+        return 1
+
     repeated = sorted({one for one in args.fixtures if args.fixtures.count(one) > 1})
     if repeated:
         # Refused rather than deduplicated: every map below is keyed by name,
@@ -1270,16 +1630,20 @@ def main(argv: list[str] | None = None) -> int:
     jobs = fixtures(args.fixtures)
     outcomes = run(
         jobs,
-        args.workdir,
+        workdir,
         args.limit,
         int(time.time()),
         MirrorRegion(args.region),
         Sync(args.sync),
     )
-    passed = [one for one in outcomes if one.verdict is Verdict.OK]
+    passed = [
+        one
+        for one in outcomes
+        if one.verdict is Verdict.OK and trusted_revision(one.revision)
+    ]
     print(f"\n{len(passed)}/{len(jobs)} passed")
     for one in outcomes:
-        if one.verdict is not Verdict.OK:
+        if one.verdict is not Verdict.OK or not trusted_revision(one.revision):
             print(f"  {one.verdict.value} {one.name}: {one.detail} ({one.log})")
     # Against what was asked for, not against what came back: a worker that
     # died without answering left its job with no outcome at all, and a run

--- a/tests/vm/driver.py
+++ b/tests/vm/driver.py
@@ -9,6 +9,8 @@ from __future__ import annotations
 
 import shutil
 import subprocess
+import tempfile
+import hashlib
 from pathlib import Path
 
 from .media import MediaError
@@ -62,51 +64,66 @@ def build(output: Path, packed: bool = False, fixtures: Path | None = None) -> P
     """
     if shutil.which("xorriso") is None:
         raise MediaError("xorriso is not installed, so the driver CD cannot be built")
-    staging = output.parent / "driver"
-    if staging.exists():
-        shutil.rmtree(staging)
-    staging.mkdir(parents=True)
-    shutil.copytree(
-        REPOSITORY / "gentoo_install",
-        staging / "gentoo_install",
-        ignore=shutil.ignore_patterns("__pycache__", "*.pyc"),
-    )
-    shutil.copytree(fixtures or REPOSITORY / "tests" / "fixtures", staging / "fixtures")
-    # The launcher is what an operator runs, so the CD carries the same one.
-    shutil.copy2(REPOSITORY / "bootstrap.sh", staging / "bootstrap.sh")
-    entry = staging / "install.sh"
-    entry.write_text(ENTRY)
-    entry.chmod(0o755)
+    output.parent.mkdir(parents=True, exist_ok=True)
+    scratch = Path(tempfile.mkdtemp(prefix=".driver-", dir=output.parent))
+    source = scratch / "source"
+    image = source
+    try:
+        shutil.copytree(
+            REPOSITORY / "gentoo_install",
+            source / "gentoo_install",
+            ignore=shutil.ignore_patterns("__pycache__", "*.pyc"),
+        )
+        shutil.copytree(fixtures or REPOSITORY / "tests" / "fixtures", source / "fixtures")
+        # The launcher is what an operator runs, so the CD carries the same one.
+        shutil.copy2(REPOSITORY / "bootstrap.sh", source / "bootstrap.sh")
+        entry = source / "install.sh"
+        entry.write_text(ENTRY)
+        entry.chmod(0o755)
 
-    if packed:
-        payload = output.parent / PAYLOAD
-        packing = subprocess.run(
-            ["tar", "czf", str(payload), "-C", str(staging), "."],
+        if packed:
+            image = scratch / "image"
+            image.mkdir()
+            payload = image / PAYLOAD
+            packing = subprocess.run(
+                ["tar", "czf", str(payload), "-C", str(source), "."],
+                capture_output=True,
+                text=True,
+            )
+            if packing.returncode != 0:
+                raise MediaError(f"the driver payload was not packed: {packing.stderr.strip()}")
+            entry = image / "install.sh"
+            entry.write_text(PACKED_ENTRY)
+            entry.chmod(0o755)
+
+        output.unlink(missing_ok=True)
+        result = subprocess.run(
+            [
+                "xorriso", "-as", "mkisofs",
+                "-volid", LABEL,
+                "-output", str(output),
+                "-quiet",
+                str(image),
+            ],
             capture_output=True,
             text=True,
         )
-        if packing.returncode != 0:
-            raise MediaError(f"the driver payload was not packed: {packing.stderr.strip()}")
-        shutil.rmtree(staging)
-        staging.mkdir(parents=True)
-        shutil.move(str(payload), staging / PAYLOAD)
-        entry = staging / "install.sh"
-        entry.write_text(PACKED_ENTRY)
-        entry.chmod(0o755)
+        if result.returncode != 0:
+            raise MediaError(f"xorriso failed: {result.stderr.strip()}")
+        return output
+    finally:
+        shutil.rmtree(scratch)
 
-    output.unlink(missing_ok=True)
-    result = subprocess.run(
-        [
-            "xorriso", "-as", "mkisofs",
-            "-volid", LABEL,
-            "-output", str(output),
-            "-quiet",
-            str(staging),
-        ],
-        capture_output=True,
-        text=True,
-    )
-    if result.returncode != 0:
-        raise MediaError(f"xorriso failed: {result.stderr.strip()}")
-    shutil.rmtree(staging)
-    return output
+
+def digest(path: Path) -> str:
+    """SHA-256 identity of a completed driver image."""
+    reader = hashlib.sha256()
+    with path.open("rb") as handle:
+        for block in iter(lambda: handle.read(1 << 20), b""):
+            reader.update(block)
+    return reader.hexdigest()
+
+
+def remote_name(path: Path) -> str:
+    """Content-addressed name used on node-local ISO storage."""
+    return f"gi-driver-{digest(path)[:20]}.iso"

--- a/tests/vm/netcheck.py
+++ b/tests/vm/netcheck.py
@@ -29,6 +29,7 @@ from typing import Final
 
 from .console import SerialConsole
 from .driver import build as build_driver
+from .workdir import WorkdirError, confined
 from .media import MEDIA
 from .qemu import Firmware, Vm, VmSpec
 
@@ -129,6 +130,7 @@ def _check(console: SerialConsole, families: str, driver: str) -> Result:
 
 
 def run(families: str, workdir: Path) -> Result:
+    workdir = confined(workdir)
     workdir.mkdir(parents=True, exist_ok=True)
     medium = MEDIA["official-minimal"]
     driver_iso = build_driver(workdir / "driver.iso", packed=True)
@@ -158,12 +160,18 @@ def main(argv: list[str] | None = None) -> int:
     parser.add_argument("--workdir", type=Path, default=WORKROOT)
     args = parser.parse_args(argv)
 
+    try:
+        workdir = confined(args.workdir)
+    except WorkdirError as error:
+        print(error, file=sys.stderr)
+        return 1
+
     wanted = args.families or sorted(EXPECTED)
     results: list[Result] = []
     for families in wanted:
         started = time.monotonic()
         print(f"→ {families}", flush=True)
-        found = run(families, args.workdir)
+        found = run(families, workdir)
         results.append(found)
         mark = "ok  " if found.good else "FAIL"
         print(f"{mark} {families:5} {(time.monotonic() - started) / 60:4.1f}m", flush=True)

--- a/tests/vm/proxmox.py
+++ b/tests/vm/proxmox.py
@@ -68,10 +68,43 @@ ISO_STORAGE: Final[str] = "local"
 #: Long enough for a stage3 to extract over a slow mirror, short enough that a
 #: node that stopped answering does not hold the whole campaign.
 API_TIMEOUT: Final[float] = 60.0
+TASK_POLL: Final[float] = 2.0
+CLEANUP_PAUSE: Final[float] = 2.0
+CLEANUP_PATIENCE: Final[float] = 300.0
 
 
 class ProxmoxError(Exception):
     """The cluster refused a call, or a task it accepted did not finish."""
+
+
+class ProxmoxNotFound(ProxmoxError):
+    """The requested cluster object no longer exists."""
+
+
+class CreateConflict(ProxmoxError):
+    """A VMID became occupied before this guest was created."""
+
+
+class _RejectRedirect(urllib.request.HTTPRedirectHandler):
+    """API credentials never follow an HTTP redirect."""
+
+    def redirect_request(
+        self,
+        req: urllib.request.Request,
+        fp: Any,
+        code: int,
+        msg: str,
+        headers: Any,
+        newurl: str,
+    ) -> None:
+        return None
+
+
+def _transient(error: ProxmoxError) -> bool:
+    said = str(error).lower()
+    return "did not answer" in said or any(
+        f"answered {code}" in said for code in (429, 500, 502, 503, 504)
+    )
 
 
 def _certificates() -> ssl.SSLContext:
@@ -105,6 +138,9 @@ class Api:
     def __init__(self, host: str = HOST) -> None:
         self.host = host
         self._context = _certificates()
+        self._opener = urllib.request.build_opener(
+            urllib.request.HTTPSHandler(context=self._context), _RejectRedirect()
+        )
         #: The cluster sits behind a load balancer that spreads requests over
         #: every node. A `termproxy` ticket is valid on the node that issued
         #: it, so a websocket landing anywhere else is answered `502 Bad
@@ -112,12 +148,19 @@ class Api:
         #: halves to one backend.
         self.affinity: str = ""
 
-    def _remember(self, headers: Any) -> None:
+    def _remember(self, headers: Any) -> str:
         for name, value in headers.items():
             if name.lower() == "set-cookie" and value.startswith("INGRESSCOOKIE="):
-                self.affinity = value.split(";", 1)[0]
+                return str(value).split(";", 1)[0]
+        return ""
 
     def call(self, method: str, path: str, **form: Any) -> Any:
+        data, affinity = self.call_with_affinity(method, path, **form)
+        if affinity:
+            self.affinity = affinity
+        return data
+
+    def call_with_affinity(self, method: str, path: str, **form: Any) -> tuple[Any, str]:
         # A body on DELETE is answered `501 Unexpected content for method`, so
         # the two methods that take no body carry their parameters in the URL.
         body: bytes | None = None
@@ -130,19 +173,19 @@ class Api:
             f"https://{self.host}/api2/json{path}", data=body, method=method
         )
         request.add_header("Authorization", f"PVEAPIToken={TOKEN_ID}={_secret()}")
-        if self.affinity:
-            request.add_header("Cookie", self.affinity)
+        affinity = self.affinity
+        if affinity:
+            request.add_header("Cookie", affinity)
         try:
-            with urllib.request.urlopen(
-                request, timeout=API_TIMEOUT, context=self._context
-            ) as answer:
-                self._remember(answer.headers)
-                return json.load(answer).get("data")
+            with self._opener.open(request, timeout=API_TIMEOUT) as answer:
+                remembered = self._remember(answer.headers)
+                return json.load(answer).get("data"), remembered or affinity
         except urllib.error.HTTPError as error:
             # The reason, not only the body: Proxmox answers `500` with
             # `{"data":null}` and puts what went wrong in the status line.
             said = error.read().decode("utf-8", "replace").strip()[:300]
-            raise ProxmoxError(
+            exception = ProxmoxNotFound if error.code == 404 else ProxmoxError
+            raise exception(
                 f"{method} {path} answered {error.code} {error.reason}: {said}"
             ) from error
         except (urllib.error.URLError, TimeoutError, OSError) as error:
@@ -162,13 +205,19 @@ class Api:
         quoted = urllib.parse.quote(upid, safe="")
         deadline = time.monotonic() + patience
         while time.monotonic() < deadline:
-            status = self.call("GET", f"/nodes/{node}/tasks/{quoted}/status")
+            try:
+                status = self.call("GET", f"/nodes/{node}/tasks/{quoted}/status")
+            except ProxmoxError as error:
+                if not _transient(error):
+                    raise
+                time.sleep(min(TASK_POLL, max(0.0, deadline - time.monotonic())))
+                continue
             if status.get("status") == "stopped":
                 exit_status = status.get("exitstatus", "")
                 if exit_status != "OK":
                     raise ProxmoxError(f"{upid} ended with {exit_status!r}")
                 return
-            time.sleep(2.0)
+            time.sleep(min(TASK_POLL, max(0.0, deadline - time.monotonic())))
         raise ProxmoxError(f"{upid} did not finish within {patience:.0f}s")
 
     def nodes(self) -> list[Node]:
@@ -244,9 +293,7 @@ class Api:
         if self.affinity:
             request.add_header("Cookie", self.affinity)
         try:
-            with urllib.request.urlopen(
-                request, timeout=600.0, context=self._context
-            ) as answer:
+            with self._opener.open(request, timeout=600.0) as answer:
                 upid = json.load(answer).get("data")
         except urllib.error.HTTPError as error:
             said = error.read().decode("utf-8", "replace").strip()[:300]
@@ -273,7 +320,7 @@ class Api:
             return str(error)
         return ""
 
-    def fetch_iso(self, node: str, url: str, filename: str) -> None:
+    def fetch_iso(self, node: str, url: str, filename: str, sha512: str) -> None:
         """Have the node download an install medium itself.
 
         The cluster is in China and the workstation is not, so the node reaches
@@ -288,6 +335,8 @@ class Api:
             url=url,
             filename=filename,
             content="iso",
+            checksum=sha512,
+            **{"checksum-algorithm": "sha512"},
         )
         self.wait(node, upid, patience=3600.0)
 
@@ -323,6 +372,7 @@ class Guest:
     vmid: int
     spec: GuestSpec
     _booted: bool = field(default=False, init=False)
+    _create_conflict: bool = field(default=False, init=False)
 
     def create(self) -> None:
         options: dict[str, Any] = {
@@ -379,6 +429,9 @@ class Guest:
                 )
                 return
             except ProxmoxError as error:
+                if "already exists" in str(error).lower():
+                    self._create_conflict = True
+                    raise CreateConflict(str(error)) from error
                 if "lock request timeout" not in str(error):
                     raise
                 last = error
@@ -387,10 +440,9 @@ class Guest:
         raise last
 
     def start(self) -> None:
-        self.api.wait(
-            self.node, self.api.call("POST", f"/nodes/{self.node}/qemu/{self.vmid}/status/start")
-        )
+        upid = self.api.call("POST", f"/nodes/{self.node}/qemu/{self.vmid}/status/start")
         self._booted = True
+        self.api.wait(self.node, upid)
 
     def boot_from_disk(self) -> None:
         """Point the firmware at the installed disk and forget the medium.
@@ -420,7 +472,7 @@ class Guest:
             self.node, self.api.call("POST", f"/nodes/{self.node}/qemu/{self.vmid}/status/reset")
         )
 
-    def transferred(self) -> int:
+    def transferred(self) -> int | None:
         """Bytes this guest has received and written since it started.
 
         What the watchdog reads when the console is silent: an install
@@ -432,7 +484,7 @@ class Guest:
         except ProxmoxError:
             # One unanswered request is not evidence about the guest, and a
             # watchdog that raises here stops the whole schedule.
-            return 0
+            return None
         return int(status.get("netin", 0)) + int(status.get("diskwrite", 0))
 
     def running(self) -> bool:
@@ -480,27 +532,36 @@ class Guest:
             time.sleep(self.KEY_PAUSE)
 
     def stop(self) -> None:
-        if not self._booted:
-            return
         try:
+            status = self.api.call(
+                "GET", f"/nodes/{self.node}/qemu/{self.vmid}/status/current"
+            )
+            if str(status.get("status")) != "running":
+                self._booted = False
+                return
             self.api.wait(
                 self.node,
                 self.api.call("POST", f"/nodes/{self.node}/qemu/{self.vmid}/status/stop"),
                 patience=180.0,
             )
+        except ProxmoxNotFound:
+            self._booted = False
+            return
         except ProxmoxError:
             # Already down, or the task record expired. Either way `destroy`
             # is what has to happen next, and it must not be skipped.
             pass
         self._booted = False
 
-    def destroy(self) -> None:
+    def destroy(self, patience: float = CLEANUP_PATIENCE) -> None:
         """Remove the machine and its disks.
 
         The tag is checked first. This token administers a cluster running
         other people's work, and a VMID is not proof of ownership: the range
         this harness allocates from already held a production template.
         """
+        if self._create_conflict:
+            return
         if not VMID_FIRST <= self.vmid <= VMID_LAST:
             # The tag is ours to write, so a machine outside the range that
             # carries it is not evidence: the range is the second guard, and
@@ -508,32 +569,48 @@ class Guest:
             raise ProxmoxError(
                 f"vm {self.vmid} is outside {VMID_FIRST}-{VMID_LAST}; refusing to remove it"
             )
-        config = self.api.call("GET", f"/nodes/{self.node}/qemu/{self.vmid}/config")
-        tags = str(config.get("tags", "")).split(";")
-        if TAG not in tags:
-            raise ProxmoxError(
-                f"vm {self.vmid} on {self.node} is not tagged {TAG!r}; refusing to remove it"
-            )
-        if self.spec.nonce and self.spec.nonce not in tags:
-            # Somebody else's guest at the VMID this one wanted: two campaigns
-            # asking the cluster in the same second both read it as free.
-            raise ProxmoxError(
-                f"vm {self.vmid} on {self.node} is not the guest this run built; "
-                "refusing to remove it"
-            )
-        self.stop()
-        try:
-            self.api.wait(
-                self.node,
-                self.api.call(
-                    "DELETE",
-                    f"/nodes/{self.node}/qemu/{self.vmid}",
-                    **{"destroy-unreferenced-disks": 1, "purge": 1},
-                ),
-                patience=300.0,
-            )
-        except ProxmoxError as error:
-            raise ProxmoxError(f"vm {self.vmid} on {self.node} was not removed: {error}") from error
+        deadline = time.monotonic() + patience
+        last = "the guest still exists"
+        while time.monotonic() <= deadline:
+            try:
+                config = self.api.call(
+                    "GET", f"/nodes/{self.node}/qemu/{self.vmid}/config"
+                )
+            except ProxmoxNotFound:
+                return
+            except ProxmoxError as error:
+                last = str(error)
+                if not _transient(error):
+                    raise
+                time.sleep(min(CLEANUP_PAUSE, max(0.0, deadline - time.monotonic())))
+                continue
+            tags = str(config.get("tags", "")).split(";")
+            if TAG not in tags:
+                raise ProxmoxError(
+                    f"vm {self.vmid} on {self.node} is not tagged {TAG!r}; refusing to remove it"
+                )
+            if not self.spec.nonce or self.spec.nonce not in tags:
+                raise ProxmoxError(
+                    f"vm {self.vmid} on {self.node} is not the guest this run built; "
+                    "refusing to remove it"
+                )
+            try:
+                self.stop()
+                self.api.wait(
+                    self.node,
+                    self.api.call(
+                        "DELETE",
+                        f"/nodes/{self.node}/qemu/{self.vmid}",
+                        **{"destroy-unreferenced-disks": 1, "purge": 1},
+                    ),
+                    patience=max(0.0, deadline - time.monotonic()),
+                )
+            except ProxmoxNotFound:
+                return
+            except ProxmoxError as error:
+                last = str(error)
+            time.sleep(min(CLEANUP_PAUSE, max(0.0, deadline - time.monotonic())))
+        raise ProxmoxError(f"vm {self.vmid} on {self.node} was not removed: {last}")
 
 
 class ConsoleChannel:
@@ -567,7 +644,9 @@ class ConsoleChannel:
         last = ""
         for attempt in range(tries):
             try:
-                ticket = api.call("POST", f"/nodes/{node}/qemu/{vmid}/termproxy")
+                ticket, affinity = api.call_with_affinity(
+                    "POST", f"/nodes/{node}/qemu/{vmid}/termproxy"
+                )
             except ProxmoxError as error:
                 last = str(error)
                 api.affinity = ""
@@ -579,8 +658,8 @@ class ConsoleChannel:
                 f"&vncticket={urllib.parse.quote(ticket['ticket'], safe='')}"
             )
             headers = {"Authorization": f"PVEAPIToken={TOKEN_ID}={_secret()}"}
-            if api.affinity:
-                headers["Cookie"] = api.affinity
+            if affinity:
+                headers["Cookie"] = affinity
             try:
                 socket = WebSocket.connect(
                     api.host, path, headers, port=PORT, context=_certificates()

--- a/tests/vm/tui.py
+++ b/tests/vm/tui.py
@@ -26,6 +26,7 @@ from .console import SerialConsole
 from .driver import build as build_driver
 from .media import MEDIA
 from .qemu import Firmware, Vm, VmSpec
+from .workdir import WorkdirError, confined
 
 WORKROOT: Final[Path] = Path.home() / "code/gentoo-install/lab/vm/tui"
 
@@ -137,7 +138,16 @@ def main(argv: list[str] | None = None) -> int:
     parser.add_argument("--keep", action="store_true", help="keep the run directory")
     args = parser.parse_args(argv)
 
-    workdir = args.workdir / f"{args.medium}-{args.lang}"
+    try:
+        root = confined(args.workdir)
+    except WorkdirError as error:
+        print(error, file=sys.stderr)
+        return 1
+    try:
+        workdir = confined(root / f"{args.medium}-{args.lang}")
+    except WorkdirError as error:
+        print(error, file=sys.stderr)
+        return 1
     workdir.mkdir(parents=True, exist_ok=True)
     medium = MEDIA[args.medium]
     driver_iso = build_driver(workdir / "driver.iso", packed=True)

--- a/tests/vm/websocket.py
+++ b/tests/vm/websocket.py
@@ -11,6 +11,7 @@ close. No extensions, no fragmentation of what is sent.
 from __future__ import annotations
 
 import base64
+import hashlib
 import os
 import socket
 import ssl
@@ -18,13 +19,17 @@ import struct
 from types import TracebackType
 from typing import Final, Protocol, Self
 
-#: Continuation and reserved opcodes never appear here: the server sends one
-#: frame per write, and this client sends one frame per call.
+_CONTINUATION: Final[int] = 0x0
 _TEXT: Final[int] = 0x1
 _BINARY: Final[int] = 0x2
 _CLOSE: Final[int] = 0x8
 _PING: Final[int] = 0x9
 _PONG: Final[int] = 0xA
+
+HANDSHAKE_LIMIT: Final[int] = 16 * 1024
+FRAME_LIMIT: Final[int] = 1024 * 1024
+MESSAGE_LIMIT: Final[int] = 4 * FRAME_LIMIT
+_ACCEPT_GUID: Final[bytes] = b"258EAFA5-E914-47DA-95CA-C5AB0DC85B11"
 
 
 class WebSocketError(Exception):
@@ -80,6 +85,8 @@ class WebSocket:
         self._sock = sock
         self._buffer = bytearray()
         self._closed = False
+        self._fragment_opcode: int | None = None
+        self._fragment = bytearray()
         #: Why it closed, for the reader that reports a dropped console.
         self._why = ""
 
@@ -94,37 +101,74 @@ class WebSocket:
         context: ssl.SSLContext | None = None,
         timeout: float = 30.0,
     ) -> Self:
-        raw = socket.create_connection((host, port), timeout=timeout)
-        secure = (context or ssl.create_default_context()).wrap_socket(
-            raw, server_hostname=host
-        )
-        lines = [
-            f"GET {path} HTTP/1.1",
-            f"Host: {host}",
-            "Upgrade: websocket",
-            "Connection: Upgrade",
-            f"Sec-WebSocket-Key: {base64.b64encode(os.urandom(16)).decode()}",
-            "Sec-WebSocket-Version: 13",
-            "Sec-WebSocket-Protocol: binary",
-            *(f"{name}: {value}" for name, value in headers.items()),
-        ]
-        secure.sendall(("\r\n".join(lines) + "\r\n\r\n").encode())
-        head = b""
-        while b"\r\n\r\n" not in head:
-            chunk = secure.recv(4096)
-            if not chunk:
+        raw: socket.socket | None = None
+        secure: ssl.SSLSocket | None = None
+        try:
+            raw = socket.create_connection((host, port), timeout=timeout)
+            secure = (context or ssl.create_default_context()).wrap_socket(
+                raw, server_hostname=host
+            )
+            key = base64.b64encode(os.urandom(16)).decode()
+            lines = [
+                f"GET {path} HTTP/1.1",
+                f"Host: {host}",
+                "Upgrade: websocket",
+                "Connection: Upgrade",
+                f"Sec-WebSocket-Key: {key}",
+                "Sec-WebSocket-Version: 13",
+                "Sec-WebSocket-Protocol: binary",
+                *(f"{name}: {value}" for name, value in headers.items()),
+            ]
+            secure.sendall(("\r\n".join(lines) + "\r\n\r\n").encode())
+            head = b""
+            while b"\r\n\r\n" not in head:
+                chunk = secure.recv(4096)
+                if not chunk:
+                    raise WebSocketError(f"the handshake closed early: {head[:200]!r}")
+                head += chunk
+                if len(head) > HANDSHAKE_LIMIT:
+                    raise WebSocketError("the websocket handshake headers are too large")
+            header, payload = head.split(b"\r\n\r\n", 1)
+            rows = header.split(b"\r\n")
+            status = rows[0].decode("utf-8", "replace")
+            fields = status.split(" ", 2)
+            if len(fields) < 2 or fields[0] != "HTTP/1.1" or fields[1] != "101":
+                raise WebSocketError(f"the server refused the upgrade: {status}")
+            response: dict[str, str] = {}
+            for row in rows[1:]:
+                if b":" not in row:
+                    raise WebSocketError("the websocket handshake has a malformed header")
+                name, value = row.split(b":", 1)
+                response[name.decode("ascii", "replace").lower()] = value.decode(
+                    "ascii", "replace"
+                ).strip()
+            expected = base64.b64encode(
+                hashlib.sha1(key.encode() + _ACCEPT_GUID).digest()
+            ).decode()
+            connection = {
+                one.strip().lower() for one in response.get("connection", "").split(",")
+            }
+            if response.get("upgrade", "").lower() != "websocket" or "upgrade" not in connection:
+                raise WebSocketError("the websocket upgrade headers are missing")
+            if response.get("sec-websocket-accept") != expected:
+                raise WebSocketError("the websocket accept value does not match the request")
+            if response.get("sec-websocket-protocol") != "binary":
+                raise WebSocketError("the websocket server did not select the binary protocol")
+            client = cls(secure)
+            client._buffer += payload
+            return client
+        except WebSocketError:
+            if secure is not None:
                 secure.close()
-                raise WebSocketError(f"the handshake closed early: {head[:200]!r}")
-            head += chunk
-        status = head.split(b"\r\n", 1)[0].decode("utf-8", "replace")
-        if "101" not in status:
-            secure.close()
-            raise WebSocketError(f"the server refused the upgrade: {status}")
-        client = cls(secure)
-        # A server may put the first payload in the same packet as the
-        # handshake, and dropping it loses the console's opening line.
-        client._buffer += head.split(b"\r\n\r\n", 1)[1]
-        return client
+            elif raw is not None:
+                raw.close()
+            raise
+        except OSError as error:
+            if secure is not None:
+                secure.close()
+            elif raw is not None:
+                raw.close()
+            raise WebSocketError(f"the websocket did not connect: {error}") from error
 
     def settimeout(self, seconds: float | None) -> None:
         self._sock.settimeout(seconds)
@@ -183,21 +227,47 @@ class WebSocket:
             frame = self._one()
             if frame is None:
                 return bytes(out)
-            opcode, payload = frame
+            final, opcode, payload = frame
             if opcode in (_TEXT, _BINARY):
-                out += payload
+                if self._fragment_opcode is not None:
+                    self._protocol_error("a new message started before the fragmented one ended")
+                if final:
+                    out += payload
+                else:
+                    self._fragment_opcode = opcode
+                    self._fragment += payload
+            elif opcode == _CONTINUATION:
+                if self._fragment_opcode is None:
+                    self._protocol_error("a continuation arrived without a fragmented message")
+                self._fragment += payload
+                if len(self._fragment) > MESSAGE_LIMIT:
+                    self._protocol_error("the fragmented websocket message is too large")
+                if final:
+                    out += self._fragment
+                    self._fragment.clear()
+                    self._fragment_opcode = None
             elif opcode == _PING:
                 self.send(payload, _PONG)
             elif opcode == _CLOSE:
+                self.send(payload, _CLOSE)
                 self._closed = True
+                self._sock.close()
                 return bytes(out)
 
-    def _one(self) -> tuple[int, bytes] | None:
+    def _one(self) -> tuple[bool, int, bytes] | None:
         """One frame out of the buffer, or None while it is still short."""
         if len(self._buffer) < 2:
             return None
-        opcode = self._buffer[0] & 0x0F
+        first = self._buffer[0]
+        final = bool(first & 0x80)
+        if first & 0x70:
+            self._protocol_error("the server set a reserved websocket bit")
+        opcode = first & 0x0F
+        if opcode not in (_CONTINUATION, _TEXT, _BINARY, _CLOSE, _PING, _PONG):
+            self._protocol_error(f"the server sent unknown websocket opcode {opcode}")
         second = self._buffer[1]
+        if second & 0x80:
+            self._protocol_error("the server sent a masked websocket frame")
         size = second & 0x7F
         at = 2
         if size == 126:
@@ -210,19 +280,21 @@ class WebSocket:
                 return None
             size = struct.unpack("!Q", self._buffer[2:10])[0]
             at = 10
-        mask = b""
-        if second & 0x80:
-            if len(self._buffer) < at + 4:
-                return None
-            mask = bytes(self._buffer[at : at + 4])
-            at += 4
+        if size > FRAME_LIMIT:
+            self._protocol_error(f"the websocket frame declares {size} bytes")
+        if opcode >= _CLOSE and (not final or size > 125):
+            self._protocol_error("the server sent an invalid websocket control frame")
         if len(self._buffer) < at + size:
             return None
         payload = bytes(self._buffer[at : at + size])
         del self._buffer[: at + size]
-        if mask:
-            payload = bytes(byte ^ mask[n % 4] for n, byte in enumerate(payload))
-        return opcode, payload
+        return final, opcode, payload
+
+    def _protocol_error(self, why: str) -> None:
+        self.send(struct.pack("!H", 1002), _CLOSE)
+        self._closed = True
+        self._sock.close()
+        raise WebSocketError(why)
 
     def close(self) -> None:
         if not self._closed:

--- a/tests/vm/workdir.py
+++ b/tests/vm/workdir.py
@@ -1,0 +1,20 @@
+"""Confinement for VM harness artifacts."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Final
+
+LAB_ROOT: Final[Path] = Path.home() / "code/gentoo-install/lab"
+
+
+class WorkdirError(ValueError):
+    """A requested work directory resolves outside the VM lab."""
+
+
+def confined(path: Path) -> Path:
+    root = LAB_ROOT.resolve()
+    resolved = path.resolve()
+    if resolved == root or not resolved.is_relative_to(root):
+        raise WorkdirError(f"{path} resolves outside {root}")
+    return resolved


### PR DESCRIPTION
Sixteen findings from an independent review of `tests/vm/`, each with a test that fails without it.

The safety-critical ones: cleanup proves ownership on every attempt rather than once, a create that failed with a conflict skips cleanup entirely so a worker cannot delete the guest whose VMID it wanted, and leases carrying the run's nonce survive a restart so an abandoned guest is reconciled instead of left running. An authenticated request now refuses a redirect, which could otherwise carry the `Authorization` header to another origin, and the boot ISO is checked against Gentoo's signed DIGESTS with the pinned release key.

The websocket completes its close handshake, verifies `Sec-WebSocket-Accept` against the key it sent, keeps fragment state across interleaved control frames, and bounds every declared length before buffering. Work directories are resolved under the lab root before any `mkdir`, `unlink` or `rmtree`.

Verified here rather than on the agent's word: mypy and the suite pass, and inverting the accept comparison fails its own test. One `FakeGuest` needed a `vmid` after #90 landed while the agent was running.