### PR TITLE
plan: make emerge source policy explicit

### DIFF
--- a/gentoo_install/plan/bootloader.py
+++ b/gentoo_install/plan/bootloader.py
@@ -436,7 +436,7 @@ def build(config: InstallConfig) -> list[Operation]:
                 stage=Stage.BOOTLOADER,
                 packages=(provider,),
                 summary="install bootctl",
-                only_if_absent=True,
+                noreplace=True,
             ),
             InstallSystemdBoot(esp=esp),
             ShowTheBootMenu(esp=esp),

--- a/gentoo_install/plan/kernel.py
+++ b/gentoo_install/plan/kernel.py
@@ -36,7 +36,7 @@ from .bootloader import GenerateHostId
 from .bootloader import initramfs_keymap as bootloader_keymap
 from .bootloader import unlock_parameters
 from .operations import Context, Operation, Stage
-from .portage import Emerge
+from .portage import Emerge, SourcePolicy
 
 #: The package that provides each kernel choice.
 KERNEL_PACKAGES: Final[dict[KernelSource, str]] = {
@@ -628,7 +628,7 @@ def build(config: InstallConfig) -> list[Operation]:
                 packages=("sys-apps/systemd",),
                 summary="rebuild systemd with the unlock generator",
                 oneshot=True,
-                binary_packages=False,
+                source=SourcePolicy.build_all(),
             ),
         ]
     operations += [
@@ -694,7 +694,7 @@ def build(config: InstallConfig) -> list[Operation]:
                 stage=Stage.KERNEL,
                 packages=tuple(one for one, _ in flagged_now),
                 summary="install the storage tools that need a flag the default build lacks",
-                binary_packages=False,
+                source=SourcePolicy.build_all(),
             )
         )
     out_of_tree = _out_of_tree_modules(config)
@@ -714,8 +714,11 @@ def build(config: InstallConfig) -> list[Operation]:
                 stage=Stage.KERNEL,
                 packages=(atom, *sorted(building)),
                 summary="install the kernel and the tools that build a module for it",
-                source_only=tuple(sorted(building)) if prebuilt else (),
-                binary_packages=prebuilt,
+                source=(
+                    SourcePolicy.build_subset(tuple(sorted(building)))
+                    if prebuilt
+                    else SourcePolicy.build_all()
+                ),
             )
         )
     else:
@@ -724,7 +727,11 @@ def build(config: InstallConfig) -> list[Operation]:
                 stage=Stage.KERNEL,
                 packages=(atom,),
                 summary="install the kernel",
-                binary_packages=prebuilt,
+                source=(
+                    SourcePolicy.binaries_allowed()
+                    if prebuilt
+                    else SourcePolicy.build_all()
+                ),
             )
         )
     if modules:

--- a/gentoo_install/plan/portage.py
+++ b/gentoo_install/plan/portage.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 
 import re
 from dataclasses import dataclass
+from enum import Enum
 from pathlib import PurePosixPath
 from typing import Final, Sequence
 
@@ -329,6 +330,54 @@ def _unversioned(atom: str) -> str:
     return f"{category}/{trimmed}"
 
 
