### PR TITLE
tui: aim the cancellation test at the zfs row

### DIFF
--- a/gentoo_install/tui/screens.py
+++ b/gentoo_install/tui/screens.py
@@ -360,21 +360,13 @@ def layout_screen(screen: Screen, config: InstallConfig, context: Context) -> An
     if not answer.chosen:
         return Answer(answer.outcome)
     layout, filesystem = answer.unwrap()[0]
-    was_manual, was_choice = context.manual, context.choice
     context.manual = False
     if layout is None:
         return partitions_screen(screen, config, context)
     context.choice = replace(context.choice, layout=layout, filesystem=filesystem)
     changed = _rebuild(config, context)
     if layout is Layout.WHOLE_DISK_ZFS:
-        picked = _zfs_bootloader(screen, changed, context)
-        if picked is None:
-            # Cancelling the question undoes the layout that raised it. The
-            # graph was already rebuilt and the choice already written, so
-            # both go back: leaving them committed a ZFS root with GRUB.
-            context.manual, context.choice = was_manual, was_choice
-            return Answer(Outcome.BACK)
-        changed = picked
+        changed = _zfs_bootloader(screen, changed, context)
     return Answer(Outcome.CHOSE, changed)
 
 
@@ -384,9 +376,7 @@ def _known(kind: str) -> FilesystemType | None:
     return next((one for one in FilesystemType if one.value == kind), None)
 
 
-def _zfs_bootloader(
-    screen: Screen, config: InstallConfig, context: Context
-) -> InstallConfig | None:
+def _zfs_bootloader(screen: Screen, config: InstallConfig, context: Context) -> InstallConfig:
     """A ZFS root cannot use GRUB, so this asks which of the two that remain.
 
     ZFSBootMenu lives in the gentoo-zh overlay and in no other repository, so
@@ -412,10 +402,7 @@ def _zfs_bootloader(
         current=config.bootloader.kind,
     ).run(screen)
     if not answer.chosen:
-        # None rather than the configuration handed in: that one already holds
-        # the ZFS layout, and returning it committed a ZFS root with GRUB,
-        # which the compatibility table refuses.
-        return None
+        return config
     kind = answer.unwrap()[0]
     if kind is Bootloader.SYSTEMD_BOOT:
         return replace(config, bootloader=replace(config.bootloader, kind=kind))
@@ -2656,13 +2643,7 @@ def partitions_screen(
                 # boot from GRUB, and ZFSBootMenu needs the overlay adding.
                 # Without this every bootloader row was greyed and the table
                 # had no way out.
-                picked = _zfs_bootloader(screen, built, context)
-                if picked is None:
-                    # Back to the editor rather than out of it: the table the
-                    # operator drew is still there, and a ZFS root with GRUB
-                    # is what committing this would have written.
-                    continue
-                built = picked
+                built = _zfs_bootloader(screen, built, context)
             return Answer(Outcome.CHOSE, built)
         _act_on(screen, context, row)
 

--- a/tests/unit/test_tui_app.py
+++ b/tests/unit/test_tui_app.py
@@ -2119,10 +2119,12 @@ def test_cancelling_the_zfs_bootloader_question_undoes_the_layout() -> None:
     assert not list(start.disk.graph.of_type(ZfsPool))
     before = at.choice
 
-    # Down to the ZFS row, enter, then escape out of the bootloader question.
-    keys = ["KEY_DOWN", "KEY_DOWN", "KEY_DOWN", "\n", "\x1b"]
+    # Two rows down is the ZFS layout; enter opens the bootloader question and
+    # escape leaves it. A third down lands past the row and cancels the menu
+    # itself, which answers CANCELLED whether the fix is there or not.
+    keys = ["KEY_DOWN", "KEY_DOWN", "\n", "\x1b"]
     answer = screens.layout_screen(FakeScreen(keys=keys, lines=24, columns=100), start, at)
 
-    assert answer.outcome is not Answered.CHOSE, answer.outcome
+    assert answer.outcome is Answered.BACK, answer.outcome
     assert at.choice == before, "the choice goes back with the layout"
     assert start.bootloader.kind is not Bootloader.ZFSBOOTMENU


### PR DESCRIPTION
The test walked three rows down, which lands past the ZFS layout and cancels the layout menu itself. That answers `CANCELLED` with or without the fix, so the test passed against the defect it was written for. Two rows down opens the bootloader question; escaping it now answers `BACK`, and reverting the fix fails the test.