### PR TITLE
exec: check the commands the plan will run, not a list somebody typed

### DIFF
--- a/gentoo_install/exec/preflight.py
+++ b/gentoo_install/exec/preflight.py
@@ -9,7 +9,7 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Final
+from typing import Final, Iterable
 
 from ..errors import DeviceNotFound, PreflightFailed
 from ..model import compat
@@ -32,7 +32,11 @@ from ..model.device import (
 from ..model.size import DEFAULT_ALIGNMENT, SectorSize, Size
 from ..model.validate import root_size_problems
 from ..plan.disk import MKFS
+from ..plan.operations import Operation
 from .probe import RELEASE_KEY, Machine, Probe
+
+# These are used while preflight inspects disks, before any operation runs.
+PREFLIGHT_ONLY: Final[tuple[str, ...]] = ("lsblk", "swapon")
 
 #: Commands every install needs, whatever the layout is.
 ALWAYS: Final[tuple[str, ...]] = (
@@ -112,7 +116,7 @@ class Report:
             )
 
 
-def required_commands(config: InstallConfig) -> frozenset[str]:
+def _configured_commands(config: InstallConfig) -> frozenset[str]:
     graph = config.disk.graph
     wanted = set(ALWAYS)
     for table in graph.of_type(PartitionTable):
@@ -137,6 +141,33 @@ def required_commands(config: InstallConfig) -> frozenset[str]:
         wanted.add(MKFS[filesystem.kind][0])
         wanted |= set(EXTRA_FILESYSTEM_COMMANDS.get(filesystem.kind, ()))
     return frozenset(wanted)
+
+
+def required_commands(
+    config: InstallConfig, operations: Iterable[Operation] | None = None
+) -> frozenset[str]:
+    """Executables preflight probes for this configuration and built plan.
+
+    The configuration-only path remains for callers that have not built a
+    plan, such as ``--missing-commands``. Installation passes its built plan.
+    """
+    if operations is None:
+        return _configured_commands(config)
+    wanted = set(PREFLIGHT_ONLY)
+    for operation in operations:
+        wanted.update(operation.required_host_commands())
+    return frozenset(wanted)
+
+
+def _command_users(operations: Iterable[Operation]) -> dict[str, tuple[str, ...]]:
+    users: dict[str, list[str]] = {}
+    for operation in operations:
+        name = type(operation).__name__
+        for command in operation.required_host_commands():
+            named = users.setdefault(command, [])
+            if name not in named:
+                named.append(name)
+    return {command: tuple(names) for command, names in users.items()}
 
 
 def _disks_at_risk(graph: DeviceGraph) -> list[Existing]:
@@ -308,15 +339,29 @@ def _memory_problems(config: InstallConfig, machine: Machine) -> list[str]:
     return []
 
 
-def check(config: InstallConfig, probe: Probe, target: str = "/mnt/gentoo") -> Report:
-    wanted = required_commands(config)
-    machine = probe.machine(wanted, judged=GNU_ONLY)
-    return inspect(config, machine, probe, target)
+def check(
+    config: InstallConfig,
+    probe: Probe,
+    target: str = "/mnt/gentoo",
+    *,
+    operations: Iterable[Operation] | None = None,
+) -> Report:
+    plan = tuple(operations) if operations is not None else None
+    wanted = required_commands(config, plan)
+    machine = probe.machine(wanted, judged=set(GNU_ONLY) & wanted)
+    return inspect(config, machine, probe, target, operations=plan)
 
 
 def inspect(
-    config: InstallConfig, machine: Machine, probe: Probe, target: str = "/mnt/gentoo"
+    config: InstallConfig,
+    machine: Machine,
+    probe: Probe,
+    target: str = "/mnt/gentoo",
+    *,
+    operations: Iterable[Operation] | None = None,
 ) -> Report:
+    plan = tuple(operations) if operations is not None else None
+    wanted = required_commands(config, plan)
     config_target = target
     fatal: list[str] = []
     warnings: list[str] = []
@@ -347,9 +392,16 @@ def inspect(
             "the amd64 EFI executables an amd64 install writes"
         )
 
-    missing = sorted(required_commands(config) - machine.commands)
-    if missing:
-        fatal.append(f"these commands are missing: {', '.join(missing)}")
+    missing = sorted(wanted - machine.commands)
+    users = _command_users(plan) if plan is not None else {}
+    unnamed = [command for command in missing if command not in users]
+    if unnamed:
+        fatal.append(f"these commands are missing: {', '.join(unnamed)}")
+    for command in missing:
+        if command in users:
+            fatal.append(
+                f"{command} is missing; required by {', '.join(users[command])}"
+            )
     fatal += _busybox_problems(machine)
 
     for disk in _disks_at_risk(config.disk.graph):

--- a/gentoo_install/plan/disk.py
+++ b/gentoo_install/plan/disk.py
@@ -121,6 +121,9 @@ class ReleaseTarget(Operation):
     #: opposite orders and both are describable.
     steps: tuple[tuple[str, ...], ...]
 
+    def required_host_commands(self) -> frozenset[str]:
+        return frozenset(("umount", *(step[0] for step in self.steps)))
+
     def describe(self) -> str:
         return "release anything a previous run of this configuration left mounted or open"
 
@@ -142,6 +145,7 @@ class WipeSignatures(Operation):
     """`mkfs` refuses, or worse silently inherits, when an old superblock is left."""
 
     stage: Stage = Stage.PARTITION
+    host_commands = ("wipefs",)
     device: DeviceId
 
     def describe(self) -> str:
@@ -165,6 +169,9 @@ class CreatePartitionTable(Operation):
     kind: TableType
     create: bool = True
     remove: tuple[int, ...] = ()
+
+    def required_host_commands(self) -> frozenset[str]:
+        return frozenset(("sgdisk" if self.kind is TableType.GPT else "parted",))
 
     def describe(self) -> str:
         if self.create:
@@ -208,6 +215,9 @@ class CreatePartition(Operation):
     #: partition at the first aligned free sector by itself, `parted` does not.
     start: Size
 
+    def required_host_commands(self) -> frozenset[str]:
+        return frozenset(("sgdisk" if self.table_kind is TableType.GPT else "parted",))
+
     def describe(self) -> str:
         extent = str(self.size) if self.size is not None else "the rest of the disk"
         name = f" labelled {self.label}" if self.label else ""
@@ -247,6 +257,7 @@ class RereadPartitionTable(Operation):
     nodes do not exist yet when the next operation asks for one."""
 
     stage: Stage = Stage.PARTITION
+    host_commands = ("blockdev", "udevadm")
     disk: DeviceId
 
     def describe(self) -> str:
@@ -265,6 +276,7 @@ class RereadPartitionTable(Operation):
 @dataclass(frozen=True, kw_only=True)
 class CreateMdRaid(Operation):
     stage: Stage = Stage.ARRAY
+    host_commands = ("mdadm",)
     array: DeviceId
     members: tuple[DeviceId, ...]
     level: RaidLevel
@@ -296,6 +308,7 @@ class CreateMdRaid(Operation):
 @dataclass(frozen=True, kw_only=True)
 class CreateLuks(Operation):
     stage: Stage = Stage.ARRAY
+    host_commands = ("cryptsetup",)
     container: DeviceId
     backing: DeviceId
     name: str
@@ -333,6 +346,7 @@ class OpenLuks(Operation):
     """
 
     stage: Stage = Stage.ARRAY
+    host_commands = ("dmsetup", "cryptsetup")
     container: DeviceId
     backing: DeviceId
     name: str
@@ -366,6 +380,7 @@ class AssembleMdRaid(Operation):
     """Assemble an array that already exists, or leave a running one alone."""
 
     stage: Stage = Stage.ARRAY
+    host_commands = ("mdadm",)
     array: DeviceId
     members: tuple[DeviceId, ...]
     name: str
@@ -396,6 +411,7 @@ class ActivateVolumeGroup(Operation):
     """Bring the group's volumes up. `vgchange` on an active group is a no-op."""
 
     stage: Stage = Stage.ARRAY
+    host_commands = ("vgchange",)
     group: DeviceId
     name: str
 
@@ -413,6 +429,7 @@ class ActivateVolumeGroup(Operation):
 @dataclass(frozen=True, kw_only=True)
 class CreateVolumeGroup(Operation):
     stage: Stage = Stage.ARRAY
+    host_commands = ("pvcreate", "vgcreate")
     group: DeviceId
     members: tuple[DeviceId, ...]
     name: str
@@ -429,6 +446,7 @@ class CreateVolumeGroup(Operation):
 @dataclass(frozen=True, kw_only=True)
 class CreateLogicalVolume(Operation):
     stage: Stage = Stage.ARRAY
+    host_commands = ("lvcreate",)
     volume: DeviceId
     group: str
     name: str
@@ -454,6 +472,9 @@ class MakeFilesystem(Operation):
     device: DeviceId
     kind: FilesystemType
     label: str
+
+    def required_host_commands(self) -> frozenset[str]:
+        return frozenset((MKFS[self.kind][0],))
 
     def describe(self) -> str:
         name = f" labelled {self.label}" if self.label else ""
@@ -503,6 +524,7 @@ class CreateSubvolume(Operation):
     mounted to create one and unmounted again before the layout is mounted."""
 
     stage: Stage = Stage.FORMAT
+    host_commands = ("mkdir", "mount", "btrfs", "umount")
     subvolume: DeviceId
     device: DeviceId
     name: str
@@ -530,6 +552,7 @@ class MakeSwap(Operation):
     the installing system keeps the device busy."""
 
     stage: Stage = Stage.FORMAT
+    host_commands = ("swapoff", "mkswap")
     swap: DeviceId
     device: DeviceId
 
@@ -547,6 +570,7 @@ class MakeSwap(Operation):
 @dataclass(frozen=True, kw_only=True)
 class CreateZpool(Operation):
     stage: Stage = Stage.ZFS
+    host_commands = ("zpool",)
     pool: DeviceId
     vdevs: tuple[DeviceId, ...]
     name: str
@@ -593,6 +617,7 @@ class ImportZpool(Operation):
     """
 
     stage: Stage = Stage.ZFS
+    host_commands = ("zpool",)
     pool: DeviceId
     name: str
 
@@ -615,6 +640,7 @@ class ImportZpool(Operation):
 @dataclass(frozen=True, kw_only=True)
 class CreateDataset(Operation):
     stage: Stage = Stage.ZFS
+    host_commands = ("zfs",)
     dataset: DeviceId
     name: str
     #: Where the dataset is mounted, or None when it only holds other datasets.
@@ -651,6 +677,7 @@ class CreateDataset(Operation):
 @dataclass(frozen=True, kw_only=True)
 class Mount(Operation):
     stage: Stage = Stage.MOUNT
+    host_commands = ("mkdir", "findmnt", "mount")
     mountpoint: DeviceId
     source: DeviceId
     path: PurePosixPath
@@ -680,6 +707,7 @@ class MountZfsDataset(Operation):
     """A dataset carries its own mountpoint property, so it is mounted by name."""
 
     stage: Stage = Stage.MOUNT
+    host_commands = ("zfs",)
     mountpoint: DeviceId
     name: str
     path: PurePosixPath
@@ -729,6 +757,12 @@ class UnmountTarget(Operation):
 
     stage: Stage = Stage.FINISH
     pools: tuple[str, ...]
+
+    def required_host_commands(self) -> frozenset[str]:
+        commands = {"umount", "findmnt"}
+        if self.pools:
+            commands.update(("zfs", "zpool", "sleep"))
+        return frozenset(commands)
 
     @property
     def releases_the_machine(self) -> bool:

--- a/gentoo_install/plan/operations.py
+++ b/gentoo_install/plan/operations.py
@@ -15,7 +15,7 @@ from abc import ABC, abstractmethod
 from dataclasses import dataclass
 from enum import Enum
 from pathlib import PurePosixPath
-from typing import Protocol, Sequence
+from typing import ClassVar, Protocol, Sequence
 
 from ..model.device import DeviceId
 
@@ -156,6 +156,10 @@ class Context(Protocol):
 
 @dataclass(frozen=True, kw_only=True)
 class Operation(ABC):
+    #: Executables this operation runs on the installing system. Commands run
+    #: inside the target are supplied by the target and do not belong here.
+    host_commands: ClassVar[tuple[str, ...]] = ()
+
     #: Which phase this runs in. A subclass fixes it with a default; the few
     #: operations that serve several phases take it from the caller.
     stage: Stage
@@ -166,6 +170,10 @@ class Operation(ABC):
 
     @abstractmethod
     def apply(self, context: Context) -> None: ...
+
+    def required_host_commands(self) -> frozenset[str]:
+        """Executables the live medium must provide for this operation."""
+        return frozenset(self.host_commands)
 
     @property
     def releases_the_machine(self) -> bool:

--- a/tests/unit/test_preflight.py
+++ b/tests/unit/test_preflight.py
@@ -1,0 +1,96 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+from typing import ClassVar, Iterable
+
+import pytest
+
+from gentoo_install.errors import PreflightFailed
+from gentoo_install.exec import preflight
+from gentoo_install.exec.probe import Machine, Probe
+from gentoo_install.exec.runner import Runner
+from gentoo_install.plan.operations import Context, Operation, Stage
+
+from .layouts import config
+
+
+@dataclass(frozen=True, kw_only=True)
+class NeedsMediumCommand(Operation):
+    stage: Stage = Stage.PREFLIGHT
+    host_commands: ClassVar[tuple[str, ...]] = ("medium-tool",)
+
+    def describe(self) -> str:
+        return "use the test medium tool"
+
+    def apply(self, context: Context) -> None:
+        raise AssertionError("preflight ran an operation")
+
+
+@dataclass(frozen=True, kw_only=True)
+class NeedsTar(NeedsMediumCommand):
+    host_commands: ClassVar[tuple[str, ...]] = ("tar",)
+
+
+def _machine(
+    commands: frozenset[str], *, versions: dict[str, str] | None = None
+) -> Machine:
+    return Machine(
+        architecture="x86_64",
+        uefi=True,
+        root=True,
+        memory_bytes=16 * 1024**3,
+        commands=commands,
+        release_key=True,
+        versions=versions if versions is not None else {},
+        efi_variables=True,
+        efi_bits=64,
+    )
+
+
+def _probe(tmp_path: Path) -> Probe:
+    return Probe(runner=Runner(log=lambda line: None), work=tmp_path)
+
+
+def test_a_plan_missing_a_declared_host_command_is_refused(tmp_path: Path) -> None:
+    operation = NeedsMediumCommand()
+    report = preflight.inspect(
+        config(), _machine(frozenset()), _probe(tmp_path), operations=(operation,)
+    )
+    with pytest.raises(PreflightFailed) as refused:
+        report.raise_if_fatal()
+    assert "medium-tool" in str(refused.value)
+    assert "NeedsMediumCommand" in str(refused.value)
+
+
+def test_gnu_tar_is_still_a_capability_requirement(tmp_path: Path) -> None:
+    operation = NeedsTar()
+    report = preflight.inspect(
+        config(),
+        _machine(
+            frozenset({"tar"}),
+            versions={"tar": "BusyBox v1.36.1 multi-call binary."},
+        ),
+        _probe(tmp_path),
+        operations=(operation,),
+    )
+    assert any("tar is not GNU tar" in problem for problem in report.fatal)
+
+
+def test_a_new_operation_command_is_probed_without_editing_preflight(tmp_path: Path) -> None:
+    asked: list[frozenset[str]] = []
+
+    class Watching(Probe):
+        def machine(
+            self, wanted: frozenset[str] = frozenset(), judged: Iterable[str] = ()
+        ) -> Machine:
+            asked.append(wanted)
+            return _machine(wanted)
+
+    operation = NeedsMediumCommand()
+    preflight.check(
+        config(),
+        Watching(runner=Runner(log=lambda line: None), work=tmp_path),
+        operations=(operation,),
+    )
+    assert asked and "medium-tool" in asked[0]


### PR DESCRIPTION
`preflight` held a hand-written tuple of the commands a live medium must carry, and the operations that invoke them are written elsewhere. The two drifted: the plan runs `install` and `sleep` on the host and neither was in the list. A missing command is what preflight exists to catch, and it caught only the ones somebody remembered.

Operations declare the host executables they need — declaring is not running, so `plan/` stays pure — and preflight aggregates that from the built plan. The capability checks that exist stay, including `tar` having to be GNU tar.

A test asserts every declared command is one preflight probes, so a new operation with a new command fails the suite rather than an install.