### PR TITLE
exec: derive command usability once

### DIFF
--- a/gentoo_install/exec/preflight.py
+++ b/gentoo_install/exec/preflight.py
@@ -9,7 +9,7 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Final, Iterable
+from typing import AbstractSet, Final, Iterable, Mapping
 
 from ..errors import DeviceNotFound, PreflightFailed
 from ..model import compat
@@ -105,6 +105,49 @@ GNU_ONLY: Final[dict[str, tuple[str, str]]] = {
     ),
 }
 
+
+@dataclass(frozen=True)
+class UnusableCommand:
+    """A present command whose implementation cannot perform the install."""
+
+    name: str
+    reason: str
+
+
+@dataclass(frozen=True)
+class CommandAssessment:
+    """Command presence and implementation facts derived for one caller."""
+
+    missing: frozenset[str]
+    unusable: tuple[UnusableCommand, ...]
+
+
+def assess_commands(
+    wanted: Iterable[str],
+    present: AbstractSet[str],
+    versions: Mapping[str, str],
+) -> CommandAssessment:
+    """Derive command usability from presence and version facts."""
+    names = frozenset(wanted)
+    missing = names - present
+    unusable: list[UnusableCommand] = []
+    for command, (required, reason) in GNU_ONLY.items():
+        if command not in names or command in missing:
+            continue
+        version = versions.get(command)
+        if version is None or required in version:
+            continue
+        if not version:
+            problem = (
+                f"{command} answered nothing to --version, so it cannot be shown "
+                f"to be {required}; {reason}"
+            )
+        else:
+            problem = f"{command} is not {required} ({version[:60]}); {reason}"
+        unusable.append(UnusableCommand(name=command, reason=problem))
+    return CommandAssessment(missing=missing, unusable=tuple(unusable))
+
+
 #: `zpool create` refuses anything shorter, and it refuses it after the disk
 #: has already been partitioned.
 ZFS_PASSPHRASE_MINIMUM: Final[int] = 8
