### PR TITLE
exec: let an absent command answer when failure is an answer

### DIFF
--- a/gentoo_install/exec/runner.py
+++ b/gentoo_install/exec/runner.py
@@ -72,7 +72,20 @@ class Runner:
         try:
             output, returncode = self._stream(full, input_text, timeout)
         except FileNotFoundError as error:
-            raise CommandFailed(f"{full[0]} is not installed") from error
+            if check:
+                raise CommandFailed(f"{full[0]} is not installed") from error
+            # `check=False` says a failure is an answer, and a medium without
+            # the command is one of the answers: the Arch live image carries
+            # no `zpool`, and asking whether a disk belongs to a pool stopped
+            # an install that used no ZFS at all.
+            self.log(f"| {full[0]} is not installed")
+            return Result(
+                argv=full,
+                returncode=127,
+                stdout=f"{full[0]} is not installed",
+                stderr="",
+                seconds=time.monotonic() - started,
+            )
         result = Result(
             argv=full,
             returncode=returncode,

--- a/tests/unit/test_exec.py
+++ b/tests/unit/test_exec.py
@@ -1561,3 +1561,26 @@ def test_a_probed_array_reaches_the_rule_that_refuses_it(tmp_path: Path) -> None
         before, _probe_answering(tmp_path, MDADM_EXPORT.replace("1.2", "1.0"), 0)
     )
     assert compat.Trait.ESP_MDRAID_SUPERBLOCK_AT_START not in compat.traits_of(older)
+
+
+def test_a_command_that_is_not_installed_answers_when_failure_is_an_answer() -> None:
+    """`check=False` says a failure is an answer, and a medium without the
+    command is one of them. `zpool` is absent on the Arch live image, and
+    asking whether a disk belongs to an imported pool stopped an install that
+    used no ZFS at all: `command: zpool is not installed`, exit 4, before a
+    single partition was written.
+    """
+    from gentoo_install.errors import CommandFailed
+    from gentoo_install.exec.runner import Runner
+
+    said: list[str] = []
+    runner = Runner(log=said.append)
+
+    answer = runner.run(["definitely-not-a-command-here"], check=False)
+    assert answer.returncode == 127, answer
+    assert "not installed" in answer.stdout
+
+    # With `check=True` it is still a fault: a command the install needs and
+    # cannot find has to stop the run.
+    with pytest.raises(CommandFailed, match="not installed"):
+        runner.run(["definitely-not-a-command-here"])


### PR DESCRIPTION
`Runner.run` turned `FileNotFoundError` into `CommandFailed` whatever `check` said, so `check=False` — which means a failure is an answer — could not survive a medium that lacks the command.

Measured today: an install from the Arch live image stopped at `command: zpool is not installed`, exit 4, before a partition was written. The layout was `vm-binpkg.toml`, which uses no ZFS at all; `_in_an_imported_pool` asks `zpool list` about every target disk and already treats a nonzero exit as "nothing this command can tell us".

With `check=True` an absent command still stops the run, because one the install needs and cannot find is a fault.