### PR TITLE
vm: report one outcome per job and name a task that never started

### DIFF
--- a/tests/unit/test_harness.py
+++ b/tests/unit/test_harness.py
@@ -1037,3 +1037,30 @@ def test_a_carriage_return_ends_a_line_the_walk_measures() -> None:
     lines = rendered(screen)
     assert lines[:3] == ["gentoo-install", "  keyboard  us", "  locale  zh_TW.UTF-8"]
     assert max(cells(one) for one in lines) <= 80
+
+
+def test_a_worker_that_answered_and_exited_is_not_reported_twice() -> None:
+    """The schedule reported `vm-xfs` twice: once with the error it raised,
+    once as a worker that never reported."""
+    import threading
+
+    from tests.vm.cluster import _unanswered
+
+    ended = threading.Thread(target=lambda: None)
+    ended.start()
+    ended.join()
+    running = {"vm-xfs": ended}
+
+    assert _unanswered(running, nothing_queued=False) == []
+    # Nothing on the queue and a dead worker is the case this covers: the name
+    # would otherwise stay in `running` and the schedule never end.
+    assert _unanswered(running, nothing_queued=True) == ["vm-xfs"]
+
+    alive = threading.Event()
+    working = threading.Thread(target=alive.wait)
+    working.start()
+    try:
+        assert _unanswered({"vm-lvm": working}, nothing_queued=True) == []
+    finally:
+        alive.set()
+        working.join()

--- a/tests/unit/test_proxmox.py
+++ b/tests/unit/test_proxmox.py
@@ -1826,3 +1826,16 @@ def test_the_address_range_avoids_the_machines_already_on_the_segment() -> None:
     assert "n=155;" in command, command
     # Bounded: the walk stops rather than running off the end of the network.
     assert "-le 249" in command, command
+
+
+def test_a_request_that_started_no_task_is_named_rather_than_crashed() -> None:
+    """The API answers an accepted request with its task id, and a `data: null`
+    where one belongs is a request that never started. Splitting it raised
+    `AttributeError: 'NoneType' object has no attribute 'split'`, and the
+    worker reported that instead of the failure behind it."""
+    from tests.vm.proxmox import Api, ProxmoxError
+
+    api = Api.__new__(Api)
+    with pytest.raises(ProxmoxError) as raised:
+        api.wait("infra-node4", "")
+    assert "did not start" in str(raised.value)

--- a/tests/vm/cluster.py
+++ b/tests/vm/cluster.py
@@ -1181,9 +1181,7 @@ def run(
                 # never finishes: one round sat idle for half an hour with an
                 # empty cluster and a job still queued. `answer_once` catches
                 # everything a Python handler can see; this covers the rest.
-                for name, thread in list(running.items()):
-                    if thread.is_alive():
-                        continue
+                for name in _unanswered(running, done.empty()):
                     done.put(
                         Outcome(
                             name,
@@ -1588,6 +1586,20 @@ def _abandon(inflight: dict[str, Running], running: dict[str, threading.Thread])
         thread.join(timeout=max(0.0, deadline - time.monotonic()))
     for name in inflight:
         print(f"  {name} outlived the schedule; remove it by hand", file=sys.stderr)
+
+
+def _unanswered(running: dict[str, threading.Thread], nothing_queued: bool) -> list[str]:
+    """The workers that ended without putting an outcome on the queue.
+
+    A dead thread is not evidence on its own: a worker that answered and then
+    exited looks exactly the same, and the schedule reported `vm-xfs` twice,
+    once with the error it raised and once as never reporting. An outcome
+    already waiting is that answer, so nothing is declared until the queue has
+    been drained.
+    """
+    if not nothing_queued:
+        return []
+    return [name for name, thread in running.items() if not thread.is_alive()]
 
 
 def _sweep(inflight: dict[str, Running]) -> None:

--- a/tests/vm/proxmox.py
+++ b/tests/vm/proxmox.py
@@ -199,6 +199,12 @@ class Api:
         and asking the wrong node for its status is a 500 on a task that is
         running perfectly well.
         """
+        if not upid:
+            # The API answers an accepted request with the task id, and a
+            # `data: null` where one belongs is a request that did not start.
+            # Splitting it raised `AttributeError: 'NoneType'`, which the
+            # worker reported instead of the failure that caused it.
+            raise ProxmoxError(f"{node} answered without a task id; the request did not start")
         parts = upid.split(":")
         if len(parts) > 1 and parts[0] == "UPID" and parts[1]:
             node = parts[1]


### PR DESCRIPTION
Round 17 reported `vm-xfs` twice: once with `AttributeError: 'NoneType' object has no attribute 'split'` and once as a worker that never reported.

Both are one failure. The API answered a request with `data: null` where a task id belongs, `wait` split it and raised, and the scheduler then saw a dead thread with its outcome already on the queue and queued a second. `wait` now names the request that did not start, and the dead-worker check drains the queue first.