### PR TITLE
vm: end a walk's line at a carriage return

### DIFF
--- a/tests/unit/test_harness.py
+++ b/tests/unit/test_harness.py
@@ -1025,3 +1025,15 @@ def test_the_walk_does_not_escape_out_of_a_row_that_never_opened(
     assert console.asked == 1, "the menu is waited for, not slept through"
     assert "\x1b" not in console.sent, console.sent
     assert any("opened nothing" in one.what for one in seen.findings), seen.findings
+
+
+def test_a_carriage_return_ends_a_line_the_walk_measures() -> None:
+    """curses moves the cursor between rows with a bare carriage return, so
+    joining on newlines alone made the whole screen one line and the width
+    check reported a 597-cell menu that is 24 rows of at most 80."""
+    from tests.vm.tui import cells, rendered
+
+    screen = b"\x1b[H\x1b[Jgentoo-install\r  keyboard  us\r  locale  zh_TW.UTF-8\r"
+    lines = rendered(screen)
+    assert lines[:3] == ["gentoo-install", "  keyboard  us", "  locale  zh_TW.UTF-8"]
+    assert max(cells(one) for one in lines) <= 80

--- a/tests/vm/tui.py
+++ b/tests/vm/tui.py
@@ -45,9 +45,15 @@ _ANSI: Final[re.Pattern[bytes]] = re.compile(rb"\x1b\[[0-9;?]*[A-Za-z]|\x1b[()][
 
 
 def rendered(said: bytes) -> list[str]:
-    """The lines a screen left, with the escape codes taken out."""
+    """The lines a screen left, with the escape codes taken out.
+
+    A bare carriage return ends a line too. curses moves the cursor with one
+    between rows, so joining on newlines alone made every screen a single line
+    and the width check reported a 597-cell menu that is 24 rows of at most 80.
+    """
     text = _ANSI.sub(b"", said).decode("utf-8", "replace")
-    return [line.rstrip() for line in text.replace("\r\n", "\n").split("\n")]
+    flattened = text.replace("\r\n", "\n").replace("\r", "\n")
+    return [line.rstrip() for line in flattened.split("\n")]
 
 
 @dataclass


### PR DESCRIPTION
curses moves the cursor between rows with a bare carriage return. Splitting on newlines alone made each screen one line, and the first walk that reached the menu reported a 597-cell row that is 24 rows of at most 80.