### PR TITLE
plan: resolve every atom once before the first package is merged

### DIFF
--- a/gentoo_install/plan/build.py
+++ b/gentoo_install/plan/build.py
@@ -7,16 +7,29 @@ order the modules happen to be called in.
 
 from __future__ import annotations
 
-from typing import Final
+from dataclasses import replace
+from typing import Final, Sequence
 
 from ..model import mirrors
 from ..model.config import InstallConfig
 from ..model.validate import validate
 from . import bootloader, disk, fonts, kernel, packages, portage, system
-from .operations import Operation
+from .operations import Operation, Stage
 
 #: The mirror a stage3 is fetched from when the configuration names none.
 DEFAULT_MIRROR: Final[str] = "https://distfiles.gentoo.org"
+
+# These operations alter the resolver's inputs, so the complete-set check has
+# to see them before their package merges run in later stages.
+PORTAGE_PREREQUISITES: Final[tuple[type[Operation], ...]] = (
+    kernel.ConfigureInstallKernel,
+    kernel.AcceptFirmwareLicence,
+    kernel.ConfigureRemoteUnlock,
+    kernel.UnmaskCjkDistKernel,
+    kernel.AcceptKernelVersion,
+    kernel.RequestCjkKernel,
+    kernel.RequestDistKernelModules,
+)
 
 
 def stage3_mirror(config: InstallConfig, fallback: str = DEFAULT_MIRROR) -> str:
@@ -73,4 +86,33 @@ def build(config: InstallConfig, catalog: packages.Catalog, *, mirror: str = DEF
         # the target, and nothing can be written once it is unmounted.
         *disk.finish(config),
     ]
-    return tuple(sorted(operations, key=lambda operation: operation.stage.order))
+    operations = [_in_portage_phase(operation) for operation in operations]
+    ordered = sorted(operations, key=lambda operation: operation.stage.order)
+    requests = _package_requests(ordered)
+    if requests:
+        after_configuration = max(
+            index for index, operation in enumerate(ordered) if operation.stage is Stage.PORTAGE
+        ) + 1
+        ordered.insert(after_configuration, portage.VerifyPackages(requests=requests))
+    return tuple(ordered)
+
+
+def _in_portage_phase(operation: Operation) -> Operation:
+    if isinstance(operation, PORTAGE_PREREQUISITES):
+        return replace(operation, stage=Stage.PORTAGE)
+    return operation
+
+
+def _package_requests(operations: Sequence[Operation]) -> tuple[portage.PackageRequest, ...]:
+    requesters: dict[str, list[str]] = {}
+    for operation in operations:
+        if not isinstance(operation, portage.Emerge) or operation.repository_bootstrap:
+            continue
+        for atom in operation.packages:
+            named = requesters.setdefault(atom, [])
+            if operation.package_requester not in named:
+                named.append(operation.package_requester)
+    return tuple(
+        portage.PackageRequest(atom=atom, requesters=tuple(named))
+        for atom, named in requesters.items()
+    )

--- a/gentoo_install/plan/packages.py
+++ b/gentoo_install/plan/packages.py
@@ -523,6 +523,7 @@ def build(config: InstallConfig, catalog: Catalog) -> list[Operation]:
                     stage=Stage.PACKAGES,
                     packages=group.packages,
                     summary=f"install the {group.name} group",
+                    requester=f"the `{group.name}` group",
                 )
             )
         if group.package_use:

--- a/gentoo_install/plan/portage.py
+++ b/gentoo_install/plan/portage.py
@@ -415,6 +415,8 @@ class Emerge(Operation):
     stage: Stage = Stage.PACKAGES
     packages: tuple[str, ...]
     summary: str
+    requester: str = ""
+    repository_bootstrap: bool = False
     oneshot: bool = False
     binary_packages: bool = True
     #: Which of `packages` have to be built here when the rest may come from a
@@ -428,6 +430,10 @@ class Emerge(Operation):
     #: run spent 132 seconds rebuilding `sys-apps/systemd` at the bootloader
     #: stage with the same flags it had been built with at the kernel stage.
     only_if_absent: bool = False
+
+    @property
+    def package_requester(self) -> str:
+        return self.requester or f"the `{self.summary}` operation"
 
     def describe(self) -> str:
         built = self._built_here()
@@ -556,64 +562,87 @@ class ConfigureBinhost(Operation):
 
 
 @dataclass(frozen=True, kw_only=True)
-class VerifyPackages(Operation):
-    """Every atom the operator typed has to resolve, and be installable.
+class PackageRequest:
+    atom: str
+    requesters: tuple[str, ...]
 
-    Asked here, right after the tree is synced and before anything is built: an
-    atom that names nothing, or one whose licence `ACCEPT_LICENSE` refuses,
-    otherwise stops the run at the packages stage, hours in and with the disks
-    already written.
-    """
+
+@dataclass(frozen=True, kw_only=True)
+class VerifyPackages(Operation):
+    """Repository bootstrap merges make repositories reachable, so they precede this check."""
 
     stage: Stage = Stage.PORTAGE
-    packages: tuple[str, ...]
+    requests: tuple[PackageRequest, ...]
 
     def describe(self) -> str:
-        return f"check that {' '.join(self.packages)} name packages this system will install"
-
+        return (
+            f"resolve {' '.join(request.atom for request in self.requests)} together "
+            "before installing the requested packages"
+        )
 
     def apply(self, context: Context) -> None:
-        missing: list[str] = []
-        refused: list[str] = []
-        rejected: list[str] = []
-        for atom in self.packages:
-            probe = ["emerge", "--pretend", "--quiet", "--nodeps", "--", atom]
-            output = context.run_in_target(probe, check=False)
-            if NO_EBUILD in output:
-                missing.append(atom)
-            elif LICENCE_MASKED in output:
-                # Told apart because the answers differ: one is a typo, the
-                # other is a licence the operator chose not to accept.
-                refused.append(atom)
-            elif isinstance(output, CommandOutput) and output.returncode != 0:
-                detail = next(
-                    (line.strip().removeprefix("!!! ") for line in output.splitlines() if line.strip()),
-                    "no output",
-                )
-                rejected.append(f"{atom}: {detail}")
+        atoms = tuple(request.atom for request in self.requests)
+        output = context.run_in_target(
+            ["emerge", "--pretend", "--quiet", "--", *atoms], check=False
+        )
+        if not isinstance(output, CommandOutput):
+            raise ConfigError("emerge --pretend returned no exit status")
+        if output.returncode == 0:
+            return
+
         problems: list[str] = []
