### PR TITLE
vm: let the missing GRUB header be a miss, not a failure

### DIFF
--- a/tests/unit/test_proxmox.py
+++ b/tests/unit/test_proxmox.py
@@ -626,9 +626,24 @@ def test_the_countdown_is_halted_before_the_first_e_is_sent() -> None:
         def closed(self) -> bool:
             return False
 
+    class Late(Menu):
+        """The header scrolled past before the console was read: the console
+        raises its own timeout, and catching only ProxmoxError ended three
+        fixtures whose menu was on the screen the whole time."""
+
+        def expect(self, pattern: str, timeout: float) -> bytes:
+            from tests.vm.console import ConsoleTimeout
+
+            self.asked = True
+            raise ConsoleTimeout(f"never matched {pattern!r}")
+
     console = Menu()
     assert b"setparams" in _editor_screen(console, 30.0)
     assert console.sent[0] == "\x1b", console.sent
+
+    late = Late()
+    assert b"setparams" in _editor_screen(late, 30.0)
+    assert late.sent[0] == "\x1b", late.sent
 
 
 def test_a_long_install_is_never_sent_twice_after_a_reconnect() -> None:

--- a/tests/vm/proxmox.py
+++ b/tests/vm/proxmox.py
@@ -878,9 +878,13 @@ def _editor_screen(console: Line, timeout: float) -> bytes:
     # arrive while the menu is on the screen. A run sent `e` before the menu was
     # drawn, the press was discarded, and the entry booted ten seconds later
     # with the harness still waiting for an editor.
+    # The console raises its own timeout, not a ProxmoxError, and catching only
+    # the latter let `never matched 'GNU GRUB'` end three fixtures whose menu
+    # was on the screen the whole time. Missing the header is not a failure
+    # here; the presses that follow are what decide.
     try:
         console.expect(r"GNU GRUB", timeout=max(1.0, min(timeout, MENU_PATIENCE)))
-    except ProxmoxError:
+    except (ProxmoxError, ConsoleTimeout):
         pass
     # ESC rather than an arrow: it halts the countdown, and unlike an arrow it
     # cannot move the selection off the entry the guest is meant to boot.


### PR DESCRIPTION
The wait added for the countdown caught `ProxmoxError`, but the console raises `ConsoleTimeout`. `vm-desktop`, `vm-gnome` and `vm-openrc-desktop` ended at `never matched 'GNU GRUB'` in under a minute with the menu on the screen and its entries in the log. Missing the header is not a failure; the presses that follow decide.