### PR TITLE
vm: install the tools preflight names on alpine

### DIFF
--- a/tests/vm/media.py
+++ b/tests/vm/media.py
@@ -184,7 +184,10 @@ ALPINE = Medium(
         "printf 'https://mirrors.ustc.edu.cn/alpine/v3.24/main\n"
         "https://mirrors.ustc.edu.cn/alpine/v3.24/community\n' > /etc/apk/repositories",
         "apk update",
-        "apk add python3 e2fsprogs dosfstools sgdisk",
+        # The list preflight itself printed, plus the interpreter it needs
+        # before it can print anything.
+        "apk add python3 e2fsprogs dosfstools sgdisk blkid findmnt gnupg "
+        "lsblk mount util-linux-misc tar eudev umount wipefs",
     ),
 )
 


### PR DESCRIPTION
Preflight prints the exact `apk add` line for what the live image lacks; the medium now runs it.