### PR TITLE
exec: declare stage3 runtime helpers

### DIFF
--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -70,6 +70,14 @@ package_for() {
 	# as package names no distribution has.
 	lvm:* | pvcreate:* | vgcreate:* | lvcreate:*) printf 'lvm2' ;;
 	gpg:*) printf 'gnupg' ;;
+	gpg-agent:gentoo | gpg-agent:arch) printf 'gnupg' ;;
+	gpg-agent:alpine | gpg-agent:debian | gpg-agent:ubuntu) printf 'gpg-agent' ;;
+	gpg-agent:fedora) printf 'gnupg2-gpg-agent' ;;
+	gpg-agent:rhel | gpg-agent:centos) printf 'gnupg2' ;;
+	gpg-agent:suse | gpg-agent:opensuse*) printf 'gpg2' ;;
+	xz:gentoo | xz:debian | xz:ubuntu) printf 'xz-utils' ;;
+	xz:alpine | xz:arch | xz:fedora | xz:rhel | xz:centos | xz:suse \
+		| xz:opensuse*) printf 'xz' ;;
 	zpool:debian | zfs:debian | zpool:ubuntu | zfs:ubuntu) printf 'zfsutils-linux' ;;
 	# Nothing official provides these on Arch: `zfs-utils` is in archzfs, a
 	# third-party repository the medium has not configured, and `pacman -S

--- a/gentoo_install/exec/preflight.py
+++ b/gentoo_install/exec/preflight.py
@@ -33,15 +33,24 @@ from ..model.size import DEFAULT_ALIGNMENT, SectorSize, Size
 from ..model.validate import root_size_problems
 from ..plan.disk import MKFS
 from ..plan.operations import Operation
+from ..plan.portage import InstallStage3
 from .probe import RELEASE_KEY, Machine, Probe
 
 # These are used while preflight inspects disks, before any operation runs.
 PREFLIGHT_ONLY: Final[tuple[str, ...]] = ("lsblk", "swapon")
 
+#: The stage3 operation's direct commands and the helpers they launch.
+STAGE3_COMMANDS: Final[tuple[str, ...]] = ("tar", "xz", "gpg", "gpg-agent")
+
 #: Commands every install needs, whatever the layout is.
 ALWAYS: Final[tuple[str, ...]] = (
     "tar", "gpg", "mount", "umount", "findmnt", "lsblk", "blkid", "chroot", "udevadm", "swapon",
 )
+
+#: Commands reached through context methods or helper subprocesses.
+BY_OPERATION: Final[dict[type[Operation], tuple[str, ...]]] = {
+    InstallStage3: STAGE3_COMMANDS,
+}
 
 #: What the menu needs and a configuration file does not: a file carries
 #: `password_hash` already, and the menu computes one with `openssl passwd -6`.
@@ -118,7 +127,7 @@ class Report:
 
 def _configured_commands(config: InstallConfig) -> frozenset[str]:
     graph = config.disk.graph
-    wanted = set(ALWAYS)
+    wanted = set(ALWAYS) | set(STAGE3_COMMANDS)
     for table in graph.of_type(PartitionTable):
         wanted |= set(BY_FEATURE["gpt" if table.table is TableType.GPT else "mbr"])
     if graph.of_type(Luks):
