### PR TITLE
cli: release the machine on every path out, and say what state it is in

### DIFF
--- a/gentoo_install/cli.py
+++ b/gentoo_install/cli.py
@@ -14,6 +14,7 @@ import shutil
 import sys
 import termios
 import time
+from dataclasses import dataclass
 from datetime import datetime, timezone
 from pathlib import Path
 from typing import Callable, Final, Sequence
@@ -59,6 +60,13 @@ EXIT_PREFLIGHT = 2
 EXIT_INTEGRITY = 3
 EXIT_COMMAND = 4
 EXIT_ABORTED = 5
+
+
+@dataclass
+class RunState:
+    """Machine state that has to survive until the exit message is printed."""
+
+    disk_was_written: bool = False
 
 
 def parser() -> argparse.ArgumentParser:
@@ -109,6 +117,7 @@ def parser() -> argparse.ArgumentParser:
 
 def main(argv: Sequence[str] | None = None) -> int:
     arguments = parser().parse_args(argv)
+    state = RunState(disk_was_written=bool(arguments.resume))
     try:
         _require_root(arguments)
         if _needs_network(arguments):
@@ -166,47 +175,70 @@ def main(argv: Sequence[str] | None = None) -> int:
             print(render(operations), end="")
             print(summarise(operations))
             return EXIT_OK
-        return install(config, operations, arguments)
+        return install(config, operations, arguments, state)
     except errors.DeviceNotFound as error:
+        _print_machine_state(state)
         print(f"device: {error}", file=sys.stderr)
         return EXIT_PREFLIGHT
     except errors.ConfigError as error:
+        _print_machine_state(state)
         print(f"configuration: {error}", file=sys.stderr)
         return EXIT_CONFIG
     except errors.PreflightFailed as error:
+        _print_machine_state(state)
         print(f"preflight: {error}", file=sys.stderr)
         return EXIT_PREFLIGHT
     except errors.IntegrityError as error:
+        _print_machine_state(state)
         print(f"integrity: {error}", file=sys.stderr)
         return EXIT_INTEGRITY
     except errors.DownloadFailed as error:
+        _print_machine_state(state)
         print(f"download: {error}", file=sys.stderr)
         return EXIT_COMMAND
     except errors.CommandFailed as error:
+        _print_machine_state(state)
         print(f"command: {error}", file=sys.stderr)
         return EXIT_COMMAND
     except errors.GentooInstallError as error:
         # A named error with no clause of its own still gets its exit code from
         # here, rather than escaping as a traceback that exits 1.
+        _print_machine_state(state)
         print(f"{type(error).__name__}: {error}", file=sys.stderr)
         return EXIT_COMMAND
     except KeyboardInterrupt:
+        _print_machine_state(state)
         print("aborted", file=sys.stderr)
         return EXIT_ABORTED
     except OSError as error:
         # The exec layer writes files and reads /proc, and ENOSPC on the target
         # is a command that did not finish, not a configuration mistake.
+        _print_machine_state(state)
         print(f"system: {error}", file=sys.stderr)
         return EXIT_COMMAND
     except Exception as error:
         # Last, and deliberately wide: this module is the one place an exception
         # becomes an exit code, and one that escapes exits 1, which means
         # "bad configuration" to anything reading the code.
+        _print_machine_state(state)
         print(f"unexpected {type(error).__name__}: {error}", file=sys.stderr)
         return EXIT_COMMAND
 
 
-def install(config: InstallConfig, operations: tuple[Operation, ...], arguments: argparse.Namespace) -> int:
+def _print_machine_state(state: RunState) -> None:
+    """Tell the operator whether a failed run changed the selected disk."""
+    if state.disk_was_written:
+        print("the selected disk has been written to and may not boot", file=sys.stderr)
+    else:
+        print("nothing was written to the selected disk", file=sys.stderr)
+
+
+def install(
+    config: InstallConfig,
+    operations: tuple[Operation, ...],
+    arguments: argparse.Namespace,
+    state: RunState,
+) -> int:
     """Check the machine, then perform every operation in order."""
     work: Path = arguments.work
     with report.recording(work, arguments.target) as active_report:
