### PR TITLE
exec: derive runtime helpers from the plan

### DIFF
--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -61,6 +61,7 @@ package_for() {
 	sgdisk:alpine) printf 'sgdisk' ;;
 	sgdisk:*) printf 'gptfdisk' ;;
 	partprobe:* | parted:*) printf 'parted' ;;
+	install:* | sleep:*) printf 'coreutils' ;;
 	mkfs.vfat:* | mkfs.fat:*) printf 'dosfstools' ;;
 	mkfs.btrfs:* | btrfs:*) printf 'btrfs-progs' ;;
 	cryptsetup:*) printf 'cryptsetup' ;;

--- a/gentoo_install/exec/preflight.py
+++ b/gentoo_install/exec/preflight.py
@@ -33,7 +33,7 @@ from ..model.size import DEFAULT_ALIGNMENT, SectorSize, Size
 from ..model.validate import root_size_problems
 from ..plan.disk import MKFS
 from ..plan.operations import Operation
-from ..plan.portage import InstallStage3
+from ..plan.portage import InstallStage3, PrepareChroot, SyncRepository
 from .probe import RELEASE_KEY, Machine, Probe
 
 # These are used while preflight inspects disks, before any operation runs.
@@ -50,6 +50,8 @@ ALWAYS: Final[tuple[str, ...]] = (
 #: Commands reached through context methods or helper subprocesses.
 BY_OPERATION: Final[dict[type[Operation], tuple[str, ...]]] = {
     InstallStage3: STAGE3_COMMANDS,
+    PrepareChroot: ("install",),
+    SyncRepository: ("sleep",),
 }
 
 #: What the menu needs and a configuration file does not: a file carries

--- a/tests/unit/test_exec.py
+++ b/tests/unit/test_exec.py
@@ -337,6 +337,32 @@ def test_a_missing_stage3_helper_is_reported_before_the_operation(
     ), report.fatal
 
 
+@pytest.mark.parametrize(
+    ("operation", "command"),
+    (("PrepareChroot", "install"), ("SyncRepository", "sleep")),
+)
+def test_runtime_helpers_are_derived_from_plan(
+    operation: str, command: str, tmp_path: Path
+) -> None:
+    from gentoo_install.plan.portage import PrepareChroot, SyncRepository
+
+    built = {
+        "PrepareChroot": PrepareChroot(),
+        "SyncRepository": SyncRepository(
+            name="gentoo", location=PurePosixPath("/var/db/repos/gentoo")
+        ),
+    }
+    selected = built[operation]
+    wanted = preflight.required_commands(config(), (selected,))
+    report = preflight.inspect(
+        config(), described(commands=wanted - {command}), probe_of(tmp_path), operations=(selected,)
+    )
+    assert any(
+        problem == f"{command} is missing; required by {operation}"
+        for problem in report.fatal
+    ), report.fatal
+
+
 def test_every_filesystem_the_installer_can_make_has_a_required_command() -> None:
     """The list is derived from the table the operations use, so a filesystem
     added there cannot be silently absent here."""

--- a/tests/unit/test_harness.py
+++ b/tests/unit/test_harness.py
@@ -244,21 +244,21 @@ def test_bootstrap_names_a_package_for_every_command_preflight_wants() -> None:
         for command in group
     }
     stage3_providers = {
-        "gentoo": {"tar": "tar", "xz": "xz-utils", "gpg": "gnupg", "gpg-agent": "gnupg"},
-        "alpine": {"tar": "tar", "xz": "xz", "gpg": "gnupg", "gpg-agent": "gpg-agent"},
-        "debian": {"tar": "tar", "xz": "xz-utils", "gpg": "gnupg", "gpg-agent": "gpg-agent"},
-        "ubuntu": {"tar": "tar", "xz": "xz-utils", "gpg": "gnupg", "gpg-agent": "gpg-agent"},
-        "arch": {"tar": "tar", "xz": "xz", "gpg": "gnupg", "gpg-agent": "gnupg"},
+        "gentoo": {"tar": "tar", "xz": "xz-utils", "gpg": "gnupg", "gpg-agent": "gnupg", "install": "coreutils", "sleep": "coreutils"},
+        "alpine": {"tar": "tar", "xz": "xz", "gpg": "gnupg", "gpg-agent": "gpg-agent", "install": "coreutils", "sleep": "coreutils"},
+        "debian": {"tar": "tar", "xz": "xz-utils", "gpg": "gnupg", "gpg-agent": "gpg-agent", "install": "coreutils", "sleep": "coreutils"},
+        "ubuntu": {"tar": "tar", "xz": "xz-utils", "gpg": "gnupg", "gpg-agent": "gpg-agent", "install": "coreutils", "sleep": "coreutils"},
+        "arch": {"tar": "tar", "xz": "xz", "gpg": "gnupg", "gpg-agent": "gnupg", "install": "coreutils", "sleep": "coreutils"},
         "fedora": {
-            "tar": "tar", "xz": "xz", "gpg": "gnupg", "gpg-agent": "gnupg2-gpg-agent",
+            "tar": "tar", "xz": "xz", "gpg": "gnupg", "gpg-agent": "gnupg2-gpg-agent", "install": "coreutils", "sleep": "coreutils",
         },
-        "rhel": {"tar": "tar", "xz": "xz", "gpg": "gnupg", "gpg-agent": "gnupg2"},
-        "centos": {"tar": "tar", "xz": "xz", "gpg": "gnupg", "gpg-agent": "gnupg2"},
-        "suse": {"tar": "tar", "xz": "xz", "gpg": "gnupg", "gpg-agent": "gpg2"},
-        "opensuse": {"tar": "tar", "xz": "xz", "gpg": "gnupg", "gpg-agent": "gpg2"},
-        "opensuse-leap": {"tar": "tar", "xz": "xz", "gpg": "gnupg", "gpg-agent": "gpg2"},
+        "rhel": {"tar": "tar", "xz": "xz", "gpg": "gnupg", "gpg-agent": "gnupg2", "install": "coreutils", "sleep": "coreutils"},
+        "centos": {"tar": "tar", "xz": "xz", "gpg": "gnupg", "gpg-agent": "gnupg2", "install": "coreutils", "sleep": "coreutils"},
+        "suse": {"tar": "tar", "xz": "xz", "gpg": "gnupg", "gpg-agent": "gpg2", "install": "coreutils", "sleep": "coreutils"},
+        "opensuse": {"tar": "tar", "xz": "xz", "gpg": "gnupg", "gpg-agent": "gpg2", "install": "coreutils", "sleep": "coreutils"},
+        "opensuse-leap": {"tar": "tar", "xz": "xz", "gpg": "gnupg", "gpg-agent": "gpg2", "install": "coreutils", "sleep": "coreutils"},
         "opensuse-tumbleweed": {
-            "tar": "tar", "xz": "xz", "gpg": "gnupg", "gpg-agent": "gpg2",
+            "tar": "tar", "xz": "xz", "gpg": "gnupg", "gpg-agent": "gpg2", "install": "coreutils", "sleep": "coreutils",
         },
     }
     assert all(set(providers) == operation_commands for providers in stage3_providers.values())


### PR DESCRIPTION
Preflight must name host helpers required by chroot preparation and repository sync, and bootstrap must map those commands to packages.