### PR TITLE
model: require the selected locale to be generated

### DIFF
--- a/gentoo_install/model/validate.py
+++ b/gentoo_install/model/validate.py
@@ -166,6 +166,7 @@ def validate(
         *_array_problems(config),
         *_network_problems(config, address_facts.system),
         *_unlock_problems(config, address_facts.remote_unlock),
+        *_locale_problems(config),
         *_l10n_problems(config),
         *(rule.describe() for rule in compat.violations(config)),
     ]
@@ -228,6 +229,13 @@ def _l10n_problems(config: InstallConfig) -> list[str]:
         for tag in config.portage.l10n
         if _L10N_TAG.fullmatch(tag) is None
     ]
+
+
+def _locale_problems(config: InstallConfig) -> list[str]:
+    selected = config.system.locale
+    if selected and selected not in config.system.locales:
+        return [f"system.locale is {selected!r}, which system.locales must include"]
+    return []
 
 
 def _pool_problems(config: InstallConfig) -> list[str]:

--- a/tests/unit/test_plan_fonts.py
+++ b/tests/unit/test_plan_fonts.py
@@ -83,7 +83,7 @@ def test_a_locale_outside_cjk_is_not_changed(locale: str) -> None:
     installation = config()
     selected = replace(
         installation,
-        system=replace(installation.system, locale=locale),
+        system=replace(installation.system, locales=(locale,), locale=locale),
         packages=PackagesConfig(applications=("configure-fonts", "noto-cjk")),
     )
     assert not [

--- a/tests/unit/test_validate.py
+++ b/tests/unit/test_validate.py
@@ -40,6 +40,46 @@ def test_the_shipped_fixture_validates() -> None:
     validate(load(FIXTURES / "btrfs-luks.toml"))
 
 
+def test_a_selected_locale_absent_from_system_locales_is_refused_and_named() -> None:
+    installation = replace(
+        config(),
+        system=replace(
+            config().system,
+            locales=("en_US.UTF-8", "zh_CN.UTF-8"),
+            locale="zh_TW.UTF-8",
+        ),
+    )
+
+    with pytest.raises(
+        ValidationFailed,
+        match=r"system\.locale is 'zh_TW\.UTF-8'.*system\.locales",
+    ):
+        validate(installation)
+
+
+def test_a_selected_locale_present_in_system_locales_validates() -> None:
+    installation = replace(
+        config(),
+        system=replace(
+            config().system,
+            locales=("en_US.UTF-8", "zh_TW.UTF-8"),
+            locale="zh_TW.UTF-8",
+        ),
+    )
+
+    validate(installation)
+
+
+def test_a_selected_locale_with_no_generated_locales_is_refused() -> None:
+    installation = replace(
+        config(),
+        system=replace(config().system, locales=(), locale="en_US.UTF-8"),
+    )
+
+    with pytest.raises(ValidationFailed, match=r"system\.locales"):
+        validate(installation)
+
+
 def test_an_l10n_tag_not_shaped_like_one_is_refused_and_named() -> None:
     installation = replace(
         config(), portage=replace(config().portage, l10n=("zh_TW",))


### PR DESCRIPTION
A selected locale that locale-gen never creates leaves the installed session with an unavailable LANG value. Reject that configuration before planning so generation and selection describe one installable state.