### PR TITLE
fetch: retry the stage3 pointer a reset connection lost

### DIFF
--- a/gentoo_install/exec/fetch.py
+++ b/gentoo_install/exec/fetch.py
@@ -151,6 +151,25 @@ def passphrase_for(device: DeviceId, source: str) -> str:
     return passphrase
 
 
+#: A reset connection is not an answer. `why_unreachable` already retries the
+#: same way and `_newest` did not, so one `Connection reset by peer` from
+#: `distfiles.gentoo.org` ended an install a minute after it started.
+READ_TRIES: Final[int] = 4
+
+
+def _read_patiently(url: str) -> str:
+    last: DownloadFailed | None = None
+    for attempt in range(READ_TRIES):
+        try:
+            return _read(url)
+        except DownloadFailed as error:
+            last = error
+            if attempt + 1 < READ_TRIES:
+                time.sleep(ONLINE_PAUSE * 2**attempt)
+    assert last is not None
+    raise last
+
+
 def _newest(builds: str, variant: str) -> str:
     """The current archive's path under `releases/amd64/autobuilds`.
 
@@ -170,7 +189,7 @@ def _newest(builds: str, variant: str) -> str:
     """
     pointer = f"{builds}/latest-stage3-amd64-{variant}.txt"
     paths: list[str] = []
-    for line in _read(pointer).splitlines():
+    for line in _read_patiently(pointer).splitlines():
         said = line.strip()
         if not said or said.startswith(("#", "-----", "Hash:")):
             continue

--- a/tests/unit/test_exec.py
+++ b/tests/unit/test_exec.py
@@ -1671,3 +1671,43 @@ def test_a_build_tmpfs_the_machine_cannot_spare_is_refused(tmp_path: Path) -> No
     assert any(
         "for the compiler and its sources" in one for one in preflight.check(tight, probe).fatal
     )
+
+
+def test_a_reset_connection_is_retried_before_the_install_is_given_up(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """`why_unreachable` already retries and `_newest` did not, so one
+    `Connection reset by peer` from `distfiles.gentoo.org` ended an install a
+    minute after it started."""
+    from gentoo_install.errors import DownloadFailed
+    from gentoo_install.exec import fetch
+
+    tries = {"n": 0}
+    body = "20260809T143052Z/stage3-amd64-systemd-20260809T143052Z.tar.xz 300\n"
+
+    def flaky(url: str) -> str:
+        tries["n"] += 1
+        if tries["n"] < 3:
+            raise DownloadFailed(f"{url} could not be read: [Errno 104] Connection reset")
+        return body
+
+    monkeypatch.setattr(fetch, "_read", flaky)
+    import time as clock
+
+    monkeypatch.setattr(clock, "sleep", lambda seconds: None)
+    where = fetch._newest("https://distfiles.invalid/releases", "systemd")
+    assert where.endswith("stage3-amd64-systemd-20260809T143052Z.tar.xz")
+    assert tries["n"] == 3
+
+    # Bounded: a host that never answers still stops the install rather than
+    # holding it open.
+    tries["n"] = 0
+
+    def dead(url: str) -> str:
+        tries["n"] += 1
+        raise DownloadFailed(f"{url} could not be read: [Errno 104] Connection reset")
+
+    monkeypatch.setattr(fetch, "_read", dead)
+    with pytest.raises(DownloadFailed):
+        fetch._newest("https://distfiles.invalid/releases", "systemd")
+    assert tries["n"] == fetch.READ_TRIES


### PR DESCRIPTION
`vm-btrfs` of round 22 stopped after 1.1 minutes: `https://distfiles.gentoo.org/releases/amd64/autobuilds/latest-stage3-amd64-systemd.txt could not be read: [Errno 104] Connection reset by peer`.

`why_unreachable` already reads a URL five times with a doubling pause, and the pointer `_newest` reads had none, so a single lost connection ended the install before anything was written. Four attempts, bounded: a host that never answers still stops the run rather than holding it open.