### PR TITLE
plan: name the network module ZFSBootMenu's image can carry

### DIFF
--- a/gentoo_install/plan/bootloader.py
+++ b/gentoo_install/plan/bootloader.py
@@ -296,7 +296,10 @@ class ConfigureZfsBootMenuRemoteAccess(Operation):
             "".join(
                 f"{line}\n"
                 for line in (
-                    'add_dracutmodules+=" crypt-ssh "',
+                    # `network-legacy` by name: dracut's `40network` picks the
+                    # first implementation already included, and the others all
+                    # reach `systemd`, which this image does not carry.
+                    'add_dracutmodules+=" crypt-ssh network-legacy "',
                     f'install_optional_items+=" {ZBM_NETWORK_CONFIG} "',
                     f'dropbear_port="{self.unlock.port}"',
                     f"dropbear_rsa_key={ZBM_KEY_DIRECTORY}/ssh_host_rsa_key",

--- a/tests/unit/test_plan_bootloader.py
+++ b/tests/unit/test_plan_bootloader.py
@@ -57,8 +57,14 @@ def test_zfsbootmenu_carries_remote_access_in_its_own_image() -> None:
     recorder = Recorder()
     configured.apply(recorder)
     zbm = recorder.files[PurePosixPath("/etc/zfsbootmenu/dracut.conf.d/dropbear.conf")]
-    assert 'add_dracutmodules+=" crypt-ssh "' in zbm
+    assert "crypt-ssh" in zbm, zbm
     assert 'dropbear_port="2201"' in zbm
+    # `generate-zbm` exited 1 with "Module 'crypt-ssh' depends on module
+    # 'network', which can't be installed": dracut's `40network` resolves to
+    # `systemd-networkd`, which needs the `systemd` module this image lacks.
+    # Naming `network-legacy` makes `40network` pick it, per its own
+    # `depends()`, which prefers an implementation already included.
+    assert "network-legacy" in zbm, zbm
     assert "dropbear_rsa_key=/etc/dropbear/ssh_host_rsa_key" in zbm
     assert "dropbear_ecdsa_key=/etc/dropbear/ssh_host_ecdsa_key" in zbm
     assert "dropbear_acl=/etc/dropbear/root_key" in zbm


### PR DESCRIPTION
A local run of `fixtures/zfs-zbm.toml` stopped at `generate-zbm`:

    dracut[E]: Module 'systemd-networkd' depends on module 'systemd', which can't be installed
    dracut[E]: Module 'network' depends on module 'systemd-networkd', which can't be installed
    dracut[E]: Module 'crypt-ssh' depends on module 'network', which can't be installed

`net-misc/dropbear` was installed and `crypt-ssh`'s own `check()` only requires that binary, so what failed is its `depends()`, which is `echo network`. dracut's `40network` picks the first of `network-manager systemd-networkd connman network-legacy` that is already included, and otherwise probes the first three in order; ZFSBootMenu's image carries no `systemd` module, and `systemd-networkd` sits ahead of `network-legacy`.

Naming `network-legacy` in `add_dracutmodules` makes `40network`'s first branch pick it. Its own `depends()` is `net-lib kernel-network-modules initqueue` and reaches no systemd.

Third defect in this path found by running it: `#193` was the key format, and `#179`'s tests assert which operations are produced rather than that they succeed on a real machine.