@@ -155,7 +164,15 @@ def required_commands(
         return _configured_commands(config)
     wanted = set(PREFLIGHT_ONLY)
     for operation in operations:
-        wanted.update(operation.required_host_commands())
+        wanted.update(_operation_commands(operation))
+    return frozenset(wanted)
+
+
+def _operation_commands(operation: Operation) -> frozenset[str]:
+    wanted = set(operation.required_host_commands())
+    for operation_type, commands in BY_OPERATION.items():
+        if isinstance(operation, operation_type):
+            wanted.update(commands)
     return frozenset(wanted)
 
 
@@ -163,7 +180,7 @@ def _command_users(operations: Iterable[Operation]) -> dict[str, tuple[str, ...]
     users: dict[str, list[str]] = {}
     for operation in operations:
         name = type(operation).__name__
-        for command in operation.required_host_commands():
+        for command in _operation_commands(operation):
             named = users.setdefault(command, [])
             if name not in named:
                 named.append(name)

--- a/tests/unit/test_exec.py
+++ b/tests/unit/test_exec.py
@@ -317,6 +317,26 @@ def test_the_required_commands_come_from_the_layout() -> None:
     assert "cryptsetup" not in plain and "zpool" not in plain
 
 
+@pytest.mark.parametrize("helper", ("xz", "gpg-agent"))
+def test_a_missing_stage3_helper_is_reported_before_the_operation(
+    helper: str, tmp_path: Path
+) -> None:
+    from gentoo_install.plan.portage import InstallStage3
+
+    operation = InstallStage3(mirror="https://example.invalid", variant="systemd")
+    wanted = preflight.required_commands(config(), (operation,))
+    report = preflight.inspect(
+        config(),
+        described(commands=wanted - {helper}),
+        probe_of(tmp_path),
+        operations=(operation,),
+    )
+    assert any(
+        problem == f"{helper} is missing; required by InstallStage3"
+        for problem in report.fatal
+    ), report.fatal
+
+
 def test_every_filesystem_the_installer_can_make_has_a_required_command() -> None:
     """The list is derived from the table the operations use, so a filesystem
     added there cannot be silently absent here."""

--- a/tests/unit/test_harness.py
+++ b/tests/unit/test_harness.py
@@ -219,8 +219,7 @@ def test_replacing_an_iso_at_the_same_path_re_extracts_it(tmp_path: Path) -> Non
 
 def test_bootstrap_names_a_package_for_every_command_preflight_wants() -> None:
     """`package_for` fell through to printing the command itself, so an LVM or
-    swap install was told to install packages named `pvcreate` and `mkswap`,
-    which no distribution has."""
+    stage3 install was told to install executable names that are not packages."""
     import subprocess
 
     from gentoo_install.exec import preflight
@@ -231,7 +230,10 @@ def test_bootstrap_names_a_package_for_every_command_preflight_wants() -> None:
     body = source[start : source.index("\n}\n", start) + 3]
     script = body + '\npackage_for "$1" "$2"\n'
 
-    wanted = {
+    operation_commands = {
+        command for commands in preflight.BY_OPERATION.values() for command in commands
+    }
+    wanted = operation_commands | {
         command
         for group in (
             preflight.ALWAYS,
@@ -241,20 +243,48 @@ def test_bootstrap_names_a_package_for_every_command_preflight_wants() -> None:
         )
         for command in group
     }
-    # These are the commands a distribution really does name its package after.
-    # Commands a distribution really does name a package after. Alpine splits
-    # util-linux into one package per tool, so each of those is its own name
-    # there and nowhere else.
+    stage3_providers = {
+        "gentoo": {"tar": "tar", "xz": "xz-utils", "gpg": "gnupg", "gpg-agent": "gnupg"},
+        "alpine": {"tar": "tar", "xz": "xz", "gpg": "gnupg", "gpg-agent": "gpg-agent"},
+        "debian": {"tar": "tar", "xz": "xz-utils", "gpg": "gnupg", "gpg-agent": "gpg-agent"},
+        "ubuntu": {"tar": "tar", "xz": "xz-utils", "gpg": "gnupg", "gpg-agent": "gpg-agent"},
+        "arch": {"tar": "tar", "xz": "xz", "gpg": "gnupg", "gpg-agent": "gnupg"},
+        "fedora": {
+            "tar": "tar", "xz": "xz", "gpg": "gnupg", "gpg-agent": "gnupg2-gpg-agent",
+        },
+        "rhel": {"tar": "tar", "xz": "xz", "gpg": "gnupg", "gpg-agent": "gnupg2"},
+        "centos": {"tar": "tar", "xz": "xz", "gpg": "gnupg", "gpg-agent": "gnupg2"},
+        "suse": {"tar": "tar", "xz": "xz", "gpg": "gnupg", "gpg-agent": "gpg2"},
+        "opensuse": {"tar": "tar", "xz": "xz", "gpg": "gnupg", "gpg-agent": "gpg2"},
+        "opensuse-leap": {"tar": "tar", "xz": "xz", "gpg": "gnupg", "gpg-agent": "gpg2"},
+        "opensuse-tumbleweed": {
+            "tar": "tar", "xz": "xz", "gpg": "gnupg", "gpg-agent": "gpg2",
+        },
+    }
+    assert all(set(providers) == operation_commands for providers in stage3_providers.values())
+    # These are the commands every distribution really names its package after.
+    # Alpine splits util-linux into one package per tool, so each of those is
+    # its own name there and nowhere else.
     itself = {"cryptsetup", "mdadm", "parted", "btrfs", "tar", "sgdisk", "zfs", "openssl"}
     split_on_alpine = {"mount", "umount", "lsblk", "blkid", "findmnt", "wipefs"}
-    # Debian keeps mount and umount in a package of that name.
-    named_that = {("mount", "debian"), ("umount", "debian")}
+    # Debian and Ubuntu keep mount and umount in a package of that name.
+    named_that = {
+        ("mount", "debian"),
+        ("umount", "debian"),
+        ("mount", "ubuntu"),
+        ("umount", "ubuntu"),
+    }
     wrong: list[str] = []
-    for command in sorted(wanted - itself):
-        for family in ("gentoo", "alpine", "debian", "arch", "fedora", "opensuse"):
+    for command in sorted(wanted):
+        for family, providers in stage3_providers.items():
             said = subprocess.run(
                 ["sh", "-c", script, "_", command, family], capture_output=True, text=True
             ).stdout.strip()
+            if command in operation_commands:
+                assert said == providers[command], (command, family, said)
+                continue
+            if command in itself:
+                continue
             allowed = (family == "alpine" and command in split_on_alpine) or (
                 command,
                 family,
@@ -262,6 +292,14 @@ def test_bootstrap_names_a_package_for_every_command_preflight_wants() -> None:
             if said == command and not allowed:
                 wrong.append(f"{command}:{family}")
     assert not wrong, wrong
+
+
+def test_alpine_gets_stage3_helpers_from_the_preflight_contract() -> None:
+    from tests.vm import media
+
+    helpers = {"xz", "gpg-agent"}
+    assert helpers <= media._fixture_commands()
+    assert helpers <= set(media.ALPINE_PACKAGES)
 
 
 def test_the_installed_checks_read_the_files_the_plan_writes() -> None:

--- a/tests/vm/media.py
+++ b/tests/vm/media.py
@@ -6,6 +6,10 @@ import hashlib
 import subprocess
 from dataclasses import dataclass
 from pathlib import Path
+from typing import Final, Iterable
+
+from gentoo_install.exec import preflight
+from gentoo_install.exec.config import load
 
 CACHE = Path.home() / "code/gentoo-install/lab/vm"
 
@@ -121,6 +125,50 @@ def _extract(iso: Path, files: dict[str, Path]) -> None:
 #: until a run failed on a path nobody had moved.
 ISO_CACHE = CACHE / "iso"
 
+#: Alpine packages for executables whose names differ. An empty package means
+#: the base image already supplies the command.
+ALPINE_PACKAGE_FOR_COMMAND: Final[dict[str, str]] = {
+    "blockdev": "util-linux-misc",
+    "btrfs": "btrfs-progs",
+    "chroot": "coreutils",
+    "hostid": "coreutils",
+    "lvcreate": "lvm2",
+    "mkfs.btrfs": "btrfs-progs",
+    "mkfs.ext2": "e2fsprogs",
+    "mkfs.ext3": "e2fsprogs",
+    "mkfs.ext4": "e2fsprogs",
+    "mkfs.f2fs": "f2fs-tools",
+    "mkfs.vfat": "dosfstools",
+    "mkfs.xfs": "xfsprogs",
+    "mkswap": "util-linux-misc",
+    "partprobe": "parted",
+    "pvcreate": "lvm2",
+    "swapoff": "util-linux-misc",
+    "swapon": "util-linux-misc",
+    "udevadm": "eudev",
+    "vgcreate": "lvm2",
+    "zpool": "zfs",
+}
+
+
+def _fixture_commands() -> frozenset[str]:
+    root = Path(__file__).resolve().parents[1] / "fixtures"
+    wanted: set[str] = set()
+    for path in sorted(root.glob("*.toml")):
+        wanted.update(preflight.required_commands(load(path)))
+    return frozenset(wanted)
+
+
+def _alpine_packages(commands: Iterable[str]) -> tuple[str, ...]:
+    packages = {
+        ALPINE_PACKAGE_FOR_COMMAND.get(command, command)
+        for command in commands
+    }
+    return tuple(sorted(package for package in packages if package))
+
+
+ALPINE_PACKAGES: Final[tuple[str, ...]] = ("python3", *_alpine_packages(_fixture_commands()))
+
 GIGOS = Medium(
     name="gigos",
     iso=ISO_CACHE / "gig-os-20260807.iso",
@@ -172,13 +220,8 @@ ALPINE = Medium(
     login_user="root",
     login_password=None,
     boot_cmdline=("modules=loop,squashfs,sd-mod,usb-storage",),
-    # Alpine ships no interpreter and no repository line, and it populates
-    # /dev with mdev, so a partition node never appears. The package list is
-    # every command `preflight.required_commands` asks for across the whole
-    # fixture set, resolved against Alpine's own APKINDEX rather than found one
-    # failed run at a time. `gpg-agent` is the exception the derivation cannot
-    # see: nothing declares it as a command, and gpg answers `probably not
-    # installed` at the first signature it checks.
+    # Alpine ships no interpreter or repository line and populates /dev with
+    # mdev, so a partition node never appears.
     prepare=(
         # The live session leaves every interface down, so apk answered
         # `DNS: transient error` on a guest whose network was never started.
@@ -187,9 +230,7 @@ ALPINE = Medium(
         "printf 'https://mirrors.ustc.edu.cn/alpine/v3.24/main\n"
         "https://mirrors.ustc.edu.cn/alpine/v3.24/community\n' > /etc/apk/repositories",
         "apk update",
-        "apk add python3 blkid btrfs-progs coreutils cryptsetup dosfstools "
-        "e2fsprogs eudev f2fs-tools findmnt gpg gpg-agent lsblk lvm2 mdadm mount parted "
-        "sgdisk tar umount util-linux-misc wipefs xfsprogs xz zfs",
+        "apk add " + " ".join(ALPINE_PACKAGES),
         "setup-devd udev",
     ),
 )


### PR DESCRIPTION
Stage3 verification and extraction launch helper processes. Declare those commands in preflight so a missing helper is rejected before disk work, and derive live-media packages from the same contract.