### PR TITLE
portage: persist the webrsync method

### DIFF
--- a/gentoo_install/plan/portage.py
+++ b/gentoo_install/plan/portage.py
@@ -255,6 +255,29 @@ class ConfigureRepository(Operation):
         )
 
 
+@dataclass(frozen=True, kw_only=True)
+class ConfigureWebrsyncRepository(Operation):
+    """Persist webrsync without a URI, which Portage's module does not consume."""
+
+    stage: Stage = Stage.PORTAGE
+    name: str
+    location: PurePosixPath
+
+    def describe(self) -> str:
+        return f"configure repository {self.name} to sync with emerge-webrsync"
+
+    def apply(self, context: Context) -> None:
+        stanza = (
+            f"[{self.name}]\n"
+            f"location = {self.location}\n"
+            "sync-type = webrsync\n"
+            "auto-sync = yes\n"
+            "sync-webrsync-verify-signature = true\n"
+            f"sync-openpgp-key-path = {RELEASE_KEY}\n"
+        )
+        context.write(PurePosixPath(f"/etc/portage/repos.conf/{self.name}.conf"), stanza)
+
+
 #: Where gemato refreshes the release key from, tried in this order. Gentoo's
 #: own server is first because it is what Portage ships; a guest that cannot
 #: reach it falls through rather than stopping at `No keyserver available`.
@@ -800,6 +823,13 @@ def build(
                 sync_uri=_repo_sync_uri(portage),
                 verify_commits=False,
                 sync_type="rsync",
+            )
+        )
+    elif portage.sync is Sync.WEBRSYNC:
+        operations.append(
+            ConfigureWebrsyncRepository(
+                name="gentoo",
+                location=gentoo,
             )
         )
     if portage.overlays and portage.sync is not Sync.GIT:

--- a/tests/unit/test_plan_portage.py
+++ b/tests/unit/test_plan_portage.py
@@ -152,8 +152,12 @@ def test_a_custom_rsync_uri_is_written_to_the_main_repository() -> None:
 
     stanza = apply_all(installation).files[PurePosixPath("/etc/portage/repos.conf/gentoo.conf")]
 
-    assert "sync-type = rsync" in stanza
-    assert f"sync-uri = {sync_uri}" in stanza
+    assert stanza == f"""[gentoo]
+location = /var/db/repos/gentoo
+sync-type = rsync
+sync-uri = {sync_uri}
+auto-sync = yes
+"""
 
 
 def test_an_empty_rsync_uri_uses_the_default_rsync_repository() -> None:
@@ -174,8 +178,33 @@ def test_a_custom_git_uri_is_written_to_the_main_repository() -> None:
 
     stanza = apply_all(installation).files[PurePosixPath("/etc/portage/repos.conf/gentoo.conf")]
 
-    assert "sync-type = git" in stanza
-    assert f"sync-uri = {sync_uri}" in stanza
+    assert stanza == f"""[gentoo]
+location = /var/db/repos/gentoo
+sync-type = git
+sync-uri = {sync_uri}
+sync-depth = 1
+auto-sync = yes
+sync-git-verify-commit-signature = true
+sync-openpgp-key-path = /usr/share/openpgp-keys/gentoo-release.asc
+"""
+
+
+def test_webrsync_is_persisted_without_a_repository_uri() -> None:
+    installation = with_portage(
+        sync=Sync.WEBRSYNC,
+        mirrors=MirrorConfig(repo_sync_uri="https://unused.example.invalid/gentoo.git"),
+    )
+    operations = portage.build(installation, MIRROR)
+
+    assert sum(isinstance(operation, portage.WebrsyncRepository) for operation in operations) == 1
+    stanza = apply_all(installation).files[PurePosixPath("/etc/portage/repos.conf/gentoo.conf")]
+    assert stanza == """[gentoo]
+location = /var/db/repos/gentoo
+sync-type = webrsync
+auto-sync = yes
+sync-webrsync-verify-signature = true
+sync-openpgp-key-path = /usr/share/openpgp-keys/gentoo-release.asc
+"""
 
 
 def test_the_local_copy_goes_before_the_first_sync_or_git_refuses() -> None:


### PR DESCRIPTION
The bootstrap snapshot did not preserve the selected method for later repository updates. Write Portage native webrsync settings with snapshot verification.