### PR TITLE
plan: three faults a correctness review found

### DIFF
--- a/gentoo_install/model/compat.py
+++ b/gentoo_install/model/compat.py
@@ -53,6 +53,52 @@ from .device import (
 #: to provide.
 CJK_FONT_SIZES = frozenset({ConsoleFontSize.SIZE_8X16})
 
+
+class FilesystemLabelUnit(Enum):
+    BYTES = "bytes"
+    CHARACTERS = "characters"
+
+    def measure(self, label: str) -> int:
+        return len(label.encode()) if self is FilesystemLabelUnit.BYTES else len(label)
+
+
+@dataclass(frozen=True)
+class FilesystemLabelRule:
+    kind: FilesystemType
+    maximum: int
+    unit: FilesystemLabelUnit
+
+    def problem(self, filesystem: Filesystem) -> str | None:
+        length = self.unit.measure(filesystem.label)
+        if not filesystem.create or length <= self.maximum:
+            return None
+        return (
+            f"filesystem {filesystem.id} has a {filesystem.kind.value} label of {length} "
+            f"{self.unit.value}, but {filesystem.kind.value} labels are limited to "
+            f"{self.maximum} {self.unit.value}"
+        )
+
+
+FILESYSTEM_LABEL_RULES: tuple[FilesystemLabelRule, ...] = (
+    FilesystemLabelRule(FilesystemType.EXT2, 16, FilesystemLabelUnit.BYTES),
+    FilesystemLabelRule(FilesystemType.EXT3, 16, FilesystemLabelUnit.BYTES),
+    FilesystemLabelRule(FilesystemType.EXT4, 16, FilesystemLabelUnit.BYTES),
+    # The CJK probe fails during CP850 conversion before length is checked, so
+    # this entry represents only mkfs.fat's independent character-count limit.
+    FilesystemLabelRule(FilesystemType.VFAT, 11, FilesystemLabelUnit.CHARACTERS),
+)
+
+
+def filesystem_label_problems(config: InstallConfig) -> tuple[str, ...]:
+    rules = {rule.kind: rule for rule in FILESYSTEM_LABEL_RULES}
+    return tuple(
+        problem
+        for filesystem in config.disk.graph.of_type(Filesystem)
+        if filesystem.kind in rules
+        if (problem := rules[filesystem.kind].problem(filesystem)) is not None
+    )
+
+
 _BOOT = PurePosixPath("/boot")
 _ROOT = PurePosixPath("/")
 _USR = PurePosixPath("/usr")

--- a/gentoo_install/model/validate.py
+++ b/gentoo_install/model/validate.py
@@ -122,6 +122,7 @@ def validate(
 ) -> None:
     problems = [
         *_layout_problems(config),
+        *compat.filesystem_label_problems(config),
         *root_size_problems(config),
         *_profile_problems(config),
         *_repository_profile_problems(config.portage.profile, available_profiles),

--- a/gentoo_install/plan/disk.py
+++ b/gentoo_install/plan/disk.py
@@ -707,7 +707,7 @@ class MountZfsDataset(Operation):
     """A dataset carries its own mountpoint property, so it is mounted by name."""
 
     stage: Stage = Stage.MOUNT
-    host_commands = ("zfs",)
+    host_commands = ("zfs", "findmnt")
     mountpoint: DeviceId
     name: str
     path: PurePosixPath
@@ -720,14 +720,27 @@ class MountZfsDataset(Operation):
         return f"mount dataset {self.name} at {self.path}"
 
     def apply(self, context: Context) -> None:
-        # Asked of ZFS, not of the path. `zfs create` mounts a dataset the
-        # moment it is given a mountpoint, and mounting it again answers
-        # `filesystem already mounted` and stops the install. The mountpoint
-        # property carries the target prefix during an install, so checking
-        # `self.path` asked about a directory on the installing system.
-        if context.run(["zfs", "get", "-H", "-o", "value", "mounted", self.name],
-                       check=False).strip() == "yes":
-            return
+        mounted = context.run(
+            ["zfs", "get", "-H", "-o", "value", "mounted", self.name],
+            check=False,
+        ).strip()
+        if mounted == "yes":
+            # A parent mounted later can hide this dataset while ZFS still
+            # reports it mounted, so the effective source decides readiness.
+            visible = context.run(
+                [
+                    "findmnt",
+                    "--noheadings",
+                    "--output",
+                    "SOURCE",
+                    "--target",
+                    str(_under(context.target, self.path)),
+                ],
+                check=False,
+            ).strip()
+            if visible == self.name:
+                return
+            context.run(["zfs", "unmount", self.name])
         context.run(["zfs", "mount", self.name])
 
 

--- a/gentoo_install/plan/system.py
+++ b/gentoo_install/plan/system.py
@@ -322,7 +322,7 @@ class WriteFstab(Operation):
                 else f"UUID={context.device_uuid(entry.device)}"
             )
             lines.append(
-                f"{where}\t{entry.path}\t{entry.kind}\t"
+                f"{where}\t{_fstab_path(entry.path)}\t{entry.kind}\t"
                 f"{options}\t{entry.dump}\t{entry.check}"
             )
         context.write(PurePosixPath("/etc/fstab"), "\n".join(lines) + "\n")
@@ -1222,6 +1222,10 @@ def _default_options(kind: FilesystemType) -> tuple[str, ...]:
 def _check_order(path: PurePosixPath) -> int:
     """fsck order: the root filesystem first, everything else after it."""
     return 1 if path == ROOT else 2
+
+
+def _fstab_path(path: PurePosixPath) -> str:
+    return str(path).replace("\t", r"\011").replace(" ", r"\040")
 
 
 def _groups_of(user: User) -> tuple[str, ...]:

--- a/tests/unit/test_plan_disk.py
+++ b/tests/unit/test_plan_disk.py
@@ -29,6 +29,7 @@ from gentoo_install.model.device import (
     Swap,
     TableType,
     VolumeGroup,
+    ZfsDataset,
     ZfsPool,
 )
 from gentoo_install.exec.config import load
@@ -476,8 +477,47 @@ def test_a_dataset_already_mounted_is_left_alone() -> None:
 
     already = Recorder()
     already.replies["zfs"] = "yes\n"
+    already.replies["findmnt"] = "rpool/ROOT/gentoo/home\n"
     told.apply(already)
-    assert not any(one[:2] == ("zfs", "mount") for one in already.commands)
+    assert not any(one[:2] in {("zfs", "mount"), ("zfs", "unmount")} for one in already.commands)
+
+
+def test_a_zfs_child_hidden_by_the_root_is_remounted_after_it() -> None:
+    nodes = zfs_root()
+    nodes += [
+        ZfsDataset(id=i("ds-home"), pool=i("pool"), name="ROOT/gentoo/home"),
+        Mountpoint(id=i("mnt-home"), source=i("ds-home"), path=PurePosixPath("/home")),
+    ]
+    operations = disk.build(config(nodes))
+    root = next(
+        index
+        for index, operation in enumerate(operations)
+        if isinstance(operation, disk.MountZfsDataset) and operation.path == PurePosixPath("/")
+    )
+    home = next(
+        (index, operation)
+        for index, operation in enumerate(operations)
+        if isinstance(operation, disk.MountZfsDataset)
+        and operation.path == PurePosixPath("/home")
+    )
+    assert root < home[0]
+
+    hidden = Recorder(replies={"zfs": "yes\n", "findmnt": "zpcala/ROOT/gentoo/root\n"})
+    home[1].apply(hidden)
+    assert (
+        "findmnt",
+        "--noheadings",
+        "--output",
+        "SOURCE",
+        "--target",
+        "/mnt/gentoo/home",
+    ) in hidden.commands
+    assert hidden.argv_starting("zfs", "unmount") == (
+        ("zfs", "unmount", "zpcala/ROOT/gentoo/home"),
+    )
+    assert hidden.argv_starting("zfs", "mount") == (
+        ("zfs", "mount", "zpcala/ROOT/gentoo/home"),
+    )
 
 
 #: What `parted --machine --script <disk> unit B print free` printed for a

--- a/tests/unit/test_plan_system.py
+++ b/tests/unit/test_plan_system.py
@@ -116,6 +116,20 @@ def test_fstab_names_devices_by_uuid_and_puts_the_root_check_first() -> None:
     assert any("umask=0077" in line for line in lines)
 
 
+def test_fstab_escapes_a_space_in_a_mountpoint() -> None:
+    nodes = ext4_on_gpt()
+    nodes.append(
+        Mountpoint(
+            id=i("mnt-shared"),
+            source=i("rootfs"),
+            path=PurePosixPath("/srv/shared files"),
+        )
+    )
+    installation = config(nodes)
+    written = apply_all(installation, generated=generated(installation)).files[FSTAB]
+    assert "\t/srv/shared\\040files\text4\t" in written
+
+
 def test_an_option_the_layout_sets_replaces_the_default_rather_than_joining_it() -> None:
     """`umask=0077,umask=0077` is what mount reads when both are written, and
     the installed system's fstab had exactly that."""

--- a/tests/unit/test_validate.py
+++ b/tests/unit/test_validate.py
@@ -7,8 +7,10 @@ from pathlib import Path, PurePosixPath
 import pytest
 
 from gentoo_install.errors import ConfigError, ValidationFailed
+from gentoo_install.model import compat
 from gentoo_install.model.config import InitSystem, InstallConfig
 from gentoo_install.model.device import (
+    Filesystem,
     Mountpoint,
     Node,
     Partition,
@@ -63,7 +65,7 @@ def test_a_root_mounted_somewhere_else_is_named() -> None:
 
 
 def test_vfat_cannot_be_the_root_filesystem() -> None:
-    from gentoo_install.model.device import Filesystem, FilesystemType
+    from gentoo_install.model.device import FilesystemType
 
     nodes = [
         replace(node, kind=FilesystemType.VFAT)
@@ -73,6 +75,56 @@ def test_vfat_cannot_be_the_root_filesystem() -> None:
     ]
     with pytest.raises(ValidationFailed, match="root filesystem is vfat"):
         validate(config(nodes))
+
+
+@pytest.mark.parametrize(
+    "rule",
+    [
+        pytest.param(rule, id=rule.kind.value)
+        for rule in compat.FILESYSTEM_LABEL_RULES
+        if rule.unit is compat.FilesystemLabelUnit.BYTES
+    ],
+)
+def test_an_ext_filesystem_label_over_16_bytes_is_refused(
+    rule: compat.FilesystemLabelRule,
+) -> None:
+    nodes = [
+        replace(node, kind=rule.kind, label="x" * (rule.maximum + 1))
+        if isinstance(node, Filesystem) and node.id == i("rootfs")
+        else node
+        for node in ext4_on_gpt()
+    ]
+    with pytest.raises(
+        ValidationFailed,
+        match=rf"{rule.kind.value}.*17 bytes.*limited to 16 bytes",
+    ):
+        validate(config(nodes))
+
+
+def test_a_vfat_label_over_11_characters_is_refused() -> None:
+    nodes = [
+        replace(node, label="x" * 12)
+        if isinstance(node, Filesystem) and node.id == i("espfs")
+        else node
+        for node in ext4_on_gpt()
+    ]
+    with pytest.raises(
+        ValidationFailed,
+        match=r"vfat.*12 characters.*limited to 11 characters",
+    ):
+        validate(config(nodes))
+
+
+def test_the_vfat_limit_measures_characters_rather_than_utf8_bytes() -> None:
+    label = "\u4e2d\u6587\u6807\u7b7e"
+    rule = next(
+        rule
+        for rule in compat.FILESYSTEM_LABEL_RULES
+        if rule.kind.value == "vfat"
+    )
+    assert len(label) == 4
+    assert len(label.encode()) == 12
+    assert rule.unit.measure(label) == 4
 
 
 def test_a_malformed_authorized_key_is_refused_while_parsing() -> None:
@@ -554,5 +606,3 @@ def test_a_zfs_kernel_ceiling_refuses_above_and_accepts_below() -> None:
         validate(above, zfs_kernel_max="7.0")
     validate(below, zfs_kernel_max="7.0")
     validate(same_minor, zfs_kernel_max="7.0")
-
-


### PR DESCRIPTION
A ZFS `/home` dataset created before the root is mounted disappears under the later root mount while `zfs get mounted` still answers yes, so the plan treated it as ready.

`fstab(5)` splits fields on whitespace; a mountpoint containing a space wrote a line the kernel parses as different fields.

A label the chosen mkfs refuses stops the install after the partition table is written. `mke2fs` documents 16 bytes, `mkfs.fat` answers `no longer than 11 characters`, so each rule carries its own tool's unit. xfs, btrfs and f2fs have no manual on this machine and stay out of the table rather than being guessed.