### PR TITLE
tui: say what the template writes rather than default

### DIFF
--- a/gentoo_install/data/locale/ja.toml
+++ b/gentoo_install/data/locale/ja.toml
@@ -294,7 +294,6 @@
 "set" = "設定済み"
 "confirmed" = "確認済み"
 "prebuilt, cjktty for CJK on the console, from gentoo-zh" = "ビルド済み、gentoo-zh の cjktty 入り"
-"the layout row writes this table" = "レイアウト行が決める"
 "A new partition table" = "新しいパーティションテーブル"
 "follow the BIOS" = "BIOS に従う"
 "the one already on the disk" = "ディスク上の既存テーブル"
@@ -469,3 +468,5 @@
 "How is this disk laid out?" = "このディスクの配置を決めるのは"
 "automatic" = "自動"
 "the installer writes the table" = "インストーラーがテーブルを書く"
+"the rest" = "残り全体"
+"written by the template" = "テンプレートが書く"

--- a/gentoo_install/data/locale/ko.toml
+++ b/gentoo_install/data/locale/ko.toml
@@ -294,7 +294,6 @@
 "set" = "설정됨"
 "confirmed" = "확인됨"
 "prebuilt, cjktty for CJK on the console, from gentoo-zh" = "사전 빌드, gentoo-zh의 cjktty 포함"
-"the layout row writes this table" = "레이아웃 행이 정함"
 "A new partition table" = "새 파티션 테이블"
 "follow the BIOS" = "BIOS를 따름"
 "the one already on the disk" = "디스크의 기존 테이블"
@@ -469,3 +468,5 @@
 "How is this disk laid out?" = "이 디스크의 배치를 정하는 주체"
 "automatic" = "자동"
 "the installer writes the table" = "설치 프로그램이 테이블을 작성"
+"the rest" = "나머지 전체"
+"written by the template" = "템플릿이 작성"

--- a/gentoo_install/data/locale/zh-CN.toml
+++ b/gentoo_install/data/locale/zh-CN.toml
@@ -294,7 +294,6 @@
 "set" = "已设置"
 "confirmed" = "已确认"
 "prebuilt, cjktty for CJK on the console, from gentoo-zh" = "预先构建，来自 gentoo-zh；cjktty 用于在控制台显示 CJK"
-"the layout row writes this table" = "由磁盘布局行决定"
 "A new partition table" = "新的分区表"
 "follow the BIOS" = "跟随 BIOS"
 "the one already on the disk" = "磁盘上原有的分区表"
@@ -470,3 +469,5 @@
 "How is this disk laid out?" = "这颗磁盘由谁排版面？"
 "automatic" = "自动"
 "the installer writes the table" = "安装器写这张分区表"
+"the rest" = "剩余空间"
+"written by the template" = "由模板写出"

--- a/gentoo_install/data/locale/zh-TW.toml
+++ b/gentoo_install/data/locale/zh-TW.toml
@@ -294,7 +294,6 @@
 "set" = "已設定"
 "confirmed" = "已確認"
 "prebuilt, cjktty for CJK on the console, from gentoo-zh" = "預先建置，來自 gentoo-zh；cjktty 用於在主控台顯示 CJK"
-"the layout row writes this table" = "由磁碟配置列決定"
 "A new partition table" = "新的分割表"
 "follow the BIOS" = "跟隨 BIOS"
 "the one already on the disk" = "磁碟上原有的分割表"
@@ -470,3 +469,5 @@
 "How is this disk laid out?" = "這顆磁碟由誰排版面？"
 "automatic" = "自動"
 "the installer writes the table" = "安裝器寫這張分割表"
+"the rest" = "剩餘空間"
+"written by the template" = "由樣板寫出"

--- a/gentoo_install/tui/settings.py
+++ b/gentoo_install/tui/settings.py
@@ -25,7 +25,19 @@ from ..model.config import (
 )
 from ..plan.kernel import CJK_KERNELS, KERNEL_PACKAGES
 from ..model import compat, mirrors
-from ..model.device import Existing, Luks, MdRaid, PartitionTable, VolumeGroup, ZfsPool
+from ..model.device import (
+    DeviceGraph,
+    DeviceId,
+    Existing,
+    Filesystem,
+    Luks,
+    MdRaid,
+    Mountpoint,
+    Partition,
+    PartitionTable,
+    VolumeGroup,
+    ZfsPool,
+)
 from ..plan import automatic as automatic_values
 from . import screens
 from .screens import Context, Step, footer
