### PR TITLE
vm: surface failed console writes

### DIFF
--- a/tests/test_console.py
+++ b/tests/test_console.py
@@ -46,6 +46,45 @@ def test_send_appends_a_newline() -> None:
     writer.close()
 
 
+@pytest.mark.parametrize(("method", "value"), [("send", "true"), ("send_raw", "x")])
+def test_a_local_write_error_is_reported_at_the_send_call(method: str, value: str) -> None:
+    class Broken:
+        closed = False
+
+        def recv(self, size: int) -> bytes:
+            return b""
+
+        def sendall(self, data: bytes) -> None:
+            raise BrokenPipeError(32, "Broken pipe")
+
+        def close(self) -> None:
+            return None
+
+    console = SerialConsole(Broken(), open("/dev/null", "wb"))
+    with pytest.raises(ConsoleClosed, match="Broken pipe") as caught:
+        getattr(console, method)(value)
+    assert caught.value.write_may_have_reached_guest is True
+
+
+def test_a_write_to_an_already_closed_channel_is_locally_rejected() -> None:
+    class Closed:
+        closed = True
+
+        def recv(self, size: int) -> bytes:
+            return b""
+
+        def sendall(self, data: bytes) -> None:
+            raise AssertionError("a closed channel must reject before writing")
+
+        def close(self) -> None:
+            return None
+
+    console = SerialConsole(Closed(), open("/dev/null", "wb"))
+    with pytest.raises(ConsoleClosed) as caught:
+        console.send("true")
+    assert caught.value.write_may_have_reached_guest is False
+
+
 def test_expect_keeps_output_that_arrived_after_the_match() -> None:
     console, writer = make_console([b"login: root\r\nPassword: "])
     console.expect(r"login:", timeout=2.0)

--- a/tests/unit/test_proxmox.py
+++ b/tests/unit/test_proxmox.py
@@ -210,6 +210,30 @@ def test_the_console_channel_frames_input_the_way_proxmox_reads_it() -> None:
     assert fake.sent == [b"0:9:uname -r\n"]
 
 
+def test_a_websocket_write_that_closes_is_reported_at_the_send_call() -> None:
+    from tests.vm.console import ConsoleClosed, SerialConsole
+
+    class Closing:
+        def __init__(self) -> None:
+            self.closed = False
+            self.why_closed = ""
+
+        def send(self, payload: bytes, opcode: int = 0x2) -> None:
+            self.closed = True
+            self.why_closed = "the connection broke: Broken pipe"
+
+        def read(self) -> bytes:
+            raise AssertionError("the failed send must not become a read timeout")
+
+        def close(self) -> None:
+            self.closed = True
+
+    console = SerialConsole(proxmox.ConsoleChannel(Closing()), io.BytesIO())
+    with pytest.raises(ConsoleClosed, match="Broken pipe") as caught:
+        console.send("uname -r")
+    assert caught.value.write_may_have_reached_guest is True
+
+
 def test_a_server_frame_is_read_whole_across_two_reads() -> None:
     """One console write can arrive in two packets, and half a frame is not a
     short read to pass upward."""
@@ -674,6 +698,45 @@ def test_a_long_install_is_never_sent_twice_after_a_reconnect() -> None:
     commands = [one for one in sent if "install.sh" in one]
     assert len(commands) == 1, commands
     assert len(opened) == 3, "one open, then one per drop"
+
+
+def test_wait_for_does_not_resend_after_an_ambiguous_write_failure() -> None:
+    from tests.vm.cluster import Reconnecting
+    from tests.vm.console import ConsoleClosed
+
+    sent: list[str] = []
+
+    class Console:
+        def __init__(self, fail_write: bool) -> None:
+            self.fail_write = fail_write
+
+        def send(self, line: str) -> None:
+            sent.append(line)
+            if self.fail_write:
+                raise ConsoleClosed(
+                    "the connection broke during the write",
+                    write_may_have_reached_guest=True,
+                )
+
+        def send_raw(self, keys: str) -> None:
+            raise AssertionError("this test sends a line")
+
+        def snapshot(self, seconds: float) -> bytes:
+            return b""
+
+        @property
+        def closed(self) -> bool:
+            return False
+
+        def expect(self, pattern: str, timeout: float, idle: float = 0.0) -> bytes:
+            return b"MARK_1_DONE"
+
+    consoles = [Console(fail_write=True), Console(fail_write=False)]
+    link = Reconnecting(lambda: consoles.pop(0), tries=2)
+    link.wait_for("sh install.sh", timeout=5.0)
+
+    commands = [one for one in sent if "install.sh" in one]
+    assert len(commands) == 1, commands
 
 
 def test_a_short_command_is_sent_again_after_a_reconnect() -> None:

