### PR TITLE
kernel: install ZFSBootMenu network tools

### DIFF
--- a/gentoo_install/plan/kernel.py
+++ b/gentoo_install/plan/kernel.py
@@ -53,6 +53,14 @@ FILESYSTEM_MODULES: Final[dict[FilesystemType, str]] = {FilesystemType.BTRFS: "b
 #: and one of the network managers dracut's network module can drive.
 REMOTE_UNLOCK_PACKAGE: Final[str] = "sys-kernel/dracut-crypt-ssh"
 
+#: Executables required by dracut's network-legacy module. ZFSBootMenu omits
+#: systemd, so its remote-unlock image cannot use systemd-networkd instead.
+ZBM_LEGACY_NETWORK_PACKAGES: Final[tuple[str, ...]] = (
+    "sys-apps/iproute2",
+    "net-misc/dhcp",
+    "net-misc/iputils",
+)
+
 #: Modules an initramfs needs to answer on the network before the root is
 #: unlocked. `crypt-ssh` is the module dracut-crypt-ssh installs as 60crypt-ssh.
 REMOTE_UNLOCK_MODULES: Final[tuple[str, ...]] = ("crypt-ssh", "network")
@@ -242,6 +250,22 @@ class RequestStorageUse(Operation):
     def apply(self, context: Context) -> None:
         lines = "".join(f"{atom} {' '.join(flags)}\n" for atom, flags in self.entries)
         context.write(PurePosixPath("/etc/portage/package.use/storage"), lines)
+
+
+@dataclass(frozen=True, kw_only=True)
+class RequestZfsBootMenuNetworkTools(Operation):
+    """Enable the two optional executables network-legacy checks for."""
+
+    stage: Stage = Stage.PORTAGE
+
+    def describe(self) -> str:
+        return "ask for dhclient and arping, which ZFSBootMenu networking requires"
+
+    def apply(self, context: Context) -> None:
+        context.write(
+            PurePosixPath("/etc/portage/package.use/zfsbootmenu-network"),
+            "net-misc/dhcp client -server\nnet-misc/iputils arping\n",
+        )
 
 
 @dataclass(frozen=True, kw_only=True)
@@ -652,11 +676,15 @@ def build(config: InstallConfig) -> list[Operation]:
     if config.kernel.remote_unlock.enabled:
         unlock = config.kernel.remote_unlock
         system_initramfs = config.bootloader.kind is not Bootloader.ZFSBOOTMENU
+        remote_packages: tuple[str, ...] = (REMOTE_UNLOCK_PACKAGE,)
+        if not system_initramfs:
+            operations.append(RequestZfsBootMenuNetworkTools())
+            remote_packages += ZBM_LEGACY_NETWORK_PACKAGES
         operations += [
             ConfigureRemoteUnlock(port=unlock.port, system_initramfs=system_initramfs),
             Emerge(
                 stage=Stage.KERNEL,
-                packages=(REMOTE_UNLOCK_PACKAGE,),
+                packages=remote_packages,
                 summary=(
                     "install the initramfs ssh daemon"
                     if system_initramfs

--- a/tests/golden/zfs-zbm.txt
+++ b/tests/golden/zfs-zbm.txt
@@ -41,12 +41,13 @@
   accept ~amd64 for packages from gentoo-zh only
   set sys-kernel/installkernel to dracut, installing into /boot
   accept the linux-firmware licence
+  ask for dhclient and arping, which ZFSBootMenu networking requires
   write /etc/dracut.conf.d/crypt-ssh.conf to omit ssh from the system initramfs
   accept sys-kernel/gentoo-cjk-kernel-bin as testing, with cjk on
   unmask virtual/dist-kernel, which the cjk kernel depends on by revision
   tell sys-fs/zfs to build against the dist-kernel
   ask for sys-apps/systemd[boot,kernel-install], which is what provides bootctl
-  resolve app-admin/sudo net-misc/openssh sys-process/cronie sys-kernel/installkernel sys-kernel/dracut sys-kernel/linux-firmware sys-kernel/dracut-crypt-ssh sys-fs/dosfstools sys-kernel/gentoo-cjk-kernel-bin sys-fs/zfs sys-boot/zfsbootmenu sys-boot/efibootmgr sys-apps/systemd sys-apps/kbd app-editors/vim together before installing the requested packages
+  resolve app-admin/sudo net-misc/openssh sys-process/cronie sys-kernel/installkernel sys-kernel/dracut sys-kernel/linux-firmware sys-kernel/dracut-crypt-ssh sys-apps/iproute2 net-misc/dhcp net-misc/iputils sys-fs/dosfstools sys-kernel/gentoo-cjk-kernel-bin sys-fs/zfs sys-boot/zfsbootmenu sys-boot/efibootmgr sys-apps/systemd sys-apps/kbd app-editors/vim together before installing the requested packages
 
 [system]
   generate and verify locales en_US.UTF-8, zh_TW.UTF-8
@@ -75,7 +76,7 @@
 [kernel]
   install the hook that puts a kernel in /boot: emerge sys-kernel/installkernel
   install the initramfs builder and firmware: emerge sys-kernel/dracut sys-kernel/linux-firmware
-  install ZFSBootMenu ssh support: emerge sys-kernel/dracut-crypt-ssh
+  install ZFSBootMenu ssh support: emerge sys-kernel/dracut-crypt-ssh sys-apps/iproute2 net-misc/dhcp net-misc/iputils
   install the storage tools: emerge sys-fs/dosfstools
   install the kernel and the tools that build a module for it: emerge sys-kernel/gentoo-cjk-kernel-bin sys-fs/zfs, from source
   tell dracut to carry zfs

--- a/tests/unit/test_plan_kernel.py
+++ b/tests/unit/test_plan_kernel.py
@@ -32,6 +32,37 @@ def test_grub_remote_unlock_keeps_the_system_dracut_path() -> None:
         isinstance(one, bootloader.ConfigureZfsBootMenuRemoteAccess)
         for one in bootloader.build(installation)
     )
+    unlock_packages = next(
+        one.packages
+        for one in kernel.build(installation)
+        if isinstance(one, Emerge) and kernel.REMOTE_UNLOCK_PACKAGE in one.packages
+    )
+    assert unlock_packages == (kernel.REMOTE_UNLOCK_PACKAGE,)
+
+
+def test_zfsbootmenu_installs_network_legacy_executables() -> None:
+    installation = load(Path("tests/fixtures/zfs-zbm.toml"))
+    operations = kernel.build(installation)
+    unlock_packages = next(
+        one.packages
+        for one in operations
+        if isinstance(one, Emerge) and kernel.REMOTE_UNLOCK_PACKAGE in one.packages
+    )
+    assert unlock_packages == (
+        kernel.REMOTE_UNLOCK_PACKAGE,
+        *kernel.ZBM_LEGACY_NETWORK_PACKAGES,
+    )
+
+    request = next(
+        one
+        for one in operations
+        if isinstance(one, kernel.RequestZfsBootMenuNetworkTools)
+    )
+    recorder = Recorder()
+    request.apply(recorder)
+    assert recorder.files[
+        PurePosixPath("/etc/portage/package.use/zfsbootmenu-network")
+    ] == "net-misc/dhcp client -server\nnet-misc/iputils arping\n"
 
 
 def test_build_derives_stack_once_for_prebuilt_zfs(


### PR DESCRIPTION
Because dracut rejects network-legacy unless ip, dhclient and arping exist, ZFSBootMenu remote unlock cannot build its image. Install their providers with the required USE flags.