@@ -238,21 +270,17 @@ def install(config: InstallConfig, operations: tuple[Operation, ...], arguments:
         # when the operator is offered a shell in it.
         closing = tuple(one for one in operations if one.stage is Stage.FINISH)
         body = tuple(one for one in operations if one.stage is not Stage.FINISH)
-        failed: GentooInstallError | None = None
-        # `BaseException`, not `Exception`: an ENOSPC on the live medium or a
-        # Ctrl-C left mounts, arrays and imported pools open and the failure
-        # log on a tmpfs that goes with the reboot. Nothing is swallowed --
-        # whatever came out is raised again below.
-        unexpected: BaseException | None = None
+        failure: BaseException | None = None
+        # Reaching the body means the partition stage is about to run. A
+        # command that fails can still have changed the disk before exiting.
+        state.disk_was_written = state.disk_was_written or any(
+            operation.stage is Stage.PARTITION for operation in body
+        )
         try:
             apply(body, machine, finished)
-        except GentooInstallError as error:
-            failed = error
-            record(f"the install stopped: {error}")
         except BaseException as error:
-            unexpected = error
-            record(f"the install stopped: {type(error).__name__}: {error}")
-        stopped = failed is not None or unexpected is not None
+            failure = _first_failure(failure, error, record)
+        stopped = failure is not None
         try:
             report.offer_paste(
                 work,
@@ -263,24 +291,24 @@ def install(config: InstallConfig, operations: tuple[Operation, ...], arguments:
                 show_the_address,
             )
             _offer_a_shell(arguments, machine, record, stopped)
-        finally:
-            # Before the closing stage and in `finally`: that stage unmounts
-            # the target, so a copy made after it lands on the install medium's
-            # tmpfs and goes with the reboot, which is what this exists to
-            # prevent. The log of a run that failed is the one worth keeping.
+        except BaseException as error:
+            failure = _first_failure(failure, error, record)
+        # Before the closing stage: that stage unmounts the target, so a later
+        # copy lands on the install medium's tmpfs and vanishes at reboot.
+        try:
             report.keep_log(work, arguments.target, record)
-        if not stopped:
-            apply(closing, machine, finished)
-        else:
-            # Only what releases the machine. The rest configures a target that
-            # a run stopping before the stage3 never populated, and
-            # `chroot: failed to run command 'ln'` then replaced the real
-            # failure in the message the operator reads.
+        except BaseException as error:
+            failure = _first_failure(failure, error, record)
+        if failure is None:
+            try:
+                apply(closing, machine, finished)
+            except BaseException as error:
+                failure = _first_failure(failure, error, record)
+        if failure is not None:
+            # Only release operations run after a failure. Configuring an
+            # incomplete target can obscure the error that stopped the run.
             _release(closing, machine, record)
-        if unexpected is not None:
-            raise unexpected
-        if failed is not None:
-            raise failed
+            raise failure
         counted = journal.counts()
         record(
             f"installed {len(operations)} operations into {arguments.target}; "
@@ -288,6 +316,19 @@ def install(config: InstallConfig, operations: tuple[Operation, ...], arguments:
             f"{counted.get('compiled', 0)} compiled"
         )
     return EXIT_OK
+
+
+def _first_failure(
+    first: BaseException | None,
+    current: BaseException,
+    record: Callable[[str], None],
+) -> BaseException:
+    """Keep the error that caused shutdown while recording later failures."""
+    if first is None:
+        record(f"the install stopped: {type(current).__name__}: {current}")
+        return current
+    record(f"warning: while handling that failure: {type(current).__name__}: {current}")
+    return first
 
 
 def _release(
@@ -303,10 +344,9 @@ def _release(
             continue
         try:
             operation.apply(machine)
-        except (GentooInstallError, OSError) as error:
-            # `OSError` too: one release raising it left the LUKS containers
-            # open, the arrays assembled and the pools imported, because this
-            # loop stopped at the first thing it did not name.
+        except BaseException as error:
+            # Release is best-effort because a prior failure owns the exit
+            # category, but later release operations still have work to do.
             record(f"warning: {operation.describe()}: {error}")
 
 

--- a/gentoo_install/exec/apply.py
+++ b/gentoo_install/exec/apply.py
@@ -55,7 +55,8 @@ class Machine:
     def run(
         self, argv: Sequence[str], *, check: bool = True, input_text: str | None = None
     ) -> str:
-        return self.runner.run(argv, check=check, input_text=input_text).stdout
+        result = self.runner.run(argv, check=check, input_text=input_text)
+        return CommandOutput(result.stdout, result.returncode)
 
     def run_in_target(self, argv: Sequence[str], *, check: bool = True) -> str:
         result = self.runner.in_target(self.mountpoint).run(argv, check=check)

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -13,8 +13,8 @@ from gentoo_install import cli
 from gentoo_install.exec import fetch
 from gentoo_install.exec import report
 from gentoo_install.exec.runner import Runner
-from gentoo_install.cli import EXIT_CONFIG, EXIT_OK, EXIT_PREFLIGHT, main
-from gentoo_install.errors import ConfigError
+from gentoo_install.cli import EXIT_CONFIG, EXIT_INTEGRITY, EXIT_OK, EXIT_PREFLIGHT, main
+from gentoo_install.errors import ConfigError, IntegrityError
 from gentoo_install.plan.build import DEFAULT_MIRROR
 from gentoo_install.exec.config import load
 
@@ -518,7 +518,7 @@ def test_an_exit_that_is_not_a_named_error_still_releases_and_keeps_the_log() ->
     caught = source.index("except BaseException as error:")
     kept = source.index("report.keep_log(")
     released = source.index("_release(closing, machine, record)")
-    raised = source.index("raise unexpected")
+    raised = source.index("raise failure")
     assert caught < kept < raised, "the log is kept before the exception leaves"
     assert caught < released < raised, "the machine is released before it leaves"
 
@@ -574,6 +574,158 @@ def test_a_release_that_fails_does_not_stop_the_ones_after_it(tmp_path: Path) ->
     cli._release(closing, machine, said.append)
     assert ran == ["close the container", "stop the array", "export the pool"]
     assert any("device busy" in one for one in said), said
+
+
+def test_a_finish_failure_releases_the_machine_and_keeps_its_exit_code(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """A cleanup operation before the unmount can fail after the target and
+    pool exist, so the release operation still has to run on that path."""
+    from dataclasses import dataclass
+
+    from gentoo_install.plan.operations import Context, Operation, Stage
+
+    from .layouts import config
+
+    released: list[str] = []
+
+    @dataclass(frozen=True, kw_only=True)
+    class Partition(Operation):
+        stage: Stage = Stage.PARTITION
+
+        def describe(self) -> str:
+            return "begin partitioning"
+
+        def apply(self, context: Context) -> None:
+            return
+
+    @dataclass(frozen=True, kw_only=True)
+    class FailFinish(Operation):
+        stage: Stage = Stage.FINISH
+
+        def describe(self) -> str:
+            return "finish the target"
+
+        def apply(self, context: Context) -> None:
+            raise IntegrityError("the finish artifact did not verify")
+
+    @dataclass(frozen=True, kw_only=True)
+    class FailRelease(Operation):
+        stage: Stage = Stage.FINISH
+
+        @property
+        def releases_the_machine(self) -> bool:
+            return True
+
+        def describe(self) -> str:
+            return "close a held resource"
+
+        def apply(self, context: Context) -> None:
+            raise OSError("one resource stayed busy")
+
+    @dataclass(frozen=True, kw_only=True)
+    class Release(Operation):
+        stage: Stage = Stage.FINISH
+
+        @property
+        def releases_the_machine(self) -> bool:
+            return True
+
+        def describe(self) -> str:
+            return "release the machine"
+
+        def apply(self, context: Context) -> None:
+            released.append("released")
+
+    monkeypatch.setattr(cli, "_require_root", lambda arguments: None)
+    monkeypatch.setattr(cli, "_needs_network", lambda arguments: False)
+    monkeypatch.setattr(cli, "load", lambda path: config())
+    monkeypatch.setattr(cli, "with_probed_facts", lambda chosen, probe: chosen)
+    monkeypatch.setattr(
+        cli,
+        "build",
+        lambda chosen, catalog, mirror: (
+            Partition(),
+            FailFinish(),
+            FailRelease(),
+            Release(),
+        ),
+    )
+    monkeypatch.setattr(report, "keep_log", lambda work, target, record: None)
+
+    code = main(
+        [
+            "--config", str(tmp_path / "install.toml"),
+            "--work", str(tmp_path / "work"),
+            "--target", str(tmp_path / "target"),
+            "--skip-preflight",
+            "--no-shell",
+        ]
+    )
+
+    assert released == ["released"]
+    assert code == EXIT_INTEGRITY
+    assert "integrity: the finish artifact did not verify" in capsys.readouterr().err
+
+
+def test_a_failure_after_partitioning_says_the_disk_may_not_boot(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    from dataclasses import dataclass
+
+    from gentoo_install.plan.operations import Context, Operation, Stage
+
+    from .layouts import config
+
+    @dataclass(frozen=True, kw_only=True)
+    class FailPartition(Operation):
+        stage: Stage = Stage.PARTITION
+
+        def describe(self) -> str:
+            return "write the partition table"
+
+        def apply(self, context: Context) -> None:
+            raise IntegrityError("partitioning stopped")
+
+    monkeypatch.setattr(cli, "_require_root", lambda arguments: None)
+    monkeypatch.setattr(cli, "_needs_network", lambda arguments: False)
+    monkeypatch.setattr(cli, "load", lambda path: config())
+    monkeypatch.setattr(cli, "with_probed_facts", lambda chosen, probe: chosen)
+    monkeypatch.setattr(cli, "build", lambda chosen, catalog, mirror: (FailPartition(),))
+    monkeypatch.setattr(report, "keep_log", lambda work, target, record: None)
+
+    code = main(
+        [
+            "--config", str(tmp_path / "install.toml"),
+            "--work", str(tmp_path / "work"),
+            "--target", str(tmp_path / "target"),
+            "--skip-preflight",
+            "--no-shell",
+        ]
+    )
+
+    assert code == EXIT_INTEGRITY
+    assert "the selected disk has been written to and may not boot" in capsys.readouterr().err
+
+
+def test_a_failure_before_partitioning_says_nothing_was_written(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    from gentoo_install.model.config import InstallConfig
+
+    monkeypatch.setattr(cli, "_require_root", lambda arguments: None)
+    monkeypatch.setattr(cli, "_needs_network", lambda arguments: False)
+
+    def invalid(path: Path) -> InstallConfig:
+        raise ConfigError("the configuration is invalid")
+
+    monkeypatch.setattr(cli, "load", invalid)
+    code = main(["--config", str(tmp_path / "install.toml"), "--dry-run"])
+
+    said = capsys.readouterr().err
+    assert code == EXIT_CONFIG
+    assert "nothing was written to the selected disk" in said
+    assert "may not boot" not in said
 
 
 def test_the_menu_starts_from_the_firmware_the_machine_booted() -> None:

--- a/tests/unit/test_exec.py
+++ b/tests/unit/test_exec.py
@@ -202,6 +202,82 @@ def test_a_target_command_keeps_its_nonzero_status(tmp_path: Path) -> None:
     assert output == "masked by package.mask\n"
 
 
+def test_a_live_command_keeps_its_nonzero_status_with_output(tmp_path: Path) -> None:
+    class Answering(Runner):
+        def run(
+            self,
+            argv: Sequence[str],
+            *,
+            check: bool = True,
+            input_text: str | None = None,
+            timeout: float | None = None,
+        ) -> Result:
+            return Result(
+                argv=tuple(argv),
+                returncode=1,
+                stdout="findmnt: not a mountpoint\n",
+                stderr="",
+                seconds=0.0,
+            )
+
+    answering = Answering(log=lambda line: None)
+    machine = apply.Machine(
+        config=config(),
+        runner=answering,
+        probe=Probe(runner=answering, work=tmp_path),
+        work=tmp_path,
+    )
+
+    output = machine.run(["findmnt", "--mountpoint", "/mnt/gentoo"], check=False)
+
+    assert isinstance(output, CommandOutput)
+    assert output.returncode == 1
+    assert "not a mountpoint" in output
+
+
+def test_a_live_findmnt_result_enables_the_lazy_unmount_fallback(tmp_path: Path) -> None:
+    from gentoo_install.plan.disk import UnmountTarget
+
+    class Mounted(Runner):
+        commands: list[tuple[str, ...]]
+
+        def __init__(self) -> None:
+            super().__init__(log=lambda line: None)
+            self.commands = []
+
+        def run(
+            self,
+            argv: Sequence[str],
+            *,
+            check: bool = True,
+            input_text: str | None = None,
+            timeout: float | None = None,
+        ) -> Result:
+            self.commands.append(tuple(argv))
+            return Result(
+                argv=tuple(argv),
+                returncode=0,
+                stdout="/mnt/gentoo\n" if argv[0] == "findmnt" else "",
+                stderr="",
+                seconds=0.0,
+            )
+
+    answering = Mounted()
+    machine = apply.Machine(
+        config=config(),
+        runner=answering,
+        probe=Probe(runner=answering, work=tmp_path),
+        work=tmp_path,
+    )
+
+    UnmountTarget(pools=()).apply(machine)
+
+    assert [argv for argv in answering.commands if argv[0] == "umount"] == [
+        ("umount", "--recursive", "/mnt/gentoo"),
+        ("umount", "--recursive", "--lazy", "/mnt/gentoo"),
+    ]
+
+
 def test_a_dry_run_runs_nothing(tmp_path: Path) -> None:
     lines: list[str] = []
     quiet = Runner(log=lines.append, dry_run=True)


### PR DESCRIPTION
Three faults around how a run ends, from a read-only correctness review.

A failure early in the FINISH stage bypassed release, so the disks stayed mounted and the pool imported and the next run found them held. Release now happens on every path out; a failure during release is a warning and never replaces the error that caused it.

The live unmount check read `findmnt`'s output and discarded its exit status, which disabled the lazy fallback. The repository's own rule is that the runner merges stderr into stdout, so the status is read first — this was that rule broken in the unmount path.

Nothing said what state the machine was in. Every mapped failure now says either that nothing was written to the selected disk, or that it has been written to and may not boot. The exit codes are unchanged.

The durable log copy still happens before the unmount, which is where a previous defect put it afterwards, onto the medium's tmpfs.