### PR TITLE
plan: derive the serial console once

### DIFF
--- a/gentoo_install/plan/bootloader.py
+++ b/gentoo_install/plan/bootloader.py
@@ -310,7 +310,7 @@ def build(config: InstallConfig) -> list[Operation]:
             WriteGrubDefaults(
                 kernel_params=(*unlock_parameters(config), *config.bootloader.kernel_params),
                 cryptodisk=compat.boot_is_encrypted(config.disk.graph),
-                serial=_serial_console(config),
+                serial=serial_console(config),
                 luks=initramfs_devices(config)[0],
                 arrays=initramfs_devices(config)[1],
                 keymap=initramfs_keymap(config),
@@ -354,7 +354,7 @@ def build(config: InstallConfig) -> list[Operation]:
                 esp=esp,
                 esp_device=esp_device,
                 kernel_params=(*unlock_parameters(config), *config.bootloader.kernel_params),
-                serial=_serial_console(config),
+                serial=serial_console(config),
             ),
         ]
     return operations
@@ -447,7 +447,8 @@ def initramfs_keymap(config: InstallConfig) -> str:
     return wanted
 
 
-def _serial_console(config: InstallConfig) -> tuple[str, int] | None:
+def serial_console(config: InstallConfig) -> tuple[str, int] | None:
+    """The serial port and speed the kernel command line asks for, if any."""
     for parameter in config.bootloader.kernel_params:
         if not parameter.startswith("console=ttyS"):
             continue

--- a/gentoo_install/plan/system.py
+++ b/gentoo_install/plan/system.py
@@ -33,6 +33,7 @@ from ..model.device import (
     ZfsDataset,
     ZfsPool,
 )
+from .bootloader import serial_console
 from .operations import Context, Operation, Stage
 from .portage import Emerge
 
@@ -900,7 +901,7 @@ def build(config: InstallConfig) -> list[Operation]:
                 keys=system.authorized_keys, accounts=key_accounts(system, unlocking)
             )
         )
-    serial = _serial_console(config)
+    serial = serial_console(config)
     if serial is not None and system.init is InitSystem.OPENRC:
         operations.append(EnableSerialGetty(port=serial[0], baud=serial[1]))
     operations.append(SetRootPassword(password_hash=system.root_password_hash))
@@ -1133,18 +1134,6 @@ def _groups_of(user: User) -> tuple[str, ...]:
         if group not in groups:
             groups.append(group)
     return tuple(groups)
-
-
-def _serial_console(config: InstallConfig) -> tuple[str, int] | None:
-    """The serial port and speed the kernel command line asks for, if any."""
-    for parameter in config.bootloader.kernel_params:
-        if not parameter.startswith("console=ttyS"):
-            continue
-        value = parameter.split("=", 1)[1]
-        port, _, rest = value.partition(",")
-        digits = "".join(character for character in rest if character.isdigit())
-        return port, int(digits) if digits else 115200
-    return None
 
 
 def key_accounts(system: SystemConfig, unlocking: bool = False) -> tuple[tuple[str, str], ...]:

--- a/tests/unit/test_plan_system.py
+++ b/tests/unit/test_plan_system.py
@@ -26,7 +26,7 @@ from gentoo_install.model.device import (
     Partition,
     PartitionRole,
 )
-from gentoo_install.plan import system
+from gentoo_install.plan import bootloader, system
 from gentoo_install.plan.portage import Emerge
 
 from .layouts import config, ext4_on_gpt, i
@@ -247,6 +247,27 @@ def test_openrc_gets_a_serial_login_when_the_cmdline_asks_for_one() -> None:
     assert PurePosixPath("/etc/inittab") not in apply_all(
         local, generated=generated(local)
     ).files
+
+
+def test_serial_frame_format_does_not_change_the_getty_baud() -> None:
+    from gentoo_install.model.config import BootloaderConfig
+
+    remote = replace(
+        with_system(init=InitSystem.OPENRC),
+        bootloader=BootloaderConfig(kernel_params=("console=ttyS0,115200n8",)),
+    )
+    getty = next(
+        operation
+        for operation in system.build(remote)
+        if isinstance(operation, system.EnableSerialGetty)
+    )
+    grub = next(
+        operation
+        for operation in bootloader.build(remote)
+        if isinstance(operation, bootloader.WriteGrubDefaults)
+    )
+    assert grub.serial is not None
+    assert getty.baud == grub.serial[1] == 115200
 
 
 def test_systemd_needs_no_inittab_entry_for_the_serial_console() -> None:


### PR DESCRIPTION
`_serial_console` was written twice and the copies had drifted into different behaviour. `bootloader.py` takes the leading digits and its comment records why: `115200n8` names the speed and then the frame format, and taking every digit made that 1152008 baud. `system.py` took every digit.

So `console=ttyS0,115200n8` gave GRUB 115200 and gave the OpenRC serial getty 1152008. The defect was found and fixed in one copy and left in the other.

Written by a codex agent under a scoped spec; I read the diff, ran the gates, and confirmed the new test fails against the `isdigit()` form with `assert 1152008 == 115200`.