### PR TITLE
packages: enable minizip compatibility for Plasma

### DIFF
--- a/gentoo_install/data/profiles/plasma-full.toml
+++ b/gentoo_install/data/profiles/plasma-full.toml
@@ -11,7 +11,10 @@ use = ["wayland", "qt6", "networkmanager"]
 # that already has them rather than by the fcitx5 group, which would install
 # Plasma alongside GNOME. Harmless when fcitx5 is not chosen: the line names a
 # package that is not merged.
-package_use = ["app-i18n/fcitx-configtool kcm"]
+package_use = [
+    "app-i18n/fcitx-configtool kcm",
+    "sys-libs/minizip-ng compat",
+]
 wayland = true
 profile = "default/linux/amd64/23.0/desktop/plasma"
 

--- a/gentoo_install/data/profiles/plasma.toml
+++ b/gentoo_install/data/profiles/plasma.toml
@@ -12,7 +12,10 @@ use = ["wayland", "qt6", "networkmanager"]
 # that already has them rather than by the fcitx5 group, which would install
 # Plasma alongside GNOME. Harmless when fcitx5 is not chosen: the line names a
 # package that is not merged.
-package_use = ["app-i18n/fcitx-configtool kcm"]
+package_use = [
+    "app-i18n/fcitx-configtool kcm",
+    "sys-libs/minizip-ng compat",
+]
 wayland = true
 profile = "default/linux/amd64/23.0/desktop/plasma"
 

--- a/tests/golden/btrfs-luks.txt
+++ b/tests/golden/btrfs-luks.txt
@@ -48,7 +48,7 @@
   accept the linux-firmware licence
   accept sys-kernel/gentoo-cjk-kernel-bin as testing, with cjk off
   unmask virtual/dist-kernel, which the cjk kernel depends on by revision
-  ask for app-i18n/fcitx-configtool kcm for the plasma group
+  ask for app-i18n/fcitx-configtool kcm; sys-libs/minizip-ng compat for the plasma group
   ask for app-i18n/rime-data extra for the rime-simplified group
   resolve app-admin/sudo net-misc/openssh sys-process/cronie sys-kernel/installkernel sys-apps/systemd sys-kernel/dracut sys-kernel/linux-firmware sys-fs/cryptsetup sys-fs/btrfs-progs sys-fs/dosfstools sys-kernel/gentoo-cjk-kernel-bin sys-boot/grub sys-boot/efibootmgr kde-plasma/plasma-meta x11-base/xorg-server kde-apps/konsole kde-apps/dolphin app-i18n/fcitx app-i18n/fcitx-gtk app-i18n/fcitx-qt app-i18n/fcitx-configtool app-i18n/fcitx-rime app-i18n/rime-data media-fonts/noto-cjk media-fonts/noto media-libs/fontconfig net-proxy/flclash-bin together before installing the requested packages
 

--- a/tests/golden/vm-desktop.txt
+++ b/tests/golden/vm-desktop.txt
@@ -32,7 +32,7 @@
   sync repository gentoo
   set sys-kernel/installkernel to dracut
   accept the linux-firmware licence
-  ask for app-i18n/fcitx-configtool kcm for the plasma group
+  ask for app-i18n/fcitx-configtool kcm; sys-libs/minizip-ng compat for the plasma group
   ask for app-i18n/rime-data extra for the rime-simplified group
   ask for media-video/pipewire sound-server for the pipewire group
   resolve net-misc/openssh net-misc/networkmanager net-wireless/wpa_supplicant sys-process/cronie sys-kernel/installkernel sys-kernel/dracut sys-kernel/linux-firmware sys-fs/dosfstools sys-fs/e2fsprogs sys-kernel/gentoo-kernel-bin sys-boot/grub sys-boot/efibootmgr kde-plasma/plasma-meta x11-base/xorg-server kde-apps/konsole kde-apps/dolphin app-i18n/fcitx app-i18n/fcitx-gtk app-i18n/fcitx-qt app-i18n/fcitx-configtool app-i18n/fcitx-rime app-i18n/rime-data media-fonts/noto-cjk media-fonts/noto media-libs/fontconfig media-video/pipewire media-video/wireplumber together before installing the requested packages

--- a/tests/unit/test_packages.py
+++ b/tests/unit/test_packages.py
@@ -94,6 +94,13 @@ def test_font_groups_declare_a_family_and_category() -> None:
     assert catalog["sarasa-mono"].font_family == "Sarasa Mono SC"
 
 
+def test_plasma_declares_the_minizip_compatibility_required_by_its_stack() -> None:
+    catalog = load_catalog()
+
+    for profile in ("plasma", "plasma-full"):
+        assert "sys-libs/minizip-ng compat" in catalog[profile].package_use
+
+
 def test_ibus_has_declared_chinese_engines() -> None:
     catalog = load_catalog()
     chinese = {


### PR DESCRIPTION
Because Plasma’s current dependency graph selects `virtual/minizip`, Portage requires `sys-libs/minizip-ng[compat]` and the unattended pretend gate refuses the desktop install. Declare that package USE requirement in both Plasma profiles.