### PR TITLE
tui: translate what the init system already has

### DIFF
--- a/gentoo_install/data/locale/ja.toml
+++ b/gentoo_install/data/locale/ja.toml
@@ -465,3 +465,4 @@
 "manual, {count} partitions" = "手動、{count} 個のパーティション"
 "{flags} (stage3 default)" = "{flags}（stage3 の既定値）"
 "this machine has no IPv4 and the mirror has no IPv6" = "このマシンに IPv4 がなく、このミラーに IPv6 がありません"
+"what the init system already has" = "init システム内蔵"

--- a/gentoo_install/data/locale/ko.toml
+++ b/gentoo_install/data/locale/ko.toml
@@ -465,3 +465,4 @@
 "manual, {count} partitions" = "수동, 파티션 {count}개"
 "{flags} (stage3 default)" = "{flags}(stage3 기본값)"
 "this machine has no IPv4 and the mirror has no IPv6" = "이 시스템에 IPv4가 없고 이 미러에 IPv6가 없습니다"
+"what the init system already has" = "init 시스템 내장"

--- a/gentoo_install/data/locale/zh-CN.toml
+++ b/gentoo_install/data/locale/zh-CN.toml
@@ -466,3 +466,4 @@
 "manual, {count} partitions" = "手动，{count} 个分区"
 "{flags} (stage3 default)" = "{flags}（stage3 默认值）"
 "this machine has no IPv4 and the mirror has no IPv6" = "本机没有 IPv4，而这个镜像没有 IPv6"
+"what the init system already has" = "init 系统内建"

--- a/gentoo_install/data/locale/zh-TW.toml
+++ b/gentoo_install/data/locale/zh-TW.toml
@@ -466,3 +466,4 @@
 "manual, {count} partitions" = "手動，{count} 個分割區"
 "{flags} (stage3 default)" = "{flags}（stage3 預設值）"
 "this machine has no IPv4 and the mirror has no IPv6" = "本機沒有 IPv4，而這個鏡像沒有 IPv6"
+"what the init system already has" = "init 系統內建"

--- a/gentoo_install/tui/settings.py
+++ b/gentoo_install/tui/settings.py
@@ -298,7 +298,13 @@ def _use(config: InstallConfig, context: Context) -> str:
 
 
 def _network(config: InstallConfig, context: Context) -> str:
-    return config.system.networking.value
+    # The NetworkManager values name a package and stay as they are. `builtin`
+    # describes what the init already has, and untranslated it read as an
+    # implementation value in a Chinese interface.
+    if config.system.networking is Networking.BUILTIN:
+        return context.translate("what the init system already has")
+    named: str = config.system.networking.value
+    return named
 
 
 def _firewall(config: InstallConfig, context: Context) -> str:

--- a/tests/unit/test_i18n.py
+++ b/tests/unit/test_i18n.py
@@ -305,6 +305,10 @@ def test_no_setting_row_shows_an_untranslated_english_word() -> None:
 #: Words a translated panel may still show: identifiers the ecosystem uses,
 #: package atoms, device names and command flags. Everything else in a row's
 #: value is prose, and prose belongs in the catalog.
+#: Words a translated row may keep. Every one is a proper noun, a filesystem,
+#: a package or a literal the system itself prints. `builtin` was here and is
+#: not one of those: it describes what the init already has, and the allowance
+#: is what let the network row read `builtin` in a Chinese interface.
 KEPT_IN_ENGLISH: frozenset[str] = frozenset(
     {
         "gentoo", "grub", "efi", "uefi", "bios", "zfs", "luks", "lvm", "mdraid", "utf",
@@ -314,7 +318,7 @@ KEPT_IN_ENGLISH: frozenset[str] = frozenset(
         "plasma", "gnome", "xfce", "sddm", "gdm", "lightdm", "greetd", "amd", "intel",
         "nvidia", "nouveau", "none", "true", "false", "auto", "cronie", "tmpfs", "dist",
         "stage", "bin", "cjk", "default", "console", "linux", "amd64", "desktop",
-        "multilib", "virtio", "target", "disk", "whole", "builtin", "profile", "kernel",
+        "multilib", "virtio", "target", "disk", "whole", "init", "profile", "kernel",
         "sys", "asia", "utc", "taipei", "shanghai", "tokyo", "seoul", "zfsbootmenu",
         "networkmanager", "iwd", "wpa", "supplicant", "guru", "gig", "rsync", "git",
         "webrsync", "official", "community", "off", "cpu", "flags", "ram",


### PR DESCRIPTION
The network row returned `Networking.value` straight out, so a Traditional Chinese interface read `builtin`. The leak test did not catch it because `builtin` was in `KEPT_IN_ENGLISH`, a list whose every other entry is a proper noun, a filesystem, a package or a literal the system prints.

The NetworkManager values name a package and stay as they are. Found by reading a real terminal recording of the menu, not by reading the code.