### PR TITLE
tui: let forms own validation retries

### DIFF
--- a/gentoo_install/tui/screens.py
+++ b/gentoo_install/tui/screens.py
@@ -78,6 +78,7 @@ from .widgets import (
     Confirm,
     Field,
     Form,
+    FormRejected,
     Item,
     Menu,
     MultipleChoiceMenu,
@@ -617,43 +618,19 @@ def user_screen(screen: Screen, config: InstallConfig, context: Context) -> Answ
     """
     translate = context.translate
     existing = config.system.users[0] if config.system.users else None
-    fields = [
-        Field(label=translate("User name"), value=existing.name if existing else "",
-              placeholder=translate("empty for root only")),
-        Field(label=translate("Password"), secret=True),
-        Field(label=translate("Type it again"), secret=True),
-        Field(label=translate("sudo"), toggle=True, value="x" if existing and existing.sudo else ""),
-        Field(
-            label=_groups_label(config, context),
-            value=" ".join(existing.groups) if existing else "",
-            placeholder=translate("separated by spaces, such as plugdev kvm docker"),
-        ),
-    ]
-    message = ""
-    while True:
-        answered = Form(
-            title=translate("User account"),
-            fields=fields,
-            footer=footer(translate),
-            done=translate("Done"),
-            message=message,
-        ).run(screen)
-        if not answered.chosen:
-            return Answer(answered.outcome)
-        name, first, again, sudo, extra = answered.unwrap()
-        # The values are put back before anything is rejected, so a form redrawn
-        # with a message is the one the operator was looking at.
-        fields[0].value, fields[3].value, fields[4].value = name, sudo, extra
-        name = name.strip()
-        if not name:
-            return Answer(Outcome.CHOSE, replace(config, system=replace(config.system, users=())))
-        wrong = _user_problem(name, first, again, extra, existing, translate)
+    def validated(values: list[str]) -> Answer[InstallConfig] | FormRejected:
+        name, first, again, sudo, extra = values
+        stripped_name = name.strip()
+        if not stripped_name:
+            return Answer(
+                Outcome.CHOSE, replace(config, system=replace(config.system, users=()))
+            )
+        wrong = _user_problem(stripped_name, first, again, extra, existing, translate)
         if wrong:
-            message = wrong
-            continue
+            return FormRejected(wrong, {1: "", 2: ""})
         groups, _ = atoms.split_use_flags(extra)
         user = User(
-            name=name,
+            name=stripped_name,
             # `plan/system.py:USER_GROUPS` is the one table for what every
             # account gets, so `wheel` is not named again here: an account that
             # declined sudo was put back in it.
@@ -665,7 +642,34 @@ def user_screen(screen: Screen, config: InstallConfig, context: Context) -> Answ
                 else (existing.password_hash if existing else "")
             ),
         )
-        return Answer(Outcome.CHOSE, replace(config, system=replace(config.system, users=(user,))))
+        return Answer(
+            Outcome.CHOSE, replace(config, system=replace(config.system, users=(user,)))
+        )
+
+    return Form(
+        title=translate("User account"),
+        fields=[
+            Field(
+                label=translate("User name"),
+                value=existing.name if existing else "",
+                placeholder=translate("empty for root only"),
+            ),
+            Field(label=translate("Password"), secret=True),
+            Field(label=translate("Type it again"), secret=True),
+            Field(
+                label=translate("sudo"),
+                toggle=True,
+                value="x" if existing and existing.sudo else "",
+            ),
+            Field(
+                label=_groups_label(config, context),
+                value=" ".join(existing.groups) if existing else "",
+                placeholder=translate("separated by spaces, such as plugdev kvm docker"),
+            ),
+        ],
+        footer=footer(translate),
+        done=translate("Done"),
+    ).run_validated(screen, validated)
 
 
 def _groups_label(config: InstallConfig, context: Context) -> str:
@@ -2749,30 +2753,27 @@ def _ask_password(screen: Screen, context: Context, title: str) -> Answer[str]:
     # arrow keys to move between, so enter is the only way forward, and a typo
     # in the second one threw the first away as well. `Field.secret` exists for
     # this and the account form already uses it.
-    kept = ["", ""]
-    while True:
-        answered = Form(
-            title=title,
-            fields=[
-                Field(label=translate("Password"), value=kept[0], secret=True),
-                Field(label=translate("Type it again"), value=kept[1], secret=True),
-            ],
-            footer=footer(translate),
-        ).run(screen)
-        if not answered.chosen:
-            return Answer(answered.outcome)
-        kept = list(answered.unwrap())
-        if not kept[0] and not kept[1]:
+    def validated(values: list[str]) -> Answer[str] | FormRejected:
+        first, again = values
+        if not first and not again:
             # Nothing typed is leaving, not an empty password: the row stays
             # required and says so, and enter through the whole form no longer
             # asks the same question for ever.
             return Answer(Outcome.BACK)
-        if kept[0] and kept[0] == kept[1]:
-            return Answer(Outcome.CHOSE, kept[0])
+        if first and first == again:
+            return Answer(Outcome.CHOSE, first)
         # The form comes back with what was typed: only the mismatched second
         # field is cleared, so a long password is not retyped from nothing.
-        kept[1] = ""
-        _say(screen, context, translate("The two do not match."))
+        return FormRejected(translate("The two do not match."), {1: ""})
+
+    return Form(
+        title=title,
+        fields=[
+            Field(label=translate("Password"), secret=True),
+            Field(label=translate("Type it again"), secret=True),
+        ],
+        footer=footer(translate),
+    ).run_validated(screen, validated)
 
 
 def _say(screen: Screen, context: Context, message: str) -> None:
@@ -2913,34 +2914,12 @@ def first_boot_screen(
     """
     translate = context.translate
     wanted = config.system.first_boot
-    fields = [
-        Field(
-            label=translate("Script address"),
-            value=wanted.url,
-            placeholder=translate("https://example.com/setup.sh, or empty for none"),
-        ),
-        Field(
-            label=translate("Commands"),
-            value=" ; ".join(wanted.commands),
-            placeholder=translate("separated by ; and run in order"),
-        ),
-    ]
-    message = ""
-    while True:
-        answered = Form(
-            title=translate("Run once at first boot"),
-            fields=fields,
-            footer=footer(translate),
-            done=translate("Done"),
-            message=message,
-        ).run(screen)
-        if not answered.chosen:
-            return Answer(answered.outcome)
-        url, typed = (one.strip() for one in answered.unwrap())
-        fields[0].value, fields[1].value = url, typed
+    def validated(values: list[str]) -> Answer[InstallConfig] | FormRejected:
+        url, typed = (one.strip() for one in values)
         if url and not url.startswith(("http://", "https://")):
-            message = translate("An address starts with http:// or https://")
-            continue
+            return FormRejected(
+                translate("An address starts with http:// or https://"), {0: url, 1: typed}
+            )
         commands = tuple(one.strip() for one in typed.split(";") if one.strip())
         return Answer(
             Outcome.CHOSE,
@@ -2949,6 +2928,24 @@ def first_boot_screen(
                 system=replace(config.system, first_boot=FirstBoot(commands=commands, url=url)),
             ),
         )
+
+    return Form(
+        title=translate("Run once at first boot"),
+        fields=[
+            Field(
+                label=translate("Script address"),
+                value=wanted.url,
+                placeholder=translate("https://example.com/setup.sh, or empty for none"),
+            ),
+            Field(
+                label=translate("Commands"),
+                value=" ; ".join(wanted.commands),
+                placeholder=translate("separated by ; and run in order"),
+            ),
+        ],
+        footer=footer(translate),
+        done=translate("Done"),
+    ).run_validated(screen, validated)
 
 
 def sshd_screen(screen: Screen, config: InstallConfig, context: Context) -> Answer[InstallConfig]:
@@ -4854,58 +4851,54 @@ def remote_unlock_screen(
             Outcome.CHOSE,
             replace(config, kernel=replace(config.kernel, remote_unlock=replace(unlock, enabled=False))),
         )
-    typed = (str(unlock.port), unlock.address, unlock.gateway, unlock.interface)
-    while True:
-        form = Form(
-            title=translate("Remote unlock"),
-            fields=[
-                Field(label=translate("Port"), value=typed[0], placeholder="222"),
-                Field(
-                    label=translate("Address"),
-                    value=typed[1],
-                    placeholder=translate("192.0.2.10/24, or empty for DHCP"),
-                ),
-                Field(
-                    label=translate("Gateway"),
-                    value=typed[2],
-                    placeholder=translate("192.0.2.1, needed to answer off this subnet"),
-                ),
-                Field(
-                    label=translate("Interface"),
-                    value=typed[3],
-                    placeholder=translate("eth0, or empty for whichever comes up"),
-                ),
-            ],
-            footer=footer(translate),
-            done=translate("Done"),
-        )
-        answer = form.run(screen)
-        if not answer.chosen:
-            return Answer(answer.outcome)
-        port, address, gateway, interface = (one.strip() for one in answer.unwrap())
-        if port.isdigit():
-            break
-        # Reopened with what was typed: dropping out of the form took the
-        # other three with it and the operator retyped them to fix one.
-        typed = (port, address, gateway, interface)
-        _say(screen, context, translate("The port has to be a number."))
-    return Answer(
-        Outcome.CHOSE,
-        replace(
-            config,
-            kernel=replace(
-                config.kernel,
-                remote_unlock=replace(
-                    unlock,
-                    enabled=True,
-                    port=int(port),
-                    address=address,
-                    gateway=gateway,
-                    interface=interface,
+    def validated(values: list[str]) -> Answer[InstallConfig] | FormRejected:
+        port, address, gateway, interface = (one.strip() for one in values)
+        if not port.isdigit():
+            return FormRejected(
+                translate("The port has to be a number."),
+                {0: port, 1: address, 2: gateway, 3: interface},
+            )
+        return Answer(
+            Outcome.CHOSE,
+            replace(
+                config,
+                kernel=replace(
+                    config.kernel,
+                    remote_unlock=replace(
+                        unlock,
+                        enabled=True,
+                        port=int(port),
+                        address=address,
+                        gateway=gateway,
+                        interface=interface,
+                    ),
                 ),
             ),
-        ),
-    )
+        )
+
+    return Form(
+        title=translate("Remote unlock"),
+        fields=[
+            Field(label=translate("Port"), value=str(unlock.port), placeholder="222"),
+            Field(
+                label=translate("Address"),
+                value=unlock.address,
+                placeholder=translate("192.0.2.10/24, or empty for DHCP"),
+            ),
+            Field(
+                label=translate("Gateway"),
+                value=unlock.gateway,
+                placeholder=translate("192.0.2.1, needed to answer off this subnet"),
+            ),
+            Field(
+                label=translate("Interface"),
+                value=unlock.interface,
+                placeholder=translate("eth0, or empty for whichever comes up"),
+            ),
+        ],
+        footer=footer(translate),
+        done=translate("Done"),
+    ).run_validated(screen, validated)
 
 
 def root_login_screen(

--- a/gentoo_install/tui/widgets.py
+++ b/gentoo_install/tui/widgets.py
@@ -10,7 +10,7 @@ from __future__ import annotations
 
 from dataclasses import dataclass, field
 from enum import Enum
-from typing import ClassVar, Final, Generic, Protocol, Sequence, TypeVar
+from typing import Callable, ClassVar, Final, Generic, Mapping, Protocol, Sequence, TypeVar
 
 from ..i18n import truncate, width
 
@@ -464,6 +464,14 @@ class Field:
     toggle: bool = False
 
 
+@dataclass(frozen=True)
+class FormRejected:
+    """A submitted form that must be redrawn with an inline explanation."""
+
+    message: str
+    corrections: Mapping[int, str] = field(default_factory=dict)
+
+
 @dataclass
 class Form:
     """Several fields on one screen, moved between with the arrow keys.
@@ -477,13 +485,22 @@ class Form:
     fields: list[Field]
     footer: str = ""
     done: str = "Done"
-    #: Drawn under the title, for a form the caller re-ran because one of the
-    #: answers was wrong. Re-running with the values kept is the point: an
+    #: Drawn under the title after one of the answers was rejected. Retrying
+    #: with the values kept is the point: an
     #: operator who mistyped the second password should not lose the first.
     message: str = ""
 
     def run(self, screen: Screen) -> Answer[list[str]]:
+        return self.run_validated(screen, lambda values: Answer(Outcome.CHOSE, values))
+
+    def run_validated(
+        self,
+        screen: Screen,
+        validator: Callable[[list[str]], Answer[V] | FormRejected],
+    ) -> Answer[V]:
+        """Retry rejected submissions while retaining the form's entered values."""
         typed = [list(field.value) for field in self.fields]
+        message = self.message
         # The last row submits, so it is a row like the others and reachable
         # the same way.
         cursor = 0
@@ -492,7 +509,7 @@ class Form:
         # footer offers Back and the form had no way at all to take it.
         touched = False
         while True:
-            self._draw(screen, typed, cursor)
+            self._draw(screen, typed, cursor, message)
             pressed = screen.key()
             if pressed in BACKWARD_FIELD:
                 cursor = max(0, cursor - 1)
@@ -500,7 +517,20 @@ class Form:
                 cursor = min(len(self.fields), cursor + 1)
             elif pressed in ("\n", "KEY_ENTER"):
                 if cursor == len(self.fields):
-                    return Answer(Outcome.CHOSE, ["".join(one) for one in typed])
+                    values = ["".join(one) for one in typed]
+                    checked = validator(values)
+                    if not isinstance(checked, FormRejected):
+                        return checked
+                    corrected = values.copy()
+                    for index, value in checked.corrections.items():
+                        if index < 0 or index >= len(corrected):
+                            raise ValueError(f"form correction index out of range: {index}")
+                        corrected[index] = value
+                    typed = [list(value) for value in corrected]
+                    message = checked.message
+                    cursor = 0
+                    touched = False
+                    continue
                 cursor += 1
             elif pressed == " " and cursor < len(self.fields) and self.fields[cursor].toggle:
                 typed[cursor] = [] if typed[cursor] else ["x"]
@@ -522,13 +552,15 @@ class Form:
                 typed[cursor].append(pressed)
                 touched = True
 
-    def _draw(self, screen: Screen, typed: list[list[str]], cursor: int) -> None:
+    def _draw(
+        self, screen: Screen, typed: list[list[str]], cursor: int, message: str
+    ) -> None:
         lines, columns = screen.size()
         screen.clear()
         screen.write(0, 0, truncate(self.title, columns))
         offset = 2
-        if self.message:
-            screen.write(1, 2, truncate(self.message, columns - 2), style=Style.REQUIRED)
+        if message:
+            screen.write(1, 2, truncate(message, columns - 2), style=Style.REQUIRED)
             offset = 3
         widest = max((width(field.label) for field in self.fields), default=0)
         room = columns - widest - 10

--- a/tests/unit/test_tui_app.py
+++ b/tests/unit/test_tui_app.py
@@ -1528,13 +1528,12 @@ def test_a_bad_port_keeps_the_address_that_was_typed_beside_it() -> None:
         config(encrypted_root()), system=replace(config().system, authorized_keys=(GOOD_KEY,))
     )
     # Yes to unlocking, then `abc` appended to the port and an address typed.
-    # After the message the form comes back holding both, so deleting the three
+    # The form comes back with an inline message and both values, so deleting the three
     # bad characters is the whole correction.
     keys = [
         "KEY_DOWN", "\n",
         *"abc", "KEY_DOWN", *"192.0.2.5/24", "KEY_DOWN", *"192.0.2.1",
         "KEY_DOWN", *"eth0", "KEY_DOWN", "\n",
-        "\n",
         "KEY_BACKSPACE", "KEY_BACKSPACE", "KEY_BACKSPACE",
         "KEY_DOWN", "KEY_DOWN", "KEY_DOWN", "KEY_DOWN", "\n",
     ]
@@ -1546,6 +1545,40 @@ def test_a_bad_port_keeps_the_address_that_was_typed_beside_it() -> None:
     assert (unlock.address, unlock.gateway, unlock.interface) == (
         "192.0.2.5/24", "192.0.2.1", "eth0"
     )
+    rejected = next(
+        frame for frame in screen.frames if "The port has to be a number." in "\n".join(frame)
+    )
+    assert "192.0.2.5/24" in "\n".join(rejected)
+
+
+def test_a_bad_first_boot_address_keeps_the_commands_and_shows_why() -> None:
+    at = context()
+    keys = [
+        *"example.com",
+        "KEY_DOWN",
+        *"echo one",
+        "KEY_DOWN",
+        "\n",
+        *("KEY_BACKSPACE" for _ in "example.com"),
+        *"https://example.com",
+        "KEY_DOWN",
+        "KEY_DOWN",
+        "\n",
+    ]
+    screen = FakeScreen(keys=keys, lines=24, columns=100)
+
+    answer = screens.first_boot_screen(screen, config(), at)
+
+    first_boot = answer.unwrap().system.first_boot
+    assert first_boot.url == "https://example.com"
+    assert first_boot.commands == ("echo one",)
+    rejected = next(
+        frame
+        for frame in screen.frames
+        if "An address starts with http:// or https://" in "\n".join(frame)
+    )
+    assert "example.com" in "\n".join(rejected)
+    assert "echo one" in "\n".join(rejected)
 
 
 def test_a_listed_key_says_that_enter_removes_it() -> None:
@@ -1628,11 +1661,10 @@ def test_a_password_is_typed_twice_before_it_is_hashed() -> None:
     way and the two passwords were not."""
     at = context()
     # One form: type, down to the second field, type something else, enter.
-    # The message, then the form again with the first field kept — down, the
+    # The inline message, then the form again with the first field kept — down, the
     # matching text, enter.
     keys = [
         *"first", "KEY_DOWN", *"second", "\n", "\n",
-        "\n",
         "KEY_DOWN", *"first", "\n", "\n",
     ]
     answer = screens.root_password_screen(FakeScreen(keys=keys, lines=24), config(), at)

--- a/tests/unit/test_tui_widgets.py
+++ b/tests/unit/test_tui_widgets.py
@@ -7,6 +7,7 @@ from gentoo_install.tui.widgets import (
     Confirm,
     Field,
     Form,
+    FormRejected,
     Item,
     Menu,
     MultipleChoiceMenu,
@@ -294,6 +295,63 @@ def test_a_form_takes_the_back_its_footer_offers() -> None:
     answer = filled.run(FakeScreen(keys=["KEY_BACKSPACE", "KEY_DOWN", "KEY_DOWN", "\n"]))
     assert answer.outcome is Outcome.CHOSE
     assert answer.unwrap()[0] == "22"
+
+
+def test_a_validated_form_retains_values_and_draws_the_error_inline() -> None:
+    submitted: list[list[str]] = []
+
+    def validate(values: list[str]) -> Answer[list[str]] | FormRejected:
+        submitted.append(values)
+        if len(submitted) == 1:
+            return FormRejected("That value is not valid.")
+        return Answer(Outcome.CHOSE, values)
+
+    screen = FakeScreen(
+        keys=[*"kept", "KEY_DOWN", "\n", "KEY_DOWN", "\n"], lines=20, columns=80
+    )
+    answer = Form(title="Account", fields=[Field(label="Name")]).run_validated(
+        screen, validate
+    )
+
+    assert answer.unwrap() == ["kept"]
+    assert submitted == [["kept"], ["kept"]]
+    retry = next(frame for frame in screen.frames if "That value is not valid." in "\n".join(frame))
+    assert "kept" in "\n".join(retry)
+
+
+def test_a_validator_can_correct_one_field_without_losing_the_others() -> None:
+    submitted: list[list[str]] = []
+
+    def validate(values: list[str]) -> Answer[tuple[str, str]] | FormRejected:
+        submitted.append(values)
+        if values[1] != "right":
+            return FormRejected("The two do not match.", {1: ""})
+        return Answer(Outcome.CHOSE, (values[0], values[1]))
+
+    keys = [
+        *"kept", "KEY_DOWN", *"wrong", "KEY_DOWN", "\n",
+        "KEY_DOWN", *"right", "KEY_DOWN", "\n",
+    ]
+    answer = Form(
+        title="Password",
+        fields=[Field(label="First"), Field(label="Again")],
+    ).run_validated(FakeScreen(keys=keys), validate)
+
+    assert answer.unwrap() == ("kept", "right")
+    assert submitted == [["kept", "wrong"], ["kept", "right"]]
+
+
+@pytest.mark.parametrize(
+    ("pressed", "outcome"),
+    [("KEY_BACKSPACE", Outcome.BACK), ("\x1b", Outcome.CANCELLED)],
+)
+def test_a_rejected_form_can_still_go_back_or_cancel(pressed: str, outcome: Outcome) -> None:
+    def reject(values: list[str]) -> Answer[str] | FormRejected:
+        return FormRejected("Try again.")
+
+    form = Form(title="Account", fields=[Field(label="Name")])
+    answer = form.run_validated(FakeScreen(keys=["KEY_DOWN", "\n", pressed]), reject)
+    assert answer.outcome is outcome
 
 
 def test_a_choice_that_became_invalid_can_still_be_dropped() -> None:


### PR DESCRIPTION
Validated forms must retain submitted values and inline errors. Keep retry state in the form widget so password, account, first-boot, and remote-unlock callers cannot diverge.