### PR TITLE
tests: install gdisk on the Fedora medium

### DIFF
--- a/tests/unit/test_harness.py
+++ b/tests/unit/test_harness.py
@@ -871,6 +871,8 @@ def test_a_medium_that_lacks_a_command_installs_it_before_the_installer_runs() -
     assert MEDIA["debian"].prepare, "13.6.0 ships without mkfs.vfat and sgdisk"
     assert any("dosfstools" in one for one in MEDIA["debian"].prepare)
     assert any("gdisk" in one for one in MEDIA["debian"].prepare)
+    assert MEDIA["fedora"].prepare, "43 ships without sgdisk"
+    assert any("gdisk" in one for one in MEDIA["fedora"].prepare)
     # A medium that carries everything is sent nothing.
     assert MEDIA["official-minimal"].prepare == ()
 

--- a/tests/vm/media.py
+++ b/tests/vm/media.py
@@ -206,6 +206,8 @@ FEDORA = Medium(
     # Without this the live image starts GDM and the serial console never
     # gets a shell.
     extra_cmdline=("systemd.unit=multi-user.target",),
+    # 43 ships without sgdisk; preflight needs it for every GPT layout.
+    prepare=("dnf install -y gdisk",),
 )
 
 OPENSUSE = Medium(


### PR DESCRIPTION
Same shape as #96: the Fedora 43 live image ships without `sgdisk`, `bootstrap.sh` printed `dnf install -y gdisk` and exited 1 as it is meant to, and the run ended before a disk was touched.

Arch and openSUSE both install and boot cleanly; Debian and Fedora needed a package first.