### PR TITLE
tui: list a hand-written table rather than its padding

### DIFF
--- a/gentoo_install/tui/settings.py
+++ b/gentoo_install/tui/settings.py
@@ -451,8 +451,12 @@ def _template_writes_the_table(config: InstallConfig, context: Context) -> str:
 def _partitions(config: InstallConfig, context: Context) -> str:
     if not context.manual:
         return _written_table(config, context)
+    # The fields, not a slice of `describe()`: that string pads its first
+    # column to ten characters, so splitting it on two spaces answered with
+    # the padding and the row read as a bare comma.
     return ", ".join(
-        entry.describe().split("  ")[1] for entry in context.layout.slices
+        f"{one.mountpoint or one.role.value} {one.size or context.translate('the rest')}"
+        for one in context.layout.slices
     ) or context.translate("none")
 
 

--- a/tests/unit/test_tui_partitions.py
+++ b/tests/unit/test_tui_partitions.py
@@ -1095,3 +1095,41 @@ def test_the_partitions_row_says_what_the_template_writes() -> None:
     ):
         shown = settings._partitions(load(Path(f"tests/fixtures/{fixture}.toml")), at)
         assert shown == wanted, f"{fixture}: {shown}"
+
+
+def test_the_partitions_row_lists_a_hand_written_table() -> None:
+    """The row read as a bare comma. It sliced `Slice.describe()`, whose first
+    column is padded to ten characters, so splitting on two spaces answered
+    with the padding: every partition contributed an empty string."""
+    from gentoo_install.model.device import FilesystemType, PartitionRole
+    from gentoo_install.model.size import Size
+    from gentoo_install.tui import settings
+
+    at = context()
+    at.manual = True
+    at.layout = manual.Layout(
+        disks=[
+            manual.Disk(
+                selector="/dev/vda",
+                slices=[
+                    manual.Slice(
+                        index=1,
+                        role=PartitionRole.ESP,
+                        size=Size.parse("1GiB"),
+                        filesystem=FilesystemType.VFAT,
+                        mountpoint="/efi",
+                    ),
+                    manual.Slice(
+                        index=2,
+                        role=PartitionRole.DATA,
+                        size=None,
+                        filesystem=FilesystemType.XFS,
+                        mountpoint="/",
+                    ),
+                ],
+            )
+        ]
+    )
+    shown = settings._partitions(config(), at)
+    assert shown == "/efi 1GiB, / the rest", shown
+    assert shown.strip(", ")


### PR DESCRIPTION
With a manual table the partitions row rendered as a bare comma. It sliced `Slice.describe()` on two spaces and took field 1, but that string pads its first column to ten characters, so field 1 is padding and every partition contributed an empty string.

The row reads the slice's own fields, the same shape the template branch now uses: `/efi 1GiB, / the rest`. Seen on a real menu, in Simplified Chinese, as `分区  ，`.