### PR TITLE
vm: reserve VMIDs by creating guests

### DIFF
--- a/tests/unit/test_cluster.py
+++ b/tests/unit/test_cluster.py
@@ -11,7 +11,7 @@ import pytest
 from gentoo_install.model.config import MirrorRegion, Sync
 from tests.vm import cluster
 from tests.vm.console import ConsoleTimeout, SerialConsole
-from tests.vm.proxmox import Node, VMID_FIRST, VMID_LAST
+from tests.vm.proxmox import Node, ProxmoxNotFound, VMID_FIRST, VMID_LAST
 
 
 class WorkerFailure(Exception):
@@ -45,6 +45,7 @@ class FailedThread:
 class FakeApi:
     def __init__(self) -> None:
         self.allocations: list[int] = []
+        self.created: dict[int, str] = {}
 
     def nodes(self) -> list[Node]:
         return [Node("node", 64 * 1024**3, 16)]
@@ -57,6 +58,26 @@ class FakeApi:
         )
         self.allocations.append(vmid)
         return vmid
+
+    def call(self, method: str, path: str, **form: Any) -> Any:
+        if method == "POST" and path.endswith("/qemu"):
+            vmid = int(form["vmid"])
+            self.created[vmid] = str(form["tags"])
+            return "UPID:create"
+        vmid = int(path.split("/qemu/", 1)[1].split("/", 1)[0])
+        if vmid not in self.created:
+            raise ProxmoxNotFound(f"VM {vmid} does not exist")
+        if method == "GET" and path.endswith("/config"):
+            return {"tags": self.created[vmid]}
+        if method == "GET" and path.endswith("/status/current"):
+            return {"status": "stopped"}
+        if method == "DELETE":
+            del self.created[vmid]
+            return "UPID:delete"
+        raise AssertionError(f"unexpected request: {method} {path}")
+
+    def wait(self, node: str, upid: str, patience: float = 1800.0) -> None:
+        return None
 
     def remove_iso(self, node: str, name: str) -> str:
         return ""
