### PR TITLE
vm: read the reason a two hundred carries

### DIFF
--- a/tests/unit/test_proxmox.py
+++ b/tests/unit/test_proxmox.py
@@ -1852,3 +1852,44 @@ def test_the_cluster_certificate_is_verified() -> None:
     context = _certificates()
     assert context.verify_mode is ssl.CERT_REQUIRED
     assert context.check_hostname is True
+
+
+def test_an_error_carried_in_a_two_hundred_is_not_thrown_away() -> None:
+    """This API reports `invalid bootorder: device 'virtio0' does not exist` as
+    HTTP 200 with `data: null` and the reason in `message`. Reading only `data`
+    turned that into `answered without a task id` on four installs that had
+    finished and collected their results. A success answers `{"data": null}`
+    with no message at all."""
+    import io
+    import json
+
+    from tests.vm.proxmox import Api, ProxmoxError
+
+    class Answer(io.BytesIO):
+        headers: dict[str, str] = {}
+
+        def __enter__(self) -> "Answer":
+            return self
+
+        def __exit__(self, *unused: object) -> None:
+            return None
+
+    class Opener:
+        def __init__(self, body: dict[str, object]) -> None:
+            self.body = body
+
+        def open(self, request: object, timeout: float = 0.0) -> Answer:
+            return Answer(json.dumps(self.body).encode())
+
+    api = Api.__new__(Api)
+    api.host = "pve.invalid"
+    api.affinity = ""
+
+    api._opener = Opener({"data": None, "message": "invalid bootorder\n"})  # type: ignore[assignment]
+    with pytest.raises(ProxmoxError) as raised:
+        api.call("PUT", "/nodes/n/qemu/9300/config", boot="order=virtio0")
+    assert "invalid bootorder" in str(raised.value)
+
+    # A config change applied then and there says nothing, and that is success.
+    api._opener = Opener({"data": None})  # type: ignore[assignment]
+    assert api.call("PUT", "/nodes/n/qemu/9300/config", description="x") is None

--- a/tests/vm/proxmox.py
+++ b/tests/vm/proxmox.py
@@ -180,7 +180,17 @@ class Api:
         try:
             with self._opener.open(request, timeout=API_TIMEOUT) as answer:
                 remembered = self._remember(answer.headers)
-                return json.load(answer).get("data"), remembered or affinity
+                said = json.load(answer)
+                data = said.get("data")
+                reason = str(said.get("message", "")).strip()
+                # 200 with `data: null` and a `message` is how this API reports
+                # `invalid bootorder: device 'virtio0' does not exist`, and
+                # reading only `data` threw that away: four finished installs
+                # were reported as a request that never started. A success
+                # answers `{"data": null}` with no message at all.
+                if data is None and reason:
+                    raise ProxmoxError(f"{method} {path} answered {reason}")
+                return data, remembered or affinity
         except urllib.error.HTTPError as error:
             # The reason, not only the body: Proxmox answers `500` with
             # `{"data":null}` and puts what went wrong in the status line.
@@ -459,12 +469,15 @@ class Guest:
         for. `order=virtio0` is what makes the firmware try the target rather
         than the CD it was built with.
         """
-        self.api.wait(
-            self.node,
-            self.api.call(
-                "PUT", f"/nodes/{self.node}/qemu/{self.vmid}/config", boot="order=virtio0"
-            ),
+        upid = self.api.call(
+            "PUT", f"/nodes/{self.node}/qemu/{self.vmid}/config", boot="order=virtio0"
         )
+        # A config change the API applies then and there answers `data: null`;
+        # only a deferred one comes back as a task. Waiting on the empty answer
+        # ended four installs that had already finished and collected their
+        # results.
+        if upid:
+            self.api.wait(self.node, upid)
 
     def reset(self) -> None:
         """Boot the firmware again with somebody already reading.


### PR DESCRIPTION
Four guests of round 20 ended at `answered without a task id; the request did not start` after seventy to eighty minutes, with `GI_RESULTS_END` in their logs: the installs had finished and their results were collected.

The API answers `PUT /config` with `{"data": null}` when it applies the change then and there, and with `{"data": null, "message": "invalid bootorder: device 'virtio0' does not exist"}` when it refuses — both HTTP 200. `call` read only `data`, so the reason was thrown away and `boot_from_disk` waited on an empty task id.

Both halves are fixed: a null answer carrying a message raises it, and a config change that needs no task is not waited on. Verified against the live API with a throwaway guest: the refusal and the success were observed as described.