### PR TITLE
boot: give one package's use flags one owner, and a fixture for the pair

### DIFF
--- a/gentoo_install/plan/bootloader.py
+++ b/gentoo_install/plan/bootloader.py
@@ -159,12 +159,19 @@ class RequestBootctl(Operation):
     stage: Stage = Stage.PORTAGE
     package: str
 
+    #: `sys-apps/systemd-utils` refuses `boot` without it: its REQUIRED_USE is
+    #: `boot? ( kernel-install )`, and an openrc install with systemd-boot
+    #: stopped at `has unmet requirements` before anything was built. Harmless
+    #: on `sys-apps/systemd`, which has the flag and enables it with `boot`.
+    FLAGS: Final[tuple[str, ...]] = ("boot", "kernel-install")
+
     def describe(self) -> str:
-        return f"ask for {self.package}[boot], which is what provides bootctl"
+        return f"ask for {self.package}[{','.join(self.FLAGS)}], which is what provides bootctl"
 
     def apply(self, context: Context) -> None:
         context.write(
-            PurePosixPath("/etc/portage/package.use/systemd-boot"), f"{self.package} boot\n"
+            PurePosixPath("/etc/portage/package.use/systemd-boot"),
+            f"{self.package} {' '.join(self.FLAGS)}\n",
         )
 
 

--- a/gentoo_install/plan/kernel.py
+++ b/gentoo_install/plan/kernel.py
@@ -151,17 +151,12 @@ class ConfigureInstallKernel(Operation):
     boot_root: str = ""
 
     def apply(self, context: Context) -> None:
-        written = f"sys-kernel/installkernel {' '.join(self._flags())}\n"
-        if self.boot_entries:
-            # `installkernel[systemd-boot]` needs `bootctl`, which on a system
-            # without systemd comes from `sys-apps/systemd-utils[boot]`, and
-            # that ebuild's REQUIRED_USE is `boot? ( kernel-install )`. Without
-            # the second flag the merge stops at `has unmet requirements`
-            # before anything is built. Harmless on a systemd system: the
-            # package is not merged there and the line names nothing.
-            written += "sys-apps/systemd-utils boot kernel-install\n"
+        # Only this package's flags. What `bootctl` comes from is
+        # `RequestBootctl`'s to say, and writing it here as well put one
+        # package's USE in two files that neither named the other.
         context.write(
-            PurePosixPath("/etc/portage/package.use/installkernel"), written
+            PurePosixPath("/etc/portage/package.use/installkernel"),
+            f"sys-kernel/installkernel {' '.join(self._flags())}\n",
         )
         if self.boot_root:
             # A drop-in, never `/etc/kernel/install.conf`. kernel-install(8):

--- a/tests/fixtures/openrc-sdboot.toml
+++ b/tests/fixtures/openrc-sdboot.toml
@@ -1,0 +1,89 @@
+# systemd-boot on OpenRC. `installkernel[systemd-boot]` needs `bootctl`, and
+# without systemd that comes from `sys-apps/systemd-utils[boot]`, whose
+# REQUIRED_USE is `boot? ( kernel-install )`. Every other openrc fixture
+# boots from GRUB and every systemd-boot one runs systemd, so the pair that
+# needs the second flag had no fixture at all.
+config_version = 1
+
+[system]
+hostname = "openrcsdbox"
+timezone = "UTC"
+locales = ["en_US.UTF-8"]
+locale = "en_US.UTF-8"
+init = "openrc"
+root_password_hash = "$6$gentooinst$IR3GrdJ862XljQYDqocr4tKniIRDIT.jQNFzIrHE3U75H6B6YSWZoSYoVd5edSHpqaYBdiNfXHCoIPRVgb9lT/"
+
+[portage]
+profile = "default/linux/amd64/23.0"
+makeopts = "-j4"
+
+[portage.binhost]
+official = true
+community = "off"
+
+[kernel]
+source = "dist-bin"
+
+[bootloader]
+kind = "systemd-boot"
+firmware = "uefi"
+kernel_params = ["console=ttyS0,115200"]
+
+[disk]
+root = "mnt-root"
+
+[[disk.devices]]
+kind = "existing"
+id = "disk"
+selector = "/dev/disk/by-id/virtio-target0"
+wipe = true
+
+[[disk.devices]]
+kind = "table"
+id = "table"
+disk = "disk"
+table = "gpt"
+
+# 1 GiB rather than 512 MiB: this esp holds every kernel and initramfs, not
+# just a bootloader.
+[[disk.devices]]
+kind = "partition"
+id = "esp"
+table = "table"
+index = 1
+role = "esp"
+size = "1GiB"
+
+[[disk.devices]]
+kind = "partition"
+id = "rootpart"
+table = "table"
+index = 2
+role = "data"
+
+[[disk.devices]]
+kind = "filesystem"
+id = "espfs"
+device = "esp"
+type = "vfat"
+label = "ESP"
+
+[[disk.devices]]
+kind = "filesystem"
+id = "rootfs"
+device = "rootpart"
+type = "ext4"
+label = "gentoo"
+
+[[disk.devices]]
+kind = "mountpoint"
+id = "mnt-root"
+source = "rootfs"
+path = "/"
+
+[[disk.devices]]
+kind = "mountpoint"
+id = "mnt-esp"
+source = "espfs"
+path = "/boot"
+options = ["umask=0077"]

