### PR TITLE
vm: use the CERNET mirror for ZFSBootMenu

### DIFF
--- a/tests/fixtures/zfs-zbm.toml
+++ b/tests/fixtures/zfs-zbm.toml
@@ -43,7 +43,7 @@ community = "off"
 
 [[portage.overlays]]
 name = "gentoo-zh"
-sync_uri = "https://github.com/gentoo-zh/overlay.git"
+sync_uri = "https://mirrors.cernet.edu.cn/gentoo-zh.git"
 
 [kernel]
 source = "cjk-bin"

--- a/tests/golden/zfs-zbm.txt
+++ b/tests/golden/zfs-zbm.txt
@@ -36,7 +36,7 @@
   install git, which every later repository sync needs: emerge dev-vcs/git
   point repository gentoo at https://github.com/gentoo-mirror/gentoo.git, commit signatures verified
   sync repository gentoo
-  point repository gentoo-zh at https://github.com/gentoo-zh/overlay.git
+  point repository gentoo-zh at https://mirrors.cernet.edu.cn/gentoo-zh.git
   sync repository gentoo-zh
   accept ~amd64 for packages from gentoo-zh only
   set sys-kernel/installkernel to dracut, installing into /boot


### PR DESCRIPTION
Because the China-region PVE nodes cannot reliably reach GitHub, the ZFSBootMenu fixture fails before testing its boot path. Use the existing CERNET gentoo-zh mirror so this fixture measures the installer.