### PR TITLE
exec: say how much of a download has arrived

### DIFF
--- a/gentoo_install/exec/fetch.py
+++ b/gentoo_install/exec/fetch.py
@@ -19,7 +19,7 @@ import urllib.error
 import urllib.request
 from pathlib import Path
 from collections.abc import Iterator
-from typing import Any, Final
+from typing import Any, Callable, Final
 
 from ..errors import (
     CommandFailed,
@@ -76,9 +76,9 @@ def stage3(mirror: str, variant: str, fingerprint: str, work: Path, runner: Runn
     if marker.is_file() and archive.is_file() and _marker_matches(marker, archive, fingerprint):
         return archive
 
-    _download(f"{builds}/{where}", archive)
+    _download(f"{builds}/{where}", archive, runner.log)
     digests = work / f"{name}.DIGESTS"
-    _download(f"{builds}/{where}.DIGESTS", digests)
+    _download(f"{builds}/{where}.DIGESTS", digests, runner.log)
     _import_release_key(runner, work)
     _verify_signature(digests, fingerprint, runner)
     _verify_digest(archive, digests)
@@ -529,7 +529,7 @@ def _read_once(url: str) -> str:
         raise DownloadFailed(f"{url} could not be read: {error}") from error
 
 
-def _download(url: str, target: Path) -> None:
+def _download(url: str, target: Path, log: Callable[[str], None] | None = None) -> None:
     """Written beside the target and renamed, so an interrupted download never
     leaves a short file that looks complete.
 
@@ -538,7 +538,7 @@ def _download(url: str, target: Path) -> None:
     family with no route fails before a byte arrives.
     """
     try:
-        _download_once(url, target)
+        _download_once(url, target, log)
         return
     except DownloadFailed as first:
         if not _unroutable(first.__cause__ or first):
@@ -547,19 +547,50 @@ def _download(url: str, target: Path) -> None:
     for family in _FAMILIES:
         try:
             with _over(family):
-                _download_once(url, target)
+                _download_once(url, target, log)
                 return
         except DownloadFailed as again:
             last = again
     raise last
 
 
-def _download_once(url: str, target: Path) -> None:
+
+#: How long a download may say nothing. The campaign's watchdog ends a guest
+#: that has printed nothing for twenty minutes, and a stage3 over a slow mirror
+#: takes longer than that to arrive.
+PROGRESS_INTERVAL: Final[float] = 30.0
+
+
+def _content_length(response: object) -> int | None:
+    length = getattr(response, "headers", {}).get("Content-Length")
+    try:
+        return int(length) if length is not None else None
+    except ValueError:
+        return None
+
+
+def _progress(name: str, got: int, total: int | None) -> str:
+    megabytes = got / (1 << 20)
+    if total:
+        return f"{name}: {megabytes:.0f} MiB of {total / (1 << 20):.0f} MiB"
+    return f"{name}: {megabytes:.0f} MiB"
+
+
+def _download_once(url: str, target: Path, log: Callable[[str], None] | None = None) -> None:
     partial = target.with_suffix(target.suffix + ".part")
     try:
         with urllib.request.urlopen(_asked(url), timeout=TIMEOUT) as response, partial.open("wb") as handle:
+            total = _content_length(response)
+            got = 0
+            said = time.monotonic()
             while chunk := response.read(1 << 20):
                 handle.write(chunk)
+                got += len(chunk)
+                # A stage3 is the longest silence in a run, and a watchdog
+                # reading the console ends the guest doing the most work.
+                if log is not None and time.monotonic() - said >= PROGRESS_INTERVAL:
+                    said = time.monotonic()
+                    log(_progress(target.name, got, total))
     except (urllib.error.URLError, TimeoutError, OSError) as error:
         partial.unlink(missing_ok=True)
         raise DownloadFailed(f"{url} could not be fetched: {error}") from error

--- a/tests/unit/test_exec.py
+++ b/tests/unit/test_exec.py
@@ -4,6 +4,8 @@ from dataclasses import replace
 from pathlib import Path, PurePosixPath
 from typing import Iterable, Mapping, Sequence
 
+import tempfile
+
 import pytest
 
 from gentoo_install.errors import (
@@ -1752,3 +1754,43 @@ def test_a_reset_connection_is_retried_before_the_install_is_given_up(
     with pytest.raises(DownloadFailed):
         fetch._newest("https://distfiles.invalid/releases", "systemd")
     assert tries["n"] == fetch.READ_TRIES
+
+
+def test_a_long_download_says_it_is_still_downloading() -> None:
+    """A stage3 arrives over minutes and `_download_once` wrote nothing while it
+    did, so the campaign's watchdog ended the guests doing the most work: it
+    reads the console, and the console was silent. `vm-f2fs` and `vm-bios` were
+    both killed inside the stage3 fetch.
+    """
+    import io
+    import time as clock
+    import urllib.request
+    from pathlib import Path
+    from unittest import mock
+
+    from gentoo_install.exec import fetch
+
+    class Slow(io.BytesIO):
+        """Two megabytes handed over with the clock moved past the interval."""
+
+        def __init__(self) -> None:
+            super().__init__(b"x" * (2 << 20))
+            self.headers = {"Content-Length": str(2 << 20)}
+
+        def __enter__(self) -> "Slow":
+            return self
+
+        def __exit__(self, *rest: object) -> None:
+            return None
+
+    said: list[str] = []
+    ticks = iter([0.0, 0.0, fetch.PROGRESS_INTERVAL + 1, fetch.PROGRESS_INTERVAL + 1] + [1e6] * 8)
+    with tempfile.TemporaryDirectory() as where:
+        target = Path(where) / "stage3.tar.xz"
+        with mock.patch.object(urllib.request, "urlopen", lambda *a, **k: Slow()), mock.patch.object(
+            clock, "monotonic", lambda: next(ticks)
+        ):
+            fetch._download_once("https://example.invalid/stage3", target, said.append)
+    assert said, "the download reported nothing"
+    assert "stage3.tar.xz" in said[0], said
+    assert "MiB" in said[0], said


### PR DESCRIPTION
`vm-f2fs` and `vm-bios` were reported as `ERROR ... never matched MARK_n_DONE` at 21 and 31 minutes. Both logs end at `[stage3] download the newest stage3`. They were not stuck; they were downloading. `_download_once` read the whole archive a megabyte at a time and wrote nothing while it did, so the watchdog — which reads the serial console — ended the two guests doing the most work.

The download now reports how much has arrived every thirty seconds, through `runner.log`. The test replaces the clock and `urlopen` and asserts a line is emitted; the negative control removes the report and the test fails.