### PR TITLE
plan: type emerge install modes

### DIFF
--- a/gentoo_install/plan/bootloader.py
+++ b/gentoo_install/plan/bootloader.py
@@ -29,7 +29,7 @@ from ..model.device import (
     ZfsPool,
 )
 from .operations import Context, Operation, Stage
-from .portage import Emerge
+from .portage import Emerge, InstallMode
 
 BOOTLOADER_PACKAGES: Final[dict[Bootloader, tuple[str, ...]]] = {
     Bootloader.GRUB: ("sys-boot/grub",),
@@ -439,7 +439,7 @@ def build(config: InstallConfig) -> list[Operation]:
                 stage=Stage.BOOTLOADER,
                 packages=(provider,),
                 summary="install bootctl",
-                noreplace=True,
+                mode=InstallMode.NOREPLACE,
             ),
             InstallSystemdBoot(esp=esp),
             ShowTheBootMenu(esp=esp),

--- a/gentoo_install/plan/kernel.py
+++ b/gentoo_install/plan/kernel.py
@@ -36,7 +36,7 @@ from .bootloader import GenerateHostId
 from .bootloader import initramfs_keymap as bootloader_keymap
 from .bootloader import unlock_parameters
 from .operations import Context, Operation, Stage
-from .portage import Emerge, SourcePolicy
+from .portage import Emerge, InstallMode, SourcePolicy
 
 #: The package that provides each kernel choice.
 KERNEL_PACKAGES: Final[dict[KernelSource, str]] = {
@@ -651,7 +651,7 @@ def build(config: InstallConfig) -> list[Operation]:
                 stage=Stage.KERNEL,
                 packages=("sys-apps/systemd",),
                 summary="rebuild systemd with the unlock generator",
-                oneshot=True,
+                mode=InstallMode.ONESHOT,
                 source=SourcePolicy.build_all(),
             ),
         ]

--- a/gentoo_install/plan/portage.py
+++ b/gentoo_install/plan/portage.py
@@ -344,6 +344,12 @@ class _SourceMode(Enum):
     BUILD_SUBSET = "build subset"
 
 
+class InstallMode(Enum):
+    NORMAL = ""
+    ONESHOT = "--oneshot"
+    NOREPLACE = "--noreplace"
+
+
 @dataclass(frozen=True, kw_only=True)
 class SourcePolicy:
     """Which requested packages may use binaries.
@@ -474,18 +480,11 @@ class Emerge(Operation):
     summary: str
     requester: str = ""
     repository_bootstrap: bool = False
-    oneshot: bool = False
+    mode: InstallMode = InstallMode.NORMAL
     source: SourcePolicy = SourcePolicy.binaries_allowed()
-    #: Install only what is absent. For a package an earlier operation already
-    #: pulled in, a plain atom is `[ebuild R]` and portage rebuilds it: one
-    #: run spent 132 seconds rebuilding `sys-apps/systemd` at the bootloader
-    #: stage with the same flags it had been built with at the kernel stage.
-    noreplace: bool = False
 
     def __post_init__(self) -> None:
         self.source.built_from(self.packages)
-        if self.oneshot and self.noreplace:
-            raise ValueError("oneshot and noreplace cannot be combined")
 
     @property
     def package_requester(self) -> str:
@@ -503,10 +502,8 @@ class Emerge(Operation):
 
     def apply(self, context: Context) -> None:
         argv = ["emerge", *EMERGE_OPTIONS]
-        if self.oneshot:
-            argv.append("--oneshot")
-        if self.noreplace:
-            argv.append("--noreplace")
+        if self.mode.value:
+            argv.append(self.mode.value)
         if context.degraded(BINARY_PACKAGES):
             # `FEATURES=getbinpkg` in make.conf keeps fetching remote binaries
             # under `--usepkg=n`, so both are needed to reach the source path

--- a/tests/unit/test_plan_boot.py
+++ b/tests/unit/test_plan_boot.py
@@ -35,7 +35,13 @@ from gentoo_install.model.size import Size
 from gentoo_install.exec.config import load
 from gentoo_install.model.validate import validate
 from gentoo_install.plan import bootloader, kernel
-from gentoo_install.plan.portage import Emerge, SourcePolicy
+from gentoo_install.plan.portage import (
+    BINPKG_OPTIONS,
+    EMERGE_OPTIONS,
+    Emerge,
+    InstallMode,
+    SourcePolicy,
+)
 
 from .layouts import config, encrypted_root, ext4_on_gpt, i, zfs_root
 from .recorder import Recorder
@@ -984,8 +990,6 @@ def test_bootctl_is_not_rebuilt_for_flags_it_already_has() -> None:
     The operation stays: nothing else guarantees `bootctl` when the provider is
     `sys-apps/systemd-utils` on openrc.
     """
-    from gentoo_install.plan.portage import Emerge
-
     installation = replace(
         config(),
         bootloader=BootloaderConfig(kind=Bootloader.SYSTEMD_BOOT, firmware=Firmware.UEFI),
@@ -995,10 +999,17 @@ def test_bootctl_is_not_rebuilt_for_flags_it_already_has() -> None:
         for one in bootloader.build(installation)
         if isinstance(one, Emerge) and "bootctl" in one.summary
     )
