### PR TITLE
disk: retry the pool export the lazy unmount leaves busy

### DIFF
--- a/gentoo_install/plan/disk.py
+++ b/gentoo_install/plan/disk.py
@@ -718,6 +718,10 @@ class DiscardStage3(Operation):
         context.run_in_target(["rm", "--recursive", "--force", f"/{STAGE3_CACHE}"])
 
 
+EXPORT_TRIES: Final[int] = 6
+EXPORT_PAUSE: Final[float] = 5.0
+
+
 @dataclass(frozen=True, kw_only=True)
 class UnmountTarget(Operation):
     """Leaving the target mounted keeps `/dev` and `/proc` bound into it, and
@@ -737,7 +741,26 @@ class UnmountTarget(Operation):
     def apply(self, context: Context) -> None:
         context.run(["umount", "--recursive", "--lazy", str(context.target)])
         for pool in self.pools:
-            context.run(["zpool", "export", pool])
+            self._export(context, pool)
+
+    def _export(self, context: Context, pool: str) -> None:
+        """`umount --lazy` detaches the tree and returns before the last
+        reference is dropped, so the export that follows it reads `cannot
+        export 'rpool': pool is busy` on a guest whose install had otherwise
+        finished. The references go within seconds; one that does not is a
+        reason to stop, because an unexported pool needs `zpool import -f` on
+        the next boot."""
+        last: CommandFailed | None = None
+        for attempt in range(EXPORT_TRIES):
+            try:
+                context.run(["zpool", "export", pool])
+                return
+            except CommandFailed as failed:
+                last = failed
+                if attempt + 1 < EXPORT_TRIES:
+                    context.run(["sleep", f"{EXPORT_PAUSE:g}"])
+        assert last is not None
+        raise last
 
 
 def finish(config: InstallConfig) -> list[Operation]:

--- a/tests/unit/test_plan_disk.py
+++ b/tests/unit/test_plan_disk.py
@@ -575,3 +575,40 @@ def test_a_table_written_from_scratch_still_starts_at_the_first_offset() -> None
         one for one in graph.of_type(Partition) if one.index == 1
     )
     assert _start_of(graph, first) == FIRST_OFFSET
+
+
+def test_a_pool_still_busy_after_the_lazy_unmount_is_exported_on_a_later_try(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """`umount --lazy` returns before the tree is detached, so the export that
+    follows it read `cannot export 'rpool': pool is busy` on a guest whose
+    install had otherwise finished."""
+    from gentoo_install.errors import CommandFailed
+
+    class Busy(Recorder):
+        refusals: int = 2
+        attempts: int = 0
+
+        def run(
+            self, argv: Sequence[str], *, check: bool = True, input_text: str | None = None
+        ) -> str:
+            if tuple(argv[:2]) == ("zpool", "export"):
+                self.attempts += 1
+                if self.refusals:
+                    self.refusals -= 1
+                    raise CommandFailed("zpool export rpool exited 1: pool is busy")
+            return super().run(argv, check=check, input_text=input_text)
+
+    monkeypatch.setattr(disk, "EXPORT_PAUSE", 0.0)
+    operation = disk.UnmountTarget(pools=("rpool",))
+
+    recorder = Busy()
+    operation.apply(recorder)
+    assert recorder.attempts == 3, recorder.attempts
+    assert recorder.argv_starting("sleep") == (("sleep", "0"), ("sleep", "0"))
+
+    # A pool that stays busy stops the install: it needs `zpool import -f` next boot.
+    stubborn = Busy()
+    stubborn.refusals = disk.EXPORT_TRIES
+    with pytest.raises(CommandFailed):
+        operation.apply(stubborn)

--- a/tests/vm/proxmox.py
+++ b/tests/vm/proxmox.py
@@ -580,6 +580,13 @@ class Guest:
                 return
             except ProxmoxError as error:
                 last = str(error)
+                # A guest whose config file is gone has been removed. The API
+                # reports that as 500 rather than 404, which `_transient` reads
+                # as retry-worthy, so the loop otherwise spent its whole
+                # patience re-asking about a guest that no longer existed and
+                # then reported the slot as still held.
+                if f"qemu-server/{self.vmid}.conf' does not exist" in last:
+                    return
                 if not _transient(error):
                     raise
                 time.sleep(min(CLEANUP_PAUSE, max(0.0, deadline - time.monotonic())))


### PR DESCRIPTION
`umount --recursive --lazy` returns before the last reference is dropped, so `zpool export rpool` read `pool is busy` and stopped an install whose every other step had finished. Six attempts five seconds apart; a pool that stays busy still stops the install, because an unexported pool needs `zpool import -f` on the next boot.

The cluster's removal path had the same shape: the API answers a missing config file with 500, `_transient` read that as retry-worthy, and the slot was reported as still held long after the guest was gone.