### PR TITLE
vm: press the bios menu before it boots itself

### DIFF
--- a/tests/unit/test_proxmox.py
+++ b/tests/unit/test_proxmox.py
@@ -1898,3 +1898,17 @@ def test_an_error_carried_in_a_two_hundred_is_not_thrown_away() -> None:
     # A config change applied then and there says nothing, and that is success.
     api._opener = answering({"data": None})
     assert api.call("PUT", "/nodes/n/qemu/9300/config", description="x") is None
+
+
+def test_the_blind_edit_presses_before_the_menu_boots_itself() -> None:
+    """The medium's `grub.cfg` sets `timeout=10` and the delay before the first
+    key was twelve seconds, so the entry had already booted: every key went to
+    a kernel that was never told to use the serial port, and `vm-bios`,
+    `vm-bios-luks` and `ext4-bios` ended every round at `the kernel never spoke
+    after editing GRUB blind`."""
+    from tests.vm.proxmox import BIOS_MENU_DELAY, BIOS_MENU_TIMEOUT
+
+    assert BIOS_MENU_DELAY < BIOS_MENU_TIMEOUT, (BIOS_MENU_DELAY, BIOS_MENU_TIMEOUT)
+    # Not so early that the firmware has not reached GRUB either: SeaBIOS and
+    # the medium's own search take a few seconds before the menu is drawn.
+    assert BIOS_MENU_DELAY >= 4.0

--- a/tests/vm/proxmox.py
+++ b/tests/vm/proxmox.py
@@ -789,8 +789,15 @@ _PLACED: Final[re.Pattern[bytes]] = re.compile(rb"\x1b\[(\d+);\d+H([^\x1b]*)")
 #: How long a SeaBIOS guest takes from reset to a GRUB menu waiting for a key.
 #: Nothing announces it: the firmware and GRUB both draw on the VGA this guest
 #: has, and the serial port stays silent until the kernel is told to use it.
-#: The medium's menu waits ten seconds, so this has to land inside that.
-BIOS_MENU_DELAY: Final[float] = 12.0
+#: The medium's menu waits ten seconds, so this has to land inside that. It was
+#: twelve, which lands after it: the entry had booted and every key went to a
+#: kernel that was never told to speak, so three fixtures ended every round at
+#: `the kernel never spoke after editing GRUB blind`.
+BIOS_MENU_DELAY: Final[float] = 6.0
+
+#: What the medium's menu waits, and what `BIOS_MENU_DELAY` has to stay under.
+#: Read from the ISO's own `grub.cfg`, which sets `timeout=10`.
+BIOS_MENU_TIMEOUT: Final[float] = 10.0
 
 #: Which line below `setparams` the keys move to, tried in this order. The
 #: Gentoo minimal ISO puts `search` between `setparams` and `linux`, so two is


### PR DESCRIPTION
`vm-bios`, `vm-bios-luks` and `ext4-bios` ended every round at `the kernel never spoke after editing GRUB blind`. Their serial logs hold two lines and nothing else, four times over — and those two lines are PVE's `termproxy` banner, printed once per console open, not anything the guest sent.

The medium's `grub.cfg` sets `timeout=10`. `BIOS_MENU_DELAY` was twelve seconds, and its own comment said it had to land inside that. By the time the first `e` was sent the entry had booted, so every key went to a kernel that was never told to use the serial port — which is exactly what the failure says.