### PR TITLE
tui: open selectors on the current value and mark a proposed display manager

### DIFF
--- a/gentoo_install/data/locale/ja.toml
+++ b/gentoo_install/data/locale/ja.toml
@@ -167,6 +167,8 @@
 "Graphics" = "グラフィック"
 "Display manager" = "ディスプレイマネージャ"
 "none" = "なし"
+"kept" = "維持"
+"proposed" = "提案"
 "measured" = "計測済み"
 "same as the console" = "コンソールと同じ"
 "i915 and xe, with the firmware they need" = "i915 と xe、必要なファームウェア込み"

--- a/gentoo_install/data/locale/ko.toml
+++ b/gentoo_install/data/locale/ko.toml
@@ -167,6 +167,8 @@
 "Graphics" = "그래픽"
 "Display manager" = "디스플레이 관리자"
 "none" = "없음"
+"kept" = "유지"
+"proposed" = "제안"
 "measured" = "측정됨"
 "same as the console" = "콘솔과 동일"
 "i915 and xe, with the firmware they need" = "i915 와 xe, 필요한 펌웨어 포함"

--- a/gentoo_install/data/locale/zh-CN.toml
+++ b/gentoo_install/data/locale/zh-CN.toml
@@ -167,6 +167,8 @@
 "Graphics" = "显卡"
 "Display manager" = "显示管理器"
 "none" = "无"
+"kept" = "保留"
+"proposed" = "建议"
 "measured" = "已测速"
 "same as the console" = "同控制台"
 "i915 and xe, with the firmware they need" = "i915 与 xe，含所需固件"

--- a/gentoo_install/data/locale/zh-TW.toml
+++ b/gentoo_install/data/locale/zh-TW.toml
@@ -167,6 +167,8 @@
 "Graphics" = "顯示卡"
 "Display manager" = "顯示管理器"
 "none" = "無"
+"kept" = "保留"
+"proposed" = "建議"
 "measured" = "已測速"
 "same as the console" = "同主控台"
 "i915 and xe, with the firmware they need" = "i915 與 xe，含所需韌體"

