### PR TITLE
disk: unmount plainly before falling back to lazy

### DIFF
--- a/gentoo_install/plan/disk.py
+++ b/gentoo_install/plan/disk.py
@@ -40,7 +40,7 @@ from ..model.device import (
     ZfsTopology,
 )
 from ..model.size import DEFAULT_ALIGNMENT, Size
-from .operations import Context, Operation, Stage
+from .operations import CommandOutput, Context, Operation, Stage
 
 #: GPT type codes as `sgdisk --typecode` spells them.
 TYPE_CODES: Final[dict[PartitionRole, str]] = {
@@ -739,7 +739,14 @@ class UnmountTarget(Operation):
         return f"unmount everything under the target{exported}"
 
     def apply(self, context: Context) -> None:
-        context.run(["umount", "--recursive", "--lazy", str(context.target)])
+        # Plain first, lazy only if that fails. A lazy unmount detaches the
+        # tree and leaves the datasets mounted as far as the kernel is
+        # concerned, so `zpool export` reads `pool is busy` for as long as the
+        # references last and `-f` does not clear it either: Gig-OS failed
+        # every attempt including the forced one.
+        plain = context.run(["umount", "--recursive", str(context.target)], check=False)
+        if not isinstance(plain, CommandOutput) or plain.returncode != 0:
+            context.run(["umount", "--recursive", "--lazy", str(context.target)])
         for pool in self.pools:
             self._export(context, pool)
 

--- a/tests/unit/recorder.py
+++ b/tests/unit/recorder.py
@@ -7,6 +7,7 @@ argv it would run is how the flags get asserted without a disk.
 from __future__ import annotations
 
 from gentoo_install.errors import CommandFailed, DownloadFailed
+from gentoo_install.plan.operations import CommandOutput
 from collections.abc import Callable
 from dataclasses import dataclass, field
 from pathlib import PurePosixPath
@@ -44,7 +45,9 @@ class Recorder:
             self.stdin.append(input_text)
         if argv[0] in self.failures:
             raise CommandFailed(f"{argv[0]} exited 1")
-        return self.replies.get(argv[0], "")
+        # A CommandOutput, the way the real runner answers: a double returning
+        # a bare str hides every caller that reads the exit code for itself.
+        return CommandOutput(self.replies.get(argv[0], ""), 0)
 
     def run_in_target(self, argv: Sequence[str], *, check: bool = True) -> str:
         """`check=False` returns the output and raises nothing, the way the real

--- a/tests/unit/test_plan_disk.py
+++ b/tests/unit/test_plan_disk.py
@@ -602,6 +602,15 @@ def test_a_pool_still_busy_after_the_lazy_unmount_is_exported_on_a_later_try(
     monkeypatch.setattr(disk, "EXPORT_PAUSE", 0.0)
     operation = disk.UnmountTarget(pools=("rpool",))
 
+    # Plain before lazy: a lazy unmount leaves the datasets mounted as far as
+    # the kernel is concerned and `zpool export` then reads `pool is busy` for
+    # as long as the references last.
+    ordered = Busy()
+    ordered.refusals = 0
+    operation.apply(ordered)
+    unmounts = [one for one in ordered.commands if one and one[0] == "umount"]
+    assert unmounts == [("umount", "--recursive", "/mnt/gentoo")], unmounts
+
     recorder = Busy()
     operation.apply(recorder)
     assert recorder.attempts == 3, recorder.attempts


### PR DESCRIPTION
`umount --recursive --lazy` detaches the tree and returns, but the datasets stay mounted as far as the kernel is concerned, so `zpool export` read `pool is busy` for as long as the references lasted. Gig-OS failed every attempt including the forced one, where the same fixture on gentoo-cjk succeeded.

A plain recursive unmount runs first and lazy remains the fallback for a target something still holds. The recorder now answers with a `CommandOutput` the way the real runner does, so a caller reading an exit code is exercised rather than hidden.