### PR TITLE
portage: strip the version an exclude option refuses

### DIFF
--- a/gentoo_install/cli.py
+++ b/gentoo_install/cli.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 
 import argparse
 import curses
+import locale
 import os
 import shutil
 import sys
@@ -340,6 +341,16 @@ def _unattended(arguments: argparse.Namespace) -> bool:
     return bool(arguments.no_shell) or not sys.stdin.isatty()
 
 
+def _draws_wide_characters() -> bool:
+    """Whether this terminal's encoding can carry a CJK glyph.
+
+    `LC_CTYPE`, not `LANG`: the codeset is what ncurses reads, and an operator
+    who exported `LC_ALL=C` over a Chinese `LANG` has a terminal that cannot
+    draw one whatever the environment says it prefers.
+    """
+    return locale.nl_langinfo(locale.CODESET).upper().replace("-", "") == "UTF8"
+
+
 def _asked(question: str) -> bool:
     """Ask, after throwing away what was typed before the question existed.
 
@@ -629,6 +640,15 @@ def _from_menu(arguments: argparse.Namespace) -> InstallConfig | None:
         cramped = too_small(display)
         if cramped:
             raise errors.PreflightFailed(cramped)
+        # A terminal whose encoding is not UTF-8 draws a wide character as its
+        # bytes, and ncurses advances one cell for each: the widths this code
+        # computes stay right and the text lands somewhere else, so a footer of
+        # three CJK segments overwrites itself. English is offered instead of a
+        # menu made of wreckage.
+        if not _draws_wide_characters():
+            context.translate = Catalog("en")
+            context.tag = "en"
+            return app.run(display, screens.with_language(start, "en"), context)
         # Asked before the menu: the environment says which language the
         # operator reads, not whether this terminal can draw it.
         if not arguments.lang:
@@ -642,6 +662,11 @@ def _from_menu(arguments: argparse.Namespace) -> InstallConfig | None:
         offered = screens.saved_config_screen(display, chosen, context)
         return app.run(display, offered.unwrap() if offered.chosen else chosen, context)
 
+    # Before `initscr`, which `wrapper` calls. Python sets `LC_CTYPE` from the
+    # environment at startup and ncursesw reads that, so this changes nothing
+    # on a machine whose environment names a UTF-8 locale; it is here because
+    # nothing else guarantees the rest of the categories agree with it.
+    locale.setlocale(locale.LC_ALL, "")
     try:
         finished = curses.wrapper(walk)
     except curses.error as error:

--- a/gentoo_install/plan/portage.py
+++ b/gentoo_install/plan/portage.py
@@ -7,6 +7,7 @@ before a key can be imported, an imported key stays untrusted until `lsign`, and
 
 from __future__ import annotations
 
+import re
 from dataclasses import dataclass
 from pathlib import PurePosixPath
 from typing import Final, Sequence
@@ -292,6 +293,23 @@ SYNC_PAUSE: Final[float] = 30.0
 RSYNC_TIMEOUT: Final[int] = 900
 
 
+def _unversioned(atom: str) -> str:
+    """The package name inside an atom, for an option that takes no version.
+
+    `--usepkg-exclude` accepts package names and slot atoms only, and a pinned
+    kernel reaches it as `=sys-kernel/gentoo-cjk-kernel-bin-7.1.7`: emerge then
+    answers `Invalid Atom(s)` and the install stops with the disks written.
+    """
+    name = atom.lstrip("=<>~!")
+    category, _, rest = name.partition("/")
+    if not rest:
+        return name
+    # `-7.1.7` and `-7.1.7-r2` alike: the version starts at the last hyphen
+    # followed by a digit, which is what `package-1.2-r3` gives portage too.
+    trimmed = re.sub(r"-\d[^-]*(-r\d+)?$", "", rest)
+    return f"{category}/{trimmed}"
+
+
 @dataclass(frozen=True, kw_only=True)
 class SyncRepository(Operation):
     """A directory holding a copy that git did not create makes `emerge --sync`
@@ -413,7 +431,10 @@ class Emerge(Operation):
             # whole dependency tree here too: `sys-apps/systemd` pulled in
             # gtk+, cups and 21 more, and died on a circular dependency.
             # `--usepkg-exclude` also blocks the remote copy under `-g`.
-            argv += [*BINPKG_OPTIONS[:-1], f"{BINPKG_EXCLUDED} {' '.join(built)}"]
+            argv += [
+                *BINPKG_OPTIONS[:-1],
+                f"{BINPKG_EXCLUDED} {' '.join(_unversioned(one) for one in built)}",
+            ]
         else:
             argv += BINPKG_OPTIONS
         context.run_in_target([*argv, "--", *self.packages])

--- a/tests/unit/test_plan_portage.py
+++ b/tests/unit/test_plan_portage.py
@@ -658,3 +658,38 @@ def test_the_first_snapshot_is_verified_against_a_reachable_keyserver() -> None:
     assert plan_portage.KEY_SERVER.startswith("hkps://"), plan_portage.KEY_SERVER
     # Not the default: naming the same one it already uses fixes nothing.
     assert "keys.gentoo.org" not in plan_portage.KEY_SERVER
