### PR TITLE
model: let the operator set L10N instead of only deriving it

### DIFF
--- a/gentoo_install/model/config.py
+++ b/gentoo_install/model/config.py
@@ -272,6 +272,8 @@ class PortageConfig:
     common_flags: str = "-O2 -pipe"
     use: tuple[str, ...] = ()
     video_cards: tuple[str, ...] = ()
+    #: Empty derives L10N from the generated locales.
+    l10n: tuple[str, ...] = ()
     #: `INPUT_DEVICES`. libinput is what every current desktop reads; the
     #: profile's own value is replaced outright by make.conf, so an empty
     #: tuple here would leave a machine with no pointer driver.

--- a/gentoo_install/model/parse.py
+++ b/gentoo_install/model/parse.py
@@ -168,8 +168,10 @@ def _portage(raw: Mapping[str, Any], at: str) -> PortageConfig:
         raw,
         at,
         {
-            "profile", "keywords", "sync", "testing_packages", "makeopts", "common_flags", "use", "video_cards",
-            "accept_license", "cpu_flags", "build_in_ram", "input_devices", "mirrors", "binhost", "overlays",
+            "profile", "keywords", "sync", "testing_packages", "makeopts",
+            "common_flags", "use", "video_cards", "l10n", "accept_license",
+            "cpu_flags", "build_in_ram", "input_devices", "mirrors", "binhost",
+            "overlays",
         },
     )
     default = PortageConfig()
@@ -182,6 +184,7 @@ def _portage(raw: Mapping[str, Any], at: str) -> PortageConfig:
         common_flags=_str(raw, "common_flags", at, default.common_flags),
         use=_strings(raw, "use", at, default.use),
         video_cards=_strings(raw, "video_cards", at, default.video_cards),
+        l10n=_strings(raw, "l10n", at, default.l10n),
         input_devices=_strings(raw, "input_devices", at, default.input_devices),
         accept_license=_strings(raw, "accept_license", at, default.accept_license),
         cpu_flags=_strings(raw, "cpu_flags", at, default.cpu_flags),

--- a/gentoo_install/model/validate.py
+++ b/gentoo_install/model/validate.py
@@ -48,6 +48,10 @@ class ProbedProfile:
 _PROFILE_ROW: Final[re.Pattern[str]] = re.compile(
     r"^\s*\[\d+\]\s+(\S+)\s+\(([^()\s]+)\)(\s+\*)?\s*$"
 )
