### PR TITLE
portage: refresh the release key from a server that serves its user IDs

### DIFF
--- a/gentoo_install/plan/portage.py
+++ b/gentoo_install/plan/portage.py
@@ -249,12 +249,16 @@ class ConfigureRepository(Operation):
         )
 
 
-#: Where gemato refreshes the release key from before it checks the snapshot
-#: signature. Not the default `keys.gentoo.org`: a guest on the Proxmox
-#: cluster resolved it to 85.143.112.91 and then reached nothing there, while
-#: `keys.openpgp.org` answered 200 and serves the same key by fingerprint.
-#: The key and the signature are unchanged; only the refresh moves.
-KEY_SERVER: Final[str] = "hkps://keys.openpgp.org"
+#: Where gemato refreshes the release key from, tried in this order. Gentoo's
+#: own server is first because it is what Portage ships; a guest that cannot
+#: reach it falls through rather than stopping at `No keyserver available`.
+#: `keys.openpgp.org` is not here: it serves a key stripped of its user IDs
+#: unless the address behind them was confirmed, gemato reads that as a failed
+#: refresh, and the snapshot is then refused as unsigned.
+KEY_SERVERS: Final[tuple[str, ...]] = (
+    "hkps://keys.gentoo.org",
+    "hkps://keyserver.ubuntu.com",
+)
 
 
 @dataclass(frozen=True, kw_only=True)
@@ -269,15 +273,20 @@ class WebrsyncRepository(Operation):
 
     def apply(self, context: Context) -> None:
         # `emerge-webrsync` verifies the snapshot with gemato, which refreshes
-        # the release key before checking the signature. Its default keyserver
-        # is unreachable on some networks: a cluster guest resolved
-        # `keys.gentoo.org` to 85.143.112.91 and then got nothing from it,
-        # so every install stopped at `No keyserver available`. Pointing the
-        # refresh at a keyserver that answers changes where the same key comes
-        # from and verifies exactly as before.
-        context.run_in_target(
-            ["env", f"PORTAGE_GPG_KEY_SERVER={KEY_SERVER}", "emerge-webrsync"]
-        )
+        # the release key first, and a refresh that fails fails the sync. One
+        # keyserver is one way for the whole install to stop, so each is tried
+        # and only the last one's failure is raised.
+        last: CommandFailed | None = None
+        for server in KEY_SERVERS:
+            try:
+                context.run_in_target(
+                    ["env", f"PORTAGE_GPG_KEY_SERVER={server}", "emerge-webrsync"]
+                )
+                return
+            except CommandFailed as failed:
+                last = failed
+        assert last is not None
+        raise last
 
 
 #: How many times a repository sync is attempted, and how long between them.

--- a/tests/unit/test_plan_portage.py
+++ b/tests/unit/test_plan_portage.py
@@ -4,7 +4,7 @@ import pytest
 
 from dataclasses import replace
 from pathlib import PurePosixPath
-from typing import Any
+from typing import Any, Sequence
 
 from gentoo_install.model.config import (
     Binhost,
@@ -636,28 +636,44 @@ def test_the_stage3_matches_the_profile_and_not_only_the_init_system() -> None:
         assert variant_of(installation) == variant, profile
 
 
-def test_the_first_snapshot_is_verified_against_a_reachable_keyserver() -> None:
+def test_the_first_snapshot_falls_through_to_a_keyserver_that_answers() -> None:
     """`emerge-webrsync` verifies the snapshot with gemato, which refreshes the
-    release key first. Its default keyserver answers nothing on some networks:
-    a cluster guest resolved `keys.gentoo.org` to 85.143.112.91 and then got
-    no connection at all, so every install stopped at `gpg: keyserver refresh
-    failed: No keyserver available` before a single package was merged.
+    release key first, so one keyserver is one way for the whole install to
+    stop. Two networks broke it in opposite directions: a cluster guest
+    resolved `keys.gentoo.org` to 85.143.112.91 and reached nothing, and
+    `keys.openpgp.org`, put there to answer that, serves the key with its user
+    IDs stripped, which gemato reports as a failed refresh and which then
+    refuses the snapshot as unsigned.
 
     The key and the signature are unchanged; only where the refresh reads the
     key from moves, so this is not a weakening of the check.
     """
+    from gentoo_install.errors import CommandFailed
     from gentoo_install.plan import portage as plan_portage
 
     from .recorder import Recorder
 
-    recorder = Recorder()
+    servers = plan_portage.KEY_SERVERS
+    assert servers[0] == "hkps://keys.gentoo.org", servers
+    assert all(one.startswith("hkps://") for one in servers), servers
+    # It answers, and it answers with a key gemato refuses.
+    assert not any("keys.openpgp.org" in one for one in servers), servers
+
+    class Refusing(Recorder):
+        """A keyserver that answers nothing, the way the first one did."""
+
+        refuse: str = servers[0]
+
+        def run_in_target(self, argv: Sequence[str], *, check: bool = True) -> str:
+            if any(self.refuse in one for one in argv):
+                raise CommandFailed(f"{self.refuse} exited 1")
+            return super().run_in_target(argv, check=check)
+
+    recorder = Refusing()
     plan_portage.WebrsyncRepository().apply(recorder)
     ran = recorder.in_target[-1]
     assert ran[-1] == "emerge-webrsync", ran
-    assert f"PORTAGE_GPG_KEY_SERVER={plan_portage.KEY_SERVER}" in ran, ran
-    assert plan_portage.KEY_SERVER.startswith("hkps://"), plan_portage.KEY_SERVER
-    # Not the default: naming the same one it already uses fixes nothing.
-    assert "keys.gentoo.org" not in plan_portage.KEY_SERVER
+    assert f"PORTAGE_GPG_KEY_SERVER={servers[1]}" in ran, ran
 
 
 def test_a_pinned_package_reaches_usepkg_exclude_without_its_version() -> None:


### PR DESCRIPTION
`vm-zfs`, `vm-raidz` and `vm-lvm` all stopped at `emerge-webrsync: signature verification failed`, with `gpg: key BB572E0E2D182910: no user ID` above it. The keyserver was pinned to `keys.openpgp.org`, which serves a key stripped of user IDs whose addresses it has not confirmed; gemato reports that as a failed refresh and then refuses the snapshot.

Measured against `0xBB572E0E2D182910`: `keys.gentoo.org` answers 32206 bytes and `keyserver.ubuntu.com` 33268, both complete, while `keys.openpgp.org` answers 10522 with no user ID.

The pin existed because a cluster guest could not reach `keys.gentoo.org` at all. `KEY_SERVERS` is now tried in order, so an unreachable one falls through instead of stopping the install.