### PR TITLE
vm: refuse a repeated job name in run, not only in main

### DIFF
--- a/tests/unit/test_harness.py
+++ b/tests/unit/test_harness.py
@@ -1137,3 +1137,21 @@ def test_a_bios_guest_whose_grub_speaks_is_read_before_it_is_typed_at_blind(
     cluster._edit_bios_cmdline(cast("Any", Guest()), cast("Any", Link()))
     assert read == ["blind"]
     assert reset == ["reset", "reopen"]
+
+
+def test_run_refuses_a_repeated_job_name_before_it_touches_the_cluster() -> None:
+    """Every map in the scheduler is keyed by name, so a repeated one had the
+    second guest overwrite the first's bookkeeping, one result end the loop
+    while the other was still running, and `1/1 passed` printed for two jobs.
+    The check lived in `main`, which left every other caller able to do it."""
+    from tests.vm import cluster
+    from tests.vm.proxmox import ProxmoxError
+
+    twice = [
+        cluster.Job("vm-lvm", Path("tests/fixtures/vm-lvm.toml")),
+        cluster.Job("vm-lvm", Path("tests/fixtures/vm-lvm.toml")),
+    ]
+    with pytest.raises(ProxmoxError) as raised:
+        cluster.run(twice, Path("/nonexistent"))
+    assert "named more than once" in str(raised.value)
+    assert "vm-lvm" in str(raised.value)

--- a/tests/vm/cluster.py
+++ b/tests/vm/cluster.py
@@ -1047,6 +1047,14 @@ def run(
 
     `limit` caps how many run at once; zero asks the cluster what fits.
     """
+    # Before the cluster is touched. Every map below is keyed by name, so a
+    # repeated one had the second guest overwrite the first's bookkeeping, one
+    # result ended the loop while the other was still running, and `1/1 passed`
+    # was printed for two jobs. The check was in `main`, which left every
+    # other caller of `run` — the tests among them — able to do it.
+    repeated = sorted({one.name for one in jobs if [j.name for j in jobs].count(one.name) > 1})
+    if repeated:
+        raise ProxmoxError(f"named more than once: {repeated}")
     workdir = confined(workdir)
     api = Api()
     workdir.mkdir(parents=True, exist_ok=True)
@@ -1705,10 +1713,8 @@ def main(argv: list[str] | None = None) -> int:
 
     repeated = sorted({one for one in args.fixtures if args.fixtures.count(one) > 1})
     if repeated:
-        # Refused rather than deduplicated: every map below is keyed by name,
-        # so the second guest overwrote the first's bookkeeping, one result
-        # ended the loop while the other was still running, and `1/1 passed`
-        # was printed for two jobs.
+        # Named here as well so the operator reads it before the cluster is
+        # asked anything; `run` refuses it too, for every other caller.
         print(f"named more than once: {repeated}", file=sys.stderr)
         return 1
 


### PR DESCRIPTION
`running`, `where` and the lease map are all keyed by `job.name`. A repeated name had the second guest overwrite the first's bookkeeping, one result end the collection loop while the other was still installing, and `1/1 passed` printed for two jobs. The refusal was in the argument parser, so every other caller of `run` — the tests among them — could still do it.