--- a/gentoo_install/tui/screens.py
+++ b/gentoo_install/tui/screens.py
@@ -984,6 +984,7 @@ def _edit_mirror(
         return _pick(
             screen, context, config, "Repository sync",
             list(SYNC_METHODS),
+            config.portage.sync,
             lambda chosen_config, value: replace(
                 chosen_config, portage=replace(chosen_config.portage, sync=value)
             ),
@@ -994,6 +995,7 @@ def _edit_mirror(
         return _pick(
             screen, context, config, "gentoo-zh binary packages",
             list(GENTOOZH_CHANNELS),
+            config.portage.binhost.community,
             lambda chosen_config, value: replace(
                 chosen_config,
                 portage=replace(
@@ -1018,25 +1020,43 @@ def _edit_mirror(
 V = TypeVar("V")
 
 
+def _current_menu(
+    screen: Screen,
+    context: Context,
+    title: str,
+    items: Sequence[Item[V]],
+    current: V,
+) -> Answer[list[V]]:
+    """A single-choice menu whose current value cannot be omitted."""
+    return Menu(
+        title=title,
+        items=items,
+        footer=footer(context.translate),
+        current=current,
+    ).run(screen)
+
+
 def _pick(
     screen: Screen,
     context: Context,
     config: InstallConfig,
     title: str,
     offered: list[tuple[V, str]],
+    current: V,
     apply: Callable[[InstallConfig, V], InstallConfig],
 ) -> InstallConfig | None:
     """One value from a short list, each row carrying what it costs."""
     translate = context.translate
-    menu: Menu[V] = Menu(
-        title=translate(title),
-        items=[
+    answer = _current_menu(
+        screen,
+        context,
+        translate(title),
+        [
             Item(label=str(getattr(value, "value", value)), value=value, detail=translate(reason))
             for value, reason in offered
         ],
-        footer=footer(translate),
+        current,
     )
-    answer = menu.run(screen)
     if not answer.chosen:
         return None
     return apply(config, answer.unwrap()[0])
@@ -1099,9 +1119,14 @@ def _edit_gentoozh(
         )
         for one in mirrors.GENTOOZH_SITES
     ]
-    answer = Menu(
-        title=translate("gentoo-zh"), items=items, footer=footer(translate)
-    ).run(screen)
+    used = any(one.name == "gentoo-zh" for one in config.portage.overlays)
+    answer = _current_menu(
+        screen,
+        context,
+        translate("gentoo-zh"),
+        items,
+        config.portage.mirrors.gentoo_zh if used else None,
+    )
     if not answer.chosen:
         return None
     picked = answer.unwrap()[0]
@@ -1720,6 +1745,7 @@ def display_manager_screen(
         "Display manager",
         DISPLAY_MANAGERS,
         lambda packages, name: replace(packages, display_manager=name),
+        current=config.packages.display_manager,
         unavailable=lambda name: without if name else "",
         say_what_it_adds=True,
     )
@@ -1747,14 +1773,17 @@ def _one_group(
     title: str,
     offered: tuple[tuple[str, str], ...],
     apply: Callable[[PackagesConfig, str], PackagesConfig],
+    current: str,
     unavailable: Callable[[str], str] = lambda name: "",
     say_what_it_adds: bool = False,
 ) -> Answer[InstallConfig]:
     """A row that holds one group name, drawn from a table of them."""
     translate = context.translate
-    menu: Menu[str] = Menu(
-        title=translate(title),
-        items=[
+    answer = _current_menu(
+        screen,
+        context,
+        translate(title),
+        [
             Item(
                 label=name or translate("none"),
                 value=name,
@@ -1765,9 +1794,8 @@ def _one_group(
             )
             for name, reason in offered
         ],
-        footer=footer(translate),
+        current,
     )
-    answer = menu.run(screen)
     if not answer.chosen:
         return Answer(answer.outcome)
     return Answer(
@@ -3189,18 +3217,30 @@ def _pick_keymap(
     families += [
         Item(label=family, value=family) for family in sorted({one for one, _ in offered})
     ]
-    answer = Menu(title=title, items=families, footer=footer(translate)).run(screen)
+    family_current = next(
+        (family for family, name in offered if name == current),
+        "",
+    )
+    answer = _current_menu(
+        screen,
+        context,
+        title,
+        families,
+        family_current,
+    )
     if not answer.chosen:
         return Answer(answer.outcome)
     family = answer.unwrap()[0]
     if not family:
         return Answer(Outcome.CHOSE, "")
     within = [name for one, name in offered if one == family]
-    chosen = Menu(
-        title=f"{title}  {family}",
-        items=[Item(label=name, value=name) for name in within],
-        footer=footer(translate),
-    ).run(screen)
+    chosen = _current_menu(
+        screen,
+        context,
+        f"{title}  {family}",
+        [Item(label=name, value=name) for name in within],
+        current,
+    )
     return (
         Answer(Outcome.CHOSE, chosen.unwrap()[0])
         if chosen.chosen
@@ -3574,11 +3614,13 @@ def _edit_disk(screen: Screen, context: Context, position: int) -> None:
         if answer.unwrap()[0] == _DROP:
             context.layout.disks.pop(position)
             return
-        picked = Menu(
-            title=translate("Partition table"),
-            items=[Item(label=one.value, value=one) for one in TableType],
-            footer=footer(translate),
-        ).run(screen)
+        picked = _current_menu(
+            screen,
+            context,
+            translate("Partition table"),
+            [Item(label=one.value, value=one) for one in TableType],
+            disk.table,
+        )
         if picked.chosen:
             disk.table = picked.unwrap()[0]
 
@@ -3695,9 +3737,11 @@ def _edit_array_field(screen: Screen, context: Context, field: str, members: int
     translate = context.translate
     array = context.layout.array
     if field == _LEVEL:
-        picked: Answer[list[RaidLevel]] = Menu(
-            title=translate("RAID level"),
-            items=[
+        picked = _current_menu(
+            screen,
+            context,
+            translate("RAID level"),
+            [
                 Item(
                     label=one.value,
                     value=one,
@@ -3707,15 +3751,17 @@ def _edit_array_field(screen: Screen, context: Context, field: str, members: int
                 )
                 for one in RaidLevel
             ],
-            footer=footer(translate),
-        ).run(screen)
+            array.level,
+        )
         if picked.chosen:
             array.level = picked.unwrap()[0]
         return
     if field == _METADATA:
-        chosen: Answer[list[RaidMetadata]] = Menu(
-            title=translate("Superblock"),
-            items=[
+        chosen = _current_menu(
+            screen,
+            context,
+            translate("Superblock"),
+            [
                 Item(
                     label=one.value,
                     value=one,
@@ -3725,17 +3771,19 @@ def _edit_array_field(screen: Screen, context: Context, field: str, members: int
                 )
                 for one in RaidMetadata
             ],
-            footer=footer(translate),
-        ).run(screen)
+            array.metadata,
+        )
         if chosen.chosen:
             array.metadata = chosen.unwrap()[0]
         return
     if field == _FILESYSTEM:
-        kind: Answer[list[FilesystemType]] = Menu(
-            title=translate("Filesystem"),
-            items=[Item(label=one.value, value=one) for one in FilesystemType],
-            footer=footer(translate),
-        ).run(screen)
+        kind = _current_menu(
+            screen,
+            context,
+            translate("Filesystem"),
+            [Item(label=one.value, value=one) for one in FilesystemType],
+            array.filesystem,
+        )
         if kind.chosen:
             array.filesystem = kind.unwrap()[0]
         return
@@ -3744,6 +3792,7 @@ def _edit_array_field(screen: Screen, context: Context, field: str, members: int
             **answers(translate),
             title=translate("Encrypt this array?"),
             footer=footer(translate),
+            current=bool(array.passphrase_file),
         ).run(screen)
         if not turned.chosen:
             return
@@ -3787,9 +3836,13 @@ def _pool_topology(
         )
         for one in ZfsTopology
     ]
-    answer = Menu(
-        title=translate("Pool topology"), items=items, footer=footer(translate)
-    ).run(screen)
+    answer = _current_menu(
+        screen,
+        context,
+        translate("Pool topology"),
+        items,
+        context.layout.topology,
+    )
     return answer.unwrap()[0] if answer.chosen else None
 
 
@@ -3936,14 +3989,16 @@ def _edit_field(
                 manual.SliceStatus.DELETE,
             ]
         )
-        chosen_status: Answer[list[manual.SliceStatus]] = Menu(
-            title=translate("What happens to it"),
-            items=[
+        chosen_status = _current_menu(
+            screen,
+            context,
+            translate("What happens to it"),
+            [
                 Item(label=translate(one.value), value=one, detail=translate(manual.STATUS_REASONS[one]))
                 for one in offered
             ],
-            footer=footer(translate),
-        ).run(screen)
+            entry.status,
+        )
         if not chosen_status.chosen:
             return None
         return replace(entry, status=chosen_status.unwrap()[0])
@@ -3959,9 +4014,11 @@ def _edit_field(
         text = typed.unwrap().strip()
         return replace(entry, size=Size.parse(text) if text else None)
     if field == _PURPOSE:
-        picked = Menu(
-            title=translate("What is this partition for?"),
-            items=[
+        picked = _current_menu(
+            screen,
+            context,
+            translate("What is this partition for?"),
+            [
                 Item(
                     label=one.label,
                     value=one,
@@ -3971,8 +4028,8 @@ def _edit_field(
                 )
                 for one in manual.PURPOSES
             ],
-            footer=footer(translate),
-        ).run(screen)
+            purpose,
+        )
         if not picked.chosen:
             return None
         return _apply_purpose(entry, picked.unwrap()[0])
@@ -3992,9 +4049,13 @@ def _edit_field(
                 disabled_because=context.zfs_unavailable,
             )
         )
-        answered = Menu(
-            title=translate("Filesystem"), items=items, footer=footer(translate)
-        ).run(screen)
+        answered = _current_menu(
+            screen,
+            context,
+            translate("Filesystem"),
+            items,
+            entry.filesystem,
+        )
         if not answered.chosen:
             return None
         kind = answered.unwrap()[0]
@@ -4047,6 +4108,7 @@ def _edit_slice_encryption(
             else translate("Encrypt this partition?")
         ),
         footer=footer(translate),
+        current=bool(entry.passphrase_file),
     ).run(screen)
     if not turned.chosen:
         return None

--- a/gentoo_install/tui/screens.py
+++ b/gentoo_install/tui/screens.py
@@ -198,6 +198,9 @@ class Context:
         #: opened is running on a default nobody chose, which the menu says in
         #: colour as well as in the value it shows.
         self.visited: set[str] = set()
+        #: A desktop proposal is withdrawn with that desktop; an explicit edit
+        #: clears this marker even when it chooses the same manager.
+        self.proposed_display_manager: str = ""
         #: The hand-written partition table, when the layout is manual.
         self.layout = manual.Layout()
         #: Whether the disk comes from that table rather than a template.
@@ -1477,8 +1480,36 @@ def desktop_screen(screen: Screen, config: InstallConfig, context: Context) -> A
                 ),
             ),
         )
+    manager = config.packages.display_manager
+    was_proposed = bool(manager and context.proposed_display_manager == manager)
+    kept_manager = (
+        manager
+        if manager and not was_proposed and desktop != config.packages.desktop
+        else ""
+    )
     changed = _desktop_proposes(changed, config, context, desktop)
-    return settle(screen, context, config, changed)
+    login = LOGIN_SCREEN.get(desktop, "")
+    proposed = (
+        login
+        if login
+        and changed.packages.display_manager == login
+        and (was_proposed or not manager)
+        else ""
+    )
+    answered = settle(
+        screen,
+        context,
+        config,
+        changed,
+        kept_display_manager=kept_manager,
+    )
+    if answered.chosen:
+        context.proposed_display_manager = (
+            proposed
+            if answered.unwrap().packages.display_manager == proposed
+            else ""
+        )
+    return answered
 
 
 #: What each desktop's own login screen is. Proposed rather than fixed: the
@@ -1504,10 +1535,18 @@ def _desktop_proposes(
     `USE=networkmanager`, and nothing moved `system.networking` with it, so the
     installed desktop had the settings panel and not the service behind it.
     """
+    if (
+        context.proposed_display_manager
+        and context.proposed_display_manager == before.packages.display_manager
+    ):
+        changed = replace(
+            changed,
+            packages=replace(changed.packages, display_manager=""),
+        )
     if not desktop:
         return changed
     login = LOGIN_SCREEN.get(desktop, "")
-    if login and not before.packages.display_manager and login in context.groups:
+    if login and not changed.packages.display_manager and login in context.groups:
         changed = replace(
             changed, packages=replace(changed.packages, display_manager=login)
         )
@@ -1520,7 +1559,11 @@ def _desktop_proposes(
 
 
 def settle(
-    screen: Screen, context: Context, before: InstallConfig, after: InstallConfig
+    screen: Screen,
+    context: Context,
+    before: InstallConfig,
+    after: InstallConfig,
+    kept_display_manager: str = "",
 ) -> Answer[InstallConfig]:
     """Confirm what a choice changes outside its own row, then write it down.
 
@@ -1542,6 +1585,7 @@ def settle(
     moved = (
         after.packages.display_manager != before.packages.display_manager
         or after.system.networking is not before.system.networking
+        or bool(kept_display_manager)
     )
     if not (flags or cards or joins or profile or moved):
         return Answer(Outcome.CHOSE, after)
@@ -1554,6 +1598,11 @@ def settle(
     if after.packages.display_manager != before.packages.display_manager:
         lines.append(
             f"{translate('Display manager')}: {after.packages.display_manager}"
+        )
+    elif kept_display_manager:
+        lines.append(
+            f"{translate('Display manager')}: {kept_display_manager} "
+            f"({translate('kept')})"
         )
     if after.system.networking is not before.system.networking:
         lines.append(f"{translate('Network')}: {after.system.networking.value}")
@@ -1751,7 +1800,10 @@ def display_manager_screen(
     )
     if not chosen.chosen:
         return chosen
-    return settle(screen, context, config, chosen.unwrap())
+    answered = settle(screen, context, config, chosen.unwrap())
+    if answered.chosen:
+        context.proposed_display_manager = ""
+    return answered
 
 
 def _needs_an_overlay(

--- a/gentoo_install/tui/settings.py
+++ b/gentoo_install/tui/settings.py
@@ -562,7 +562,10 @@ def _input_devices(config: InstallConfig, context: Context) -> str:
 
 
 def _display_manager(config: InstallConfig, context: Context) -> str:
-    return config.packages.display_manager or context.translate("none")
+    chosen = config.packages.display_manager
+    if chosen and context.proposed_display_manager == chosen:
+        return f"{chosen} ({context.translate('proposed')})"
+    return chosen or context.translate("none")
 
 
 def _applications(config: InstallConfig, context: Context) -> str:

--- a/tests/unit/test_tui_app.py
+++ b/tests/unit/test_tui_app.py
@@ -2432,6 +2432,40 @@ def test_a_desktop_proposes_its_login_screen_and_a_network_manager() -> None:
     assert kept.packages.display_manager == "greetd"
 
 
+def test_a_proposed_display_manager_is_withdrawn_but_an_operator_choice_is_kept() -> None:
+    at = context()
+    plasma = screens.desktop_screen(
+        FakeScreen(keys=[*down(4), "\n", "\n"], lines=30), config(), at
+    ).unwrap()
+    assert "proposed" in settings._display_manager(plasma, at)
+
+    gnome = screens.desktop_screen(
+        FakeScreen(keys=["KEY_UP", "KEY_UP", "\n", "\n"], lines=30), plasma, at
+    ).unwrap()
+    assert gnome.packages.display_manager == "gdm"
+    assert "sddm" not in gnome.portage.use
+
+    explicit_at = context()
+    proposed = screens.desktop_screen(
+        FakeScreen(keys=[*down(4), "\n", "\n"], lines=30),
+        config(),
+        explicit_at,
+    ).unwrap()
+    explicit = screens.display_manager_screen(
+        FakeScreen(keys=["\n"], lines=30), proposed, explicit_at
+    ).unwrap()
+    assert "proposed" not in settings._display_manager(explicit, explicit_at)
+
+    kept_screen = FakeScreen(
+        keys=["KEY_UP", "KEY_UP", "\n", "\n"], lines=30, columns=100
+    )
+    kept = screens.desktop_screen(kept_screen, explicit, explicit_at).unwrap()
+    assert kept.packages.display_manager == "sddm"
+    assert "Display manager: sddm (kept)" in "\n".join(
+        "\n".join(frame) for frame in kept_screen.frames
+    )
+
+
 def test_what_a_desktop_brings_is_listed_in_one_place() -> None:
     """Every place the choice reaches, on the screen that asks about it."""
     at = context()

--- a/tests/unit/test_tui_app.py
+++ b/tests/unit/test_tui_app.py
@@ -17,7 +17,7 @@ from gentoo_install.model.config import (
     MirrorRegion,
 )
 from gentoo_install.model import manual
-from gentoo_install.model.device import FilesystemType
+from gentoo_install.model.device import FilesystemType, RaidLevel, RaidMetadata, ZfsTopology
 from gentoo_install.model.validate import validate
 from gentoo_install.model import compat
 from gentoo_install.tui import screens, settings
@@ -567,6 +567,44 @@ def test_the_mirror_row_shows_every_service_and_lets_each_be_chosen() -> None:
         assert label in drawn, label
 
 
+def test_mirror_subselectors_reopen_on_the_values_their_rows_show() -> None:
+    from gentoo_install.model.config import BinhostChannel, GentooZhMirror, Sync
+    from gentoo_install.model.config import Overlay
+    from gentoo_install.model import mirrors
+
+    at = context()
+    base = config()
+    held = replace(
+        base,
+        portage=replace(
+            base.portage,
+            sync=Sync.WEBRSYNC,
+            binhost=replace(
+                base.portage.binhost,
+                community=BinhostChannel.UNSTABLE,
+            ),
+            mirrors=replace(
+                base.portage.mirrors,
+                gentoo_zh=GentooZhMirror.NJU,
+            ),
+            overlays=(Overlay(name="gentoo-zh", sync_uri="https://example.invalid"),),
+        ),
+    )
+
+    sync = FakeScreen(keys=["q"])
+    screens._edit_mirror(sync, at, held, screens._SYNC)
+    assert "webrsync" in sync.highlighted[0]
+
+    community = FakeScreen(keys=["q"])
+    screens._edit_mirror(community, at, held, screens._ZH_BINHOST)
+    assert "unstable" in community.highlighted[0]
+
+    overlay = FakeScreen(keys=["q"])
+    screens._edit_mirror(overlay, at, held, screens._ZH_SITE)
+    expected = at.translate(mirrors.gentoozh(GentooZhMirror.NJU).name)
+    assert expected in overlay.highlighted[0]
+
+
 def test_choosing_a_gentoozh_mirror_is_what_adds_the_overlay() -> None:
     """A mirror chosen for an overlay nobody selected changes nothing, so the
     two are one row."""
@@ -980,6 +1018,29 @@ def test_an_empty_disk_opens_on_the_template_proposal() -> None:
     screens.partitions_screen(screen, config(), at)
     assert at.layout.slices
     assert all(one.status is manual.SliceStatus.CREATE for one in at.layout.slices)
+
+
+def test_manual_storage_subselectors_reopen_on_the_values_their_rows_show() -> None:
+    at = context()
+    at.layout.array.level = RaidLevel.RAID6
+    at.layout.array.metadata = RaidMetadata.V1_2
+    at.layout.array.filesystem = FilesystemType.XFS
+    at.layout.topology = ZfsTopology.RAIDZ2
+
+    cases = (
+        (screens._LEVEL, "raid6"),
+        (screens._METADATA, "1.2"),
+        (screens._FILESYSTEM, "xfs"),
+    )
+    for field, shown in cases:
+        reopened = FakeScreen(keys=["q"])
+        screens._edit_array_field(reopened, at, field, members=4)
+        assert shown in reopened.highlighted[0], field
+
+    topology = FakeScreen(keys=["q"])
+    screens._pool_topology(topology, at, members=4)
+    assert "raidz2" in topology.highlighted[0]
+
 
 def test_the_reuse_layout_is_never_built_from_a_template() -> None:
     """A template has no existing partitions to name, so approximating one
@@ -1605,6 +1666,21 @@ def test_the_keyboard_layout_is_picked_from_what_the_machine_ships() -> None:
     # The field is prefilled with the current keymap, so `us` is cleared first.
     typed = FakeScreen(keys=["KEY_BACKSPACE", "KEY_BACKSPACE", *"fr", "\n"], lines=24, columns=90)
     assert screens.keymap_screen(typed, config(), at).unwrap().system.keymap == "fr"
+
+
+def test_the_keymap_picker_reopens_on_the_current_family_and_keymap() -> None:
+    at = context()
+    at.keymaps = lambda: (
+        ("qwerty", "de"),
+        ("qwerty", "us"),
+        ("dvorak", "dvorak"),
+    )
+    reopened = FakeScreen(keys=["\n", "\n"])
+
+    answer = screens.keymap_screen(reopened, config(), at)
+
+    assert answer.unwrap().system.keymap == "us"
+    assert reopened.highlighted[:2] == ["qwerty", "us"]
 
 
 def test_the_unlock_keyboard_offers_following_the_console() -> None:


### PR DESCRIPTION
A selector opened on its first item rather than the value its row displayed, so the mirror, keymap and manual-storage rows showed a value the operator had already changed. `_current_menu` makes `current` a required argument, which turns the next omission into a mypy error rather than a silent wrong default.

A display manager derived from the desktop was stored the same way as one the operator picked, so switching from KDE to GNOME left sddm in the configuration. The provenance is now recorded and the summary marks the value `proposed` or `kept`.