### PR TITLE
tui: move between rows and fields with tab

### DIFF
--- a/gentoo_install/tui/widgets.py
+++ b/gentoo_install/tui/widgets.py
@@ -111,6 +111,24 @@ class Item(Generic[V]):
     style: Style = Style.PLAIN
 
 
+#: Tab moves on and shift-tab moves back, alongside the arrows. An operator
+#: coming from a browser or an installer with a graphical toolkit reaches for
+#: it first, and nothing in these screens uses tab for anything else.
+#: `KEY_BTAB` is what ncurses calls shift-tab once keypad mode is on; the raw
+#: sequence is what arrives before that.
+TAB: Final[str] = "\t"
+SHIFT_TAB: Final[tuple[str, ...]] = ("KEY_BTAB", "\x1b[Z")
+
+#: `j` and `k` as well: a serial console over ssh may swallow an arrow, and
+#: these are what an operator who reads vi bindings tries.
+FORWARD: Final[tuple[str, ...]] = ("KEY_DOWN", "j", TAB)
+BACKWARD: Final[tuple[str, ...]] = ("KEY_UP", "k", *SHIFT_TAB)
+
+#: No `j` or `k` in a form: those are characters somebody is typing.
+FORWARD_FIELD: Final[tuple[str, ...]] = ("KEY_DOWN", TAB)
+BACKWARD_FIELD: Final[tuple[str, ...]] = ("KEY_UP", *SHIFT_TAB)
+
+
 @dataclass
 class Menu(Generic[V]):
     title: str
@@ -145,9 +163,9 @@ class Menu(Generic[V]):
             self.cursor = cursor
             self._draw(screen, cursor)
             pressed = screen.key()
-            if pressed in ("KEY_UP", "k"):
+            if pressed in BACKWARD:
                 cursor = self._step(cursor, -1)
-            elif pressed in ("KEY_DOWN", "j"):
+            elif pressed in FORWARD:
                 cursor = self._step(cursor, 1)
             elif pressed == " " and self.multiple:
                 self._toggle(cursor)
@@ -398,9 +416,9 @@ class Form:
         while True:
             self._draw(screen, typed, cursor)
             pressed = screen.key()
-            if pressed in ("KEY_UP",):
+            if pressed in BACKWARD_FIELD:
                 cursor = max(0, cursor - 1)
-            elif pressed in ("KEY_DOWN",):
+            elif pressed in FORWARD_FIELD:
                 cursor = min(len(self.fields), cursor + 1)
             elif pressed in ("\n", "KEY_ENTER"):
                 if cursor == len(self.fields):

--- a/tests/unit/test_harness.py
+++ b/tests/unit/test_harness.py
@@ -626,7 +626,7 @@ def test_preinstall_console_timeout_is_an_error_with_its_phase(
         def run(self, command: str, timeout: float = 120.0) -> None:
             return None
 
-        def wait_for(self, command: str, timeout: float) -> None:
+        def wait_for(self, command: str, timeout: float, idle: float = 0.0) -> None:
             return None
 
     class Links:

--- a/tests/unit/test_tui_widgets.py
+++ b/tests/unit/test_tui_widgets.py
@@ -285,3 +285,36 @@ def test_the_cursor_still_skips_a_disabled_row_nobody_chose() -> None:
         multiple=True,
     )
     assert menu._step(0, 1) == 2
+
+
+def test_tab_moves_on_and_shift_tab_moves_back() -> None:
+    """An operator coming from a browser or a graphical installer reaches for
+    tab first, and nothing in these screens used it for anything. The arrows
+    keep working; this is another way to the same row."""
+    from gentoo_install.tui.widgets import Field, Form, Item, Menu
+
+    # Three rows, tab twice to the third, shift-tab once back to the second.
+    menu: Menu[int] = Menu(
+        title="pick",
+        items=[Item(label="one", value=1), Item(label="two", value=2), Item(label="three", value=3)],
+    )
+    answer = menu.run(FakeScreen(keys=["\t", "\t", "KEY_BTAB", "\n"], lines=24))
+    assert answer.unwrap()[0] == 2
+
+    # The raw sequence too: ncurses reports `KEY_BTAB` only once keypad mode is
+    # on, and what arrives before that is the escape sequence itself.
+    raw: Menu[int] = Menu(
+        title="pick",
+        items=[Item(label="one", value=1), Item(label="two", value=2)],
+    )
+    assert raw.run(FakeScreen(keys=["\t", "\x1b[Z", "\n"], lines=24)).unwrap()[0] == 1
+
+    # A form moves between fields the same way, and tab is not typed into one.
+    form = Form(
+        title="account",
+        fields=[Field(label="name"), Field(label="shell")],
+    )
+    typed = form.run(
+        FakeScreen(keys=[*"zakk", "\t", *"bash", "KEY_BTAB", "\t", "\n", "\n"], lines=24)
+    )
+    assert typed.unwrap() == ["zakk", "bash"]


### PR DESCRIPTION
Tab moves on, shift-tab moves back, in menus and in forms alike; the arrows are unchanged and `j`/`k` stay in menus only, because in a form they are characters somebody is typing. `KEY_BTAB` is what ncurses reports once keypad mode is on and the raw `ESC[Z` is what arrives before that, so both are bound.

The branch also repairs a double left by #165: one fake console's `wait_for` did not take the new `idle` argument, so `test_preinstall_console_timeout_is_an_error_with_its_phase` failed on master.