### PR TITLE
plan: unlock ZFSBootMenu in its own image, not the system initramfs

### DIFF
--- a/gentoo_install/plan/bootloader.py
+++ b/gentoo_install/plan/bootloader.py
@@ -52,6 +52,17 @@ EFI_PACKAGE: Final[str] = "sys-boot/efibootmgr"
 ZBM_DIRECTORY: Final[str] = "EFI/zbm"
 FALLBACK_IMAGE: Final[str] = "EFI/BOOT/BOOTX64.EFI"
 
+#: ZFSBootMenu's dracut tree is separate from the installed system's tree.
+ZBM_REMOTE_CONFIG: Final[PurePosixPath] = PurePosixPath(
+    "/etc/zfsbootmenu/dracut.conf.d/dropbear.conf"
+)
+ZBM_NETWORK_CONFIG: Final[PurePosixPath] = PurePosixPath(
+    "/etc/cmdline.d/dracut-network.conf"
+)
+ZBM_KEY_DIRECTORY: Final[PurePosixPath] = PurePosixPath("/etc/dropbear")
+ZBM_AUTHORIZED_KEYS: Final[PurePosixPath] = ZBM_KEY_DIRECTORY / "root_key"
+ZBM_HOST_KEY_TYPES: Final[tuple[str, ...]] = ("rsa", "ecdsa", "ed25519")
+
 
 @dataclass(frozen=True, kw_only=True)
 class InstallGrub(Operation):
@@ -208,6 +219,67 @@ class GenerateHostId(Operation):
 
 
 @dataclass(frozen=True, kw_only=True)
+class ConfigureZfsBootMenuRemoteAccess(Operation):
+    """Files and dedicated keys embedded by ZFSBootMenu's dracut build."""
+
+    stage: Stage = Stage.BOOTLOADER
+    unlock: RemoteUnlock
+    authorized_keys: tuple[str, ...]
+
+    def describe(self) -> str:
+        return (
+            f"write {ZBM_REMOTE_CONFIG} and {ZBM_NETWORK_CONFIG}, authorise keys at "
+            f"{ZBM_AUTHORIZED_KEYS}, and generate dedicated host keys under {ZBM_KEY_DIRECTORY}"
+        )
+
+    def apply(self, context: Context) -> None:
+        context.write(
+            ZBM_AUTHORIZED_KEYS,
+            "".join(f"{key}\n" for key in self.authorized_keys),
+            mode=0o600,
+        )
+        for keytype in ZBM_HOST_KEY_TYPES:
+            key = ZBM_KEY_DIRECTORY / f"ssh_host_{keytype}_key"
+            if context.read(key):
+                continue
+            # PEM lets dracut-crypt-ssh convert dedicated keys without copying
+            # the installed system's private host identity into the EFI image.
+            context.run_in_target(
+                [
+                    "ssh-keygen",
+                    "-q",
+                    "-g",
+                    "-N",
+                    "",
+                    "-m",
+                    "PEM",
+                    "-t",
+                    keytype,
+                    "-f",
+                    str(key),
+                ]
+            )
+        context.write(
+            ZBM_NETWORK_CONFIG,
+            f"ip={_ip_parameter(self.unlock)} rd.neednet=1\n",
+        )
+        context.write(
+            ZBM_REMOTE_CONFIG,
+            "".join(
+                f"{line}\n"
+                for line in (
+                    'add_dracutmodules+=" crypt-ssh "',
+                    f'install_optional_items+=" {ZBM_NETWORK_CONFIG} "',
+                    f'dropbear_port="{self.unlock.port}"',
+                    f"dropbear_rsa_key={ZBM_KEY_DIRECTORY}/ssh_host_rsa_key",
+                    f"dropbear_ecdsa_key={ZBM_KEY_DIRECTORY}/ssh_host_ecdsa_key",
+                    f"dropbear_acl={ZBM_AUTHORIZED_KEYS}",
+                )
+            ),
+        )
+
+
+@dataclass(frozen=True, kw_only=True)
 class InstallZfsBootMenu(Operation):
     """No `zpool.cache`: the boot path is hostid plus an import scan, which
     survives the pool being seen under a different device path."""
@@ -348,12 +420,21 @@ def build(config: InstallConfig) -> list[Operation]:
                 packages=(BOOTCTL_PACKAGE[config.system.init],),
                 summary="install the EFI stub generate-zbm builds around",
             ),
