### PR TITLE
plan: draw a CJK desktop in Noto Sans, not the font a dependency brought

### DIFF
--- a/gentoo_install/plan/build.py
+++ b/gentoo_install/plan/build.py
@@ -12,7 +12,7 @@ from typing import Final
 from ..model import mirrors
 from ..model.config import InstallConfig
 from ..model.validate import validate
-from . import bootloader, disk, kernel, packages, portage, system
+from . import bootloader, disk, fonts, kernel, packages, portage, system
 from .operations import Operation
 
 #: The mirror a stage3 is fetched from when the configuration names none.
@@ -67,6 +67,7 @@ def build(config: InstallConfig, catalog: packages.Catalog, *, mirror: str = DEF
         *kernel.build(config),
         *bootloader.build(config),
         *packages.build(config, catalog),
+        *fonts.build(config, catalog),
         *portage.finish(config),
         # Last of all: the keyword change above still has to reach make.conf in
         # the target, and nothing can be written once it is unmounted.

--- a/gentoo_install/plan/fonts.py
+++ b/gentoo_install/plan/fonts.py
@@ -1,0 +1,111 @@
+"""Font selection configured for the package groups that provide the faces."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from enum import Enum
+from pathlib import PurePosixPath
+from typing import Final
+
+from ..model.config import InstallConfig
+from . import packages
+from .operations import Context, Operation, Stage
+
+
+class CjkFontconfigLocale(Enum):
+    ZH_CN = ("zh_CN", "zh-cn", "Noto Sans CJK SC")
+    ZH_TW = ("zh_TW", "zh-tw", "Noto Sans CJK TC")
+    ZH_HK = ("zh_HK", "zh-hk", "Noto Sans CJK HK")
+    JA_JP = ("ja_JP", "ja", "Noto Sans CJK JP")
+    KO_KR = ("ko_KR", "ko", "Noto Sans CJK KR")
+
+    def __init__(self, locale: str, language: str, face: str) -> None:
+        self.locale = locale
+        self.language = language
+        self.face = face
+
+    @classmethod
+    def selected(cls, locale: str) -> CjkFontconfigLocale | None:
+        locale_name = locale.partition(".")[0]
+        return next((candidate for candidate in cls if candidate.locale == locale_name), None)
+
+
+NOTO_CJK_GROUP: Final[str] = "noto-cjk"
+NOTO_CJK_AVAILABLE: Final[PurePosixPath] = PurePosixPath(
+    "/etc/fonts/conf.avail/70-noto-cjk.conf"
+)
+NOTO_CJK_ENABLED: Final[PurePosixPath] = PurePosixPath(
+    "/etc/fonts/conf.d/70-noto-cjk.conf"
+)
+CJK_SANS_PREFERENCE: Final[PurePosixPath] = PurePosixPath(
+    "/etc/fonts/conf.d/71-gentoo-install-cjk-sans.conf"
+)
+
+#: Every CJK sans face, so the one the operator's locale asks for leads and the
+#: others still answer text in the languages they cover.
+CJK_SANS_ORDER: Final[tuple[str, ...]] = (
+    "Noto Sans CJK TC",
+    "Noto Sans CJK SC",
+    "Noto Sans CJK HK",
+    "Noto Sans CJK JP",
+    "Noto Sans CJK KR",
+)
+
+
+@dataclass(frozen=True, kw_only=True)
+class EnableNotoCjkFontconfig(Operation):
+    stage: Stage = Stage.PACKAGES
+
+    def describe(self) -> str:
+        return f"enable {NOTO_CJK_ENABLED}"
+
+    def apply(self, context: Context) -> None:
+        context.run_in_target(
+            ["eselect", "fontconfig", "enable", NOTO_CJK_AVAILABLE.name]
+        )
+
+
+@dataclass(frozen=True, kw_only=True)
+class WriteCjkSansPreference(Operation):
+    stage: Stage = Stage.PACKAGES
+    locale: CjkFontconfigLocale
+
+    def describe(self) -> str:
+        return f"write {CJK_SANS_PREFERENCE}"
+
+    def apply(self, context: Context) -> None:
+        context.write(CJK_SANS_PREFERENCE, self.content())
+
+    def content(self) -> str:
+        """The chosen regional face ahead of every other CJK family.
+
+        A `lang` test does not separate the CJK languages: measured on a real
+        machine, a rule tested on `zh-tw` also fired for `ja` and `ko`, so the
+        alias names the order instead and the file is written only for a system
+        whose own locale is Chinese.
+        """
+        others = tuple(one for one in CJK_SANS_ORDER if one != self.locale.face)
+        families = "".join(
+            f"      <family>{one}</family>\n" for one in (self.locale.face, *others)
+        )
+        return (
+            '<?xml version="1.0"?>\n'
+            '<!DOCTYPE fontconfig SYSTEM "urn:fontconfig:fonts.dtd">\n'
+            "<fontconfig>\n"
+            '  <alias binding="same">\n'
+            "    <family>sans-serif</family>\n"
+            "    <prefer>\n"
+            f"{families}"
+            "    </prefer>\n"
+            "  </alias>\n"
+            "</fontconfig>\n"
+        )
+
+
+def build(config: InstallConfig, catalog: packages.Catalog) -> tuple[Operation, ...]:
+    locale = CjkFontconfigLocale.selected(config.system.locale)
+    if locale is None:
+        return ()
+    if not any(group.name == NOTO_CJK_GROUP for group in packages.groups(config, catalog)):
+        return ()
+    return (EnableNotoCjkFontconfig(), WriteCjkSansPreference(locale=locale))

--- a/tests/unit/test_plan_fonts.py
+++ b/tests/unit/test_plan_fonts.py
@@ -1,0 +1,108 @@
+from __future__ import annotations
+
+from dataclasses import replace
+from typing import Final
+from xml.etree import ElementTree
+
+import pytest
+
+from gentoo_install.data import load_catalog
+from gentoo_install.model.config import InstallConfig, PackagesConfig
+from gentoo_install.plan.build import build as build_plan
+from gentoo_install.plan.fonts import (
+    CJK_SANS_ORDER,
+    CJK_SANS_PREFERENCE,
+    CjkFontconfigLocale,
+    EnableNotoCjkFontconfig,
+    WriteCjkSansPreference,
+)
+
+from .layouts import config
+from .recorder import Recorder
+
+
+CJK_RULES: Final[tuple[tuple[str, str, str], ...]] = (
+    ("zh_TW.UTF-8", "zh-tw", "Noto Sans CJK TC"),
+    ("zh_CN.UTF-8", "zh-cn", "Noto Sans CJK SC"),
+    ("zh_HK.UTF-8", "zh-hk", "Noto Sans CJK HK"),
+    ("ja_JP.UTF-8", "ja", "Noto Sans CJK JP"),
+    ("ko_KR.UTF-8", "ko", "Noto Sans CJK KR"),
+)
+
+
+def zh_tw_desktop() -> InstallConfig:
+    installation = config()
+    return replace(
+        installation,
+        system=replace(installation.system, locale="zh_TW.UTF-8"),
+        packages=PackagesConfig(desktop="plasma", applications=("noto-cjk",)),
+    )
+
+
+def test_a_zh_tw_desktop_writes_the_regional_sans_rule() -> None:
+    operations = [
+        one
+        for one in build_plan(zh_tw_desktop(), load_catalog())
+        if isinstance(one, (EnableNotoCjkFontconfig, WriteCjkSansPreference))
+    ]
+    recorder = Recorder()
+    for operation in operations:
+        operation.apply(recorder)
+
+    assert [operation.describe() for operation in operations] == [
+        "enable /etc/fonts/conf.d/70-noto-cjk.conf",
+        "write /etc/fonts/conf.d/71-gentoo-install-cjk-sans.conf",
+    ]
+    assert recorder.only("eselect", "fontconfig") == (
+        "eselect",
+        "fontconfig",
+        "enable",
+        "70-noto-cjk.conf",
+    )
+    assert "<family>Noto Sans CJK TC</family>" in recorder.files[CJK_SANS_PREFERENCE]
+    # The face the operator's locale asks for leads the alias.
+    written = recorder.files[CJK_SANS_PREFERENCE]
+    assert written.index("Noto Sans CJK TC") < written.index("Noto Sans CJK SC"), written
+
+
+def test_a_plan_without_the_font_group_enables_no_fontconfig_file() -> None:
+    assert not [
+        one
+        for one in build_plan(config(), load_catalog())
+        if isinstance(one, (EnableNotoCjkFontconfig, WriteCjkSansPreference))
+    ]
+
+
+@pytest.mark.parametrize("locale", ["en_US.UTF-8", "de_DE.UTF-8", "fr_FR.UTF-8"])
+def test_a_locale_outside_cjk_is_not_changed(locale: str) -> None:
+    installation = config()
+    selected = replace(
+        installation,
+        system=replace(installation.system, locale=locale),
+        packages=PackagesConfig(applications=("noto-cjk",)),
+    )
+    assert not [
+        one
+        for one in build_plan(selected, load_catalog())
+        if isinstance(one, (EnableNotoCjkFontconfig, WriteCjkSansPreference))
+    ]
+
+
+@pytest.mark.parametrize(("locale", "language", "face"), CJK_RULES)
+def test_the_written_file_is_a_regional_sans_match(
+    locale: str, language: str, face: str
+) -> None:
+    selected = CjkFontconfigLocale.selected(locale)
+    assert selected is not None
+    content = WriteCjkSansPreference(locale=selected).content()
+    root = ElementTree.fromstring(content)
+    assert root.tag == "fontconfig"
+    aliases = root.findall("alias")
+    assert len(aliases) == 1, content
+    assert aliases[0].findtext("family") == "sans-serif"
+    preferred = [one.text for one in aliases[0].findall("./prefer/family")]
+    # The locale's own face leads; the rest still answer the languages they
+    # cover, and a `lang` test cannot separate them.
+    assert preferred[0] == face, preferred
+    assert set(preferred) == set(CJK_SANS_ORDER), preferred
+    assert language


### PR DESCRIPTION
Read off a machine this installer produced: `fc-match "sans-serif:lang=zh-tw"` answered `AR PL KaitiM Big5` and `serif:lang=zh-tw` answered `AR PL ShanHeiSun Uni`, the Song face that was reported. `media-fonts/arphicfonts` is not in `world`; it arrives as a dependency of `app-text/ghostscript-gpl`, and fontconfig's `65-nonlatin.conf` ranks its families ahead of Noto for han. Korean answered the JP face.

Enabling Gentoo's `70-noto-cjk.conf` corrects Korean and leaves Chinese behind arphic, because its rules use `mode="prepend"`. `prepend_first` corrects Chinese and bleeds: measured on that machine, a rule tested on `zh-tw` also fires for `ja` and `ko`. So the alias names the order instead, and the file is written only when the system locale is itself CJK — an `en_US` system resolves exactly as before.

The cost, stated in `docs/design.md`: the other CJK languages on one machine follow the system language's faces.