### PR TITLE
model: refuse a profile the target's repository does not carry

### DIFF
--- a/gentoo_install/exec/probe.py
+++ b/gentoo_install/exec/probe.py
@@ -21,6 +21,7 @@ from typing import ClassVar, Final, Iterable, Mapping
 from ..errors import CommandFailed, DeviceNotFound
 from ..model.config import InstallConfig
 from ..model.device import DeviceGraph, DeviceId, Existing, Extent, PartitionTable
+from ..model.validate import ProbedProfile, parse_profile_list
 from .runner import Runner
 
 EFI_MARKER: Final[Path] = Path("/sys/firmware/efi")
@@ -154,6 +155,11 @@ def _efi_bits() -> int:
 #: Where both install media keep the release engineering public key.
 RELEASE_KEY: Final[Path] = Path("/usr/share/openpgp-keys/gentoo-release.asc")
 MEMINFO: Final[Path] = Path("/proc/meminfo")
+
+
+def profiles_from_eselect(output: str) -> tuple[ProbedProfile, ...]:
+    """Parse profile output already read from the machine that owns the tree."""
+    return parse_profile_list(output)
 
 
 @dataclass(frozen=True)

--- a/gentoo_install/model/validate.py
+++ b/gentoo_install/model/validate.py
@@ -10,10 +10,11 @@ import ipaddress
 
 import re
 from collections import Counter
+from dataclasses import dataclass
 from pathlib import PurePosixPath
-from typing import Final, Mapping
+from typing import Collection, Final, Mapping
 
