### PR TITLE
vm: give a removed guest's vmid back to the pool

### DIFF
--- a/tests/unit/test_harness.py
+++ b/tests/unit/test_harness.py
@@ -934,3 +934,53 @@ def test_a_schedule_that_ends_early_stops_the_guests_it_left_running() -> None:
     assert all(guest.stopped for guest in guests.values()), guests
     assert sorted(joined) == ["vm-lvm", "vm-xfs"]
     assert not inflight, "each worker removes its own guest once the console closes"
+
+
+def test_a_removed_guest_gives_its_vmid_back(monkeypatch: pytest.MonkeyPatch) -> None:
+    """`handed` only ever grew, so a campaign of more than a hundred jobs
+    stopped at `no free vmid` with the whole range unoccupied. The outcome has
+    to carry the VMID for the scheduler to know which one to release."""
+    import queue
+    from typing import cast
+
+    from tests.vm import cluster
+
+    monkeypatch.setattr(
+        cluster,
+        "install_one",
+        lambda *args, **kwargs: cluster.Outcome("vm-lvm", cluster.Verdict.OK, 60.0),
+    )
+    done: queue.Queue[cluster.Outcome] = queue.Queue()
+    from tests.vm.proxmox import Api
+
+    nowhere = cast(Api, object())
+    cluster.answer_once(
+        done,
+        nowhere,
+        "infra-node1",
+        cluster.Job("vm-lvm", Path("tests/fixtures/vm-lvm.toml")),
+        "gi-driver.iso",
+        Path("/nonexistent"),
+        {},
+        9307,
+    )
+    outcome = done.get_nowait()
+    assert outcome.vmid == 9307, "the scheduler releases by VMID and cannot guess one"
+    assert outcome.removed
+
+    # A worker that died still names its VMID, or the range leaks one per crash.
+    monkeypatch.setattr(
+        cluster, "install_one", lambda *args, **kwargs: (_ for _ in ()).throw(RuntimeError("x"))
+    )
+    cluster.answer_once(
+        done,
+        nowhere,
+        "infra-node1",
+        cluster.Job("vm-xfs", Path("tests/fixtures/vm-xfs.toml")),
+        "gi-driver.iso",
+        Path("/nonexistent"),
+        {},
+        9308,
+    )
+    died = done.get_nowait()
+    assert died.vmid == 9308 and not died.removed

--- a/tests/vm/cluster.py
+++ b/tests/vm/cluster.py
@@ -215,6 +215,9 @@ class Outcome:
     removed: bool = True
     phase: Phase = Phase.SCHEDULE
     revision: str = ""
+    #: Which VMID the job held. Zero for an outcome raised before one was
+    #: taken, which is the only case that reserves nothing.
+    vmid: int = 0
 
 
 @dataclass
@@ -1016,7 +1019,9 @@ def answer_once(
         outcome = install_one(
             api, node, job, driver, workdir, inflight, vmid, nonce, revision
         )
-        outcome = replace(outcome, removed=outcome.name not in LEFT_BEHIND)
+        outcome = replace(
+            outcome, removed=outcome.name not in LEFT_BEHIND, vmid=outcome.vmid or vmid
+        )
         if outcome.removed and lease_path is not None:
             lease_path.unlink(missing_ok=True)
         done.put(outcome)
@@ -1029,6 +1034,7 @@ def answer_once(
                 f"{type(error).__name__}: {error}"[:300],
                 removed=False,
                 revision=revision,
+                vmid=vmid,
             )
         )
 
@@ -1191,6 +1197,11 @@ def run(
                 continue
             finished.append(outcome)
             running.pop(outcome.name, None)
+            # A removed guest gives its VMID back. Without this the reserved
+            # set only grows, and a campaign of more than a hundred jobs
+            # stopped at `no free vmid` with the whole range unoccupied.
+            if outcome.removed and outcome.vmid:
+                handed.discard(outcome.vmid)
             gone = where.pop(outcome.name, "")
             if gone and not outcome.removed:
                 # The guest is still on that node holding its memory, so the


### PR DESCRIPTION
The reserved set only grew. A campaign of more than a hundred jobs would stop at `no free vmid` with the whole 9300-9399 range unoccupied. The outcome now carries the VMID it held, including when the worker died, and the scheduler releases it only once the guest is confirmed gone.