-    assert merge.noreplace
+    assert merge.mode is InstallMode.NOREPLACE
     recorder = Recorder()
     merge.apply(recorder)
-    assert any("--noreplace" in one for one in recorder.in_target[0])
+    assert recorder.only("emerge") == (
+        "emerge",
+        *EMERGE_OPTIONS,
+        "--noreplace",
+        *BINPKG_OPTIONS,
+        "--",
+        *merge.packages,
+    )
 
 
 def test_zfsbootmenu_configures_the_pool_the_root_is_on() -> None:

--- a/tests/unit/test_plan_kernel.py
+++ b/tests/unit/test_plan_kernel.py
@@ -8,7 +8,14 @@ import pytest
 from gentoo_install.exec.config import load
 from gentoo_install.model.config import InstallConfig, KernelSource
 from gentoo_install.plan import bootloader, kernel
-from gentoo_install.plan.portage import Emerge, SourcePolicy
+from gentoo_install.plan.portage import (
+    BINPKG_EXCLUDED,
+    BINPKG_OPTIONS,
+    EMERGE_OPTIONS,
+    Emerge,
+    InstallMode,
+    SourcePolicy,
+)
 
 from .recorder import Recorder
 
@@ -63,6 +70,28 @@ def test_zfsbootmenu_installs_network_legacy_executables() -> None:
     assert recorder.files[
         PurePosixPath("/etc/portage/package.use/zfsbootmenu-network")
     ] == "net-misc/dhcp client -server\nnet-misc/iputils arping\n"
+
+
+def test_systemd_unlock_rebuild_uses_exact_oneshot_argv() -> None:
+    installation = load(Path("tests/fixtures/vm-unlock.toml"))
+    rebuild = next(
+        one
+        for one in kernel.build(installation)
+        if isinstance(one, Emerge) and one.summary == "rebuild systemd with the unlock generator"
+    )
+
+    assert rebuild.mode is InstallMode.ONESHOT
+    recorder = Recorder()
+    rebuild.apply(recorder)
+    assert recorder.only("emerge") == (
+        "emerge",
+        *EMERGE_OPTIONS,
+        "--oneshot",
+        *BINPKG_OPTIONS[:-1],
+        f"{BINPKG_EXCLUDED} sys-apps/systemd",
+        "--",
+        "sys-apps/systemd",
+    )
 
 
 def test_build_derives_stack_once_for_prebuilt_zfs(

--- a/tests/unit/test_plan_portage.py
+++ b/tests/unit/test_plan_portage.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import pytest
 
-from dataclasses import replace
+from dataclasses import fields, replace
 from pathlib import PurePosixPath
 from typing import Any, Sequence
 
@@ -440,32 +440,42 @@ def test_invalid_source_subsets_are_rejected(
         )
 
 
-def test_oneshot_and_noreplace_cannot_be_combined() -> None:
-    with pytest.raises(ValueError, match="oneshot and noreplace cannot be combined"):
-        portage.Emerge(
-            packages=("app-editors/nano",),
-            summary="install the editor",
-            oneshot=True,
-            noreplace=True,
-        )
+def test_an_emerge_has_one_typed_install_mode() -> None:
+    operation = portage.Emerge(
+        packages=("app-editors/nano",),
+        summary="install the editor",
+    )
+
+    assert operation.mode is portage.InstallMode.NORMAL
+    assert {"oneshot", "noreplace"}.isdisjoint(field.name for field in fields(portage.Emerge))
 
 
 @pytest.mark.parametrize(
-    ("oneshot", "noreplace", "expected"),
-    ((True, False, "--oneshot"), (False, True, "--noreplace")),
-    ids=("oneshot", "noreplace"),
+    ("mode", "mode_options"),
+    (
+        (portage.InstallMode.NORMAL, ()),
+        (portage.InstallMode.ONESHOT, ("--oneshot",)),
+        (portage.InstallMode.NOREPLACE, ("--noreplace",)),
+    ),
+    ids=("normal", "oneshot", "noreplace"),
 )
-def test_oneshot_and_noreplace_are_rendered_explicitly(
-    oneshot: bool, noreplace: bool, expected: str
+def test_install_modes_map_to_exact_emerge_argv(
+    mode: portage.InstallMode, mode_options: tuple[str, ...]
 ) -> None:
     recorder = Recorder()
     portage.Emerge(
         packages=("app-editors/nano",),
         summary="install the editor",
-        oneshot=oneshot,
-        noreplace=noreplace,
+        mode=mode,
     ).apply(recorder)
-    assert expected in recorder.only("emerge")
+    assert recorder.only("emerge") == (
+        "emerge",
+        *portage.EMERGE_OPTIONS,
+        *mode_options,
+        *portage.BINPKG_OPTIONS,
+        "--",
+        "app-editors/nano",
+    )
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
A single install mode prevents contradictory oneshot and noreplace flags from reaching Portage.