### PR TITLE
preflight: refuse a disk too small and a tmpfs the machine cannot spare

### DIFF
--- a/gentoo_install/exec/preflight.py
+++ b/gentoo_install/exec/preflight.py
@@ -22,6 +22,7 @@ from ..model.device import (
     FilesystemType,
     Luks,
     MdRaid,
+    Mountpoint,
     Partition,
     PartitionTable,
     TableType,
@@ -29,6 +30,7 @@ from ..model.device import (
     ZfsPool,
 )
 from ..model.size import DEFAULT_ALIGNMENT, SectorSize, Size
+from ..model.validate import ROOT_MINIMUM
 from ..plan.disk import MKFS
 from .probe import RELEASE_KEY, Machine, Probe
 
@@ -272,7 +274,69 @@ def _capacity_problems(config: InstallConfig, probe: Probe) -> list[str]:
                 f"{disk.selector} holds {Size(capacity)} and {table.id} claims "
                 f"{Size(claimed)} in fixed sizes, which does not fit"
             )
+        # The root of a whole-disk layout takes what is left, so it carries no
+        # size and `validate._root_size_problems` has nothing to compare. The
+        # disk itself is what has to be big enough, and an install into 8 GiB
+        # runs out during linux-firmware, an hour after the disks are written.
+        if _carries_the_root(graph, table.id) and usable.bytes < ROOT_MINIMUM.bytes:
+            problems.append(
+                f"{disk.selector} holds {Size(capacity)} and carries /, under the "
+                f"{ROOT_MINIMUM} a stage3, a kernel and linux-firmware need"
+            )
     return problems
+
+
+#: What the build needs outside the tmpfs: the compiler, the sources it has
+#: open, and the page cache under them.
+RAM_HEADROOM: Final[int] = 2 * 1024**3
+
+
+def _memory_problems(config: InstallConfig, machine: Machine) -> list[str]:
+    """A tmpfs the machine cannot spare is a failure this can see coming.
+
+    The size is the operator's, so it is comparable before anything runs: a
+    build that outgrows its tmpfs fails on ENOSPC after hours of compiling.
+    """
+    wanted = config.portage.build_in_ram
+    if wanted is None or not machine.memory_bytes:
+        return []
+    held = Size(machine.memory_bytes)
+    if wanted.bytes >= machine.memory_bytes:
+        return [
+            f"the build tmpfs is {wanted} and this machine has {held}, "
+            "so nothing would be left to build with"
+        ]
+    if machine.memory_bytes - wanted.bytes < RAM_HEADROOM:
+        return [
+            f"the build tmpfs is {wanted} of {held}, leaving "
+            f"{Size(machine.memory_bytes - wanted.bytes)} for the compiler and its sources"
+        ]
+    return []
+
+
+def _carries_the_root(graph: DeviceGraph, table: str) -> bool:
+    """Whether `/` ends up on a partition of this table.
+
+    Walked rather than assumed: the root may sit under LUKS, a volume group or
+    a pool, and each of those hides the partition it was built from.
+    """
+    root = next(
+        (one for one in graph.of_type(Mountpoint) if str(one.path) == "/"), None
+    )
+    if root is None:
+        return False
+    seen: set[str] = set()
+    frontier = [root.id]
+    while frontier:
+        current = frontier.pop()
+        if current in seen or current not in graph.nodes:
+            continue
+        seen.add(current)
+        node = graph[current]
+        if isinstance(node, Partition) and node.table == table:
+            return True
+        frontier.extend(node.inputs)
+    return False
 
 
 def check(config: InstallConfig, probe: Probe, target: str = "/mnt/gentoo") -> Report:
@@ -346,8 +410,16 @@ def inspect(
             f"{RELEASE_KEY} is absent, so the release key is fetched before the stage3 is verified"
         )
 
-    if machine.memory_bytes and machine.memory_bytes < TMPFS_MINIMUM:
+    fatal.extend(_memory_problems(config, machine))
+    if (
+        config.portage.build_in_ram is not None
+        and machine.memory_bytes
+        and machine.memory_bytes < TMPFS_MINIMUM
+    ):
+        # Only when a tmpfs was asked for. The warning fired on every machine
+        # under 8 GiB, including the ones building on disk, where how much
+        # memory there is decides nothing.
         warnings.append(
-            f"{machine.memory_bytes // 1024**3} GiB of memory: build in /var/tmp rather than a tmpfs"
+            f"{Size(machine.memory_bytes)} of memory: build in /var/tmp rather than a tmpfs"
         )
     return Report(fatal=tuple(fatal), warnings=tuple(warnings))

--- a/tests/unit/test_exec.py
+++ b/tests/unit/test_exec.py
@@ -267,12 +267,24 @@ def test_a_bios_configuration_on_a_uefi_boot_is_only_a_warning(tmp_path: Path) -
     assert report.warnings
 
 
