### PR TITLE
plan: resolve mounts once for runtime and fstab

### DIFF
--- a/gentoo_install/plan/disk.py
+++ b/gentoo_install/plan/disk.py
@@ -40,6 +40,7 @@ from ..model.device import (
     ZfsTopology,
 )
 from ..model.size import DEFAULT_ALIGNMENT, Size
+from .mounts import ResolvedMount, resolve_mounts
 from .operations import CommandOutput, Context, Operation, Stage
 
 #: GPT type codes as `sgdisk --typecode` spells them.
@@ -870,10 +871,10 @@ def build(config: InstallConfig) -> list[Operation]:
     for node in topological(graph):
         for operation in _operations_for(graph, node):
             (mounts if operation.stage is Stage.MOUNT else operations).append(operation)
+    mounts += [_mount_operation(mount) for mount in resolve_mounts(graph)]
     for disk in _disks_with_partitions(graph):
         operations.append(RereadPartitionTable(disk=disk))
-    # `/` before `/home`, or the second mount is hidden by the first.
-    operations += sorted(mounts, key=_mount_depth)
+    operations += mounts
     # Every partition exists before the first mkfs, so the stage decides here
     # too, not only once the whole plan is assembled.
     return sorted(operations, key=lambda operation: operation.stage.order)
@@ -913,12 +914,6 @@ def _order_key(node: Node) -> tuple[int, int, str]:
     index = node.index if isinstance(node, Partition) else 0
     takes_the_rest = isinstance(node, (Partition, LogicalVolume)) and node.size is None
     return (index, 1 if takes_the_rest else 0, node.id)
-
-
-def _mount_depth(operation: Operation) -> int:
-    if isinstance(operation, (Mount, MountZfsDataset)):
-        return len(operation.path.parts)
-    return 0
 
 
 #: What closes each kind of device, by the node that describes it.
@@ -1046,33 +1041,22 @@ def _operations_for(graph: DeviceGraph, node: Node) -> list[Operation]:
                 mountpoint=_dataset_mountpoint(graph, node.id),
             )
         ]
-    if isinstance(node, Mountpoint):
-        return _mount_operations(graph, node)
     return []
 
 
-def _mount_operations(graph: DeviceGraph, node: Mountpoint) -> list[Operation]:
-    source = graph[node.source]
-    if isinstance(source, ZfsDataset):
-        pool = _expect(graph, source.pool, ZfsPool)
-        return [
-            MountZfsDataset(mountpoint=node.id, name=f"{pool.name}/{source.name}", path=node.path)
-        ]
-    if isinstance(source, Subvolume):
-        filesystem = _expect(graph, source.filesystem, Filesystem)
-        return [
-            Mount(
-                mountpoint=node.id,
-                source=filesystem.device,
-                path=node.path,
-                options=(*node.options, f"subvol={source.name}"),
-            )
-        ]
-    if isinstance(source, Filesystem):
-        return [
-            Mount(mountpoint=node.id, source=source.device, path=node.path, options=node.options)
-        ]
-    return [Mount(mountpoint=node.id, source=node.source, path=node.path, options=node.options)]
+def _mount_operation(mount: ResolvedMount) -> Operation:
+    if mount.dataset is not None:
+        return MountZfsDataset(
+            mountpoint=mount.mountpoint, name=mount.dataset, path=mount.path
+        )
+    if mount.device is None:
+        raise InvalidLayout(f"mountpoint {mount.mountpoint!r} has no resolved source")
+    return Mount(
+        mountpoint=mount.mountpoint,
+        source=mount.device,
+        path=mount.path,
+        options=mount.options,
+    )
 
 
 def _dataset_mountpoint(graph: DeviceGraph, dataset: DeviceId) -> PurePosixPath | None:

