### PR TITLE
disk: force the last pool export attempt

### DIFF
--- a/gentoo_install/plan/disk.py
+++ b/gentoo_install/plan/disk.py
@@ -752,12 +752,19 @@ class UnmountTarget(Operation):
         the next boot."""
         last: CommandFailed | None = None
         for attempt in range(EXPORT_TRIES):
+            # The last attempt forces. A live environment running `zed` holds
+            # the pool open for as long as it runs, so waiting never clears it:
+            # Gig-OS failed all six plain attempts where the same fixture on a
+            # medium without `zed` succeeded on the second. Forcing is bounded
+            # here because the target tree was unmounted a moment ago and the
+            # only datasets left attached are the ones this run created.
+            forced = attempt + 1 == EXPORT_TRIES
             try:
-                context.run(["zpool", "export", pool])
+                context.run(["zpool", "export", *(["-f"] if forced else []), pool])
                 return
             except CommandFailed as failed:
                 last = failed
-                if attempt + 1 < EXPORT_TRIES:
+                if not forced:
                     context.run(["sleep", f"{EXPORT_PAUSE:g}"])
         assert last is not None
         raise last

--- a/tests/unit/test_plan_disk.py
+++ b/tests/unit/test_plan_disk.py
@@ -607,7 +607,15 @@ def test_a_pool_still_busy_after_the_lazy_unmount_is_exported_on_a_later_try(
     assert recorder.attempts == 3, recorder.attempts
     assert recorder.argv_starting("sleep") == (("sleep", "0"), ("sleep", "0"))
 
-    # A pool that stays busy stops the install: it needs `zpool import -f` next boot.
+    # A live environment running `zed` holds the pool for as long as it runs,
+    # so the last attempt forces rather than waiting again.
+    zed = Busy()
+    zed.refusals = disk.EXPORT_TRIES - 1
+    operation.apply(zed)
+    assert zed.commands[-1] == ("zpool", "export", "-f", "rpool"), zed.commands[-1]
+
+    # A pool that refuses even that stops the install: an unexported pool needs
+    # `zpool import -f` on the next boot.
     stubborn = Busy()
     stubborn.refusals = disk.EXPORT_TRIES
     with pytest.raises(CommandFailed):


### PR DESCRIPTION
`zed` in a live environment holds the pool open for as long as it runs, so retrying alone never clears it: Gig-OS failed all six attempts where the same fixture on gentoo-cjk succeeded on the second. The last attempt passes `-f`, which is bounded here because the target tree was unmounted a moment earlier and the only datasets still attached are the ones the run created. A pool that refuses even that still stops the install.