### PR TITLE
tests: install what a medium lacks before the installer runs

### DIFF
--- a/tests/unit/test_harness.py
+++ b/tests/unit/test_harness.py
@@ -853,3 +853,26 @@ def test_parallel_driver_builds_do_not_share_staging(
         built = [future.result(timeout=30.0) for future in futures]
     assert all(path.is_file() for path in built)
     assert driver.remote_name(built[0]) != driver.remote_name(built[1])
+
+
+def test_a_medium_that_lacks_a_command_installs_it_before_the_installer_runs() -> None:
+    """`bootstrap.sh` prints the package manager line and stops rather than
+    running it, which is what an operator wants: the command has to be read
+    before it is run. Every Debian run therefore ended at `missing commands:
+    mkfs.vfat sgdisk`, exit 1, before anything was attempted.
+
+    The medium declares what it lacks, and `reach_shell` installs it.
+    """
+    import inspect
+
+    from tests.vm import run as vm_run
+    from tests.vm.media import MEDIA
+
+    assert MEDIA["debian"].prepare, "13.6.0 ships without mkfs.vfat and sgdisk"
+    assert any("dosfstools" in one for one in MEDIA["debian"].prepare)
+    assert any("gdisk" in one for one in MEDIA["debian"].prepare)
+    # A medium that carries everything is sent nothing.
+    assert MEDIA["official-minimal"].prepare == ()
+
+    source = inspect.getsource(vm_run.reach_shell)
+    assert "medium.prepare" in source

--- a/tests/vm/media.py
+++ b/tests/vm/media.py
@@ -32,6 +32,11 @@ class Medium:
     login_user: str | None = None
     login_password: str | None = None
     extra_cmdline: tuple[str, ...] = ()
+    #: What to run before the installer, for a medium that ships without a
+    #: command preflight needs. `bootstrap.sh` prints the package manager line
+    #: and stops rather than running it, which is what an operator wants and
+    #: what left every Debian run at `missing commands: mkfs.vfat sgdisk`.
+    prepare: tuple[str, ...] = ()
     #: Set when the medium does not boot the dracut way. Alpine's initramfs
     #: takes `modules=` and finds its own media; it has no `root=live:`.
     boot_cmdline: tuple[str, ...] = ()
@@ -171,6 +176,8 @@ DEBIAN = Medium(
     login_password="live",
     become_root="sudo -i",
     boot_cmdline=("boot=live", "components", "username=user"),
+    # `mkfs.vfat` and `sgdisk` are what preflight found missing on 13.6.0.
+    prepare=("apt-get update -qq", "apt-get install -y dosfstools gdisk"),
 )
 
 ARCH = Medium(

--- a/tests/vm/run.py
+++ b/tests/vm/run.py
@@ -240,6 +240,11 @@ def reach_shell(console: SerialConsole, medium: Medium) -> None:
         console.send(medium.become_root)
         console.expect(r"root@", timeout=60.0)
     pin_resolver(console)
+    for command in medium.prepare:
+        # `bootstrap.sh` prints the package manager line and stops rather than
+        # running it, which is what an operator wants and what left every
+        # Debian run at `missing commands: mkfs.vfat sgdisk`.
+        console.run(command, timeout=600.0)
 
 
 def pin_resolver(console: SerialConsole) -> None:


### PR DESCRIPTION
`bootstrap.sh` reports the missing commands, prints the package manager line for the distribution it recognised, and exits 1 without running it — deliberate, and what the README tells the operator to expect. So every run from the Debian live image ended at `missing commands: mkfs.vfat sgdisk`, exit 1, before a disk was touched.

A medium now declares what it ships without, and `reach_shell` runs that first. Debian 13.6.0 needs `dosfstools` and `gdisk`; the media that carry everything declare nothing and are sent nothing.

Arch and openSUSE both installed and booted cleanly today once #94 landed, so this is the third of six.