--- a/tests/golden/openrc-sdboot.txt
+++ b/tests/golden/openrc-sdboot.txt
@@ -2,24 +2,20 @@
   release anything a previous run of this configuration left mounted or open
   wipe existing signatures from disk
   create a gpt partition table on disk as table
-  create partition 1 on disk as esp: esp, 512MiB
-  create partition 2 on disk as poolpart: data, the rest of the disk
+  create partition 1 on disk as esp: esp, 1GiB
+  create partition 2 on disk as rootpart: data, the rest of the disk
   reread the partition table of disk and wait for its nodes
 
 [format]
   make a vfat filesystem on esp as espfs labelled ESP
-
-[zfs]
-  create zpool rpool as pool from poolpart as a stripe
-  import zpool rpool under pool
-  create dataset rpool/ROOT/gentoo as ds-root, mountpoint /
+  make a ext4 filesystem on rootpart as rootfs labelled gentoo
 
 [mount]
-  mount dataset rpool/ROOT/gentoo at /
-  mount esp at /efi with umask=0077
+  mount rootpart at /
+  mount esp at /boot with umask=0077
 
 [stage3]
-  download the newest systemd stage3 from https://distfiles.gentoo.org, verify it against BB572E0E2D182910 and unpack it into the target
+  download the newest openrc stage3 from https://distfiles.gentoo.org, verify it against BB572E0E2D182910 and unpack it into the target
 
 [chroot]
   mount proc, sys, dev and run into the target and copy resolv.conf
@@ -30,56 +26,47 @@
   run getuto so Portage has a keyring to verify binary packages against
   add verified binary package host gentoo at https://distfiles.gentoo.org/releases/amd64/binpackages/23.0/x86-64
   fetch the first ebuild repository snapshot with emerge-webrsync
-  select profile default/linux/amd64/23.0/systemd
+  select profile default/linux/amd64/23.0
   install git, which every later repository sync needs: emerge dev-vcs/git
   point repository gentoo at https://github.com/gentoo-mirror/gentoo.git, commit signatures verified
   sync repository gentoo
-  point repository gentoo-zh at https://github.com/gentoo-zh/overlay.git
-  sync repository gentoo-zh
-  accept ~amd64 for packages from gentoo-zh only
-  ask for sys-apps/systemd[boot,kernel-install], which is what provides bootctl
+  ask for sys-apps/systemd-utils[boot,kernel-install], which is what provides bootctl
 
 [system]
   generate and verify locales en_US.UTF-8
   set the system locale to en_US.UTF-8
   set the timezone to UTC
   set the console keymap to us and its font to default8x16
-  set the hostname to zfsbox
+  set the hostname to openrcsdbox
   give the target its own machine id
-  write /etc/fstab with entries for /efi
+  write /etc/fstab with entries for /, /boot
   treat the hardware clock as UTC
+  start a login on ttyS0 at 115200 baud
   set the root password
+  install the network tools: emerge net-misc/netifrc net-misc/dhcpcd
   configure the wired interface for DHCP
