### PR TITLE
cli: report disk writes after partitioning starts

### DIFF
--- a/gentoo_install/cli.py
+++ b/gentoo_install/cli.py
@@ -68,6 +68,10 @@ class RunState:
 
     disk_was_written: bool = False
 
+    def operation_started(self, operation: Operation) -> None:
+        if operation.stage is Stage.PARTITION:
+            self.disk_was_written = True
+
 
 def parser() -> argparse.ArgumentParser:
     parsed = argparse.ArgumentParser(
@@ -271,13 +275,8 @@ def install(
         closing = tuple(one for one in operations if one.stage is Stage.FINISH)
         body = tuple(one for one in operations if one.stage is not Stage.FINISH)
         failure: BaseException | None = None
-        # Reaching the body means the partition stage is about to run. A
-        # command that fails can still have changed the disk before exiting.
-        state.disk_was_written = state.disk_was_written or any(
-            operation.stage is Stage.PARTITION for operation in body
-        )
         try:
-            apply(body, machine, finished)
+            apply(body, machine, finished, state.operation_started)
         except BaseException as error:
             failure = _first_failure(failure, error, record)
         stopped = failure is not None

--- a/gentoo_install/exec/apply.py
+++ b/gentoo_install/exec/apply.py
@@ -13,7 +13,7 @@ import time
 from dataclasses import astuple, dataclass, field, is_dataclass
 from functools import lru_cache
 from pathlib import Path, PurePosixPath
-from typing import Sequence
+from typing import Callable, Sequence
 
 from ..errors import CommandFailed, GentooInstallError, InvalidLayout
 from ..model.config import InstallConfig
@@ -325,13 +325,15 @@ def apply(
     operations: Sequence[Operation],
     machine: Machine,
     finished: frozenset[tuple[int, str]] = frozenset(),
+    on_start: Callable[[Operation], None] | None = None,
 ) -> None:
     """Perform each operation in order, stopping at the first failure.
 
     Nothing is retried: a disk operation that failed leaves a state the next
     one cannot assume anything about. `finished` names what an earlier run
     completed, so a resumed run does not partition a disk it already installed
-    onto.
+    onto. `on_start` runs before the operation because a failed command may
+    still have changed the machine.
     """
     total = len(operations)
     opened = time.monotonic()
@@ -342,6 +344,8 @@ def apply(
                 f"{counted} [{operation.stage.value}] done earlier: {operation.describe()}"
             )
             continue
+        if on_start is not None:
+            on_start(operation)
         machine.runner.log(f"{counted} [{operation.stage.value}] {operation.describe()}")
         started = time.monotonic()
         try:

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -728,6 +728,65 @@ def test_a_failure_before_partitioning_says_nothing_was_written(
     assert "may not boot" not in said
 
 
+def test_a_body_failure_before_partitioning_says_nothing_was_written(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    from dataclasses import dataclass
+
+    from gentoo_install.plan.operations import Context, Operation, Stage
+
+    from .layouts import config
+
+    partitioned: list[bool] = []
+
+    @dataclass(frozen=True, kw_only=True)
+    class FailBeforePartition(Operation):
+        stage: Stage = Stage.PREFLIGHT
+
+        def describe(self) -> str:
+            return "prepare the install"
+
+        def apply(self, context: Context) -> None:
+            raise IntegrityError("preparation stopped")
+
+    @dataclass(frozen=True, kw_only=True)
+    class Partition(Operation):
+        stage: Stage = Stage.PARTITION
+
+        def describe(self) -> str:
+            return "write the partition table"
+
+        def apply(self, context: Context) -> None:
+            partitioned.append(True)
+
+    monkeypatch.setattr(cli, "_require_root", lambda arguments: None)
+    monkeypatch.setattr(cli, "_needs_network", lambda arguments: False)
+    monkeypatch.setattr(cli, "load", lambda path: config())
+    monkeypatch.setattr(cli, "with_probed_facts", lambda chosen, probe: chosen)
+    monkeypatch.setattr(
+        cli,
+        "build",
+        lambda chosen, catalog, mirror: (FailBeforePartition(), Partition()),
+    )
+    monkeypatch.setattr(report, "keep_log", lambda work, target, record: None)
+
+    code = main(
+        [
+            "--config", str(tmp_path / "install.toml"),
+            "--work", str(tmp_path / "work"),
+            "--target", str(tmp_path / "target"),
+            "--skip-preflight",
+            "--no-shell",
+        ]
+    )
+
+    said = capsys.readouterr().err
+    assert partitioned == []
+    assert code == EXIT_INTEGRITY
+    assert "nothing was written to the selected disk" in said
+    assert "may not boot" not in said
+
+
 def test_the_menu_starts_from_the_firmware_the_machine_booted() -> None:
     """`_blank` took `BootloaderConfig`'s default, so a machine that booted
     BIOS opened the menu on a row reading `uefi - detected` and a template


### PR DESCRIPTION
A plan can fail before its later partition operation, so plan contents cannot say whether the disk changed. Observe the first partition operation as it starts, before a partially successful command can fail.