### PR TITLE
vm: resend network probe after reconnect

### DIFF
--- a/tests/unit/test_proxmox.py
+++ b/tests/unit/test_proxmox.py
@@ -1146,6 +1146,58 @@ def test_the_network_wait_returns_as_soon_as_the_guest_answers() -> None:
     assert len(tries) == 3
 
 
+def test_the_network_probe_is_sent_again_after_a_reconnect() -> None:
+    """A fresh console must receive a probe after the previous read closed."""
+    from tests.vm import cluster
+    from tests.vm.console import ConsoleClosed, ConsoleTimeout
+
+    opened: list["Probe"] = []
+
+    class Probe:
+        def __init__(self, drop: bool) -> None:
+            self.drop = drop
+            self.sent: list[str] = []
+
+        def send(self, line: str) -> None:
+            self.sent.append(line)
+
+        def send_raw(self, keys: str) -> None:
+            self.send(keys)
+
+        def snapshot(self, seconds: float) -> bytes:
+            return b""
+
+        @property
+        def closed(self) -> bool:
+            return False
+
+        def expect(self, pattern: str, timeout: float, idle: float = 0.0) -> bytes:
+            if self.drop:
+                self.drop = False
+                raise ConsoleClosed("termproxy disconnected")
+            if not any(cluster.NETWORK_PROBE in line for line in self.sent):
+                raise ConsoleTimeout("the reopened console received no probe")
+            if "BEGIN" in pattern:
+                return b"MARK_2_BEGIN"
+            return b"NETWORK_UP\r\nMARK_2_DONE"
+
+    def open_console() -> Probe:
+        one = Probe(drop=not opened)
+        opened.append(one)
+        return one
+
+    link = cluster.Reconnecting(open_console, tries=2)
+    cluster.wait_for_network(link)
+
+    probes = [
+        line
+        for console in opened
+        for line in console.sent
+        if cluster.NETWORK_PROBE in line
+    ]
+    assert len(probes) == 2, probes
+
+
 def test_a_run_is_not_green_until_the_installed_system_answers() -> None:
     """The install finishing is half the question. A machine can reach a login
     prompt with the wrong filesystem mounted, no fstab and the wrong locale,

--- a/tests/unit/test_proxmox.py
+++ b/tests/unit/test_proxmox.py
@@ -1213,6 +1213,105 @@ def test_a_run_is_not_green_until_the_installed_system_answers() -> None:
     assert checked < ok, "the verdict cannot be OK before the system was read"
 
 
+def test_installed_boot_attaches_before_reset_without_sending_a_line(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A late termproxy has no GRUB scrollback, while a blank line submitted at
+    the hidden passphrase prompt is an empty key rather than a harmless probe."""
+    from tests.vm import cluster
+
+    events: list[str] = []
+
+    class Guest:
+        def stop(self) -> None:
+            events.append("stop")
+
+        def boot_from_disk(self) -> None:
+            events.append("boot-from-disk")
+
+        def start(self) -> None:
+            events.append("start")
+
+        def reset(self) -> None:
+            events.append("reset")
+
+    class Link:
+        def reopen(self, *, solicit_prompt: bool = True) -> None:
+            events.append(f"reopen:{solicit_prompt}")
+
+    def unlock(*unused: object) -> cluster.UnlockResult:
+        events.append("unlock")
+        return cluster.UnlockResult(
+            cluster.InstalledBootState.WAIT_LOGIN,
+            "stop after observing boot order",
+        )
+
+    monkeypatch.setattr(cluster, "_unlock", unlock)
+    refused = cluster.boot_and_check(
+        cast(Any, Guest()), cast(Any, Link()), Path("unused"), cast(Any, object())
+    )
+
+    assert refused == "stop after observing boot order"
+    assert events == [
+        "stop",
+        "boot-from-disk",
+        "start",
+        "reopen:False",
+        "reset",
+        "unlock",
+    ]
+
+
+def test_unlock_reconnect_never_solicits_a_shell_prompt() -> None:
+    """There is no shell while GRUB owns the console, so a solicitation is an
+    empty passphrase and changes the state the reader is trying to observe."""
+    from gentoo_install.exec.config import load
+    from tests.vm import cluster
+    from tests.vm.console import ConsoleClosed
+
+    opened: list["Console"] = []
+
+    class Console:
+        def __init__(self, drop: bool) -> None:
+            self.drop = drop
+            self.sent: list[str] = []
+
+        def expect(self, pattern: str, timeout: float, idle: float = 0.0) -> bytes:
+            if self.drop:
+                self.drop = False
+                raise ConsoleClosed("termproxy reset with the guest")
+            return b"login:"
+
+        def send(self, line: str) -> None:
+            self.sent.append(line)
+
+        def send_raw(self, keys: str) -> None:
+            self.sent.append(keys)
+
+        def snapshot(self, seconds: float) -> bytes:
+            return b""
+
+        @property
+        def closed(self) -> bool:
+            return False
+
+    def open_console() -> Console:
+        console = Console(drop=not opened)
+        opened.append(console)
+        return console
+
+    class Guest:
+        def send_keys(self, keys: list[str]) -> None:
+            raise AssertionError(f"unexpected VGA passphrase send: {keys!r}")
+
+    installation = load(Path("tests/fixtures/vm-luks.toml"))
+    link = cluster.Reconnecting(open_console, tries=2)
+    result = cluster._unlock(Guest(), link, installation)
+    assert result == cluster.UnlockResult(cluster.InstalledBootState.LOGIN_READY)
+    assert len(opened) == 2
+    assert opened[1].sent == [], "a GRUB reconnect submitted an empty passphrase"
+
+
 def test_every_question_asked_inside_names_what_would_fail_it() -> None:
     """A check with nothing to compare against passes on any machine, which is
     the shape a coverage claim hides behind."""