-  enable systemd-networkd at boot
-  enable systemd-resolved at boot
+  enable dhcpcd in the default runlevel
+  install the system logger: emerge app-admin/sysklogd
+  enable sysklogd in the default runlevel
   install cron: emerge sys-process/cronie
-  enable cronie at boot
+  enable cronie in the default runlevel
 
 [kernel]
-  set sys-kernel/installkernel to dracut, installing into /boot
+  set sys-kernel/installkernel to dracut systemd systemd-boot
+  write /etc/kernel/cmdline so the boot entries mount rootpart
   install the hook that puts a kernel in /boot: emerge sys-kernel/installkernel
   accept the linux-firmware licence
   install the initramfs builder and firmware: emerge sys-kernel/dracut sys-kernel/linux-firmware
-  install the storage tools: emerge sys-fs/dosfstools
-  tell sys-fs/zfs to build against the dist-kernel
-  install the kernel and the tools that build a module for it: emerge sys-kernel/gentoo-kernel-bin sys-fs/zfs, building sys-fs/zfs here
-  tell dracut to carry zfs
-  copy the installing system's hostid into the target so the pool imports
+  install the storage tools: emerge sys-fs/dosfstools sys-fs/e2fsprogs
+  install the kernel: emerge sys-kernel/gentoo-kernel-bin
   delete any kernel image in /boot that has no modules directory
   rebuild the initramfs from sys-kernel/gentoo-kernel-bin with the modules written above
-  check that a kernel image reached /boot or /efi
+  check that a kernel image reached /boot or /boot
 
 [bootloader]
-  install the bootloader: emerge sys-boot/zfsbootmenu sys-boot/efibootmgr
-  install the EFI stub generate-zbm builds around: emerge sys-apps/systemd
-  build ZFSBootMenu into /efi/EFI/zbm and boot rpool/ROOT/gentoo from it
-
-[packages]
-  enable zfs-import-scan.service at boot
-  enable zfs-mount.service at boot
-  enable zfs.target at boot
+  install bootctl: emerge sys-apps/systemd-utils
+  install systemd-boot on the esp at /boot
 
 [finish]
-  point /etc/resolv.conf at systemd-resolved rather than the install medium's
   delete the downloaded stage3 from /var/cache/gentoo-install
-  unmount everything under the target and export rpool
+  unmount everything under the target

--- a/tests/golden/vm-raidz.txt
+++ b/tests/golden/vm-raidz.txt
@@ -45,7 +45,7 @@
   point repository gentoo-zh at https://github.com/gentoo-zh/overlay.git
   sync repository gentoo-zh
   accept ~amd64 for packages from gentoo-zh only
-  ask for sys-apps/systemd[boot], which is what provides bootctl
+  ask for sys-apps/systemd[boot,kernel-install], which is what provides bootctl
 
 [system]
   generate and verify locales en_US.UTF-8

--- a/tests/golden/vm-sdboot.txt
+++ b/tests/golden/vm-sdboot.txt
@@ -30,7 +30,7 @@
   install git, which every later repository sync needs: emerge dev-vcs/git
   point repository gentoo at https://github.com/gentoo-mirror/gentoo.git, commit signatures verified
   sync repository gentoo
-  ask for sys-apps/systemd[boot], which is what provides bootctl
+  ask for sys-apps/systemd[boot,kernel-install], which is what provides bootctl
 
 [system]
   generate and verify locales en_US.UTF-8

--- a/tests/golden/vm-zfs-encrypted.txt
+++ b/tests/golden/vm-zfs-encrypted.txt
@@ -37,7 +37,7 @@
   point repository gentoo-zh at https://github.com/gentoo-zh/overlay.git
   sync repository gentoo-zh
   accept ~amd64 for packages from gentoo-zh only
-  ask for sys-apps/systemd[boot], which is what provides bootctl
+  ask for sys-apps/systemd[boot,kernel-install], which is what provides bootctl
 
 [system]
   generate and verify locales en_US.UTF-8

--- a/tests/golden/vm-zfs-mirror.txt
+++ b/tests/golden/vm-zfs-mirror.txt
@@ -41,7 +41,7 @@
   point repository gentoo-zh at https://github.com/gentoo-zh/overlay.git
   sync repository gentoo-zh
   accept ~amd64 for packages from gentoo-zh only
