### PR TITLE
tui: put the two password fields on one form

### DIFF
--- a/gentoo_install/tui/screens.py
+++ b/gentoo_install/tui/screens.py
@@ -2054,18 +2054,33 @@ def _ask_password(screen: Screen, context: Context, title: str) -> str | None:
     that has already been installed.
     """
     translate = context.translate
+    # One form, not two screens in a row. Two screens have nothing for the
+    # arrow keys to move between, so enter is the only way forward, and a typo
+    # in the second one threw the first away as well. `Field.secret` exists for
+    # this and the account form already uses it.
+    kept = ["", ""]
     while True:
-        first = TextField(title=title, masked=True, footer=footer(translate)).run(screen)
-        if not first.chosen:
-            return None
-        typed = first.unwrap()
-        again = TextField(
-            title=translate("Type it again"), masked=True, footer=footer(translate)
+        answered = Form(
+            title=title,
+            fields=[
+                Field(label=translate("Password"), value=kept[0], secret=True),
+                Field(label=translate("Type it again"), value=kept[1], secret=True),
+            ],
+            footer=footer(translate),
         ).run(screen)
-        if not again.chosen:
+        if not answered.chosen:
             return None
-        if again.unwrap() == typed:
-            return typed
+        kept = list(answered.unwrap())
+        if not kept[0] and not kept[1]:
+            # Nothing typed is leaving, not an empty password: the row stays
+            # required and says so, and enter through the whole form no longer
+            # asks the same question for ever.
+            return None
+        if kept[0] and kept[0] == kept[1]:
+            return kept[0]
+        # The form comes back with what was typed: only the mismatched second
+        # field is cleared, so a long password is not retyped from nothing.
+        kept[1] = ""
         _say(screen, context, translate("The two do not match."))
 
 

--- a/tests/unit/test_tui_app.py
+++ b/tests/unit/test_tui_app.py
@@ -1410,8 +1410,14 @@ def test_a_password_is_typed_twice_before_it_is_hashed() -> None:
     machine that has already been installed. The passphrase was checked this
     way and the two passwords were not."""
     at = context()
-    # Two that differ, the message, then two that match.
-    keys = [*"first", "\n", *"second", "\n", "\n", *"right", "\n", *"right", "\n"]
+    # One form: type, down to the second field, type something else, enter.
+    # The message, then the form again with the first field kept — down, the
+    # matching text, enter.
+    keys = [
+        *"first", "KEY_DOWN", *"second", "\n", "\n",
+        "\n",
+        "KEY_DOWN", *"first", "\n", "\n",
+    ]
     answer = screens.root_password_screen(FakeScreen(keys=keys, lines=24), config(), at)
     assert answer.unwrap().system.root_password_hash == "$6$test$5"
 
@@ -2041,7 +2047,8 @@ def test_a_filled_row_is_not_still_asked_for() -> None:
 
     row = next(one for one in settings.SETTINGS if one.key == "root")
     assert row.edit is not None
-    typed = list("hunter2") + ["\n"] + list("hunter2") + ["\n"]
+    # One form: the first field, down to the second, then enter past Done.
+    typed = list("hunter2") + ["KEY_DOWN"] + list("hunter2") + ["\n", "\n"]
     # Deliberately not marking it visited: the value is the answer.
     done = row.edit(FakeScreen(keys=typed, lines=24), empty, at).unwrap()
     assert settings._root(done, at) == "set"
@@ -2213,3 +2220,25 @@ def test_switching_desktops_takes_the_last_one_s_use_flags_with_it() -> None:
         FakeScreen(keys=["KEY_UP", "KEY_UP", "\n", "\n"], lines=30), typed, at
     ).unwrap()
     assert "lto" in after.portage.use
+
+
+def test_the_password_fields_are_one_form_the_arrows_move_between() -> None:
+    """Two screens in a row have nothing for the arrow keys to move between,
+    so enter was the only way forward and a typo in the second one threw the
+    first away as well. `Field.secret` exists for this and the account form
+    already used it."""
+    at = context()
+    # Up from the second field to correct the first, without retyping either.
+    keys = [
+        *"wrong", "KEY_DOWN", *"right",
+        "KEY_UP", *(["\x7f"] * 5), *"right",
+        "KEY_DOWN", "\n", "\n",
+    ]
+    answer = screens.root_password_screen(FakeScreen(keys=keys, lines=24), config(), at)
+    assert answer.unwrap().system.root_password_hash == "$6$test$5"
+
+    # Nothing typed leaves the row alone rather than asking for ever.
+    away = screens.root_password_screen(
+        FakeScreen(keys=["\n", "\n", "\n"], lines=24), config(), at
+    )
+    assert not away.chosen


### PR DESCRIPTION
The root password was two `TextField` screens one after the other. Arrow keys had nothing to move between, so enter was the only way forward, and a typo in the second screen threw the first away and asked for both again.

They are now one `Form`, the same shape the account screen already uses — `Field.secret` exists for this and its comment says so. A mismatch redraws with the first field kept, and typing nothing leaves the row alone instead of asking the same question for ever.