### PR TITLE
kernel: give systemd-utils the flag its REQUIRED_USE asks for

### DIFF
--- a/gentoo_install/plan/kernel.py
+++ b/gentoo_install/plan/kernel.py
@@ -151,9 +151,17 @@ class ConfigureInstallKernel(Operation):
     boot_root: str = ""
 
     def apply(self, context: Context) -> None:
+        written = f"sys-kernel/installkernel {' '.join(self._flags())}\n"
+        if self.boot_entries:
+            # `installkernel[systemd-boot]` needs `bootctl`, which on a system
+            # without systemd comes from `sys-apps/systemd-utils[boot]`, and
+            # that ebuild's REQUIRED_USE is `boot? ( kernel-install )`. Without
+            # the second flag the merge stops at `has unmet requirements`
+            # before anything is built. Harmless on a systemd system: the
+            # package is not merged there and the line names nothing.
+            written += "sys-apps/systemd-utils boot kernel-install\n"
         context.write(
-            PurePosixPath("/etc/portage/package.use/installkernel"),
-            f"sys-kernel/installkernel {' '.join(self._flags())}\n",
+            PurePosixPath("/etc/portage/package.use/installkernel"), written
         )
         if self.boot_root:
             # A drop-in, never `/etc/kernel/install.conf`. kernel-install(8):

--- a/tests/unit/test_plan_boot.py
+++ b/tests/unit/test_plan_boot.py
@@ -1094,3 +1094,26 @@ def test_pinning_a_kernel_version_writes_the_keyword_file_it_describes() -> None
     ]
     assert written == f"={accepted[0].package}-6.12.4 ~amd64\n", written
     assert accepted[0].package.startswith("sys-kernel/"), accepted[0].package
+
+
+def test_systemd_boot_on_openrc_gets_the_flag_systemd_utils_requires() -> None:
+    """`installkernel[systemd-boot]` needs `bootctl`, which on a system without
+    systemd comes from `sys-apps/systemd-utils[boot]`, whose REQUIRED_USE is
+    `boot? ( kernel-install )`. An OpenRC install with systemd-boot stopped at
+    `The ebuild selected to satisfy sys-apps/systemd-utils[boot(-)] has unmet
+    requirements` before anything was built."""
+    from gentoo_install.plan.kernel import ConfigureInstallKernel
+
+    recorder = Recorder()
+    ConfigureInstallKernel(boot_entries=True).apply(recorder)
+    written = recorder.files[PurePosixPath("/etc/portage/package.use/installkernel")]
+    assert "sys-apps/systemd-utils boot kernel-install" in written
+    assert "sys-kernel/installkernel dracut systemd systemd-boot" in written
+
+    # Nothing to say when no boot entries are written: the package is not
+    # merged and the line would name one that is absent.
+    plain = Recorder()
+    ConfigureInstallKernel(boot_entries=False).apply(plain)
+    assert "systemd-utils" not in plain.files[
+        PurePosixPath("/etc/portage/package.use/installkernel")
+    ]


### PR DESCRIPTION
An OpenRC install with KDE, btrfs, LUKS and systemd-boot stopped at:

```
!!! The ebuild selected to satisfy "sys-apps/systemd-utils[boot(-)]" has unmet requirements.
    boot? ( kernel-install )
(dependency required by "sys-kernel/installkernel-68-r1::gentoo[dracut,systemd-boot,-uki]")
```

`installkernel[systemd-boot]` needs `bootctl`, which on a system without systemd comes from `sys-apps/systemd-utils[boot]`, and that ebuild's REQUIRED_USE is `boot? ( kernel-install )`. Only the first package's flags were written. The line is added alongside them and only when boot entries are asked for; on a systemd system the package is not merged and it names nothing.