-def test_little_memory_warns_instead_of_stopping(tmp_path: Path) -> None:
-    report = preflight.inspect(present(), described(memory_bytes=2 * 1024**3), probe_of(tmp_path))
+def test_little_memory_warns_only_when_the_build_wants_it(tmp_path: Path) -> None:
+    """The warning fired on every machine under 8 GiB, including the ones
+    building on disk, where how much memory there is decides nothing."""
+    from gentoo_install.model.size import Size
+
+    small = described(memory_bytes=2 * 1024**3)
+    on_disk = replace(present(), portage=replace(present().portage, build_in_ram=None))
+    report = preflight.inspect(on_disk, small, probe_of(tmp_path))
     # Only about memory: `present()` points its disk at /dev/null, which
     # reports no size, and an unreadable capacity is fatal on its own.
     assert not [one for one in report.fatal if "memory" in one], report.fatal
-    assert any("tmpfs" in warning for warning in report.warnings)
+    assert not [one for one in report.warnings if "tmpfs" in one], report.warnings
+
+    in_ram = replace(
+        present(), portage=replace(present().portage, build_in_ram=Size.parse("1GiB"))
+    )
+    asked = preflight.inspect(in_ram, small, probe_of(tmp_path))
+    assert any("tmpfs" in warning for warning in asked.warnings), asked.warnings
 
 
 def test_a_digests_file_without_the_archive_is_an_integrity_error(tmp_path: Path) -> None:
@@ -1584,3 +1596,78 @@ def test_a_command_that_is_not_installed_answers_when_failure_is_an_answer() -> 
     # cannot find has to stop the run.
     with pytest.raises(CommandFailed, match="not installed"):
         runner.run(["definitely-not-a-command-here"])
+
+
+def test_a_disk_too_small_to_hold_a_gentoo_is_refused_before_it_is_written(
+    tmp_path: Path,
+) -> None:
+    """`validate` compares the root's own size, and a whole-disk layout gives
+    the root what is left, so it carries none and nothing was compared. The
+    disk is what has to be big enough: an install into 8 GiB runs out during
+    linux-firmware, an hour after the disks are written."""
+    from gentoo_install.model.size import Size
+    from gentoo_install.model.validate import ROOT_MINIMUM
+
+    class Small(Probe):
+        capacity: int = 8 * 1024**3
+
+        def versions(self, wanted: Iterable[str]) -> dict[str, str]:
+            return {}
+
+        def disk_bytes(self, disk: str) -> int:
+            return self.capacity
+
+        def path_of(self, device: DeviceId) -> str:
+            return "/dev/vda"
+
+    probe = Small(runner=runner(tmp_path), work=tmp_path)
+    report = preflight.check(present(), probe)
+    assert any("carries /" in one and "under the" in one for one in report.fatal), report.fatal
+
+    # A disk with room says nothing.
+    probe.capacity = ROOT_MINIMUM.bytes * 4
+    assert not [
+        one for one in preflight.check(present(), probe).fatal if "carries /" in one
+    ]
+    assert Size(probe.capacity) > ROOT_MINIMUM
+
+
+def test_a_build_tmpfs_the_machine_cannot_spare_is_refused(tmp_path: Path) -> None:
+    """The size is the operator's, so it is comparable before anything runs: a
+    build that outgrows its tmpfs fails on ENOSPC after hours of compiling.
+    The warning it replaces fired on every machine under 8 GiB, including the
+    ones building on disk, where how much memory there is decides nothing."""
+    from dataclasses import replace as replaced
+
+    from gentoo_install.exec import probe as probe_module
+    from gentoo_install.model.size import Size
+
+    class Sized(Probe):
+        held: int = 4 * 1024**3
+
+        def versions(self, wanted: Iterable[str]) -> dict[str, str]:
+            return {}
+
+        def machine(
+            self, wanted: frozenset[str] = frozenset(), judged: Iterable[str] = ()
+        ) -> probe_module.Machine:
+            return replaced(super().machine(wanted, judged), memory_bytes=self.held)
+
+    probe = Sized(runner=runner(tmp_path), work=tmp_path)
+    config = present()
+    on_disk = replaced(config, portage=replaced(config.portage, build_in_ram=None))
+    assert not [
+        one for one in preflight.check(on_disk, probe).warnings if "memory" in one
+    ], "nothing is built in memory, so how much there is decides nothing"
+
+    greedy = replaced(
+        config, portage=replaced(config.portage, build_in_ram=Size.parse("8GiB"))
+    )
+    assert any("nothing would be left" in one for one in preflight.check(greedy, probe).fatal)
+
+    tight = replaced(
+        config, portage=replaced(config.portage, build_in_ram=Size.parse("3GiB"))
+    )
+    assert any(
+        "for the compiler and its sources" in one for one in preflight.check(tight, probe).fatal
+    )


### PR DESCRIPTION
`validate` compares the root's own size. A whole-disk layout gives the root what is left, so it carries none and nothing was compared: an 8 GiB disk was partitioned, written, and ran out during `linux-firmware` an hour later. The capacity check belongs where the real size is readable, so preflight walks from `/` down through LUKS, volume groups and pools to the table it lands on, and refuses a disk under `ROOT_MINIMUM`.

The memory warning fired on every machine under 8 GiB, including the ones building on disk, where how much memory there is decides nothing. It now fires only when `build_in_ram` is set, and compares against the size asked for: a tmpfs at least as large as memory is fatal, and one leaving under 2 GiB for the compiler is fatal too.