### PR TITLE
tui: derive profile choices from the Gentoo tree

### DIFF
--- a/gentoo_install/cli.py
+++ b/gentoo_install/cli.py
@@ -559,6 +559,7 @@ def _from_menu(arguments: argparse.Namespace) -> InstallConfig | None:
         translate=Catalog(tag_for(override=arguments.lang)),
         ipv4=has_ipv4,
         ipv6=has_ipv6,
+        profile_paths=probe.amd64_profiles(),
         disks=probe.disks(),
         names_for=probe.names_for,
         groups=load_catalog(),

--- a/gentoo_install/exec/probe.py
+++ b/gentoo_install/exec/probe.py
@@ -155,11 +155,26 @@ def _efi_bits() -> int:
 #: Where both install media keep the release engineering public key.
 RELEASE_KEY: Final[Path] = Path("/usr/share/openpgp-keys/gentoo-release.asc")
 MEMINFO: Final[Path] = Path("/proc/meminfo")
+PROFILES_DESC: Final[Path] = Path("/var/db/repos/gentoo/profiles/profiles.desc")
 
 
 def profiles_from_eselect(output: str) -> tuple[ProbedProfile, ...]:
     """Parse profile output already read from the machine that owns the tree."""
     return parse_profile_list(output)
+
+
+def amd64_profiles(path: Path = PROFILES_DESC) -> tuple[str, ...]:
+    """Read amd64 profile paths from the repository's profiles.desc."""
+    try:
+        lines = path.read_text(encoding="utf-8").splitlines()
+    except OSError:
+        return ()
+    found: list[str] = []
+    for line in lines:
+        fields = line.split()
+        if len(fields) >= 3 and fields[0] == "amd64" and fields[2] in {"stable", "exp"}:
+            found.append(fields[1])
+    return tuple(found)
 
 
 @dataclass(frozen=True)
@@ -219,6 +234,10 @@ class Probe:
     runner: Runner
     work: Path
     resolved: dict[DeviceId, str] = field(default_factory=dict)
+
+    def amd64_profiles(self) -> tuple[str, ...]:
+        """Return profile paths advertised by the installed Gentoo tree."""
+        return amd64_profiles()
 
     def versions(self, wanted: Iterable[str]) -> dict[str, str]:
         """What each command answers to `--version`, first line only.

--- a/gentoo_install/tui/screens.py
+++ b/gentoo_install/tui/screens.py
@@ -135,10 +135,12 @@ class Context:
         #: machine that cannot be read refuses nothing.
         ipv4: bool = True,
         ipv6: bool = True,
+        profile_paths: Sequence[str] = (),
     ) -> None:
         self.translate = translate
         self.ipv4 = ipv4
         self.ipv6 = ipv6
+        self.profile_paths = tuple(profile_paths)
         #: Selector and a human description, from `exec/probe.py`.
         self.disks = disks
         self.groups = groups
@@ -1426,14 +1428,19 @@ def kernel_screen(screen: Screen, config: InstallConfig, context: Context) -> An
 BASE_PROFILE: Final[str] = "default/linux/amd64/23.0"
 
 
-def desktop_profiles(groups: Groups) -> dict[str, str]:
+def desktop_profiles(groups: Groups, profile_paths: Sequence[str] = ()) -> dict[str, str]:
     """The desktops and the profile each is built against, read from the files
     that declare them: a table beside `data/profiles/` meant a desktop added
     there never reached the menu, and one added here installed nothing."""
-    found = {"": BASE_PROFILE}
+    release = next(
+        (path.split("/")[3] for path in profile_paths if path.startswith("default/linux/amd64/")),
+        BASE_PROFILE.split("/")[3],
+    )
+    prefix = f"default/linux/amd64/{release}"
+    found = {"": prefix}
     for name, group in groups.items():
         if group.profile:
-            found[name] = group.profile
+            found[name] = group.profile.replace(BASE_PROFILE, prefix, 1)
     return found
 
 
@@ -1456,7 +1463,7 @@ def desktop_screen(screen: Screen, config: InstallConfig, context: Context) -> A
             detail=detail.get(name, "")
             + _adds(config, context, lambda packages, one: replace(packages, desktop=one), name),
         )
-        for name in sorted(desktop_profiles(context.groups))
+        for name in sorted(desktop_profiles(context.groups, context.profile_paths))
     ]
     menu: Menu[str] = Menu(
         title=translate("Desktop and applications"),
@@ -1478,7 +1485,7 @@ def desktop_screen(screen: Screen, config: InstallConfig, context: Context) -> A
             portage=replace(
                 config.portage,
                 profile=_profile_for(
-                    desktop_profiles(context.groups)[desktop], config.system.init
+                    desktop_profiles(context.groups, context.profile_paths)[desktop], config.system.init
                 ),
             ),
         )
@@ -2439,7 +2446,7 @@ def packages_screen(
     # A desktop, a driver and a display manager each decide something else as
     # well, so each has its own screen and none is a row to tick here.
     elsewhere = (
-        set(desktop_profiles(context.groups))
+        set(desktop_profiles(context.groups, context.profile_paths))
         | {name for name, _ in GRAPHICS}
         | {name for name, _ in DISPLAY_MANAGERS}
         | set(input_method_groups(context.groups))
@@ -3188,9 +3195,10 @@ def overview_screen(screen: Screen, config: InstallConfig, context: Context) -> 
 def _profile_screen(screen: Screen, config: InstallConfig, context: Context) -> Answer[InstallConfig]:
     """Only the profiles that match the chosen init, because the validator
     refuses the other half and the operator should not be offered them."""
+    choices = context.profile_paths or PROFILES
     wanted = [
         profile
-        for profile in PROFILES
+        for profile in choices
         if ("systemd" in profile.split("/")) is (config.system.init is InitSystem.SYSTEMD)
     ]
     menu: Menu[str] = Menu(

--- a/tests/unit/test_validate.py
+++ b/tests/unit/test_validate.py
@@ -23,13 +23,28 @@ from gentoo_install.model.device import (
 )
 from gentoo_install.model.size import Size
 from gentoo_install.exec.config import load
-from gentoo_install.exec.probe import profiles_from_eselect
+from gentoo_install.exec.probe import amd64_profiles, profiles_from_eselect
 from gentoo_install.model.validate import validate
 from gentoo_install.model.parse import parse
 
 from .layouts import encrypted_root, config, ext4_on_gpt, i, zfs_root
 
 FIXTURES = Path(__file__).resolve().parents[1] / "fixtures"
+
+
+def test_the_profile_probe_reads_current_amd64_paths(tmp_path: Path) -> None:
+    desc = tmp_path / "profiles.desc"
+    desc.write_text(
+        "amd64 default/linux/amd64/24.0 stable\n"
+        "amd64 default/linux/amd64/24.0/systemd stable\n"
+        "amd64 default/linux/amd64/24.0/x32 dev\n"
+        "arm64 default/linux/arm64/24.0 stable\n",
+        encoding="utf-8",
+    )
+    assert amd64_profiles(desc) == (
+        "default/linux/amd64/24.0",
+        "default/linux/amd64/24.0/systemd",
+    )
 
 
 def test_a_plain_uefi_install_validates() -> None:


### PR DESCRIPTION
The installed repository advertises the current amd64 profile release, so the menu must not pin desktop choices to 23.0.