### PR TITLE
vm: halt GRUB's countdown before asking for the editor

### DIFF
--- a/tests/unit/test_proxmox.py
+++ b/tests/unit/test_proxmox.py
@@ -580,7 +580,8 @@ def test_the_editor_is_reopened_with_escape_not_a_second_e() -> None:
             self.sent.append(line)
 
         def expect(self, pattern: str, timeout: float) -> bytes:
-            raise AssertionError("the editor is read by snapshot, not by expect")
+            assert pattern == "GNU GRUB", pattern
+            return b"GNU GRUB  version 2.14"
 
         @property
         def closed(self) -> bool:
@@ -589,7 +590,45 @@ def test_the_editor_is_reopened_with_escape_not_a_second_e() -> None:
     console = Slow()
     screen = _editor_screen(console, 30.0)
     assert b"setparams" in screen
-    assert console.sent == ["e", "\x1b", "e"]
+    # The leading ESC halts the countdown: GRUB stops it on the first key it
+    # receives, and a run whose `e` arrived before the menu was drawn watched
+    # the entry boot ten seconds later.
+    assert console.sent == ["\x1b", "e", "\x1b", "e"]
+
+
+def test_the_countdown_is_halted_before_the_first_e_is_sent() -> None:
+    """A guest whose menu is never waited for boots the default entry: the
+    press that would have stopped the countdown arrived before the menu."""
+    from tests.vm.proxmox import _editor_screen
+
+    class Menu:
+        def __init__(self) -> None:
+            self.sent: list[str] = []
+            self.asked = False
+
+        def send_raw(self, keys: str) -> None:
+            # Everything before the menu is drawn is discarded, which is what
+            # the guest's firmware does with it.
+            if self.asked:
+                self.sent.append(keys)
+
+        def snapshot(self, seconds: float) -> bytes:
+            return GENTOO_EDITOR if self.sent else b""
+
+        def send(self, line: str) -> None:
+            self.sent.append(line)
+
+        def expect(self, pattern: str, timeout: float) -> bytes:
+            self.asked = True
+            return b"GNU GRUB  version 2.14"
+
+        @property
+        def closed(self) -> bool:
+            return False
+
+    console = Menu()
+    assert b"setparams" in _editor_screen(console, 30.0)
+    assert console.sent[0] == "\x1b", console.sent
 
 
 def test_a_long_install_is_never_sent_twice_after_a_reconnect() -> None:

--- a/tests/vm/proxmox.py
+++ b/tests/vm/proxmox.py
@@ -854,6 +854,11 @@ class Reopenable(Protocol):
     def reopen(self) -> None: ...
 
 
+#: How long the menu itself is waited for. GRUB's own countdown is ten
+#: seconds, and a console that attaches after it has expired never sees one.
+MENU_PATIENCE: Final[float] = 30.0
+
+
 def _editor_screen(console: Line, timeout: float) -> bytes:
     """Press `e` until GRUB draws the entry, and answer with that screen.
 
@@ -863,10 +868,24 @@ def _editor_screen(console: Line, timeout: float) -> bytes:
     countdown line eight seconds from booting.
     """
     deadline = time.monotonic() + timeout
+    # GRUB stops its countdown on the first key it receives, so that key has to
+    # arrive while the menu is on the screen. A run sent `e` before the menu was
+    # drawn, the press was discarded, and the entry booted ten seconds later
+    # with the harness still waiting for an editor.
+    try:
+        console.expect(r"GNU GRUB", timeout=max(1.0, min(timeout, MENU_PATIENCE)))
+    except ProxmoxError:
+        pass
+    # ESC rather than an arrow: it halts the countdown, and unlike an arrow it
+    # cannot move the selection off the entry the guest is meant to boot.
+    console.send_raw("\x1b")
+    time.sleep(0.5)
     seen = b""
+    everything = b""
     console.send_raw("e")
     while time.monotonic() < deadline:
         seen = console.snapshot(3.0)
+        everything += seen
         if b"setparams" in seen:
             return seen
         # ESC first, and only then `e` again: in the editor it discards the
@@ -875,7 +894,9 @@ def _editor_screen(console: Line, timeout: float) -> bytes:
         console.send_raw("\x1b")
         time.sleep(0.5)
         console.send_raw("e")
-    raise ProxmoxError(f"GRUB never opened its editor: {seen[-400:]!r}")
+    # The whole read, not the last snapshot: the last one is empty on a guest
+    # that booted while the loop was still pressing, which says nothing.
+    raise ProxmoxError(f"GRUB never opened its editor: {everything[-400:]!r}")
 
 
 def _line_of_linux(screen: bytes) -> int:


### PR DESCRIPTION
`_editor_screen` sent `e` blind. On a guest whose console attached while the firmware was still running, the press was discarded, the countdown reached zero and the entry booted; the loop then pressed at a booting kernel and reported `GRUB never opened its editor: b''`. The menu is waited for first, then ESC halts the countdown, and the error now carries the whole read rather than the last empty snapshot.