### PR TITLE
tui: ask who lays the disk out before what goes on it

### DIFF
--- a/gentoo_install/data/locale/ja.toml
+++ b/gentoo_install/data/locale/ja.toml
@@ -466,3 +466,6 @@
 "{flags} (stage3 default)" = "{flags}（stage3 の既定値）"
 "this machine has no IPv4 and the mirror has no IPv6" = "このマシンに IPv4 がなく、このミラーに IPv6 がありません"
 "builtin" = "init システム内蔵"
+"How is this disk laid out?" = "このディスクの配置を決めるのは"
+"automatic" = "自動"
+"the installer writes the table" = "インストーラーがテーブルを書く"

--- a/gentoo_install/data/locale/ko.toml
+++ b/gentoo_install/data/locale/ko.toml
@@ -466,3 +466,6 @@
 "{flags} (stage3 default)" = "{flags}(stage3 기본값)"
 "this machine has no IPv4 and the mirror has no IPv6" = "이 시스템에 IPv4가 없고 이 미러에 IPv6가 없습니다"
 "builtin" = "init 시스템 내장"
+"How is this disk laid out?" = "이 디스크의 배치를 정하는 주체"
+"automatic" = "자동"
+"the installer writes the table" = "설치 프로그램이 테이블을 작성"

--- a/gentoo_install/data/locale/zh-CN.toml
+++ b/gentoo_install/data/locale/zh-CN.toml
@@ -467,3 +467,6 @@
 "{flags} (stage3 default)" = "{flags}（stage3 默认值）"
 "this machine has no IPv4 and the mirror has no IPv6" = "本机没有 IPv4，而这个镜像没有 IPv6"
 "builtin" = "init 系统内建"
+"How is this disk laid out?" = "这颗磁盘由谁排版面？"
+"automatic" = "自动"
+"the installer writes the table" = "安装器写这张分区表"

--- a/gentoo_install/data/locale/zh-TW.toml
+++ b/gentoo_install/data/locale/zh-TW.toml
@@ -467,3 +467,6 @@
 "{flags} (stage3 default)" = "{flags}（stage3 預設值）"
 "this machine has no IPv4 and the mirror has no IPv6" = "本機沒有 IPv4，而這個鏡像沒有 IPv6"
 "builtin" = "init 系統內建"
+"How is this disk laid out?" = "這顆磁碟由誰排版面？"
+"automatic" = "自動"
+"the installer writes the table" = "安裝器寫這張分割表"

--- a/gentoo_install/tui/screens.py
+++ b/gentoo_install/tui/screens.py
@@ -321,6 +321,44 @@ def disk_screen(screen: Screen, config: InstallConfig, context: Context) -> Answ
 
 
 def layout_screen(screen: Screen, config: InstallConfig, context: Context) -> Answer[InstallConfig]:
+    """Who lays the disk out, and only then what goes on it.
+
+    One list held both questions: four filesystems and `manual` side by side,
+    as if `manual` were a fifth filesystem. It is the other question, and
+    asking it first is what makes the automatic path a path rather than a
+    default nobody was offered an alternative to.
+    """
+    translate = context.translate
+    by_hand = context.choice.layout is Layout.REUSE
+    how = Menu[bool](
+        title=translate("How is this disk laid out?"),
+        items=[
+            Item(
+                label=translate("automatic"),
+                value=False,
+                detail=translate("the installer writes the table"),
+            ),
+            Item(
+                label=translate("manual"),
+                value=True,
+                detail=translate("one table: keep, format, delete or add each partition"),
+            ),
+        ],
+        footer=footer(translate),
+        current=by_hand,
+    ).run(screen)
+    if not how.chosen:
+        return Answer(how.outcome)
+    if how.unwrap()[0]:
+        context.manual = False
+        return partitions_screen(screen, config, context)
+    return _template_screen(screen, config, context)
+
+
+def _template_screen(
+    screen: Screen, config: InstallConfig, context: Context
+) -> Answer[InstallConfig]:
+    """What the installer writes when it lays the disk out itself."""
     translate = context.translate
     items: list[Item[tuple[Layout | None, FilesystemType]]] = [
         Item(label="ext4", value=(Layout.WHOLE_DISK, FilesystemType.EXT4)),
@@ -335,11 +373,6 @@ def layout_screen(screen: Screen, config: InstallConfig, context: Context) -> An
             value=(Layout.WHOLE_DISK_ZFS, FilesystemType.EXT4),
             detail=translate("with ZFSBootMenu"),
             disabled_because=context.zfs_unavailable,
-        ),
-        Item(
-            label=translate("manual"),
-            value=(None, FilesystemType.EXT4),
-            detail=translate("one table: keep, format, delete or add each partition"),
         ),
     ]
     # On the row the configuration already holds, so enter keeps what is set

--- a/tests/unit/test_tui_app.py
+++ b/tests/unit/test_tui_app.py
@@ -269,9 +269,9 @@ def test_every_repository_choice_is_on_the_mirror_screen() -> None:
 def test_choosing_zfs_asks_before_adding_the_overlay() -> None:
     """ZFSBootMenu is in gentoo-zh and in no other repository, so choosing it
     is consenting to that overlay rather than having it added silently."""
