### PR TITLE
disk: unmount the pool's own datasets before exporting

### DIFF
--- a/gentoo_install/plan/disk.py
+++ b/gentoo_install/plan/disk.py
@@ -752,6 +752,7 @@ class UnmountTarget(Operation):
         if self._still_mounted(context):
             context.run(["umount", "--recursive", "--lazy", str(context.target)])
         for pool in self.pools:
+            self._unmount_datasets(context, pool)
             self._export(context, pool)
 
     def _still_mounted(self, context: Context) -> bool:
@@ -759,6 +760,24 @@ class UnmountTarget(Operation):
             ["findmnt", "--mountpoint", str(context.target)], check=False
         )
         return isinstance(found, CommandOutput) and found.returncode == 0
+
+    def _unmount_datasets(self, context: Context, pool: str) -> None:
+        """Unmount the pool's own datasets, deepest first.
+
+        Unmounting the target tree is not enough. A live environment that
+        imported the pool itself mounts each dataset at its `mountpoint`
+        property rather than under the altroot, so those mounts are outside
+        `/mnt/gentoo` and `zpool export` reads `pool is busy` with the target
+        already clear: Gig-OS failed there where gentoo-cjk did not.
+        """
+        listed = context.run(
+            ["zfs", "list", "-H", "-o", "name", "-r", pool], check=False
+        )
+        if isinstance(listed, CommandOutput) and listed.returncode != 0:
+            return
+        names = [one.strip() for one in str(listed).splitlines() if one.strip()]
+        for name in sorted(names, key=lambda one: one.count("/"), reverse=True):
+            context.run(["zfs", "unmount", name], check=False)
 
     def _export(self, context: Context, pool: str) -> None:
         """`umount --lazy` detaches the tree and returns before the last

--- a/tests/unit/test_plan_disk.py
+++ b/tests/unit/test_plan_disk.py
@@ -616,6 +616,8 @@ def test_a_pool_still_busy_after_the_lazy_unmount_is_exported_on_a_later_try(
         ) -> str:
             if argv[0] == "findmnt":
                 return CommandOutput("/mnt/gentoo" if self.mounted else "", 0 if self.mounted else 1)
+            if tuple(argv[:2]) == ("zfs", "list"):
+                return CommandOutput("rpool\nrpool/ROOT\nrpool/ROOT/gentoo\nrpool/home\n", 0)
             return super().run(argv, check=check, input_text=input_text)
 
     ordered = Clean()
@@ -641,6 +643,14 @@ def test_a_pool_still_busy_after_the_lazy_unmount_is_exported_on_a_later_try(
     operation.apply(recorder)
     assert recorder.attempts == 3, recorder.attempts
     assert recorder.argv_starting("sleep") == (("sleep", "0"), ("sleep", "0"))
+
+    # The pool's own datasets are unmounted first, deepest before shallowest: a
+    # live environment that imported the pool mounts them at their `mountpoint`
+    # property, which is outside the target tree the unmount above cleared.
+    unmounted = [one[2] for one in recorder.commands if tuple(one[:2]) == ("zfs", "unmount")]
+    assert unmounted == ["rpool/ROOT/gentoo", "rpool/ROOT", "rpool/home", "rpool"] or (
+        unmounted[0] == "rpool/ROOT/gentoo" and unmounted[-1] == "rpool"
+    ), unmounted
 
     # A live environment running `zed` holds the pool for as long as it runs,
     # so the last attempt forces rather than waiting again.


### PR DESCRIPTION
With the target tree fully unmounted and `findmnt` finding nothing, Gig-OS still read `cannot export 'rpool': pool is busy` on every attempt including the forced one, where gentoo-cjk succeeded. A live environment that imported the pool itself mounts each dataset at its `mountpoint` property rather than under the altroot, so those mounts are outside `/mnt/gentoo`. The pool's own datasets are unmounted by name, deepest first.