### PR TITLE
vm: verify the cluster's certificate

### DIFF
--- a/tests/unit/test_proxmox.py
+++ b/tests/unit/test_proxmox.py
@@ -1838,3 +1838,17 @@ def test_a_request_that_started_no_task_is_named_rather_than_crashed() -> None:
     with pytest.raises(ProxmoxError) as raised:
         api.wait("infra-node4", "")
     assert "did not start" in str(raised.value)
+
+
+def test_the_cluster_certificate_is_verified() -> None:
+    """An administrator token for seventy-nine machines went to whatever
+    answered on port 443. The comment justifying that said the cluster serves a
+    certificate its own CA signed; it is issued by Let's Encrypt and the
+    default context verifies it."""
+    import ssl
+
+    from tests.vm.proxmox import _certificates
+
+    context = _certificates()
+    assert context.verify_mode is ssl.CERT_REQUIRED
+    assert context.check_hostname is True

--- a/tests/vm/proxmox.py
+++ b/tests/vm/proxmox.py
@@ -108,14 +108,15 @@ def _transient(error: ProxmoxError) -> bool:
 
 
 def _certificates() -> ssl.SSLContext:
-    """The cluster serves a certificate its own CA signed, and that CA is not
-    in the workstation's store. Verification is off for this host alone; the
-    token is what authenticates, and it never leaves this process except in a
-    header on this connection."""
-    context = ssl.create_default_context()
-    context.check_hostname = False
-    context.verify_mode = ssl.CERT_NONE
-    return context
+    """The system trust store, verified.
+
+    The comment this replaced said the cluster serves a certificate its own CA
+    signed. It does not: `pve.infra.plz.ac` is issued by Let's Encrypt and the
+    default context verifies it. Turning verification off sent an
+    administrator token for a cluster of seventy-nine machines to whatever
+    answered on port 443.
+    """
+    return ssl.create_default_context()
 
 
 def _secret() -> str:


### PR DESCRIPTION
`_certificates` set `check_hostname = False` and `verify_mode = CERT_NONE`, justified by a comment saying the cluster serves a certificate its own CA signed and that CA is not in the workstation's store.

That is not true. `pve.infra.plz.ac` presents a Let's Encrypt chain and the default context verifies it; `curl` without `-k` and a plain `ssl.create_default_context()` both succeed. An administrator token holding all 42 privileges on a cluster of 79 machines was being sent to whatever answered on port 443.

Verified against the live API with verification on: `GET /version` answered and `ours()` listed the twelve guests of the running round.