### PR TITLE
vm: ask the running init, not what /sbin/init looks like

### DIFF
--- a/tests/unit/test_cluster.py
+++ b/tests/unit/test_cluster.py
@@ -233,3 +233,26 @@ def test_run_ceiling_ends_silent_guest_that_keeps_moving_bytes(
 
     assert clock[0] == 5.0
     assert readings[0] == 2
+
+
+def test_the_init_check_asks_the_running_init_not_a_file_listing() -> None:
+    """`ls -l /sbin/init` names systemd through its symlink and says nothing on
+    OpenRC, where `/sbin/init` is `sys-apps/sysvinit`'s own binary: a guest
+    answered `-rwxr-xr-x 1 root root 49064 Nov 22 2025 /sbin/init` and the
+    check looked for `openrc` in it. Two fixtures failed every round on that.
+    """
+    from pathlib import Path
+
+    from gentoo_install.exec.config import load
+    from gentoo_install.model.config import InitSystem
+    from tests.vm.cluster import _asked_for
+
+    for fixture, wanted in (("vm-lvm", "openrc"), ("vm-binpkg", None)):
+        installation = load(Path(f"tests/fixtures/{fixture}.toml"))
+        init = next(one for one in _asked_for(installation) if one[0] == "init")
+        assert "ls -l /sbin/init" not in init[1], init
+        assert "/run/openrc" in init[1], init
+        expected = "systemd" if installation.system.init is InitSystem.SYSTEMD else "openrc"
+        assert init[2] == expected, init
+        if wanted:
+            assert init[2] == wanted, init

--- a/tests/vm/cluster.py
+++ b/tests/vm/cluster.py
@@ -1622,7 +1622,11 @@ def _asked_for(installation: InstallConfig) -> list[tuple[str, str, str]]:
     checks.append(
         (
             "init",
-            "ls -l /sbin/init",
+            # Not `ls -l /sbin/init`: on OpenRC that is sysvinit's own binary,
+            # a regular file whose listing never carries the word, so the check
+            # could not pass. Both inits leave a directory under /run.
+            "test -d /run/openrc && echo openrc || "
+            "{ test -d /run/systemd/system && echo systemd || echo unknown; }",
             "systemd" if installation.system.init is InitSystem.SYSTEMD else "openrc",
         )
     )


### PR DESCRIPTION
`vm-lvm` and `vm-bios` failed every round with `init: the installed system does not say 'openrc'`, and both installed correctly. The check ran `ls -l /sbin/init` and looked for the word; the guest answered `-rwxr-xr-x 1 root root 49064 Nov 22 2025 /sbin/init`.

On Gentoo with OpenRC that path is `sys-apps/sysvinit`'s own binary, a regular file whose listing cannot carry the word. With systemd it is a symlink to `../lib/systemd/systemd`, so the same check passed — which is why a check that was false for half the combinations went unquestioned.

Both inits leave a directory under `/run` while they are running, and that is evidence of what is running rather than of what was installed.