### PR TITLE
vm: let a term signal reach the closing path

### DIFF
--- a/tests/unit/test_harness.py
+++ b/tests/unit/test_harness.py
@@ -1186,3 +1186,22 @@ def test_run_refuses_a_repeated_job_name_before_it_touches_the_cluster() -> None
         cluster.run(twice, Path("/nonexistent"))
     assert "named more than once" in str(raised.value)
     assert "vm-lvm" in str(raised.value)
+
+
+def test_a_term_signal_reaches_the_closing_path() -> None:
+    """Python ends the process on SIGTERM without unwinding, so no `finally`
+    runs: `kill` on the scheduler left eight guests on the cluster with the
+    path that removes them never reached."""
+    import signal as signals
+
+    from tests.vm import cluster
+
+    before = signals.getsignal(signals.SIGTERM)
+    try:
+        cluster._leave_on_a_signal()
+        handler = signals.getsignal(signals.SIGTERM)
+        assert callable(handler), handler
+        with pytest.raises(KeyboardInterrupt):
+            handler(signals.SIGTERM, None)
+    finally:
+        signals.signal(signals.SIGTERM, before)

--- a/tests/vm/cluster.py
+++ b/tests/vm/cluster.py
@@ -20,6 +20,7 @@ import itertools
 import json
 import os
 import queue
+import signal
 import re
 import subprocess
 import sys
@@ -1693,6 +1694,21 @@ def fixtures(names: list[str]) -> list[Job]:
     return found
 
 
+def _leave_on_a_signal() -> None:
+    """Turn SIGTERM into the exception SIGINT already raises.
+
+    Python's default handler for SIGTERM ends the process without unwinding,
+    so no `finally` runs: `kill` on the scheduler left eight guests on the
+    cluster with the closing path that removes them never reached.
+    """
+
+    def raised(number: int, frame: object) -> None:
+        raise KeyboardInterrupt(f"signal {number}")
+
+    signal.signal(signal.SIGTERM, raised)
+    signal.signal(signal.SIGHUP, raised)
+
+
 def main(argv: list[str] | None = None) -> int:
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("fixtures", nargs="+", help="fixture names, without .toml")
@@ -1718,6 +1734,7 @@ def main(argv: list[str] | None = None) -> int:
     )
     args = parser.parse_args(argv)
 
+    _leave_on_a_signal()
     try:
         workdir = confined(args.workdir)
     except WorkdirError as error:


### PR DESCRIPTION
#132 gave the scheduler a closing path that stops each guest, joins the workers and removes whatever outlived them. Stopping a round with `kill` left eight guests running anyway: Python's default SIGTERM handler ends the process without unwinding, so no `finally` runs and that path is never reached. SIGINT already raises; SIGTERM and SIGHUP now do too.