### PR TITLE
vm: fit every fixture's job count to a test guest

### DIFF
--- a/tests/fixtures/btrfs-luks.toml
+++ b/tests/fixtures/btrfs-luks.toml
@@ -18,7 +18,7 @@ sudo = true
 [portage]
 profile = "default/linux/amd64/23.0/desktop/systemd"
 keywords = "stable"
-makeopts = "-j32 -l32"
+makeopts = "-j4"
 common_flags = "-O2 -pipe -march=x86-64-v3"
 use = ["dracut", "initramfs", "cjk"]
 video_cards = ["amdgpu", "radeonsi"]

--- a/tests/unit/test_harness.py
+++ b/tests/unit/test_harness.py
@@ -1059,3 +1059,21 @@ def test_a_worker_that_answered_and_exited_is_not_reported_twice() -> None:
     finally:
         alive.set()
         working.join()
+
+
+def test_no_fixture_asks_for_more_jobs_than_a_test_guest_has() -> None:
+    """`btrfs-luks.toml` carried `-j32 -l32`, written for this workstation's
+    thread count. In a guest with five processors `ninja -l32 -j32` thrashed
+    and poppler died in its compile phase, which reads as an installer failure
+    and is not one."""
+    import re
+    import tomllib
+
+    from tests.vm.qemu import VmSpec
+
+    allowed = 2 * VmSpec.cpus
+    for fixture in sorted(Path("tests/fixtures").glob("*.toml")):
+        settings = tomllib.loads(fixture.read_text())
+        makeopts = str(settings.get("portage", {}).get("makeopts", ""))
+        for jobs in re.findall(r"-[jl](\d+)", makeopts):
+            assert int(jobs) <= allowed, f"{fixture.name} asks for {makeopts}"


### PR DESCRIPTION
`btrfs-luks.toml` carried `-j32 -l32`, the thread count of the workstation it was written on. In a five-processor guest `ninja -l32 -j32` thrashed and `app-text/poppler` died in its compile phase, which reads as an installer failure and is not one. Every other fixture already used `-j4` or `-j8`; the rule is now a test.