### PR TITLE
vm: replay a screen into a grid before measuring it

### DIFF
--- a/tests/unit/test_harness.py
+++ b/tests/unit/test_harness.py
@@ -1022,16 +1022,33 @@ def test_the_walk_does_not_escape_out_of_a_row_that_never_opened(
     assert any("opened nothing" in one.what for one in seen.findings), seen.findings
 
 
-def test_a_carriage_return_ends_a_line_the_walk_measures() -> None:
-    """curses moves the cursor between rows with a bare carriage return, so
-    joining on newlines alone made the whole screen one line and the width
-    check reported a 597-cell menu that is 24 rows of at most 80."""
+def test_a_screen_is_replayed_into_a_grid_rather_than_flattened() -> None:
+    """curses draws by moving the cursor, not by ending lines. Stripping the
+    escape codes ran the whole screen together and the width check reported a
+    597-cell row that is 24 rows of at most 80."""
     from tests.vm.tui import cells, rendered
 
-    screen = b"\x1b[H\x1b[Jgentoo-install\r  keyboard  us\r  locale  zh_TW.UTF-8\r"
+    screen = (
+        b"\x1b[2J\x1b[1;1Hgentoo-install"
+        b"\x1b[3;3Hkeyboard  us"
+        b"\x1b[4;3Hlocale  zh_TW.UTF-8"
+    )
     lines = rendered(screen)
-    assert lines[:3] == ["gentoo-install", "  keyboard  us", "  locale  zh_TW.UTF-8"]
+    assert lines[0] == "gentoo-install"
+    assert lines[2] == "  keyboard  us"
+    assert lines[3] == "  locale  zh_TW.UTF-8"
     assert max(cells(one) for one in lines) <= 80
+
+    # A row written past the edge is the finding this walk exists to make, and
+    # flattening hid it among rows that were never that wide.
+    wide = b"\x1b[2J\x1b[1;1H" + b"x" * 96 + b"\x1b[2;1Hshort"
+    drawn = rendered(wide)
+    assert cells(drawn[0]) == 96
+    assert drawn[1] == "short"
+
+    # Erase to end of line clears what a previous screen left behind.
+    stale = b"\x1b[2J\x1b[1;1Hlonger text here\x1b[1;5H\x1b[Kx"
+    assert rendered(stale)[0] == "longx"
 
 
 def test_a_worker_that_answered_and_exited_is_not_reported_twice() -> None:

--- a/tests/vm/tui.py
+++ b/tests/vm/tui.py
@@ -41,19 +41,70 @@ LINES: Final[int] = 24
 #: writes, and reading for less than this catches half of one.
 REDRAW_SECONDS: Final[float] = 2.0
 
-_ANSI: Final[re.Pattern[bytes]] = re.compile(rb"\x1b\[[0-9;?]*[A-Za-z]|\x1b[()][A-B]|\x1b[=>]")
+_CSI: Final[re.Pattern[str]] = re.compile(r"\x1b\[([0-9;?]*)([A-Za-z])")
+_OTHER_ESCAPE: Final[re.Pattern[str]] = re.compile(r"\x1b[()][A-B]|\x1b[=>]|\x1b.")
 
 
 def rendered(said: bytes) -> list[str]:
-    """The lines a screen left, with the escape codes taken out.
+    """The rows a screen holds, replayed into a grid.
 
-    A bare carriage return ends a line too. curses moves the cursor with one
-    between rows, so joining on newlines alone made every screen a single line
-    and the width check reported a 597-cell menu that is 24 rows of at most 80.
+    Taking the escape codes out is not enough. curses draws by moving the
+    cursor, not by ending lines, so stripping the codes ran the whole screen
+    together and the width check reported a 597-cell row that is 24 rows of at
+    most 80. The sequences that move or clear are replayed instead, and what is
+    measured is where each character actually landed.
     """
-    text = _ANSI.sub(b"", said).decode("utf-8", "replace")
-    flattened = text.replace("\r\n", "\n").replace("\r", "\n")
-    return [line.rstrip() for line in flattened.split("\n")]
+    grid: list[list[str]] = [[] for _ in range(LINES)]
+    row = column = 0
+
+    def place(character: str) -> None:
+        nonlocal row, column
+        if not 0 <= row < LINES:
+            return
+        line = grid[row]
+        while len(line) <= column:
+            line.append(" ")
+        line[column] = character
+        column += 1
+
+    text = said.decode("utf-8", "replace")
+    at = 0
+    while at < len(text):
+        found = _CSI.match(text, at)
+        if found:
+            at = found.end()
+            arguments = [one for one in found.group(1).split(";") if one.isdigit()]
+            letter = found.group(2)
+            if letter == "H":
+                # Rows and columns are one-based in the sequence and zero-based
+                # here, and an absent argument means the first.
+                row = (int(arguments[0]) if arguments else 1) - 1
+                column = (int(arguments[1]) if len(arguments) > 1 else 1) - 1
+            elif letter == "J":
+                grid = [[] for _ in range(LINES)]
+                row = column = 0
+            elif letter == "K":
+                if 0 <= row < LINES:
+                    del grid[row][column:]
+            continue
+        found = _OTHER_ESCAPE.match(text, at)
+        if found:
+            at = found.end()
+            continue
+        character = text[at]
+        at += 1
+        if character == "\r":
+            column = 0
+        elif character == "\n":
+            row += 1
+            column = 0
+        elif character == "\b":
+            column = max(0, column - 1)
+        elif character == "\x07":
+            continue
+        else:
+            place(character)
+    return ["".join(line).rstrip() for line in grid]
 
 
 @dataclass


### PR DESCRIPTION
Stripping the escape codes lost the cursor movement curses draws with, so every screen became one run of text and the walk reported rows of 597, 154 and 87 cells that are 24 rows of at most 80. The sequences that move and clear are replayed into a 24-row grid and what is measured is where each character landed, so a row genuinely written past column 80 is now the only thing that reports one.