+class _SourceMode(Enum):
+    BINARIES_ALLOWED = "binaries allowed"
+    BUILD_ALL = "build all"
+    BUILD_SUBSET = "build subset"
+
+
+@dataclass(frozen=True, kw_only=True)
+class SourcePolicy:
+    """Which requested packages may use binaries.
+
+    Dependencies may still use the binhost when requested packages are built.
+    """
+
+    mode: _SourceMode
+    subset: tuple[str, ...] = ()
+
+    def __post_init__(self) -> None:
+        if self.mode is _SourceMode.BUILD_SUBSET:
+            if not self.subset:
+                raise ValueError("a source subset cannot be empty")
+        elif self.subset:
+            raise ValueError(f"{self.mode.value} cannot carry a source subset")
+
+    @classmethod
+    def binaries_allowed(cls) -> SourcePolicy:
+        return cls(mode=_SourceMode.BINARIES_ALLOWED)
+
+    @classmethod
+    def build_all(cls) -> SourcePolicy:
+        return cls(mode=_SourceMode.BUILD_ALL)
+
+    @classmethod
+    def build_subset(cls, packages: tuple[str, ...]) -> SourcePolicy:
+        return cls(mode=_SourceMode.BUILD_SUBSET, subset=packages)
+
+    def built_from(self, packages: tuple[str, ...]) -> tuple[str, ...]:
+        if self.mode is _SourceMode.BINARIES_ALLOWED:
+            return ()
+        if self.mode is _SourceMode.BUILD_ALL:
+            return packages
+        outside = tuple(atom for atom in self.subset if atom not in packages)
+        if outside:
+            raise ValueError(
+                f"source subset contains atoms outside packages: {' '.join(outside)}"
+            )
+        return self.subset
+
+
 @dataclass(frozen=True, kw_only=True)
 class SyncRepository(Operation):
     """A directory holding a copy that git did not create makes `emerge --sync`
@@ -418,18 +467,17 @@ class Emerge(Operation):
     requester: str = ""
     repository_bootstrap: bool = False
     oneshot: bool = False
-    binary_packages: bool = True
-    #: Which of `packages` have to be built here when the rest may come from a
-    #: binary host. Empty means `binary_packages` decides for all of them. One
-    #: emerge naming a kernel and the module built against it needs both
-    #: answers at once, and Portage has to resolve them together or it picks a
-    #: kernel the module's own version cap forbids.
-    source_only: tuple[str, ...] = ()
+    source: SourcePolicy = SourcePolicy.binaries_allowed()
     #: Install only what is absent. For a package an earlier operation already
     #: pulled in, a plain atom is `[ebuild R]` and portage rebuilds it: one
     #: run spent 132 seconds rebuilding `sys-apps/systemd` at the bootloader
     #: stage with the same flags it had been built with at the kernel stage.
-    only_if_absent: bool = False
+    noreplace: bool = False
+
+    def __post_init__(self) -> None:
+        self.source.built_from(self.packages)
+        if self.oneshot and self.noreplace:
+            raise ValueError("oneshot and noreplace cannot be combined")
 
     @property
     def package_requester(self) -> str:
@@ -443,15 +491,13 @@ class Emerge(Operation):
         return f"{self.summary}: emerge {' '.join(self.packages)}{how}"
 
     def _built_here(self) -> tuple[str, ...]:
-        if self.source_only:
-            return self.source_only
-        return () if self.binary_packages else self.packages
+        return self.source.built_from(self.packages)
 
     def apply(self, context: Context) -> None:
         argv = ["emerge", *EMERGE_OPTIONS]
         if self.oneshot:
             argv.append("--oneshot")
-        if self.only_if_absent:
+        if self.noreplace:
             argv.append("--noreplace")
         if context.degraded(BINARY_PACKAGES):
             # `FEATURES=getbinpkg` in make.conf keeps fetching remote binaries
@@ -789,7 +835,7 @@ def build(
                 stage=Stage.PORTAGE,
                 packages=("sec-keys/openpgp-keys-gentoozh",),
                 summary="install the key the community binary packages are signed with",
-                binary_packages=False,
+                source=SourcePolicy.build_all(),
                 repository_bootstrap=True,
             ),
             TrustBinhostKey(

--- a/tests/unit/test_plan_boot.py
+++ b/tests/unit/test_plan_boot.py
@@ -35,7 +35,7 @@ from gentoo_install.model.size import Size
 from gentoo_install.exec.config import load
 from gentoo_install.model.validate import validate
 from gentoo_install.plan import bootloader, kernel
-from gentoo_install.plan.portage import Emerge
+from gentoo_install.plan.portage import Emerge, SourcePolicy
 
 from .layouts import config, encrypted_root, ext4_on_gpt, i, zfs_root
 from .recorder import Recorder
@@ -190,7 +190,7 @@ def test_the_kernel_and_its_module_are_resolved_in_one_emerge() -> None:
     assert len(merging) == 1, [one.describe() for one in merging]
     assert "sys-fs/zfs" in merging[0].packages
     # The kernel still comes prebuilt; only the module is built here.
-    assert merging[0].source_only == ("sys-fs/zfs",)
+    assert merging[0].source == SourcePolicy.build_subset(("sys-fs/zfs",))
     told = next(n for n, o in enumerate(operations) if "dist-kernel" in o.describe())
     assert told < operations.index(merging[0])
 
@@ -995,7 +995,7 @@ def test_bootctl_is_not_rebuilt_for_flags_it_already_has() -> None:
         for one in bootloader.build(installation)
         if isinstance(one, Emerge) and "bootctl" in one.summary
     )
-    assert merge.only_if_absent
+    assert merge.noreplace
     recorder = Recorder()
     merge.apply(recorder)
     assert any("--noreplace" in one for one in recorder.in_target[0])

--- a/tests/unit/test_plan_portage.py
+++ b/tests/unit/test_plan_portage.py
@@ -278,7 +278,7 @@ def test_a_binhost_that_can_be_trusted_is_used() -> None:
 
 
 def test_a_package_built_here_still_takes_its_dependencies_from_the_host() -> None:
-    """`binary_packages=False` means this atom carries a flag the host's build
+    """A build-all policy means this atom carries a flag the host's build
     lacks, not that the machine has to compile everything under it: turning
     binaries off wholesale pulled gtk+, cups and 21 more into a systemd
     rebuild and died on a circular dependency between docutils and pillow."""
