### PR TITLE
plan: show the systemd-boot menu instead of booting past it

### DIFF
--- a/gentoo_install/plan/bootloader.py
+++ b/gentoo_install/plan/bootloader.py
@@ -44,6 +44,10 @@ BOOTCTL_PACKAGE: Final[dict[InitSystem, str]] = {
     InitSystem.OPENRC: "sys-apps/systemd-utils",
 }
 
+#: How long the boot menu waits. The same five seconds `GRUB_TIMEOUT` uses, so
+#: the two bootloaders behave alike from the operator's side.
+MENU_SECONDS: Final[int] = 5
+
 #: Writing an NVRAM entry needs this, and only UEFI has NVRAM to write to.
 EFI_PACKAGE: Final[str] = "sys-boot/efibootmgr"
 
@@ -196,6 +200,28 @@ class InstallSystemdBoot(Operation):
 
     def apply(self, context: Context) -> None:
         context.run_in_target(["bootctl", f"--esp-path={self.esp}", "install"])
+
+
+@dataclass(frozen=True, kw_only=True)
+class ShowTheBootMenu(Operation):
+    """`bootctl install` writes no `loader.conf`, and systemd-boot's own
+    default for `timeout` is 0: no menu at all, straight into the default
+    entry. An encrypted machine went from firmware to the passphrase prompt
+    with no way to pick an older kernel.
+    """
+
+    stage: Stage = Stage.BOOTLOADER
+    esp: PurePosixPath
+    seconds: int = MENU_SECONDS
+
+    def describe(self) -> str:
+        return f"show the boot menu for {self.seconds}s in {self.esp}/loader/loader.conf"
+
+    def apply(self, context: Context) -> None:
+        context.write(
+            self.esp / "loader" / "loader.conf",
+            f"timeout {self.seconds}\nconsole-mode keep\n",
+        )
 
 
 @dataclass(frozen=True, kw_only=True)
@@ -408,6 +434,7 @@ def build(config: InstallConfig) -> list[Operation]:
                 only_if_absent=True,
             ),
             InstallSystemdBoot(esp=esp),
+            ShowTheBootMenu(esp=esp),
         ]
     elif kind is Bootloader.ZFSBOOTMENU and esp is not None and esp_device is not None:
         pool, dataset = _root_pool_and_dataset(config)

--- a/tests/golden/openrc-sdboot.txt
+++ b/tests/golden/openrc-sdboot.txt
@@ -66,6 +66,7 @@
 [bootloader]
   install bootctl: emerge sys-apps/systemd-utils
   install systemd-boot on the esp at /boot
+  show the boot menu for 5s in /boot/loader/loader.conf
 
 [finish]
   delete the downloaded stage3 from /var/cache/gentoo-install

--- a/tests/golden/vm-sdboot.txt
+++ b/tests/golden/vm-sdboot.txt
@@ -63,6 +63,7 @@
 [bootloader]
   install bootctl: emerge sys-apps/systemd
   install systemd-boot on the esp at /boot
+  show the boot menu for 5s in /boot/loader/loader.conf
 
 [finish]
   point /etc/resolv.conf at systemd-resolved rather than the install medium's

--- a/tests/unit/test_plan_bootloader.py
+++ b/tests/unit/test_plan_bootloader.py
@@ -78,3 +78,29 @@ def test_zfsbootmenu_carries_remote_access_in_its_own_image() -> None:
     )
     assert "crypt-ssh" not in kernel.dracut_modules(installation)
     assert "network" not in kernel.dracut_modules(installation)
+
+
+def test_a_systemd_boot_machine_shows_its_menu() -> None:
+    """`bootctl install` writes no `loader.conf`, and systemd-boot's documented
+    default for `timeout` is 0: "no menu is shown and the default entry will be
+    booted immediately". An encrypted openrc machine went from firmware
+    straight to the passphrase prompt, with no way to pick an older kernel.
+    """
+    installation = load(Path("tests/fixtures/openrc-sdboot.toml"))
+    operations = bootloader.build(installation)
+    shown = [one for one in operations if isinstance(one, bootloader.ShowTheBootMenu)]
+    assert len(shown) == 1, [one.describe() for one in operations]
+    assert shown[0].seconds > 0, shown[0]
+
+    recorder = Recorder()
+    shown[0].apply(recorder)
+    written = recorder.files[shown[0].esp / "loader" / "loader.conf"]
+    assert f"timeout {shown[0].seconds}" in written, written
+
+
+def test_a_grub_machine_writes_no_loader_conf() -> None:
+    """The menu timeout for GRUB is `GRUB_TIMEOUT` in `/etc/default/grub`, and
+    a `loader.conf` beside it would be read by nothing."""
+    installation = load(Path("tests/fixtures/vm-btrfs.toml"))
+    operations = bootloader.build(installation)
+    assert not [one for one in operations if isinstance(one, bootloader.ShowTheBootMenu)]


### PR DESCRIPTION
A systemd-boot machine went from firmware straight into the LUKS passphrase prompt, with no kernel menu. `loader.conf` was never written, and systemd-boot documents its own default: "If set to menu-disabled or menu-hidden or 0 (the default), no menu is shown and the default entry will be booted immediately."

`<esp>/loader/loader.conf` now carries `timeout 5`, the same wait `GRUB_TIMEOUT` already used, so the two bootloaders behave alike. `console-mode keep` leaves the firmware's resolution alone.

The two systemd-boot golden plans gained the line; a GRUB plan writes no `loader.conf`, and a test asserts that too.