-from ..errors import ValidationFailed
+from ..errors import CommandFailed, ValidationFailed
 from . import compat
 from .config import InitSystem, InstallConfig
 from .device import (
@@ -35,11 +36,64 @@ from .size import Size
 _ROOT = PurePosixPath("/")
 
 
-def validate(config: InstallConfig) -> None:
+@dataclass(frozen=True)
+class ProbedProfile:
+    """One row from `eselect profile list`."""
+
+    path: str
+    stability: str
+    current: bool = False
+
+
+_PROFILE_ROW: Final[re.Pattern[str]] = re.compile(
+    r"^\s*\[\d+\]\s+(\S+)\s+\(([^()\s]+)\)(\s+\*)?\s*$"
+)
+
+
+def parse_profile_list(
+    output: str,
+    *,
+    source: str = "`eselect profile list`",
+) -> tuple[ProbedProfile, ...]:
+    """Parse the numbered rows emitted by eselect on the repository in use."""
+    found: list[ProbedProfile] = []
+    for line in output.splitlines():
+        if not line.strip() or line.strip() == "Available profile symlink targets:":
+            continue
+        matched = _PROFILE_ROW.fullmatch(line)
+        if matched is None:
+            raise CommandFailed(
+                f"{source} could not be read: unrecognised profile row {line.strip()!r}"
+            )
+        found.append(
+            ProbedProfile(
+                path=matched.group(1),
+                stability=matched.group(2),
+                current=matched.group(3) is not None,
+            )
+        )
+    if not found:
+        raise CommandFailed(f"{source} could not be read: no profile rows were returned")
+    return tuple(found)
+
+
+class _ProfilesNotRead:
+    pass
+
+
+_PROFILES_NOT_READ: Final[_ProfilesNotRead] = _ProfilesNotRead()
+
+
+def validate(
+    config: InstallConfig,
+    *,
+    available_profiles: Collection[str] | None | _ProfilesNotRead = _PROFILES_NOT_READ,
+) -> None:
     problems = [
         *_layout_problems(config),
         *root_size_problems(config),
         *_profile_problems(config),
+        *_repository_profile_problems(config.portage.profile, available_profiles),
         *_kernel_package_problems(config),
         *_reuse_problems(config),
         *_pool_problems(config),
@@ -282,6 +336,33 @@ def _profile_problems(config: InstallConfig) -> list[str]:
         return []
     wanted = "one ending in /systemd" if wants_systemd else "one without /systemd"
     return [f"init is {config.system.init.value} and the profile is {profile}; use {wanted}"]
+
+
+def _repository_profile_problems(
+    profile: str,
+    available_profiles: Collection[str] | None | _ProfilesNotRead,
+) -> list[str]:
+    """The chosen profile must exist in the repository used by the target."""
+    if isinstance(available_profiles, _ProfilesNotRead):
+        return []
+    if available_profiles is None:
+        return [
+            f"configured profile {profile!r} cannot be resolved because the target repository "
+            "list from `eselect profile list` could not be read"
+        ]
+    if profile not in available_profiles:
+        return [
+            f"configured profile {profile!r} is not in the target repository list returned by "
+            "`eselect profile list`"
+        ]
+    return []
+
+
+def validate_profile(profile: str, available_profiles: Collection[str] | None) -> None:
+    """Apply the repository-membership rule to one configured profile."""
+    problems = _repository_profile_problems(profile, available_profiles)
+    if problems:
+        raise ValidationFailed(problems[0])
 
 
 def _layout_problems(config: InstallConfig) -> list[str]:

--- a/tests/unit/test_validate.py
+++ b/tests/unit/test_validate.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from dataclasses import replace
+from dataclasses import FrozenInstanceError, replace
 from pathlib import Path, PurePosixPath
 
 import pytest
@@ -16,6 +16,7 @@ from gentoo_install.model.device import (
 )
 from gentoo_install.model.size import Size
 from gentoo_install.exec.config import load
+from gentoo_install.exec.probe import profiles_from_eselect
 from gentoo_install.model.validate import validate
 
 from .layouts import encrypted_root, config, ext4_on_gpt, i, zfs_root
@@ -133,6 +134,56 @@ def test_a_profile_that_disagrees_with_the_init_is_refused() -> None:
 
     with pytest.raises(ValidationFailed, match="ending in /systemd"):
         validate(replace(openrc, system=replace(openrc.system, init=InitSystem.SYSTEMD)))
+
+
+def test_a_configured_profile_absent_from_eselect_is_refused() -> None:
+    installation = config()
+
+    with pytest.raises(ValidationFailed) as refused:
+        validate(
+            installation,
+            available_profiles=("default/linux/amd64/24.0/systemd",),
+        )
+
+    message = str(refused.value)
+    assert installation.portage.profile in message
+    assert "eselect profile list" in message
+
+
+def test_a_configured_profile_present_in_eselect_passes() -> None:
+    installation = config()
+
+    validate(installation, available_profiles=(installation.portage.profile,))
+
+
+def test_an_unreadable_eselect_profile_list_is_reported() -> None:
+    installation = config()
+
+    with pytest.raises(ValidationFailed) as refused:
+        validate(installation, available_profiles=None)
+
+    message = str(refused.value)
+    assert installation.portage.profile in message
+    assert "could not be read" in message
+    assert "eselect profile list" in message
+
+
+def test_the_profile_parser_keeps_the_observed_eselect_markers() -> None:
+    profiles = profiles_from_eselect(
+        """Available profile symlink targets:
+  [8]   default/linux/amd64/23.0/desktop/plasma/systemd (stable) *
+  [15]  default/linux/amd64/23.0/no-multilib/prefix (exp)
+  [40]  default/linux/amd64/23.0/x32 (dev)
+"""
+    )
+
+    assert tuple((one.path, one.stability, one.current) for one in profiles) == (
+        ("default/linux/amd64/23.0/desktop/plasma/systemd", "stable", True),
+        ("default/linux/amd64/23.0/no-multilib/prefix", "exp", False),
+        ("default/linux/amd64/23.0/x32", "dev", False),
+    )
+    with pytest.raises(FrozenInstanceError):
+        setattr(profiles[0], "path", "default/linux/amd64/24.0")
 
 
 def test_a_static_address_with_no_resolver_is_refused() -> None:


### PR DESCRIPTION
`default/linux/amd64/23.0` is a literal in `screens.py`, in `model/config.py` and in every row of the six profile catalogs. Gentoo renumbers that tree — 17.1 became 23.0 — and on the day it does, every row names a profile that does not exist and `eselect profile set` is where it is found out, an hour into a run.

The list is read in the target with `eselect profile list`, parsed against its real output, and checked at `SelectProfile`: the snapshot is in place by then and nothing has been merged. Reading it on the live medium would have been wrong — the official minimal CD carries no ebuild repository at all.

The enforcement in `plan/portage.py` landed inside #183 by mistake: that branch and this one both touched the file, and naming paths does not separate two changes to one file. This carries the probe, the pure rule and its tests.