### PR TITLE
tui: preserve staged passphrases on child exit

### DIFF
--- a/gentoo_install/tui/screens.py
+++ b/gentoo_install/tui/screens.py
@@ -2675,29 +2675,33 @@ def encryption_screen(screen: Screen, config: InstallConfig, context: Context) -
         # over a graph with no container in it at all.
         _say(screen, context, translate("Encryption is a field of each partition, under Partitions."))
         return Answer(Outcome.BACK)
-    encrypted = bool(context.choice.passphrase_file)
-    wanted = Confirm(
+    edited = _edit_passphrase(
+        screen,
+        context,
+        context.choice.passphrase_file,
+        translate("Encrypt the root filesystem?"),
+    )
+    if edited.chosen:
+        context.choice = replace(context.choice, passphrase_file=edited.unwrap())
+    return edited.map(lambda _: _rebuild(config, context))
+
+
+def _edit_passphrase(
+    screen: Screen, context: Context, staged_path: str, title: str
+) -> Answer[str]:
+    """Enable, disable, or replace one staged encryption passphrase."""
+    translate = context.translate
+    enabled = Confirm(
         **answers(translate),
-        title=translate("Encrypt the root filesystem?"),
-        # Without this the cursor starts on `No`, so reopening the row and
-        # pressing enter removed the container and the passphrase with it.
-        current=encrypted,
+        title=title,
         footer=footer(translate),
+        current=bool(staged_path),
     ).run(screen)
-    if not wanted.chosen:
-        return Answer(wanted.outcome)
-    if not wanted.unwrap():
-        context.choice = replace(context.choice, passphrase_file="")
-        return Answer(Outcome.CHOSE, _rebuild(config, context))
-    staged = _ask_passphrase(screen, context)
-    if not staged.chosen:
-        # The key that is already staged, not an empty one: cancelling the
-        # field is declining to change the passphrase, not declining to have
-        # one, and clearing it here turned an encrypted layout into a plain
-        # one on the way out.
-        return Answer(staged.outcome)
-    context.choice = replace(context.choice, passphrase_file=staged.unwrap())
-    return Answer(Outcome.CHOSE, _rebuild(config, context))
+    if not enabled.chosen:
+        return Answer(enabled.outcome)
+    if not enabled.unwrap():
+        return Answer(Outcome.CHOSE, "")
+    return _ask_passphrase(screen, context)
 
 
 def _ask_passphrase(screen: Screen, context: Context) -> Answer[str]:
@@ -3831,20 +3835,14 @@ def _edit_array_field(screen: Screen, context: Context, field: str, members: int
             array.filesystem = kind.unwrap()
         return
     if field == _ENCRYPTION:
-        turned = Confirm(
-            **answers(translate),
-            title=translate("Encrypt this array?"),
-            footer=footer(translate),
-            current=bool(array.passphrase_file),
-        ).run(screen)
-        if not turned.chosen:
-            return
-        if not turned.unwrap():
-            array.passphrase_file = ""
-            return
-        staged = _ask_passphrase(screen, context)
-        if staged.chosen:
-            array.passphrase_file = staged.unwrap()
+        edited = _edit_passphrase(
+            screen,
+            context,
+            array.passphrase_file,
+            translate("Encrypt this array?"),
+        )
+        if edited.chosen:
+            array.passphrase_file = edited.unwrap()
         return
     titles = {_NAME: "Name", _MOUNTPOINT: "Mount point", _LABEL: "Label"}
     values = {_NAME: array.name, _MOUNTPOINT: array.mountpoint, _LABEL: array.label}
@@ -4143,24 +4141,16 @@ def _edit_slice_encryption(
     screen: Screen, context: Context, entry: manual.Slice, purpose: manual.Purpose
 ) -> manual.Slice | None:
     translate = context.translate
-    turned = Confirm(
-        **answers(translate),
-        title=(
+    return _edit_passphrase(
+        screen,
+        context,
+        entry.passphrase_file,
+        (
             translate("Encrypt the pool?")
             if purpose.role is PartitionRole.ZFS
             else translate("Encrypt this partition?")
         ),
-        footer=footer(translate),
-        current=bool(entry.passphrase_file),
-    ).run(screen)
-    if not turned.chosen:
-        return None
-    if not turned.unwrap():
-        return replace(entry, passphrase_file="")
-    staged = _ask_passphrase(screen, context)
-    if not staged.chosen:
-        return None
-    return replace(entry, passphrase_file=staged.unwrap())
+    ).map(lambda staged_path: replace(entry, passphrase_file=staged_path)).value
 
 
 def extra_packages_screen(

--- a/tests/unit/test_tui_app.py
+++ b/tests/unit/test_tui_app.py
@@ -17,7 +17,13 @@ from gentoo_install.model.config import (
     MirrorRegion,
 )
 from gentoo_install.model import manual
-from gentoo_install.model.device import FilesystemType, RaidLevel, RaidMetadata, ZfsTopology
+from gentoo_install.model.device import (
+    FilesystemType,
+    PartitionRole,
+    RaidLevel,
+    RaidMetadata,
+    ZfsTopology,
+)
 from gentoo_install.model.validate import validate
 from gentoo_install.model import compat
 from gentoo_install.tui import screens, settings
@@ -376,6 +382,111 @@ def test_declining_encryption_clears_the_passphrase() -> None:
     at.choice = replace(at.choice, passphrase_file="/run/keys/old")
     screens.encryption_screen(FakeScreen(keys=["KEY_UP", "\n"]), config(), at)
     assert at.choice.passphrase_file == ""
+
+
+@pytest.mark.parametrize(
+    ("leave", "outcome"),
+    [("KEY_BACKSPACE", Outcome.BACK), ("\x1b", Outcome.CANCELLED)],
+)
+def test_reopening_template_encryption_preserves_its_passphrase_on_child_exit(
+    leave: str, outcome: Outcome
+) -> None:
+    at = context()
+    at.choice = replace(at.choice, passphrase_file="/run/keys/old")
+
+    answer = screens.encryption_screen(FakeScreen(keys=["\n", leave]), config(), at)
+
+    assert answer.outcome is outcome
+    assert at.choice.passphrase_file == "/run/keys/old"
+    assert STAGED == []
+
+
+def test_template_encryption_replaces_its_staged_passphrase_after_success() -> None:
+    at = context()
+    at.choice = replace(at.choice, passphrase_file="/run/keys/old")
+    typed = list("replacement")
+
+    answer = screens.encryption_screen(
+        FakeScreen(keys=["\n", *typed, "\n", *typed, "\n"]), config(), at
+    )
+
+    assert answer.outcome is Outcome.CHOSE
+    assert at.choice.passphrase_file == "/run/keys/tui"
+    assert STAGED == ["replacement"]
+
+
+@pytest.mark.parametrize("leave", ["KEY_BACKSPACE", "\x1b"])
+def test_reopening_array_encryption_preserves_its_passphrase_on_child_exit(
+    leave: str,
+) -> None:
+    at = context()
+    at.layout.array.passphrase_file = "/run/keys/old"
+
+    screens._edit_array_field(
+        FakeScreen(keys=["\n", leave]), at, screens._ENCRYPTION, members=2
+    )
+
+    assert at.layout.array.passphrase_file == "/run/keys/old"
+    assert STAGED == []
+
+
+def test_array_encryption_replaces_its_staged_passphrase_after_success() -> None:
+    at = context()
+    at.layout.array.passphrase_file = "/run/keys/old"
+    typed = list("replacement")
+
+    screens._edit_array_field(
+        FakeScreen(keys=["\n", *typed, "\n", *typed, "\n"]),
+        at,
+        screens._ENCRYPTION,
+        members=2,
+    )
+
+    assert at.layout.array.passphrase_file == "/run/keys/tui"
+    assert STAGED == ["replacement"]
+
+
+def encrypted_partition() -> manual.Slice:
+    return manual.Slice(
+        index=1,
+        role=PartitionRole.DATA,
+        size=None,
+        filesystem=FilesystemType.EXT4,
+        passphrase_file="/run/keys/old",
+    )
+
+
+@pytest.mark.parametrize("leave", ["KEY_BACKSPACE", "\x1b"])
+def test_reopening_partition_encryption_preserves_its_passphrase_on_child_exit(
+    leave: str,
+) -> None:
+    at = context()
+    entry = encrypted_partition()
+
+    changed = screens._edit_slice_encryption(
+        FakeScreen(keys=["\n", leave]), at, entry, manual.purpose_of(entry)
+    )
+
+    assert changed is None
+    assert entry.passphrase_file == "/run/keys/old"
+    assert STAGED == []
+
+
+def test_partition_encryption_replaces_its_staged_passphrase_after_success() -> None:
+    at = context()
+    entry = encrypted_partition()
+    typed = list("replacement")
+
+    changed = screens._edit_slice_encryption(
+        FakeScreen(keys=["\n", *typed, "\n", *typed, "\n"]),
+        at,
+        entry,
+        manual.purpose_of(entry),
+    )
+
+    assert changed is not None
+    assert changed.passphrase_file == "/run/keys/tui"
+    assert STAGED == ["replacement"]
 
 
 def test_escape_asks_before_throwing_the_answers_away() -> None:
@@ -1131,10 +1242,9 @@ def test_what_still_asks_before_it_changes() -> None:
     }
     for title in asked:
         assert title in source, title
-    # Seven call sites, eight titles: the slice screen words its question for a
-    # pool or for a partition. sudo left the list when the account became one
-    # form: a tick beside the other four answers, not a screen of its own.
-    assert source.count("Confirm(") == 7
+    # Five call sites, eight titles: one encryption editor serves three titles,
+    # and the slice screen words its title for a pool or for a partition.
+    assert source.count("Confirm(") == 5
     # `settle` asks the same kind of question with three answers rather than
     # two, because the third opens the row the values land on.
     assert "This choice also sets" in source


### PR DESCRIPTION
Passphrase entry can return Back or Cancelled after encryption was already enabled, so the shared editor carries that outcome without replacing the staged path with an empty value.