### PR TITLE
vm: keep the medium's trust record outside one round

### DIFF
--- a/tests/unit/test_harness.py
+++ b/tests/unit/test_harness.py
@@ -721,7 +721,7 @@ def test_zero_cluster_capacity_returns_an_error_after_a_deadline(
     monkeypatch.setattr(
         cluster,
         "current_minimal",
-        lambda path: ("minimal-deadbeef.iso", ("https://invalid/iso",), "0" * 128),
+        lambda: ("minimal-deadbeef.iso", ("https://invalid/iso",), "0" * 128),
     )
     monkeypatch.setattr(clock, "monotonic", lambda: now[0])
     monkeypatch.setattr(clock, "sleep", lambda seconds: now.__setitem__(0, now[0] + seconds))
@@ -732,6 +732,22 @@ def test_zero_cluster_capacity_returns_an_error_after_a_deadline(
     assert outcome[0].verdict is cluster.Verdict.ERROR
     assert outcome[0].phase is cluster.Phase.SCHEDULE
     assert now[0] == cluster.CAPACITY_PATIENCE
+
+
+def test_the_record_of_an_uploaded_medium_outlives_the_round_that_uploaded_it() -> None:
+    """The ISO stays on the node between rounds, so a per-round work directory
+    met its own upload as `already exists without its signed SHA-512 record`
+    and the round could not start."""
+    from tests.vm import cluster
+
+    import inspect
+
+    assert cluster.MEDIUM_TRUST.parent == cluster.WORKROOT
+    # Deriving it from a round's work directory is what the parameter allowed.
+    assert not inspect.signature(cluster.current_minimal).parameters
+    assert "trust" not in inspect.signature(cluster.prepare).parameters or (
+        list(inspect.signature(cluster.prepare).parameters)[5] == "trust"
+    )
 
 
 def test_reconcile_removes_only_an_expired_locally_leased_guest(

--- a/tests/vm/cluster.py
+++ b/tests/vm/cluster.py
@@ -76,6 +76,12 @@ from .workdir import WorkdirError, confined
 REPOSITORY: Final[Path] = Path(__file__).resolve().parents[2]
 WORKROOT: Final[Path] = Path.home() / "code/gentoo-install/lab/vm/cluster"
 
+#: Outside any one round's work directory: the ISO stays on the node between
+#: rounds, so the record of what was uploaded has to outlive the round that
+#: uploaded it. A fresh work directory otherwise met its own upload as
+#: `already exists on infra-node5 without its signed SHA-512 record`.
+MEDIUM_TRUST: Final[Path] = WORKROOT / "medium-trust"
+
 #: Where the guest gathers what the run produced before it is read back.
 RESULT_DIR: Final[str] = "/tmp/gentoo-install-results"
 
@@ -343,9 +349,9 @@ def _medium_name(name: str, sha512: str) -> str:
     return f"{Path(name).stem}-{sha512[:20]}.iso"
 
 
-def current_minimal(workdir: Path) -> tuple[str, tuple[str, ...], str]:
+def current_minimal() -> tuple[str, tuple[str, ...], str]:
     """The verified current minimal ISO, its mirrors and signed SHA-512."""
-    trust = workdir / "medium-trust"
+    trust = MEDIUM_TRUST
     trust.mkdir(parents=True, exist_ok=True)
     key = RELEASE_KEY
     if not key.is_file():
@@ -1051,7 +1057,7 @@ def run(
     )
     revision = revision_identity(driver_path)
     driver = remote_name(driver_path)
-    medium, urls, medium_sha512 = current_minimal(workdir)
+    medium, urls, medium_sha512 = current_minimal()
     prepared: set[str] = set()
     done: queue.Queue[Outcome] = queue.Queue()
     waiting = list(jobs)
@@ -1115,7 +1121,7 @@ def run(
                         medium,
                         urls,
                         medium_sha512,
-                        workdir / "medium-trust",
+                        MEDIUM_TRUST,
                         driver_path,
                         driver,
                     )


### PR DESCRIPTION
`current_minimal` and `prepare` recorded the uploaded medium's signed SHA-512 under the round's own work directory, but `local` storage keeps the ISO between rounds. Round 17 met round 16's upload as `already exists on infra-node5 without its signed SHA-512 record` and refused to start.