### PR TITLE
portage: honor configured rsync URI

### DIFF
--- a/gentoo_install/plan/portage.py
+++ b/gentoo_install/plan/portage.py
@@ -797,7 +797,7 @@ def build(
             ConfigureRepository(
                 name="gentoo",
                 location=gentoo,
-                sync_uri=_rsync_uri(portage),
+                sync_uri=_repo_sync_uri(portage),
                 verify_commits=False,
                 sync_type="rsync",
             )
@@ -910,10 +910,6 @@ def _distfiles(portage: PortageConfig) -> tuple[str, ...]:
     return mirrors.gentoo_distfiles(portage.mirrors.region, portage.mirrors.site)
 
 
-def _rsync_uri(portage: PortageConfig) -> str:
-    return mirrors.gentoo_rsync_uri(portage.mirrors.region, portage.mirrors.site)
-
-
 def _appended_distfiles(portage: PortageConfig) -> tuple[str, ...]:
     """gentoo-zh's own distfiles, when they were asked for. They hold the
     sources of that overlay's packages and no main mirror carries them."""
@@ -923,7 +919,11 @@ def _appended_distfiles(portage: PortageConfig) -> tuple[str, ...]:
 
 
 def _repo_sync_uri(portage: PortageConfig) -> str:
-    return portage.mirrors.repo_sync_uri or mirrors.gentoo_sync_uri(
+    if portage.mirrors.repo_sync_uri:
+        return portage.mirrors.repo_sync_uri
+    if portage.sync is Sync.RSYNC:
+        return mirrors.gentoo_rsync_uri(portage.mirrors.region, portage.mirrors.site)
+    return mirrors.gentoo_sync_uri(
         portage.mirrors.region, portage.mirrors.site
     )
 

--- a/tests/unit/test_plan_portage.py
+++ b/tests/unit/test_plan_portage.py
@@ -18,6 +18,7 @@ from gentoo_install.model.config import (
     Overlay,
     PackagesConfig,
     PortageConfig,
+    Sync,
     SystemConfig,
 )
 from gentoo_install.errors import CommandFailed, ConfigError, ValidationFailed
@@ -140,6 +141,41 @@ def test_the_repository_is_configured_before_it_is_synced() -> None:
     assert "sync-type = git" in stanza
     assert "sync-depth = 1" in stanza
     assert "sync-git-verify-commit-signature = true" in stanza
+
+
+def test_a_custom_rsync_uri_is_written_to_the_main_repository() -> None:
+    sync_uri = "rsync://mirror.example.invalid/gentoo-portage"
+    installation = with_portage(
+        sync=Sync.RSYNC,
+        mirrors=MirrorConfig(repo_sync_uri=sync_uri),
+    )
+
+    stanza = apply_all(installation).files[PurePosixPath("/etc/portage/repos.conf/gentoo.conf")]
+
+    assert "sync-type = rsync" in stanza
+    assert f"sync-uri = {sync_uri}" in stanza
+
+
+def test_an_empty_rsync_uri_uses_the_default_rsync_repository() -> None:
+    installation = with_portage(sync=Sync.RSYNC, mirrors=MirrorConfig())
+
+    stanza = apply_all(installation).files[PurePosixPath("/etc/portage/repos.conf/gentoo.conf")]
+
+    assert "sync-type = rsync" in stanza
+    assert "sync-uri = rsync://rsync.gentoo.org/gentoo-portage" in stanza
+
+
+def test_a_custom_git_uri_is_written_to_the_main_repository() -> None:
+    sync_uri = "https://git.example.invalid/gentoo.git"
+    installation = with_portage(
+        sync=Sync.GIT,
+        mirrors=MirrorConfig(repo_sync_uri=sync_uri),
+    )
+
+    stanza = apply_all(installation).files[PurePosixPath("/etc/portage/repos.conf/gentoo.conf")]
+
+    assert "sync-type = git" in stanza
+    assert f"sync-uri = {sync_uri}" in stanza
 
 
 def test_the_local_copy_goes_before_the_first_sync_or_git_refuses() -> None:


### PR DESCRIPTION
A configured main repository source was used for Git but silently replaced for rsync. Apply the same explicit override before deriving either default.