### PR TITLE
exec: an unread ZFS kernel ceiling is not an unlimited one

### DIFF
--- a/gentoo_install/exec/fetch.py
+++ b/gentoo_install/exec/fetch.py
@@ -31,6 +31,7 @@ from ..errors import (
 )
 from ..model import paste
 from ..model.device import DeviceId
+from ..model.validate import KernelCeiling
 from .probe import RELEASE_KEY
 from .runner import Runner
 
@@ -423,8 +424,8 @@ def overlay_versions(atom: str) -> tuple[tuple[str, bool], ...]:
     return tuple((version, False) for version in sorted(named, key=_version_key, reverse=True))
 
 
-def zfs_kernel_max() -> str:
-    """The highest kernel `sys-fs/zfs` builds a module for, or empty if unread.
+def zfs_kernel_max() -> KernelCeiling:
+    """The highest kernel `sys-fs/zfs` builds a module for, or unknown.
 
     `MODULES_KERNEL_MAX` in the newest ebuild. A real ceiling: 2.4.3 stops at
     7.0, so a 7.1 kernel leaves a ZFS root with no module to import the pool.
@@ -433,11 +434,11 @@ def zfs_kernel_max() -> str:
         try:
             ebuild = _read(f"{GITWEB}/sys-fs/zfs/zfs-{version}.ebuild")
         except DownloadFailed:
-            return ""
+            return KernelCeiling(None)
         for line in ebuild.splitlines():
             if line.startswith("MODULES_KERNEL_MAX="):
-                return line.split("=", 1)[1].strip().strip("\"'")
-    return ""
+                return KernelCeiling(line.split("=", 1)[1].strip().strip("\"'"))
+    return KernelCeiling(None)
 
 
 def _version_key(version: str) -> tuple[int, ...]:

--- a/gentoo_install/exec/probe.py
+++ b/gentoo_install/exec/probe.py
@@ -21,7 +21,7 @@ from typing import ClassVar, Final, Iterable, Mapping
 from ..errors import CommandFailed, DeviceNotFound
 from ..model.config import InstallConfig
 from ..model.device import DeviceGraph, DeviceId, Existing, Extent, PartitionTable
-from ..model.validate import ProbedProfile, parse_profile_list
+from ..model.validate import KernelCeiling, ProbedProfile, parse_profile_list
 from .runner import Runner
 
 EFI_MARKER: Final[Path] = Path("/sys/firmware/efi")
@@ -636,6 +636,28 @@ class Probe:
         if loaded.returncode != 0 or not any(path.exists() for path in self.ZFS_LOADED):
             return "this live system cannot load the zfs kernel module"
         return ""
+
+    def zfs_kernel_max(self, target: Path | None = None) -> KernelCeiling:
+        """Read the visible ZFS ebuild's ceiling from Portage metadata."""
+        runner = self.runner.in_target(target) if target is not None else self.runner
+        visible = runner.run(["portageq", "best_visible", "/", "sys-fs/zfs"])
+        cpv = visible.stdout.strip()
+        if not cpv or "\n" in cpv:
+            raise CommandFailed("portageq best_visible returned no single visible sys-fs/zfs ebuild")
+        metadata = runner.run(
+            ["portageq", "metadata", "/", "ebuild", cpv, "RDEPEND"]
+        ).stdout
+        bounds = re.findall(r"<virtual/dist-kernel-(\d+)\.(\d+)(?=[\s)])", metadata)
+        if len(bounds) != 1:
+            raise CommandFailed(
+                f"portageq metadata for {cpv} returned no single ZFS dist-kernel ceiling"
+            )
+        major, exclusive_minor = (int(part) for part in bounds[0])
+        if exclusive_minor == 0:
+            raise CommandFailed(
+                f"portageq metadata for {cpv} returned an invalid dist-kernel ceiling"
+            )
+        return KernelCeiling(f"{major}.{exclusive_minor - 1}")
 
     def cores(self) -> int:
         return os.cpu_count() or 1

--- a/gentoo_install/model/validate.py
+++ b/gentoo_install/model/validate.py
@@ -89,16 +89,43 @@ class _ProfilesNotRead:
 _PROFILES_NOT_READ: Final[_ProfilesNotRead] = _ProfilesNotRead()
 
 