-    # Two, not three: the cursor starts on the row the configuration already
-    # holds, and the default filesystem is xfs, which is the second row.
-    zfs = ["KEY_DOWN", "KEY_DOWN", "\n"]
+    # `automatic` first, then two down: the cursor starts on the row the
+    # configuration already holds, and the default filesystem is xfs.
+    zfs = ["\n", "KEY_DOWN", "KEY_DOWN", "\n"]
     screen = FakeScreen(keys=[*zfs, "\n"])
     answer = screens.layout_screen(screen, config(), context())
     assert answer.unwrap().bootloader.kind is Bootloader.ZFSBOOTMENU
@@ -283,9 +283,8 @@ def test_choosing_zfs_asks_before_adding_the_overlay() -> None:
 
 def test_declining_the_overlay_leaves_zfs_on_systemd_boot() -> None:
     """The other bootloader a ZFS root can use, and it needs no overlay."""
-    # Two, not three: the cursor starts on the row the configuration already
-    # holds, and the default filesystem is xfs, which is the second row.
-    zfs = ["KEY_DOWN", "KEY_DOWN", "\n"]
+    # `automatic` first, then two down to the zfs row.
+    zfs = ["\n", "KEY_DOWN", "KEY_DOWN", "\n"]
     answer = screens.layout_screen(FakeScreen(keys=[*zfs, "KEY_DOWN", "\n"]), config(), context())
     assert answer.unwrap().bootloader.kind is Bootloader.SYSTEMD_BOOT
     assert answer.unwrap().portage.overlays == ()
@@ -2122,7 +2121,7 @@ def test_cancelling_the_zfs_bootloader_question_undoes_the_layout() -> None:
     # Two rows down is the ZFS layout; enter opens the bootloader question and
     # escape leaves it. A third down lands past the row and cancels the menu
     # itself, which answers CANCELLED whether the fix is there or not.
-    keys = ["KEY_DOWN", "KEY_DOWN", "\n", "\x1b"]
+    keys = ["\n", "KEY_DOWN", "KEY_DOWN", "\n", "\x1b"]
     answer = screens.layout_screen(FakeScreen(keys=keys, lines=24, columns=100), start, at)
 
     assert answer.outcome is Answered.BACK, answer.outcome

--- a/tests/unit/test_tui_partitions.py
+++ b/tests/unit/test_tui_partitions.py
@@ -904,9 +904,10 @@ def test_a_medium_with_no_zfs_offers_no_zfs_layout() -> None:
     """Alpine and Debian live images carry none, and the installer is meant to
     run from them; the row says why rather than failing at zpool create."""
     at = without_zfs()
-    screen = FakeScreen(keys=["q"], lines=24, columns=100)
+    # `automatic` first: the filesystem list is the screen after it.
+    screen = FakeScreen(keys=["\n", "q"], lines=24, columns=100)
     screens.layout_screen(screen, config(), at)
-    drawn = "\n".join(screen.frames[0])
+    drawn = "\n".join(screen.frames[1])
     assert "zfs  with ZFSBootMenu - this live system has no zpool" in drawn
 
 
@@ -987,7 +988,7 @@ def test_the_layout_row_opens_on_what_is_already_set() -> None:
     from gentoo_install.tui import screens
 
     at = context()
-    kept = screens.layout_screen(FakeScreen(keys=["\n"], lines=26), config(), at).unwrap()
+    kept = screens.layout_screen(FakeScreen(keys=["\n", "\n"], lines=26), config(), at).unwrap()
     chosen = [
         one.kind
         for one in kept.disk.graph.of_type(Filesystem)
@@ -1056,3 +1057,19 @@ def test_an_edited_table_keeps_the_numbers_the_disk_gave_out() -> None:
     ])
     graph, _ = manual.build(layout)
     assert [one.index for one in graph.of_type(Partition)] == [3]
+
+
+def test_who_lays_the_disk_out_is_asked_before_what_goes_on_it() -> None:
+    """One list held both questions: four filesystems and `manual` side by
+    side, as if `manual` were a fifth filesystem. It is the other question,
+    and a list that mixes them offers the automatic path as a default nobody
+    was shown an alternative to."""
+    from gentoo_install.tui import screens
+
+    at = context()
+    first = FakeScreen(keys=["q"], lines=24, columns=100)
+    screens.layout_screen(first, config(), at)
+    drawn = "\n".join(first.frames[0])
+    assert "automatic" in drawn and "manual" in drawn
+    for filesystem in ("ext4", "xfs", "btrfs"):
+        assert filesystem not in drawn, f"{filesystem} belongs to the next question"


### PR DESCRIPTION
Driving the menu on a guest showed the `Layout` row holding two questions in one list: `ext4`, `xfs`, `btrfs`, `zfs` answer which filesystem, and `manual` answers who writes the table. Reading it as a fifth filesystem is the obvious reading, and it made the automatic path a default rather than a choice.

The row now asks who lays it out, and the filesystem list is the screen after `automatic`. `docs/design.md` carries the new order and the two questions still missing from it: how many disks, and which array.