+
+
+def test_a_pinned_package_reaches_usepkg_exclude_without_its_version() -> None:
+    """`--usepkg-exclude` takes package names and slot atoms only. A pinned
+    kernel reached it as `=sys-kernel/gentoo-cjk-kernel-bin-7.1.7` and emerge
+    answered `Invalid Atom(s) in --usepkg-exclude parameter`, which stopped an
+    install with the disks already written. Measured against the real emerge:
+    `cat/pkg` and `cat/pkg:0` are accepted and anything carrying a version is
+    not."""
+    from gentoo_install.plan.portage import Emerge, _unversioned
+
+    assert _unversioned("=sys-kernel/gentoo-cjk-kernel-bin-7.1.7") == (
+        "sys-kernel/gentoo-cjk-kernel-bin"
+    )
+    assert _unversioned("=sys-kernel/gentoo-kernel-bin-6.18.43-r2") == (
+        "sys-kernel/gentoo-kernel-bin"
+    )
+    # Already a plain name, and one with a digit in it that is not a version.
+    assert _unversioned("sys-fs/zfs") == "sys-fs/zfs"
+    assert _unversioned("app-i18n/fcitx5") == "app-i18n/fcitx5"
+
+    recorder = Recorder()
+    Emerge(
+        summary="install the kernel",
+        packages=("=sys-kernel/gentoo-cjk-kernel-bin-7.1.7",),
+        source_only=("=sys-kernel/gentoo-cjk-kernel-bin-7.1.7",),
+        binary_packages=True,
+    ).apply(recorder)
+    excluded = next(
+        one[one.index("--usepkg-exclude") + 1]
+        for one in recorder.in_target
+        if "--usepkg-exclude" in one
+    )
+    assert "7.1.7" not in excluded, excluded
+    assert "sys-kernel/gentoo-cjk-kernel-bin" in excluded

--- a/tests/unit/test_tui_curses.py
+++ b/tests/unit/test_tui_curses.py
@@ -372,3 +372,46 @@ def test_a_window_that_grows_is_read_again_rather_than_kept() -> None:
     assert result.get("error") is None, result.get("error")
     assert result["before"] == list(SIZE), result
     assert result["after"] == list(grown), result
+
+
+#: What a terminal does with a wide glyph, asked of ncurses rather than of the
+#: width table: the two must agree or the text after it lands in the wrong cell.
+WIDE = r"""
+import curses
+import locale
+
+from gentoo_install.i18n import width
+
+answer["codeset"] = locale.nl_langinfo(locale.CODESET)
+
+
+def walk(window):
+    window.addstr(0, 0, "繼續")
+    window.addstr(0, width("繼續"), "|end")
+    window.refresh()
+    answer["row"] = window.instr(0, 0, 12).decode("utf-8", "replace").rstrip()
+
+
+curses.wrapper(walk)
+"""
+
+
+def test_a_terminal_that_cannot_draw_a_wide_glyph_is_recognised() -> None:
+    """ncurses reads `LC_CTYPE`. Where the codeset is not UTF-8 it writes a
+    wide character as its bytes and advances one cell for each, so the widths
+    this code computes stay right and the text after them lands elsewhere: the
+    installer's footer is three segments joined by two spaces, and the second
+    landed on top of the first. The menu offers English there rather than a
+    screen made of wreckage."""
+    from gentoo_install.cli import _draws_wide_characters
+
+    result = drive("", WIDE)
+    assert result.get("error") is None, result.get("error")
+    utf8 = result["codeset"].upper().replace("-", "") == "UTF8"
+    assert _draws_wide_characters() == utf8
+    if utf8:
+        assert result["row"] == "繼續|end", result["row"]
+    else:
+        # Two cells of nothing where the glyph belongs, which is the state the
+        # check exists to refuse.
+        assert "繼" not in result["row"], result["row"]


### PR DESCRIPTION
A manual install stopped at:

```
emerge: error: Invalid Atom(s) in --usepkg-exclude parameter:
'=sys-kernel/gentoo-cjk-kernel-bin-7.1.7' (only package names and slot atoms allowed)
```

Pinning a kernel version puts the full atom in `packages` and in `source_only`, and the second list is what reaches `--usepkg-exclude`. Measured against the real emerge on this machine: `sys-apps/portage` and `sys-apps/portage:0` are accepted, `sys-apps/portage-3.0.69` is refused. The version is stripped for that option and kept everywhere else.

The same branch carries the menu's locale check: ncurses reads `LC_CTYPE` and writes a wide character as its bytes where the codeset is not UTF-8, so a footer of three CJK segments overwrote itself. `setlocale(LC_ALL, "")` before `initscr` is there, and measured not to be enough on its own — Python already sets `LC_CTYPE` at startup, and where the environment says `C` the empty string means `C`. The menu opens in English instead.