### PR TITLE
tui: preserve nested answer outcomes

### DIFF
--- a/gentoo_install/tui/screens.py
+++ b/gentoo_install/tui/screens.py
@@ -410,13 +410,12 @@ def _template_screen(
     changed = _rebuild(config, context)
     if layout is Layout.WHOLE_DISK_ZFS:
         picked = _zfs_bootloader(screen, changed, context)
-        if picked is None:
-            # Cancelling the question undoes the layout that raised it. The
-            # graph was already rebuilt and the choice already written, so
-            # both go back: leaving them committed a ZFS root with GRUB.
+        if not picked.chosen:
+            # The graph was already rebuilt and the choice already written, so
+            # both go back before the child's outcome leaves this screen.
             context.manual, context.choice = was_manual, was_choice
-            return Answer(Outcome.BACK)
-        changed = picked
+            return Answer(picked.outcome)
+        changed = picked.unwrap()
     return Answer(Outcome.CHOSE, changed)
 
 
@@ -428,7 +427,7 @@ def _known(kind: str) -> FilesystemType | None:
 
 def _zfs_bootloader(
     screen: Screen, config: InstallConfig, context: Context
-) -> InstallConfig | None:
+) -> Answer[InstallConfig]:
     """A ZFS root cannot use GRUB, so this asks which of the two that remain.
 
     ZFSBootMenu lives in the gentoo-zh overlay and in no other repository, so
@@ -453,19 +452,17 @@ def _zfs_bootloader(
         footer=footer(translate),
         current=config.bootloader.kind,
     ).run(screen)
-    if not answer.chosen:
-        # None rather than the configuration handed in: that one already holds
-        # the ZFS layout, and returning it committed a ZFS root with GRUB,
-        # which the compatibility table refuses.
-        return None
-    kind = answer.unwrap()
-    if kind is Bootloader.SYSTEMD_BOOT:
-        return replace(config, bootloader=replace(config.bootloader, kind=kind))
-    return replace(
-        config,
-        bootloader=replace(config.bootloader, kind=kind),
-        portage=_with_gentoo_zh(config),
-    )
+
+    def apply(kind: Bootloader) -> InstallConfig:
+        if kind is Bootloader.SYSTEMD_BOOT:
+            return replace(config, bootloader=replace(config.bootloader, kind=kind))
+        return replace(
+            config,
+            bootloader=replace(config.bootloader, kind=kind),
+            portage=_with_gentoo_zh(config),
+        )
+
+    return answer.map(apply)
 
 
 def _with_gentoo_zh(config: InstallConfig) -> PortageConfig:
@@ -3497,12 +3494,14 @@ def partitions_screen(
                 # Without this every bootloader row was greyed and the table
                 # had no way out.
                 picked = _zfs_bootloader(screen, built, context)
-                if picked is None:
+                if not picked.chosen:
+                    if picked.outcome is Outcome.CANCELLED:
+                        return Answer(picked.outcome)
                     # Back to the editor rather than out of it: the table the
                     # operator drew is still there, and a ZFS root with GRUB
                     # is what committing this would have written.
                     continue
-                built = picked
+                built = picked.unwrap()
             return Answer(Outcome.CHOSE, built)
         _act_on(screen, context, row)
 

--- a/gentoo_install/tui/widgets.py
+++ b/gentoo_install/tui/widgets.py
@@ -16,6 +16,7 @@ from ..i18n import truncate, width
 
 V = TypeVar("V")
 A = TypeVar("A")
+U = TypeVar("U")
 
 #: What asks to leave. ctrl-c is here rather than a signal because raw mode
 #: delivers it as a byte, so it is answered rather than obeyed.
@@ -84,6 +85,11 @@ class Answer(Generic[V]):
         if isinstance(self._value, _Missing):
             raise ValueError("no value: the operator went back or cancelled")
         return self._value
+
+    def map(self, transform: Callable[[V], U]) -> Answer[U]:
+        if not self.chosen:
+            return Answer(self.outcome)
+        return Answer(Outcome.CHOSE, transform(self.unwrap()))
 
 
 class Screen(Protocol):

--- a/tests/unit/test_tui_app.py
+++ b/tests/unit/test_tui_app.py
@@ -2169,8 +2169,7 @@ def test_the_zfs_bootloader_prompt_returns_only_installable_answers() -> None:
         answered = screens._zfs_bootloader(
             FakeScreen(keys=keys, lines=24, columns=100), start, at
         )
-        assert answered is not None, "neither key cancels"
-        validate(answered)
+        validate(answered.unwrap())
 
 
 def test_the_erase_field_is_visibly_empty_before_anything_is_typed() -> None:
@@ -2395,15 +2394,19 @@ def test_a_reopened_selector_starts_on_what_is_already_set() -> None:
     assert all(seen.values()), sorted(one for one, has in seen.items() if not has)
 
 
-def test_cancelling_the_zfs_bootloader_question_undoes_the_layout() -> None:
+@pytest.mark.parametrize(
+    ("leaving", "outcome"),
+    [("KEY_BACKSPACE", Outcome.BACK), ("\x1b", Outcome.CANCELLED)],
+)
+def test_the_zfs_bootloader_outcome_leaves_the_layout_screen(
+    leaving: str, outcome: Outcome
+) -> None:
     """The layout is written and the graph rebuilt before the question is
     asked, so cancelling it committed a ZFS root with GRUB — a combination
     `model/compat.py` refuses and no later screen would have offered a way
     out of."""
     from gentoo_install.model.config import Bootloader
     from gentoo_install.model.device import ZfsPool
-    from gentoo_install.tui.widgets import Outcome as Answered
-
     from .layouts import ext4_on_gpt
 
     at = context()
@@ -2412,12 +2415,12 @@ def test_cancelling_the_zfs_bootloader_question_undoes_the_layout() -> None:
     before = at.choice
 
     # Two rows down is the ZFS layout; enter opens the bootloader question and
-    # escape leaves it. A third down lands past the row and cancels the menu
-    # itself, which answers CANCELLED whether the fix is there or not.
-    keys = ["\n", "KEY_DOWN", "KEY_DOWN", "\n", "\x1b"]
+    # the final key leaves it. A third down lands past the row and cancels the
+    # menu itself, which answers CANCELLED whether the helper preserves it or not.
+    keys = ["\n", "KEY_DOWN", "KEY_DOWN", "\n", leaving]
     answer = screens.layout_screen(FakeScreen(keys=keys, lines=24, columns=100), start, at)
 
-    assert answer.outcome is Answered.BACK, answer.outcome
+    assert answer.outcome is outcome
     assert at.choice == before, "the choice goes back with the layout"
     assert start.bootloader.kind is not Bootloader.ZFSBOOTMENU
 

--- a/tests/unit/test_tui_widgets.py
+++ b/tests/unit/test_tui_widgets.py
@@ -47,6 +47,23 @@ def test_going_back_is_not_cancelling() -> None:
     assert not Answer(Outcome.BACK).chosen
 
 
+def test_answer_map_transforms_only_a_chosen_value() -> None:
+    transformed: list[int] = []
+
+    def describe(value: int) -> str:
+        transformed.append(value)
+        return f"value {value}"
+
+    chosen: Answer[int] = Answer(Outcome.CHOSE, 3)
+    back: Answer[int] = Answer(Outcome.BACK)
+    cancelled: Answer[int] = Answer(Outcome.CANCELLED)
+
+    assert chosen.map(describe).unwrap() == "value 3"
+    assert back.map(describe).outcome is Outcome.BACK
+    assert cancelled.map(describe).outcome is Outcome.CANCELLED
+    assert transformed == [3]
+
+
 def test_a_disabled_row_cannot_be_chosen_and_says_why() -> None:
     """The reason comes from the compatibility table, so the interface and the
     validator give the operator the same sentence."""


### PR DESCRIPTION
Helper screens already know whether the operator went back or cancelled, so typed Answer mapping carries that outcome through composition instead of reconstructing it from sentinels.