### PR TITLE
model: start the Chinese region at USTC

### DIFF
--- a/gentoo_install/model/mirrors.py
+++ b/gentoo_install/model/mirrors.py
@@ -146,8 +146,12 @@ GENTOO_SITES: Final[tuple[Site, ...]] = (
 
 #: Which sites a region offers, in the order the menu lists them.
 GENTOO_REGIONS: Final[dict[MirrorRegion, tuple[str, ...]]] = {
+    # USTC and NJU first. This list is what picks the sync address, not the
+    # order of `GENTOO_SITES`: reordering that alone left `gentoo_rsync_uri`
+    # answering tuna, whose rsync tree served a snapshot its own signed
+    # Manifest did not match on three separate rounds.
     MirrorRegion.CN: (
-        "tuna", "bfsu", "ustc", "zju", "nju", "sdu", "hust", "sustech", "hit",
+        "ustc", "nju", "bfsu", "tuna", "zju", "sdu", "hust", "sustech", "hit",
         "lzu", "aliyun", "netease", "cernet", "cicku-hk", "planetunix-hk",
         "xtom-hk", "rackspace-hk", "aditsu-hk", "nchc-tw", "cicku-tw",
         "freedif-sg", "cicku-sg", "planetunix-sg",

--- a/tests/golden/btrfs-luks.txt
+++ b/tests/golden/btrfs-luks.txt
@@ -22,7 +22,7 @@
   mount root-luks at /home with compress=zstd:1,subvol=@home
 
 [stage3]
-  download the newest desktop-systemd stage3 from https://mirrors.tuna.tsinghua.edu.cn/gentoo, verify it against BB572E0E2D182910 and unpack it into the target
+  download the newest desktop-systemd stage3 from https://mirrors.ustc.edu.cn/gentoo, verify it against BB572E0E2D182910 and unpack it into the target
 
 [chroot]
   mount proc, sys, dev and run into the target and copy resolv.conf
@@ -31,11 +31,11 @@
   write /etc/portage/make.conf with COMMON_FLAGS, CFLAGS, CXXFLAGS, FCFLAGS, FFLAGS, MAKEOPTS, USE, VIDEO_CARDS, INPUT_DEVICES, ACCEPT_LICENSE, L10N, FEATURES; 23 mirrors fastest first, measured, 5 appended
   create the three autounmask files emerge writes its decisions into
   run getuto so Portage has a keyring to verify binary packages against
-  add verified binary package host gentoo at https://mirrors.tuna.tsinghua.edu.cn/gentoo/releases/amd64/binpackages/23.0/x86-64
+  add verified binary package host gentoo at https://mirrors.ustc.edu.cn/gentoo/releases/amd64/binpackages/23.0/x86-64
   fetch the first ebuild repository snapshot with emerge-webrsync
   select profile default/linux/amd64/23.0/desktop/systemd
   install git, which every later repository sync needs: emerge dev-vcs/git
-  point repository gentoo at https://mirrors.bfsu.edu.cn/git/gentoo-portage.git, commit signatures verified
+  point repository gentoo at https://mirrors.ustc.edu.cn/gentoo.git, commit signatures verified
   sync repository gentoo
   point repository gentoo-zh at https://mirrors.cernet.edu.cn/gentoo-zh.git
   sync repository gentoo-zh

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -4,6 +4,7 @@ import os
 import shutil
 import time
 from typing import Sequence, cast
+import re
 from pathlib import Path
 
 import pytest
@@ -664,7 +665,13 @@ def test_the_mirror_check_names_the_mirror_it_could_not_reach(
         fetch, "why_unreachable", lambda url: "certificate verify failed: unable to get issuer"
     )
     config = load(Path("tests/fixtures/btrfs-luks.toml"))
-    with pytest.raises(errors.PreflightFailed, match="tuna") as raised:
+    # The host is read from the configuration rather than written here: the
+    # region's first mirror changes, and a test naming one of them fails for
+    # a reason that has nothing to do with the rule it holds.
+    from gentoo_install.model.mirrors import gentoo_distfiles
+
+    host = gentoo_distfiles(config.portage.mirrors.region)[0].split("//", 1)[1].split("/", 1)[0]
+    with pytest.raises(errors.PreflightFailed, match=re.escape(host)) as raised:
         cli._require_mirror(config, DEFAULT_MIRROR)
     # The reason is carried out, not discarded: `cannot reach X` sent a run to
     # look at the network when the answer was a certificate the medium could

--- a/tests/unit/test_mirrors.py
+++ b/tests/unit/test_mirrors.py
@@ -86,3 +86,24 @@ def test_the_chinese_default_is_ustc_and_not_tuna() -> None:
     names = [one.key for one in GENTOO_SITES]
     assert names[:2] == ["ustc", "nju"], names[:4]
     assert names.index("tuna") > names.index("ustc"), names
+
+    # The addresses an install actually uses, not only the declaration order:
+    # reordering `GENTOO_SITES` alone left `gentoo_rsync_uri` answering tuna,
+    # because `GENTOO_REGIONS` is the list those functions walk. A cluster
+    # guest then synced from tuna and stopped at the same Manifest mismatch.
+    from gentoo_install.model.config import MirrorRegion
+    from gentoo_install.model.mirrors import (
+        gentoo_binhost,
+        gentoo_rsync_uri,
+        gentoo_sites,
+        gentoo_sync_uri,
+    )
+
+    assert [one.key for one in gentoo_sites(MirrorRegion.CN)][:2] == ["ustc", "nju"]
+    for address in (
+        gentoo_rsync_uri(MirrorRegion.CN),
+        gentoo_sync_uri(MirrorRegion.CN),
+        gentoo_binhost(MirrorRegion.CN),
+    ):
+        assert "ustc" in address, address
+        assert "tuna" not in address, address

--- a/tests/unit/test_plan_portage.py
+++ b/tests/unit/test_plan_portage.py
@@ -496,7 +496,7 @@ def test_the_stage3_comes_from_the_mirror_the_operator_chose() -> None:
         config(),
         portage=replace(config().portage, mirrors=MirrorConfig(region=MirrorRegion.CN)),
     )
-    assert stage3_mirror(region_only) == "https://mirrors.tuna.tsinghua.edu.cn/gentoo"
+    assert stage3_mirror(region_only) == "https://mirrors.ustc.edu.cn/gentoo"
 
     # Nothing chosen at all is still the official one, which is the region's
     # first as well as what the flag defaults to.


### PR DESCRIPTION
#84 reordered `GENTOO_SITES` and a cluster guest still synced from tuna, then stopped at `Manifest mismatch for metadata/Manifest.gz __size__: expected: 23355, have: 23359` — the third round to fail that way.

`gentoo_sites` walks `GENTOO_REGIONS[region]`, a list of keys, not the declaration order, and that list still began with tuna. Now `gentoo_rsync_uri`, `gentoo_sync_uri` and `gentoo_binhost` all answer USTC for the Chinese region.

The test asserts the addresses an install uses rather than the declaration order — the exact gap that let #84 pass while changing nothing. Two tests that named tuna now derive the host from the configuration, since the region's first mirror is not the rule they hold.