### PR TITLE
tui: gather locale, input method and fonts into one Language section

### DIFF
--- a/gentoo_install/tui/screens.py
+++ b/gentoo_install/tui/screens.py
@@ -1792,6 +1792,107 @@ def _adds(
     return f" (+{' '.join(added)})" if added else ""
 
 
+FONT_PACKAGE_CATEGORY: Final[str] = "media-fonts/"
+
+
+def input_method_groups(groups: Groups) -> tuple[str, ...]:
+    """Framework and engine groups, classified by their catalog metadata."""
+    return tuple(sorted(name for name, group in groups.items() if group.input_framework))
+
+
+def cjk_font_groups(groups: Groups) -> tuple[str, ...]:
+    """Font groups from the catalog; the catalog currently carries CJK fonts."""
+    return tuple(
+        sorted(
+            name
+            for name, group in groups.items()
+            if any(package.startswith(FONT_PACKAGE_CATEGORY) for package in group.packages)
+        )
+    )
+
+
+def _language_package_screen(
+    screen: Screen,
+    config: InstallConfig,
+    context: Context,
+    title: str,
+    names: Sequence[str],
+) -> Answer[InstallConfig]:
+    """Edit one catalog-defined subset without disturbing other applications."""
+    translate = context.translate
+    selected_names = frozenset(names)
+    have = {overlay.name for overlay in config.portage.overlays}
+    items = [
+        Item(
+            label=name,
+            value=name,
+            detail=" ".join(context.groups[name].packages)
+            + _adds(
+                config,
+                context,
+                lambda packages, one: replace(
+                    packages, applications=(*packages.applications, one)
+                ),
+                name,
+            ),
+            disabled_because=_needs_an_overlay(
+                context.groups[name].repositories, have, translate
+            ),
+        )
+        for name in names
+    ]
+    chosen_already = set(config.packages.applications) & selected_names
+    while True:
+        answer = Menu(
+            title=translate(title),
+            items=items,
+            multiple=True,
+            selected={
+                index for index, item in enumerate(items) if item.value in chosen_already
+            },
+            footer=footer(translate),
+        ).run(screen)
+        if not answer.chosen:
+            return Answer(answer.outcome)
+        chosen = tuple(answer.unwrap())
+        kept = tuple(
+            name for name in config.packages.applications if name not in selected_names
+        )
+        edited = replace(
+            config,
+            packages=replace(config.packages, applications=(*kept, *chosen)),
+        )
+        clash = framework_conflict(edited, context.groups)
+        if not clash:
+            return settle(screen, context, config, edited)
+        chosen_already = set(chosen)
+        _say(screen, context, clash)
+
+
+def input_method_screen(
+    screen: Screen, config: InstallConfig, context: Context
+) -> Answer[InstallConfig]:
+    return _language_package_screen(
+        screen,
+        config,
+        context,
+        "Input method",
+        input_method_groups(context.groups),
+    )
+
+
+def cjk_fonts_screen(
+    screen: Screen, config: InstallConfig, context: Context
+) -> Answer[InstallConfig]:
+    return _language_package_screen(
+        screen,
+        config,
+        context,
+        "CJK fonts",
+        cjk_font_groups(context.groups),
+    )
+
+
 def packages_screen(
     screen: Screen, config: InstallConfig, context: Context
 ) -> Answer[InstallConfig]:
@@ -1802,6 +1903,8 @@ def packages_screen(
         set(desktop_profiles(context.groups))
         | {name for name, _ in GRAPHICS}
         | {name for name, _ in DISPLAY_MANAGERS}
+        | set(input_method_groups(context.groups))
+        | set(cjk_font_groups(context.groups))
     )
     names = sorted(name for name in context.groups if name not in elsewhere)
     have = {overlay.name for overlay in config.portage.overlays}
@@ -1835,7 +1938,11 @@ def packages_screen(
         if not answer.chosen:
             return Answer(answer.outcome)
         chosen = answer.unwrap()
-        edited = replace(config, packages=replace(config.packages, applications=tuple(chosen)))
+        kept = tuple(name for name in config.packages.applications if name in elsewhere)
+        edited = replace(
+            config,
+            packages=replace(config.packages, applications=(*kept, *chosen)),
+        )
         # Checked here rather than at the Install row: the conflict is between
         # two ticks on this screen and this is where either can be unticked.
         clash = framework_conflict(edited, context.groups)
@@ -1890,20 +1997,68 @@ def locale_screen(screen: Screen, config: InstallConfig, context: Context) -> An
     translate = context.translate
     menu: Menu[str] = Menu(
         title=translate("System language"),
-        items=[Item(label=f"{name}  {label}", value=name) for name, label in LOCALES],
+        items=[
+            Item(label=f"{name}  {translate(label)}", value=name) for name, label in LOCALES
+        ],
         footer=footer(translate),
         current=config.system.locale,
+        preamble=(translate("The installed system starts in this locale."),),
     )
     answer = menu.run(screen)
     if not answer.chosen:
         return Answer(answer.outcome)
     chosen = answer.unwrap()[0]
-    # Every offered locale is generated whichever one is selected: switching
-    # afterwards then needs no regeneration.
-    generated = tuple(name for name, _ in LOCALES)
+    generated = config.system.locales
+    if chosen not in generated:
+        generated = (*generated, chosen)
     return Answer(
         Outcome.CHOSE,
         replace(config, system=replace(config.system, locale=chosen, locales=generated)),
+    )
+
+
+def additional_locales_screen(
+    screen: Screen, config: InstallConfig, context: Context
+) -> Answer[InstallConfig]:
+    """Locales generated in addition to the one used for `LANG`."""
+    translate = context.translate
+    items = [
+        Item(label=f"{name}  {translate(label)}", value=name)
+        for name, label in LOCALES
+        if name != config.system.locale
+    ]
+    selected = {
+        index for index, item in enumerate(items) if item.value in config.system.locales
+    }
+    answer = Menu(
+        title=translate("Other locales"),
+        items=items,
+        multiple=True,
+        selected=selected,
+        footer=footer(translate),
+        preamble=(translate("The system language is always generated."),),
+    ).run(screen)
+    if not answer.chosen:
+        return Answer(answer.outcome)
+    chosen = answer.unwrap()
+    chosen_set = frozenset(chosen)
+    generated = tuple(
+        locale
+        for locale in config.system.locales
+        if locale == config.system.locale or locale in chosen_set
+    )
+    generated += tuple(locale for locale in chosen if locale not in generated)
+    if config.system.locale not in generated:
+        generated = (config.system.locale, *generated)
+    return Answer(
+        Outcome.CHOSE,
+        replace(
+            config,
+            system=replace(
+                config.system,
+                locales=generated,
+            ),
+        ),
     )
 
 

--- a/gentoo_install/tui/settings.py
+++ b/gentoo_install/tui/settings.py
@@ -110,7 +110,13 @@ def style_of(setting: Setting, config: InstallConfig, context: Context) -> Style
     return Style.PLAIN
 
 
-def nested(title: str, rows: tuple[Setting, ...]) -> Step:
+def nested(
+    title: str,
+    rows: tuple[Setting, ...],
+    preamble: Callable[[InstallConfig, Context], tuple[str, ...]] = (
+        lambda config, context: ()
+    ),
+) -> Step:
     """A row that opens a list of rows, drawn the same way the main menu is.
 
     Six decisions about one subject read as six unrelated rows in a menu of
@@ -141,6 +147,7 @@ def nested(title: str, rows: tuple[Setting, ...]) -> Step:
                 items=items,
                 footer=footer(context.translate),
                 cursor=cursor,
+                preamble=preamble(current, context),
             )
             answer = menu.run(screen)
             cursor = menu.cursor
@@ -559,7 +566,65 @@ def _display_manager(config: InstallConfig, context: Context) -> str:
 
 
 def _applications(config: InstallConfig, context: Context) -> str:
-    return ", ".join(config.packages.applications) or context.translate("none")
+    language_groups = frozenset(
+        (*screens.input_method_groups(context.groups), *screens.cjk_font_groups(context.groups))
+    )
+    applications = [
+        name for name in config.packages.applications if name not in language_groups
+    ]
+    return ", ".join(applications) or context.translate("none")
+
+
+def _other_locales(config: InstallConfig, context: Context) -> str:
+    return ", ".join(
+        locale for locale in config.system.locales if locale != config.system.locale
+    ) or context.translate("none")
+
+
+def _selected_groups(
+    config: InstallConfig, context: Context, offered: tuple[str, ...]
+) -> str:
+    selected = [name for name in config.packages.applications if name in offered]
+    return ", ".join(selected) or context.translate("none")
+
+
+def _input_method(config: InstallConfig, context: Context) -> str:
+    return _selected_groups(config, context, screens.input_method_groups(context.groups))
+
+
+def _cjk_fonts(config: InstallConfig, context: Context) -> str:
+    return _selected_groups(config, context, screens.cjk_font_groups(context.groups))
+
+
+def _desktop_language_preamble(
+    config: InstallConfig, context: Context
+) -> tuple[str, ...]:
+    """What the selected desktop lets the installer configure itself."""
+    packages = context.translate(
+        "The selected font and input method packages will be installed."
+    )
+    if not config.packages.desktop:
+        return (
+            packages,
+            context.translate(
+                "No desktop is selected; font and input method configuration will not "
+                "be applied."
+            ),
+        )
+    desktop = context.groups.get(config.packages.desktop)
+    if desktop is not None and desktop.input_method_launcher:
+        return (
+            packages,
+            context.translate(
+                "{desktop} configures the selected fonts and input method automatically."
+            ).format(desktop=config.packages.desktop),
+        )
+    return (
+        packages,
+        context.translate(
+            "{desktop} leaves font and input method configuration to its settings."
+        ).format(desktop=config.packages.desktop),
+    )
 
 
 def _root_login(config: InstallConfig, context: Context) -> str:
@@ -675,6 +740,20 @@ KERNEL: Final[tuple[Setting, ...]] = (
     Setting("version", "Version", _kernel_version, screens.kernel_version_screen),
 )
 
+
+LANGUAGE: Final[tuple[Setting, ...]] = (
+    Setting("locale", "System language", lambda c, x: c.system.locale, screens.locale_screen),
+    Setting("locales", "Other locales", _other_locales, screens.additional_locales_screen),
+    Setting(
+        "input_method",
+        "Input method",
+        _input_method,
+        screens.input_method_screen,
+    ),
+    Setting("cjk_fonts", "CJK fonts", _cjk_fonts, screens.cjk_fonts_screen),
+)
+
+
 #: Who reaches the machine over the network once it boots.
 SSH: Final[tuple[Setting, ...]] = (
     Setting("sshd", "SSH server", _sshd, screens.sshd_screen),
@@ -725,7 +804,13 @@ NETWORK: Final[tuple[Setting, ...]] = (
 SETTINGS: Final[tuple[Setting, ...]] = (
     Setting("firmware", "Firmware", _firmware, None),
     Setting("keymap", "Keyboard layout", lambda c, x: c.system.keymap, screens.keymap_screen),
-    Setting("locale", "System language", lambda c, x: c.system.locale, screens.locale_screen),
+    Setting(
+        "language",
+        "Language",
+        _summary(LANGUAGE),
+        nested("Language", LANGUAGE, _desktop_language_preamble),
+        rows=LANGUAGE,
+    ),
     Setting("timezone", "Timezone", lambda c, x: c.system.timezone, screens.timezone_screen),
     Setting("mirror", "Mirrors", _mirror, screens.mirror_screen, required=True, detected=True),
     Setting(

--- a/tests/unit/test_tui_app.py
+++ b/tests/unit/test_tui_app.py
@@ -612,6 +612,72 @@ def test_a_grouped_row_shows_its_own_rows_and_comes_back() -> None:
             assert row.label in screen.last, (title, row.label)
 
 
+def test_language_section_reaches_every_language_setting_from_the_menu() -> None:
+    assert tuple(row.key for row in settings.LANGUAGE) == (
+        "locale",
+        "locales",
+        "input_method",
+        "cjk_fonts",
+    )
+    at = context()
+    keys = [
+        *down(steps("Language")),
+        "\n",
+        *down(len(settings.LANGUAGE) - 1),
+        "q",
+        "KEY_DOWN",
+        "\n",
+    ]
+    screen = FakeScreen(keys=keys, lines=30, columns=100)
+    finished = run(screen, config(), at)
+    assert finished.cancelled
+    language_frames = [frame for frame in screen.frames if frame[0] == "Language"]
+    assert language_frames
+    drawn = "\n".join("\n".join(frame) for frame in language_frames)
+    for label in ("System language", "Other locales", "Input method", "CJK fonts"):
+        assert label in drawn, label
+
+
+def test_a_chinese_system_locale_selects_no_input_method_or_font_group() -> None:
+    start = replace(
+        config(),
+        system=replace(
+            config().system,
+            locale="en_US.UTF-8",
+            locales=("en_US.UTF-8",),
+        ),
+        packages=replace(config().packages, applications=()),
+    )
+    chosen = screens.locale_screen(
+        FakeScreen(keys=["KEY_UP", "\n"]), start, context()
+    ).unwrap()
+    assert chosen.system.locale == "zh_CN.UTF-8"
+    language_packages = {
+        *screens.input_method_groups(context().groups),
+        *screens.cjk_font_groups(context().groups),
+    }
+    assert not language_packages.intersection(chosen.packages.applications)
+
+
+def test_plasma_and_gnome_rows_describe_different_desktop_configuration() -> None:
+    def language_preamble(desktop: str) -> str:
+        chosen = replace(
+            config(), packages=replace(config().packages, desktop=desktop)
+        )
+        screen = FakeScreen(keys=["q"], lines=30, columns=80)
+        settings.nested(
+            "Language", settings.LANGUAGE, settings._desktop_language_preamble
+        )(screen, chosen, context())
+        return "\n".join(screen.frames[0])
+
+    plasma = language_preamble("plasma")
+    gnome = language_preamble("gnome")
+    assert "packages will be installed" in plasma
+    assert "plasma configures the selected fonts and input method automatically" in plasma
+    assert "gnome leaves font and input method configuration to its settings" in gnome
+    assert "automatically" not in gnome
+
+
 def test_a_grouped_row_names_the_row_behind_it_that_is_missing() -> None:
     """`Disk` says nothing about which of its six the operator has not reached."""
     blank = replace(config(), system=replace(config().system, root_password_hash=""))
@@ -1232,7 +1298,7 @@ def test_a_required_row_inside_any_group_is_named_by_its_own_label() -> None:
     from dataclasses import replace as _replace
 
     groups = [one for one in settings.SETTINGS if one.rows]
-    assert len(groups) == 8
+    assert len(groups) == 9
     # Every group row's members are reachable, and no group row is walked itself.
     at = context()
     blank = replace(config(), system=replace(config().system, root_password_hash=""))


### PR DESCRIPTION
What decides the language of the installed system was spread across the menu: the locale list with the system settings, the input method framework and its engines among the applications, and the CJK fonts as another package group.

One Language section now holds the system locale, the other generated locales, the input method and the CJK fonts. Each stays a switch: a Chinese locale selects no engine and no font by itself. The section states what the chosen desktop can configure automatically — Plasma can, GNOME and Xfce are left to their own settings — rather than leaving the operator to find out afterwards.

The four translated catalogs do not carry the new keys yet and fall back to English until they do.