### PR TITLE
tui: undo the layout when its bootloader question is cancelled

### DIFF
--- a/gentoo_install/tui/screens.py
+++ b/gentoo_install/tui/screens.py
@@ -360,13 +360,21 @@ def layout_screen(screen: Screen, config: InstallConfig, context: Context) -> An
     if not answer.chosen:
         return Answer(answer.outcome)
     layout, filesystem = answer.unwrap()[0]
+    was_manual, was_choice = context.manual, context.choice
     context.manual = False
     if layout is None:
         return partitions_screen(screen, config, context)
     context.choice = replace(context.choice, layout=layout, filesystem=filesystem)
     changed = _rebuild(config, context)
     if layout is Layout.WHOLE_DISK_ZFS:
-        changed = _zfs_bootloader(screen, changed, context)
+        picked = _zfs_bootloader(screen, changed, context)
+        if picked is None:
+            # Cancelling the question undoes the layout that raised it. The
+            # graph was already rebuilt and the choice already written, so
+            # both go back: leaving them committed a ZFS root with GRUB.
+            context.manual, context.choice = was_manual, was_choice
+            return Answer(Outcome.BACK)
+        changed = picked
     return Answer(Outcome.CHOSE, changed)
 
 
@@ -376,7 +384,9 @@ def _known(kind: str) -> FilesystemType | None:
     return next((one for one in FilesystemType if one.value == kind), None)
 
 
-def _zfs_bootloader(screen: Screen, config: InstallConfig, context: Context) -> InstallConfig:
+def _zfs_bootloader(
+    screen: Screen, config: InstallConfig, context: Context
+) -> InstallConfig | None:
     """A ZFS root cannot use GRUB, so this asks which of the two that remain.
 
     ZFSBootMenu lives in the gentoo-zh overlay and in no other repository, so
@@ -402,7 +412,10 @@ def _zfs_bootloader(screen: Screen, config: InstallConfig, context: Context) -> 
         current=config.bootloader.kind,
     ).run(screen)
     if not answer.chosen:
-        return config
+        # None rather than the configuration handed in: that one already holds
+        # the ZFS layout, and returning it committed a ZFS root with GRUB,
+        # which the compatibility table refuses.
+        return None
     kind = answer.unwrap()[0]
     if kind is Bootloader.SYSTEMD_BOOT:
         return replace(config, bootloader=replace(config.bootloader, kind=kind))
@@ -2643,7 +2656,13 @@ def partitions_screen(
                 # boot from GRUB, and ZFSBootMenu needs the overlay adding.
                 # Without this every bootloader row was greyed and the table
                 # had no way out.
-                built = _zfs_bootloader(screen, built, context)
+                picked = _zfs_bootloader(screen, built, context)
+                if picked is None:
+                    # Back to the editor rather than out of it: the table the
+                    # operator drew is still there, and a ZFS root with GRUB
+                    # is what committing this would have written.
+                    continue
+                built = picked
             return Answer(Outcome.CHOSE, built)
         _act_on(screen, context, row)
 

--- a/tests/unit/test_tui_app.py
+++ b/tests/unit/test_tui_app.py
@@ -1878,6 +1878,7 @@ def test_the_zfs_bootloader_prompt_returns_only_installable_answers() -> None:
         answered = screens._zfs_bootloader(
             FakeScreen(keys=keys, lines=24, columns=100), start, at
         )
+        assert answered is not None, "neither key cancels"
         validate(answered)
 
 
@@ -2100,3 +2101,28 @@ def test_a_reopened_selector_starts_on_what_is_already_set() -> None:
             seen[title] = any(one.arg == "current" for one in node.keywords)
     assert set(seen) == WANTED, f"a selector was renamed or removed: {sorted(seen)}"
     assert all(seen.values()), sorted(one for one, has in seen.items() if not has)
+
+
+def test_cancelling_the_zfs_bootloader_question_undoes_the_layout() -> None:
+    """The layout is written and the graph rebuilt before the question is
+    asked, so cancelling it committed a ZFS root with GRUB — a combination
+    `model/compat.py` refuses and no later screen would have offered a way
+    out of."""
+    from gentoo_install.model.config import Bootloader
+    from gentoo_install.model.device import ZfsPool
+    from gentoo_install.tui.widgets import Outcome as Answered
+
+    from .layouts import ext4_on_gpt
+
+    at = context()
+    start = config(ext4_on_gpt())
+    assert not list(start.disk.graph.of_type(ZfsPool))
+    before = at.choice
+
+    # Down to the ZFS row, enter, then escape out of the bootloader question.
+    keys = ["KEY_DOWN", "KEY_DOWN", "KEY_DOWN", "\n", "\x1b"]
+    answer = screens.layout_screen(FakeScreen(keys=keys, lines=24, columns=100), start, at)
+
+    assert answer.outcome is not Answered.CHOSE, answer.outcome
+    assert at.choice == before, "the choice goes back with the layout"
+    assert start.bootloader.kind is not Bootloader.ZFSBOOTMENU


### PR DESCRIPTION
`layout_screen` writes the choice and rebuilds the graph before opening the bootloader submenu, and `_zfs_bootloader` returned that already-changed configuration on cancellation while the caller still answered `CHOSE`. The menu was then holding a ZFS root with GRUB — a pair `model/compat.py` refuses, and one no later screen offered a way out of, because every bootloader row is greyed.

Cancelling now takes the layout and the choice back with it. The manual editor's copy of the same question returns to the editor rather than out of it, so the table the operator drew is not lost.