### PR TITLE
packages: verify installed payload contracts

### DIFF
--- a/gentoo_install/exec/apply.py
+++ b/gentoo_install/exec/apply.py
@@ -15,7 +15,7 @@ from functools import lru_cache
 from pathlib import Path, PurePosixPath
 from typing import Sequence
 
-from ..errors import GentooInstallError, InvalidLayout
+from ..errors import CommandFailed, GentooInstallError, InvalidLayout
 from ..model.config import InstallConfig
 from ..model.device import (
     DeviceId,
@@ -31,7 +31,7 @@ from ..model.device import (
 from ..log import Journal
 from ..plan.disk import STAGE3_CACHE
 from ..plan.operations import CommandOutput, Operation
-from . import fetch
+from . import fetch, packages
 from .probe import Probe
 from .runner import Runner, open_in_target, under, write_file
 
@@ -61,6 +61,21 @@ class Machine:
     def run_in_target(self, argv: Sequence[str], *, check: bool = True) -> str:
         result = self.runner.in_target(self.mountpoint).run(argv, check=check)
         return CommandOutput(result.stdout, result.returncode)
+
+    def installed_package_paths(self, package: str) -> frozenset[PurePosixPath]:
+        return packages.installed_package_paths(self.mountpoint, package)
+
+    def installed_command_help(self, package: str, command: PurePosixPath) -> str:
+        result = self.runner.in_target(self.mountpoint).run([str(command), "--help"], check=False)
+        if result.returncode != 0:
+            raise CommandFailed(
+                f"cannot verify options installed by {package}: "
+                f"{command} --help exited {result.returncode}"
+            )
+        return result.stdout
+
+    def target_is_directory(self, path: PurePosixPath) -> bool:
+        return packages.target_is_directory(self.mountpoint, path)
 
     def write(self, path: PurePosixPath, content: str, *, mode: int = 0o644) -> None:
         # The mode is set at open time: writing first and narrowing afterwards

--- a/gentoo_install/exec/packages.py
+++ b/gentoo_install/exec/packages.py
@@ -1,0 +1,96 @@
+"""Read package payload contracts from an installed Gentoo target."""
+
+from __future__ import annotations
+
+import os
+import re
+
+from pathlib import Path, PurePosixPath
+
+from ..errors import CommandFailed
+from .runner import TargetEscape, open_in_target
+
+
+_ATOM = re.compile(r"^[A-Za-z0-9+_.-]+/[A-Za-z0-9+_.-]+$")
+
+
+def parse_contents(content: str) -> frozenset[PurePosixPath]:
+    """Return paths from the VDB CONTENTS format emitted by Portage."""
+    paths: set[PurePosixPath] = set()
+    for line_number, line in enumerate(content.splitlines(), start=1):
+        kind, separator, fields = line.partition(" ")
+        if not separator:
+            raise CommandFailed(f"VDB CONTENTS line {line_number} has no path")
+        if kind == "dir":
+            raw_path = fields
+        elif kind == "obj":
+            parts = fields.rsplit(maxsplit=2)
+            if len(parts) != 3:
+                raise CommandFailed(f"VDB CONTENTS object line {line_number} is malformed")
+            raw_path = parts[0]
+        elif kind == "sym":
+            target = fields.rsplit(maxsplit=1)
+            if len(target) != 2:
+                raise CommandFailed(f"VDB CONTENTS symlink line {line_number} is malformed")
+            raw_path, arrow, _ = target[0].partition(" -> ")
+            if not arrow:
+                raise CommandFailed(f"VDB CONTENTS symlink line {line_number} has no target")
+        else:
+            raise CommandFailed(f"VDB CONTENTS line {line_number} has unknown type {kind!r}")
+        path = PurePosixPath(raw_path)
+        if not path.is_absolute():
+            raise CommandFailed(f"VDB CONTENTS line {line_number} has a relative path")
+        paths.add(path)
+    return frozenset(paths)
+
+
+def installed_package_paths(target: Path, package: str) -> frozenset[PurePosixPath]:
+    """Read every installed version of an atom from the target's VDB."""
+    atom = package.split(":", 1)[0]
+    if not _ATOM.fullmatch(atom):
+        raise CommandFailed(f"cannot inspect installed files for invalid package atom {package!r}")
+    category, name = atom.split("/", 1)
+    category_path = PurePosixPath(f"/var/db/pkg/{category}")
+    try:
+        category_handle = open_in_target(target, category_path, os.O_RDONLY | os.O_DIRECTORY)
+    except (FileNotFoundError, NotADirectoryError):
+        return frozenset()
+    except (OSError, TargetEscape) as error:
+        raise CommandFailed(f"cannot read the installed package database for {package}") from error
+
+    try:
+        versions = os.listdir(category_handle)
+    except OSError as error:
+        raise CommandFailed(f"cannot list installed versions of {package}") from error
+    finally:
+        os.close(category_handle)
+
+    prefix = f"{name}-"
+    matched = [
+        version
+        for version in versions
+        if version.startswith(prefix)
+        and version[len(prefix) : len(prefix) + 1].isdigit()
+    ]
+    paths: set[PurePosixPath] = set()
+    for version in matched:
+        contents_path = category_path / version / "CONTENTS"
+        try:
+            handle = open_in_target(target, contents_path, os.O_RDONLY)
+            with os.fdopen(handle, "r") as contents:
+                paths.update(parse_contents(contents.read()))
+        except (OSError, TargetEscape) as error:
+            raise CommandFailed(f"cannot read {contents_path} for {package}") from error
+    return frozenset(paths)
+
+
+def target_is_directory(target: Path, path: PurePosixPath) -> bool:
+    """Whether an absolute target path is an existing directory."""
+    try:
+        handle = open_in_target(target, path, os.O_RDONLY | os.O_DIRECTORY)
+    except (FileNotFoundError, NotADirectoryError):
+        return False
+    except (OSError, TargetEscape) as error:
+        raise CommandFailed(f"cannot inspect target directory {path}") from error
+    os.close(handle)
+    return True

--- a/gentoo_install/plan/packages.py
+++ b/gentoo_install/plan/packages.py
@@ -10,14 +10,17 @@ function of its arguments.
 
 from __future__ import annotations
 
+import json
 import re
+import shlex
+import tomllib
 
 from dataclasses import dataclass
 from enum import Enum
 from pathlib import PurePosixPath
-from typing import Final, Mapping, Sequence
+from typing import Final, Mapping, Protocol, Sequence, runtime_checkable
 
-from ..errors import ConfigError, ValidationFailed
+from ..errors import CommandFailed, ConfigError, ValidationFailed
 from ..model.config import InitSystem, InstallConfig
 from .operations import Context, Operation, Stage
 from .portage import Emerge
@@ -125,6 +128,217 @@ class WriteGroupFile(Operation):
 
     def apply(self, context: Context) -> None:
         context.write(self.file.path, self.file.content)
+
+
+@runtime_checkable
+class PackageInspection(Protocol):
+    """Apply-time access to package-owned state in the installed target."""
+
+    def installed_package_paths(self, package: str) -> frozenset[PurePosixPath]: ...
+
+    def installed_command_help(self, package: str, command: PurePosixPath) -> str: ...
+
+    def target_is_directory(self, path: PurePosixPath) -> bool: ...
+
+
+def _package_inspection(context: Context, package: str) -> PackageInspection:
+    if not isinstance(context, PackageInspection):
+        raise CommandFailed(
+            f"cannot verify files installed by {package}: the apply context "
+            "does not expose package inspection"
+        )
+    return context
+
+
+@dataclass(frozen=True, kw_only=True)
+class VerifyPackagePaths(Operation):
+    stage: Stage = Stage.PACKAGES
+    package: str
+    paths: tuple[PurePosixPath, ...]
+
+    def describe(self) -> str:
+        return f"verify {self.package} installed {', '.join(map(str, self.paths))}"
+
+    def apply(self, context: Context) -> None:
+        installed = _package_inspection(context, self.package).installed_package_paths(
+            self.package
+        )
+        missing = tuple(path for path in self.paths if path not in installed)
+        if missing:
+            raise CommandFailed(
+                f"{self.package} was expected to provide "
+                f"{', '.join(map(str, missing))}, but its VDB CONTENTS does not list it"
+            )
+
+
+_LONG_OPTION = re.compile(
+    r'''(?<![A-Za-z0-9_-])--[A-Za-z0-9][A-Za-z0-9-]*(?=[\s,=\[\]"']|$)'''
+)
+
+
+@dataclass(frozen=True, kw_only=True)
+class VerifyCommandOptions(Operation):
+    stage: Stage = Stage.PACKAGES
+    package: str
+    command: PurePosixPath
+    options: tuple[str, ...]
+
+    def describe(self) -> str:
+        return f"verify {self.package} installed {self.command} with {', '.join(self.options)}"
+
+    def apply(self, context: Context) -> None:
+        inspection = _package_inspection(context, self.package)
+        installed = inspection.installed_package_paths(self.package)
+        if self.command not in installed:
+            raise CommandFailed(
+                f"{self.package} was expected to provide {self.command}, "
+                "but its VDB CONTENTS does not list it"
+            )
+        help_text = inspection.installed_command_help(self.package, self.command)
+        available = frozenset(_LONG_OPTION.findall(help_text))
+        missing = tuple(option for option in self.options if option not in available)
+        if missing:
+            raise CommandFailed(
+                f"{self.package} installed {self.command}, but {self.command} --help "
+                f"does not list {', '.join(missing)}"
+            )
+
+
+@dataclass(frozen=True, kw_only=True)
+class VerifySessionDirectories(Operation):
+    stage: Stage = Stage.PACKAGES
+    package: str
+    paths: tuple[PurePosixPath, ...]
+
+    def describe(self) -> str:
+        return f"verify session directories for {self.package}"
+
+    def apply(self, context: Context) -> None:
+        if not self.package:
+            raise CommandFailed(
+                "cannot verify greetd session directories because no desktop package was selected"
+            )
+        inspection = _package_inspection(context, self.package)
+        missing = tuple(path for path in self.paths if not inspection.target_is_directory(path))
+        if missing:
+            raise CommandFailed(
+                f"{self.package} was expected to provide a session in "
+                f"{', '.join(map(str, missing))}, but the directory does not exist"
+            )
+
+
+GREETD_PACKAGE: Final[str] = "gui-libs/greetd"
+GREETD_CONFIG: Final[PurePosixPath] = PurePosixPath("/etc/greetd/config.toml")
+TUIGREET_PACKAGE: Final[str] = "gui-apps/tuigreet"
+TUIGREET_COMMAND: Final[PurePosixPath] = PurePosixPath("/usr/bin/tuigreet")
+
+
+@dataclass(frozen=True, kw_only=True)
+class UpdateGreetdConfig(Operation):
+    stage: Stage = Stage.PACKAGES
+    command: str
+
+    def describe(self) -> str:
+        return f"set the greetd default session command in {GREETD_CONFIG}"
+
+    def apply(self, context: Context) -> None:
+        installed = _package_inspection(context, GREETD_PACKAGE).installed_package_paths(
+            GREETD_PACKAGE
+        )
+        if GREETD_CONFIG not in installed:
+            raise CommandFailed(
+                f"{GREETD_PACKAGE} was expected to provide {GREETD_CONFIG}, "
+                "but its VDB CONTENTS does not list it"
+            )
+        current = context.read(GREETD_CONFIG)
+        context.write(GREETD_CONFIG, _replace_greetd_command(current, self.command))
+
+
+_TOML_TABLE = re.compile(r"^\s*\[([^]]+)]\s*(?:#.*)?(?:\r?\n)?$")
+_TOML_COMMAND = re.compile(
+    r'^(\s*command\s*=\s*)("(?:[^"\\]|\\.)*")(\s*(?:#.*)?)(\r?\n?)$'
+)
+
+
+def _replace_greetd_command(content: str, command: str) -> str:
+    try:
+        parsed = tomllib.loads(content)
+    except tomllib.TOMLDecodeError as error:
+        raise CommandFailed(f"cannot parse {GREETD_CONFIG} installed by {GREETD_PACKAGE}") from error
+    session = parsed.get("default_session")
+    if not isinstance(session, dict) or not isinstance(session.get("command"), str):
+        raise CommandFailed(
+            f"{GREETD_CONFIG} installed by {GREETD_PACKAGE} has no "
+            "default_session.command string"
+        )
+
+    table = ""
+    replaced = 0
+    lines: list[str] = []
+    for line in content.splitlines(keepends=True):
+        header = _TOML_TABLE.match(line)
+        if header:
+            table = header.group(1).strip()
+        match = _TOML_COMMAND.match(line) if table == "default_session" else None
+        if match:
+            line = f"{match.group(1)}{json.dumps(command)}{match.group(3)}{match.group(4)}"
+            replaced += 1
+        lines.append(line)
+    if replaced != 1:
+        raise CommandFailed(
+            f"cannot safely update default_session.command in {GREETD_CONFIG} "
+            f"installed by {GREETD_PACKAGE}"
+        )
+    return "".join(lines)
+
+
+@dataclass(frozen=True, kw_only=True)
+class UpdatePackageShellAssignment(Operation):
+    stage: Stage = Stage.PACKAGES
+    group: str
+    package: str
+    path: PurePosixPath
+    key: str
+    value: str
+
+    def describe(self) -> str:
+        return f"write {self.path} for the {self.group} group"
+
+    def apply(self, context: Context) -> None:
+        installed = _package_inspection(context, self.package).installed_package_paths(
+            self.package
+        )
+        if self.path not in installed:
+            raise CommandFailed(
+                f"{self.package} was expected to provide {self.path}, "
+                "but its VDB CONTENTS does not list it"
+            )
+        current = context.read(self.path)
+        updated = _replace_shell_assignment(current, self.key, self.value, self.path)
+        context.write(self.path, updated)
+
+
+def _replace_shell_assignment(
+    content: str, key: str, value: str, path: PurePosixPath
+) -> str:
+    if not re.fullmatch(r"[A-Za-z_][A-Za-z0-9_]*", key):
+        raise ConfigError(f"{key!r} is not a shell variable")
+    if not re.fullmatch(r"[A-Za-z0-9_.-]+", value):
+        raise ConfigError(f"{value!r} is not a safe value for {key}")
+    assignment = re.compile(
+        rf'^(\s*{re.escape(key)}\s*=\s*)("(?:[^"\\]|\\.)*")(\s*(?:#.*)?)(\r?\n?)$'
+    )
+    replaced = 0
+    lines: list[str] = []
+    for line in content.splitlines(keepends=True):
+        match = assignment.match(line)
+        if match:
+            line = f'{match.group(1)}"{value}"{match.group(3)}{match.group(4)}'
+            replaced += 1
+        lines.append(line)
+    if replaced != 1:
+        raise CommandFailed(f"cannot safely update {key} in {path}")
+    return "".join(lines)
 
 
 Catalog = Mapping[str, Group]
@@ -361,6 +575,11 @@ FONT_CONFIGURATION_STATES: Final[frozenset[str]] = frozenset(
     {FONT_CONFIGURATION_ENABLED, FONT_CONFIGURATION_DISABLED}
 )
 
+CHROMIUM_PACKAGE: Final[str] = "www-client/chromium"
+CHROMIUM_CONFIG_PACKAGE: Final[str] = "www-client/chromium-common"
+CHROMIUM_COMMAND: Final[PurePosixPath] = PurePosixPath("/usr/bin/chromium")
+CHROMIUM_CONFIG: Final[PurePosixPath] = PurePosixPath("/etc/chromium/default")
+
 
 @dataclass(frozen=True, kw_only=True)
 class ConfigureKwinInputMethod(Operation):
@@ -570,6 +789,54 @@ def framework_conflict(config: InstallConfig, catalog: Catalog) -> str:
     )
 
 
+def _group_file_operations(
+    config: InstallConfig, catalog: Catalog, group: Group, wanted: GroupFile
+) -> list[Operation]:
+    if wanted.path != GREETD_CONFIG:
+        return [WriteGroupFile(group=group.name, file=wanted)]
+    if group.name != "greetd" or GREETD_PACKAGE not in group.packages:
+        raise ConfigError(f"{wanted.path} has no declared package contract")
+    try:
+        desired = tomllib.loads(wanted.content)
+    except tomllib.TOMLDecodeError as error:
+        raise ConfigError(f"the {group.name} group has invalid TOML for {wanted.path}") from error
+    session = desired.get("default_session")
+    command = session.get("command") if isinstance(session, dict) else None
+    if not isinstance(command, str):
+        raise ConfigError(f"the {group.name} group does not declare default_session.command")
+    try:
+        words = shlex.split(command)
+    except ValueError as error:
+        raise ConfigError(f"the {group.name} group has an invalid greeter command") from error
+    if not words or PurePosixPath(words[0]).name != TUIGREET_COMMAND.name:
+        raise ConfigError(
+            f"the {group.name} group expected {TUIGREET_PACKAGE} to provide {words[0] if words else ''}"
+        )
+    options = tuple(dict.fromkeys(_LONG_OPTION.findall(command)))
+    directories: list[PurePosixPath] = []
+    for option in ("--sessions", "--xsessions"):
+        if option not in words:
+            continue
+        position = words.index(option)
+        if position + 1 >= len(words):
+            raise ConfigError(f"the {group.name} group gives {option} no directory")
+        directories += [PurePosixPath(path) for path in words[position + 1].split(":")]
+    if any(not path.is_absolute() for path in directories):
+        raise ConfigError(f"the {group.name} group names a relative session directory")
+    desktop = catalog.get(config.packages.desktop)
+    provider = desktop.packages[0] if desktop is not None and desktop.packages else ""
+    return [
+        VerifyPackagePaths(package=GREETD_PACKAGE, paths=(GREETD_CONFIG,)),
+        VerifyCommandOptions(
+            package=TUIGREET_PACKAGE,
+            command=TUIGREET_COMMAND,
+            options=options,
+        ),
+        VerifySessionDirectories(package=provider, paths=tuple(directories)),
+        UpdateGreetdConfig(command=command),
+    ]
+
+
 def build(config: InstallConfig, catalog: Catalog) -> list[Operation]:
     _check_repositories(config, catalog)
     conflict = framework_conflict(config, catalog) or driver_conflict(config, catalog)
@@ -597,7 +864,7 @@ def build(config: InstallConfig, catalog: Catalog) -> list[Operation]:
                 EnableUserUnits(group=group.name, units=group.user_services)
             )
         for wanted in group.files:
-            operations.append(WriteGroupFile(group=group.name, file=wanted))
+            operations += _group_file_operations(config, catalog, group, wanted)
         if group.display_manager:
             operations += _display_manager(
                 group.display_manager, group.packages, config.system.init
@@ -825,9 +1092,12 @@ def _display_manager(name: str, packages: Sequence[str], init: InitSystem) -> li
             packages=(DISPLAY_MANAGER_INIT,),
             summary="install the openrc display manager script",
         ),
-        WriteGroupFile(
+        UpdatePackageShellAssignment(
             group=name,
-            file=GroupFile(path=DISPLAY_MANAGER_CONF, content=f'DISPLAYMANAGER="{name}"\n'),
+            package=DISPLAY_MANAGER_INIT,
+            path=DISPLAY_MANAGER_CONF,
+            key="DISPLAYMANAGER",
+            value=name,
         ),
         EnableService(stage=Stage.PACKAGES, service="display-manager", init=init),
     ]
@@ -845,6 +1115,28 @@ def required_licenses(config: InstallConfig, catalog: Catalog) -> tuple[str, ...
 
 def _known(catalog: Catalog) -> str:
     return ", ".join(sorted(catalog)) or "nothing"
+
+
+def _wayland_file_operations(group: Group, wanted: GroupFile) -> list[Operation]:
+    if group.name != "chromium" or wanted.path != CHROMIUM_CONFIG:
+        raise ConfigError(f"{wanted.path} has no declared package contract")
+    if CHROMIUM_PACKAGE not in group.packages:
+        raise ConfigError(f"the {group.name} group does not install {CHROMIUM_PACKAGE}")
+    return [
+        VerifyPackagePaths(package=CHROMIUM_CONFIG_PACKAGE, paths=(wanted.path,)),
+        VerifyPackagePaths(
+            package=CHROMIUM_PACKAGE,
+            paths=(CHROMIUM_COMMAND,),
+        ),
+        AppendWaylandFlags(group=group.name, file=wanted),
+    ]
+
+
+def _framework_package(chosen: Sequence[Group], framework: str) -> str:
+    for group in chosen:
+        if group.input_framework == framework and not group.input_method and group.packages:
+            return group.packages[0]
+    return ""
 
 
 def _input_method(config: InstallConfig, catalog: Catalog) -> list[Operation]:
@@ -919,12 +1211,15 @@ def _input_method(config: InstallConfig, catalog: Catalog) -> list[Operation]:
             # The launcher names fcitx's own desktop entry, so a session that
             # chose ibus was telling KWin to exec a file no package installed.
             if group.input_method_launcher and framework == "fcitx":
-                operations.append(
-                    ConfigureKwinInputMethod(launcher=group.input_method_launcher)
-                )
-            operations += [
-                AppendWaylandFlags(group=group.name, file=one) for one in group.wayland_files
-            ]
+                operations += [
+                    VerifyPackagePaths(
+                        package=_framework_package(chosen, framework),
+                        paths=(PurePosixPath(group.input_method_launcher),),
+                    ),
+                    ConfigureKwinInputMethod(launcher=group.input_method_launcher),
+                ]
+            for wanted in group.wayland_files:
+                operations += _wayland_file_operations(group, wanted)
     return operations
 
 

--- a/tests/golden/btrfs-luks.txt
+++ b/tests/golden/btrfs-luks.txt
@@ -101,6 +101,7 @@
   install the flclash group: emerge net-proxy/flclash-bin
   set XMODIFIERS, QT_IM_MODULES in /etc/environment for fcitx
   configure fcitx with rime and luna_pinyin pinyin_simp for skel, zakk
+  verify app-i18n/fcitx installed /usr/share/applications/fcitx5-wayland-launcher.desktop
   set /etc/xdg/kwinrc so the Wayland session starts /usr/share/applications/fcitx5-wayland-launcher.desktop
   enable /etc/fonts/conf.d/70-noto-cjk.conf
   write /etc/fonts/conf.d/71-gentoo-install-cjk-sans.conf

--- a/tests/golden/vm-desktop.txt
+++ b/tests/golden/vm-desktop.txt
@@ -81,6 +81,7 @@
   enable pipewire.socket, pipewire-pulse.socket, wireplumber.service for every user
   set XMODIFIERS, QT_IM_MODULES in /etc/environment for fcitx
   configure fcitx with rime and luna_pinyin pinyin_simp for skel
+  verify app-i18n/fcitx installed /usr/share/applications/fcitx5-wayland-launcher.desktop
   set /etc/xdg/kwinrc so the Wayland session starts /usr/share/applications/fcitx5-wayland-launcher.desktop
 
 [finish]

--- a/tests/unit/test_packages.py
+++ b/tests/unit/test_packages.py
@@ -1,7 +1,14 @@
 from dataclasses import replace
+from pathlib import PurePosixPath
+
+import pytest
 
 from gentoo_install.data import load_catalog
+from gentoo_install.errors import CommandFailed
+from gentoo_install.plan import packages as plan_packages
 from gentoo_install.plan.packages import build
+
+from .recorder import Recorder
 
 from .layouts import config
 
@@ -69,3 +76,216 @@ def test_ibus_has_declared_chinese_engines() -> None:
     descriptions = tuple(operation.describe() for operation in build(selected, load_catalog()))
     assert not any("input" in description and "environment" in description for description in descriptions)
     assert not any("dconf" in description for description in descriptions)
+
+
+class PackageRecorder(Recorder):
+    def __init__(self) -> None:
+        super().__init__()
+        self.package_paths: dict[str, frozenset[PurePosixPath]] = {}
+        self.help: dict[str, str] = {}
+        self.directories: set[PurePosixPath] = set()
+
+    def installed_package_paths(self, package: str) -> frozenset[PurePosixPath]:
+        return self.package_paths.get(package, frozenset())
+
+    def installed_command_help(self, package: str, command: PurePosixPath) -> str:
+        return self.help.get(str(command), "")
+
+    def target_is_directory(self, path: PurePosixPath) -> bool:
+        return path in self.directories
+
+
+def test_greetd_update_preserves_package_owned_defaults() -> None:
+    recorder = PackageRecorder()
+    path = PurePosixPath("/etc/greetd/config.toml")
+    recorder.package_paths["gui-libs/greetd"] = frozenset({path})
+    recorder.files[path] = (
+        "[terminal]\n"
+        "vt = \"next\"\n"
+        "switch = false\n"
+        "\n"
+        "[default_session]\n"
+        'command = "agreety --cmd $SHELL"\n'
+        'user = "greeter-from-package"\n'
+    )
+
+    plan_packages.UpdateGreetdConfig(command="tuigreet --time").apply(recorder)
+
+    written = recorder.files[path]
+    assert 'command = "tuigreet --time"' in written
+    assert 'vt = "next"' in written
+    assert "switch = false" in written
+    assert 'user = "greeter-from-package"' in written
+
+
+def test_openrc_display_manager_update_preserves_package_defaults() -> None:
+    recorder = PackageRecorder()
+    path = PurePosixPath("/etc/conf.d/display-manager")
+    recorder.package_paths["gui-libs/display-manager-init"] = frozenset({path})
+    recorder.files[path] = (
+        "# Keep the package's VT policy.\n"
+        "CHECKVT=7\n"
+        'DISPLAYMANAGER="xdm"\n'
+    )
+
+    plan_packages.UpdatePackageShellAssignment(
+        group="lightdm",
+        package="gui-libs/display-manager-init",
+        path=path,
+        key="DISPLAYMANAGER",
+        value="lightdm",
+    ).apply(recorder)
+
+    assert recorder.files[path] == (
+        "# Keep the package's VT policy.\n"
+        "CHECKVT=7\n"
+        'DISPLAYMANAGER="lightdm"\n'
+    )
+
+
+TUIGREET_HELP = """\
+Usage: tuigreet [OPTIONS]
+
+Options:
+    -s, --sessions DIRS
+    -x, --xsessions DIRS
+    -t, --time
+    -r, --remember
+        --remember-session
+"""
+
+
+@pytest.mark.parametrize(
+    ("paths", "help_text", "missing"),
+    (
+        (frozenset(), TUIGREET_HELP, "/usr/bin/tuigreet"),
+        (
+            frozenset({PurePosixPath("/usr/bin/tuigreet")}),
+            TUIGREET_HELP.replace("        --remember-session\n", ""),
+            "--remember-session",
+        ),
+    ),
+)
+def test_missing_tuigreet_contract_stops_with_the_package(
+    paths: frozenset[PurePosixPath], help_text: str, missing: str
+) -> None:
+    recorder = PackageRecorder()
+    recorder.package_paths["gui-apps/tuigreet"] = paths
+    recorder.help["/usr/bin/tuigreet"] = help_text
+    operation = plan_packages.VerifyCommandOptions(
+        package="gui-apps/tuigreet",
+        command=PurePosixPath("/usr/bin/tuigreet"),
+        options=("--time", "--remember", "--remember-session", "--sessions", "--xsessions"),
+    )
+
+    with pytest.raises(CommandFailed, match="gui-apps/tuigreet") as stopped:
+        operation.apply(recorder)
+
+    assert missing in str(stopped.value)
+
+
+def test_vdb_contents_parser_keeps_paths_with_spaces() -> None:
+    from gentoo_install.exec.packages import parse_contents
+
+    sample = (
+        "dir /usr/share/example sessions\n"
+        "obj /usr/share/example sessions/plasma.desktop deadbeef 1786090234\n"
+        "sym /usr/bin/example greeter -> ../libexec/example greeter 1786090234\n"
+    )
+
+    assert parse_contents(sample) == frozenset(
+        {
+            PurePosixPath("/usr/share/example sessions"),
+            PurePosixPath("/usr/share/example sessions/plasma.desktop"),
+            PurePosixPath("/usr/bin/example greeter"),
+        }
+    )
+
+
+def test_chromium_help_need_not_list_internal_feature_switches() -> None:
+    group = load_catalog()["chromium"]
+    wanted = group.wayland_files[0]
+    recorder = PackageRecorder()
+    recorder.package_paths["www-client/chromium-common"] = frozenset({wanted.path})
+    recorder.package_paths["www-client/chromium"] = frozenset(
+        {PurePosixPath("/usr/bin/chromium")}
+    )
+    recorder.help["/usr/bin/chromium"] = "Usage: chromium [options]\n"
+
+    for operation in plan_packages._wayland_file_operations(group, wanted):
+        operation.apply(recorder)
+
+    assert recorder.files[wanted.path] == f"{wanted.content}\n"
+
+
+def test_missing_fcitx_launcher_stops_before_kwin_write() -> None:
+    installation = config()
+    selected = replace(
+        installation,
+        packages=replace(
+            installation.packages,
+            desktop="plasma",
+            applications=("fcitx5", "rime"),
+        ),
+    )
+    operations = plan_packages.build(selected, load_catalog())
+    write_position = next(
+        index
+        for index, operation in enumerate(operations)
+        if isinstance(operation, plan_packages.ConfigureKwinInputMethod)
+    )
+    verification = operations[write_position - 1]
+    launcher = PurePosixPath("/usr/share/applications/fcitx5-wayland-launcher.desktop")
+
+    assert isinstance(verification, plan_packages.VerifyPackagePaths)
+    assert verification.package == "app-i18n/fcitx"
+    assert verification.paths == (launcher,)
+    with pytest.raises(CommandFailed, match="app-i18n/fcitx") as stopped:
+        verification.apply(PackageRecorder())
+
+    assert str(launcher) in str(stopped.value)
+
+
+def test_selected_package_contracts_are_verified_before_writes() -> None:
+    installation = config()
+    selected = replace(
+        installation,
+        packages=replace(
+            installation.packages,
+            desktop="plasma",
+            display_manager="greetd",
+            applications=("fcitx5", "rime", "chromium"),
+        ),
+    )
+
+    operations = plan_packages.build(selected, load_catalog())
+    paths = [one for one in operations if isinstance(one, plan_packages.VerifyPackagePaths)]
+    commands = [one for one in operations if isinstance(one, plan_packages.VerifyCommandOptions)]
+    directories = [
+        one for one in operations if isinstance(one, plan_packages.VerifySessionDirectories)
+    ]
+
+    assert any(
+        one.package == "gui-libs/greetd"
+        and PurePosixPath("/etc/greetd/config.toml") in one.paths
+        for one in paths
+    )
+    assert any(
+        one.package == "www-client/chromium-common"
+        and PurePosixPath("/etc/chromium/default") in one.paths
+        for one in paths
+    )
+    assert any(
+        one.package == "www-client/chromium"
+        and PurePosixPath("/usr/bin/chromium") in one.paths
+        for one in paths
+    )
+    assert any(
+        one.package == "app-i18n/fcitx"
+        and PurePosixPath("/usr/share/applications/fcitx5-wayland-launcher.desktop")
+        in one.paths
+        for one in paths
+    )
+    assert {one.package for one in commands} == {"gui-apps/tuigreet"}
+    assert directories
+    assert directories[0].package == "kde-plasma/plasma-meta"


### PR DESCRIPTION
Package upgrades can move files or options silently, so stop before writing stale configuration.