-  ask for sys-apps/systemd[boot], which is what provides bootctl
+  ask for sys-apps/systemd[boot,kernel-install], which is what provides bootctl
 
 [system]
   generate and verify locales en_US.UTF-8

--- a/tests/golden/zfs-zbm.txt
+++ b/tests/golden/zfs-zbm.txt
@@ -39,7 +39,7 @@
   point repository gentoo-zh at https://github.com/gentoo-zh/overlay.git
   sync repository gentoo-zh
   accept ~amd64 for packages from gentoo-zh only
-  ask for sys-apps/systemd[boot], which is what provides bootctl
+  ask for sys-apps/systemd[boot,kernel-install], which is what provides bootctl
 
 [system]
   generate and verify locales en_US.UTF-8, zh_TW.UTF-8

--- a/tests/unit/test_plan_boot.py
+++ b/tests/unit/test_plan_boot.py
@@ -1104,16 +1104,34 @@ def test_systemd_boot_on_openrc_gets_the_flag_systemd_utils_requires() -> None:
     requirements` before anything was built."""
     from gentoo_install.plan.kernel import ConfigureInstallKernel
 
-    recorder = Recorder()
-    ConfigureInstallKernel(boot_entries=True).apply(recorder)
-    written = recorder.files[PurePosixPath("/etc/portage/package.use/installkernel")]
-    assert "sys-apps/systemd-utils boot kernel-install" in written
-    assert "sys-kernel/installkernel dracut systemd systemd-boot" in written
+    from gentoo_install.plan.bootloader import RequestBootctl
 
-    # Nothing to say when no boot entries are written: the package is not
-    # merged and the line would name one that is absent.
-    plain = Recorder()
-    ConfigureInstallKernel(boot_entries=False).apply(plain)
-    assert "systemd-utils" not in plain.files[
-        PurePosixPath("/etc/portage/package.use/installkernel")
-    ]
+    recorder = Recorder()
+    RequestBootctl(package="sys-apps/systemd-utils").apply(recorder)
+    written = recorder.files[PurePosixPath("/etc/portage/package.use/systemd-boot")]
+    assert written.split() == ["sys-apps/systemd-utils", "boot", "kernel-install"], written
+
+    # One owner: the kernel operation writes its own package and no other, so
+    # one package's USE does not sit in two files that neither name the other.
+    kernel = Recorder()
+    ConfigureInstallKernel(boot_entries=True).apply(kernel)
+    theirs = kernel.files[PurePosixPath("/etc/portage/package.use/installkernel")]
+    assert "systemd-utils" not in theirs, theirs
+    assert "sys-kernel/installkernel dracut systemd systemd-boot" in theirs
+
+
+def test_openrc_with_systemd_boot_has_a_fixture() -> None:
+    """The pair needs `sys-apps/systemd-utils[boot,kernel-install]`, and every
+    openrc fixture booted from GRUB while every systemd-boot one ran systemd,
+    so the combination that needs the flag had nothing exercising it."""
+    import tomllib
+    from pathlib import Path
+
+    paired = []
+    for fixture in sorted(Path("tests/fixtures").glob("*.toml")):
+        settings = tomllib.loads(fixture.read_text())
+        init = settings.get("system", {}).get("init", "systemd")
+        kind = settings.get("bootloader", {}).get("kind", "")
+        if init == "openrc" and kind == "systemd-boot":
+            paired.append(fixture.name)
+    assert paired, "no fixture pairs openrc with systemd-boot"


### PR DESCRIPTION
#149 fixed the `boot? ( kernel-install )` refusal by writing `sys-apps/systemd-utils boot kernel-install` into `package.use/installkernel`. `RequestBootctl` already owns that package's flags and writes them to `package.use/systemd-boot`, so one package's USE sat in two files that neither named the other. The flag moves to the owner and the kernel operation writes only its own package.

`openrc-sdboot.toml` is the fixture the pair never had: every openrc fixture boots from GRUB and every systemd-boot one runs systemd, which is why the combination reached a real machine before a test.