### PR TITLE
vm: carry the cleanup result in the outcome

### DIFF
--- a/tests/unit/test_harness.py
+++ b/tests/unit/test_harness.py
@@ -513,6 +513,53 @@ def test_a_guest_that_could_not_be_removed_keeps_its_slot() -> None:
     assert "not outcome.removed" in inspect.getsource(cluster.run)
 
 
+def test_cleanup_result_does_not_leak_between_workers(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A later campaign may run the same job after an earlier cleanup failed.
+    Its removed guest must return the slot and VMID."""
+    import queue
+    from typing import cast
+
+    from tests.vm import cluster
+    from tests.vm.proxmox import Api, ProxmoxError
+
+    destroy_fails = iter((True, False))
+
+    class FakeGuest:
+        def __init__(self, *args: object, **kwargs: object) -> None:
+            self.vmid = 9300
+
+        def create(self) -> None:
+            raise ProxmoxError("the test stops before installation")
+
+        def transferred(self) -> int:
+            return 0
+
+        def destroy(self) -> None:
+            if next(destroy_fails):
+                raise ProxmoxError("the guest remains")
+
+    monkeypatch.setattr(cluster, "Guest", FakeGuest)
+    done: queue.Queue[cluster.Outcome] = queue.Queue()
+    inflight: dict[str, cluster.Running] = {}
+    job = cluster.Job("vm-lvm", Path("tests/fixtures/vm-lvm.toml"))
+    nowhere = cast(Api, object())
+
+    cluster.answer_once(
+        done, nowhere, "infra-node1", job, "driver.iso", tmp_path, inflight, 9300
+    )
+    cluster.answer_once(
+        done, nowhere, "infra-node1", job, "driver.iso", tmp_path, inflight, 9301
+    )
+
+    left_behind = done.get_nowait()
+    removed = done.get_nowait()
+    assert (left_behind.vmid, removed.vmid) == (9300, 9301)
+    assert not left_behind.removed
+    assert removed.removed
+
+
 def test_a_worker_that_ends_without_reporting_becomes_an_error() -> None:
     """`answer_once` puts an outcome on the queue for everything a Python
     handler can see. A thread that ends any other way left its name in the

--- a/tests/vm/cluster.py
+++ b/tests/vm/cluster.py
@@ -851,12 +851,6 @@ class Running:
     watch: Watchdog
 
 
-#: Jobs whose guest could not be removed. A node's memory is still allocated
-#: for one of these, so its slot is not handed back: doing that put the next
-#: guest onto a node with no room and the hypervisor ended it.
-LEFT_BEHIND: set[str] = set()
-
-
 def install_one(
     api: Api,
     node: str,
@@ -891,6 +885,7 @@ def install_one(
     )
     phase = Phase.CREATE
     watch = Watchdog(log=log, counters=lambda: guest.transferred())
+    outcome: Outcome | None = None
     if inflight is not None:
         inflight[job.name] = Running(guest=guest, watch=watch)
     try:
@@ -932,7 +927,7 @@ def install_one(
         files = collect(guest, link, log)
         code = files.get("install.rc", b"").strip()
         if code != b"0":
-            return Outcome(
+            outcome = Outcome(
                 job.name,
                 Verdict.FAIL,
                 time.monotonic() - started,
@@ -941,13 +936,14 @@ def install_one(
                 phase=phase,
                 revision=revision,
             )
+            return outcome
         # The install finishing is half the question. The other half is whether
         # the machine it produced comes up and carries what was asked for, and
         # nothing in the log above can answer that.
         phase = Phase.BOOT_INSTALLED
         wrong = boot_and_check(guest, link, log, load(job.fixture))
         if wrong:
-            return Outcome(
+            outcome = Outcome(
                 job.name,
                 Verdict.FAIL,
                 time.monotonic() - started,
@@ -956,7 +952,8 @@ def install_one(
                 phase=phase,
                 revision=revision,
             )
-        return Outcome(
+            return outcome
+        outcome = Outcome(
             job.name,
             Verdict.OK,
             time.monotonic() - started,
@@ -964,9 +961,10 @@ def install_one(
             phase=phase,
             revision=revision,
         )
+        return outcome
     except (ConsoleTimeout, ConsoleClosed) as error:
         verdict = Verdict.STUCK if watch.stuck else Verdict.ERROR
-        return Outcome(
+        outcome = Outcome(
             job.name,
             verdict,
             time.monotonic() - started,
@@ -975,8 +973,9 @@ def install_one(
             phase=phase,
             revision=revision,
         )
+        return outcome
     except (ProxmoxError, ResultError, OSError) as error:
-        return Outcome(
+        outcome = Outcome(
             job.name,
             Verdict.ERROR,
             time.monotonic() - started,
@@ -985,6 +984,7 @@ def install_one(
             phase=phase,
             revision=revision,
         )
+        return outcome
     finally:
         if inflight is not None:
             inflight.pop(job.name, None)
@@ -995,7 +995,8 @@ def install_one(
             # and the operator has to know, but the result already exists. The
             # slot stays held below, because the memory does.
             print(f"{job.name}: the guest was not removed: {error}", file=sys.stderr)
-            LEFT_BEHIND.add(job.name)
+            if outcome is not None:
+                outcome.removed = False
 
 
 def answer_once(
@@ -1022,9 +1023,7 @@ def answer_once(
         outcome = install_one(
             api, node, job, driver, workdir, inflight, vmid, nonce, revision
         )
-        outcome = replace(
-            outcome, removed=outcome.name not in LEFT_BEHIND, vmid=outcome.vmid or vmid
-        )
+        outcome = replace(outcome, vmid=outcome.vmid or vmid)
         if outcome.removed and lease_path is not None:
             lease_path.unlink(missing_ok=True)
         done.put(outcome)


### PR DESCRIPTION
`LEFT_BEHIND` was a module-level mutable set: a worker added its job's name when the guest could not be removed and `answer_once` read it back to decide `Outcome.removed`. One set is shared by every worker in the process, so a second campaign in the same interpreter — which the tests do — started with whatever the first left in it, and the project's own rules forbid a mutable global.

The worker reports it through the `Outcome` it already puts on the queue. Written by a codex agent under a scoped spec; I read the diff, ran the gates, and confirmed the new test fails against the shared set with `assert False`.