--- a/tests/vm/console.py
+++ b/tests/vm/console.py
@@ -27,7 +27,18 @@ class ConsoleIdle(ConsoleTimeout):
 
 
 class ConsoleClosed(Exception):
-    """The guest closed the serial connection."""
+    """The guest closed the serial connection.
+
+    `write_may_have_reached_guest` is false only when the channel was already
+    known closed. Once a transport write starts, its failure cannot prove how
+    many bytes reached the peer.
+    """
+
+    def __init__(
+        self, reason: str, *, write_may_have_reached_guest: bool | None = None
+    ) -> None:
+        super().__init__(reason)
+        self.write_may_have_reached_guest = write_may_have_reached_guest
 
 
 def strip_ansi(data: bytes) -> bytes:
@@ -164,12 +175,35 @@ class SerialConsole:
         )
 
     def send(self, line: str) -> None:
-        self._sock.sendall(line.encode() + b"\n")
+        self._write(line.encode() + b"\n")
 
     def send_raw(self, keys: str) -> None:
         """Exactly these bytes, with no newline. GRUB's editor acts on the
         keystroke itself, and a trailing newline there is an extra line."""
-        self._sock.sendall(keys.encode())
+        self._write(keys.encode())
+
+    def _write(self, data: bytes) -> None:
+        if self._sock.closed:
+            raise ConsoleClosed(
+                self._why_closed(), write_may_have_reached_guest=False
+            )
+        try:
+            self._sock.sendall(data)
+        except OSError as error:
+            reason = self._why_closed()
+            detail = str(error)
+            if detail and detail not in reason:
+                reason = f"{reason}: {detail}"
+            # sendall does not report how many bytes preceded its error.
+            raise ConsoleClosed(
+                reason, write_may_have_reached_guest=True
+            ) from error
+        if self._sock.closed:
+            # A websocket records its socket error and returns. Its frame may
+            # have reached the peer in whole or in part before that happened.
+            raise ConsoleClosed(
+                self._why_closed(), write_may_have_reached_guest=True
+            )
 
     def run(self, command: str, timeout: float = 120.0) -> None:
         """Run a shell command and wait for it to finish.
@@ -215,6 +249,9 @@ class SerialConsole:
         self._buffer += chunk
 
     def _why_closed(self) -> str:
+        transport_reason = getattr(self._sock, "why_closed", "")
+        if transport_reason:
+            return str(transport_reason)
         said = ""
         if self._errors is not None and self._errors.exists():
             lines = self._errors.read_text(errors="replace").strip().splitlines()
@@ -226,8 +263,8 @@ class SerialConsole:
     def closed(self) -> bool:
         """Whether the transport under this console has hung up.
 
-        A write to a dropped connection is discarded rather than raised, so a
-        caller that has to deliver a command asks first and reopens.
+        A caller can ask before a write and reopen proactively. `send` still
+        checks around the write, because a connection can drop between them.
         """
         return self._sock.closed
 

--- a/tests/vm/proxmox.py
+++ b/tests/vm/proxmox.py
@@ -720,6 +720,10 @@ class ConsoleChannel:
     def closed(self) -> bool:
         return self._socket.closed
 
+    @property
+    def why_closed(self) -> str:
+        return str(getattr(self._socket, "why_closed", ""))
+
     def close(self) -> None:
         self._socket.close()
 


### PR DESCRIPTION
A closed transport must fail at the send call so reconnect logic can distinguish locally rejected delivery from an ambiguous write without replaying an install command.