### PR TITLE
model: keep probed facts out of the configuration it writes

### DIFF
--- a/gentoo_install/exec/probe.py
+++ b/gentoo_install/exec/probe.py
@@ -856,14 +856,14 @@ def with_probed_facts(config: InstallConfig, probe: Probe) -> InstallConfig:
     without it, and firmware cannot read such a member.
     """
     graph = config.disk.graph
-    reused = [one for one in graph.of_type(Existing) if not one.mdraid_metadata]
+    reused = [one for one in graph.of_type(Existing) if one.mdraid_metadata is None]
     known = {one.id: probe.mdraid_metadata(one.selector) for one in reused}
     free = _free_extents(graph, probe)
-    if not any(known.values()) and not free:
+    if not known and not free:
         return config
     nodes = [
         replace(one, mdraid_metadata=known[one.id])
-        if isinstance(one, Existing) and known.get(one.id)
+        if isinstance(one, Existing) and one.id in known
         else replace(one, free_extents=free[one.id])
         if isinstance(one, PartitionTable) and one.id in free
         else one

--- a/gentoo_install/model/device.py
+++ b/gentoo_install/model/device.py
@@ -111,12 +111,9 @@ class Existing(Node):
 
     selector: str
     wipe: bool = False
-    #: The mdraid metadata version this device already carries, when it is an
-    #: array being reused. Empty for anything else, and filled in by the probe
-    #: before validation: the model cannot read a superblock, and without it a
-    #: reused RAID1 esp with metadata 1.1 or 1.2 met no rule at all, although
-    #: firmware cannot read a member whose superblock is at the start.
-    mdraid_metadata: str = ""
+    #: None until probed and empty when no array was found, so compatibility
+    #: can distinguish missing evidence from a machine with no superblock.
+    mdraid_metadata: str | None = None
 
 
 @dataclass(frozen=True)

--- a/gentoo_install/model/serialise.py
+++ b/gentoo_install/model/serialise.py
@@ -55,6 +55,12 @@ KINDS: Final[dict[type[Node], str]] = {
 #: one case: the node discriminator already claims `kind`.
 RENAMED: Final[dict[tuple[type[Node], str], str]] = {(Filesystem, "kind"): "type"}
 
+#: Probe-only facts stay available to planning and compatibility but are omitted
+#: here because the parser accepts only operator-authored configuration.
+PROBED_FIELDS: Final[frozenset[tuple[type[Node], str]]] = frozenset(
+    {(Existing, "mdraid_metadata"), (PartitionTable, "free_extents")}
+)
+
 #: Fields whose value is replaced when the configuration is published. A crypt
 #: hash is not the password, but it is what an offline attack starts from, and
 #: the pastebin is a public address.
@@ -151,6 +157,8 @@ def _disk(config: InstallConfig) -> list[str]:
             raise KeyError(f"{type(node).__name__} has no kind to write it as")
         lines += ["", "[[disk.devices]]", f'kind = "{kind}"']
         for field in fields(node):
+            if (type(node), field.name) in PROBED_FIELDS:
+                continue
             held = getattr(node, field.name)
             if held is None:
                 continue

--- a/tests/unit/test_serialise.py
+++ b/tests/unit/test_serialise.py
@@ -7,7 +7,7 @@ from pathlib import Path
 import pytest
 
 from gentoo_install.model.config import InstallConfig, Overlay, User
-from gentoo_install.model.device import DeviceGraph, DeviceId, PartitionTable
+from gentoo_install.model.device import DeviceGraph, DeviceId, Existing, PartitionTable
 from gentoo_install.model.parse import _NODES, parse
 from gentoo_install.model.serialise import KINDS, REDACTED, SECRET, to_toml
 
@@ -22,6 +22,16 @@ def _round_trip(config: InstallConfig) -> InstallConfig:
 def test_every_fixture_survives_a_round_trip(path: Path) -> None:
     config = parse(tomllib.loads(path.read_text()))
     assert _round_trip(config) == config
+
+
+def test_probed_facts_are_not_written_as_configuration() -> None:
+    config = parse(tomllib.loads((FIXTURES / "vm-mdraid.toml").read_text()))
+    nodes = [
+        replace(node, mdraid_metadata="1.0") if isinstance(node, Existing) else node
+        for node in config.disk.graph.nodes.values()
+    ]
+    probed = replace(config, disk=replace(config.disk, graph=DeviceGraph.build(nodes)))
+    assert _round_trip(probed) == config
 
 
 def test_every_node_kind_can_be_written() -> None:


### PR DESCRIPTION
`with_probed_facts` fills `Existing.mdraid_metadata` and `PartitionTable.free_extents` from the machine and puts them back in the graph. The serializer reflects over the dataclass fields, so a probed value is written out, and the parser accepts neither:

```
ConfigError: disk.devices[0] has unknown keys: mdraid_metadata
```

The installer wrote a configuration file it then refused to read. The menu's `save the configuration and leave` and its pastebin upload both walk that path, on any run that probed anything.

`PROBED_FIELDS` names them in the serializer, so they stay available to planning and compatibility and are not written. `mdraid_metadata` also becomes `str | None`, which separates a device nothing asked about from one with no superblock. Written by a codex agent whose first run died on a 403; I resumed its thread rather than re-dispatching.