### PR TITLE
boot: exclude systemd modules from ZFSBootMenu

### DIFF
--- a/gentoo_install/plan/bootloader.py
+++ b/gentoo_install/plan/bootloader.py
@@ -300,6 +300,9 @@ class ConfigureZfsBootMenuRemoteAccess(Operation):
                     # first implementation already included, and the others all
                     # reach `systemd`, which this image does not carry.
                     'add_dracutmodules+=" crypt-ssh network-legacy "',
+                    # Their checks pass on the installed system, but
+                    # ZFSBootMenu deliberately omits the systemd module.
+                    'omit_dracutmodules+=" systemd-networkd systemd-battery-check "',
                     f'install_optional_items+=" {ZBM_NETWORK_CONFIG} "',
                     f'dropbear_port="{self.unlock.port}"',
                     f"dropbear_rsa_key={ZBM_KEY_DIRECTORY}/ssh_host_rsa_key",

--- a/tests/unit/test_plan_bootloader.py
+++ b/tests/unit/test_plan_bootloader.py
@@ -65,6 +65,9 @@ def test_zfsbootmenu_carries_remote_access_in_its_own_image() -> None:
     # Naming `network-legacy` makes `40network` pick it, per its own
     # `depends()`, which prefers an implementation already included.
     assert "network-legacy" in zbm, zbm
+    assert (
+        'omit_dracutmodules+=" systemd-networkd systemd-battery-check "' in zbm
+    ), zbm
     assert "dropbear_rsa_key=/etc/dropbear/ssh_host_rsa_key" in zbm
     assert "dropbear_ecdsa_key=/etc/dropbear/ssh_host_ecdsa_key" in zbm
     assert "dropbear_acl=/etc/dropbear/root_key" in zbm


### PR DESCRIPTION
Because dracut selects systemd-networkd on the installed system while ZFSBootMenu deliberately omits systemd, image generation fails before remote unlock. Exclude the incompatible systemd modules so crypt-ssh retains the selected network-legacy implementation.