### PR TITLE
vm: reserve scheduler capacity in exact bytes

### DIFF
--- a/tests/unit/test_cluster.py
+++ b/tests/unit/test_cluster.py
@@ -4,14 +4,14 @@ import time
 from collections.abc import Callable
 from io import BytesIO
 from pathlib import Path
-from typing import Any
+from typing import Any, cast
 
 import pytest
 
 from gentoo_install.model.config import MirrorRegion, Sync
 from tests.vm import cluster
 from tests.vm.console import ConsoleTimeout, SerialConsole
-from tests.vm.proxmox import Node, ProxmoxNotFound, VMID_FIRST, VMID_LAST
+from tests.vm.proxmox import Api, Node, ProxmoxNotFound, VMID_FIRST, VMID_LAST
 
 
 class WorkerFailure(Exception):
@@ -161,6 +161,50 @@ def test_worker_failure_reports_outcome_and_releases_vmid(
     assert all(outcome.vmid == VMID_FIRST for outcome in outcomes)
     assert api.allocations == [VMID_FIRST, VMID_FIRST]
     assert api.created == {}
+
+
+def test_non_double_memory_reservation_is_admitted_in_exact_bytes(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    monkeypatch.setattr(cluster, "HEAVY_MEMORY_MIB", 6144)
+    job = cluster.Job("odd-sized", tmp_path / "odd-sized.toml", heavy=True)
+    reservation = 6 * 1024**3
+    node = Node(
+        "node",
+        cluster.NODE_HEADROOM_BYTES + reservation,
+        16,
+    )
+
+    class CapacityApi:
+        def nodes(self) -> list[Node]:
+            return [node]
+
+    slots = cluster.free_slots(cast(Api, CapacityApi()))
+    assert slots == [node]
+    assert cluster.room_for(node, job)
+
+    class Guest:
+        def stop(self) -> None:
+            return None
+
+        def destroy(self) -> None:
+            return None
+
+    execution = cluster.Running(
+        Guest(),
+        cluster.Watchdog(tmp_path / "odd-sized.log", lambda: 0),
+        job.reservation_bytes,
+    )
+    dispatched = job.dispatch(
+        node.name,
+        VMID_FIRST,
+        tmp_path / "odd-sized.lease",
+        tmp_path / "odd-sized.log",
+        execution,
+    )
+    assert job.reservation_bytes == reservation
+    assert execution.reservation_bytes == reservation
+    assert cluster._reserved_bytes({job.name: dispatched}) == {node.name: reservation}
 
 
 class TimedChannel:

--- a/tests/unit/test_harness.py
+++ b/tests/unit/test_harness.py
@@ -520,35 +520,53 @@ def test_a_run_that_collected_fewer_results_than_it_dispatched_fails(
     assert cluster.main(["vm-lvm", "vm-xfs"]) == 0
 
 
-def test_a_guest_that_could_not_be_removed_keeps_its_slot() -> None:
+def test_a_guest_that_could_not_be_removed_keeps_its_slot(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
     """`destroy()` failing printed a line and the scheduler handed the node's
     slot back anyway. The memory is still allocated, so the next guest went
     onto a node with no room for it and the hypervisor ended it."""
-    from dataclasses import replace
-
     from tests.vm import cluster
 
-    ok = cluster.Outcome(name="x", verdict=cluster.Verdict.OK, seconds=1.0)
-    assert ok.removed is True, "a guest that was deleted returns its slot"
+    class Guest:
+        def stop(self) -> None:
+            return None
 
-    # The count a node is charged, before and after each outcome. `run` keeps
-    # this in a Counter and subtracts on an outcome whose guest is gone.
-    from collections import Counter
+        def destroy(self) -> None:
+            return None
 
-    placed: Counter[str] = Counter({"infra-node1": 1})
-    for outcome, expected in (
-        (replace(ok, removed=True), 0),
-        (replace(ok, removed=False), 1),
-    ):
-        held: Counter[str] = Counter(placed)
-        if outcome.removed:
-            held["infra-node1"] -= 1
-        assert held["infra-node1"] == expected, outcome
+    def dispatch(name: str) -> cluster.Job:
+        job = cluster.Job(name, Path(f"tests/fixtures/{name}.toml"))
+        execution = cluster.Running(
+            Guest(),
+            cluster.Watchdog(Path(f"/nonexistent/{name}.log"), lambda: 0),
+            job.reservation_bytes,
+        )
+        return job.dispatch(
+            "infra-node1",
+            9300,
+            Path(f"/nonexistent/{name}.lease"),
+            Path(f"/nonexistent/{name}.log"),
+            execution,
+        )
 
-    # And the scheduler is what applies it: the guard names the field.
-    import inspect
+    removed = dispatch("vm-lvm")
+    retained = dispatch("vm-xfs")
+    before = cluster._reserved_bytes({removed.name: removed, retained.name: retained})
+    assert retained.execution is not None
+    reservation = retained.execution.reservation_bytes
+    monkeypatch.setattr(cluster, "GUEST_MEMORY_MIB", 5120)
 
-    assert "not outcome.removed" in inspect.getsource(cluster.run)
+    removed = removed.answered(
+        cluster.Outcome(removed.name, cluster.Verdict.OK, 1.0, removed=True)
+    ).collect(0)
+    retained = retained.answered(
+        cluster.Outcome(retained.name, cluster.Verdict.ERROR, 1.0, removed=False)
+    ).collect(1)
+    after = cluster._reserved_bytes({removed.name: removed, retained.name: retained})
+
+    assert before["infra-node1"] == 2 * reservation
+    assert after == {"infra-node1": reservation}
 
 
 def test_cleanup_result_does_not_leak_between_workers(
@@ -1004,7 +1022,12 @@ def test_a_schedule_that_ends_early_stops_the_guests_it_left_running() -> None:
     quiet = cluster.Watchdog(log=Path("/nonexistent"), counters=lambda: None)
     guests = {name: Guest() for name in ("vm-lvm", "vm-xfs")}
     inflight = {
-        name: cluster.Running(guest=guest, watch=quiet) for name, guest in guests.items()
+        name: cluster.Running(
+            guest=guest,
+            watch=quiet,
+            reservation_bytes=cluster.GUEST_MEMORY_MIB * 1024**2,
+        )
+        for name, guest in guests.items()
     }
 
     joined: list[str] = []
@@ -1029,7 +1052,13 @@ def test_a_schedule_that_ends_early_stops_the_guests_it_left_running() -> None:
     # there is nobody left to race: reporting it and walking away left guests
     # running on a cluster the harness does not own.
     wedged = Guest()
-    held = {"vm-zfs": cluster.Running(guest=wedged, watch=quiet)}
+    held = {
+        "vm-zfs": cluster.Running(
+            guest=wedged,
+            watch=quiet,
+            reservation_bytes=cluster.GUEST_MEMORY_MIB * 1024**2,
+        )
+    }
 
     class Stuck(threading.Thread):
         def join(self, timeout: float | None = None) -> None:

--- a/tests/unit/test_proxmox.py
+++ b/tests/unit/test_proxmox.py
@@ -638,7 +638,7 @@ def test_a_guest_moving_nothing_at_all_is_stuck(tmp_path: Path) -> None:
 def test_a_stuck_guest_is_stopped_and_not_deleted_by_the_sweep(tmp_path: Path) -> None:
     """Stopping is what wakes the worker blocked on its console; the worker
     then reports and deletes. A sweep that deleted would race it."""
-    from tests.vm.cluster import WATCH_STRIKES, Running, Watchdog, _sweep
+    from tests.vm.cluster import GUEST_MEMORY_MIB, WATCH_STRIKES, Running, Watchdog, _sweep
 
     stopped: list[str] = []
 
@@ -652,7 +652,13 @@ def test_a_stuck_guest_is_stopped_and_not_deleted_by_the_sweep(tmp_path: Path) -
     log = tmp_path / "quiet.log"
     log.write_bytes(b"")
     watch = Watchdog(log=log, counters=lambda: 0, strikes=WATCH_STRIKES - 1)
-    inflight = {"vm-zfs": Running(guest=Quiet(), watch=watch)}
+    inflight = {
+        "vm-zfs": Running(
+            guest=Quiet(),
+            watch=watch,
+            reservation_bytes=GUEST_MEMORY_MIB * 1024**2,
+        )
+    }
     _sweep(inflight)
     assert stopped == ["stopped"]
 
@@ -941,9 +947,9 @@ def test_guests_already_placed_are_subtracted_from_what_a_node_reports() -> None
 
     api = Lagging(host="nowhere.invalid")
     assert len(free_slots(api)) == 3
-    assert len(free_slots(api, {"one": 2})) == 1
-    assert free_slots(api, {"one": 3}) == []
-    assert free_slots(api, {"one": 9}) == [], "never negative"
+    assert len(free_slots(api, {"one": guest * 2})) == 1
+    assert free_slots(api, {"one": guest * 3}) == []
+    assert free_slots(api, {"one": guest * 9}) == [], "never negative"
 
 
 def test_the_archive_is_waited_for_rather_than_timed() -> None:
@@ -1686,11 +1692,17 @@ def test_a_reserved_guest_is_not_created_twice_and_is_still_cleaned_up(
     monkeypatch.setattr(guest, "start", fail_start)
     monkeypatch.setattr(guest, "destroy", destroy)
     log = tmp_path / "reserved.log"
-    execution = Running(guest, Watchdog(log=log, counters=lambda: 0), created=True)
+    job = Job(name="reserved", fixture=tmp_path / "reserved.toml", iso="minimal.iso")
+    execution = Running(
+        guest,
+        Watchdog(log=log, counters=lambda: 0),
+        job.reservation_bytes,
+        created=True,
+    )
     outcome = install_one(
         api,
         guest.node,
-        Job(name="reserved", fixture=tmp_path / "reserved.toml", iso="minimal.iso"),
+        job,
         "driver.iso",
         tmp_path,
         execution=execution,

--- a/tests/vm/cluster.py
+++ b/tests/vm/cluster.py
@@ -270,6 +270,10 @@ class Job:
         return HEAVY_MEMORY_MIB if self.heavy else GUEST_MEMORY_MIB
 
     @property
+    def reservation_bytes(self) -> int:
+        return self.memory_mib * 1024**2
+
+    @property
     def cores(self) -> int:
         return HEAVY_CORES if self.heavy else GUEST_CORES
 
@@ -285,10 +289,6 @@ class Job:
     def holds_resources(self) -> bool:
         return self.running or self.outcome is not None and not self.outcome.removed
 
-    @property
-    def weight(self) -> int:
-        return 2 if self.heavy else 1
-
     def dispatch(
         self,
         node: str,
@@ -299,6 +299,8 @@ class Job:
     ) -> Job:
         if self.status is not JobStatus.WAITING:
             raise ProxmoxError(f"{self.name} cannot be dispatched from {self.status.value}")
+        if execution.reservation_bytes != self.reservation_bytes:
+            raise ProxmoxError(f"{self.name} execution has the wrong memory reservation")
         return replace(
             self,
             status=JobStatus.RUNNING,
@@ -930,8 +932,8 @@ def free_slots(api: Api, placed: Mapping[str, int] | None = None) -> list[Node]:
     slot per node capped a six-node cluster with 51 GiB spare at three guests
     at a time, with the queue twenty deep.
 
-    `placed` is what this schedule has already put on each node, and it is
-    subtracted from what the node reports. A guest's memory is allocated
+    `placed` is the bytes this schedule has already put on each node, and it
+    is subtracted from what the node reports. A guest's memory is allocated
     lazily, so a node with eleven of them freshly started still reported 13.8
     GiB free: reading that alone dispatched twenty guests wanting 120 GiB onto
     a cluster with 71, on hardware that is running other people's machines.
@@ -940,7 +942,7 @@ def free_slots(api: Api, placed: Mapping[str, int] | None = None) -> list[Node]:
     held = placed or {}
     per_node: list[list[Node]] = []
     for node in api.nodes():
-        room = node.free_bytes - NODE_HEADROOM_BYTES - held.get(node.name, 0) * need
+        room = node.free_bytes - NODE_HEADROOM_BYTES - held.get(node.name, 0)
         per_node.append([node] * max(0, int(room // need)))
     # One from each node in turn, rather than a node's whole share before the
     # next one is touched: five guests went onto `infra-node5` and left the
@@ -957,13 +959,13 @@ def free_slots(api: Api, placed: Mapping[str, int] | None = None) -> list[Node]:
 def room_for(node: Node, job: Job, placed: Mapping[str, int] | None = None) -> bool:
     """Whether this node can carry this job now.
 
-    A heavy guest asks for twice the memory, so a slot list built from the
-    light size does not answer for it: eight of them were dispatched onto
-    nodes with room for four and the last four were killed by the hypervisor.
+    A slot list built from the light size does not answer for a larger job:
+    eight heavy guests were dispatched onto nodes with room for four and the
+    last four were killed by the hypervisor.
     """
-    held = (placed or {}).get(node.name, 0) * GUEST_MEMORY_MIB * 1024**2
+    held = (placed or {}).get(node.name, 0)
     room = node.free_bytes - NODE_HEADROOM_BYTES - held
-    return room >= job.memory_mib * 1024**2
+    return room >= job.reservation_bytes
 
 
 class Stoppable(Protocol):
@@ -986,6 +988,7 @@ class Running:
 
     guest: Stoppable
     watch: Watchdog
+    reservation_bytes: int
     created: bool = False
 
 
@@ -1014,7 +1017,22 @@ def _execution(
             nonce=nonce or f"gi-{uuid.uuid4().hex[:12]}",
         ),
     )
-    return Running(guest, Watchdog(log=log, counters=lambda: guest.transferred()))
+    return Running(
+        guest,
+        Watchdog(log=log, counters=lambda: guest.transferred()),
+        job.reservation_bytes,
+    )
+
+
+def _reserved_bytes(scheduled: Mapping[str, Job]) -> Counter[str]:
+    held: Counter[str] = Counter()
+    for job in scheduled.values():
+        if not job.holds_resources:
+            continue
+        if job.node is None or job.execution is None:
+            raise ProxmoxError(f"{job.name} holds resources without an execution")
+        held[job.node] += job.execution.reservation_bytes
+    return held
 
 
 def _reserve_job(
@@ -1295,12 +1313,7 @@ def run(
         while not all(job.collected for job in scheduled.values()):
             waiting = [job for job in scheduled.values() if job.status is JobStatus.WAITING]
             running = [job for job in scheduled.values() if job.running]
-            placed = Counter(
-                job.node
-                for job in scheduled.values()
-                if job.holds_resources and job.node is not None
-                for _ in range(job.weight)
-            )
+            placed = _reserved_bytes(scheduled)
             slots = free_slots(api, placed)
             if limit:
                 slots = slots[: max(0, limit - len(running))]
@@ -1383,7 +1396,7 @@ def run(
                     daemon=True,
                 )
                 scheduled[job.name] = job.started(thread)
-                placed[node.name] += job.weight
+                placed[node.name] += execution.reservation_bytes
                 thread.start()
                 print(f"→ {job.name} on {node.name} ({len(waiting)} waiting)", flush=True)
                 if waiting and slots:


### PR DESCRIPTION
Job memory requirements are not fixed light/heavy multiples. The scheduler now retains each dispatch-time byte reservation and releases that same value after confirmed cleanup.