+class KernelCeiling(str):
+    """A read kernel ceiling, with unknown kept distinct from no ceiling."""
+
+    maximum: str | None
+
+    def __new__(cls, maximum: str | None) -> KernelCeiling:
+        normalised = maximum.strip() if maximum else None
+        if normalised is not None and re.fullmatch(r"\d+(?:\.\d+)+", normalised) is None:
+            normalised = None
+        ceiling = super().__new__(cls, normalised or "unknown")
+        ceiling.maximum = normalised
+        return ceiling
+
+
+class _ZfsKernelCeilingNotChecked:
+    pass
+
+
+_ZFS_KERNEL_CEILING_NOT_CHECKED: Final[_ZfsKernelCeilingNotChecked] = (
+    _ZfsKernelCeilingNotChecked()
+)
+
+
 def validate(
     config: InstallConfig,
     *,
     available_profiles: Collection[str] | None | _ProfilesNotRead = _PROFILES_NOT_READ,
+    zfs_kernel_max: str | None | _ZfsKernelCeilingNotChecked = (
+        _ZFS_KERNEL_CEILING_NOT_CHECKED
+    ),
 ) -> None:
     problems = [
         *_layout_problems(config),
         *root_size_problems(config),
         *_profile_problems(config),
         *_repository_profile_problems(config.portage.profile, available_profiles),
+        *_zfs_kernel_problems(config, zfs_kernel_max),
         *_kernel_package_problems(config),
         *_reuse_problems(config),
         *_pool_problems(config),
@@ -112,6 +139,53 @@ def validate(
         raise ValidationFailed(
             "the configuration does not describe an installable system:\n  " + "\n  ".join(problems)
         )
+
+
+def _zfs_kernel_problems(
+    config: InstallConfig,
+    ceiling: str | None | _ZfsKernelCeilingNotChecked,
+) -> list[str]:
+    """Refuse a ZFS root unless its selected kernel fits a read ceiling."""
+    if isinstance(ceiling, _ZfsKernelCeilingNotChecked):
+        return []
+    if not config.disk.graph.of_type(ZfsPool):
+        return []
+    unknown = [
+        "the sys-fs/zfs kernel ceiling could not be read, so this ZFS install "
+        "cannot establish that its kernel will build the module"
+    ]
+    maximum = ceiling.maximum if isinstance(ceiling, KernelCeiling) else ceiling
+    if maximum is None or not maximum.strip():
+        return unknown
+    version = config.kernel.version
+    if not version:
+        return [
+            f"the kernel is not pinned under the sys-fs/zfs ceiling {maximum}, so Portage "
+            "could select an unsupported version"
+        ]
+    limit = _numeric_version(maximum)
+    if not limit:
+        return unknown
+    selected = _numeric_version(version)
+    if not selected:
+        return [f"kernel version {version!r} cannot be compared with the sys-fs/zfs ceiling"]
+    if selected[: len(limit)] > limit:
+        return [
+            f"kernel {version} is above the sys-fs/zfs ceiling {maximum}, so its ZFS "
+            "module will not build"
+        ]
+    return []
+
+
+def _numeric_version(version: str) -> tuple[int, ...]:
+    """Numeric prefix components used by kernel and module version metadata."""
+    found: list[int] = []
+    for component in version.split("."):
+        matched = re.match(r"\d+", component)
+        if matched is None:
+            break
+        found.append(int(matched.group()))
+    return tuple(found)
 
 
 def _l10n_problems(config: InstallConfig) -> list[str]:

--- a/tests/unit/test_exec.py
+++ b/tests/unit/test_exec.py
@@ -12,6 +12,7 @@ from gentoo_install.errors import (
     CommandFailed,
     ConfigError,
     DeviceNotFound,
+    DownloadFailed,
     IntegrityError,
     PreflightFailed,
 )
@@ -67,6 +68,52 @@ def described(
 
 def probe_of(tmp_path: Path) -> Probe:
     return Probe(runner=runner(tmp_path), work=tmp_path)
+
+
+def test_an_unreadable_pre_tree_zfs_ceiling_is_unknown(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(fetch, "package_versions", lambda atom: (("2.4.3", True),))
+
+    def unreadable(url: str) -> str:
+        raise DownloadFailed(f"{url} could not be read")
+
+    monkeypatch.setattr(fetch, "_read", unreadable)
+
+    assert fetch.zfs_kernel_max().maximum is None
+
+
+def test_target_portage_metadata_carries_the_zfs_kernel_ceiling(tmp_path: Path) -> None:
+    class Answering(Runner):
+        def in_target(self, target: Path) -> Runner:
+            return self
+
+        def run(
+            self,
+            argv: Sequence[str],
+            *,
+            check: bool = True,
+            input_text: str | None = None,
+            timeout: float | None = None,
+        ) -> Result:
+            output = {
+                ("portageq", "best_visible", "/", "sys-fs/zfs"): "sys-fs/zfs-2.4.3\n",
+                (
+                    "portageq",
+                    "metadata",
+                    "/",
+                    "ebuild",
+                    "sys-fs/zfs-2.4.3",
+                    "RDEPEND",
+                ): "dist-kernel-cap? ( dist-kernel? ( <virtual/dist-kernel-7.1 ) )\n",
+            }[tuple(argv)]
+            return Result(tuple(argv), 0, output, "", 0.0)
+
+    ceiling = Probe(runner=Answering(log=lambda line: None), work=tmp_path).zfs_kernel_max(
+        Path("/mnt/gentoo")
+    )
+
+    assert ceiling.maximum == "7.0"
 
 
 def present() -> InstallConfig:

--- a/tests/unit/test_validate.py
+++ b/tests/unit/test_validate.py
@@ -514,3 +514,45 @@ def test_the_last_partition_may_still_take_the_rest_of_the_disk() -> None:
     """Every shipped layout does this, and it is the point of the rule that
     only the last one may."""
     validate(config(ext4_on_gpt()))
+
+
+from gentoo_install.model.config import Bootloader, InitSystem, InstallConfig, Overlay
+def test_an_unknown_zfs_kernel_ceiling_refuses_the_run() -> None:
+    with pytest.raises(ValidationFailed, match="sys-fs/zfs kernel ceiling could not be read"):
+        validate(config(zfs_root()), zfs_kernel_max=None)
+
+
+def test_a_zfs_kernel_ceiling_refuses_above_and_accepts_below() -> None:
+    base = config(zfs_root())
+    installation = replace(
+        base,
+        bootloader=replace(base.bootloader, kind=Bootloader.ZFSBOOTMENU),
+        portage=replace(
+            base.portage,
+            overlays=(
+                Overlay(
+                    name="gentoo-zh",
+                    sync_uri="https://example.invalid/gentoo-zh.git",
+                ),
+            ),
+        ),
+    )
+    above = replace(
+        installation,
+        kernel=replace(installation.kernel, version="7.1.2"),
+    )
+    below = replace(
+        installation,
+        kernel=replace(installation.kernel, version="6.12.58"),
+    )
+    same_minor = replace(
+        installation,
+        kernel=replace(installation.kernel, version="7.0.1"),
+    )
+
+    with pytest.raises(ValidationFailed, match="7.1.2 is above the sys-fs/zfs ceiling 7.0"):
+        validate(above, zfs_kernel_max="7.0")
+    validate(below, zfs_kernel_max="7.0")
+    validate(same_minor, zfs_kernel_max="7.0")
+
+


### PR DESCRIPTION
Which kernels `sys-fs/zfs` supports was read by scraping the newest entry from a package site and parsing an exact ebuild assignment. Any change to the network, the API, the ebuild's formatting or the package's visibility returned an empty ceiling, and an empty ceiling was read as no ceiling: the operator got a system whose ZFS module will not build against its kernel, discovered after the kernel was merged or on the first reboot.

Unknown is now its own value and refuses the run, naming what could not be read.

Measured on this machine: `portageq best_visible / sys-fs/zfs` prints `sys-fs/zfs-2.4.3`, and `portageq metadata / ebuild sys-fs/zfs-2.4.3 RDEPEND` carries `dist-kernel-cap? ( dist-kernel? ( <virtual/dist-kernel-7.1 ) )`. The ebuild's own `MODULES_KERNEL_MAX=7.0` is a private variable absent from the metadata cache; the constraint derived from it is in the cache, so that is what is read. `portageq metadata` needs a visible CPV — an unversioned name exits 2 with `insufficient parameters!`.

The TUI's call site still shows the old value and is the next change.