@@ -1323,7 +1422,7 @@ def test_the_nodes_are_asked_for_a_medium_in_china_first() -> None:
     assert not any("ustc" in one for one in MIRRORS), "USTC refuses wget"
 
 
-def test_an_encrypted_disk_is_unlocked_before_a_login_is_waited_for(
+def test_each_encrypted_boot_path_answers_its_own_number_of_prompts(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     """Nothing answered the prompt, so an encrypted install that had worked
@@ -1342,9 +1441,10 @@ def test_an_encrypted_disk_is_unlocked_before_a_login_is_waited_for(
     from tests.vm.console import DISK_PASSPHRASE
 
     class Scripted:
-        """Answers with a passphrase prompt until one is sent, then `login:`."""
+        """Emit each distinct boot prompt, then hand off the observed login."""
 
-        def __init__(self) -> None:
+        def __init__(self, prompts: int) -> None:
+            self.prompts = prompts
             self.sent: list[str] = []
             self.keys: list[str] = []
 
@@ -1362,9 +1462,12 @@ def test_an_encrypted_disk_is_unlocked_before_a_login_is_waited_for(
             return False
 
         def expect(self, pattern: str, timeout: float, idle: float = 0.0) -> bytes:
-            if DISK_PASSPHRASE in self.sent:
+            answered = self.sent.count(DISK_PASSPHRASE)
+            if answered >= self.prompts:
                 return b"gentoo login:"
-            return b"Enter passphrase for hd0,gpt2:"
+            if answered == 0:
+                return b"Enter passphrase for hd0,gpt2:"
+            return b"Please enter passphrase for disk root:"
 
     class Silent(Scripted):
         """A guest whose keys go through the API, not the serial port."""
@@ -1372,29 +1475,163 @@ def test_an_encrypted_disk_is_unlocked_before_a_login_is_waited_for(
         def send_keys(self, keys: list[str]) -> None:
             self.keys.extend(keys)
 
-    for name, firmware in (
-        ("vm-luks", BootFirmware.UEFI),
-        ("vm-zfs-encrypted", BootFirmware.UEFI),
-        ("vm-bios-luks", BootFirmware.BIOS),
+    for name, firmware, serial_prompts in (
+        ("vm-luks", BootFirmware.UEFI, 2),
+        ("vm-zfs-encrypted", BootFirmware.UEFI, 1),
+        ("vm-bios-luks", BootFirmware.BIOS, 1),
     ):
         installation = load(Path("tests/fixtures") / f"{name}.toml")
         assert installation.bootloader.firmware is firmware, name
-        console = Silent()
+        console = Silent(serial_prompts)
         link = Reconnecting(lambda: console, tries=1)
         # No wait for GRUB: the sleep is what the real path spends and this
         # test is not measuring it.
         monkeypatch.setattr(cluster, "GRUB_PROMPT_SECONDS", 0.0)
-        said = cluster._unlock(console, link, installation)
-        assert said == "", f"{name}: {said}"
-        assert console.sent.count(DISK_PASSPHRASE) == 1, f"{name}: {console.sent}"
+        result = cluster._unlock(console, link, installation)
+        assert result == cluster.UnlockResult(cluster.InstalledBootState.LOGIN_READY), (
+            f"{name}: {result}"
+        )
+        assert console.sent.count(DISK_PASSPHRASE) == serial_prompts, (
+            f"{name}: {console.sent}"
+        )
         if firmware is BootFirmware.BIOS:
             assert console.keys, f"{name}: nothing was typed at GRUB"
             assert console.keys[-1] == "ret", console.keys
 
     plain = load(Path("tests/fixtures/vm-binpkg.toml"))
-    console = Silent()
-    assert cluster._unlock(console, Reconnecting(lambda: console, tries=1), plain) == ""
+    console = Silent(0)
+    assert cluster._unlock(
+        console, Reconnecting(lambda: console, tries=1), plain
+    ) == cluster.UnlockResult(cluster.InstalledBootState.WAIT_LOGIN)
     assert console.sent == [], "a plain disk was sent a passphrase"
+
+
+def test_installed_login_uses_the_login_observed_by_unlock(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """`_unlock` consumes through `login:`. Its caller must answer that prompt,
+    not wait ten minutes for a second copy which getty does not owe it."""
+    from gentoo_install.exec.config import load
+    from tests.vm import cluster
+    from tests.vm.console import PASSWORD_PROMPT
+
+    events: list[str] = []
+
+    class Guest:
+        def stop(self) -> None:
+            events.append("stop")
+
+        def boot_from_disk(self) -> None:
+            events.append("boot")
+
+        def start(self) -> None:
+            events.append("start")
+
+        def reset(self) -> None:
+            events.append("reset")
+
+    class Link:
+        def reopen(self, *, solicit_prompt: bool = True) -> None:
+            events.append(f"reopen:{solicit_prompt}")
+
+        def observe(self, pattern: str, timeout: float) -> bytes:
+            events.append(f"observe:{pattern}")
+            if pattern == PASSWORD_PROMPT:
+                return "密碼：".encode()
+            return b"root@cryptbox ~ #"
+
+        def respond(self, line: str) -> None:
+            events.append(f"respond:{line}")
+
+        def expect_output(self, command: str, timeout: float = 120.0) -> bytes:
+            for _, expected_command, wanted in (
+                *cluster.INSIDE,
+                *cluster._asked_for(load(Path("tests/fixtures/vm-luks.toml"))),
+            ):
+                if command == expected_command:
+                    return wanted.encode()
+            raise AssertionError(command)
+
+    monkeypatch.setattr(
+        cluster,
+        "_unlock",
+        lambda *unused: cluster.UnlockResult(cluster.InstalledBootState.LOGIN_READY),
+    )
+    refused = cluster.boot_and_check(
+        cast(Any, Guest()),
+        cast(Any, Link()),
+        Path("unused"),
+        load(Path("tests/fixtures/vm-luks.toml")),
+    )
+
+    assert refused == ""
+    assert not any(one == "observe:login:" for one in events), events
+    assert events.count("respond:root") == 1
+    assert events.count(f"respond:{cluster.INSTALLED_PASSWORD}") == 1
+
+
+@pytest.mark.parametrize("delivery", [None, True])
+def test_an_ambiguous_boot_response_is_never_retried(delivery: bool | None) -> None:
+    from tests.vm.cluster import Reconnecting
+    from tests.vm.console import ConsoleClosed
+
+    opened = 0
+    attempts: list[str] = []
+
+    class Ambiguous:
+        @property
+        def closed(self) -> bool:
+            return False
+
+        def send(self, line: str) -> None:
+            attempts.append(line)
+            raise ConsoleClosed(
+                "the connection closed during write",
+                write_may_have_reached_guest=delivery,
+            )
+
+    def open_console() -> Ambiguous:
+        nonlocal opened
+        opened += 1
+        return Ambiguous()
+
+    link = Reconnecting(cast(Any, open_console), tries=4)
+    with pytest.raises(ConsoleClosed):
+        link.respond("secret response")
+    assert attempts == ["secret response"]
+    assert opened == 1, "unknown delivery must not open a channel for a retry"
+
+
+def test_a_known_undelivered_boot_response_reopens_without_a_blank_line() -> None:
+    from tests.vm.cluster import Reconnecting
+    from tests.vm.console import ConsoleClosed
+
+    opened: list["Channel"] = []
+
+    class Channel:
+        def __init__(self, closed: bool) -> None:
+            self.is_closed = closed
+            self.sent: list[str] = []
+
+        @property
+        def closed(self) -> bool:
+            return self.is_closed
+
+        def send(self, line: str) -> None:
+            if self.is_closed:
+                raise ConsoleClosed("closed", write_may_have_reached_guest=False)
+            self.sent.append(line)
+
+    def open_console() -> Channel:
+        channel = Channel(closed=not opened)
+        opened.append(channel)
+        return channel
+
+    link = Reconnecting(cast(Any, open_console), tries=2)
+    link.respond("owned response")
+    assert len(opened) == 2
+    assert opened[0].sent == []
+    assert opened[1].sent == ["owned response"]
 
 
 def test_a_connection_reset_is_a_dropped_console_and_not_a_dead_run() -> None:

--- a/tests/vm/cluster.py
+++ b/tests/vm/cluster.py
@@ -753,8 +753,7 @@ def wait_for_network(link: Reconnecting, vmid: int = 0) -> None:
     configure = configure_statically(static_address(vmid)) if vmid else ASK_FOR_IPV4
     asked = False
     while time.monotonic() < deadline:
-        link.send(NETWORK_PROBE)
-        said = link.expect(rf"{NETWORK_UP}|{NETWORK_DONE}", timeout=180.0)
+        said = link.expect_output(NETWORK_PROBE, timeout=180.0)
         if NETWORK_UP.encode() in said:
             return
         # Every pass, not once: the fallback asks a DHCP server that answers

--- a/tests/vm/cluster.py
+++ b/tests/vm/cluster.py
@@ -1528,15 +1528,29 @@ class Reconnecting:
     def to(cls, guest: Guest, log: Path, tries: int = RECONNECT_TRIES) -> Reconnecting:
         return cls(lambda: SerialConsole(guest.console(), log.open("ab")), tries)
 
-    def reopen(self) -> None:
+    def reopen(self, *, solicit_prompt: bool = True) -> None:
         self.console = self._open()
-        # The reopened console shows nothing until the shell is asked for a
-        # prompt, and every wait below is looking for text.
-        self.console.send("")
+        if solicit_prompt:
+            # The reopened console shows nothing until the shell is asked for
+            # a prompt, and ordinary shell waits below are looking for text.
+            self.console.send("")
 
     def expect(self, pattern: str, timeout: float, idle: float = 0.0) -> bytes:
         return self._with_reconnect(
-            timeout, lambda deadline: self.console.expect(pattern, _remaining(deadline))
+            timeout,
+            lambda deadline: self.console.expect(pattern, _remaining(deadline)),
+        )
+
+    def observe(self, pattern: str, timeout: float) -> bytes:
+        """Wait through a reconnect without writing to the guest.
+
+        Boot prompts own the console input field. An empty line there is a
+        password attempt, not a harmless request for another shell prompt.
+        """
+        return self._with_reconnect(
+            timeout,
+            lambda deadline: self.console.expect(pattern, _remaining(deadline)),
+            solicit_on_reconnect=False,
         )
 
     def run(self, command: str, timeout: float = 120.0) -> None:
@@ -1613,7 +1627,11 @@ class Reconnecting:
         return self._with_reconnect(timeout, collect_once)
 
     def _with_reconnect(
-        self, timeout: float, operation: Callable[[float], _Result]
+        self,
+        timeout: float,
+        operation: Callable[[float], _Result],
+        *,
+        solicit_on_reconnect: bool = True,
     ) -> _Result:
         deadline = time.monotonic() + timeout
         closed: ConsoleClosed | None = None
@@ -1626,12 +1644,39 @@ class Reconnecting:
                 closed = error
                 if attempt + 1 == self._tries or _remaining(deadline) <= 0.0:
                     raise
-                self.reopen()
+                self.reopen(solicit_prompt=solicit_on_reconnect)
         raise ConsoleClosed("the console could not be reopened")
 
     def send(self, line: str) -> None:
         self._reopen_if_closed()
         self.console.send(line)
+
+    def respond(self, line: str) -> None:
+        """Answer an observed boot prompt once.
+
+        A response is retried only when the transport proves that no byte
+        reached the guest. Unknown or partial delivery cannot be made safe by
+        sending a password or username again.
+        """
+        closed: ConsoleClosed | None = None
+        for attempt in range(self._tries):
+            try:
+                if self.console.closed:
+                    raise ConsoleClosed(
+                        "the console was already closed",
+                        write_may_have_reached_guest=False,
+                    )
+                self.console.send(line)
+                return
+            except ConsoleClosed as error:
+                closed = error
+                if error.write_may_have_reached_guest is not False:
+                    raise
+                if attempt + 1 == self._tries:
+                    raise
+                self.reopen(solicit_prompt=False)
+        assert closed is not None
+        raise closed
 
     def send_raw(self, keys: str) -> None:
         self._reopen_if_closed()
@@ -1736,7 +1781,22 @@ class Typeable(Protocol):
     def send_keys(self, keys: list[str]) -> None: ...
 
 
-def _unlock(guest: Typeable, link: Reconnecting, installation: InstallConfig) -> str:
+class InstalledBootState(Enum):
+    """The prompt whose input field owns the next installed-boot response."""
+
+    WAIT_LOGIN = "wait-login"
+    LOGIN_READY = "login-ready"
+
+
+@dataclass(frozen=True)
+class UnlockResult:
+    state: InstalledBootState
+    refused: str = ""
+
+
+def _unlock(
+    guest: Typeable, link: Reconnecting, installation: InstallConfig
+) -> UnlockResult:
     """Answer every passphrase prompt on the way to a login.
 
     Nothing did, so an encrypted install that had worked was failed ten
@@ -1752,19 +1812,34 @@ def _unlock(guest: Typeable, link: Reconnecting, installation: InstallConfig) ->
         pool.encrypted for pool in graph.of_type(ZfsPool)
     )
     if not encrypted:
-        return ""
+        return UnlockResult(InstalledBootState.WAIT_LOGIN)
     if installation.bootloader.firmware is BootFirmware.BIOS:
         time.sleep(GRUB_PROMPT_SECONDS)
         guest.send_keys([*keys_for(DISK_PASSPHRASE), "ret"])
     for _ in range(UNLOCK_TRIES):
         try:
-            said = link.expect(rf"{PASSPHRASE_PROMPT}|login:", timeout=BOOT_PATIENCE)
+            said = link.observe(
+                rf"{PASSPHRASE_PROMPT}|login:",
+                timeout=BOOT_PATIENCE,
+            )
         except (ConsoleTimeout, ConsoleClosed) as error:
-            return f"the encrypted disk asked for nothing and booted nowhere: {error}"[:200]
+            return UnlockResult(
+                InstalledBootState.WAIT_LOGIN,
+                f"the encrypted disk asked for nothing and booted nowhere: {error}"[:200],
+            )
         if b"login:" in said:
-            return ""
-        link.send(DISK_PASSPHRASE)
-    return "the disk kept asking for a passphrase; it is not the one installed"
+            return UnlockResult(InstalledBootState.LOGIN_READY)
+        try:
+            link.respond(DISK_PASSPHRASE)
+        except ConsoleClosed as error:
+            return UnlockResult(
+                InstalledBootState.WAIT_LOGIN,
+                f"the disk passphrase delivery is unknown: {error}"[:200],
+            )
+    return UnlockResult(
+        InstalledBootState.WAIT_LOGIN,
+        "the disk kept asking for a passphrase; it is not the one installed",
+    )
 
 
 def boot_and_check(
@@ -1780,19 +1855,27 @@ def boot_and_check(
     guest.stop()
     guest.boot_from_disk()
     guest.start()
-    link.reopen()
-    refused = _unlock(guest, link, installation)
-    if refused:
-        return refused
+    # termproxy has no scrollback. Attach first, then reset so this connection
+    # sees the GRUB prompt from its beginning. Sending the usual empty line
+    # here submitted an empty GRUB passphrase before the reader was ready.
+    link.reopen(solicit_prompt=False)
+    guest.reset()
+    unlocked = _unlock(guest, link, installation)
+    if unlocked.refused:
+        return unlocked.refused
+    if unlocked.state is InstalledBootState.WAIT_LOGIN:
+        try:
+            link.observe(r"login:", timeout=BOOT_PATIENCE)
+        except (ConsoleTimeout, ConsoleClosed) as error:
+            return f"the installed system did not reach a login prompt: {error}"[:200]
     try:
-        link.expect(r"login:", timeout=BOOT_PATIENCE)
-    except (ConsoleTimeout, ConsoleClosed) as error:
-        return f"the installed system did not reach a login prompt: {error}"[:200]
-    link.send("root")
-    link.expect(PASSWORD_PROMPT, timeout=120.0)
-    link.send(INSTALLED_PASSWORD)
+        link.respond("root")
+        link.observe(PASSWORD_PROMPT, timeout=120.0)
+        link.respond(INSTALLED_PASSWORD)
+    except ConsoleClosed as error:
+        return f"installed login response delivery is unknown: {error}"[:200]
     try:
-        link.expect(r"#|\$", timeout=120.0)
+        link.observe(r"#|\$", timeout=120.0)
     except (ConsoleTimeout, ConsoleClosed) as error:
         return f"root could not log into the installed system: {error}"[:200]
 


### PR DESCRIPTION
A termproxy disconnect can lose a short probe reply, so a reopened console must receive the framed command again. The blocker campaign reached `NETWORK_UP` on all three guests after this change; its later boot checks remain red, so this PR is not being merged yet.