@@ -139,6 +160,7 @@ def test_worker_failure_reports_outcome_and_releases_vmid(
     assert all(outcome.verdict is cluster.Verdict.ERROR for outcome in outcomes)
     assert all(outcome.vmid == VMID_FIRST for outcome in outcomes)
     assert api.allocations == [VMID_FIRST, VMID_FIRST]
+    assert api.created == {}
 
 
 class TimedChannel:

--- a/tests/unit/test_proxmox.py
+++ b/tests/unit/test_proxmox.py
@@ -1524,6 +1524,252 @@ def test_a_create_conflict_never_cleans_up_the_conflicting_vmid() -> None:
     assert api.asked == [("POST", "/nodes/infra-node1/qemu")]
 
 
+def test_two_campaigns_reserve_distinct_vmids_before_dispatch(tmp_path: Path) -> None:
+    """Both campaigns first read 9300 as free; only its creator dispatches it."""
+    import threading
+
+    from tests.vm.cluster import Job, _read_lease, _reserve_job
+
+    barrier = threading.Barrier(2)
+    lock = threading.Lock()
+    owners: dict[int, str] = {}
+    attempted: dict[str, list[int]] = {"first": [], "second": []}
+
+    class Campaign(Api):
+        def __init__(self, name: str) -> None:
+            self.name = name
+            self.probes = 0
+            self.controls: list[str] = []
+
+        def free_vmid(self, held: frozenset[int] = frozenset()) -> int:
+            with lock:
+                candidate = next(
+                    vmid
+                    for vmid in range(9300, 9400)
+                    if vmid not in owners and vmid not in held
+                )
+                self.probes += 1
+                first_probe = self.probes == 1
+            if first_probe:
+                barrier.wait()
+            return candidate
+
+        def call(self, method: str, path: str, **form: Any) -> Any:
+            if method == "POST" and path.endswith("/qemu"):
+                vmid = int(form["vmid"])
+                attempted[self.name].append(vmid)
+                with lock:
+                    if vmid in owners:
+                        raise ProxmoxError(f"VM {vmid} already exists")
+                    owners[vmid] = self.name
+                return f"UPID:{self.name}"
+            self.controls.append(f"{method} {path}")
+            raise AssertionError(f"unexpected cluster operation: {method} {path}")
+
+        def wait(self, node: str, upid: str, patience: float = 1800.0) -> None:
+            return None
+
+    jobs: dict[str, Job] = {}
+
+    def reserve(name: str) -> None:
+        api = Campaign(name)
+        jobs[name] = _reserve_job(
+            api,
+            "infra-node1",
+            Job(name=name, fixture=tmp_path / f"{name}.toml", iso="minimal.iso"),
+            "driver.iso",
+            tmp_path / name,
+            frozenset(),
+        )
+        assert api.controls == []
+
+    threads = [threading.Thread(target=reserve, args=(name,)) for name in attempted]
+    for thread in threads:
+        thread.start()
+    for thread in threads:
+        thread.join()
+
+    assert set(jobs) == set(attempted)
+    assert {job.vmid for job in jobs.values()} == {9300, 9301}
+    winner = owners[9300]
+    loser = next(name for name in attempted if name != winner)
+    assert attempted[winner] == [9300]
+    assert attempted[loser] == [9300, 9301]
+    assert jobs[winner].vmid == 9300
+    assert jobs[loser].vmid == 9301
+    for job in jobs.values():
+        assert job.execution is not None
+        guest = cast(Guest, job.execution.guest)
+        assert job.execution.created
+        assert (job.node, job.vmid) == (guest.node, guest.vmid)
+        assert job.lease is not None
+        lease = _read_lease(job.lease)
+        assert lease is not None
+        assert (lease.node, lease.vmid, lease.nonce) == (
+            guest.node,
+            guest.vmid,
+            guest.spec.nonce,
+        )
+
+
+def test_a_reserved_guest_is_not_created_twice_and_is_still_cleaned_up(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    from tests.vm.cluster import Job, Running, Watchdog, install_one
+
+    class Recording(Api):
+        def __init__(self) -> None:
+            self.creates = 0
+
+        def call(self, method: str, path: str, **form: Any) -> Any:
+            if method == "POST" and path.endswith("/qemu"):
+                self.creates += 1
+                return "UPID:created"
+            raise AssertionError(f"unexpected cluster operation: {method} {path}")
+
+        def wait(self, node: str, upid: str, patience: float = 1800.0) -> None:
+            return None
+
+    api = Recording()
+    guest = Guest(
+        api,
+        "infra-node1",
+        9300,
+        GuestSpec(name="reserved", iso="minimal.iso", nonce="gi-reserved"),
+    )
+    guest.create()
+    removed: list[int] = []
+
+    def fail_start() -> None:
+        raise ProxmoxError("start failed")
+
+    def destroy() -> None:
+        removed.append(guest.vmid)
+
+    monkeypatch.setattr(guest, "start", fail_start)
+    monkeypatch.setattr(guest, "destroy", destroy)
+    log = tmp_path / "reserved.log"
+    execution = Running(guest, Watchdog(log=log, counters=lambda: 0), created=True)
+    outcome = install_one(
+        api,
+        guest.node,
+        Job(name="reserved", fixture=tmp_path / "reserved.toml", iso="minimal.iso"),
+        "driver.iso",
+        tmp_path,
+        execution=execution,
+    )
+
+    assert outcome.detail == "start failed"
+    assert api.creates == 1
+    assert removed == [9300]
+
+
+def test_an_ordinary_reservation_failure_is_immediate_and_writes_no_lease(
+    tmp_path: Path,
+) -> None:
+    from tests.vm.cluster import Job, _reserve_job
+
+    class Full(Api):
+        def __init__(self) -> None:
+            self.creates = 0
+
+        def free_vmid(self, held: frozenset[int] = frozenset()) -> int:
+            return 9300
+
+        def call(self, method: str, path: str, **form: Any) -> Any:
+            self.creates += 1
+            raise ProxmoxError("no space left on device")
+
+    api = Full()
+    with pytest.raises(ProxmoxError, match="no space"):
+        _reserve_job(
+            api,
+            "infra-node1",
+            Job(name="full", fixture=tmp_path / "full.toml", iso="minimal.iso"),
+            "driver.iso",
+            tmp_path,
+            frozenset(),
+        )
+
+    assert api.creates == 1
+    assert not (tmp_path / "leases").exists()
+
+
+def test_reservation_bookkeeping_failure_removes_the_created_guest(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    from tests.vm import cluster
+    from tests.vm.cluster import Job, _reserve_job
+
+    class Recording(Api):
+        def __init__(self) -> None:
+            self.creates = 0
+
+        def free_vmid(self, held: frozenset[int] = frozenset()) -> int:
+            return 9300
+
+        def call(self, method: str, path: str, **form: Any) -> Any:
+            self.creates += 1
+            return "UPID:created"
+
+        def wait(self, node: str, upid: str, patience: float = 1800.0) -> None:
+            return None
+
+    removed: list[int] = []
+    monkeypatch.setattr(
+        Guest, "destroy", lambda guest: removed.append(guest.vmid)
+    )
+
+    def fail_lease(workdir: Path, lease: object) -> Path:
+        raise OSError("lease storage is read-only")
+
+    monkeypatch.setattr(cluster, "_write_lease", fail_lease)
+    api = Recording()
+    with pytest.raises(OSError, match="read-only"):
+        _reserve_job(
+            api,
+            "infra-node1",
+            Job(name="lease", fixture=tmp_path / "lease.toml", iso="minimal.iso"),
+            "driver.iso",
+            tmp_path,
+            frozenset(),
+        )
+
+    assert api.creates == 1
+    assert removed == [9300]
+
+
+def test_create_conflict_reservations_refresh_until_the_attempt_bound(
+    tmp_path: Path,
+) -> None:
+    from tests.vm.cluster import RESERVATION_TRIES, Job, _reserve_job
+
+    class Conflicting(Api):
+        def __init__(self) -> None:
+            self.candidates: list[int] = []
+
+        def free_vmid(self, held: frozenset[int] = frozenset()) -> int:
+            return next(vmid for vmid in range(9300, 9400) if vmid not in held)
+
+        def call(self, method: str, path: str, **form: Any) -> Any:
+            self.candidates.append(int(form["vmid"]))
+            raise ProxmoxError(f"VM {form['vmid']} already exists")
+
+    api = Conflicting()
+    with pytest.raises(CreateConflict):
+        _reserve_job(
+            api,
+            "infra-node1",
+            Job(name="busy", fixture=tmp_path / "busy.toml", iso="minimal.iso"),
+            "driver.iso",
+            tmp_path,
+            frozenset(),
+        )
+
+    assert api.candidates == list(range(9300, 9300 + RESERVATION_TRIES))
+    assert not (tmp_path / "leases").exists()
+
+
 def test_transient_task_status_failures_do_not_abort_a_completed_task(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:

--- a/tests/vm/cluster.py
+++ b/tests/vm/cluster.py
@@ -62,6 +62,7 @@ from .driver import build as build_driver, digest as driver_digest, remote_name
 from .monitor import keys_for
 from .proxmox import (
     Api,
+    CreateConflict,
     Guest,
     GuestSpec,
     Node,
@@ -188,6 +189,10 @@ BOOT_PATIENCE: Final[float] = 600.0
 
 #: A cluster with no room must produce a result rather than poll for ever.
 CAPACITY_PATIENCE: Final[float] = 120.0
+
+#: A conflict refreshes cluster allocation before another create. The bound
+#: prevents a busy VMID range from holding the scheduler indefinitely.
+RESERVATION_TRIES: Final[int] = 4
 
 
 class Verdict(Enum):
@@ -981,6 +986,7 @@ class Running:
 
     guest: Stoppable
     watch: Watchdog
+    created: bool = False
 
 
 def _execution(
@@ -1011,6 +1017,56 @@ def _execution(
     return Running(guest, Watchdog(log=log, counters=lambda: guest.transferred()))
 
 
+def _reserve_job(
+    api: Api,
+    node: str,
+    job: Job,
+    driver: str,
+    workdir: Path,
+    held_vmids: frozenset[int],
+) -> Job:
+    """Create a cluster guest before recording its lease and dispatch."""
+    excluded = set(held_vmids)
+    nonce = f"gi-{uuid.uuid4().hex[:12]}"
+    conflict: CreateConflict | None = None
+    for _ in range(RESERVATION_TRIES):
+        vmid = api.free_vmid(frozenset(excluded))
+        execution = _execution(api, node, job, driver, workdir, vmid, nonce)
+        guest = cast(Guest, execution.guest)
+        try:
+            guest.create()
+        except CreateConflict as error:
+            excluded.add(vmid)
+            conflict = error
+            continue
+        execution.created = True
+        lease: Path | None = None
+        try:
+            lease = _write_lease(
+                workdir, Lease(guest.node, guest.vmid, guest.spec.nonce, os.getpid())
+            )
+            return job.dispatch(
+                guest.node,
+                guest.vmid,
+                lease,
+                execution.watch.log,
+                execution,
+            )
+        except Exception as error:
+            if lease is not None:
+                lease.unlink(missing_ok=True)
+            try:
+                guest.destroy()
+            except ProxmoxError as cleanup:
+                raise ProxmoxError(
+                    f"reservation bookkeeping failed: {error}; "
+                    f"VM {guest.vmid} was not removed: {cleanup}"
+                ) from error
+            raise
+    assert conflict is not None
+    raise conflict
+
+
 def install_one(
     api: Api,
     node: str,
@@ -1037,7 +1093,8 @@ def install_one(
     if inflight is not None:
         inflight[job.name] = held
     try:
-        guest.create()
+        if not held.created:
+            guest.create()
         guest.start()
         phase = Phase.BOOT_LIVE
         log.write_text(f"installer revision: {revision}\n")
@@ -1294,21 +1351,20 @@ def run(
                     for one in scheduled.values()
                     if one.holds_resources and one.vmid
                 )
-                vmid = api.free_vmid(held_vmids)
-                nonce = f"gi-{uuid.uuid4().hex[:12]}"
-                lease = _write_lease(
-                    workdir, Lease(node.name, vmid, nonce, os.getpid())
-                )
-                execution = _execution(
-                    api, node.name, job, driver, workdir, vmid, nonce
-                )
-                job = job.dispatch(
+                job = _reserve_job(
+                    api,
                     node.name,
-                    vmid,
-                    lease,
-                    execution.watch.log,
-                    execution,
+                    job,
+                    driver,
+                    workdir,
+                    held_vmids,
                 )
+                execution = job.execution
+                if execution is None:
+                    raise ProxmoxError(f"{job.name} has no reserved guest")
+                guest = cast(Guest, execution.guest)
+                vmid = guest.vmid
+                nonce = guest.spec.nonce
                 thread = threading.Thread(
                     target=answer_once,
                     args=(
@@ -1343,6 +1399,14 @@ def run(
                     failed = job.worker_failed(revision)
                     if failed.outcome is None:
                         raise ProxmoxError(f"{job.name} failed without an outcome")
+                    if job.execution is None:
+                        failed.outcome.removed = False
+                    else:
+                        try:
+                            job.execution.guest.destroy()
+                        except ProxmoxError as error:
+                            failed.outcome.removed = False
+                            failed.outcome.detail += f"; the guest was not removed: {error}"
                     done.put(failed.outcome)
                 if unanswered:
                     continue


### PR DESCRIPTION
Two schedulers can observe the same free VMID, so dispatch begins only after Proxmox create has atomically claimed it. Failed bookkeeping and unanswered workers remove that owned reservation before releasing its lease.