### PR TITLE
vm: ask the hypervisor before calling a guest idle

### DIFF
--- a/tests/unit/test_cluster.py
+++ b/tests/unit/test_cluster.py
@@ -1,6 +1,8 @@
 from __future__ import annotations
 
+import time
 from collections.abc import Callable
+from io import BytesIO
 from pathlib import Path
 from typing import Any
 
@@ -8,6 +10,7 @@ import pytest
 
 from gentoo_install.model.config import MirrorRegion, Sync
 from tests.vm import cluster
+from tests.vm.console import ConsoleTimeout, SerialConsole
 from tests.vm.proxmox import Node, VMID_FIRST, VMID_LAST
 
 
@@ -136,3 +139,97 @@ def test_worker_failure_reports_outcome_and_releases_vmid(
     assert all(outcome.verdict is cluster.Verdict.ERROR for outcome in outcomes)
     assert all(outcome.vmid == VMID_FIRST for outcome in outcomes)
     assert api.allocations == [VMID_FIRST, VMID_FIRST]
+
+
+class TimedChannel:
+    def __init__(self, clock: list[float], output_at: float | None = None) -> None:
+        self._clock = clock
+        self._output_at = output_at
+        self._answered = False
+
+    def recv(self, size: int) -> bytes:
+        self._clock[0] += 1.0
+        if (
+            self._output_at is not None
+            and self._clock[0] >= self._output_at
+            and not self._answered
+        ):
+            self._answered = True
+            return b"MARK_1_DONE\n"
+        return b""
+
+    def sendall(self, data: bytes) -> None:
+        return None
+
+    def close(self) -> None:
+        return None
+
+    @property
+    def closed(self) -> bool:
+        return False
+
+
+def _timed_wait(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    clock: list[float],
+    counters: Callable[[], int | None],
+    output_at: float | None = None,
+) -> tuple[cluster.Reconnecting, cluster.Watchdog]:
+    monkeypatch.setattr(time, "monotonic", lambda: clock[0])
+    serial = SerialConsole(TimedChannel(clock, output_at), BytesIO())
+    link = cluster.Reconnecting(lambda: serial)
+    watch = cluster.Watchdog(tmp_path / "install.log", counters)
+    return link, watch
+
+
+def test_install_wait_continues_when_silent_guest_moves_bytes(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    clock = [0.0]
+    traffic = [0]
+
+    def counters() -> int:
+        traffic[0] += cluster.QUIET_BYTES * 2
+        return traffic[0]
+
+    link, watch = _timed_wait(monkeypatch, tmp_path, clock, counters, output_at=3.0)
+    link.wait_for("install", timeout=5.0, idle=2.0, watch=watch)
+
+    assert clock[0] == 3.0
+    assert traffic[0] == cluster.QUIET_BYTES * 2
+
+
+def test_install_wait_names_silent_console_and_flat_counters(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    clock = [0.0]
+    link, watch = _timed_wait(monkeypatch, tmp_path, clock, lambda: 0)
+    watch.log.write_bytes(b"output before the idle window\n")
+
+    with pytest.raises(ConsoleTimeout) as raised:
+        link.wait_for("install", timeout=5.0, idle=2.0, watch=watch)
+
+    message = str(raised.value)
+    assert clock[0] == 2.0
+    assert "console was silent" in message
+    assert "counters were flat" in message
+    assert "0 -> 0 bytes" in message
+
+
+def test_run_ceiling_ends_silent_guest_that_keeps_moving_bytes(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    clock = [0.0]
+    readings = [0]
+
+    def counters() -> int:
+        readings[0] += 1
+        return readings[0] * cluster.QUIET_BYTES * 2
+
+    link, watch = _timed_wait(monkeypatch, tmp_path, clock, counters)
+    with pytest.raises(ConsoleTimeout, match="never matched"):
+        link.wait_for("install", timeout=5.0, idle=2.0, watch=watch)
+
+    assert clock[0] == 5.0
+    assert readings[0] == 2

--- a/tests/unit/test_harness.py
+++ b/tests/unit/test_harness.py
@@ -626,7 +626,13 @@ def test_preinstall_console_timeout_is_an_error_with_its_phase(
         def run(self, command: str, timeout: float = 120.0) -> None:
             return None
 
-        def wait_for(self, command: str, timeout: float, idle: float = 0.0) -> None:
+        def wait_for(
+            self,
+            command: str,
+            timeout: float,
+            idle: float = 0.0,
+            watch: object | None = None,
+        ) -> None:
             return None
 
     class Links:

--- a/tests/vm/cluster.py
+++ b/tests/vm/cluster.py
@@ -54,6 +54,7 @@ from .console import (
     PASSPHRASE_PROMPT,
     PASSWORD_PROMPT,
     ConsoleClosed,
+    ConsoleIdle,
     ConsoleTimeout,
     SerialConsole,
 )
@@ -377,16 +378,25 @@ class Watchdog:
     strikes: int = 0
     _seen: int = field(default=0, init=False)
     _moved: int = field(default=0, init=False)
+    _counter_before: int = field(default=0, init=False)
+    _counter_after: int = field(default=0, init=False)
+    _lock: threading.Lock = field(default_factory=threading.Lock, init=False, repr=False)
 
     def moved(self) -> bool:
-        size = self.log.stat().st_size if self.log.exists() else 0
+        with self._lock:
+            size = self.log.stat().st_size if self.log.exists() else 0
+            talking = size > self._seen
+            self._seen = max(self._seen, size)
+            return self._observe(talking)
+
+    def _observe(self, talking: bool) -> bool:
         traffic = self.counters()
-        talking = size > self._seen
-        self._seen = max(self._seen, size)
         if traffic is None:
             if talking:
                 self.strikes = 0
             return True
+        self._counter_before = self._moved
+        self._counter_after = traffic
         working = traffic - self._moved >= QUIET_BYTES
         self._moved = max(self._moved, traffic)
         if talking or working:
@@ -394,6 +404,15 @@ class Watchdog:
             return True
         self.strikes += 1
         return False
+
+    def idle_reason(self) -> str | None:
+        with self._lock:
+            if self._observe(talking=False):
+                return None
+            return (
+                "counters were flat "
+                f"({self._counter_before} -> {self._counter_after} bytes)"
+            )
 
     @property
     def stuck(self) -> bool:
@@ -1053,6 +1072,7 @@ def install_one(
             f"echo $? > {RESULT_DIR}/install.rc; }} 2>&1 | tee {RESULT_DIR}/install.txt",
             timeout=RUN_CEILING,
             idle=INSTALL_IDLE,
+            watch=watch,
         )
         files = collect(guest, link, log)
         code = files.get("install.rc", b"").strip()
@@ -1450,7 +1470,13 @@ class Reconnecting:
 
         self._with_reconnect(timeout, run_once)
 
-    def wait_for(self, command: str, timeout: float, idle: float = 0.0) -> None:
+    def wait_for(
+        self,
+        command: str,
+        timeout: float,
+        idle: float = 0.0,
+        watch: Watchdog | None = None,
+    ) -> None:
         """Send a command once and wait for it however long it takes.
 
         Reconnecting does not re-send it: an install that is already running
@@ -1467,7 +1493,19 @@ class Reconnecting:
             if not sent:
                 sent = True
                 self.console.send(_marked(command, token))
-            self.console.expect(_done(token), _remaining(deadline), idle=idle)
+            while True:
+                try:
+                    self.console.expect(_done(token), _remaining(deadline), idle=idle)
+                    return
+                except ConsoleIdle as error:
+                    if watch is None:
+                        raise
+                    reason = watch.idle_reason()
+                    if reason is None:
+                        continue
+                    raise ConsoleTimeout(
+                        f"{error}; console was silent for {idle:.0f}s and {reason}"
+                    ) from error
 
         self._with_reconnect(timeout, wait_once)
 

--- a/tests/vm/console.py
+++ b/tests/vm/console.py
@@ -22,6 +22,10 @@ class ConsoleTimeout(Exception):
     """A pattern did not appear on the console within its deadline."""
 
 
+class ConsoleIdle(ConsoleTimeout):
+    """A pattern did not appear before the console stopped speaking."""
+
+
 class ConsoleClosed(Exception):
     """The guest closed the serial connection."""
 
@@ -137,7 +141,8 @@ class SerialConsole:
         # Two deadlines, whichever comes first: the ceiling bounds a guest that
         # prints for ever, and the idle window ends one that stopped.
         ceiling = time.monotonic() + timeout
-        deadline = min(ceiling, time.monotonic() + idle) if idle else ceiling
+        idle_deadline = time.monotonic() + idle if idle else ceiling
+        deadline = min(ceiling, idle_deadline)
         seen = len(self._buffer)
         while time.monotonic() < deadline:
             clean = strip_ansi(self._buffer)
@@ -150,9 +155,12 @@ class SerialConsole:
             self._read_once()
             if idle and len(self._buffer) != seen:
                 seen = len(self._buffer)
-                deadline = min(ceiling, time.monotonic() + idle)
-        raise ConsoleTimeout(
-            f"never matched {pattern!r}; last output was {strip_ansi(self._buffer)[-600:]!r}"
+                idle_deadline = time.monotonic() + idle
+                deadline = min(ceiling, idle_deadline)
+        error = ConsoleIdle if idle and idle_deadline < ceiling else ConsoleTimeout
+        raise error(
+            f"never matched {pattern!r}; "
+            f"last output was {strip_ansi(self._buffer)[-600:]!r}"
         )
 
     def send(self, line: str) -> None:


### PR DESCRIPTION
`INSTALL_IDLE` was measured on the serial console and nothing else. `vm-f2fs` and `vm-lvm` were ended at 21 minutes downloading a stage3, and `vm-sdboot` at 45 minutes with `>>> Emerging sys-kernel/linux-firmware` followed by `Fetching files in the background` — Portage's `parallel-fetch` writes to `/var/log/emerge-fetch.log`, not the console, and that package is over a gigabyte.

`Watchdog` already read the guest's byte counters and said in its own docstring why the console is not enough; it was not consulted by the wait that ends guests. It is now: silence raises `ConsoleIdle`, the scheduler asks the counters, and a guest that moved more than `QUIET_BYTES` keeps going. `RUN_CEILING` still ends anything after eight hours.

The message names both tests and carries the byte figures, so "never matched MARK_5_DONE" no longer sends somebody reading an install log for a fault that was not there.

Giving each silent step a voice of its own — `#178` for the download, `#183` for the unpack — does not scale: every one has to be found by losing a guest to it first.