@@ -287,7 +287,7 @@ def test_a_package_built_here_still_takes_its_dependencies_from_the_host() -> No
     portage.Emerge(
         packages=("sys-apps/systemd",),
         summary="rebuild systemd with the unlock generator",
-        binary_packages=False,
+        source=portage.SourcePolicy.build_all(),
     ).apply(recorder)
     emerge = next(argv for argv in recorder.in_target if argv[0] == "emerge")
     assert "--getbinpkg=y" in emerge
@@ -299,12 +299,126 @@ def test_a_package_built_here_still_takes_its_dependencies_from_the_host() -> No
     assert "virtual/*" in excluded.split()
 
 
-def test_a_degraded_binhost_reaches_the_source_path_at_all() -> None:
+@pytest.mark.parametrize(
+    ("policy", "built", "description"),
+    (
+        (
+            portage.SourcePolicy.binaries_allowed(),
+            (),
+            "install packages: emerge app-editors/nano app-misc/tmux",
+        ),
+        (
+            portage.SourcePolicy.build_all(),
+            ("app-editors/nano", "app-misc/tmux"),
+            "install packages: emerge app-editors/nano app-misc/tmux, from source",
+        ),
+        (
+            portage.SourcePolicy.build_subset(("app-misc/tmux",)),
+            ("app-misc/tmux",),
+            (
+                "install packages: emerge app-editors/nano app-misc/tmux, "
+                "building app-misc/tmux here"
+            ),
+        ),
+    ),
+    ids=("binaries-allowed", "build-all", "build-subset"),
+)
+def test_source_policies_render_their_commands_and_descriptions(
+    policy: portage.SourcePolicy,
+    built: tuple[str, ...],
+    description: str,
+) -> None:
+    operation = portage.Emerge(
+        packages=("app-editors/nano", "app-misc/tmux"),
+        summary="install packages",
+        source=policy,
+    )
+    recorder = Recorder()
+
+    operation.apply(recorder)
+
+    emerge = recorder.only("emerge")
+    excluded = emerge[emerge.index("--usepkg-exclude") + 1]
+    expected = portage.BINPKG_EXCLUDED
+    if built:
+        expected += " " + " ".join(portage._unversioned(atom) for atom in built)
+    assert excluded == expected
+    assert operation.describe() == description
+
+
+@pytest.mark.parametrize(
+    ("packages", "subset"),
+    (
+        (("app-editors/nano",), ()),
+        (("app-editors/nano",), ("app-misc/tmux",)),
+        (("app-editors/nano",), ("app-editors/nano", "app-misc/tmux")),
+    ),
+    ids=("empty", "outside", "mixed"),
+)
+def test_invalid_source_subsets_are_rejected(
+    packages: tuple[str, ...], subset: tuple[str, ...]
+) -> None:
+    if not subset:
+        with pytest.raises(ValueError, match="source subset cannot be empty"):
+            portage.SourcePolicy.build_subset(subset)
+        return
+    with pytest.raises(ValueError, match="source subset contains atoms outside packages"):
+        portage.Emerge(
+            packages=packages,
+            summary="install packages",
+            source=portage.SourcePolicy.build_subset(subset),
+        )
+
+
+def test_oneshot_and_noreplace_cannot_be_combined() -> None:
+    with pytest.raises(ValueError, match="oneshot and noreplace cannot be combined"):
+        portage.Emerge(
+            packages=("app-editors/nano",),
+            summary="install the editor",
+            oneshot=True,
+            noreplace=True,
+        )
+
+
+@pytest.mark.parametrize(
+    ("oneshot", "noreplace", "expected"),
+    ((True, False, "--oneshot"), (False, True, "--noreplace")),
+    ids=("oneshot", "noreplace"),
+)
+def test_oneshot_and_noreplace_are_rendered_explicitly(
+    oneshot: bool, noreplace: bool, expected: str
+) -> None:
+    recorder = Recorder()
+    portage.Emerge(
+        packages=("app-editors/nano",),
+        summary="install the editor",
+        oneshot=oneshot,
+        noreplace=noreplace,
+    ).apply(recorder)
+    assert expected in recorder.only("emerge")
+
+
+@pytest.mark.parametrize(
+    "policy",
+    (
+        portage.SourcePolicy.binaries_allowed(),
+        portage.SourcePolicy.build_all(),
+        portage.SourcePolicy.build_subset(("sys-boot/grub",)),
+    ),
+    ids=("binaries-allowed", "build-all", "build-subset"),
+)
+def test_a_degraded_binhost_reaches_the_source_path_at_all(
+    policy: portage.SourcePolicy,
+) -> None:
     """`FEATURES=getbinpkg` in make.conf outlives `--usepkg=n`, so a host that
     cannot be verified still served every package until both were passed."""
     recorder = Recorder()
     recorder.given_up.add(portage.BINARY_PACKAGES)
