### PR TITLE
tui: keep builtin as the English network value

### DIFF
--- a/gentoo_install/data/locale/ja.toml
+++ b/gentoo_install/data/locale/ja.toml
@@ -465,4 +465,4 @@
 "manual, {count} partitions" = "手動、{count} 個のパーティション"
 "{flags} (stage3 default)" = "{flags}（stage3 の既定値）"
 "this machine has no IPv4 and the mirror has no IPv6" = "このマシンに IPv4 がなく、このミラーに IPv6 がありません"
-"what the init system already has" = "init システム内蔵"
+"builtin" = "init システム内蔵"

--- a/gentoo_install/data/locale/ko.toml
+++ b/gentoo_install/data/locale/ko.toml
@@ -465,4 +465,4 @@
 "manual, {count} partitions" = "수동, 파티션 {count}개"
 "{flags} (stage3 default)" = "{flags}(stage3 기본값)"
 "this machine has no IPv4 and the mirror has no IPv6" = "이 시스템에 IPv4가 없고 이 미러에 IPv6가 없습니다"
-"what the init system already has" = "init 시스템 내장"
+"builtin" = "init 시스템 내장"

--- a/gentoo_install/data/locale/zh-CN.toml
+++ b/gentoo_install/data/locale/zh-CN.toml
@@ -466,4 +466,4 @@
 "manual, {count} partitions" = "手动，{count} 个分区"
 "{flags} (stage3 default)" = "{flags}（stage3 默认值）"
 "this machine has no IPv4 and the mirror has no IPv6" = "本机没有 IPv4，而这个镜像没有 IPv6"
-"what the init system already has" = "init 系统内建"
+"builtin" = "init 系统内建"

--- a/gentoo_install/data/locale/zh-TW.toml
+++ b/gentoo_install/data/locale/zh-TW.toml
@@ -466,4 +466,4 @@
 "manual, {count} partitions" = "手動，{count} 個分割區"
 "{flags} (stage3 default)" = "{flags}（stage3 預設值）"
 "this machine has no IPv4 and the mirror has no IPv6" = "本機沒有 IPv4，而這個鏡像沒有 IPv6"
-"what the init system already has" = "init 系統內建"
+"builtin" = "init 系統內建"

--- a/gentoo_install/tui/settings.py
+++ b/gentoo_install/tui/settings.py
@@ -302,7 +302,9 @@ def _network(config: InstallConfig, context: Context) -> str:
     # describes what the init already has, and untranslated it read as an
     # implementation value in a Chinese interface.
     if config.system.networking is Networking.BUILTIN:
-        return context.translate("what the init system already has")
+        # The key is the English row, so it stays the word Portage and the
+        # init systems use; the catalogs carry the description.
+        return context.translate("builtin")
     named: str = config.system.networking.value
     return named
 


### PR DESCRIPTION
#129 replaced the row's value with `context.translate("what the init system already has")`. The catalog key is what an English interface shows, so the English row grew a sentence where a value belongs — visible on a real menu as `Network  what the init system already has, DHCP`.

The key goes back to `builtin`, the word Portage and the init systems use, and the four catalogs carry the description. Found by opening the menu on a guest and reading it.