### PR TITLE
vm: switch the alpine medium to udev

### DIFF
--- a/tests/vm/media.py
+++ b/tests/vm/media.py
@@ -187,7 +187,10 @@ ALPINE = Medium(
         # The list preflight itself printed, plus the interpreter it needs
         # before it can print anything.
         "apk add python3 e2fsprogs dosfstools sgdisk blkid findmnt gnupg "
-        "lsblk mount util-linux-misc tar eudev umount wipefs",
+        "lsblk mount util-linux-misc tar eudev parted umount wipefs",
+        # The live session populates /dev with mdev, so a partition node never
+        # appeared and every install stopped at `/dev/vdb2 did not appear`.
+        "setup-devd udev",
     ),
 )
 


### PR DESCRIPTION
The live session populates `/dev` with mdev, so `/dev/vdb2` never appeared and every install stopped there. `parted` joins the list because `partprobe` comes from it.