### PR TITLE
vm: run the openrc systemd-boot fixture in the matrix

### DIFF
--- a/tests/vm/campaign.py
+++ b/tests/vm/campaign.py
@@ -144,6 +144,11 @@ STAGES: Final[dict[str, tuple[Run, ...]]] = {
         Run("fixtures/vm-lvm.toml"),
         Run("fixtures/vm-mdraid.toml"),
         Run("fixtures/vm-sdboot.toml"),
+        # `installkernel[systemd-boot]` needs `bootctl`, and without systemd
+        # that is `sys-apps/systemd-utils[boot,kernel-install]`. Every other
+        # openrc fixture boots from GRUB and every systemd-boot one runs
+        # systemd, so the pair reached a real machine before a test.
+        Run("fixtures/openrc-sdboot.toml"),
         Run("fixtures/vm-zfs-encrypted.toml"),
         Run("fixtures/zfs-zbm.toml"),
         Run("fixtures/btrfs-luks.toml"),


### PR DESCRIPTION
#153 added `openrc-sdboot.toml` and did not add it to the campaign, so `test_the_campaign_covers_every_vm_fixture` has been red on master since it landed. I ran `test_plan_boot.py` and `tests/golden` before merging and not `test_harness.py`, which is the one that owns that rule.