### PR TITLE
vm: read a bios guest's GRUB menu before typing at it blind

### DIFF
--- a/tests/unit/test_harness.py
+++ b/tests/unit/test_harness.py
@@ -1094,3 +1094,46 @@ def test_no_fixture_asks_for_more_jobs_than_a_test_guest_has() -> None:
         makeopts = str(settings.get("portage", {}).get("makeopts", ""))
         for jobs in re.findall(r"-[jl](\d+)", makeopts):
             assert int(jobs) <= allowed, f"{fixture.name} asks for {makeopts}"
+
+
+def test_a_bios_guest_whose_grub_speaks_is_read_before_it_is_typed_at_blind(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The blind path exists for a GRUB that writes only to VGA. The official
+    minimal ISO answers `starting serial terminal on interface serial0` and can
+    be read; typing at it blind landed on no line and three fixtures ended at
+    `the kernel never spoke after editing GRUB blind`."""
+    from typing import Any, cast
+
+    from tests.vm import cluster
+
+    read: list[str] = []
+    monkeypatch.setattr(cluster, "append_to_cmdline", lambda link, extra: read.append("read"))
+    monkeypatch.setattr(
+        cluster, "append_to_cmdline_blind", lambda guest, link, extra: read.append("blind")
+    )
+    cluster._edit_bios_cmdline(cast("Any", object()), cast("Any", object()))
+    assert read == ["read"], "a menu that can be read is not typed at blind"
+
+    # A GRUB that says nothing still gets the blind attempt, from a menu the
+    # failed one did not touch.
+    reset: list[str] = []
+
+    class Guest:
+        def reset(self) -> None:
+            reset.append("reset")
+
+    class Link:
+        def reopen(self) -> None:
+            reset.append("reopen")
+
+    from tests.vm.console import ConsoleTimeout
+
+    def silent(link: object, extra: str) -> None:
+        raise ConsoleTimeout("never matched")
+
+    read.clear()
+    monkeypatch.setattr(cluster, "append_to_cmdline", silent)
+    cluster._edit_bios_cmdline(cast("Any", Guest()), cast("Any", Link()))
+    assert read == ["blind"]
+    assert reset == ["reset", "reopen"]

--- a/tests/vm/cluster.py
+++ b/tests/vm/cluster.py
@@ -899,11 +899,7 @@ def install_one(
         if job.uefi:
             append_to_cmdline(link, EXTRA_CMDLINE)
         else:
-            # SeaBIOS hands over to a GRUB that writes only to VGA, so the
-            # serial log stops at `Welcome to GRUB!` and there is no menu to
-            # read. The keys go through the API and the kernel appearing on
-            # the console is what says the edit landed.
-            append_to_cmdline_blind(guest, link, EXTRA_CMDLINE)
+            _edit_bios_cmdline(guest, link)
         reach_prompt(link)
         # The guest's own resolver is left alone. A local run pins one because
         # slirp reads the host's `/etc/resolv.conf` once at startup; the
@@ -1586,6 +1582,28 @@ def _abandon(inflight: dict[str, Running], running: dict[str, threading.Thread])
         thread.join(timeout=max(0.0, deadline - time.monotonic()))
     for name in inflight:
         print(f"  {name} outlived the schedule; remove it by hand", file=sys.stderr)
+
+
+def _edit_bios_cmdline(guest: Guest, link: "Reconnecting") -> None:
+    """Read the menu when GRUB speaks on the serial port, and type blind if not.
+
+    SeaBIOS hands over to a GRUB that on some media writes only to VGA, which
+    is why the blind path exists at all. The official minimal ISO answers
+    `starting serial terminal on interface serial0` and can be read, and typing
+    at it blind landed on no line: `vm-bios`, `vm-bios-luks` and `ext4-bios`
+    all ended at `the kernel never spoke after editing GRUB blind` with that
+    line in the log.
+    """
+    try:
+        append_to_cmdline(link, EXTRA_CMDLINE)
+        return
+    except (ProxmoxError, ConsoleTimeout, ConsoleClosed):
+        pass
+    # The half-finished edit goes with the reset, so the blind attempt starts
+    # from a menu nobody has touched.
+    guest.reset()
+    link.reopen()
+    append_to_cmdline_blind(guest, link, EXTRA_CMDLINE)
 
 
 def _unanswered(running: dict[str, threading.Thread], nothing_queued: bool) -> list[str]:


### PR DESCRIPTION
The blind path exists for a GRUB that writes only to VGA. The official minimal ISO answers `starting serial terminal on interface serial0` under SeaBIOS and can be read; typing at it blind landed on no line, and `vm-bios`, `vm-bios-luks` and `ext4-bios` all ended at `the kernel never spoke after editing GRUB blind` with that very line in the log. The readable path is tried first and the blind one remains the fallback, from a menu the failed attempt did not touch.