+        ]
+        if config.kernel.remote_unlock.enabled:
+            operations.append(
+                ConfigureZfsBootMenuRemoteAccess(
+                    unlock=config.kernel.remote_unlock,
+                    authorized_keys=config.system.authorized_keys,
+                )
+            )
+        operations += [
             InstallZfsBootMenu(
                 pool=pool,
                 dataset=dataset,
                 esp=esp,
                 esp_device=esp_device,
-                kernel_params=(*unlock_parameters(config), *config.bootloader.kernel_params),
+                kernel_params=config.bootloader.kernel_params,
                 serial=serial_console(config),
             ),
         ]

--- a/gentoo_install/plan/kernel.py
+++ b/gentoo_install/plan/kernel.py
@@ -313,17 +313,20 @@ class AcceptFirmwareLicence(Operation):
 
 @dataclass(frozen=True, kw_only=True)
 class ConfigureRemoteUnlock(Operation):
-    """dracut-crypt-ssh's own configuration file.
+    """Keyword dracut-crypt-ssh and configure the system initramfs when used.
 
     It is `~amd64`, so the keyword is accepted for that atom alone. `dropbear`
-    comes in through its RDEPEND; the module reads this file at initramfs build
-    time, so it has to exist before dracut runs.
+    comes in through its RDEPEND. ZFSBootMenu uses the package in its own image
+    and explicitly omits the module from the boot environment's initramfs.
     """
 
     stage: Stage = Stage.KERNEL
     port: int
+    system_initramfs: bool = True
 
     def describe(self) -> str:
+        if not self.system_initramfs:
+            return "write /etc/dracut.conf.d/crypt-ssh.conf to omit ssh from the system initramfs"
         return f"configure remote unlock over ssh on port {self.port}"
 
     def apply(self, context: Context) -> None:
@@ -331,6 +334,12 @@ class ConfigureRemoteUnlock(Operation):
             PurePosixPath("/etc/portage/package.accept_keywords/dracut-crypt-ssh"),
             f"{REMOTE_UNLOCK_PACKAGE} ~amd64\n",
         )
+        if not self.system_initramfs:
+            context.write(
+                PurePosixPath("/etc/dracut.conf.d/crypt-ssh.conf"),
+                'omit_dracutmodules+=" crypt-ssh "\n',
+            )
+            return
         lines = [
             f'dropbear_port="{self.port}"',
             # SYSTEM converts the target's own host key, so a client that has
@@ -642,12 +651,17 @@ def build(config: InstallConfig) -> list[Operation]:
         operations.append(AcceptKernelVersion(package=package, version=version))
     if config.kernel.remote_unlock.enabled:
         unlock = config.kernel.remote_unlock
+        system_initramfs = config.bootloader.kind is not Bootloader.ZFSBOOTMENU
         operations += [
-            ConfigureRemoteUnlock(port=unlock.port),
+            ConfigureRemoteUnlock(port=unlock.port, system_initramfs=system_initramfs),
             Emerge(
                 stage=Stage.KERNEL,
                 packages=(REMOTE_UNLOCK_PACKAGE,),
-                summary="install the initramfs ssh daemon",
+                summary=(
+                    "install the initramfs ssh daemon"
+                    if system_initramfs
+                    else "install ZFSBootMenu ssh support"
+                ),
             ),
         ]
     if config.kernel.source in CJK_KERNELS:
@@ -777,7 +791,10 @@ def dracut_modules(config: InstallConfig) -> tuple[str, ...]:
         module = FILESYSTEM_MODULES.get(filesystem.kind)
         if module is not None and module not in modules:
             modules.append(module)
-    if config.kernel.remote_unlock.enabled:
+    if (
+        config.kernel.remote_unlock.enabled
+        and config.bootloader.kind is not Bootloader.ZFSBOOTMENU
+    ):
         modules += [one for one in REMOTE_UNLOCK_MODULES if one not in modules]
     for extra in config.kernel.dracut_modules:
         if extra not in modules:

--- a/tests/fixtures/zfs-zbm.toml
+++ b/tests/fixtures/zfs-zbm.toml
@@ -12,10 +12,23 @@ root_password_hash = "$6$gentooinst$IR3GrdJ862XljQYDqocr4tKniIRDIT.jQNFzIrHE3U75
 console_cjk = true
 console_font = "8x16"
 
+sshd = true
+authorized_keys = ["ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIB+85deBslaLOMFw71dx23wo7fFT76GVcEyQS9IdVvvT installer@example"]
+
 [[system.users]]
 name = "zakk"
 sudo = true
 password_hash = "$6$rounds=656000$fixedsaltforthetest$0"
+
+[kernel.remote_unlock]
+# ZFSBootMenu is what opens the pool, so the ssh server has to be in its image
+# and not in the system initramfs built afterwards. No other fixture covers
+# that combination.
+enabled = true
+port = 2222
+address = "192.0.2.10/24"
+gateway = "192.0.2.1"
+interface = "eth0"
 
 [portage]
 profile = "default/linux/amd64/23.0/systemd"

--- a/tests/golden/zfs-zbm.txt
+++ b/tests/golden/zfs-zbm.txt
@@ -51,9 +51,14 @@
   write /etc/fstab with entries for /efi
   treat the hardware clock as UTC
   create user zakk in users, wheel, audio, video, render, usb, input with a password
+  authorise 1 ssh key(s) for root, zakk
   set the root password
   install sudo: emerge app-admin/sudo
   let the wheel group run sudo, with a password
+  install sshd: emerge net-misc/openssh
+  ssh password login: off, root: off
+  enable sshd at boot
+  generate the ssh host keys so the initramfs and sshd present the same host
   configure the wired interface for DHCP
   enable systemd-networkd at boot
   enable systemd-resolved at boot
@@ -65,6 +70,8 @@
   install the hook that puts a kernel in /boot: emerge sys-kernel/installkernel
   accept the linux-firmware licence
   install the initramfs builder and firmware: emerge sys-kernel/dracut sys-kernel/linux-firmware
+  write /etc/dracut.conf.d/crypt-ssh.conf to omit ssh from the system initramfs
+  install ZFSBootMenu ssh support: emerge sys-kernel/dracut-crypt-ssh
   accept sys-kernel/gentoo-cjk-kernel-bin as testing, with cjk on
   unmask virtual/dist-kernel, which the cjk kernel depends on by revision
   install the storage tools: emerge sys-fs/dosfstools
@@ -80,6 +87,7 @@
 [bootloader]
   install the bootloader: emerge sys-boot/zfsbootmenu sys-boot/efibootmgr
   install the EFI stub generate-zbm builds around: emerge sys-apps/systemd
+  write /etc/zfsbootmenu/dracut.conf.d/dropbear.conf and /etc/cmdline.d/dracut-network.conf, authorise keys at /etc/dropbear/root_key, and generate dedicated host keys under /etc/dropbear
   build ZFSBootMenu into /efi/EFI/zbm and boot zpcala/ROOT/gentoo/root from it
 
 [packages]

--- a/tests/unit/test_plan_bootloader.py
+++ b/tests/unit/test_plan_bootloader.py
@@ -1,0 +1,80 @@
+from __future__ import annotations
+
+from dataclasses import replace
+from pathlib import Path, PurePosixPath
+
+from gentoo_install.exec.config import load
+from gentoo_install.model.config import InstallConfig, RemoteUnlock
+from gentoo_install.plan import bootloader, kernel
+
+from .recorder import Recorder
+
+
+def zfsbootmenu_remote_installation() -> InstallConfig:
+    installation = load(Path("tests/fixtures/vm-zfs-encrypted.toml"))
+    return replace(
+        installation,
+        system=replace(
+            installation.system,
+            authorized_keys=("ssh-ed25519 operator-key remote@example",),
+        ),
+        kernel=replace(
+            installation.kernel,
+            remote_unlock=RemoteUnlock(
+                enabled=True,
+                port=2201,
+                address="192.0.2.10/24",
+                gateway="192.0.2.1",
+                interface="eth0",
+            ),
+        ),
+    )
+
+
+def test_zfsbootmenu_carries_remote_access_in_its_own_image() -> None:
+    installation = zfsbootmenu_remote_installation()
+    boot_operations = bootloader.build(installation)
+    configured = next(
+        operation
+        for operation in boot_operations
+        if isinstance(operation, bootloader.ConfigureZfsBootMenuRemoteAccess)
+    )
+    generated = next(
+        index
+        for index, operation in enumerate(boot_operations)
+        if isinstance(operation, bootloader.InstallZfsBootMenu)
+    )
+    installed = boot_operations[generated]
+    assert isinstance(installed, bootloader.InstallZfsBootMenu)
+    assert "rd.neednet=1" not in installed.kernel_params
+    assert not any(parameter.startswith("ip=") for parameter in installed.kernel_params)
+    assert boot_operations.index(configured) < generated
+    assert "/etc/zfsbootmenu/dracut.conf.d/dropbear.conf" in configured.describe()
+    assert "/etc/dropbear" in configured.describe()
+
+    recorder = Recorder()
+    configured.apply(recorder)
+    zbm = recorder.files[PurePosixPath("/etc/zfsbootmenu/dracut.conf.d/dropbear.conf")]
+    assert 'add_dracutmodules+=" crypt-ssh "' in zbm
+    assert 'dropbear_port="2201"' in zbm
+    assert "dropbear_rsa_key=/etc/dropbear/ssh_host_rsa_key" in zbm
+    assert "dropbear_ecdsa_key=/etc/dropbear/ssh_host_ecdsa_key" in zbm
+    assert "dropbear_acl=/etc/dropbear/root_key" in zbm
+    assert recorder.files[PurePosixPath("/etc/dropbear/root_key")] == (
+        "ssh-ed25519 operator-key remote@example\n"
+    )
+    assert recorder.modes[PurePosixPath("/etc/dropbear/root_key")] == 0o600
+    assert recorder.files[PurePosixPath("/etc/cmdline.d/dracut-network.conf")] == (
+        "ip=192.0.2.10::192.0.2.1:255.255.255.0::eth0:none rd.neednet=1\n"
+    )
+    assert len(recorder.argv_starting("ssh-keygen")) == 3
+
+    kernel_recorder = Recorder()
+    for operation in kernel.build(installation):
+        if isinstance(operation, kernel.ConfigureRemoteUnlock):
+            operation.apply(kernel_recorder)
+    assert kernel_recorder.files[PurePosixPath("/etc/dracut.conf.d/crypt-ssh.conf")] == (
+        'omit_dracutmodules+=" crypt-ssh "\n'
+    )
+    assert "crypt-ssh" not in kernel.dracut_modules(installation)
+    assert "network" not in kernel.dracut_modules(installation)

--- a/tests/unit/test_plan_kernel.py
+++ b/tests/unit/test_plan_kernel.py
@@ -1,0 +1,29 @@
+from __future__ import annotations
+
+from pathlib import Path, PurePosixPath
+
+from gentoo_install.exec.config import load
+from gentoo_install.plan import bootloader, kernel
+
+from .recorder import Recorder
+
+
+def test_grub_remote_unlock_keeps_the_system_dracut_path() -> None:
+    installation = load(Path("tests/fixtures/vm-unlock.toml"))
+    operation = next(
+        one
+        for one in kernel.build(installation)
+        if isinstance(one, kernel.ConfigureRemoteUnlock)
+    )
+    recorder = Recorder()
+    operation.apply(recorder)
+
+    written = recorder.files[PurePosixPath("/etc/dracut.conf.d/crypt-ssh.conf")]
+    assert 'dropbear_port="2222"' in written
+    assert 'dropbear_rsa_key="SYSTEM"' in written
+    assert 'install_items+=" /sbin/cryptsetup "' in written
+    assert kernel.dracut_modules(installation)[-2:] == ("crypt-ssh", "network")
+    assert not any(
+        isinstance(one, bootloader.ConfigureZfsBootMenuRemoteAccess)
+        for one in bootloader.build(installation)
+    )


### PR DESCRIPTION
`RemoteUnlock` put dropbear into the system's dracut initramfs whatever the bootloader was. For ZFSBootMenu that is the wrong layer: ZFSBootMenu imports the pool, unlocks the encryption root and `kexec`s, and the system's own initramfs is built after that, so an operator sitting at the pool passphrase prompt cannot reach it.

Following ZFSBootMenu 3.0.1's own Remote Access guide: `sys-kernel/dracut-crypt-ssh` from `::gentoo`, `ip=dhcp rd.neednet=1` in `/etc/cmdline.d/dracut-network.conf` (upstream warns that putting it in `kernel_cmdline` makes it appear twice and `dracut-network` then refuses to boot), the module and keys in ZFSBootMenu's own `/etc/zfsbootmenu/dracut.conf.d/dropbear.conf`, and `omit_dracutmodules+=" crypt-ssh "` for the boot environment, which upstream asks for too.

`tests/fixtures/zfs-zbm.toml` now enables `remote_unlock`; no fixture covered that combination, so the golden plan showed nothing.