### PR TITLE
plan: honor Portage keyserver policy

### DIFF
--- a/gentoo_install/plan/portage.py
+++ b/gentoo_install/plan/portage.py
@@ -278,18 +278,6 @@ class ConfigureWebrsyncRepository(Operation):
         context.write(PurePosixPath(f"/etc/portage/repos.conf/{self.name}.conf"), stanza)
 
 
-#: Where gemato refreshes the release key from, tried in this order. Gentoo's
-#: own server is first because it is what Portage ships; a guest that cannot
-#: reach it falls through rather than stopping at `No keyserver available`.
-#: `keys.openpgp.org` is not here: it serves a key stripped of its user IDs
-#: unless the address behind them was confirmed, gemato reads that as a failed
-#: refresh, and the snapshot is then refused as unsigned.
-KEY_SERVERS: Final[tuple[str, ...]] = (
-    "hkps://keys.gentoo.org",
-    "hkps://keyserver.ubuntu.com",
-)
-
-
 @dataclass(frozen=True, kw_only=True)
 class WebrsyncRepository(Operation):
     """The first sync cannot be a git sync: a stage3 has no `dev-vcs/git`, and
@@ -301,21 +289,18 @@ class WebrsyncRepository(Operation):
         return "fetch the first ebuild repository snapshot with emerge-webrsync"
 
     def apply(self, context: Context) -> None:
-        # `emerge-webrsync` verifies the snapshot with gemato, which refreshes
-        # the release key first, and a refresh that fails fails the sync. One
-        # keyserver is one way for the whole install to stop, so each is tried
-        # and only the last one's failure is raised.
-        last: CommandFailed | None = None
-        for server in KEY_SERVERS:
-            try:
-                context.run_in_target(
-                    ["env", f"PORTAGE_GPG_KEY_SERVER={server}", "emerge-webrsync"]
-                )
-                return
-            except CommandFailed as failed:
-                last = failed
-        assert last is not None
-        raise last
+        # Portage owns this policy in the stage3; overriding it can select a
+        # server incompatible with the installed gemato configuration.
+        policy = context.run_in_target(
+            ["portageq", "envvar", "PORTAGE_GPG_KEY_SERVER"], check=False
+        )
+        if not isinstance(policy, CommandOutput) or policy.returncode != 0:
+            raise ConfigError("portageq could not read the keyserver policy")
+        server = policy.strip()
+        command = ["emerge-webrsync"]
+        if server:
+            command = ["env", f"PORTAGE_GPG_KEY_SERVER={server}", *command]
+        context.run_in_target(command)
 
 
 #: Records between the lines tar prints while unpacking. One every few

--- a/tests/unit/test_plan_portage.py
+++ b/tests/unit/test_plan_portage.py
@@ -40,6 +40,11 @@ PROFILE_LIST = f"""Available profile symlink targets:
 
 def apply_all(installation: InstallConfig) -> Recorder:
     recorder = Recorder()
+    recorder.answering = lambda argv: (
+        CommandOutput("", 0)
+        if tuple(argv[:3]) == ("portageq", "envvar", "PORTAGE_GPG_KEY_SERVER")
+        else None
+    )
     recorder.replies["eselect"] = PROFILE_LIST
     for operation in [*portage.build(installation, MIRROR), *portage.finish(installation)]:
         operation.apply(recorder)
@@ -1010,44 +1015,53 @@ def test_the_stage3_matches_the_profile_and_not_only_the_init_system() -> None:
         assert variant_of(installation) == variant, profile
 
 
-def test_the_first_snapshot_falls_through_to_a_keyserver_that_answers() -> None:
-    """`emerge-webrsync` verifies the snapshot with gemato, which refreshes the
-    release key first, so one keyserver is one way for the whole install to
-    stop. Two networks broke it in opposite directions: a cluster guest
-    resolved `keys.gentoo.org` to 85.143.112.91 and reached nothing, and
-    `keys.openpgp.org`, put there to answer that, serves the key with its user
-    IDs stripped, which gemato reports as a failed refresh and which then
-    refuses the snapshot as unsigned.
-
-    The key and the signature are unchanged; only where the refresh reads the
-    key from moves, so this is not a weakening of the check.
-    """
-    from gentoo_install.errors import CommandFailed
+def test_the_first_snapshot_uses_portages_keyserver_policy() -> None:
+    from gentoo_install.plan.operations import CommandOutput
     from gentoo_install.plan import portage as plan_portage
-
     from .recorder import Recorder
 
-    servers = plan_portage.KEY_SERVERS
-    assert servers[0] == "hkps://keys.gentoo.org", servers
-    assert all(one.startswith("hkps://") for one in servers), servers
-    # It answers, and it answers with a key gemato refuses.
-    assert not any("keys.openpgp.org" in one for one in servers), servers
+    def answer(argv: Sequence[str]) -> str | None:
+        if tuple(argv[:3]) == ("portageq", "envvar", "PORTAGE_GPG_KEY_SERVER"):
+            return CommandOutput("hkps://keys.gentoo.org\n", 0)
+        return None
 
-    class Refusing(Recorder):
-        """A keyserver that answers nothing, the way the first one did."""
-
-        refuse: str = servers[0]
-
-        def run_in_target(self, argv: Sequence[str], *, check: bool = True) -> str:
-            if any(self.refuse in one for one in argv):
-                raise CommandFailed(f"{self.refuse} exited 1")
-            return super().run_in_target(argv, check=check)
-
-    recorder = Refusing()
+    recorder = Recorder(answering=answer)
     plan_portage.WebrsyncRepository().apply(recorder)
-    ran = recorder.in_target[-1]
-    assert ran[-1] == "emerge-webrsync", ran
-    assert f"PORTAGE_GPG_KEY_SERVER={servers[1]}" in ran, ran
+    assert recorder.in_target[-1] == (
+        "env", "PORTAGE_GPG_KEY_SERVER=hkps://keys.gentoo.org", "emerge-webrsync"
+    )
+
+
+def test_the_first_snapshot_keeps_portages_empty_keyserver_policy() -> None:
+    from gentoo_install.plan.operations import CommandOutput
+    from gentoo_install.plan import portage as plan_portage
+    from .recorder import Recorder
+
+    def answer(argv: Sequence[str]) -> str | None:
+        if tuple(argv[:3]) == ("portageq", "envvar", "PORTAGE_GPG_KEY_SERVER"):
+            return CommandOutput("\n", 0)
+        return None
+
+    recorder = Recorder(answering=answer)
+    plan_portage.WebrsyncRepository().apply(recorder)
+    assert recorder.in_target[-1] == ("emerge-webrsync",)
+
+
+def test_keyserver_policy_query_failure_stops_the_first_snapshot() -> None:
+    from gentoo_install.errors import ConfigError
+    from gentoo_install.plan.operations import CommandOutput
+    from gentoo_install.plan import portage as plan_portage
+    from .recorder import Recorder
+
+    def answer(argv: Sequence[str]) -> str | None:
+        if tuple(argv[:3]) == ("portageq", "envvar", "PORTAGE_GPG_KEY_SERVER"):
+            return CommandOutput("query failed\n", 1)
+        return None
+
+    recorder = Recorder(answering=answer)
+    with pytest.raises(ConfigError, match="keyserver policy"):
+        plan_portage.WebrsyncRepository().apply(recorder)
+    assert not any(command[-1] == "emerge-webrsync" for command in recorder.in_target)
 
 
 def test_a_pinned_package_reaches_usepkg_exclude_without_its_version() -> None:


### PR DESCRIPTION
Portage owns the stage3 keyserver setting, so read it before the first webrsync instead of replacing it.