### PR TITLE
vm: stop asking twice for a menu hold_the_menu already waited for

### DIFF
--- a/tests/unit/test_proxmox.py
+++ b/tests/unit/test_proxmox.py
@@ -593,24 +593,24 @@ def test_the_editor_is_reopened_with_escape_not_a_second_e() -> None:
     # The leading ESC halts the countdown: GRUB stops it on the first key it
     # receives, and a run whose `e` arrived before the menu was drawn watched
     # the entry boot ten seconds later.
-    assert console.sent == ["\x1b", "e", "\x1b", "e"]
+    assert console.sent == ["e", "\x1b", "e"]
 
 
-def test_the_countdown_is_halted_before_the_first_e_is_sent() -> None:
-    """A guest whose menu is never waited for boots the default entry: the
-    press that would have stopped the countdown arrived before the menu."""
+def test_the_editor_is_asked_for_without_waiting_for_the_menu_again() -> None:
+    """`hold_the_menu` waits for the menu and stops the countdown. Asking again
+    inside `_editor_screen` blocked the whole patience on a header that had
+    already gone past, and every press landed after it: nineteen guests of one
+    round ended at `GRUB never opened its editor`."""
     from tests.vm.proxmox import _editor_screen
 
-    class Menu:
+    class Held:
+        """The menu is already up and its countdown already stopped."""
+
         def __init__(self) -> None:
             self.sent: list[str] = []
-            self.asked = False
 
         def send_raw(self, keys: str) -> None:
-            # Everything before the menu is drawn is discarded, which is what
-            # the guest's firmware does with it.
-            if self.asked:
-                self.sent.append(keys)
+            self.sent.append(keys)
 
         def snapshot(self, seconds: float) -> bytes:
             return GENTOO_EDITOR if self.sent else b""
@@ -619,31 +619,15 @@ def test_the_countdown_is_halted_before_the_first_e_is_sent() -> None:
             self.sent.append(line)
 
         def expect(self, pattern: str, timeout: float) -> bytes:
-            self.asked = True
-            return b"GNU GRUB  version 2.14"
+            raise AssertionError("hold_the_menu already waited for the menu")
 
         @property
         def closed(self) -> bool:
             return False
 
-    class Late(Menu):
-        """The header scrolled past before the console was read: the console
-        raises its own timeout, and catching only ProxmoxError ended three
-        fixtures whose menu was on the screen the whole time."""
-
-        def expect(self, pattern: str, timeout: float) -> bytes:
-            from tests.vm.console import ConsoleTimeout
-
-            self.asked = True
-            raise ConsoleTimeout(f"never matched {pattern!r}")
-
-    console = Menu()
+    console = Held()
     assert b"setparams" in _editor_screen(console, 30.0)
-    assert console.sent[0] == "\x1b", console.sent
-
-    late = Late()
-    assert b"setparams" in _editor_screen(late, 30.0)
-    assert late.sent[0] == "\x1b", late.sent
+    assert console.sent == ["e"], console.sent
 
 
 def test_a_long_install_is_never_sent_twice_after_a_reconnect() -> None:

--- a/tests/vm/proxmox.py
+++ b/tests/vm/proxmox.py
@@ -860,9 +860,9 @@ class Reopenable(Protocol):
     def reopen(self) -> None: ...
 
 
-#: How long the menu itself is waited for. GRUB's own countdown is ten
-#: seconds, and a console that attaches after it has expired never sees one.
-MENU_PATIENCE: Final[float] = 30.0
+#: How long an escape is left alone before the next key, so the two are not
+#: read as one sequence.
+ESCAPE_SETTLES: Final[float] = 2.0
 
 
 def _editor_screen(console: Line, timeout: float) -> bytes:
@@ -873,23 +873,11 @@ def _editor_screen(console: Line, timeout: float) -> bytes:
     the editor: a run read `no GRUB entry to edit on this screen` off a
     countdown line eight seconds from booting.
     """
+    # No wait for the menu here: `hold_the_menu` did that and stopped the
+    # countdown, and asking again blocked the whole patience on a header that
+    # had already gone past, so every press landed after it. Nineteen guests of
+    # one round ended at `GRUB never opened its editor` that way.
     deadline = time.monotonic() + timeout
-    # GRUB stops its countdown on the first key it receives, so that key has to
-    # arrive while the menu is on the screen. A run sent `e` before the menu was
-    # drawn, the press was discarded, and the entry booted ten seconds later
-    # with the harness still waiting for an editor.
-    # The console raises its own timeout, not a ProxmoxError, and catching only
-    # the latter let `never matched 'GNU GRUB'` end three fixtures whose menu
-    # was on the screen the whole time. Missing the header is not a failure
-    # here; the presses that follow are what decide.
-    try:
-        console.expect(r"GNU GRUB", timeout=max(1.0, min(timeout, MENU_PATIENCE)))
-    except (ProxmoxError, ConsoleTimeout):
-        pass
-    # ESC rather than an arrow: it halts the countdown, and unlike an arrow it
-    # cannot move the selection off the entry the guest is meant to boot.
-    console.send_raw("\x1b")
-    time.sleep(0.5)
     seen = b""
     everything = b""
     console.send_raw("e")
@@ -900,9 +888,10 @@ def _editor_screen(console: Line, timeout: float) -> bytes:
             return seen
         # ESC first, and only then `e` again: in the editor it discards the
         # edits and returns to the menu, and in the menu it does nothing. A
-        # bare second `e` would type the letter into the command line.
+        # bare second `e` would type the letter into the command line. The gap
+        # keeps them two keys rather than one escape sequence.
         console.send_raw("\x1b")
-        time.sleep(0.5)
+        time.sleep(ESCAPE_SETTLES)
         console.send_raw("e")
     # The whole read, not the last snapshot: the last one is empty on a guest
     # that booted while the loop was still pressing, which says nothing.


### PR DESCRIPTION
`hold_the_menu` waits for GRUB's countdown line and stops it. The wait added inside `_editor_screen` asked again for a header that had already gone past, blocked the full patience, and every press landed after it: nineteen guests of one round ended at `GRUB never opened its editor` with the menu drawn and its countdown already halted in the log.

Verified on one cluster guest, which reached `[11/50] download the newest systemd stage3`.