--- a/gentoo_install/plan/mounts.py
+++ b/gentoo_install/plan/mounts.py
@@ -1,0 +1,84 @@
+"""Resolve device graph mountpoints for runtime and persistent consumers."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import PurePosixPath
+
+from ..errors import InvalidLayout
+from ..model.device import (
+    DeviceGraph,
+    DeviceId,
+    Filesystem,
+    FilesystemType,
+    Mountpoint,
+    Subvolume,
+    ZfsDataset,
+    ZfsPool,
+)
+
+
+@dataclass(frozen=True, kw_only=True)
+class ResolvedMount:
+    """One mount with its graph references reduced to executable meaning."""
+
+    mountpoint: DeviceId
+    path: PurePosixPath
+    device: DeviceId | None
+    dataset: str | None
+    filesystem_kind: FilesystemType | None
+    subvolume: str | None
+    options: tuple[str, ...]
+
+
+def resolve_mounts(graph: DeviceGraph) -> tuple[ResolvedMount, ...]:
+    """Resolve every mount in deterministic parent-before-child order."""
+    mounts = (_resolve_mount(graph, mount) for mount in graph.of_type(Mountpoint))
+    return tuple(sorted(mounts, key=lambda mount: (len(mount.path.parts), str(mount.path))))
+
+
+def _resolve_mount(graph: DeviceGraph, mount: Mountpoint) -> ResolvedMount:
+    source = graph[mount.source]
+    if isinstance(source, ZfsDataset):
+        pool = graph[source.pool]
+        if not isinstance(pool, ZfsPool):
+            raise InvalidLayout(
+                f"dataset {source.id!r} names {source.pool!r}, which is not a ZFS pool"
+            )
+        return ResolvedMount(
+            mountpoint=mount.id,
+            path=mount.path,
+            device=None,
+            dataset=f"{pool.name}/{source.name}",
+            filesystem_kind=None,
+            subvolume=None,
+            options=mount.options,
+        )
+    if isinstance(source, Subvolume):
+        filesystem = graph[source.filesystem]
+        if not isinstance(filesystem, Filesystem):
+            raise InvalidLayout(
+                f"subvolume {source.id!r} names {source.filesystem!r}, which is not a filesystem"
+            )
+        return ResolvedMount(
+            mountpoint=mount.id,
+            path=mount.path,
+            device=filesystem.device,
+            dataset=None,
+            filesystem_kind=filesystem.kind,
+            subvolume=source.name,
+            options=(*mount.options, f"subvol={source.name}"),
+        )
+    if isinstance(source, Filesystem):
+        return ResolvedMount(
+            mountpoint=mount.id,
+            path=mount.path,
+            device=source.device,
+            dataset=None,
+            filesystem_kind=source.kind,
+            subvolume=None,
+            options=mount.options,
+        )
+    raise InvalidLayout(
+        f"mountpoint {mount.id!r} names {mount.source!r}, which is not a mountable source"
+    )

--- a/gentoo_install/plan/system.py
+++ b/gentoo_install/plan/system.py
@@ -8,7 +8,7 @@ from pathlib import PurePosixPath
 from types import MappingProxyType
 from typing import Final, Mapping
 
-from ..errors import LocaleMissing
+from ..errors import InvalidLayout, LocaleMissing
 from ..model import compat
 from ..model.config import (
     ConsoleFontSize,
@@ -25,17 +25,14 @@ from ..model.device import (
     MdRaid,
     Node,
     DeviceId,
-    Filesystem,
     FilesystemType,
     Luks,
-    Mountpoint,
-    Subvolume,
     Swap,
     VolumeGroup,
-    ZfsDataset,
     ZfsPool,
 )
 from .bootloader import serial_console
+from .mounts import resolve_mounts
 from .operations import Context, Operation, Stage
 from .portage import Emerge
 
@@ -1119,42 +1116,22 @@ def _zfs_services(config: InstallConfig) -> list[Operation]:
 def fstab_entries(config: InstallConfig) -> tuple[FstabEntry, ...]:
     graph = config.disk.graph
     entries: list[FstabEntry] = []
-    # Depth first so a nested mount follows its parent, then the path itself:
-    # `/efi` and `/home` are the same depth and reading them in graph order
-    # made fstab depend on how the devices happen to be written.
-    for mount in sorted(
-        graph.of_type(Mountpoint), key=lambda node: (len(node.path.parts), str(node.path))
-    ):
-        source = graph[mount.source]
-        if isinstance(source, ZfsDataset):
+    for mount in resolve_mounts(graph):
+        if mount.dataset is not None:
             # A dataset carries its mountpoint property; fstab would fight it.
             continue
-        if isinstance(source, Subvolume):
-            filesystem = graph[source.filesystem]
-            if not isinstance(filesystem, Filesystem):
-                continue
-            entries.append(
-                FstabEntry(
-                    device=filesystem.device,
-                    path=mount.path,
-                    kind=filesystem.kind.value,
-                    options=_options(filesystem.kind, mount.options, f"subvol={source.name}"),
-                    dump=0,
-                    check=_check_order(mount.path),
-                )
+        if mount.device is None or mount.filesystem_kind is None:
+            raise InvalidLayout(f"mountpoint {mount.mountpoint!r} has no resolved filesystem")
+        entries.append(
+            FstabEntry(
+                device=mount.device,
+                path=mount.path,
+                kind=mount.filesystem_kind.value,
+                options=_options(mount.filesystem_kind, mount.options),
+                dump=0,
+                check=_check_order(mount.path),
             )
-            continue
-        if isinstance(source, Filesystem):
-            entries.append(
-                FstabEntry(
-                    device=source.device,
-                    path=mount.path,
-                    kind=source.kind.value,
-                    options=_options(source.kind, mount.options),
-                    dump=0,
-                    check=_check_order(mount.path),
-                )
-            )
+        )
     if config.portage.build_in_ram is not None:
         # Exactly the line a Gentoo desktop carries for this: portage is 250:250
         # and needs to write into it, and nothing under it is ever executed or

--- a/tests/unit/test_plan_system.py
+++ b/tests/unit/test_plan_system.py
@@ -6,7 +6,7 @@ from typing import Any
 
 import pytest
 
-from gentoo_install.errors import LocaleMissing
+from gentoo_install.errors import InvalidLayout, LocaleMissing
 from gentoo_install.model.config import (
     Networking,
     ConsoleFontSize,
@@ -18,6 +18,8 @@ from gentoo_install.model.config import (
 )
 from gentoo_install.model.size import Size
 from gentoo_install.model.device import (
+    DeviceGraph,
+    Existing,
     Filesystem,
     FilesystemType,
     Luks,
@@ -25,8 +27,11 @@ from gentoo_install.model.device import (
     Node,
     Partition,
     PartitionRole,
+    Subvolume,
+    ZfsDataset,
+    ZfsPool,
 )
-from gentoo_install.plan import bootloader, system
+from gentoo_install.plan import bootloader, disk, mounts, system
 from gentoo_install.plan.portage import Emerge
 
 from .layouts import config, ext4_on_gpt, i
@@ -137,6 +142,121 @@ def test_an_option_the_layout_sets_replaces_the_default_rather_than_joining_it()
     written = apply_all(installation, generated=generated(installation)).files[FSTAB]
     esp = next(line for line in written.splitlines() if "/efi" in line)
     assert esp.count("umask=") == 1
+
+
+def test_runtime_mounts_and_fstab_share_resolved_graph_meaning(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    nodes = [
+        node for node in ext4_on_gpt() if node.id not in {i("rootfs"), i("mnt-root")}
+    ]
+    nodes += [
+        Filesystem(id=i("rootfs"), device=i("rootpart"), kind=FilesystemType.BTRFS),
+        Subvolume(id=i("sub-root"), filesystem=i("rootfs"), name="@"),
+        Mountpoint(
+            id=i("mnt-root"),
+            source=i("sub-root"),
+            path=PurePosixPath("/"),
+            options=("compress=zstd:2",),
+        ),
+        Existing(id=i("pool-disk"), selector="/dev/disk/by-id/pool"),
+        ZfsPool(id=i("pool"), vdevs=(i("pool-disk"),), name="tank"),
+        ZfsDataset(id=i("ds-home"), pool=i("pool"), name="home"),
+        Mountpoint(id=i("mnt-home"), source=i("ds-home"), path=PurePosixPath("/home")),
+    ]
+    installation = config(nodes)
+    resolved = mounts.resolve_mounts(installation.disk.graph)
+    root = next(mount for mount in resolved if mount.path == PurePosixPath("/"))
+    assert root.device == i("rootpart")
+    assert root.filesystem_kind is FilesystemType.BTRFS
+    assert root.subvolume == "@"
+    assert root.options == ("compress=zstd:2", "subvol=@")
+    assert any(
+        mount.path == PurePosixPath("/efi")
+        and mount.device == i("esp")
+        and mount.filesystem_kind is FilesystemType.VFAT
+        for mount in resolved
+    )
+    assert any(
+        mount.path == PurePosixPath("/home") and mount.dataset == "tank/home"
+        for mount in resolved
+    )
+
+    shared = tuple(
+        replace(mount, device=i("resolved-root"), options=(*mount.options, "shared"))
+        if mount.path == PurePosixPath("/")
+        else replace(mount, device=i("resolved-esp"))
+        if mount.path == PurePosixPath("/efi")
+        else replace(mount, dataset="resolved/home")
+        for mount in resolved
+    )
+    calls = {"disk": 0, "system": 0}
+
+    def for_disk(graph: DeviceGraph) -> tuple[mounts.ResolvedMount, ...]:
+        calls["disk"] += 1
+        assert graph is installation.disk.graph
+        return shared
+
+    def for_system(graph: DeviceGraph) -> tuple[mounts.ResolvedMount, ...]:
+        calls["system"] += 1
+        assert graph is installation.disk.graph
+        return shared
+
+    monkeypatch.setattr(disk, "resolve_mounts", for_disk)
+    monkeypatch.setattr(system, "resolve_mounts", for_system)
+
+    runtime = [
+        operation
+        for operation in disk.build(installation)
+        if isinstance(operation, (disk.Mount, disk.MountZfsDataset))
+    ]
+    entries = system.fstab_entries(installation)
+
+    assert calls == {"disk": 1, "system": 1}
+    assert [operation.path for operation in runtime] == [
+        PurePosixPath("/"),
+        PurePosixPath("/efi"),
+        PurePosixPath("/home"),
+    ]
+    root_mount = next(operation for operation in runtime if operation.path == PurePosixPath("/"))
+    assert isinstance(root_mount, disk.Mount)
+    assert root_mount.source == i("resolved-root")
+    assert root_mount.options == ("compress=zstd:2", "subvol=@", "shared")
+    assert any(
+        isinstance(operation, disk.Mount)
+        and operation.path == PurePosixPath("/efi")
+        and operation.source == i("resolved-esp")
+        for operation in runtime
+    )
+    assert any(
+        isinstance(operation, disk.MountZfsDataset)
+        and operation.path == PurePosixPath("/home")
+        and operation.name == "resolved/home"
+        for operation in runtime
+    )
+
+    root_entry = next(entry for entry in entries if entry.path == PurePosixPath("/"))
+    assert root_entry.device == i("resolved-root")
+    assert root_entry.kind == "btrfs"
+    assert root_entry.options.count("subvol=@") == 1
+    assert "compress=zstd:2" in root_entry.options
+    assert "shared" in root_entry.options
+    assert any(
+        entry.path == PurePosixPath("/efi") and entry.device == i("resolved-esp")
+        for entry in entries
+    )
+    assert not any(entry.path == PurePosixPath("/home") for entry in entries)
+
+
+def test_unsupported_mount_sources_are_rejected_by_both_consumers() -> None:
+    nodes = [node for node in ext4_on_gpt() if node.id != i("mnt-root")]
+    nodes.append(
+        Mountpoint(id=i("mnt-root"), source=i("rootpart"), path=PurePosixPath("/"))
+    )
+    installation = config(nodes)
+    for consumer in (disk.build, system.fstab_entries):
+        with pytest.raises(InvalidLayout, match="not a mountable source"):
+            consumer(installation)
 
 
 def test_a_swap_entry_is_written_even_though_the_installer_never_enables_it() -> None:


### PR DESCRIPTION
Runtime mounts and fstab entries must describe the same resolved graph. Derive one typed mount sequence so nested subvolumes, datasets, and filesystems cannot drift between the two consumers.