### PR TITLE
portage: stop fetching the tree twice on an rsync install

### DIFF
--- a/gentoo_install/plan/portage.py
+++ b/gentoo_install/plan/portage.py
@@ -693,16 +693,22 @@ def build(
     elif portage.sync is Sync.RSYNC:
         # No `dev-vcs/git`: rsync needs none, and the stage3 already has the
         # rsync binary. Signatures are verified per snapshot, not per commit.
-        operations += [
+        #
+        # No sync here either. `emerge-webrsync` has just placed a signed
+        # snapshot, and `SyncRepository` deletes it and fetches the same tree
+        # again over rsync. Twelve guests behind one address did that at once
+        # and rsync.gentoo.org answered `access denied ... from UNKNOWN`, which
+        # its own MOTD warns about. The repository is configured so the
+        # installed system syncs, and the snapshot is what this install uses.
+        operations.append(
             ConfigureRepository(
                 name="gentoo",
                 location=gentoo,
                 sync_uri=_rsync_uri(portage),
                 verify_commits=False,
                 sync_type="rsync",
-            ),
-            SyncRepository(name="gentoo", location=gentoo),
-        ]
+            )
+        )
     if portage.overlays and portage.sync is not Sync.GIT:
         # Every overlay is a git repository whichever way the main tree syncs,
         # and a stage3 has no git: without this the first overlay sync fails.

--- a/tests/unit/test_plan_portage.py
+++ b/tests/unit/test_plan_portage.py
@@ -709,3 +709,32 @@ def test_a_pinned_package_reaches_usepkg_exclude_without_its_version() -> None:
     )
     assert "7.1.7" not in excluded, excluded
     assert "sys-kernel/gentoo-cjk-kernel-bin" in excluded
+
+
+def test_an_rsync_install_does_not_fetch_the_tree_twice() -> None:
+    """`emerge-webrsync` places a signed snapshot, and `SyncRepository` deletes
+    it and fetches the same tree again over rsync. Twelve guests behind one
+    address did that at once and `rsync.gentoo.org` answered `access denied to
+    gentoo-portage from UNKNOWN`, which its own MOTD warns about. The
+    repository is still configured, so the installed system syncs later.
+    """
+    from pathlib import Path
+
+    from gentoo_install.exec.config import load
+    from gentoo_install.model.config import Sync
+    from gentoo_install.plan import portage as plan_portage
+
+    installation = load(Path("tests/fixtures/vm-btrfs.toml"))
+    over_rsync = replace(
+        installation,
+        portage=replace(installation.portage, sync=Sync.RSYNC, overlays=()),
+    )
+    operations = plan_portage.build(over_rsync, "https://distfiles.gentoo.org")
+    synced = [
+        one
+        for one in operations
+        if isinstance(one, plan_portage.SyncRepository) and one.name == "gentoo"
+    ]
+    assert not synced, [one.describe() for one in operations]
+    pointed = [one for one in operations if isinstance(one, plan_portage.ConfigureRepository)]
+    assert [one for one in pointed if one.name == "gentoo"], [one.describe() for one in operations]


### PR DESCRIPTION
Guests stopped at `emerge --sync gentoo` with `@ERROR: access denied to gentoo-portage from UNKNOWN`. The same log carries Gentoo's own MOTD above it: syncing more than once a day may lead to an automatic temporary ban, and twelve guests behind one address had just done exactly that.

The ban is the symptom. `emerge-webrsync` had already placed a signed snapshot, and `SyncRepository` then ran `rm --recursive --force /var/db/repos/gentoo` and fetched the same tree again over rsync — the whole tree twice, and the second time is the banned request. The handbook's flow is webrsync or rsync, not both.

An rsync install now writes `repos.conf` and stops there; the snapshot is what the install uses and the installed system syncs later. A git install still syncs, because a webrsync tree is not a git checkout and has to be replaced.