### PR TITLE
tui: reopen a selector on what is already set

### DIFF
--- a/gentoo_install/tui/screens.py
+++ b/gentoo_install/tui/screens.py
@@ -399,6 +399,7 @@ def _zfs_bootloader(screen: Screen, config: InstallConfig, context: Context) -> 
             ),
         ],
         footer=footer(translate),
+        current=config.bootloader.kind,
     ).run(screen)
     if not answer.chosen:
         return config
@@ -501,6 +502,7 @@ def init_screen(screen: Screen, config: InstallConfig, context: Context) -> Answ
         title=translate("Init system"),
         items=[Item(label=init.value, value=init) for init in InitSystem],
         footer=footer(translate),
+        current=config.system.init,
     )
     answer = menu.run(screen)
     if not answer.chosen:
@@ -888,6 +890,7 @@ def _edit_mirror(
             title=translate("Region"),
             items=[Item(label=one.value, value=one) for one in MirrorRegion],
             footer=footer(translate),
+            current=current.region,
         ).run(screen)
         if not picked.chosen:
             return None
@@ -908,6 +911,7 @@ def _edit_mirror(
                 for one in offered
             ],
             footer=footer(translate),
+            current=current.site,
         ).run(screen)
         if not chosen.chosen:
             return None
@@ -2456,7 +2460,10 @@ def console_font_screen(
             )
         )
     answer = Menu(
-        title=context.translate("Console font"), items=items, footer=footer(context.translate)
+        title=context.translate("Console font"),
+        items=items,
+        footer=footer(context.translate),
+        current=config.system.console_font,
     ).run(screen)
     if not answer.chosen:
         return Answer(answer.outcome)

--- a/tests/unit/test_tui_app.py
+++ b/tests/unit/test_tui_app.py
@@ -2062,3 +2062,41 @@ def test_a_detected_row_still_has_to_be_opened() -> None:
     said = app._blocked(whole, at)
     for label in ("Mirrors", "Drive", "Compiler"):
         assert label in said, said
+
+
+def test_a_reopened_selector_starts_on_what_is_already_set() -> None:
+    """`Menu.current` exists because without it the first row wins: its own
+    comment records encryption enabled becoming disabled. These selectors were
+    built without it, so reopening the row and pressing enter without
+    navigating answered with the first item rather than what was set."""
+    import ast
+    from pathlib import Path
+
+    #: Every one holds a value the configuration already carries. A prompt that
+    #: creates something, or asks a question with no prior answer, is not here.
+    WANTED: frozenset[str] = frozenset(
+        {
+            "Init system",
+            "Region",
+            "Gentoo mirror",
+            "Console font",
+            "A ZFS root cannot boot from GRUB. Which bootloader?",
+        }
+    )
+    tree = ast.parse(Path("gentoo_install/tui/screens.py").read_text())
+    seen: dict[str, bool] = {}
+    for node in ast.walk(tree):
+        if not (isinstance(node, ast.Call) and isinstance(node.func, ast.Name)):
+            continue
+        if node.func.id != "Menu":
+            continue
+        title = ""
+        for one in node.keywords:
+            if one.arg == "title" and isinstance(one.value, ast.Call) and one.value.args:
+                argument = one.value.args[0]
+                if isinstance(argument, ast.Constant):
+                    title = str(argument.value)
+        if title in WANTED:
+            seen[title] = any(one.arg == "current" for one in node.keywords)
+    assert set(seen) == WANTED, f"a selector was renamed or removed: {sorted(seen)}"
+    assert all(seen.values()), sorted(one for one, has in seen.items() if not has)


### PR DESCRIPTION
`Menu.current` exists for exactly this, and its own comment records what happens without it: encryption enabled became disabled. The init system, region, Gentoo mirror, console font and ZFS bootloader selectors were built without it, so reopening one and pressing enter without navigating answered with the first item rather than the value the configuration holds.

The test names the five and fails if one loses `current` or is renamed. Prompts that create something, or ask a question with no prior answer, are deliberately not in the list.