### PR TITLE
cli: do not ask what stdin cannot answer, and name the readable log

### DIFF
--- a/gentoo_install/cli.py
+++ b/gentoo_install/cli.py
@@ -225,7 +225,11 @@ def _keep_the_log(work: Path, target: Path, record: Callable[[str], None]) -> No
     except OSError as error:
         record(f"warning: the log could not be copied to {kept}: {error}")
         return
-    record(f"the log of this run is in {kept}")
+    # Both paths. `kept` is inside the target and the target is unmounted a
+    # moment later, so on a stopped install the only readable copy is the one
+    # in the work directory, and an operator told about the other went looking
+    # in an empty mount point.
+    record(f"the log of this run is in {kept}, and until the next reboot in {work}")
 
 
 def install(config: InstallConfig, operations: tuple[Operation, ...], arguments: argparse.Namespace) -> int:
@@ -336,6 +340,16 @@ def _unattended(arguments: argparse.Namespace) -> bool:
 
 
 def _asked(question: str) -> bool:
+    """No when nobody can answer.
+
+    A question printed at a stdin that is not a terminal is answered `No` by
+    the empty line `readline` returns at once, so the prompt flashes past and
+    the operator reads it as an offer that was never made. `--config` alone
+    does not settle this: a run started by hand from a script has a terminal
+    for its output and none for its input.
+    """
+    if not sys.stdin.isatty():
+        return False
     print(f"{question} [y/N] ", end="")
     sys.stdout.flush()
     try:
@@ -388,6 +402,12 @@ def _offer_a_paste(
     if _unattended(arguments):
         return
     outcome = "the install stopped" if stopped else "the install finished"
+    if not sys.stdin.isatty():
+        # Said rather than asked. The question needs an answer this run cannot
+        # be given, and an operator who wants the log on the pastebin can send
+        # it themselves; the address is what they are missing.
+        record(f"{outcome}. the log to publish is {work / 'install.log'}")
+        return
     if not _asked(f"{outcome}. send the log to {paste.HOST}, which is public?"):
         return
     source = work / "install.log"

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -677,3 +677,27 @@ def test_the_mirror_check_names_the_mirror_it_could_not_reach(
     # look at the network when the answer was a certificate the medium could
     # not verify.
     assert "certificate verify failed" in str(raised.value)
+
+
+def test_a_question_nobody_can_answer_is_not_asked(
+    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """A prompt printed at a stdin that is not a terminal is answered `No` by
+    the empty line `readline` returns at once, so it flashes past and the
+    operator reads it as an offer that was never made."""
+    import io
+    import sys as system
+
+    from gentoo_install import cli
+
+    monkeypatch.setattr(system, "stdin", io.StringIO("y\n"))
+    assert cli._asked("well?") is False
+    assert "well?" not in capsys.readouterr().out
+
+    class Terminal(io.StringIO):
+        def isatty(self) -> bool:
+            return True
+
+    monkeypatch.setattr(system, "stdin", Terminal("y\n"))
+    assert cli._asked("well?") is True
+    assert "well?" in capsys.readouterr().out


### PR DESCRIPTION
On a failed install the operator saw `send the log to paste.gentoozh.org, which is public? [y/N]` and `enter a root shell? [y/N]` go past without stopping, then `the log of this run is in /mnt/gentoo/var/log/gentoo-install`, and then that mount point being unmounted.

Both prompts were printed at a stdin that is not a terminal, where `readline` returns an empty line at once and `No` is taken for an answer. `--config` alone does not settle it: a run started by hand from a script has a terminal for its output and none for its input. The questions are no longer asked there, and the paste one says where the log to publish is instead.

The log message names both copies. The one inside the target survives a reboot into the installed system; on a stopped install there is no such system, so the readable one is in the work directory until the medium is rebooted.