### PR TITLE
locale: say which locale is always generated, not that one is

### DIFF
--- a/gentoo_install/data/locale/ja.toml
+++ b/gentoo_install/data/locale/ja.toml
@@ -473,7 +473,7 @@
 "Input method" = "入力メソッド"
 "CJK fonts" = "CJK フォント"
 "The installed system starts in this locale." = "インストールしたシステムはこのロケールで起動します。"
-"The system language is always generated." = "システム言語は必ず生成されます。"
+"The system language is always generated." = "システム言語のロケールは必ず生成されるため、ここで選ぶ必要はありません。"
 "The selected font and input method packages will be installed." = "選択したフォントと入力メソッドのパッケージをインストールします。"
 "{desktop} configures the selected fonts and input method automatically." = "{desktop} は選択したフォントと入力メソッドを自動的に設定します。"
 "{desktop} leaves font and input method configuration to its settings." = "{desktop} はフォントと入力メソッドの設定を自身の設定画面に任せます。"

--- a/gentoo_install/data/locale/ko.toml
+++ b/gentoo_install/data/locale/ko.toml
@@ -473,7 +473,7 @@
 "Input method" = "입력기"
 "CJK fonts" = "CJK 글꼴"
 "The installed system starts in this locale." = "설치한 시스템은 이 로캘로 시작합니다."
-"The system language is always generated." = "시스템 언어는 항상 생성됩니다."
+"The system language is always generated." = "시스템 언어의 로캘은 항상 생성되므로 여기서 다시 선택할 필요가 없습니다."
 "The selected font and input method packages will be installed." = "선택한 글꼴과 입력기 패키지를 설치합니다."
 "{desktop} configures the selected fonts and input method automatically." = "선택한 글꼴과 입력기를 {desktop} 환경에서 자동으로 설정합니다."
 "{desktop} leaves font and input method configuration to its settings." = "글꼴과 입력기 설정은 {desktop} 자체 설정에서 관리합니다."

--- a/gentoo_install/data/locale/zh-CN.toml
+++ b/gentoo_install/data/locale/zh-CN.toml
@@ -474,7 +474,7 @@
 "Input method" = "输入法"
 "CJK fonts" = "中日韩字体"
 "The installed system starts in this locale." = "安装完成的系统以这个语系启动。"
-"The system language is always generated." = "系统语言一定会生成。"
+"The system language is always generated." = "系统语言的语系一定会生成，这里不必重复选。"
 "The selected font and input method packages will be installed." = "选定的字体与输入法软件包会被安装。"
 "{desktop} configures the selected fonts and input method automatically." = "{desktop} 会自动配置选定的字体与输入法。"
 "{desktop} leaves font and input method configuration to its settings." = "{desktop} 将字体与输入法的配置交给它自己的设置程序。"

--- a/gentoo_install/data/locale/zh-TW.toml
+++ b/gentoo_install/data/locale/zh-TW.toml
@@ -474,7 +474,7 @@
 "Input method" = "輸入法"
 "CJK fonts" = "中日韓字型"
 "The installed system starts in this locale." = "安裝完成的系統以這個語系啟動。"
-"The system language is always generated." = "系統語言一定會產生。"
+"The system language is always generated." = "系統語言的語系一定會產生，這裡不必重複選。"
 "The selected font and input method packages will be installed." = "選定的字型與輸入法套件會被安裝。"
 "{desktop} configures the selected fonts and input method automatically." = "{desktop} 會自動設定選定的字型與輸入法。"
 "{desktop} leaves font and input method configuration to its settings." = "{desktop} 將字型與輸入法的設定交給它自己的設定程式。"


### PR DESCRIPTION
The Other locales row carried "系統語言一定會產生", which names no object: generated into what, and why is it being said here. The row means the system language's own locale is added whether or not it is ticked, so it needs no second selection in that list.

The Japanese and Korean readings had the same gap and are rewritten with the reason in them.