### PR TITLE
network: require an OpenRC static interface

### DIFF
--- a/gentoo_install/model/validate.py
+++ b/gentoo_install/model/validate.py
@@ -16,7 +16,7 @@ from typing import Collection, Final, Mapping
 
 from ..errors import CommandFailed, ValidationFailed
 from . import compat
-from .config import InitSystem, InstallConfig
+from .config import InitSystem, InstallConfig, Networking
 from .device import (
     DeviceGraph,
     DeviceId,
@@ -256,6 +256,16 @@ def _network_problems(config: InstallConfig) -> list[str]:
                 ipaddress.ip_address(one)
             except ValueError:
                 problems.append(f"{one!r} is not an address, so it is not a {named}")
+    if (
+        system.addresses
+        and system.init is InitSystem.OPENRC
+        and system.networking is Networking.BUILTIN
+        and not system.interface
+    ):
+        problems.append(
+            "system.interface must name the OpenRC interface when builtin networking uses "
+            "static addresses because netifrc has no wildcard match"
+        )
     if problems or not system.addresses:
         return problems
     if not system.dns:

--- a/gentoo_install/plan/system.py
+++ b/gentoo_install/plan/system.py
@@ -489,8 +489,8 @@ class WriteNetworkConfig(Operation):
     stage: Stage = Stage.SYSTEM
     init: InitSystem
     networking: Networking
-    #: Empty matches `en*` and `eth*` on systemd. netifrc has no wildcard, so
-    #: an empty name there falls back to `eth0`.
+    #: Empty matches `en*` and `eth*` on systemd. Static netifrc configurations
+    #: are validated to require a name because netifrc has no wildcard.
     interface: str = ""
     #: CIDR, either family. Empty is DHCP and router advertisements.
     addresses: tuple[str, ...] = ()
@@ -528,6 +528,8 @@ class WriteNetworkConfig(Operation):
             context.write(
                 PurePosixPath("/etc/systemd/network/20-wired.network"), self._networkd()
             )
+            return
+        if self.addresses and not self.interface:
             return
         context.write(PurePosixPath("/etc/conf.d/net"), self._netifrc())
 
@@ -573,9 +575,10 @@ class WriteNetworkConfig(Operation):
         return "".join(lines)
 
     def _netifrc(self) -> str:
-        name = self.interface or "eth0"
         if not self.addresses:
+            name = self.interface or "eth0"
             return f'config_{name}="dhcp"\n'
+        name = self.interface
         lines = [f'config_{name}="{" ".join(self.addresses)}"\n']
         # `default via` for v4 and `default via` for v6 both go in `routes_`;
         # netifrc reads the family from the address.
@@ -1064,7 +1067,8 @@ def build(config: InstallConfig) -> list[Operation]:
         if network_service is NetworkService.NETIFRC_INTERFACE:
             # dhcpcd would DHCP over the static address, while netifrc needs an
             # interface service before it reads /etc/conf.d/net.
-            operations.append(LinkNetifrcService(interface=system.interface or "eth0"))
+            if system.interface:
+                operations.append(LinkNetifrcService(interface=system.interface))
         else:
             operations.append(EnableService(service=network_service.value, init=system.init))
     if requirements.link_resolv_conf:

--- a/tests/unit/test_plan_system.py
+++ b/tests/unit/test_plan_system.py
@@ -513,6 +513,17 @@ def test_netifrc_names_the_interface_the_operator_gave() -> None:
     assert 'config_enp1s0="192.0.2.10/24"' in written
 
 
+def test_netifrc_has_no_eth0_fallback_for_an_unresolved_static_interface() -> None:
+    openrc = static(init=InitSystem.OPENRC, addresses=("192.0.2.10/24",))
+    recorder = Recorder()
+    for operation in system.build(openrc):
+        if isinstance(operation, (system.WriteNetworkConfig, system.LinkNetifrcService)):
+            operation.apply(recorder)
+
+    assert CONFD_NET not in recorder.files
+    assert not any("net.eth0" in argument for argv in recorder.in_target for argument in argv)
+
+
 def test_an_openrc_static_address_is_applied_by_netifrc_and_not_by_dhcpcd() -> None:
     """dhcpcd manages every interface itself and would DHCP over the static
     address, and nothing reads /etc/conf.d/net unless net.<iface> is enabled."""
@@ -858,7 +869,12 @@ def test_the_installed_system_resolves_with_its_own_nameservers() -> None:
     assert linked[-2] == "../run/systemd/resolve/stub-resolv.conf"
 
     # netifrc writes resolv.conf itself, so openrc needs none of it.
-    openrc = with_system(init=InitSystem.OPENRC, addresses=("192.0.2.10/24",), dns=("223.5.5.5",))
+    openrc = with_system(
+        init=InitSystem.OPENRC,
+        interface="enp1s0",
+        addresses=("192.0.2.10/24",),
+        dns=("223.5.5.5",),
+    )
     plain = apply_all(openrc, generated=generated(openrc))
     assert "dns_servers_" in plain.files[PurePosixPath("/etc/conf.d/net")]
     assert not any("resolved" in " ".join(argv) for argv in plain.in_target)

--- a/tests/unit/test_validate.py
+++ b/tests/unit/test_validate.py
@@ -345,6 +345,28 @@ def test_dhcp_needs_neither_a_gateway_nor_a_resolver() -> None:
     assert _network_problems(config()) == []
 
 
+def test_openrc_builtin_static_networking_requires_an_interface() -> None:
+    from gentoo_install.model.config import Networking
+
+    installation = replace(
+        config(),
+        portage=replace(
+            config().portage, profile="default/linux/amd64/23.0/desktop"
+        ),
+        system=replace(
+            config().system,
+            init=InitSystem.OPENRC,
+            networking=Networking.BUILTIN,
+            addresses=("192.0.2.10/24",),
+            gateways=("192.0.2.1",),
+            dns=("192.0.2.1",),
+        ),
+    )
+
+    with pytest.raises(ValidationFailed, match=r"system\.interface.*OpenRC.*static"):
+        validate(installation)
+
+
 @pytest.mark.parametrize("address", ["192.0.2.10/99", "not-an-address", "999.1.1.1/24"])
 def test_a_static_address_that_is_not_an_address_is_refused(address: str) -> None:
     """`_family_of` answered 0 for anything unparsable and every check then


### PR DESCRIPTION
netifrc has no interface wildcard, so an empty static interface silently targets no usable link. Require the interface during validation and refuse to synthesize `eth0` if plan application bypasses validation.