### PR TITLE
vm: isolate console affinity per ticket exchange

### DIFF
--- a/tests/unit/test_proxmox.py
+++ b/tests/unit/test_proxmox.py
@@ -4,10 +4,12 @@ from __future__ import annotations
 
 import shlex
 from collections import Counter
+from concurrent.futures import ThreadPoolExecutor
 from dataclasses import dataclass
 from email.message import Message
 import io
 import struct
+from threading import Event
 import urllib.error
 import urllib.response
 import urllib.request
@@ -162,6 +164,41 @@ def test_a_delete_carries_its_parameters_in_the_url(monkeypatch: pytest.MonkeyPa
 
     assert removed == ("https://nowhere.invalid/api2/json/nodes/n/qemu/9300?purge=1", None)
     assert created == ("https://nowhere.invalid/api2/json/nodes/n/qemu", b"vmid=9300")
+
+
+def test_ordinary_api_calls_do_not_reuse_load_balancer_affinity(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    requests: list[urllib.request.Request] = []
+
+    class Answer(io.BytesIO):
+        def __init__(self, cookie: str) -> None:
+            super().__init__(b'{"data":{}}')
+            self.headers = Message()
+            self.headers.add_header("Set-Cookie", cookie)
+
+        def __enter__(self) -> Answer:
+            return self
+
+        def __exit__(self, *unused: object) -> None:
+            return None
+
+    class Opener:
+        def open(
+            self, request: urllib.request.Request, timeout: float = 0.0
+        ) -> Answer:
+            requests.append(request)
+            return Answer(f"INGRESSCOOKIE=worker-{len(requests)}; Path=/")
+
+    api = Api(host="nowhere.invalid")
+    api._opener = cast(urllib.request.OpenerDirector, Opener())
+    monkeypatch.setattr(proxmox, "_secret", lambda: "secret")
+
+    api.call("GET", "/nodes")
+    api.call("GET", "/cluster/status")
+
+    assert [request.get_header("Cookie") for request in requests] == [None, None]
+    assert not hasattr(api, "affinity")
 
 
 class _HttpRefusal:
@@ -2006,20 +2043,31 @@ def test_a_refused_stop_is_reported_before_the_guest_is_destroyed() -> None:
     assert api.absent
 
 
-def test_a_console_uses_the_cookie_returned_with_its_own_ticket(
+def test_interleaved_consoles_use_the_cookie_from_their_own_ticket(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """Another worker replaced the shared affinity cookie between ticket and connect."""
-    captured: dict[str, str] = {}
+    """Ticket B replaces simulated shared state before ticket A connects."""
+    captured: dict[int, str] = {}
+    first_ticket = Event()
+    second_ticket = Event()
 
     class Tickets(Api):
         def __init__(self) -> None:
             self.host = "pve.invalid"
-            self.affinity = "cookie-before"
 
         def call_with_affinity(self, method: str, path: str, **form: Any) -> tuple[Any, str]:
-            self.affinity = "INGRESSCOOKIE=worker-b"
-            return {"port": 1, "ticket": "ticket-a", "user": "root@pam"}, "INGRESSCOOKIE=worker-a"
+            vmid = int(path.split("/qemu/", 1)[1].split("/", 1)[0])
+            cookie = f"INGRESSCOOKIE=worker-{vmid}"
+            if vmid == 9300:
+                setattr(self, "affinity", cookie)
+                first_ticket.set()
+                assert second_ticket.wait(timeout=5.0)
+            else:
+                assert first_ticket.wait(timeout=5.0)
+                setattr(self, "affinity", cookie)
+                second_ticket.set()
+            ticket = {"port": vmid, "ticket": f"ticket-{vmid}", "user": "root@pam"}
+            return ticket, cookie
 
     class Framed:
         closed = False
@@ -2042,13 +2090,23 @@ def test_a_console_uses_the_cookie_returned_with_its_own_ticket(
         headers: dict[str, str],
         **kwargs: Any,
     ) -> Framed:
-        captured.update(headers)
+        vmid = int(path.split("/qemu/", 1)[1].split("/", 1)[0])
+        captured[vmid] = headers.get("Cookie", "")
         return Framed()
 
     monkeypatch.setattr(WebSocket, "connect", connect)
     monkeypatch.setattr(proxmox, "_secret", lambda: "secret")
-    proxmox.ConsoleChannel.open(Tickets(), "node", 9300, tries=1)
-    assert captured["Cookie"] == "INGRESSCOOKIE=worker-a"
+    api = Tickets()
+    with ThreadPoolExecutor(max_workers=2) as workers:
+        first = workers.submit(proxmox.ConsoleChannel.open, api, "node", 9300, 1)
+        second = workers.submit(proxmox.ConsoleChannel.open, api, "node", 9301, 1)
+        first.result()
+        second.result()
+
+    assert captured == {
+        9300: "INGRESSCOOKIE=worker-9300",
+        9301: "INGRESSCOOKIE=worker-9301",
+    }
 
 
 def test_a_guest_is_asked_for_an_address_on_the_first_pass() -> None:
@@ -2353,7 +2411,6 @@ def test_an_error_carried_in_a_two_hundred_is_not_thrown_away() -> None:
 
     api = Api.__new__(Api)
     api.host = "pve.invalid"
-    api.affinity = ""
 
     api._opener = answering({"data": None, "message": "invalid bootorder\n"})
     with pytest.raises(ProxmoxError) as raised:

--- a/tests/vm/proxmox.py
+++ b/tests/vm/proxmox.py
@@ -163,12 +163,6 @@ class Api:
         self._opener = urllib.request.build_opener(
             urllib.request.HTTPSHandler(context=self._context), _RejectRedirect()
         )
-        #: The cluster sits behind a load balancer that spreads requests over
-        #: every node. A `termproxy` ticket is valid on the node that issued
-        #: it, so a websocket landing anywhere else is answered `502 Bad
-        #: Gateway`. Holding the balancer's own affinity cookie pins both
-        #: halves to one backend.
-        self.affinity: str = ""
 
     def _remember(self, headers: Any) -> str:
         for name, value in headers.items():
@@ -177,9 +171,7 @@ class Api:
         return ""
 
     def call(self, method: str, path: str, **form: Any) -> Any:
-        data, affinity = self.call_with_affinity(method, path, **form)
-        if affinity:
-            self.affinity = affinity
+        data, _ = self.call_with_affinity(method, path, **form)
         return data
 
     def call_with_affinity(self, method: str, path: str, **form: Any) -> tuple[Any, str]:
@@ -195,9 +187,6 @@ class Api:
             f"https://{self.host}/api2/json{path}", data=body, method=method
         )
         request.add_header("Authorization", f"PVEAPIToken={TOKEN_ID}={_secret()}")
-        affinity = self.affinity
-        if affinity:
-            request.add_header("Cookie", affinity)
         try:
             with self._opener.open(request, timeout=API_TIMEOUT) as answer:
                 remembered = self._remember(answer.headers)
@@ -211,7 +200,7 @@ class Api:
                 # answers `{"data": null}` with no message at all.
                 if data is None and reason:
                     raise ProxmoxError(f"{method} {path} answered {reason}")
-                return data, remembered or affinity
+                return data, remembered
         except urllib.error.HTTPError as error:
             # The reason, not only the body: Proxmox answers `500` with
             # `{"data":null}` and puts what went wrong in the status line.
@@ -326,8 +315,6 @@ class Api:
         )
         request.add_header("Authorization", f"PVEAPIToken={TOKEN_ID}={_secret()}")
         request.add_header("Content-Type", f"multipart/form-data; boundary={boundary}")
-        if self.affinity:
-            request.add_header("Cookie", self.affinity)
         try:
             with self._opener.open(request, timeout=600.0) as answer:
                 upid = json.load(answer).get("data")
@@ -566,7 +553,6 @@ class Guest:
                     if not _transient(error):
                         raise
                     last = str(error)
-                    self.api.affinity = ""
                     time.sleep(0.5 * (attempt + 1))
             else:
                 raise ProxmoxError(f"{key!r} was not delivered to vm {self.vmid}: {last}")
@@ -679,10 +665,9 @@ class ConsoleChannel:
         after its own five-second wait, so this retries rather than failing a
         run that was one second early.
 
-        Each retry drops the balancer's affinity cookie first. The failure is
-        intermittent and follows which backend the cookie pinned: the same call
-        answered 500 five times running on one backend and succeeded first try
-        on the next, so retrying without moving would just wait.
+        Each retry starts a new ticket exchange. The failure is intermittent
+        and follows which backend answered: one backend refused five calls in
+        a row while the next succeeded, so a failed exchange is not reused.
         """
         last = ""
         for attempt in range(tries):
@@ -694,7 +679,6 @@ class ConsoleChannel:
                 if not _transient(error):
                     raise
                 last = str(error)
-                api.affinity = ""
                 time.sleep(2.0 * (attempt + 1))
                 continue
             path = (
@@ -711,7 +695,6 @@ class ConsoleChannel:
                 )
             except WebSocketError as error:
                 last = str(error)
-                api.affinity = ""
                 time.sleep(2.0 * (attempt + 1))
                 continue
             socket.settimeout(1.0)


### PR DESCRIPTION
The load balancer can route concurrent termproxy requests to different backends, so each websocket upgrade now uses the affinity cookie returned with its own ticket instead of mutable API-wide state.