-        if missing:
-            problems.append(
-                f"no ebuild matches {', '.join(missing)}; check the name, or add the "
-                "overlay that carries it"
+        for request in self.requests:
+            available = context.run_in_target(
+                [
+                    "portageq",
+                    "pquery",
+                    "--no-version",
+                    "--no-filters",
+                    request.atom,
+                ]
             )
-        if refused:
-            problems.append(
-                f"ACCEPT_LICENSE refuses {', '.join(refused)}; widen it on the compiler "
-                "screen, or drop the package"
+            if not available.strip():
+                problems.append(
+                    f"{_requesters_ask(request)} for `{request.atom}`, which the target's "
+                    "repositories do not carry"
+                )
+                continue
+            visible = context.run_in_target(
+                ["portageq", "best_visible", "/", request.atom], check=False
             )
-        if rejected:
-            problems.append(f"emerge --pretend rejected {'; '.join(rejected)}")
+            if not isinstance(visible, CommandOutput):
+                raise ConfigError("portageq best_visible returned no exit status")
+            if visible.returncode == 1:
+                problems.append(
+                    f"{_requesters_ask(request)} for `{request.atom}`, which the target's "
+                    "configuration masks"
+                )
+            elif visible.returncode != 0:
+                raise ConfigError(
+                    f"portageq best_visible failed for `{request.atom}` with exit "
+                    f"{visible.returncode}"
+                )
         if problems:
             raise ConfigError("; ".join(problems))
 
+        detail = next(
+            (line.strip().removeprefix("!!! ") for line in output.splitlines() if line.strip()),
+            "no output",
+        )
+        requesters = tuple(
+            dict.fromkeys(
+                requester for request in self.requests for requester in request.requesters
+            )
+        )
+        raise ConfigError(
+            f"emerge --pretend rejected packages requested by {', '.join(requesters)}: {detail}"
+        )
 
-#: What Portage prints for an atom no ebuild matches, and for one every ebuild
-#: of which a licence masks. Taken from real `emerge --pretend --quiet` output:
-#: a substring test over the whole text matched the letters of `license` in a
-#: path or an atom and reported a typo as a licence refusal.
-NO_EBUILD: Final[str] = "there are no ebuilds to satisfy"
-LICENCE_MASKED: Final[str] = "license(s))"
+
+def _requesters_ask(request: PackageRequest) -> str:
+    if len(request.requesters) == 1:
+        return f"{request.requesters[0]} asks"
+    return f"{', '.join(request.requesters[:-1])} and {request.requesters[-1]} ask"
 
 
 @dataclass(frozen=True, kw_only=True)
@@ -698,6 +727,7 @@ def build(
                 stage=Stage.PORTAGE,
                 packages=("dev-vcs/git",),
                 summary="install git, which every later repository sync needs",
+                repository_bootstrap=True,
             ),
             ConfigureRepository(
                 name="gentoo",
@@ -734,6 +764,7 @@ def build(
                 stage=Stage.PORTAGE,
                 packages=("dev-vcs/git",),
                 summary="install git, which the overlays are cloned with",
+                repository_bootstrap=True,
             )
         )
     for overlay in portage.overlays:
@@ -752,8 +783,6 @@ def build(
         # Before the check below: an atom accepted as testing is one the
         # verifier would otherwise report as having no ebuild at all.
         operations.append(AcceptTestingPackages(packages=portage.testing_packages))
-    if config.packages.extra:
-        operations.append(VerifyPackages(packages=config.packages.extra))
     if portage.binhost.community is not BinhostChannel.OFF:
         operations += [
             Emerge(
@@ -761,6 +790,7 @@ def build(
                 packages=("sec-keys/openpgp-keys-gentoozh",),
                 summary="install the key the community binary packages are signed with",
                 binary_packages=False,
+                repository_bootstrap=True,
             ),
             TrustBinhostKey(
                 binhost="gentoo-zh",

--- a/tests/golden/btrfs-luks.txt
+++ b/tests/golden/btrfs-luks.txt
@@ -43,9 +43,14 @@
   install the key the community binary packages are signed with: emerge sec-keys/openpgp-keys-gentoozh, from source
   import 38A0234EC16AD42E from /usr/share/openpgp-keys/gentoozh.asc and locally sign it for gentoo-zh
   add verified binary package host gentoo-zh at https://distfiles.gentoozh.org/binpkgs/x86-64
+  set sys-kernel/installkernel to dracut
   ask for sys-apps/systemd[cryptsetup], which provides the unlock generator
+  accept the linux-firmware licence
+  accept sys-kernel/gentoo-cjk-kernel-bin as testing, with cjk off
+  unmask virtual/dist-kernel, which the cjk kernel depends on by revision
   ask for app-i18n/fcitx-configtool kcm for the plasma group
   ask for app-i18n/rime-data extra for the rime-simplified group
+  resolve app-admin/sudo net-misc/openssh sys-process/cronie sys-kernel/installkernel sys-apps/systemd sys-kernel/dracut sys-kernel/linux-firmware sys-fs/cryptsetup sys-fs/btrfs-progs sys-fs/dosfstools sys-kernel/gentoo-cjk-kernel-bin sys-boot/grub sys-boot/efibootmgr kde-plasma/plasma-meta x11-base/xorg-server kde-apps/konsole kde-apps/dolphin app-i18n/fcitx app-i18n/fcitx-gtk app-i18n/fcitx-qt app-i18n/fcitx-configtool app-i18n/fcitx-rime app-i18n/rime-data media-fonts/noto-cjk media-fonts/noto media-libs/fontconfig net-proxy/flclash-bin together before installing the requested packages
 
 [system]
   generate and verify locales en_US.UTF-8, zh_TW.UTF-8
@@ -72,13 +77,9 @@
   enable cronie at boot
 
 [kernel]
-  set sys-kernel/installkernel to dracut
   install the hook that puts a kernel in /boot: emerge sys-kernel/installkernel
   rebuild systemd with the unlock generator: emerge sys-apps/systemd, from source
-  accept the linux-firmware licence
   install the initramfs builder and firmware: emerge sys-kernel/dracut sys-kernel/linux-firmware
-  accept sys-kernel/gentoo-cjk-kernel-bin as testing, with cjk off
-  unmask virtual/dist-kernel, which the cjk kernel depends on by revision
   install the storage tools: emerge sys-fs/cryptsetup sys-fs/btrfs-progs sys-fs/dosfstools
   install the kernel: emerge sys-kernel/gentoo-cjk-kernel-bin, from source
   tell dracut to carry crypt, btrfs

--- a/tests/golden/ext4-bios.txt
+++ b/tests/golden/ext4-bios.txt
@@ -27,6 +27,9 @@
   install git, which every later repository sync needs: emerge dev-vcs/git
   point repository gentoo at https://github.com/gentoo-mirror/gentoo.git, commit signatures verified
   sync repository gentoo
+  set sys-kernel/installkernel to dracut
+  accept the linux-firmware licence
+  resolve net-misc/netifrc net-misc/dhcpcd app-admin/sysklogd sys-process/cronie sys-kernel/installkernel sys-kernel/dracut sys-kernel/linux-firmware sys-fs/e2fsprogs sys-kernel/gentoo-kernel-bin sys-boot/grub together before installing the requested packages
 
 [system]
   generate and verify locales en_US.UTF-8
@@ -48,9 +51,7 @@
   enable cronie in the default runlevel
 
 [kernel]
-  set sys-kernel/installkernel to dracut
   install the hook that puts a kernel in /boot: emerge sys-kernel/installkernel
-  accept the linux-firmware licence
   install the initramfs builder and firmware: emerge sys-kernel/dracut sys-kernel/linux-firmware
   install the storage tools: emerge sys-fs/e2fsprogs
   install the kernel: emerge sys-kernel/gentoo-kernel-bin

--- a/tests/golden/mbr-edit.txt
+++ b/tests/golden/mbr-edit.txt
@@ -26,6 +26,9 @@
   install git, which every later repository sync needs: emerge dev-vcs/git
   point repository gentoo at https://github.com/gentoo-mirror/gentoo.git, commit signatures verified
   sync repository gentoo
+  set sys-kernel/installkernel to dracut
+  accept the linux-firmware licence
+  resolve net-misc/netifrc net-misc/dhcpcd app-admin/sysklogd sys-process/cronie sys-kernel/installkernel sys-kernel/dracut sys-kernel/linux-firmware sys-fs/e2fsprogs sys-kernel/gentoo-kernel-bin sys-boot/grub together before installing the requested packages
 
 [system]
   generate and verify locales en_US.UTF-8
@@ -47,9 +50,7 @@
   enable cronie in the default runlevel
 
 [kernel]
-  set sys-kernel/installkernel to dracut
   install the hook that puts a kernel in /boot: emerge sys-kernel/installkernel
-  accept the linux-firmware licence
   install the initramfs builder and firmware: emerge sys-kernel/dracut sys-kernel/linux-firmware
   install the storage tools: emerge sys-fs/e2fsprogs
   install the kernel: emerge sys-kernel/gentoo-kernel-bin

--- a/tests/golden/openrc-sdboot.txt
+++ b/tests/golden/openrc-sdboot.txt
@@ -30,7 +30,10 @@
   install git, which every later repository sync needs: emerge dev-vcs/git
   point repository gentoo at https://github.com/gentoo-mirror/gentoo.git, commit signatures verified
   sync repository gentoo
+  set sys-kernel/installkernel to dracut systemd systemd-boot
+  accept the linux-firmware licence
   ask for sys-apps/systemd-utils[boot,kernel-install], which is what provides bootctl
+  resolve net-misc/netifrc net-misc/dhcpcd app-admin/sysklogd sys-process/cronie sys-kernel/installkernel sys-kernel/dracut sys-kernel/linux-firmware sys-fs/dosfstools sys-fs/e2fsprogs sys-kernel/gentoo-kernel-bin sys-apps/systemd-utils together before installing the requested packages
 
 [system]
   generate and verify locales en_US.UTF-8
@@ -52,10 +55,8 @@
   enable cronie in the default runlevel
 
 [kernel]
-  set sys-kernel/installkernel to dracut systemd systemd-boot
   write /etc/kernel/cmdline so the boot entries mount rootpart
   install the hook that puts a kernel in /boot: emerge sys-kernel/installkernel
-  accept the linux-firmware licence
   install the initramfs builder and firmware: emerge sys-kernel/dracut sys-kernel/linux-firmware
   install the storage tools: emerge sys-fs/dosfstools sys-fs/e2fsprogs
   install the kernel: emerge sys-kernel/gentoo-kernel-bin

--- a/tests/golden/vm-binpkg.txt
+++ b/tests/golden/vm-binpkg.txt
@@ -30,6 +30,9 @@
   install git, which every later repository sync needs: emerge dev-vcs/git
   point repository gentoo at https://github.com/gentoo-mirror/gentoo.git, commit signatures verified
   sync repository gentoo
+  set sys-kernel/installkernel to dracut
+  accept the linux-firmware licence
+  resolve net-misc/openssh sys-process/cronie sys-kernel/installkernel sys-kernel/dracut sys-kernel/linux-firmware sys-fs/dosfstools sys-fs/e2fsprogs sys-kernel/gentoo-kernel-bin sys-boot/grub sys-boot/efibootmgr together before installing the requested packages
 
 [system]
   generate and verify locales en_US.UTF-8
@@ -52,9 +55,7 @@
   enable cronie at boot
 
 [kernel]
-  set sys-kernel/installkernel to dracut
   install the hook that puts a kernel in /boot: emerge sys-kernel/installkernel
-  accept the linux-firmware licence
   install the initramfs builder and firmware: emerge sys-kernel/dracut sys-kernel/linux-firmware
   install the storage tools: emerge sys-fs/dosfstools sys-fs/e2fsprogs
   install the kernel: emerge sys-kernel/gentoo-kernel-bin

--- a/tests/golden/vm-bios-luks.txt
+++ b/tests/golden/vm-bios-luks.txt
@@ -33,6 +33,9 @@
   install git, which every later repository sync needs: emerge dev-vcs/git
   point repository gentoo at https://github.com/gentoo-mirror/gentoo.git, commit signatures verified
   sync repository gentoo
+  set sys-kernel/installkernel to dracut
+  accept the linux-firmware licence
+  resolve net-misc/netifrc net-misc/dhcpcd app-admin/sysklogd sys-process/cronie sys-kernel/installkernel sys-kernel/dracut sys-kernel/linux-firmware sys-fs/cryptsetup sys-fs/e2fsprogs sys-kernel/gentoo-kernel-bin sys-boot/grub together before installing the requested packages
 
 [system]
   generate and verify locales en_US.UTF-8
@@ -55,9 +58,7 @@
   enable cronie in the default runlevel
 
 [kernel]
-  set sys-kernel/installkernel to dracut
   install the hook that puts a kernel in /boot: emerge sys-kernel/installkernel
-  accept the linux-firmware licence
   install the initramfs builder and firmware: emerge sys-kernel/dracut sys-kernel/linux-firmware
   install the storage tools: emerge sys-fs/cryptsetup sys-fs/e2fsprogs
   install the kernel: emerge sys-kernel/gentoo-kernel-bin

--- a/tests/golden/vm-bios.txt
+++ b/tests/golden/vm-bios.txt
@@ -29,6 +29,9 @@
   install git, which every later repository sync needs: emerge dev-vcs/git
   point repository gentoo at https://github.com/gentoo-mirror/gentoo.git, commit signatures verified
   sync repository gentoo
+  set sys-kernel/installkernel to dracut
+  accept the linux-firmware licence
+  resolve net-misc/netifrc net-misc/dhcpcd app-admin/sysklogd sys-process/cronie sys-kernel/installkernel sys-kernel/dracut sys-kernel/linux-firmware sys-fs/e2fsprogs sys-kernel/gentoo-kernel-bin sys-boot/grub together before installing the requested packages
 
 [system]
   generate and verify locales en_US.UTF-8
@@ -50,9 +53,7 @@
   enable cronie in the default runlevel
 
 [kernel]
-  set sys-kernel/installkernel to dracut
   install the hook that puts a kernel in /boot: emerge sys-kernel/installkernel
-  accept the linux-firmware licence
   install the initramfs builder and firmware: emerge sys-kernel/dracut sys-kernel/linux-firmware
   install the storage tools: emerge sys-fs/e2fsprogs
   install the kernel: emerge sys-kernel/gentoo-kernel-bin

--- a/tests/golden/vm-btrfs.txt
+++ b/tests/golden/vm-btrfs.txt
@@ -33,6 +33,9 @@
   install git, which every later repository sync needs: emerge dev-vcs/git
   point repository gentoo at https://github.com/gentoo-mirror/gentoo.git, commit signatures verified
   sync repository gentoo
+  set sys-kernel/installkernel to dracut
+  accept the linux-firmware licence
+  resolve sys-process/cronie sys-kernel/installkernel sys-kernel/dracut sys-kernel/linux-firmware sys-fs/btrfs-progs sys-fs/dosfstools sys-kernel/gentoo-kernel-bin sys-boot/grub sys-boot/efibootmgr together before installing the requested packages
 
 [system]
   generate and verify locales en_US.UTF-8, zh_TW.UTF-8
@@ -51,9 +54,7 @@
   enable cronie at boot
 
 [kernel]
-  set sys-kernel/installkernel to dracut
   install the hook that puts a kernel in /boot: emerge sys-kernel/installkernel
-  accept the linux-firmware licence
   install the initramfs builder and firmware: emerge sys-kernel/dracut sys-kernel/linux-firmware
   install the storage tools: emerge sys-fs/btrfs-progs sys-fs/dosfstools
   install the kernel: emerge sys-kernel/gentoo-kernel-bin

--- a/tests/golden/vm-cjk-kernel.txt
+++ b/tests/golden/vm-cjk-kernel.txt
@@ -33,6 +33,11 @@
   point repository gentoo-zh at https://github.com/gentoo-zh/overlay.git
   sync repository gentoo-zh
   accept ~amd64 for packages from gentoo-zh only
+  set sys-kernel/installkernel to dracut
+  accept the linux-firmware licence
+  accept sys-kernel/gentoo-cjk-kernel-bin as testing, with cjk on
+  unmask virtual/dist-kernel, which the cjk kernel depends on by revision
+  resolve sys-process/cronie sys-kernel/installkernel sys-kernel/dracut sys-kernel/linux-firmware sys-fs/dosfstools sys-fs/e2fsprogs sys-kernel/gentoo-cjk-kernel-bin sys-boot/grub sys-boot/efibootmgr together before installing the requested packages
 
 [system]
   generate and verify locales en_US.UTF-8
@@ -51,12 +56,8 @@
   enable cronie at boot
 
 [kernel]
-  set sys-kernel/installkernel to dracut
   install the hook that puts a kernel in /boot: emerge sys-kernel/installkernel
-  accept the linux-firmware licence
   install the initramfs builder and firmware: emerge sys-kernel/dracut sys-kernel/linux-firmware
-  accept sys-kernel/gentoo-cjk-kernel-bin as testing, with cjk on
-  unmask virtual/dist-kernel, which the cjk kernel depends on by revision
   install the storage tools: emerge sys-fs/dosfstools sys-fs/e2fsprogs
   install the kernel: emerge sys-kernel/gentoo-cjk-kernel-bin, from source
   delete any kernel image in /boot that has no modules directory

--- a/tests/golden/vm-desktop.txt
+++ b/tests/golden/vm-desktop.txt
@@ -30,9 +30,12 @@
   install git, which every later repository sync needs: emerge dev-vcs/git
   point repository gentoo at https://github.com/gentoo-mirror/gentoo.git, commit signatures verified
   sync repository gentoo
+  set sys-kernel/installkernel to dracut
+  accept the linux-firmware licence
   ask for app-i18n/fcitx-configtool kcm for the plasma group
   ask for app-i18n/rime-data extra for the rime-simplified group
   ask for media-video/pipewire sound-server for the pipewire group
+  resolve net-misc/openssh net-misc/networkmanager net-wireless/wpa_supplicant sys-process/cronie sys-kernel/installkernel sys-kernel/dracut sys-kernel/linux-firmware sys-fs/dosfstools sys-fs/e2fsprogs sys-kernel/gentoo-kernel-bin sys-boot/grub sys-boot/efibootmgr kde-plasma/plasma-meta x11-base/xorg-server kde-apps/konsole kde-apps/dolphin app-i18n/fcitx app-i18n/fcitx-gtk app-i18n/fcitx-qt app-i18n/fcitx-configtool app-i18n/fcitx-rime app-i18n/rime-data media-fonts/noto-cjk media-fonts/noto media-libs/fontconfig media-video/pipewire media-video/wireplumber together before installing the requested packages
 
 [system]
   generate and verify locales en_US.UTF-8
@@ -55,9 +58,7 @@
   enable cronie at boot
 
 [kernel]
-  set sys-kernel/installkernel to dracut
   install the hook that puts a kernel in /boot: emerge sys-kernel/installkernel
-  accept the linux-firmware licence
   install the initramfs builder and firmware: emerge sys-kernel/dracut sys-kernel/linux-firmware
   install the storage tools: emerge sys-fs/dosfstools sys-fs/e2fsprogs
   install the kernel: emerge sys-kernel/gentoo-kernel-bin

--- a/tests/golden/vm-f2fs.txt
+++ b/tests/golden/vm-f2fs.txt
@@ -30,6 +30,9 @@
   install git, which every later repository sync needs: emerge dev-vcs/git
   point repository gentoo at https://github.com/gentoo-mirror/gentoo.git, commit signatures verified
   sync repository gentoo
+  set sys-kernel/installkernel to dracut
+  accept the linux-firmware licence
+  resolve net-misc/openssh sys-process/cronie sys-kernel/installkernel sys-kernel/dracut sys-kernel/linux-firmware sys-fs/dosfstools sys-fs/f2fs-tools sys-kernel/gentoo-kernel-bin sys-boot/grub sys-boot/efibootmgr together before installing the requested packages
 
 [system]
   generate and verify locales en_US.UTF-8
@@ -52,9 +55,7 @@
   enable cronie at boot
 
 [kernel]
-  set sys-kernel/installkernel to dracut
   install the hook that puts a kernel in /boot: emerge sys-kernel/installkernel
-  accept the linux-firmware licence
   install the initramfs builder and firmware: emerge sys-kernel/dracut sys-kernel/linux-firmware
   install the storage tools: emerge sys-fs/dosfstools sys-fs/f2fs-tools
   install the kernel: emerge sys-kernel/gentoo-kernel-bin

--- a/tests/golden/vm-gnome.txt
+++ b/tests/golden/vm-gnome.txt
@@ -30,8 +30,11 @@
   install git, which every later repository sync needs: emerge dev-vcs/git
   point repository gentoo at https://github.com/gentoo-mirror/gentoo.git, commit signatures verified
   sync repository gentoo
+  set sys-kernel/installkernel to dracut
+  accept the linux-firmware licence
   ask for gnome-base/gdm systemd; sys-auth/pambase systemd for the gdm group
   ask for media-video/pipewire sound-server for the pipewire group
+  resolve net-misc/openssh net-misc/networkmanager net-wireless/wpa_supplicant sys-process/cronie sys-kernel/installkernel sys-kernel/dracut sys-kernel/linux-firmware sys-fs/dosfstools sys-fs/e2fsprogs sys-kernel/gentoo-kernel-bin sys-boot/grub sys-boot/efibootmgr gnome-base/gnome-light x11-base/xorg-server gnome-base/gdm media-fonts/noto-cjk media-fonts/noto media-libs/fontconfig media-video/pipewire media-video/wireplumber together before installing the requested packages
 
 [system]
   generate and verify locales en_US.UTF-8
@@ -54,9 +57,7 @@
   enable cronie at boot
 
 [kernel]
-  set sys-kernel/installkernel to dracut
   install the hook that puts a kernel in /boot: emerge sys-kernel/installkernel
-  accept the linux-firmware licence
   install the initramfs builder and firmware: emerge sys-kernel/dracut sys-kernel/linux-firmware
   install the storage tools: emerge sys-fs/dosfstools sys-fs/e2fsprogs
   install the kernel: emerge sys-kernel/gentoo-kernel-bin

--- a/tests/golden/vm-luks.txt
+++ b/tests/golden/vm-luks.txt
@@ -37,7 +37,10 @@
   install git, which every later repository sync needs: emerge dev-vcs/git
   point repository gentoo at https://github.com/gentoo-mirror/gentoo.git, commit signatures verified
   sync repository gentoo
+  set sys-kernel/installkernel to dracut
   ask for sys-apps/systemd[cryptsetup], which provides the unlock generator
+  accept the linux-firmware licence
+  resolve sys-process/cronie sys-kernel/installkernel sys-apps/systemd sys-kernel/dracut sys-kernel/linux-firmware sys-fs/cryptsetup sys-fs/btrfs-progs sys-fs/dosfstools sys-kernel/gentoo-kernel-bin sys-boot/grub sys-boot/efibootmgr together before installing the requested packages
 
 [system]
   generate and verify locales en_US.UTF-8, zh_TW.UTF-8
@@ -57,10 +60,8 @@
   enable cronie at boot
 
 [kernel]
-  set sys-kernel/installkernel to dracut
   install the hook that puts a kernel in /boot: emerge sys-kernel/installkernel
   rebuild systemd with the unlock generator: emerge sys-apps/systemd, from source
-  accept the linux-firmware licence
   install the initramfs builder and firmware: emerge sys-kernel/dracut sys-kernel/linux-firmware
   install the storage tools: emerge sys-fs/cryptsetup sys-fs/btrfs-progs sys-fs/dosfstools
   install the kernel: emerge sys-kernel/gentoo-kernel-bin

--- a/tests/golden/vm-lvm.txt
+++ b/tests/golden/vm-lvm.txt
@@ -39,6 +39,9 @@
   point repository gentoo at https://github.com/gentoo-mirror/gentoo.git, commit signatures verified
   sync repository gentoo
   ask for sys-fs/lvm2[lvm], which dracut needs and the default build lacks
+  set sys-kernel/installkernel to dracut
+  accept the linux-firmware licence
+  resolve net-misc/netifrc net-misc/dhcpcd app-admin/sysklogd sys-process/cronie sys-kernel/installkernel sys-kernel/dracut sys-kernel/linux-firmware sys-fs/dosfstools sys-fs/e2fsprogs sys-fs/lvm2 sys-kernel/gentoo-kernel-bin sys-boot/grub sys-boot/efibootmgr together before installing the requested packages
 
 [system]
   generate and verify locales en_US.UTF-8
@@ -60,9 +63,7 @@
   enable cronie in the default runlevel
 
 [kernel]
-  set sys-kernel/installkernel to dracut
   install the hook that puts a kernel in /boot: emerge sys-kernel/installkernel
-  accept the linux-firmware licence
   install the initramfs builder and firmware: emerge sys-kernel/dracut sys-kernel/linux-firmware
   install the storage tools: emerge sys-fs/dosfstools sys-fs/e2fsprogs
   install the storage tools that need a flag the default build lacks: emerge sys-fs/lvm2, from source

--- a/tests/golden/vm-mdraid.txt
+++ b/tests/golden/vm-mdraid.txt
@@ -38,6 +38,9 @@
   install git, which every later repository sync needs: emerge dev-vcs/git
   point repository gentoo at https://github.com/gentoo-mirror/gentoo.git, commit signatures verified
   sync repository gentoo
+  set sys-kernel/installkernel to dracut
+  accept the linux-firmware licence
+  resolve sys-process/cronie sys-kernel/installkernel sys-kernel/dracut sys-kernel/linux-firmware sys-fs/mdadm sys-fs/dosfstools sys-fs/e2fsprogs sys-kernel/gentoo-kernel-bin sys-boot/grub sys-boot/efibootmgr together before installing the requested packages
 
 [system]
   generate and verify locales en_US.UTF-8
@@ -57,9 +60,7 @@
   enable cronie at boot
 
 [kernel]
-  set sys-kernel/installkernel to dracut
   install the hook that puts a kernel in /boot: emerge sys-kernel/installkernel
-  accept the linux-firmware licence
   install the initramfs builder and firmware: emerge sys-kernel/dracut sys-kernel/linux-firmware
   install the storage tools: emerge sys-fs/mdadm sys-fs/dosfstools sys-fs/e2fsprogs
   install the kernel: emerge sys-kernel/gentoo-kernel-bin

--- a/tests/golden/vm-openrc-desktop.txt
+++ b/tests/golden/vm-openrc-desktop.txt
@@ -30,8 +30,11 @@
   install git, which every later repository sync needs: emerge dev-vcs/git
   point repository gentoo at https://github.com/gentoo-mirror/gentoo.git, commit signatures verified
   sync repository gentoo
+  set sys-kernel/installkernel to dracut
+  accept the linux-firmware licence
   ask for x11-misc/lightdm elogind; sys-auth/pambase elogind for the lightdm group
   ask for media-video/pipewire sound-server for the pipewire group
+  resolve net-misc/openssh net-misc/networkmanager net-wireless/wpa_supplicant app-admin/sysklogd sys-process/cronie sys-kernel/installkernel sys-kernel/dracut sys-kernel/linux-firmware sys-fs/dosfstools sys-fs/e2fsprogs sys-kernel/gentoo-kernel-bin sys-boot/grub sys-boot/efibootmgr xfce-base/xfce4-meta x11-base/xorg-server x11-misc/lightdm x11-misc/lightdm-gtk-greeter gui-libs/display-manager-init media-video/pipewire media-video/wireplumber sys-apps/dbus sys-auth/elogind together before installing the requested packages
 
 [system]
   generate and verify locales en_US.UTF-8
@@ -57,9 +60,7 @@
   enable cronie in the default runlevel
 
 [kernel]
-  set sys-kernel/installkernel to dracut
   install the hook that puts a kernel in /boot: emerge sys-kernel/installkernel
-  accept the linux-firmware licence
   install the initramfs builder and firmware: emerge sys-kernel/dracut sys-kernel/linux-firmware
   install the storage tools: emerge sys-fs/dosfstools sys-fs/e2fsprogs
   install the kernel: emerge sys-kernel/gentoo-kernel-bin

--- a/tests/golden/vm-raidz.txt
+++ b/tests/golden/vm-raidz.txt
@@ -45,7 +45,11 @@
   point repository gentoo-zh at https://github.com/gentoo-zh/overlay.git
   sync repository gentoo-zh
   accept ~amd64 for packages from gentoo-zh only
+  set sys-kernel/installkernel to dracut, installing into /boot
+  accept the linux-firmware licence
+  tell sys-fs/zfs to build against the dist-kernel
   ask for sys-apps/systemd[boot,kernel-install], which is what provides bootctl
+  resolve sys-process/cronie sys-kernel/installkernel sys-kernel/dracut sys-kernel/linux-firmware sys-fs/dosfstools sys-kernel/gentoo-kernel-bin sys-fs/zfs sys-boot/zfsbootmenu sys-boot/efibootmgr sys-apps/systemd together before installing the requested packages
 
 [system]
   generate and verify locales en_US.UTF-8
@@ -64,12 +68,9 @@
   enable cronie at boot
 
 [kernel]
-  set sys-kernel/installkernel to dracut, installing into /boot
   install the hook that puts a kernel in /boot: emerge sys-kernel/installkernel
-  accept the linux-firmware licence
   install the initramfs builder and firmware: emerge sys-kernel/dracut sys-kernel/linux-firmware
   install the storage tools: emerge sys-fs/dosfstools
-  tell sys-fs/zfs to build against the dist-kernel
   install the kernel and the tools that build a module for it: emerge sys-kernel/gentoo-kernel-bin sys-fs/zfs, building sys-fs/zfs here
   tell dracut to carry zfs
   copy the installing system's hostid into the target so the pool imports

--- a/tests/golden/vm-sdboot.txt
+++ b/tests/golden/vm-sdboot.txt
@@ -30,7 +30,10 @@
   install git, which every later repository sync needs: emerge dev-vcs/git
   point repository gentoo at https://github.com/gentoo-mirror/gentoo.git, commit signatures verified
   sync repository gentoo
+  set sys-kernel/installkernel to dracut systemd systemd-boot
+  accept the linux-firmware licence
   ask for sys-apps/systemd[boot,kernel-install], which is what provides bootctl
+  resolve sys-process/cronie sys-kernel/installkernel sys-kernel/dracut sys-kernel/linux-firmware sys-fs/dosfstools sys-fs/e2fsprogs sys-kernel/gentoo-kernel-bin sys-apps/systemd together before installing the requested packages
 
 [system]
   generate and verify locales en_US.UTF-8
@@ -49,10 +52,8 @@
   enable cronie at boot
 
 [kernel]
-  set sys-kernel/installkernel to dracut systemd systemd-boot
   write /etc/kernel/cmdline so the boot entries mount rootpart
   install the hook that puts a kernel in /boot: emerge sys-kernel/installkernel
-  accept the linux-firmware licence
   install the initramfs builder and firmware: emerge sys-kernel/dracut sys-kernel/linux-firmware
   install the storage tools: emerge sys-fs/dosfstools sys-fs/e2fsprogs
   install the kernel: emerge sys-kernel/gentoo-kernel-bin

--- a/tests/golden/vm-unlock.txt
+++ b/tests/golden/vm-unlock.txt
@@ -37,7 +37,11 @@
   install git, which every later repository sync needs: emerge dev-vcs/git
   point repository gentoo at https://github.com/gentoo-mirror/gentoo.git, commit signatures verified
   sync repository gentoo
+  set sys-kernel/installkernel to dracut
   ask for sys-apps/systemd[cryptsetup], which provides the unlock generator
+  accept the linux-firmware licence
+  configure remote unlock over ssh on port 2222
+  resolve net-misc/openssh sys-process/cronie sys-kernel/installkernel sys-apps/systemd sys-kernel/dracut sys-kernel/linux-firmware sys-kernel/dracut-crypt-ssh sys-fs/cryptsetup sys-fs/btrfs-progs sys-fs/dosfstools sys-kernel/gentoo-kernel-bin sys-boot/grub sys-boot/efibootmgr together before installing the requested packages
 
 [system]
   generate and verify locales en_US.UTF-8, zh_TW.UTF-8
@@ -62,12 +66,9 @@
   enable cronie at boot
 
 [kernel]
-  set sys-kernel/installkernel to dracut
   install the hook that puts a kernel in /boot: emerge sys-kernel/installkernel
   rebuild systemd with the unlock generator: emerge sys-apps/systemd, from source
-  accept the linux-firmware licence
   install the initramfs builder and firmware: emerge sys-kernel/dracut sys-kernel/linux-firmware
-  configure remote unlock over ssh on port 2222
   install the initramfs ssh daemon: emerge sys-kernel/dracut-crypt-ssh
   install the storage tools: emerge sys-fs/cryptsetup sys-fs/btrfs-progs sys-fs/dosfstools
   install the kernel: emerge sys-kernel/gentoo-kernel-bin

--- a/tests/golden/vm-xfs.txt
+++ b/tests/golden/vm-xfs.txt
@@ -30,6 +30,9 @@
   install git, which every later repository sync needs: emerge dev-vcs/git
   point repository gentoo at https://github.com/gentoo-mirror/gentoo.git, commit signatures verified
   sync repository gentoo
+  set sys-kernel/installkernel to dracut
+  accept the linux-firmware licence
+  resolve net-misc/openssh sys-process/cronie sys-kernel/installkernel sys-kernel/dracut sys-kernel/linux-firmware sys-fs/dosfstools sys-fs/xfsprogs sys-kernel/gentoo-kernel-bin sys-boot/grub sys-boot/efibootmgr together before installing the requested packages
 
 [system]
   generate and verify locales en_US.UTF-8
@@ -52,9 +55,7 @@
   enable cronie at boot
 
 [kernel]
-  set sys-kernel/installkernel to dracut
   install the hook that puts a kernel in /boot: emerge sys-kernel/installkernel
-  accept the linux-firmware licence
   install the initramfs builder and firmware: emerge sys-kernel/dracut sys-kernel/linux-firmware
   install the storage tools: emerge sys-fs/dosfstools sys-fs/xfsprogs
   install the kernel: emerge sys-kernel/gentoo-kernel-bin

--- a/tests/golden/vm-zfs-encrypted.txt
+++ b/tests/golden/vm-zfs-encrypted.txt
@@ -37,7 +37,11 @@
   point repository gentoo-zh at https://github.com/gentoo-zh/overlay.git
   sync repository gentoo-zh
   accept ~amd64 for packages from gentoo-zh only
+  set sys-kernel/installkernel to dracut, installing into /boot
+  accept the linux-firmware licence
+  tell sys-fs/zfs to build against the dist-kernel
   ask for sys-apps/systemd[boot,kernel-install], which is what provides bootctl
+  resolve sys-process/cronie sys-kernel/installkernel sys-kernel/dracut sys-kernel/linux-firmware sys-fs/dosfstools sys-kernel/gentoo-kernel-bin sys-fs/zfs sys-boot/zfsbootmenu sys-boot/efibootmgr sys-apps/systemd together before installing the requested packages
 
 [system]
   generate and verify locales en_US.UTF-8
@@ -56,12 +60,9 @@
   enable cronie at boot
 
 [kernel]
-  set sys-kernel/installkernel to dracut, installing into /boot
   install the hook that puts a kernel in /boot: emerge sys-kernel/installkernel
-  accept the linux-firmware licence
   install the initramfs builder and firmware: emerge sys-kernel/dracut sys-kernel/linux-firmware
   install the storage tools: emerge sys-fs/dosfstools
-  tell sys-fs/zfs to build against the dist-kernel
   install the kernel and the tools that build a module for it: emerge sys-kernel/gentoo-kernel-bin sys-fs/zfs, building sys-fs/zfs here
   tell dracut to carry zfs
   put the rpool key in /etc/zfs/rpool.key so only ZFSBootMenu asks for it

--- a/tests/golden/vm-zfs-mirror.txt
+++ b/tests/golden/vm-zfs-mirror.txt
@@ -41,7 +41,11 @@
   point repository gentoo-zh at https://github.com/gentoo-zh/overlay.git
   sync repository gentoo-zh
   accept ~amd64 for packages from gentoo-zh only
+  set sys-kernel/installkernel to dracut, installing into /boot
+  accept the linux-firmware licence
+  tell sys-fs/zfs to build against the dist-kernel
   ask for sys-apps/systemd[boot,kernel-install], which is what provides bootctl
+  resolve sys-process/cronie sys-kernel/installkernel sys-kernel/dracut sys-kernel/linux-firmware sys-fs/dosfstools sys-kernel/gentoo-kernel-bin sys-fs/zfs sys-boot/zfsbootmenu sys-boot/efibootmgr sys-apps/systemd together before installing the requested packages
 
 [system]
   generate and verify locales en_US.UTF-8
@@ -60,12 +64,9 @@
   enable cronie at boot
 
 [kernel]
-  set sys-kernel/installkernel to dracut, installing into /boot
   install the hook that puts a kernel in /boot: emerge sys-kernel/installkernel
-  accept the linux-firmware licence
   install the initramfs builder and firmware: emerge sys-kernel/dracut sys-kernel/linux-firmware
   install the storage tools: emerge sys-fs/dosfstools
-  tell sys-fs/zfs to build against the dist-kernel
   install the kernel and the tools that build a module for it: emerge sys-kernel/gentoo-kernel-bin sys-fs/zfs, building sys-fs/zfs here
   tell dracut to carry zfs
   copy the installing system's hostid into the target so the pool imports

--- a/tests/golden/vm-zfs.txt
+++ b/tests/golden/vm-zfs.txt
@@ -37,7 +37,11 @@
   point repository gentoo-zh at https://github.com/gentoo-zh/overlay.git
   sync repository gentoo-zh
   accept ~amd64 for packages from gentoo-zh only
+  set sys-kernel/installkernel to dracut, installing into /boot
+  accept the linux-firmware licence
+  tell sys-fs/zfs to build against the dist-kernel
   ask for sys-apps/systemd[boot,kernel-install], which is what provides bootctl
+  resolve sys-process/cronie sys-kernel/installkernel sys-kernel/dracut sys-kernel/linux-firmware sys-fs/dosfstools sys-kernel/gentoo-kernel-bin sys-fs/zfs sys-boot/zfsbootmenu sys-boot/efibootmgr sys-apps/systemd together before installing the requested packages
 
 [system]
   generate and verify locales en_US.UTF-8
@@ -56,12 +60,9 @@
   enable cronie at boot
 
 [kernel]
-  set sys-kernel/installkernel to dracut, installing into /boot
   install the hook that puts a kernel in /boot: emerge sys-kernel/installkernel
-  accept the linux-firmware licence
   install the initramfs builder and firmware: emerge sys-kernel/dracut sys-kernel/linux-firmware
   install the storage tools: emerge sys-fs/dosfstools
-  tell sys-fs/zfs to build against the dist-kernel
   install the kernel and the tools that build a module for it: emerge sys-kernel/gentoo-kernel-bin sys-fs/zfs, building sys-fs/zfs here
   tell dracut to carry zfs
   copy the installing system's hostid into the target so the pool imports

--- a/tests/golden/vm-zram.txt
+++ b/tests/golden/vm-zram.txt
@@ -30,6 +30,9 @@
   install git, which every later repository sync needs: emerge dev-vcs/git
   point repository gentoo at https://github.com/gentoo-mirror/gentoo.git, commit signatures verified
   sync repository gentoo
+  set sys-kernel/installkernel to dracut
+  accept the linux-firmware licence
+  resolve sys-apps/zram-generator net-misc/openssh sys-process/cronie sys-kernel/installkernel sys-kernel/dracut sys-kernel/linux-firmware sys-fs/dosfstools sys-fs/xfsprogs sys-kernel/gentoo-kernel-bin sys-boot/grub sys-boot/efibootmgr together before installing the requested packages
 
 [system]
   generate and verify locales en_US.UTF-8
@@ -54,9 +57,7 @@
   enable cronie at boot
 
 [kernel]
-  set sys-kernel/installkernel to dracut
   install the hook that puts a kernel in /boot: emerge sys-kernel/installkernel
-  accept the linux-firmware licence
   install the initramfs builder and firmware: emerge sys-kernel/dracut sys-kernel/linux-firmware
   install the storage tools: emerge sys-fs/dosfstools sys-fs/xfsprogs
   install the kernel: emerge sys-kernel/gentoo-kernel-bin

--- a/tests/golden/zfs-zbm.txt
+++ b/tests/golden/zfs-zbm.txt
@@ -39,7 +39,14 @@
   point repository gentoo-zh at https://github.com/gentoo-zh/overlay.git
   sync repository gentoo-zh
   accept ~amd64 for packages from gentoo-zh only
+  set sys-kernel/installkernel to dracut, installing into /boot
+  accept the linux-firmware licence
+  write /etc/dracut.conf.d/crypt-ssh.conf to omit ssh from the system initramfs
+  accept sys-kernel/gentoo-cjk-kernel-bin as testing, with cjk on
+  unmask virtual/dist-kernel, which the cjk kernel depends on by revision
+  tell sys-fs/zfs to build against the dist-kernel
   ask for sys-apps/systemd[boot,kernel-install], which is what provides bootctl
+  resolve app-admin/sudo net-misc/openssh sys-process/cronie sys-kernel/installkernel sys-kernel/dracut sys-kernel/linux-firmware sys-kernel/dracut-crypt-ssh sys-fs/dosfstools sys-kernel/gentoo-cjk-kernel-bin sys-fs/zfs sys-boot/zfsbootmenu sys-boot/efibootmgr sys-apps/systemd sys-apps/kbd app-editors/vim together before installing the requested packages
 
 [system]
   generate and verify locales en_US.UTF-8, zh_TW.UTF-8
@@ -66,16 +73,10 @@
   enable cronie at boot
 
 [kernel]
-  set sys-kernel/installkernel to dracut, installing into /boot
   install the hook that puts a kernel in /boot: emerge sys-kernel/installkernel
-  accept the linux-firmware licence
   install the initramfs builder and firmware: emerge sys-kernel/dracut sys-kernel/linux-firmware
-  write /etc/dracut.conf.d/crypt-ssh.conf to omit ssh from the system initramfs
   install ZFSBootMenu ssh support: emerge sys-kernel/dracut-crypt-ssh
-  accept sys-kernel/gentoo-cjk-kernel-bin as testing, with cjk on
-  unmask virtual/dist-kernel, which the cjk kernel depends on by revision
   install the storage tools: emerge sys-fs/dosfstools
-  tell sys-fs/zfs to build against the dist-kernel
   install the kernel and the tools that build a module for it: emerge sys-kernel/gentoo-cjk-kernel-bin sys-fs/zfs, from source
   tell dracut to carry zfs
   put the zpcala key in /etc/zfs/zpcala.key so only ZFSBootMenu asks for it

--- a/tests/unit/test_plan_portage.py
+++ b/tests/unit/test_plan_portage.py
@@ -16,12 +16,15 @@ from gentoo_install.model.config import (
     MirrorConfig,
     MirrorRegion,
     Overlay,
+    PackagesConfig,
     PortageConfig,
     SystemConfig,
 )
 from gentoo_install.errors import CommandFailed, ConfigError, ValidationFailed
 from gentoo_install.plan import portage
+from gentoo_install.plan.build import PORTAGE_PREREQUISITES, build as build_plan
 from gentoo_install.plan.operations import CommandOutput, Operation
+from gentoo_install.plan.packages import Group
 
 from .layouts import config
 from .recorder import Recorder
@@ -354,15 +357,112 @@ PACKAGE_MASKED = (
 )
 
 
+def test_an_absent_catalog_atom_stops_the_run_and_names_its_group() -> None:
+    wanted = replace(
+        config(),
+        packages=PackagesConfig(applications=("plasma",)),
+    )
+    operations = build_plan(
+        wanted,
+        {"plasma": Group(name="plasma", packages=("kde-plasma/foo",))},
+    )
+    check = next(one for one in operations if isinstance(one, portage.VerifyPackages))
+    recorder = Recorder()
+
+    def answer(argv: Sequence[str]) -> str | None:
+        if argv[0] == "emerge":
+            return CommandOutput(NO_SUCH_PACKAGE, 1)
+        if argv[:4] == ["portageq", "pquery", "--no-version", "--no-filters"]:
+            return CommandOutput("" if argv[-1] == "kde-plasma/foo" else f"{argv[-1]}\n", 0)
+        if argv[:3] == ["portageq", "best_visible", "/"]:
+            return CommandOutput(f"{argv[-1]}-1\n", 0)
+        return None
+
+    recorder.answering = answer
+    with pytest.raises(
+        ConfigError,
+        match=r"the `plasma` group asks for `kde-plasma/foo`, which the target's repositories do not carry",
+    ):
+        check.apply(recorder)
+
+
+def test_every_requested_atom_is_resolved_in_one_pass_and_the_run_continues() -> None:
+    wanted = replace(
+        config(),
+        packages=PackagesConfig(applications=("plasma",)),
+    )
+    operations = build_plan(
+        wanted,
+        {"plasma": Group(name="plasma", packages=("kde-plasma/plasma-meta",))},
+    )
+    check = next(one for one in operations if isinstance(one, portage.VerifyPackages))
+    recorder = Recorder(replies={"emerge": CommandOutput("", 0)})
+
+    check.apply(recorder)
+
+    pretend = recorder.only("emerge", "--pretend", "--quiet")
+    atoms = pretend[pretend.index("--") + 1 :]
+    assert "kde-plasma/plasma-meta" in atoms
+    assert "sys-kernel/gentoo-kernel" in atoms
+    assert "sys-boot/grub" in atoms
+    assert "dev-vcs/git" not in atoms
+    assert len(atoms) == len(set(atoms))
+    assert len(recorder.argv_starting("emerge")) == 1
+    assert not recorder.argv_starting("portageq")
+
+
+def test_the_resolution_check_follows_repository_bootstrap_and_precedes_requested_merges() -> None:
+    wanted = replace(
+        config(),
+        portage=replace(
+            config().portage,
+            overlays=(Overlay(name="local", sync_uri="https://example.invalid/local.git"),),
+        ),
+        packages=PackagesConfig(applications=("plasma",)),
+    )
+    operations = build_plan(
+        wanted,
+        {"plasma": Group(name="plasma", packages=("kde-plasma/plasma-meta",))},
+    )
+    check = next(n for n, one in enumerate(operations) if isinstance(one, portage.VerifyPackages))
+    bootstrap = [
+        n
+        for n, one in enumerate(operations)
+        if isinstance(one, portage.Emerge) and one.repository_bootstrap
+    ]
+    requested = [
+        n
+        for n, one in enumerate(operations)
+        if isinstance(one, portage.Emerge) and not one.repository_bootstrap
+    ]
+
+    assert bootstrap and requested
+    assert max(bootstrap) < check < min(requested)
+    assert next(
+        n for n, one in enumerate(operations) if isinstance(one, portage.AcceptOverlayKeywords)
+    ) < check
+    assert all(
+        n < check
+        for n, one in enumerate(operations)
+        if isinstance(one, PORTAGE_PREREQUISITES)
+    )
+
+
 def test_a_package_name_that_matches_nothing_stops_before_the_disks_fill() -> None:
     """Asked once the tree is synced: otherwise the run dies at the packages
     stage, hours in and with the disks already written."""
-    recorder = Recorder()
-    recorder.replies["emerge"] = NO_SUCH_PACKAGE
-    with pytest.raises(ConfigError, match="no ebuild matches"):
-        portage.VerifyPackages(packages=("app-misc/not-a-real-package",)).apply(recorder)
-
-    portage.VerifyPackages(packages=("app-editors/neovim",)).apply(Recorder())
+    recorder = Recorder(
+        replies={"emerge": CommandOutput(NO_SUCH_PACKAGE, 1), "portageq": CommandOutput("", 0)}
+    )
+    check = portage.VerifyPackages(
+        requests=(
+            portage.PackageRequest(
+                atom="app-misc/not-a-real-package", requesters=("the extra packages group",)
+            ),
+        )
+    )
+    with pytest.raises(ConfigError, match="repositories do not carry"):
+        check.apply(recorder)
 
 
 def test_a_package_the_licence_refuses_is_named_as_that_and_not_as_a_typo() -> None:
@@ -370,16 +470,47 @@ def test_a_package_the_licence_refuses_is_named_as_that_and_not_as_a_typo() -> N
     ACCEPT_LICENSE to widen. Reporting both as "no ebuild matches" sends the
     operator hunting for a spelling mistake that is not there."""
     recorder = Recorder()
-    recorder.replies["emerge"] = LICENCE_REFUSED
-    with pytest.raises(ConfigError, match="ACCEPT_LICENSE refuses"):
-        portage.VerifyPackages(packages=("x11-drivers/nvidia-drivers",)).apply(recorder)
+
+    def answer(argv: Sequence[str]) -> str | None:
+        if argv[0] == "emerge":
+            return CommandOutput(LICENCE_REFUSED, 1)
+        if argv[1] == "pquery":
+            return CommandOutput("x11-drivers/nvidia-drivers\n", 0)
+        return CommandOutput("", 1)
+
+    recorder.answering = answer
+    check = portage.VerifyPackages(
+        requests=(
+            portage.PackageRequest(
+                atom="x11-drivers/nvidia-drivers", requesters=("the `nvidia` group",)
+            ),
+        )
+    )
+    with pytest.raises(ConfigError, match="configuration masks") as caught:
+        check.apply(recorder)
+    assert "repositories do not carry" not in str(caught.value)
 
 
 def test_an_unclassified_nonzero_package_probe_is_rejected() -> None:
     recorder = Recorder()
-    recorder.replies["emerge"] = CommandOutput(PACKAGE_MASKED, 1)
-    with pytest.raises(ConfigError, match=r"app-text/catdoc: All ebuilds.*masked"):
-        portage.VerifyPackages(packages=("app-text/catdoc",)).apply(recorder)
+
+    def answer(argv: Sequence[str]) -> str | None:
+        if argv[0] == "emerge":
+            return CommandOutput(PACKAGE_MASKED, 1)
+        if argv[1] == "pquery":
+            return CommandOutput("app-text/catdoc\n", 0)
+        return CommandOutput("app-text/catdoc-0.95-r1\n", 0)
+
+    recorder.answering = answer
+    check = portage.VerifyPackages(
+        requests=(
+            portage.PackageRequest(atom="app-text/catdoc", requesters=("the `catdoc` group",)),
+        )
+    )
+    with pytest.raises(
+        ConfigError, match=r"requested by the `catdoc` group: All ebuilds.*masked"
+    ):
+        check.apply(recorder)
 
 
 def test_the_word_license_in_a_path_is_not_a_licence_refusal() -> None:
@@ -387,19 +518,30 @@ def test_the_word_license_in_a_path_is_not_a_licence_refusal() -> None:
     names, and in `ACCEPT_LICENSE` itself. Matching it anywhere in the output
     reported a missing package as a licence the operator had refused."""
     recorder = Recorder()
-    recorder.replies["emerge"] = (
+    recorder.replies["emerge"] = CommandOutput(
         "\n[ebuild  N     ] app-misc/license-tools-1.0::gentoo\n"
-        "A copy of the 'GPL-2' license is located at /usr/portage/licenses/GPL-2.\n"
+        "A copy of the 'GPL-2' license is located at /usr/portage/licenses/GPL-2.\n",
+        0,
     )
-    portage.VerifyPackages(packages=("app-misc/license-tools",)).apply(recorder)
+    portage.VerifyPackages(
+        requests=(
+            portage.PackageRequest(
+                atom="app-misc/license-tools", requesters=("the `tools` group",)
+            ),
+        )
+    ).apply(recorder)
 
 
 def test_one_probe_per_package_and_not_two() -> None:
-    """It ran `emerge --pretend` twice for every atom that resolved, doubling
-    the cost of the check on a long list."""
-    recorder = Recorder()
-    portage.VerifyPackages(packages=("app-editors/neovim", "app-misc/tmux")).apply(recorder)
-    assert len([argv for argv in recorder.in_target if argv[0] == "emerge"]) == 2
+    """The package set is one dependency-aware question, not one per atom."""
+    recorder = Recorder(replies={"emerge": CommandOutput("", 0)})
+    portage.VerifyPackages(
+        requests=(
+            portage.PackageRequest(atom="app-editors/neovim", requesters=("the editor group",)),
+            portage.PackageRequest(atom="app-misc/tmux", requesters=("the console group",)),
+        )
+    ).apply(recorder)
+    assert len([argv for argv in recorder.in_target if argv[0] == "emerge"]) == 1
 
 
 def test_the_licence_choice_is_not_undone_by_autounmask() -> None:


### PR DESCRIPTION
`plan/portage.py` checked the atoms an operator typed and nothing else. Everything the catalogs, the kernel and the bootloader named went straight to `emerge`, so an atom renamed, removed or masked upstream was discovered after the disks were written and a stage3 unpacked — and the message named the atom without saying which group had asked for it.

One dependency-aware resolution over the complete set now runs after the profile, overlays, keywords, licences and USE files are in place and before the first package the configuration asked for. `dev-vcs/git` and anything else merged only to reach a repository still precedes it, because the check reads what those make reachable.

Absent is distinguished from masked by `portageq`, not by matching two English sentences out of `emerge` output, which is what the old check did.