+_L10N_TAG: Final[re.Pattern[str]] = re.compile(
+    r"^[a-z]{2,3}(?:-[A-Z][a-z]{3})?(?:-(?:[A-Z]{2}|[0-9]{3}))?"
+    r"(?:-(?:[0-9][a-z0-9]{3}|[a-z][a-z0-9]{4,7}))*$"
+)
 
 
 def parse_profile_list(
@@ -100,12 +104,21 @@ def validate(
         *_array_problems(config),
         *_network_problems(config),
         *_unlock_problems(config),
+        *_l10n_problems(config),
         *(rule.describe() for rule in compat.violations(config)),
     ]
     if problems:
         raise ValidationFailed(
             "the configuration does not describe an installable system:\n  " + "\n  ".join(problems)
         )
+
+
+def _l10n_problems(config: InstallConfig) -> list[str]:
+    return [
+        f"L10N tag {tag!r} is not a hyphenated BCP 47 language tag"
+        for tag in config.portage.l10n
+        if _L10N_TAG.fullmatch(tag) is None
+    ]
 
 
 def _pool_problems(config: InstallConfig) -> list[str]:

--- a/gentoo_install/plan/portage.py
+++ b/gentoo_install/plan/portage.py
@@ -898,6 +898,8 @@ def community_binhost(portage: PortageConfig) -> str:
 
 def _l10n(config: InstallConfig) -> tuple[str, ...]:
     """`L10N` uses a hyphen and no encoding, so `zh_CN.UTF-8` becomes `zh-CN`."""
+    if config.portage.l10n:
+        return config.portage.l10n
     tags: list[str] = []
     for locale in config.system.locales:
         tag = locale.split(".", 1)[0].replace("_", "-")

--- a/tests/unit/test_plan_portage.py
+++ b/tests/unit/test_plan_portage.py
@@ -102,6 +102,20 @@ def test_l10n_is_derived_from_the_locales_rather_than_listed_twice() -> None:
     assert 'L10N="en-US zh-CN zh-TW"' in written
 
 
+def test_an_l10n_override_reaches_make_conf_without_changing_the_locales() -> None:
+    locales = ("en_US.UTF-8", "zh_TW.UTF-8")
+    installation = replace(
+        config(),
+        system=SystemConfig(locales=locales),
+        portage=replace(PortageConfig(), l10n=("en", "qaa", "zh-TW")),
+    )
+
+    written = apply_all(installation).files[PurePosixPath("/etc/portage/make.conf")]
+
+    assert 'L10N="en qaa zh-TW"' in written
+    assert installation.system.locales == locales
+
+
 def test_a_chinese_region_gets_the_chinese_mirrors() -> None:
     installation = with_portage(mirrors=MirrorConfig(region=MirrorRegion.CN))
     written = apply_all(installation).files[PurePosixPath("/etc/portage/make.conf")]

--- a/tests/unit/test_serialise.py
+++ b/tests/unit/test_serialise.py
@@ -6,7 +6,7 @@ from pathlib import Path
 
 import pytest
 
-from gentoo_install.model.config import InstallConfig, Overlay, User
+from gentoo_install.model.config import InstallConfig, Overlay, PortageConfig, User
 from gentoo_install.model.device import DeviceGraph, DeviceId, Existing, PartitionTable
 from gentoo_install.model.parse import _NODES, parse
 from gentoo_install.model.serialise import KINDS, REDACTED, SECRET, to_toml
@@ -68,6 +68,16 @@ def test_users_and_overlays_are_written_as_tables() -> None:
         ),
     )
     assert _round_trip(config) == config
+
+
+def test_an_l10n_override_survives_a_round_trip() -> None:
+    config = parse(tomllib.loads((FIXTURES / "ext4-bios.toml").read_text()))
+    held = replace(config, portage=replace(PortageConfig(), l10n=("en", "zh-TW")))
+
+    written = to_toml(held)
+
+    assert 'l10n = ["en", "zh-TW"]' in written
+    assert _round_trip(held).portage.l10n == ("en", "zh-TW")
 
 
 def test_a_default_is_left_out_of_the_file() -> None:

--- a/tests/unit/test_validate.py
+++ b/tests/unit/test_validate.py
@@ -32,6 +32,15 @@ def test_the_shipped_fixture_validates() -> None:
     validate(load(FIXTURES / "btrfs-luks.toml"))
 
 
+def test_an_l10n_tag_not_shaped_like_one_is_refused_and_named() -> None:
+    installation = replace(
+        config(), portage=replace(config().portage, l10n=("zh_TW",))
+    )
+
+    with pytest.raises(ValidationFailed, match=r"L10N tag 'zh_TW'"):
+        validate(installation)
+
+
 def test_a_root_that_no_device_defines_is_named() -> None:
     broken = replace(config(), disk=replace(config().disk, root=i("absent")))
     with pytest.raises(ValidationFailed, match="'absent', which no device defines"):


### PR DESCRIPTION
`_l10n()` turned `config.system.locales` into `make.conf`'s `L10N` and there was no way to write anything else. `L10N` decides which translations and locale data build, and that is not always the set the system generates: an operator may generate one locale and want several languages' translations, or generate several and want the builds smaller.

Unset still means derived, so nothing changes for a configuration that does not set it. Setting it replaces the derivation and clearing it returns to derived. `_l10n()` remains the only code that turns locales into tags. A tag that is not shaped like one is refused, naming it.

The two rows that read this field — one beside the rest of `make.conf`, one in the language section — are the next change.