### PR TITLE
model: define persisted sections once

### DIFF
--- a/gentoo_install/exec/report.py
+++ b/gentoo_install/exec/report.py
@@ -13,9 +13,9 @@ from pathlib import Path
 from .. import errors
 from ..errors import GentooInstallError
 from ..log import Journal
+from ..model import config as model_config
 from ..model import paste
 from ..model.config import InstallConfig
-from ..model.parse import TOP_LEVEL
 from ..model.serialise import to_toml
 from . import fetch, preflight
 from .probe import Probe
@@ -136,7 +136,7 @@ def configs_here(save_as: str) -> tuple[str, ...]:
             if path.name == save_as:
                 found.append(path.name)
             continue
-        if set(held) & (TOP_LEVEL - {"config_version"}):
+        if set(held).intersection(model_config.PERSISTED_SECTIONS):
             found.append(path.name)
     return tuple(found)
 

--- a/gentoo_install/model/config.py
+++ b/gentoo_install/model/config.py
@@ -8,12 +8,26 @@ from __future__ import annotations
 
 from dataclasses import dataclass, field
 from enum import Enum
+from typing import Final
 
 from .size import Size
 from .device import DeviceGraph, DeviceId
 
 #: `parse.py` refuses a newer file and migrates an older one.
-CONFIG_VERSION = 1
+CONFIG_VERSION: Final[int] = 1
+
+#: The scalar written before every table section.
+CONFIG_VERSION_KEY: Final[str] = "config_version"
+
+#: Persisted table sections in TOML order. The disk graph stays last.
+PERSISTED_SECTIONS: Final[tuple[str, ...]] = (
+    "system",
+    "portage",
+    "kernel",
+    "bootloader",
+    "packages",
+    "disk",
+)
 
 
 class InitSystem(Enum):

--- a/gentoo_install/model/parse.py
+++ b/gentoo_install/model/parse.py
@@ -10,9 +10,10 @@ from __future__ import annotations
 import tomllib
 from enum import Enum
 from pathlib import Path, PurePosixPath
-from typing import Any, Final, Mapping, Sequence, TypeVar
+from typing import Any, Mapping, Sequence, TypeVar
 
 from ..errors import ConfigError
+from . import config as model_config
 from . import sshkey
 from .config import (
     CONFIG_VERSION,
@@ -72,15 +73,8 @@ from .size import Size
 E = TypeVar("E", bound=Enum)
 
 
-#: The tables a configuration file holds. Named here so the menu can tell a
-#: configuration from the `pyproject.toml` sitting in the same directory.
-TOP_LEVEL: Final[frozenset[str]] = frozenset(
-    {"config_version", "disk", "system", "portage", "kernel", "bootloader", "packages"}
-)
-
-
 def parse(raw: Mapping[str, Any]) -> InstallConfig:
-    version = _int(raw, "config_version", "", default=CONFIG_VERSION)
+    version = _int(raw, model_config.CONFIG_VERSION_KEY, "", default=CONFIG_VERSION)
     if version > CONFIG_VERSION:
         raise ConfigError(
             f"config_version {version} is newer than this installer understands "
@@ -89,7 +83,11 @@ def parse(raw: Mapping[str, Any]) -> InstallConfig:
     if version < CONFIG_VERSION:
         raise ConfigError(f"config_version {version} has no migration to {CONFIG_VERSION}")
 
-    _reject_unknown(raw, "", set(TOP_LEVEL))
+    _reject_unknown(
+        raw,
+        "",
+        {model_config.CONFIG_VERSION_KEY, *model_config.PERSISTED_SECTIONS},
+    )
     return InstallConfig(
         config_version=version,
         disk=_disk(_table(raw, "disk", "", required=True), "disk"),

--- a/gentoo_install/model/serialise.py
+++ b/gentoo_install/model/serialise.py
@@ -14,6 +14,7 @@ from enum import Enum
 from pathlib import PurePosixPath
 from typing import Any, Final
 
+from . import config as model_config
 from .config import InstallConfig
 from .device import (
     Existing,
@@ -70,18 +71,14 @@ SECRET: Final[frozenset[str]] = frozenset({"password_hash", "root_password_hash"
 #: published one locks the account rather than setting a password nobody knows.
 REDACTED: Final[str] = "removed-before-publishing"
 
-#: Sections of `InstallConfig`, in the order a person reads them.
-SECTIONS: Final[tuple[str, ...]] = ("system", "portage", "kernel", "bootloader", "packages")
-
-
 def to_toml(config: InstallConfig, *, publishing: bool = False) -> str:
     """The configuration as a file that parses back into the same object.
 
     `publishing` replaces every password hash, for the copy that goes to a
     pastebin. The result still parses; it just installs no password.
     """
-    lines = [f"config_version = {config.config_version}"]
-    for name in SECTIONS:
+    lines = [f"{model_config.CONFIG_VERSION_KEY} = {config.config_version}"]
+    for name in model_config.PERSISTED_SECTIONS[:-1]:
         lines += _section(name, getattr(config, name), publishing=publishing)
     lines += _disk(config)
     return "\n".join(lines).rstrip("\n") + "\n"

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -457,6 +457,38 @@ def test_only_files_that_could_be_our_configuration_are_offered(tmp_path: Path) 
         os.chdir(here)
 
 
+def test_persisted_sections_drive_parse_serialise_and_discovery(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    from dataclasses import fields
+    import tomllib
+
+    from gentoo_install.model import config as model_config
+    from gentoo_install.model.parse import parse
+    from gentoo_install.model.serialise import to_toml
+
+    table_fields = {
+        field.name for field in fields(model_config.InstallConfig)
+    } - {model_config.CONFIG_VERSION_KEY}
+    assert set(model_config.PERSISTED_SECTIONS) == table_fields
+
+    config = load(FIXTURES / "btrfs-luks.toml")
+    raw = tomllib.loads(to_toml(config))
+    monkeypatch.setattr(
+        model_config,
+        "PERSISTED_SECTIONS",
+        tuple(name for name in model_config.PERSISTED_SECTIONS if name != "system"),
+    )
+
+    with pytest.raises(ConfigError, match="system"):
+        parse(raw)
+    assert "[system]" not in to_toml(config)
+
+    (tmp_path / "system-only.toml").write_text("[system]\nhostname = 'gentoo'\n")
+    monkeypatch.chdir(tmp_path)
+    assert report.configs_here("my-install.toml") == ()
+
+
 def test_the_address_handed_over_carries_no_extension() -> None:
     """The extension asks wastebin to highlight the paste. An 8.7 MB install
     log answered 408 after five seconds every time; the same address without


### PR DESCRIPTION
Parsing, serialization, and candidate discovery could drift when a configuration section changed. Derive all three from the model-owned ordered section set.