### PR TITLE
tui: drop the ssh detail that describes the menu

### DIFF
--- a/gentoo_install/data/locale/ja.toml
+++ b/gentoo_install/data/locale/ja.toml
@@ -130,7 +130,6 @@
 "keys only" = "公開鍵のみ"
 "no password is accepted" = "パスワードは受け付けません"
 "password login" = "パスワードログインを許可"
-"root is a row of its own" = "root は別の行です"
 "Root login over SSH" = "SSH での root ログイン"
 "Let root log in over SSH?" = "SSH での root ログインを許可しますか？"
 "allowed" = "許可"

--- a/gentoo_install/data/locale/ko.toml
+++ b/gentoo_install/data/locale/ko.toml
@@ -130,7 +130,6 @@
 "keys only" = "공개 키만"
 "no password is accepted" = "암호를 받지 않습니다"
 "password login" = "암호 로그인 허용"
-"root is a row of its own" = "root는 별도 행입니다"
 "Root login over SSH" = "SSH로 root 로그인"
 "Let root log in over SSH?" = "SSH로 root 로그인을 허용하시겠습니까?"
 "allowed" = "허용"

--- a/gentoo_install/data/locale/zh-CN.toml
+++ b/gentoo_install/data/locale/zh-CN.toml
@@ -130,7 +130,6 @@
 "keys only" = "仅接受公钥"
 "no password is accepted" = "不接受密码登录"
 "password login" = "允许密码登录"
-"root is a row of its own" = "root 单独一行"
 "Root login over SSH" = "root 以 SSH 登录"
 "Let root log in over SSH?" = "允许 root 以 SSH 登录吗？"
 "allowed" = "允许"

--- a/gentoo_install/data/locale/zh-TW.toml
+++ b/gentoo_install/data/locale/zh-TW.toml
@@ -130,7 +130,6 @@
 "keys only" = "僅接受公鑰"
 "no password is accepted" = "不接受密碼登入"
 "password login" = "允許密碼登入"
-"root is a row of its own" = "root 單獨一列"
 "Root login over SSH" = "root 以 SSH 登入"
 "Let root log in over SSH?" = "允許 root 以 SSH 登入嗎？"
 "allowed" = "允許"

--- a/gentoo_install/tui/screens.py
+++ b/gentoo_install/tui/screens.py
@@ -2181,11 +2181,12 @@ def sshd_screen(screen: Screen, config: InstallConfig, context: Context) -> Answ
                 detail=translate("no password is accepted"),
             ),
             Item(
+                # No detail: the one it had said `root is a row of its own`,
+                # which describes this menu rather than what the option does.
+                # `sshd_root_login` is that row and starts off, so
+                # `PermitRootLogin no` is written whichever of these is picked.
                 label=translate("password login"),
                 value=(True, True),
-                # Not `root included`: `sshd_root_login` is a row of its own
-                # and starts off, so `PermitRootLogin no` is what gets written.
-                detail=translate("root is a row of its own"),
             ),
         ],
         footer=footer(translate),


### PR DESCRIPTION
The `password login` row carried `root is a row of its own`, which describes where another setting lives rather than what this one does. Seen on a real menu in Simplified Chinese as `允许密码登录  root 单独一行`.

The row keeps no detail; its sibling's `no password is accepted` already says what the pair differ in, and the reason `PermitRootLogin no` is written either way stays in the code comment.