### PR TITLE
vm: make the tui walk wait for the screen it is reading

### DIFF
--- a/tests/unit/test_harness.py
+++ b/tests/unit/test_harness.py
@@ -984,3 +984,44 @@ def test_a_removed_guest_gives_its_vmid_back(monkeypatch: pytest.MonkeyPatch) ->
     )
     died = done.get_nowait()
     assert died.vmid == 9308 and not died.removed
+
+
+def test_the_walk_does_not_escape_out_of_a_row_that_never_opened(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Escape on the main menu leaves the installer. A walk that pressed it
+    after a press which opened nothing ended on its first row, and the review
+    of that recording reported no findings because there was one screen."""
+    from typing import Any, cast
+
+    from tests.vm import tui
+
+    class Console:
+        def __init__(self) -> None:
+            self.sent: list[str] = []
+            self.asked = 0
+
+        def run(self, line: str, timeout: float = 0.0) -> str:
+            return ""
+
+        def send_raw(self, keys: str) -> None:
+            self.sent.append(keys)
+
+        def expect(self, pattern: str, timeout: float) -> bytes:
+            self.asked += 1
+            return b"gentoo-install"
+
+        def snapshot(self, seconds: float) -> bytes:
+            # The same screen every time: the row never opens.
+            return b"gentoo-install\r\nstorage\r\n"
+
+    import time as clock
+
+    monkeypatch.setattr(clock, "sleep", lambda seconds: None)
+    monkeypatch.setattr(tui, "_ROWS", 3)
+    console = Console()
+    seen = tui.walk(cast("Any", console), "en")
+
+    assert console.asked == 1, "the menu is waited for, not slept through"
+    assert "\x1b" not in console.sent, console.sent
+    assert any("opened nothing" in one.what for one in seen.findings), seen.findings

--- a/tests/vm/tui.py
+++ b/tests/vm/tui.py
@@ -76,6 +76,11 @@ def cells(line: str) -> int:
     return width(line)
 
 
+#: How long the menu is waited for. The interpreter starts, reads the driver
+#: archive and probes the disks before it draws anything.
+MENU_PATIENCE: Final[float] = 180.0
+
+
 def _open_menu(console: SerialConsole, lang: str) -> None:
     console.run("mkdir -p /mnt/driver")
     console.run("mountpoint -q /mnt/driver || mount -o ro /dev/sr1 /mnt/driver")
@@ -93,9 +98,11 @@ def walk(console: SerialConsole, lang: str) -> Walk:
     """Open every row of the menu and read what the terminal shows."""
     seen = Walk()
     _open_menu(console, lang)
-    # The shell echoes the launch line and it is longer than the console is
-    # wide, so it is read and discarded before the first screen is measured.
-    time.sleep(8.0)
+    # Waited for rather than slept through: a walk that sent its first keys on
+    # a timer had them land on the shell, and the escape that followed reached
+    # the main menu, where escape means leave. The recording then held one
+    # screen and the review of it reported nothing.
+    console.expect(r"gentoo-install", timeout=MENU_PATIENCE)
     console.snapshot(REDRAW_SECONDS)
     console.send_raw("\x1b[B")
     time.sleep(0.5)
@@ -118,8 +125,14 @@ def walk(console: SerialConsole, lang: str) -> Walk:
         for line in opened:
             if cells(line) > COLUMNS:
                 seen.note(f"row {step} opened", f"{cells(line)} cells: {line!r}")
-        console.send_raw("\x1b")
-        time.sleep(0.5)
+        # Only when the row actually opened. Escape on the main menu leaves the
+        # installer, so sending it after a press that opened nothing ends the
+        # walk on its first row.
+        if opened != drawn:
+            console.send_raw("\x1b")
+            time.sleep(0.5)
+        else:
+            seen.note(f"row {step}", "enter opened nothing")
         console.send_raw("\x1b[B")
         time.sleep(0.3)
     return seen


### PR DESCRIPTION
The walk slept eight seconds and started pressing. On a medium that took longer the keys landed on the shell, and the escape that follows an unopened row reached the main menu, where escape leaves the installer. The recording held a single screen and the review of it reported nothing.

The menu is now waited for, and escape is sent only when the screen actually changed; a row that opens nothing is a finding rather than the end of the walk.