### PR TITLE
model: own the smallest root that can hold a Gentoo

### DIFF
--- a/gentoo_install/exec/preflight.py
+++ b/gentoo_install/exec/preflight.py
@@ -16,13 +16,13 @@ from ..model import compat
 from ..model.config import Firmware, InstallConfig
 from ..model.device import (
     DeviceGraph,
+    DeviceId,
     Existing,
     Filesystem,
     Swap,
     FilesystemType,
     Luks,
     MdRaid,
-    Mountpoint,
     Partition,
     PartitionTable,
     TableType,
@@ -30,7 +30,7 @@ from ..model.device import (
     ZfsPool,
 )
 from ..model.size import DEFAULT_ALIGNMENT, SectorSize, Size
-from ..model.validate import ROOT_MINIMUM
+from ..model.validate import root_size_problems
 from ..plan.disk import MKFS
 from .probe import RELEASE_KEY, Machine, Probe
 
@@ -216,6 +216,7 @@ def _capacity_problems(config: InstallConfig, probe: Probe) -> list[str]:
     """
     graph = config.disk.graph
     problems: list[str] = []
+    supplied_root_sizes: dict[DeviceId, Size] = {}
     for table in graph.of_type(PartitionTable):
         disk = graph[table.disk]
         if not isinstance(disk, Existing):
@@ -269,20 +270,13 @@ def _capacity_problems(config: InstallConfig, probe: Probe) -> list[str]:
             usable = usable.gpt_last_usable(SectorSize(512))
         # The first partition starts at the alignment boundary, not at zero.
         usable = Size(max(0, usable.bytes - DEFAULT_ALIGNMENT))
+        supplied_root_sizes[table.id] = usable
         if claimed > usable.bytes:
             problems.append(
                 f"{disk.selector} holds {Size(capacity)} and {table.id} claims "
                 f"{Size(claimed)} in fixed sizes, which does not fit"
             )
-        # The root of a whole-disk layout takes what is left, so it carries no
-        # size and `validate._root_size_problems` has nothing to compare. The
-        # disk itself is what has to be big enough, and an install into 8 GiB
-        # runs out during linux-firmware, an hour after the disks are written.
-        if _carries_the_root(graph, table.id) and usable.bytes < ROOT_MINIMUM.bytes:
-            problems.append(
-                f"{disk.selector} holds {Size(capacity)} and carries /, under the "
-                f"{ROOT_MINIMUM} a stage3, a kernel and linux-firmware need"
-            )
+    problems += root_size_problems(config, supplied_root_sizes)
     return problems
 
 
@@ -312,31 +306,6 @@ def _memory_problems(config: InstallConfig, machine: Machine) -> list[str]:
             f"{Size(machine.memory_bytes - wanted.bytes)} for the compiler and its sources"
         ]
     return []
-
-
-def _carries_the_root(graph: DeviceGraph, table: str) -> bool:
-    """Whether `/` ends up on a partition of this table.
-
-    Walked rather than assumed: the root may sit under LUKS, a volume group or
-    a pool, and each of those hides the partition it was built from.
-    """
-    root = next(
-        (one for one in graph.of_type(Mountpoint) if str(one.path) == "/"), None
-    )
-    if root is None:
-        return False
-    seen: set[str] = set()
-    frontier = [root.id]
-    while frontier:
-        current = frontier.pop()
-        if current in seen or current not in graph.nodes:
-            continue
-        seen.add(current)
-        node = graph[current]
-        if isinstance(node, Partition) and node.table == table:
-            return True
-        frontier.extend(node.inputs)
-    return False
 
 
 def check(config: InstallConfig, probe: Probe, target: str = "/mnt/gentoo") -> Report:

--- a/gentoo_install/model/validate.py
+++ b/gentoo_install/model/validate.py
@@ -11,7 +11,7 @@ import ipaddress
 import re
 from collections import Counter
 from pathlib import PurePosixPath
-from typing import Final
+from typing import Final, Mapping
 
 from ..errors import ValidationFailed
 from . import compat
@@ -38,7 +38,7 @@ _ROOT = PurePosixPath("/")
 def validate(config: InstallConfig) -> None:
     problems = [
         *_layout_problems(config),
-        *_root_size_problems(config),
+        *root_size_problems(config),
         *_profile_problems(config),
         *_kernel_package_problems(config),
         *_reuse_problems(config),
@@ -218,32 +218,41 @@ def _kernel_package_problems(config: InstallConfig) -> list[str]:
 ROOT_MINIMUM: Final[Size] = Size.parse("12GiB")
 
 
-def _root_size_problems(config: InstallConfig) -> list[str]:
-    """Checked here because the size is in the configuration: a root too small
-    is knowable before anything is partitioned."""
+def root_size_problems(
+    config: InstallConfig,
+    supplied_sizes: Mapping[DeviceId, Size] | None = None,
+) -> list[str]:
+    """Reject undersized declared or supplied sizes beneath the root.
+
+    The nearest declared size describes the root itself. Supplied backing sizes
+    remain constraints even when a nearer logical device declares its size.
+    """
     graph = config.disk.graph
     root = graph.nodes.get(config.disk.root)
     if not isinstance(root, Mountpoint):
         return []
-    node = _nearest_sized(graph, root.id)
-    if node is None:
-        return []
-    size = getattr(node, "size")
     return [
         f"{node.id} carries / and is {size}, under the {ROOT_MINIMUM} a stage3, "
         "a kernel and linux-firmware need"
-    ] if size < ROOT_MINIMUM else []
+        for node, size in _root_sizes(graph, root.id, supplied_sizes or {})
+        if size < ROOT_MINIMUM
+    ]
 
 
-def _nearest_sized(graph: DeviceGraph, device: DeviceId) -> Node | None:
-    """The first node with a size, walking down from the mount point.
+def _root_sizes(
+    graph: DeviceGraph,
+    device: DeviceId,
+    supplied_sizes: Mapping[DeviceId, Size],
+) -> list[tuple[Node, Size]]:
+    """The nearest declared size and supplied sizes on the root path.
 
-    The nearest one, not every ancestor: a logical volume or an array is as
-    large as its members together, and testing each member refused a root that
-    is the right size for being built out of small ones.
+    Declared member sizes are excluded because an array may be large enough
+    when each member is not. A supplied physical limit still constrains it.
     """
     seen: set[DeviceId] = set()
     edge = [device]
+    declared_size: tuple[Node, Size] | None = None
+    supplied: list[tuple[Node, Size]] = []
     while edge:
         following: list[DeviceId] = []
         for current in edge:
@@ -251,11 +260,16 @@ def _nearest_sized(graph: DeviceGraph, device: DeviceId) -> Node | None:
                 continue
             seen.add(current)
             node = graph[current]
-            if isinstance(getattr(node, "size", None), Size):
-                return node
+            supplied_size = supplied_sizes.get(current)
+            if supplied_size is not None:
+                supplied.append((node, supplied_size))
+            elif declared_size is None:
+                node_size = getattr(node, "size", None)
+                if isinstance(node_size, Size):
+                    declared_size = node, node_size
             following.extend(node.inputs)
         edge = following
-    return None
+    return ([declared_size] if declared_size is not None else []) + supplied
 
 
 def _profile_problems(config: InstallConfig) -> list[str]:

--- a/tests/unit/test_exec.py
+++ b/tests/unit/test_exec.py
@@ -1632,6 +1632,47 @@ def test_a_disk_too_small_to_hold_a_gentoo_is_refused_before_it_is_written(
     assert Size(probe.capacity) > ROOT_MINIMUM
 
 
+def test_validation_and_preflight_agree_that_a_declared_root_is_too_small(
+    tmp_path: Path,
+) -> None:
+    """A roomy disk used to hide an undersized declared root from preflight,
+    while validation refused the same configuration."""
+    from gentoo_install.errors import ValidationFailed
+    from gentoo_install.model.device import DeviceGraph, Partition
+    from gentoo_install.model.size import Size
+    from gentoo_install.model.validate import validate
+
+    base = present()
+    nodes = [
+        replace(node, size=Size.parse("8GiB"))
+        if isinstance(node, Partition) and node.id == i("rootpart")
+        else node
+        for node in base.disk.graph.nodes.values()
+    ]
+    installation = replace(
+        base, disk=replace(base.disk, graph=DeviceGraph.build(nodes))
+    )
+
+    class Roomy(Probe):
+        def disk_bytes(self, disk: str) -> int:
+            return 64 * 1024**3
+
+    try:
+        validate(installation)
+    except ValidationFailed:
+        validation_refused = True
+    else:
+        validation_refused = False
+    preflight_refused = any(
+        "carries /" in problem
+        for problem in preflight._capacity_problems(
+            installation, Roomy(runner=runner(tmp_path), work=tmp_path)
+        )
+    )
+
+    assert validation_refused == preflight_refused
+
+
 def test_a_build_tmpfs_the_machine_cannot_spare_is_refused(tmp_path: Path) -> None:
     """The size is the operator's, so it is comparable before anything runs: a
     build that outgrows its tmpfs fails on ENOSPC after hours of compiling.


### PR DESCRIPTION
#141 added a capacity check to `exec/preflight.py` beside the declared-size check already in `model/validate.py`, each with its own walk from `/` to the partition it rests on. Two implementations of one rule drift, and this repository proved it this week: `_serial_console` was written twice, fixed in one copy, and left giving the serial getty 1152008 baud in the other.

The rule and the walk live in `model/`, which holds the graph and has no I/O to do it with. `exec/preflight.py` keeps the part only it can do — reading the disk's real capacity — and hands it in. Written by a codex agent; the new test fails against the two-implementation code with `assert True == False`.