### PR TITLE
cli: throw away the keys typed before the question

### DIFF
--- a/gentoo_install/cli.py
+++ b/gentoo_install/cli.py
@@ -11,6 +11,7 @@ import curses
 import os
 import shutil
 import sys
+import termios
 import time
 from datetime import datetime, timezone
 import tomllib
@@ -340,22 +341,36 @@ def _unattended(arguments: argparse.Namespace) -> bool:
 
 
 def _asked(question: str) -> bool:
-    """No when nobody can answer.
+    """Ask, after throwing away what was typed before the question existed.
 
-    A question printed at a stdin that is not a terminal is answered `No` by
-    the empty line `readline` returns at once, so the prompt flashes past and
-    the operator reads it as an offer that was never made. `--config` alone
-    does not settle this: a run started by hand from a script has a terminal
-    for its output and none for its input.
+    The menu is curses and the key that left it is still in the terminal's
+    input queue when this runs, so `readline` returned it at once: both
+    questions after a failed install were answered by keystrokes aimed at the
+    screen before them, and the operator watched two offers go past.
     """
-    if not sys.stdin.isatty():
-        return False
+    _forget_what_was_typed()
     print(f"{question} [y/N] ", end="")
     sys.stdout.flush()
     try:
         return sys.stdin.readline().strip().lower() in ("y", "yes")
     except (EOFError, KeyboardInterrupt):
         return False
+
+
+def _forget_what_was_typed() -> None:
+    """Discard input that arrived before the question was printed.
+
+    Nothing to discard on a terminal this run does not own, and `tcflush`
+    raises there rather than answering.
+    """
+    if not sys.stdin.isatty():
+        return
+    try:
+        termios.tcflush(sys.stdin.fileno(), termios.TCIFLUSH)
+    except (termios.error, OSError, ValueError):
+        # A console that cannot be flushed still gets its question asked; the
+        # worst case is the one this replaces.
+        return
 
 
 #: Black on white, so the code reads as a code. A terminal's own colours are
@@ -402,13 +417,8 @@ def _offer_a_paste(
     if _unattended(arguments):
         return
     outcome = "the install stopped" if stopped else "the install finished"
-    if not sys.stdin.isatty():
-        # Said rather than asked. The question needs an answer this run cannot
-        # be given, and an operator who wants the log on the pastebin can send
-        # it themselves; the address is what they are missing.
-        record(f"{outcome}. the log to publish is {work / 'install.log'}")
-        return
     if not _asked(f"{outcome}. send the log to {paste.HOST}, which is public?"):
+        record(f"the log to publish by hand is {work / 'install.log'}")
         return
     source = work / "install.log"
     try:

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -679,20 +679,20 @@ def test_the_mirror_check_names_the_mirror_it_could_not_reach(
     assert "certificate verify failed" in str(raised.value)
 
 
-def test_a_question_nobody_can_answer_is_not_asked(
+def test_a_question_is_asked_after_the_earlier_keys_are_thrown_away(
     monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
 ) -> None:
-    """A prompt printed at a stdin that is not a terminal is answered `No` by
-    the empty line `readline` returns at once, so it flashes past and the
-    operator reads it as an offer that was never made."""
+    """The menu is curses and the key that left it is still in the terminal's
+    input queue, so `readline` returned it at once and both questions after a
+    failed install were answered by keystrokes aimed at the screen before
+    them."""
     import io
     import sys as system
 
     from gentoo_install import cli
 
-    monkeypatch.setattr(system, "stdin", io.StringIO("y\n"))
-    assert cli._asked("well?") is False
-    assert "well?" not in capsys.readouterr().out
+    flushed: list[str] = []
+    monkeypatch.setattr(cli, "_forget_what_was_typed", lambda: flushed.append("flushed"))
 
     class Terminal(io.StringIO):
         def isatty(self) -> bool:
@@ -700,4 +700,20 @@ def test_a_question_nobody_can_answer_is_not_asked(
 
     monkeypatch.setattr(system, "stdin", Terminal("y\n"))
     assert cli._asked("well?") is True
+    assert flushed == ["flushed"], "the leftover keys go before the question"
     assert "well?" in capsys.readouterr().out
+
+
+def test_nothing_is_flushed_on_a_terminal_this_run_does_not_own(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """`tcflush` raises on a stdin that is not a terminal rather than
+    answering, and a run reading its configuration from a pipe still has to
+    reach its own closing path."""
+    import io
+    import sys as system
+
+    from gentoo_install import cli
+
+    monkeypatch.setattr(system, "stdin", io.StringIO(""))
+    cli._forget_what_was_typed()


### PR DESCRIPTION
`send the log to paste.gentoozh.org, which is public? [y/N]` and `enter a root shell? [y/N]` both went past on a real machine without stopping.

#147 read that as a stdin which is not a terminal, and that diagnosis was wrong: `_unattended` already covers exactly that case and `_offer_a_paste` returns on it, so a printed prompt proves stdin *was* a terminal. The check added there could never be false. The cause is the input queue — the menu is curses, and the key that left it is still queued when the first question is printed, so `readline` answers with a keystroke aimed at the screen before it.

The queue is flushed before each question. Declining now also says where the log to publish by hand is.