### PR TITLE
vm: remove the guests that outlived the join

### DIFF
--- a/tests/unit/test_harness.py
+++ b/tests/unit/test_harness.py
@@ -902,9 +902,13 @@ def test_a_schedule_that_ends_early_stops_the_guests_it_left_running() -> None:
     class Guest:
         def __init__(self) -> None:
             self.stopped = False
+            self.removed = False
 
         def stop(self) -> None:
             self.stopped = True
+
+        def destroy(self) -> None:
+            self.removed = True
 
     quiet = cluster.Watchdog(log=Path("/nonexistent"), counters=lambda: None)
     guests = {name: Guest() for name in ("vm-lvm", "vm-xfs")}
@@ -929,6 +933,19 @@ def test_a_schedule_that_ends_early_stops_the_guests_it_left_running() -> None:
     assert all(guest.stopped for guest in guests.values()), guests
     assert sorted(joined) == ["vm-lvm", "vm-xfs"]
     assert not inflight, "each worker removes its own guest once the console closes"
+
+    # A worker that never got there leaves its guest held, and after the join
+    # there is nobody left to race: reporting it and walking away left guests
+    # running on a cluster the harness does not own.
+    wedged = Guest()
+    held = {"vm-zfs": cluster.Running(guest=wedged, watch=quiet)}
+
+    class Stuck(threading.Thread):
+        def join(self, timeout: float | None = None) -> None:
+            return
+
+    cluster._abandon(held, {"vm-zfs": Stuck(daemon=True)})
+    assert wedged.stopped and wedged.removed, "the closing path removes it"
 
 
 def test_a_removed_guest_gives_its_vmid_back(monkeypatch: pytest.MonkeyPatch) -> None:

--- a/tests/vm/cluster.py
+++ b/tests/vm/cluster.py
@@ -829,11 +829,17 @@ def room_for(node: Node, job: Job, placed: Mapping[str, int] | None = None) -> b
 
 
 class Stoppable(Protocol):
-    """All the sweep needs of a guest. Stopping is what wakes the worker that
-    is blocked reading its console; deleting is the worker's own job, and a
-    sweep that deleted would race it."""
+    """What the sweep and the closing path need of a guest.
+
+    Stopping is what wakes the worker blocked reading its console. During the
+    schedule deleting is the worker's own job and a sweep that deleted would
+    race it; once the closing path has joined the workers there is nobody left
+    to race, and a guest still held there is one nothing else will remove.
+    """
 
     def stop(self) -> None: ...
+
+    def destroy(self) -> None: ...
 
 
 @dataclass
@@ -1588,8 +1594,15 @@ def _abandon(inflight: dict[str, Running], running: dict[str, threading.Thread])
     deadline = time.monotonic() + ABANDON_PATIENCE
     for thread in running.values():
         thread.join(timeout=max(0.0, deadline - time.monotonic()))
-    for name in inflight:
-        print(f"  {name} outlived the schedule; remove it by hand", file=sys.stderr)
+    # After the join, not before: a worker that was going to remove its own
+    # guest has had its chance, and what is left is what nothing else will
+    # remove. Reporting it and walking away left guests running on the cluster.
+    for name, one in list(inflight.items()):
+        try:
+            one.guest.destroy()
+            print(f"  {name} removed by the closing path", file=sys.stderr)
+        except ProxmoxError as error:
+            print(f"  {name} outlived the schedule: {error}", file=sys.stderr)
 
 
 def _edit_bios_cmdline(guest: Guest, link: "Reconnecting") -> None:


### PR DESCRIPTION
The closing path stopped each guest, joined the workers, then printed `remove it by hand` for anything still held. A worker that reaches its own `finally` removes its guest, so what survives the join is precisely what nothing else will remove — and after the join there is no worker left to race. `Stoppable` gains `destroy` and the closing path calls it.