@@ -431,15 +443,55 @@ def _template_writes_the_table(config: InstallConfig, context: Context) -> str:
     """
     if context.manual:
         return ""
-    return context.translate("the layout row writes this table")
+    # Named for what it is rather than for a row: the row it used to point at
+    # was renamed when the layout question was split in two.
+    return context.translate("written by the template")
 
 
 def _partitions(config: InstallConfig, context: Context) -> str:
     if not context.manual:
-        return context.translate("default")
+        return _written_table(config, context)
     return ", ".join(
         entry.describe().split("  ")[1] for entry in context.layout.slices
     ) or context.translate("none")
+
+
+def _written_table(config: InstallConfig, context: Context) -> str:
+    """The table the template produces, read off the graph it built.
+
+    The row said `default`, which names nothing: an operator asking what a
+    template does to their disk was told that it is the default one. The
+    partitions are already in the graph by the time this row is drawn.
+    """
+    graph = config.disk.graph
+    written: list[str] = []
+    for partition in sorted(graph.of_type(Partition), key=lambda one: one.index):
+        # Every mount point that ends up on this partition, not the one
+        # directly above it: a btrfs root reaches it through a subvolume and an
+        # encrypted one through a container, and both answered with the
+        # filesystem's own name where a path belongs.
+        paths = sorted(
+            str(one.path)
+            for one in graph.of_type(Mountpoint)
+            if _rests_on(graph, one.id, partition.id)
+        )
+        size = str(partition.size) if partition.size else context.translate("the rest")
+        written.append(f"{' '.join(paths) or partition.role.value} {size}")
+    return ", ".join(written) or context.translate("none")
+
+
+def _rests_on(graph: DeviceGraph, above: DeviceId, below: DeviceId) -> bool:
+    seen: set[DeviceId] = set()
+    frontier = [above]
+    while frontier:
+        current = frontier.pop()
+        if current in seen or current not in graph.nodes:
+            continue
+        seen.add(current)
+        if current == below:
+            return True
+        frontier.extend(graph[current].inputs)
+    return False
 
 
 def _encryption(config: InstallConfig, context: Context) -> str:

--- a/tests/unit/test_tui_app.py
+++ b/tests/unit/test_tui_app.py
@@ -1489,7 +1489,10 @@ def test_a_grouped_row_uses_the_width_the_terminal_actually_has() -> None:
     at.columns = 200
     wide = disk.value(config(), at)
     assert "+" not in wide
-    assert wide.count(",") == len(said) - 1
+    # Every field, not a comma count: one of them lists the partitions and
+    # carries commas of its own.
+    for one in said:
+        assert one in wide, one
 
     at.columns = 40
     narrow = disk.value(config(), at)

--- a/tests/unit/test_tui_partitions.py
+++ b/tests/unit/test_tui_partitions.py
@@ -1073,3 +1073,25 @@ def test_who_lays_the_disk_out_is_asked_before_what_goes_on_it() -> None:
     assert "automatic" in drawn and "manual" in drawn
     for filesystem in ("ext4", "xfs", "btrfs"):
         assert filesystem not in drawn, f"{filesystem} belongs to the next question"
+
+
+def test_the_partitions_row_says_what_the_template_writes() -> None:
+    """The row answered `default`, which names nothing: an operator asking
+    what a template does to their disk was told that it is the default one.
+    The partitions are in the graph by the time the row is drawn, and the
+    mount points reach them through subvolumes, containers and pools."""
+    from pathlib import Path
+
+    from gentoo_install.exec.config import load
+    from gentoo_install.tui import settings
+
+    at = context()
+    at.manual = False
+    for fixture, wanted in (
+        ("vm-binpkg", "/efi 512MiB, / the rest"),
+        ("vm-btrfs", "/efi 512MiB, / /home the rest"),
+        ("vm-zfs", "/efi 512MiB, / the rest"),
+        ("vm-luks", "/efi 512MiB, / /home the rest"),
+    ):
+        shown = settings._partitions(load(Path(f"tests/fixtures/{fixture}.toml")), at)
+        assert shown == wanted, f"{fixture}: {shown}"


### PR DESCRIPTION
The partitions row read `default - the layout row writes this table`. `default` names nothing — an operator asking what a template does to their disk was told that it is the default one — and the detail pointed at a row that no longer exists under that name after the layout question was split in two.

It now lists the table the template produced, read off the graph that is already built by the time the row is drawn: `/efi 512MiB, / the rest`. The mount points are reached through subvolumes, containers and pools, so a btrfs root shows `/ /home` and an encrypted one shows the same rather than the container's own name.