### PR TITLE
tui: let a desktop propose its login screen and network manager

### DIFF
--- a/gentoo_install/tui/screens.py
+++ b/gentoo_install/tui/screens.py
@@ -1448,7 +1448,46 @@ def desktop_screen(screen: Screen, config: InstallConfig, context: Context) -> A
                 ),
             ),
         )
+    changed = _desktop_proposes(changed, config, context, desktop)
     return settle(screen, context, config, changed)
+
+
+#: What each desktop's own login screen is. Proposed rather than fixed: the
+#: row stays editable, and pulling the login screen out of the desktop profile
+#: was right — leaving it empty was not, because the row is then required and
+#: red on a menu whose operator has already said which desktop they want.
+LOGIN_SCREEN: Final[dict[str, str]] = {
+    "plasma": "sddm",
+    "plasma-full": "sddm",
+    "gnome": "gdm",
+    "gnome-full": "gdm",
+    "xfce": "lightdm",
+}
+
+
+def _desktop_proposes(
+    changed: InstallConfig, before: InstallConfig, context: Context, desktop: str
+) -> InstallConfig:
+    """The login screen and the network manager a desktop implies.
+
+    Only over what the operator has not set: a login screen they picked stands,
+    and so does a network manager. The Plasma and GNOME profiles already carry
+    `USE=networkmanager`, and nothing moved `system.networking` with it, so the
+    installed desktop had the settings panel and not the service behind it.
+    """
+    if not desktop:
+        return changed
+    login = LOGIN_SCREEN.get(desktop, "")
+    if login and not before.packages.display_manager and login in context.groups:
+        changed = replace(
+            changed, packages=replace(changed.packages, display_manager=login)
+        )
+    if before.system.networking is Networking.BUILTIN:
+        changed = replace(
+            changed,
+            system=replace(changed.system, networking=Networking.NETWORKMANAGER_WPA),
+        )
+    return changed
 
 
 def settle(
@@ -1471,7 +1510,11 @@ def settle(
     cards = _new(automatic_values.video_cards, before, after, context.groups)
     joins = _new(automatic_values.user_groups, before, after, context.groups)
     profile = after.portage.profile if after.portage.profile != before.portage.profile else ""
-    if not (flags or cards or joins or profile):
+    moved = (
+        after.packages.display_manager != before.packages.display_manager
+        or after.system.networking is not before.system.networking
+    )
+    if not (flags or cards or joins or profile or moved):
         return Answer(Outcome.CHOSE, after)
     translate = context.translate
     lines = []
@@ -1479,6 +1522,12 @@ def settle(
         lines.append(f"VIDEO_CARDS: {' '.join(cards)}")
     if flags:
         lines.append(f"USE: {' '.join(flags)}")
+    if after.packages.display_manager != before.packages.display_manager:
+        lines.append(
+            f"{translate('Display manager')}: {after.packages.display_manager}"
+        )
+    if after.system.networking is not before.system.networking:
+        lines.append(f"{translate('Network')}: {after.system.networking.value}")
     if joins:
         # Not pinned into the account: `AddUserToGroups` derives them from the
         # same catalog at build time, so the account is put in them whether or
@@ -1511,7 +1560,8 @@ def settle(
             )
         )
     asked: Menu[str] = Menu(
-        title=f"{translate('This choice also sets')} — {', '.join(lines)}",
+        title=translate("This choice also sets"),
+        preamble=tuple(lines),
         items=items,
         footer=footer(translate),
         current="yes",

--- a/gentoo_install/tui/widgets.py
+++ b/gentoo_install/tui/widgets.py
@@ -119,6 +119,9 @@ class Menu(Generic[V]):
     selected: set[int] = field(default_factory=set)
     multiple: bool = False
     footer: str = ""
+    #: Lines drawn between the title and the rows. For a question whose
+    #: subject is a list: the title is one line and truncated to the width.
+    preamble: tuple[str, ...] = ()
     #: Where the highlight starts, and where it was left. A menu re-entered
     #: after editing a row has to come back to that row.
     cursor: int = 0
@@ -197,7 +200,13 @@ class Menu(Generic[V]):
         lines, columns = screen.size()
         screen.clear()
         screen.write(0, 0, truncate(self.title, columns))
-        room = lines - 4
+        # One line each, under the title. A question whose subject is a list
+        # crammed the list into the title, and the title is truncated to the
+        # width: the profile a desktop moves to fell off the end of it.
+        for offset, one in enumerate(self.preamble):
+            screen.write(offset + 1, 2, truncate(one, columns - 4))
+        above = len(self.preamble)
+        room = lines - 4 - above
         top = max(0, min(cursor - room // 2, len(self.items) - room))
         for row, index in enumerate(range(top, min(top + room, len(self.items)))):
             item = self.items[index]
@@ -219,9 +228,9 @@ class Menu(Generic[V]):
             # naming a mark nobody draws describes an interface that does not
             # exist. In the left margin, so the labels stay aligned.
             if item.style is not Style.PLAIN:
-                screen.write(row + 2, 0, MARKS[item.style], style=item.style)
+                screen.write(row + 2 + above, 0, MARKS[item.style], style=item.style)
             screen.write(
-                row + 2,
+                row + 2 + above,
                 2,
                 truncate(text, columns - 4),
                 highlight=index == cursor,

--- a/tests/unit/test_tui_app.py
+++ b/tests/unit/test_tui_app.py
@@ -2148,3 +2148,40 @@ def test_the_values_a_choice_brings_are_accepted_by_pressing_enter() -> None:
 
     assert answer.unwrap().packages.desktop == "plasma"
     assert answer.unwrap().portage.profile.endswith("desktop/plasma/systemd")
+
+
+def test_a_desktop_proposes_its_login_screen_and_a_network_manager() -> None:
+    """Pulling the login screen out of the desktop profile was right — the row
+    stays editable — but leaving it empty was not: the row is required and red
+    on a menu whose operator has already said they want Plasma. The Plasma and
+    GNOME profiles carry `USE=networkmanager` and nothing moved
+    `system.networking` with it, so the installed desktop had the settings
+    panel and not the service behind it."""
+    from gentoo_install.model.config import Networking
+
+    at = context()
+    keys = [*down(4), "\n", "\n"]  # plasma, then accept what it brings
+    answer = screens.desktop_screen(FakeScreen(keys=keys, lines=30), config(), at)
+    chosen = answer.unwrap()
+    assert chosen.packages.desktop == "plasma"
+    assert chosen.packages.display_manager == "sddm"
+    assert chosen.system.networking is Networking.NETWORKMANAGER_WPA
+
+    # Proposed, not imposed: a login screen the operator picked stands.
+    picked = replace(
+        config(), packages=replace(config().packages, display_manager="greetd")
+    )
+    kept = screens.desktop_screen(
+        FakeScreen(keys=[*down(4), "\n", "\n"], lines=30), picked, context()
+    ).unwrap()
+    assert kept.packages.display_manager == "greetd"
+
+
+def test_what_a_desktop_brings_is_listed_in_one_place() -> None:
+    """Every place the choice reaches, on the screen that asks about it."""
+    at = context()
+    screen = FakeScreen(keys=[*down(4), "\n", "q"], lines=30, columns=120)
+    screens.desktop_screen(screen, config(), at)
+    listed = "\n".join(screen.frames[-1])
+    for named in ("Display manager", "sddm", "Network", "networkmanager", "Profile"):
+        assert named in listed, f"{named} is not on the confirmation: {listed}"


### PR DESCRIPTION
Pulling the login screen out of the desktop profile was right — the row stays editable — but leaving it empty was not: it is required and red on a menu whose operator has already said they want Plasma. A desktop now proposes its own (`sddm`, `gdm`, `lightdm`) and only over a row nobody has set.

The Plasma and GNOME profiles carry `USE=networkmanager` and nothing moved `system.networking` with it, so the installed desktop had the settings panel and not the service behind it. Both land in the confirmation that already lists the profile, `USE`, `VIDEO_CARDS` and the extra groups, so every place the choice reaches is on the screen that asks about it.

That list had been crammed into the title, which is one line truncated to the width — the profile fell off the end. `Menu` gained a preamble drawn under the title.