@@ -195,24 +238,6 @@ def _disks_at_risk(graph: DeviceGraph) -> list[Existing]:
     device the operator kept.
     """
     return list(compat.destroyed(graph))
-
-
-def _busybox_problems(machine: Machine) -> list[str]:
-    """Named here rather than discovered when the flag is rejected, which is
-    after the disks are partitioned and the archive is downloaded."""
-    problems: list[str] = []
-    for command, (wanted, reason) in GNU_ONLY.items():
-        version = machine.versions.get(command)
-        if version is None or wanted in version:
-            continue
-        if not version:
-            problems.append(
-                f"{command} answered nothing to --version, so it cannot be shown "
-                f"to be {wanted}; {reason}"
-            )
-            continue
-        problems.append(f"{command} is not {wanted} ({version[:60]}); {reason}")
-    return problems
 
 
 def _passphrase_problems(config: InstallConfig, probe: Probe) -> list[str]:
@@ -409,7 +434,8 @@ def inspect(
             "the amd64 EFI executables an amd64 install writes"
         )
 
-    missing = sorted(wanted - machine.commands)
+    commands = assess_commands(wanted, machine.commands, machine.versions)
+    missing = sorted(commands.missing)
     users = _command_users(plan) if plan is not None else {}
     unnamed = [command for command in missing if command not in users]
     if unnamed:
@@ -419,7 +445,7 @@ def inspect(
             fatal.append(
                 f"{command} is missing; required by {', '.join(users[command])}"
             )
-    fatal += _busybox_problems(machine)
+    fatal += [problem.reason for problem in commands.unusable]
 
     for disk in _disks_at_risk(config.disk.graph):
         try:

--- a/gentoo_install/exec/report.py
+++ b/gentoo_install/exec/report.py
@@ -161,16 +161,8 @@ def stage_passphrase(passphrase: str, work: Path) -> str:
 def absent(wanted: Iterable[str], probe: Probe | None = None) -> set[str]:
     """Find required commands absent from the machine or provided by BusyBox."""
     names = list(wanted)
-    missing = {command for command in names if shutil.which(command) is None}
-    if probe is None:
-        return missing
-    judged = [
-        command
-        for command in names
-        if command in preflight.GNU_ONLY and command not in missing
-    ]
-    versions = probe.versions(judged)
-    for command in judged:
-        if preflight.GNU_ONLY[command][0] not in versions.get(command, ""):
-            missing.add(command)
-    return missing
+    present = frozenset(command for command in names if shutil.which(command) is not None)
+    judged = set(preflight.GNU_ONLY) & present if probe is not None else set()
+    versions = probe.versions(judged) if probe is not None else {}
+    assessment = preflight.assess_commands(names, present, versions)
+    return set(assessment.missing) | {problem.name for problem in assessment.unusable}

--- a/tests/unit/test_exec.py
+++ b/tests/unit/test_exec.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from dataclasses import replace
 from pathlib import Path, PurePosixPath
-from typing import Iterable, Mapping, Sequence
+from typing import AbstractSet, Iterable, Mapping, Sequence
 
 import tempfile
 
@@ -16,7 +16,7 @@ from gentoo_install.errors import (
     IntegrityError,
     PreflightFailed,
 )
-from gentoo_install.exec import apply, fetch, preflight
+from gentoo_install.exec import apply, fetch, preflight, report as exec_report
 from gentoo_install.exec.probe import Machine as ProbedMachine
 from gentoo_install.exec.probe import Probe
 from gentoo_install.exec.runner import Result, Runner, under
@@ -734,6 +734,55 @@ def test_every_command_that_has_to_be_the_real_one_is_checked(tmp_path: Path) ->
     ).fatal)
 
 
+def test_command_assessment_separates_missing_and_unusable_commands() -> None:
+    missing = preflight.assess_commands(
+        ("tar", "printf"), frozenset({"printf"}), {"tar": "tar (busybox) 1.36"}
+    )
+    assert missing.missing == frozenset({"tar"})
+    assert missing.unusable == ()
+
+    unusable = preflight.assess_commands(
+        ("tar", "printf"), frozenset({"tar", "printf"}), {"tar": ""}
+    )
+    assert unusable.missing == frozenset()
+    assert [problem.name for problem in unusable.unusable] == ["tar"]
+    assert "answered nothing" in unusable.unusable[0].reason
+
+
+def test_both_command_consumers_use_the_shared_assessment(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    required = "GnuPG"
+    reason = "signature checks need its command-line interface"
+    monkeypatch.setitem(preflight.GNU_ONLY, "gpg", (required, reason))
+    original = preflight.assess_commands
+    calls: list[frozenset[str]] = []
+
+    def watching(
+        wanted: Iterable[str],
+        present_commands: AbstractSet[str],
+        versions: Mapping[str, str],
+    ) -> preflight.CommandAssessment:
+        calls.append(frozenset(wanted))
+        return original(wanted, present_commands, versions)
+
+    monkeypatch.setattr(preflight, "assess_commands", watching)
+    machine = described(versions={"gpg": "gpg (other) 1.0"})
+    checked = preflight.inspect(present(), machine, probe_of(tmp_path))
+    assert any(f"gpg is not {required}" in problem for problem in checked.fatal)
+
+    class OtherGpg(Probe):
+        def versions(self, wanted: Iterable[str]) -> dict[str, str]:
+            return {command: "gpg (other) 1.0" for command in wanted}
+
+    monkeypatch.setattr(
+        "gentoo_install.exec.report.shutil.which", lambda command: f"/{command}"
+    )
+    probe = OtherGpg(runner=runner(tmp_path), work=tmp_path)
+    assert exec_report.absent(("gpg",), probe) == {"gpg"}
+    assert len(calls) == 2
+
+
 def test_the_commands_whose_implementation_matters_are_the_ones_probed(tmp_path: Path) -> None:
     """`preflight` owns the table and `probe` reads the versions, so a command
     added to `GNU_ONLY` is asked for without a second list to update."""
@@ -1430,14 +1479,18 @@ def test_removing_a_partition_the_disk_does_not_have_is_refused(tmp_path: Path) 
     assert asked((1,)) == [], "removing a partition the disk has is a working layout"
 
 
-def test_a_command_that_answers_nothing_is_named_rather_than_crashing(tmp_path: Path) -> None:
+def test_a_command_that_answers_nothing_is_named_rather_than_crashing() -> None:
     """`versions()` discarded the exit status, so a command present on PATH
     that exits nonzero with no output reached `splitlines()[0]` and raised
     IndexError where a named preflight problem belongs."""
-    said = preflight._busybox_problems(described(versions={"tar": ""}))
+    empty = preflight.assess_commands(("tar",), frozenset({"tar"}), {"tar": ""})
+    said = [problem.reason for problem in empty.unusable]
     assert any("answered nothing" in one for one in said), said
 
-    wrong = preflight._busybox_problems(described(versions={"tar": "tar (busybox) 1.36"}))
+    assessed = preflight.assess_commands(
+        ("tar",), frozenset({"tar"}), {"tar": "tar (busybox) 1.36"}
+    )
+    wrong = [problem.reason for problem in assessed.unusable]
     assert any("is not GNU tar" in one or "is not" in one for one in wrong), wrong
 
 


### PR DESCRIPTION
Preflight and missing-command reports could classify the same present command differently. Keep one assessment boundary for presence and implementation facts.