### PR TITLE
plan: verify console font package payload

### DIFF
--- a/gentoo_install/plan/packages.py
+++ b/gentoo_install/plan/packages.py
@@ -24,7 +24,7 @@ from ..errors import CommandFailed, ConfigError, ValidationFailed
 from ..model.config import InitSystem, InstallConfig
 from .operations import Context, Operation, Stage
 from .portage import Emerge
-from .system import EnableService
+from .system import CONSOLE_FONTS, EnableService
 
 
 @dataclass(frozen=True)
@@ -579,6 +579,12 @@ CHROMIUM_PACKAGE: Final[str] = "www-client/chromium"
 CHROMIUM_CONFIG_PACKAGE: Final[str] = "www-client/chromium-common"
 CHROMIUM_COMMAND: Final[PurePosixPath] = PurePosixPath("/usr/bin/chromium")
 CHROMIUM_CONFIG: Final[PurePosixPath] = PurePosixPath("/etc/chromium/default")
+KBD_PACKAGE: Final[str] = "sys-apps/kbd"
+
+
+def console_font_path(font: str) -> PurePosixPath:
+    """Return the compressed console-font file owned by `sys-apps/kbd`."""
+    return PurePosixPath(f"/usr/share/consolefonts/{font}.psfu.gz")
 
 
 @dataclass(frozen=True, kw_only=True)
@@ -869,6 +875,13 @@ def _operations(
                     requester=f"the `{group.name}` group",
                 )
             )
+            if group.name == "console" and KBD_PACKAGE in group.packages:
+                operations.append(
+                    VerifyPackagePaths(
+                        package=KBD_PACKAGE,
+                        paths=(console_font_path(CONSOLE_FONTS[config.system.console_font]),),
+                    )
+                )
         if group.package_use:
             operations.append(WriteGroupUse(group=group.name, lines=group.package_use))
         if group.accept_keywords:

--- a/tests/golden/zfs-zbm.txt
+++ b/tests/golden/zfs-zbm.txt
@@ -97,6 +97,7 @@
   enable zfs-mount.service at boot
   enable zfs.target at boot
   install the console group: emerge sys-apps/kbd app-editors/vim
+  verify sys-apps/kbd installed /usr/share/consolefonts/default8x16.psfu.gz
 
 [finish]
   point /etc/resolv.conf at systemd-resolved rather than the install medium's

--- a/tests/unit/test_packages.py
+++ b/tests/unit/test_packages.py
@@ -5,7 +5,7 @@ import pytest
 
 from gentoo_install.data import load_catalog
 from gentoo_install.errors import CommandFailed
-from gentoo_install.model.config import InstallConfig, Overlay, User
+from gentoo_install.model.config import ConsoleFontSize, InstallConfig, Overlay, User
 from gentoo_install.plan import packages as plan_packages
 from gentoo_install.plan.packages import build
 from gentoo_install.plan.portage import Emerge
@@ -70,6 +70,38 @@ def test_build_resolves_the_selected_package_groups_once(
         if isinstance(one, Emerge) and one.requester
     }
     assert {"the `nvidia` group", "the `wemeet` group"} <= emerged
+
+
+def test_console_profile_verifies_the_selected_kbd_font_payload() -> None:
+    selected = replace(
+        config(),
+        system=replace(config().system, console_font=ConsoleFontSize.SIZE_16X32),
+        packages=replace(config().packages, desktop="console"),
+    )
+    operations = build(selected, load_catalog())
+    verification = next(
+        operation for operation in operations if isinstance(operation, plan_packages.VerifyPackagePaths)
+    )
+    assert verification.package == "sys-apps/kbd"
+    assert verification.paths == (PurePosixPath("/usr/share/consolefonts/latarcyrheb-sun32.psfu.gz"),)
+
+    recorder = PackageRecorder()
+    recorder.package_paths["sys-apps/kbd"] = frozenset(verification.paths)
+    verification.apply(recorder)
+
+
+def test_console_profile_rejects_a_kbd_payload_without_the_selected_font() -> None:
+    selected = replace(
+        config(),
+        packages=replace(config().packages, desktop="console"),
+    )
+    verification = next(
+        operation
+        for operation in build(selected, load_catalog())
+        if isinstance(operation, plan_packages.VerifyPackagePaths)
+    )
+    with pytest.raises(CommandFailed, match="sys-apps/kbd was expected to provide"):
+        verification.apply(PackageRecorder())
 
 
 def test_input_engines_declare_the_language_they_type() -> None:


### PR DESCRIPTION
The selected console font must be present in the kbd package payload before the installed system is accepted.