### PR TITLE
tui: take the last choice's use flags with it

### DIFF
--- a/gentoo_install/tui/screens.py
+++ b/gentoo_install/tui/screens.py
@@ -1569,12 +1569,24 @@ def settle(
     answered = asked.run(screen)
     if not answered.chosen or answered.unwrap()[0] == "no":
         return Answer(Outcome.BACK, before)
+    # Pinned without what the choice being replaced had derived. Adding to
+    # `portage.use` and never taking anything out meant switching from Plasma
+    # to GNOME left `qt6` and `sddm` behind and read as
+    # `wayland qt6 networkmanager sddm gnome gtk`. What the operator typed is
+    # not derivable and stays; what the last choice derived goes with it.
+    withdrawn = {one.value for one in automatic_values.use_flags(before, context.groups)}
+    withdrawn |= _derived_by(before, context)
+    kept = tuple(one for one in after.portage.use if one not in withdrawn)
+    dropped = {one.value for one in automatic_values.video_cards(before, context.groups)}
     pinned = replace(
         after,
         portage=replace(
             after.portage,
-            use=(*after.portage.use, *flags),
-            video_cards=(*after.portage.video_cards, *cards),
+            use=(*kept, *flags),
+            video_cards=(
+                *(one for one in after.portage.video_cards if one not in dropped),
+                *cards,
+            ),
         ),
     )
     if answered.unwrap()[0] == "open" and where is not None:
@@ -1587,6 +1599,22 @@ def settle(
             # the operator had just refused.
             return Answer(Outcome.CANCELLED)
     return Answer(Outcome.CHOSE, pinned)
+
+
+def _derived_by(config: InstallConfig, context: Context) -> set[str]:
+    """The USE every group this configuration selects asks for.
+
+    `automatic.use_flags` reports only what is not already in `portage.use`,
+    and a pinned flag is in there, so it stops reporting the very values that
+    have to be withdrawn. The catalog is asked directly instead.
+    """
+    from ..plan import packages as plan_packages
+
+    return {
+        flag
+        for group in plan_packages.groups(config, context.groups)
+        for flag in group.use
+    }
 
 
 def _new(

--- a/tests/unit/test_tui_app.py
+++ b/tests/unit/test_tui_app.py
@@ -2185,3 +2185,31 @@ def test_what_a_desktop_brings_is_listed_in_one_place() -> None:
     listed = "\n".join(screen.frames[-1])
     for named in ("Display manager", "sddm", "Network", "networkmanager", "Profile"):
         assert named in listed, f"{named} is not on the confirmation: {listed}"
+
+
+def test_switching_desktops_takes_the_last_one_s_use_flags_with_it() -> None:
+    """Choosing Plasma and then GNOME read as
+    `wayland qt6 networkmanager sddm gnome gtk`: the flags were added to
+    `portage.use` and nothing was ever taken out, so Qt and SDDM followed an
+    operator onto a GNOME desktop that has no use for either."""
+    at = context()
+    plasma = screens.desktop_screen(
+        FakeScreen(keys=[*down(4), "\n", "\n"], lines=30), config(), at
+    ).unwrap()
+    assert "qt6" in plasma.portage.use and "sddm" in plasma.portage.use
+
+    # The cursor opens on what is set, so gnome is two rows up from plasma.
+    swapped = screens.desktop_screen(
+        FakeScreen(keys=["KEY_UP", "KEY_UP", "\n", "\n"], lines=30), plasma, at
+    ).unwrap()
+    assert swapped.packages.desktop == "gnome"
+    assert "qt6" not in swapped.portage.use, swapped.portage.use
+    assert "sddm" not in swapped.portage.use, swapped.portage.use
+    assert "gnome" in swapped.portage.use
+
+    # What the operator typed is not derivable and stays.
+    typed = replace(plasma, portage=replace(plasma.portage, use=(*plasma.portage.use, "lto")))
+    after = screens.desktop_screen(
+        FakeScreen(keys=["KEY_UP", "KEY_UP", "\n", "\n"], lines=30), typed, at
+    ).unwrap()
+    assert "lto" in after.portage.use


### PR DESCRIPTION
Choosing Plasma and then GNOME read as `wayland qt6 networkmanager sddm gnome gtk`. The derived flags were pinned into `portage.use` so an operator's own edits would survive a later change, and nothing was ever taken out, so Qt and SDDM followed onto a desktop that has no use for either.

What the last choice derived is withdrawn before the new choice's flags go in. The catalog is asked directly for it: `automatic.use_flags` reports only what is *not* already in `portage.use`, so it stops reporting the very values that have to be withdrawn. What the operator typed is not derivable from any group and stays.