### PR TITLE
model: carry partition numbers as device facts

### DIFF
--- a/gentoo_install/exec/probe.py
+++ b/gentoo_install/exec/probe.py
@@ -99,6 +99,7 @@ class ProbedPartition:
     """Facts read for a device nested below a whole disk."""
 
     kernel_path: str
+    partition_number: int | None
     size_bytes: int
     filesystem: str
     device_type: str
@@ -115,11 +116,17 @@ def _lsblk_children(value: object) -> tuple[ProbedPartition, ...]:
         if not isinstance(child, Mapping):
             continue
         name, size = child.get("name"), child.get("size")
+        partition_number = child.get("partn")
         filesystem, device_type = child.get("fstype"), child.get("type")
         if isinstance(name, str) and isinstance(size, int) and not isinstance(size, bool):
             found.append(
                 ProbedPartition(
                     kernel_path=name,
+                    partition_number=(
+                        partition_number
+                        if isinstance(partition_number, int) and not isinstance(partition_number, bool)
+                        else None
+                    ),
                     size_bytes=size,
                     filesystem=filesystem if isinstance(filesystem, str) else "",
                     device_type=device_type if isinstance(device_type, str) else "",
@@ -675,7 +682,7 @@ class Probe:
                 "--bytes",
                 "--paths",
                 "--output",
-                "NAME,SIZE,FSTYPE,TYPE",
+                "NAME,PARTN,SIZE,FSTYPE,TYPE",
                 disk,
             ],
             check=False,
@@ -772,16 +779,24 @@ class Probe:
         configuration never names, and their space is claimed just as much as
         a new partition's.
         """
+        found = {
+            partition.partition_number: partition.size_bytes
+            for partition in self.probed_partitions(disk)
+            if partition.partition_number is not None
+        }
+        if found:
+            return found
         listed = self.runner.run(
             ["lsblk", "--bytes", "--noheadings", "--output", "PARTN,SIZE", disk], check=False
         )
         if listed.returncode != 0:
             raise DeviceNotFound(f"lsblk could not read the partitions of {disk}")
-        found: dict[int, int] = {}
         for line in listed.stdout.splitlines():
             fields = line.split()
             if len(fields) == 2 and fields[0].isdigit() and fields[1].isdigit():
                 found[int(fields[0])] = int(fields[1])
+        if not found:
+            raise DeviceNotFound(f"lsblk could not read the partitions of {disk}")
         return found
 
     def _zone_table(self, path: Path) -> tuple[str, ...]:

--- a/gentoo_install/model/manual.py
+++ b/gentoo_install/model/manual.py
@@ -166,6 +166,9 @@ class Slice:
     #: The path `exec/probe.py` listed, for a row that is already on the disk.
     #: Empty for `create`, which has no device until the plan runs.
     selector: str = ""
+    #: Partition-table number supplied by the block-device probe. New rows use
+    #: `index`; existing rows must retain the number the machine reported.
+    partition_number: int | None = None
 
     def describe(self) -> str:
         # A row already on the disk has whatever size it has; only a new one is
@@ -305,15 +308,10 @@ def dataset_for(mountpoint: str) -> str:
 def _index_of(entry: Slice) -> int:
     """The number the partition has in the table on the disk.
 
-    Read off the selector rather than taken from `index`: the row order in the
-    editor is not the entry number, and `sgdisk --delete` addresses the entry.
+    Use the probe fact rather than parsing a kernel name: `/dev/nvme0n1p2` and
+    `/dev/mapper/...` do not have a reliable suffix to interpret.
     """
-    trailing = ""
-    for character in reversed(entry.selector):
-        if not character.isdigit():
-            break
-        trailing = character + trailing
-    return int(trailing) if trailing else entry.index
+    return entry.partition_number if entry.partition_number is not None else entry.index
 
 
 def _table_nodes(disk: Disk, prefix: str) -> list[Node]:

--- a/tests/unit/test_exec.py
+++ b/tests/unit/test_exec.py
@@ -1607,9 +1607,9 @@ def test_partition_rows_are_read_from_nested_lsblk_json(tmp_path: Path) -> None:
       "blockdevices": [{
         "name": "/dev/vda", "size": 68719476736, "fstype": null, "type": "disk",
         "children": [{
-          "name": "/dev/vda1", "size": 17179869184, "fstype": null, "type": "part",
+          "name": "/dev/vda1", "partn": 1, "size": 17179869184, "fstype": null, "type": "part",
           "children": [{
-            "name": "/dev/mapper/root", "size": 17179869184,
+            "name": "/dev/mapper/root", "partn": null, "size": 17179869184,
             "fstype": "ext4", "type": "crypt"
           }]
         }]
@@ -1641,7 +1641,7 @@ def test_partition_rows_are_read_from_nested_lsblk_json(tmp_path: Path) -> None:
         "--bytes",
         "--paths",
         "--output",
-        "NAME,SIZE,FSTYPE,TYPE",
+        "NAME,PARTN,SIZE,FSTYPE,TYPE",
         "/dev/vda",
     )
 

--- a/tests/unit/test_probe.py
+++ b/tests/unit/test_probe.py
@@ -45,7 +45,7 @@ class PartitionListing(Runner):
             "name": "/dev/vda", "size": 68719476736,
             "fstype": null, "type": "disk",
             "children": [{
-              "name": "/dev/vda1", "size": 17179869185,
+              "name": "/dev/vda1", "partn": 1, "size": 17179869185,
               "fstype": "ext4", "type": "part"
             }]
           }]
@@ -81,6 +81,7 @@ def test_a_partition_probe_keeps_the_exact_size_that_the_display_tuple_lost(
     partition = probe.probed_partitions("/dev/vda")[0]
 
     assert partition.kernel_path == "/dev/vda1"
+    assert partition.partition_number == 1
     assert partition.size_bytes == 17179869185
     assert partition.filesystem == "ext4"
     assert partition.device_type == "part"

--- a/tests/unit/test_tui_partitions.py
+++ b/tests/unit/test_tui_partitions.py
@@ -689,19 +689,19 @@ def test_a_table_nobody_edits_writes_no_table_at_all() -> None:
     assert graph.of_type(PartitionTable) == ()
 
 
-def test_the_entry_number_comes_off_the_selector_and_not_the_row() -> None:
+def test_the_entry_number_does_not_parse_the_selector() -> None:
     """`sgdisk --delete` addresses the entry in the table, and the row order in
     the editor is not that number."""
     layout = one_disk(slices=[
         manual.Slice(
-            index=1, role=PartitionRole.DATA, size=None, filesystem=None,
-            status=manual.SliceStatus.DELETE, selector="/dev/nvme0n1p7",
+            index=3, role=PartitionRole.DATA, size=None, filesystem=None,
+            status=manual.SliceStatus.DELETE, selector="/dev/nvme0n1p7", partition_number=1,
         )
     ])
     from gentoo_install.model.device import PartitionTable
 
     graph, _ = manual.build(layout)
-    assert graph.of_type(PartitionTable)[0].remove == (7,)
+    assert graph.of_type(PartitionTable)[0].remove == (1,)
 
 
 def two_disks() -> manual.Layout:


### PR DESCRIPTION
Partition selectors do not encode table numbers consistently, so carry PARTN from lsblk through the manual layout.