### PR TITLE
vm: keep the caller's deadline across a reconnect

### DIFF
--- a/tests/unit/test_harness.py
+++ b/tests/unit/test_harness.py
@@ -1252,3 +1252,53 @@ def test_a_term_signal_reaches_the_closing_path() -> None:
             handler(signals.SIGTERM, None)
     finally:
         signals.signal(signals.SIGTERM, before)
+
+
+def test_reconnects_share_the_callers_deadline(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A dropped console cannot turn one bounded wait into one per connection."""
+    import time as clock
+
+    from tests.vm import cluster
+    from tests.vm.console import ConsoleClosed, ConsoleTimeout
+
+    now = [0.0]
+    opened = 0
+
+    class Missing:
+        def __init__(self, drops: bool) -> None:
+            self.drops = drops
+
+        def send(self, line: str) -> None:
+            pass
+
+        def send_raw(self, keys: str) -> None:
+            pass
+
+        def snapshot(self, seconds: float) -> bytes:
+            return b""
+
+        @property
+        def closed(self) -> bool:
+            return False
+
+        def expect(self, pattern: str, timeout: float) -> bytes:
+            if self.drops:
+                now[0] += min(4.0, timeout)
+                raise ConsoleClosed("the guest closed the serial connection")
+            now[0] += timeout
+            raise ConsoleTimeout(f"never matched {pattern!r}")
+
+    def open_console() -> Missing:
+        nonlocal opened
+        opened += 1
+        return Missing(drops=opened < 3)
+
+    monkeypatch.setattr(clock, "monotonic", lambda: now[0])
+    link = cluster.Reconnecting(open_console, tries=3)
+    with pytest.raises(ConsoleTimeout, match="never matched"):
+        link.expect("installation complete", timeout=10.0)
+
+    assert opened == 3, "both dropped connections are reopened"
+    assert now[0] == pytest.approx(10.0)

--- a/tests/vm/cluster.py
+++ b/tests/vm/cluster.py
@@ -33,7 +33,7 @@ from enum import Enum
 from pathlib import Path, PurePosixPath
 from collections import Counter
 from collections.abc import Callable, Mapping
-from typing import Final, Protocol
+from typing import Final, Protocol, TypeVar
 
 from gentoo_install.model.config import Firmware as BootFirmware
 from gentoo_install.model.config import InitSystem, InstallConfig
@@ -1264,6 +1264,9 @@ _BEGIN_TEXT: Final[str] = "MARK_{token}_BEGIN"
 _DONE_TEXT: Final[str] = "MARK_{token}_DONE"
 
 
+_Result = TypeVar("_Result")
+
+
 def _marked(command: str, token: int) -> str:
     return (
         f"printf 'MARK_%s_BEGIN\\n' {token}; {command}; printf 'MARK_%s_DONE\\n' {token}"
@@ -1276,6 +1279,10 @@ def _begin(token: int) -> str:
 
 def _done(token: int) -> str:
     return _DONE_TEXT.format(token=token)
+
+
+def _remaining(deadline: float) -> float:
+    return max(0.0, deadline - time.monotonic())
 
 
 class Reconnecting:
@@ -1309,26 +1316,17 @@ class Reconnecting:
         self.console.send("")
 
     def expect(self, pattern: str, timeout: float) -> bytes:
-        for attempt in range(self._tries):
-            try:
-                return self.console.expect(pattern, timeout)
-            except ConsoleClosed:
-                if attempt + 1 == self._tries:
-                    raise
-                self.reopen()
-        raise ConsoleClosed("the console could not be reopened")
+        return self._with_reconnect(
+            timeout, lambda deadline: self.console.expect(pattern, _remaining(deadline))
+        )
 
     def run(self, command: str, timeout: float = 120.0) -> None:
-        for attempt in range(self._tries):
+        def run_once(deadline: float) -> None:
             token = next(self._marks)
             self.console.send(_marked(command, token))
-            try:
-                self.console.expect(_done(token), timeout)
-                return
-            except ConsoleClosed:
-                if attempt + 1 == self._tries:
-                    raise
-                self.reopen()
+            self.console.expect(_done(token), _remaining(deadline))
+
+        self._with_reconnect(timeout, run_once)
 
     def wait_for(self, command: str, timeout: float) -> None:
         """Send a command once and wait for it however long it takes.
@@ -1337,15 +1335,16 @@ class Reconnecting:
         would be started a second time on a target it has half written.
         """
         token = next(self._marks)
-        self.console.send(_marked(command, token))
-        for attempt in range(self._tries):
-            try:
-                self.console.expect(_done(token), timeout)
-                return
-            except ConsoleClosed:
-                if attempt + 1 == self._tries:
-                    raise
-                self.reopen()
+        sent = False
+
+        def wait_once(deadline: float) -> None:
+            nonlocal sent
+            if not sent:
+                sent = True
+                self.console.send(_marked(command, token))
+            self.console.expect(_done(token), _remaining(deadline))
+
+        self._with_reconnect(timeout, wait_once)
 
     def expect_output(self, command: str, timeout: float = 120.0) -> bytes:
         """Run a command and answer with what it printed, and nothing else.
@@ -1356,15 +1355,28 @@ class Reconnecting:
         echo of that command carries one, so the check passed on a guest whose
         `findmnt` printed nothing at all.
         """
-        for attempt in range(self._tries):
+        def collect_once(deadline: float) -> bytes:
             token = next(self._marks)
             self.console.send(_marked(command, token))
+            self.console.expect(_begin(token), _remaining(deadline))
+            said = self.console.expect(_done(token), _remaining(deadline))
+            return said.split(_DONE_TEXT.format(token=token).encode())[0]
+
+        return self._with_reconnect(timeout, collect_once)
+
+    def _with_reconnect(
+        self, timeout: float, operation: Callable[[float], _Result]
+    ) -> _Result:
+        deadline = time.monotonic() + timeout
+        closed: ConsoleClosed | None = None
+        for attempt in range(self._tries):
+            if closed is not None and _remaining(deadline) <= 0.0:
+                raise closed
             try:
-                self.console.expect(_begin(token), timeout)
-                said = self.console.expect(_done(token), timeout)
-                return said.split(_DONE_TEXT.format(token=token).encode())[0]
-            except ConsoleClosed:
-                if attempt + 1 == self._tries:
+                return operation(deadline)
+            except ConsoleClosed as error:
+                closed = error
+                if attempt + 1 == self._tries or _remaining(deadline) <= 0.0:
                     raise
                 self.reopen()
         raise ConsoleClosed("the console could not be reopened")


### PR DESCRIPTION
`termproxy` connections drop during an hour-long install, and `Reconnecting` reopened and retried. Every copy of that loop restarted the full timeout, so a caller asking for `expect(pattern, timeout=600)` got ten minutes *per connection* rather than ten minutes: `vm-sdboot` sat for thirty minutes with its machine alive and its log not growing, and the round ended without a verdict for it.

One loop, and a deadline set when the caller asks. Written by a codex agent; I took only the `Reconnecting` region of its diff, because its worktree predated #157 and copying the file whole would have put `LEFT_BEHIND` back. The new test fails against the old shape with `assert 18.0 == 10.0`.