### PR TITLE
plan: restore the serial derivation a later merge took back

### DIFF
--- a/gentoo_install/plan/system.py
+++ b/gentoo_install/plan/system.py
@@ -33,6 +33,7 @@ from ..model.device import (
     ZfsDataset,
     ZfsPool,
 )
+from .bootloader import serial_console
 from .operations import Context, Operation, Stage
 from .portage import Emerge
 
@@ -905,7 +906,7 @@ def build(config: InstallConfig) -> list[Operation]:
                 keys=system.authorized_keys, accounts=key_accounts(system, unlocking)
             )
         )
-    serial = _serial_console(config)
+    serial = serial_console(config)
     if serial is not None and system.init is InitSystem.OPENRC:
         operations.append(EnableSerialGetty(port=serial[0], baud=serial[1]))
     operations.append(SetRootPassword(password_hash=system.root_password_hash))
@@ -1138,18 +1139,6 @@ def _groups_of(user: User) -> tuple[str, ...]:
         if group not in groups:
             groups.append(group)
     return tuple(groups)
-
-
-def _serial_console(config: InstallConfig) -> tuple[str, int] | None:
-    """The serial port and speed the kernel command line asks for, if any."""
-    for parameter in config.bootloader.kernel_params:
-        if not parameter.startswith("console=ttyS"):
-            continue
-        value = parameter.split("=", 1)[1]
-        port, _, rest = value.partition(",")
-        digits = "".join(character for character in rest if character.isdigit())
-        return port, int(digits) if digits else 115200
-    return None
 
 
 def key_accounts(system: SystemConfig, unlocking: bool = False) -> tuple[tuple[str, str], ...]:

--- a/tests/unit/test_plan_system.py
+++ b/tests/unit/test_plan_system.py
@@ -26,7 +26,7 @@ from gentoo_install.model.device import (
     Partition,
     PartitionRole,
 )
-from gentoo_install.plan import system
+from gentoo_install.plan import bootloader, system
 from gentoo_install.plan.portage import Emerge
 
 from .layouts import config, ext4_on_gpt, i
@@ -247,6 +247,27 @@ def test_openrc_gets_a_serial_login_when_the_cmdline_asks_for_one() -> None:
     assert PurePosixPath("/etc/inittab") not in apply_all(
         local, generated=generated(local)
     ).files
+
+
+def test_serial_frame_format_does_not_change_the_getty_baud() -> None:
+    from gentoo_install.model.config import BootloaderConfig
+
+    remote = replace(
+        with_system(init=InitSystem.OPENRC),
+        bootloader=BootloaderConfig(kernel_params=("console=ttyS0,115200n8",)),
+    )
+    getty = next(
+        operation
+        for operation in system.build(remote)
+        if isinstance(operation, system.EnableSerialGetty)
+    )
+    grub = next(
+        operation
+        for operation in bootloader.build(remote)
+        if isinstance(operation, bootloader.WriteGrubDefaults)
+    )
+    assert grub.serial is not None
+    assert getty.baud == grub.serial[1] == 115200
 
 
 def test_systemd_needs_no_inittab_entry_for_the_serial_console() -> None:


### PR DESCRIPTION
#155 made `serial_console` one derivation and added the test that pins it: `console=ttyS0,115200n8` must give the OpenRC getty and GRUB the same 115200. #159 was written in a worktree branched before that landed, carried its own copy of `gentoo_install/plan/system.py`, and restored both the duplicate function and its `isdigit()` form. The test went with it, so the suite stayed green while the OpenRC serial getty went back to 1152008 baud.

Two agents had the same file in their write scope. That is the planning error, not theirs.