-    portage.Emerge(packages=("sys-boot/grub",), summary="install the bootloader").apply(recorder)
+    portage.Emerge(
+        packages=("sys-boot/grub",),
+        summary="install the bootloader",
+        source=policy,
+    ).apply(recorder)
     emerge = next(argv for argv in recorder.in_target if argv[0] == "emerge")
     assert "--usepkg=n" in emerge and "--getbinpkg=n" in emerge
 
@@ -878,7 +992,7 @@ def test_a_pinned_package_reaches_usepkg_exclude_without_its_version() -> None:
     install with the disks already written. Measured against the real emerge:
     `cat/pkg` and `cat/pkg:0` are accepted and anything carrying a version is
     not."""
-    from gentoo_install.plan.portage import Emerge, _unversioned
+    from gentoo_install.plan.portage import Emerge, SourcePolicy, _unversioned
 
     assert _unversioned("=sys-kernel/gentoo-cjk-kernel-bin-7.1.7") == (
         "sys-kernel/gentoo-cjk-kernel-bin"
@@ -894,8 +1008,9 @@ def test_a_pinned_package_reaches_usepkg_exclude_without_its_version() -> None:
     Emerge(
         summary="install the kernel",
         packages=("=sys-kernel/gentoo-cjk-kernel-bin-7.1.7",),
-        source_only=("=sys-kernel/gentoo-cjk-kernel-bin-7.1.7",),
-        binary_packages=True,
+        source=SourcePolicy.build_subset(
+            ("=sys-kernel/gentoo-cjk-kernel-bin-7.1.7",)
+        ),
     ).apply(recorder)
     excluded = next(
         one[one.index("--usepkg-exclude") + 1]

--- a/tests/unit/test_resume.py
+++ b/tests/unit/test_resume.py
@@ -283,7 +283,7 @@ def test_an_emerge_after_a_resume_still_builds_from_source(tmp_path: Path) -> No
     recorder = Recorder()
     for what in already_degraded(journal):
         recorder.given_up.add(what)
-    Emerge(packages=("app-editors/nano",), summary="editor", binary_packages=True).apply(recorder)
+    Emerge(packages=("app-editors/nano",), summary="editor").apply(recorder)
     merged = " ".join(" ".join(one) for one in recorder.in_target)
     assert "--usepkg=n" in merged and "--getbinpkg=n" in merged, merged
 


### PR DESCRIPTION
Interacting booleans allowed source-only atoms outside the requested package set. One validated policy now represents binary-allowed, build-all, and build-subset behavior.