### PR TITLE
vm: give the alpine medium xz for the stage3

### DIFF
--- a/tests/vm/media.py
+++ b/tests/vm/media.py
@@ -187,7 +187,7 @@ ALPINE = Medium(
         # The list preflight itself printed, plus the interpreter it needs
         # before it can print anything.
         "apk add python3 e2fsprogs dosfstools sgdisk blkid findmnt gnupg "
-        "lsblk mount util-linux-misc tar eudev parted umount wipefs",
+        "lsblk mount util-linux-misc tar eudev parted xz umount wipefs",
         # The live session populates /dev with mdev, so a partition node never
         # appeared and every install stopped at `/dev/vdb2 did not appear`.
         "setup-devd udev",


### PR DESCRIPTION
`tar` shells out to `xz` to unpack the stage3 and answered `xz: Cannot exec: No such file or directory`.