### PR TITLE
plan: separate chroot mounts from resolver seeding

### DIFF
--- a/gentoo_install/exec/preflight.py
+++ b/gentoo_install/exec/preflight.py
@@ -33,7 +33,7 @@ from ..model.size import DEFAULT_ALIGNMENT, SectorSize, Size
 from ..model.validate import root_size_problems
 from ..plan.disk import MKFS
 from ..plan.operations import Operation
-from ..plan.portage import InstallStage3, PrepareChroot, SyncRepository
+from ..plan.portage import InstallStage3, MountChrootFilesystems, SyncRepository
 from .probe import RELEASE_KEY, Machine, Probe
 
 # These are used while preflight inspects disks, before any operation runs.
@@ -50,7 +50,7 @@ ALWAYS: Final[tuple[str, ...]] = (
 #: Commands reached through context methods or helper subprocesses.
 BY_OPERATION: Final[dict[type[Operation], tuple[str, ...]]] = {
     InstallStage3: STAGE3_COMMANDS,
-    PrepareChroot: ("install",),
+    MountChrootFilesystems: ("install",),
     SyncRepository: ("sleep",),
 }
 

--- a/gentoo_install/plan/portage.py
+++ b/gentoo_install/plan/portage.py
@@ -116,7 +116,7 @@ class InstallStage3(Operation):
 
 
 @dataclass(frozen=True, kw_only=True)
-class PrepareChroot(Operation):
+class MountChrootFilesystems(Operation):
     """`/run` is bound and made slave rather than mounted as a fresh tmpfs: that
     is the Handbook's form and it keeps the installing system's udev reachable.
 
@@ -134,7 +134,7 @@ class PrepareChroot(Operation):
         return False
 
     def describe(self) -> str:
-        return "mount proc, sys, dev and run into the target and copy resolv.conf"
+        return "mount transient proc, sys, dev and run filesystems into the target"
 
     def apply(self, context: Context) -> None:
         target = context.target
@@ -143,6 +143,26 @@ class PrepareChroot(Operation):
             where = str(target / source.lstrip("/"))
             context.run(["mount", "--rbind" if propagation == "rslave" else "--bind", source, where])
             context.run(["mount", f"--make-{propagation}", where])
+
+
+@dataclass(frozen=True, kw_only=True)
+class SeedResolver(Operation):
+    """Give chrooted commands working DNS until the target's own resolver is
+    configured at the end of the system stage."""
+
+    stage: Stage = Stage.CHROOT
+
+    @property
+    def survives_a_reboot(self) -> bool:
+        # This is an ordinary file in the target and remains there until
+        # LinkResolvConf replaces it after the last emerge.
+        return True
+
+    def describe(self) -> str:
+        return "seed the target's resolv.conf from the install medium"
+
+    def apply(self, context: Context) -> None:
+        target = context.target
         context.run(["install", "--mode=0644", "/etc/resolv.conf", str(target / "etc/resolv.conf")])
 
 
@@ -740,7 +760,8 @@ def build(
     gentoo = PurePosixPath("/var/db/repos/gentoo")
     operations: list[Operation] = [
         InstallStage3(mirror=mirror, variant=variant_of(config)),
-        PrepareChroot(),
+        MountChrootFilesystems(),
+        SeedResolver(),
     ]
     operations += [
         WriteMakeConf(

--- a/tests/golden/btrfs-luks.txt
+++ b/tests/golden/btrfs-luks.txt
@@ -25,7 +25,8 @@
   download the newest desktop-systemd stage3 from https://mirrors.ustc.edu.cn/gentoo, verify it against BB572E0E2D182910 and unpack it into the target
 
 [chroot]
-  mount proc, sys, dev and run into the target and copy resolv.conf
+  mount transient proc, sys, dev and run filesystems into the target
+  seed the target's resolv.conf from the install medium
 
 [portage]
   write /etc/portage/make.conf with COMMON_FLAGS, CFLAGS, CXXFLAGS, FCFLAGS, FFLAGS, MAKEOPTS, USE, VIDEO_CARDS, INPUT_DEVICES, ACCEPT_LICENSE, L10N, FEATURES; 23 mirrors fastest first, measured, 5 appended

--- a/tests/golden/ext4-bios.txt
+++ b/tests/golden/ext4-bios.txt
@@ -17,7 +17,8 @@
   download the newest openrc stage3 from https://distfiles.gentoo.org, verify it against BB572E0E2D182910 and unpack it into the target
 
 [chroot]
-  mount proc, sys, dev and run into the target and copy resolv.conf
+  mount transient proc, sys, dev and run filesystems into the target
+  seed the target's resolv.conf from the install medium
 
 [portage]
   write /etc/portage/make.conf with MAKEOPTS, INPUT_DEVICES, ACCEPT_LICENSE, L10N; 2 mirrors in the configured order, 5 appended

--- a/tests/golden/mbr-edit.txt
+++ b/tests/golden/mbr-edit.txt
@@ -14,7 +14,8 @@
   download the newest openrc stage3 from https://distfiles.gentoo.org, verify it against BB572E0E2D182910 and unpack it into the target
 
 [chroot]
-  mount proc, sys, dev and run into the target and copy resolv.conf
+  mount transient proc, sys, dev and run filesystems into the target
+  seed the target's resolv.conf from the install medium
 
 [portage]
   write /etc/portage/make.conf with MAKEOPTS, INPUT_DEVICES, ACCEPT_LICENSE, L10N, FEATURES; 2 mirrors in the configured order, 5 appended

--- a/tests/golden/openrc-sdboot.txt
+++ b/tests/golden/openrc-sdboot.txt
@@ -18,7 +18,8 @@
   download the newest openrc stage3 from https://distfiles.gentoo.org, verify it against BB572E0E2D182910 and unpack it into the target
 
 [chroot]
-  mount proc, sys, dev and run into the target and copy resolv.conf
+  mount transient proc, sys, dev and run filesystems into the target
+  seed the target's resolv.conf from the install medium
 
 [portage]
   write /etc/portage/make.conf with MAKEOPTS, INPUT_DEVICES, ACCEPT_LICENSE, L10N, FEATURES; 2 mirrors in the configured order, 5 appended

--- a/tests/golden/vm-binpkg.txt
+++ b/tests/golden/vm-binpkg.txt
@@ -18,7 +18,8 @@
   download the newest systemd stage3 from https://distfiles.gentoo.org, verify it against BB572E0E2D182910 and unpack it into the target
 
 [chroot]
-  mount proc, sys, dev and run into the target and copy resolv.conf
+  mount transient proc, sys, dev and run filesystems into the target
+  seed the target's resolv.conf from the install medium
 
 [portage]
   write /etc/portage/make.conf with MAKEOPTS, INPUT_DEVICES, ACCEPT_LICENSE, L10N, FEATURES; 2 mirrors in the configured order, 5 appended

--- a/tests/golden/vm-bios-luks.txt
+++ b/tests/golden/vm-bios-luks.txt
@@ -21,7 +21,8 @@
   download the newest openrc stage3 from https://distfiles.gentoo.org, verify it against BB572E0E2D182910 and unpack it into the target
 
 [chroot]
-  mount proc, sys, dev and run into the target and copy resolv.conf
+  mount transient proc, sys, dev and run filesystems into the target
+  seed the target's resolv.conf from the install medium
 
 [portage]
   write /etc/portage/make.conf with MAKEOPTS, INPUT_DEVICES, ACCEPT_LICENSE, L10N, FEATURES; 2 mirrors in the configured order, 5 appended

--- a/tests/golden/vm-bios.txt
+++ b/tests/golden/vm-bios.txt
@@ -17,7 +17,8 @@
   download the newest openrc stage3 from https://distfiles.gentoo.org, verify it against BB572E0E2D182910 and unpack it into the target
 
 [chroot]
-  mount proc, sys, dev and run into the target and copy resolv.conf
+  mount transient proc, sys, dev and run filesystems into the target
+  seed the target's resolv.conf from the install medium
 
 [portage]
   write /etc/portage/make.conf with MAKEOPTS, INPUT_DEVICES, ACCEPT_LICENSE, L10N, FEATURES; 2 mirrors in the configured order, 5 appended

--- a/tests/golden/vm-btrfs.txt
+++ b/tests/golden/vm-btrfs.txt
@@ -21,7 +21,8 @@
   download the newest systemd stage3 from https://distfiles.gentoo.org, verify it against BB572E0E2D182910 and unpack it into the target
 
 [chroot]
-  mount proc, sys, dev and run into the target and copy resolv.conf
+  mount transient proc, sys, dev and run filesystems into the target
+  seed the target's resolv.conf from the install medium
 
 [portage]
   write /etc/portage/make.conf with MAKEOPTS, INPUT_DEVICES, ACCEPT_LICENSE, L10N, FEATURES; 2 mirrors in the configured order, 5 appended

--- a/tests/golden/vm-cjk-kernel.txt
+++ b/tests/golden/vm-cjk-kernel.txt
@@ -18,7 +18,8 @@
   download the newest systemd stage3 from https://distfiles.gentoo.org, verify it against BB572E0E2D182910 and unpack it into the target
 
 [chroot]
-  mount proc, sys, dev and run into the target and copy resolv.conf
+  mount transient proc, sys, dev and run filesystems into the target
+  seed the target's resolv.conf from the install medium
 
 [portage]
   write /etc/portage/make.conf with MAKEOPTS, INPUT_DEVICES, ACCEPT_LICENSE, L10N, FEATURES; 2 mirrors in the configured order, 5 appended

--- a/tests/golden/vm-desktop.txt
+++ b/tests/golden/vm-desktop.txt
@@ -18,7 +18,8 @@
   download the newest desktop-systemd stage3 from https://distfiles.gentoo.org, verify it against BB572E0E2D182910 and unpack it into the target
 
 [chroot]
-  mount proc, sys, dev and run into the target and copy resolv.conf
+  mount transient proc, sys, dev and run filesystems into the target
+  seed the target's resolv.conf from the install medium
 
 [portage]
   write /etc/portage/make.conf with MAKEOPTS, USE, INPUT_DEVICES, ACCEPT_LICENSE, L10N, FEATURES; 2 mirrors in the configured order, 5 appended

--- a/tests/golden/vm-f2fs.txt
+++ b/tests/golden/vm-f2fs.txt
@@ -18,7 +18,8 @@
   download the newest systemd stage3 from https://distfiles.gentoo.org, verify it against BB572E0E2D182910 and unpack it into the target
 
 [chroot]
-  mount proc, sys, dev and run into the target and copy resolv.conf
+  mount transient proc, sys, dev and run filesystems into the target
+  seed the target's resolv.conf from the install medium
 
 [portage]
   write /etc/portage/make.conf with MAKEOPTS, INPUT_DEVICES, ACCEPT_LICENSE, L10N, FEATURES; 2 mirrors in the configured order, 5 appended

--- a/tests/golden/vm-gnome.txt
+++ b/tests/golden/vm-gnome.txt
@@ -18,7 +18,8 @@
   download the newest desktop-systemd stage3 from https://distfiles.gentoo.org, verify it against BB572E0E2D182910 and unpack it into the target
 
 [chroot]
-  mount proc, sys, dev and run into the target and copy resolv.conf
+  mount transient proc, sys, dev and run filesystems into the target
+  seed the target's resolv.conf from the install medium
 
 [portage]
   write /etc/portage/make.conf with MAKEOPTS, USE, INPUT_DEVICES, ACCEPT_LICENSE, L10N, FEATURES; 2 mirrors in the configured order, 5 appended

--- a/tests/golden/vm-luks.txt
+++ b/tests/golden/vm-luks.txt
@@ -25,7 +25,8 @@
   download the newest systemd stage3 from https://distfiles.gentoo.org, verify it against BB572E0E2D182910 and unpack it into the target
 
 [chroot]
-  mount proc, sys, dev and run into the target and copy resolv.conf
+  mount transient proc, sys, dev and run filesystems into the target
+  seed the target's resolv.conf from the install medium
 
 [portage]
   write /etc/portage/make.conf with MAKEOPTS, INPUT_DEVICES, ACCEPT_LICENSE, L10N, FEATURES; 2 mirrors in the configured order, 5 appended

--- a/tests/golden/vm-lvm.txt
+++ b/tests/golden/vm-lvm.txt
@@ -26,7 +26,8 @@
   download the newest openrc stage3 from https://distfiles.gentoo.org, verify it against BB572E0E2D182910 and unpack it into the target
 
 [chroot]
-  mount proc, sys, dev and run into the target and copy resolv.conf
+  mount transient proc, sys, dev and run filesystems into the target
+  seed the target's resolv.conf from the install medium
 
 [portage]
   write /etc/portage/make.conf with MAKEOPTS, INPUT_DEVICES, ACCEPT_LICENSE, L10N, FEATURES; 2 mirrors in the configured order, 5 appended

--- a/tests/golden/vm-mdraid.txt
+++ b/tests/golden/vm-mdraid.txt
@@ -26,7 +26,8 @@
   download the newest systemd stage3 from https://distfiles.gentoo.org, verify it against BB572E0E2D182910 and unpack it into the target
 
 [chroot]
-  mount proc, sys, dev and run into the target and copy resolv.conf
+  mount transient proc, sys, dev and run filesystems into the target
+  seed the target's resolv.conf from the install medium
 
 [portage]
   write /etc/portage/make.conf with MAKEOPTS, INPUT_DEVICES, ACCEPT_LICENSE, L10N, FEATURES; 2 mirrors in the configured order, 5 appended

--- a/tests/golden/vm-openrc-desktop.txt
+++ b/tests/golden/vm-openrc-desktop.txt
@@ -18,7 +18,8 @@
   download the newest desktop-openrc stage3 from https://distfiles.gentoo.org, verify it against BB572E0E2D182910 and unpack it into the target
 
 [chroot]
-  mount proc, sys, dev and run into the target and copy resolv.conf
+  mount transient proc, sys, dev and run filesystems into the target
+  seed the target's resolv.conf from the install medium
 
 [portage]
   write /etc/portage/make.conf with MAKEOPTS, USE, INPUT_DEVICES, ACCEPT_LICENSE, L10N, FEATURES; 2 mirrors in the configured order, 5 appended

--- a/tests/golden/vm-raidz.txt
+++ b/tests/golden/vm-raidz.txt
@@ -30,7 +30,8 @@
   download the newest systemd stage3 from https://distfiles.gentoo.org, verify it against BB572E0E2D182910 and unpack it into the target
 
 [chroot]
-  mount proc, sys, dev and run into the target and copy resolv.conf
+  mount transient proc, sys, dev and run filesystems into the target
+  seed the target's resolv.conf from the install medium
 
 [portage]
   write /etc/portage/make.conf with MAKEOPTS, INPUT_DEVICES, ACCEPT_LICENSE, L10N, FEATURES; 2 mirrors in the configured order, 5 appended

--- a/tests/golden/vm-sdboot.txt
+++ b/tests/golden/vm-sdboot.txt
@@ -18,7 +18,8 @@
   download the newest systemd stage3 from https://distfiles.gentoo.org, verify it against BB572E0E2D182910 and unpack it into the target
 
 [chroot]
-  mount proc, sys, dev and run into the target and copy resolv.conf
+  mount transient proc, sys, dev and run filesystems into the target
+  seed the target's resolv.conf from the install medium
 
 [portage]
   write /etc/portage/make.conf with MAKEOPTS, INPUT_DEVICES, ACCEPT_LICENSE, L10N, FEATURES; 2 mirrors in the configured order, 5 appended

--- a/tests/golden/vm-unlock.txt
+++ b/tests/golden/vm-unlock.txt
@@ -25,7 +25,8 @@
   download the newest systemd stage3 from https://distfiles.gentoo.org, verify it against BB572E0E2D182910 and unpack it into the target
 
 [chroot]
-  mount proc, sys, dev and run into the target and copy resolv.conf
+  mount transient proc, sys, dev and run filesystems into the target
+  seed the target's resolv.conf from the install medium
 
 [portage]
   write /etc/portage/make.conf with MAKEOPTS, INPUT_DEVICES, ACCEPT_LICENSE, L10N, FEATURES; 2 mirrors in the configured order, 5 appended

--- a/tests/golden/vm-xfs.txt
+++ b/tests/golden/vm-xfs.txt
@@ -18,7 +18,8 @@
   download the newest systemd stage3 from https://distfiles.gentoo.org, verify it against BB572E0E2D182910 and unpack it into the target
 
 [chroot]
-  mount proc, sys, dev and run into the target and copy resolv.conf
+  mount transient proc, sys, dev and run filesystems into the target
+  seed the target's resolv.conf from the install medium
 
 [portage]
   write /etc/portage/make.conf with MAKEOPTS, INPUT_DEVICES, ACCEPT_LICENSE, L10N, FEATURES; 2 mirrors in the configured order, 5 appended

--- a/tests/golden/vm-zfs-encrypted.txt
+++ b/tests/golden/vm-zfs-encrypted.txt
@@ -22,7 +22,8 @@
   download the newest systemd stage3 from https://distfiles.gentoo.org, verify it against BB572E0E2D182910 and unpack it into the target
 
 [chroot]
-  mount proc, sys, dev and run into the target and copy resolv.conf
+  mount transient proc, sys, dev and run filesystems into the target
+  seed the target's resolv.conf from the install medium
 
 [portage]
   write /etc/portage/make.conf with MAKEOPTS, INPUT_DEVICES, ACCEPT_LICENSE, L10N, FEATURES; 2 mirrors in the configured order, 5 appended

--- a/tests/golden/vm-zfs-mirror.txt
+++ b/tests/golden/vm-zfs-mirror.txt
@@ -26,7 +26,8 @@
   download the newest systemd stage3 from https://distfiles.gentoo.org, verify it against BB572E0E2D182910 and unpack it into the target
 
 [chroot]
-  mount proc, sys, dev and run into the target and copy resolv.conf
+  mount transient proc, sys, dev and run filesystems into the target
+  seed the target's resolv.conf from the install medium
 
 [portage]
   write /etc/portage/make.conf with MAKEOPTS, INPUT_DEVICES, ACCEPT_LICENSE, L10N, FEATURES; 2 mirrors in the configured order, 5 appended

--- a/tests/golden/vm-zfs.txt
+++ b/tests/golden/vm-zfs.txt
@@ -22,7 +22,8 @@
   download the newest systemd stage3 from https://distfiles.gentoo.org, verify it against BB572E0E2D182910 and unpack it into the target
 
 [chroot]
-  mount proc, sys, dev and run into the target and copy resolv.conf
+  mount transient proc, sys, dev and run filesystems into the target
+  seed the target's resolv.conf from the install medium
 
 [portage]
   write /etc/portage/make.conf with MAKEOPTS, INPUT_DEVICES, ACCEPT_LICENSE, L10N, FEATURES; 2 mirrors in the configured order, 5 appended

--- a/tests/golden/vm-zram.txt
+++ b/tests/golden/vm-zram.txt
@@ -18,7 +18,8 @@
   download the newest systemd stage3 from https://distfiles.gentoo.org, verify it against BB572E0E2D182910 and unpack it into the target
 
 [chroot]
-  mount proc, sys, dev and run into the target and copy resolv.conf
+  mount transient proc, sys, dev and run filesystems into the target
+  seed the target's resolv.conf from the install medium
 
 [portage]
   write /etc/portage/make.conf with MAKEOPTS, INPUT_DEVICES, ACCEPT_LICENSE, L10N, FEATURES; 2 mirrors in the configured order, 5 appended

--- a/tests/golden/zfs-zbm.txt
+++ b/tests/golden/zfs-zbm.txt
@@ -24,7 +24,8 @@
   download the newest systemd stage3 from https://distfiles.gentoo.org, verify it against BB572E0E2D182910 and unpack it into the target
 
 [chroot]
-  mount proc, sys, dev and run into the target and copy resolv.conf
+  mount transient proc, sys, dev and run filesystems into the target
+  seed the target's resolv.conf from the install medium
 
 [portage]
   write /etc/portage/make.conf with MAKEOPTS, INPUT_DEVICES, ACCEPT_LICENSE, L10N, FEATURES; 2 mirrors in the configured order, 5 appended

--- a/tests/unit/test_exec.py
+++ b/tests/unit/test_exec.py
@@ -339,15 +339,15 @@ def test_a_missing_stage3_helper_is_reported_before_the_operation(
 
 @pytest.mark.parametrize(
     ("operation", "command"),
-    (("PrepareChroot", "install"), ("SyncRepository", "sleep")),
+    (("MountChrootFilesystems", "install"), ("SyncRepository", "sleep")),
 )
 def test_runtime_helpers_are_derived_from_plan(
     operation: str, command: str, tmp_path: Path
 ) -> None:
-    from gentoo_install.plan.portage import PrepareChroot, SyncRepository
+    from gentoo_install.plan.portage import MountChrootFilesystems, SyncRepository
 
     built = {
-        "PrepareChroot": PrepareChroot(),
+        "MountChrootFilesystems": MountChrootFilesystems(),
         "SyncRepository": SyncRepository(
             name="gentoo", location=PurePosixPath("/var/db/repos/gentoo")
         ),

--- a/tests/unit/test_plan_portage.py
+++ b/tests/unit/test_plan_portage.py
@@ -24,7 +24,7 @@ from gentoo_install.model.config import (
 from gentoo_install.errors import CommandFailed, ConfigError, ValidationFailed
 from gentoo_install.plan import portage
 from gentoo_install.plan.build import PORTAGE_PREREQUISITES, build as build_plan
-from gentoo_install.plan.operations import CommandOutput, Operation
+from gentoo_install.plan.operations import CommandOutput, Operation, Stage
 from gentoo_install.plan.packages import Group
 
 from .layouts import config
@@ -63,19 +63,44 @@ def test_stage3_is_unpacked_with_xattrs_because_capabilities_would_be_lost() -> 
 
 
 def test_the_chroot_gets_proc_rbinds_and_a_slave_run() -> None:
-    recorder = apply_all(config())
-    mounts = recorder.argv_starting("mount")
-    assert ("mount", "--types", "proc", "/proc", "/mnt/gentoo/proc") in mounts
-    assert ("mount", "--rbind", "/sys", "/mnt/gentoo/sys") in mounts
-    assert ("mount", "--make-rslave", "/mnt/gentoo/sys") in mounts
-    assert ("mount", "--bind", "/run", "/mnt/gentoo/run") in mounts
-    assert ("mount", "--make-slave", "/mnt/gentoo/run") in mounts
+    recorder = Recorder()
+
+    portage.MountChrootFilesystems().apply(recorder)
+
+    assert recorder.commands == [
+        ("mount", "--types", "proc", "/proc", "/mnt/gentoo/proc"),
+        ("mount", "--rbind", "/sys", "/mnt/gentoo/sys"),
+        ("mount", "--make-rslave", "/mnt/gentoo/sys"),
+        ("mount", "--rbind", "/dev", "/mnt/gentoo/dev"),
+        ("mount", "--make-rslave", "/mnt/gentoo/dev"),
+        ("mount", "--bind", "/run", "/mnt/gentoo/run"),
+        ("mount", "--make-slave", "/mnt/gentoo/run"),
+    ]
 
 
 def test_resolv_conf_is_copied_so_the_chroot_can_resolve_a_mirror() -> None:
-    assert apply_all(config()).only(
-        "install", "--mode=0644", "/etc/resolv.conf", "/mnt/gentoo/etc/resolv.conf"
+    recorder = Recorder()
+
+    portage.SeedResolver().apply(recorder)
+
+    assert recorder.commands == [
+        ("install", "--mode=0644", "/etc/resolv.conf", "/mnt/gentoo/etc/resolv.conf")
+    ]
+
+
+def test_chroot_mounts_and_resolver_seed_keep_their_stage_and_order() -> None:
+    operations = portage.build(config(), MIRROR)
+    mounted = next(
+        n for n, operation in enumerate(operations)
+        if isinstance(operation, portage.MountChrootFilesystems)
     )
+    seeded = next(
+        n for n, operation in enumerate(operations)
+        if isinstance(operation, portage.SeedResolver)
+    )
+    assert seeded == mounted + 1
+    assert operations[mounted].stage is Stage.CHROOT
+    assert operations[seeded].stage is Stage.CHROOT
 
 
 def test_efivarfs_comes_with_the_recursive_bind_rather_than_a_second_mount() -> None:

--- a/tests/unit/test_plan_system.py
+++ b/tests/unit/test_plan_system.py
@@ -968,7 +968,7 @@ def test_every_logger_has_a_package_a_service_and_a_row() -> None:
 
 
 def test_the_installed_system_resolves_with_its_own_nameservers() -> None:
-    """`PrepareChroot` copies the install medium's `/etc/resolv.conf` in and
+    """`SeedResolver` copies the install medium's `/etc/resolv.conf` in and
     nothing takes it out, and `systemd-networkd` publishes what it learns only
     through `systemd-resolved`, so the DNS the operator typed reached nothing."""
     static = with_system(

--- a/tests/unit/test_resume.py
+++ b/tests/unit/test_resume.py
@@ -321,7 +321,19 @@ def test_a_resumed_run_re_establishes_what_a_reboot_takes_away(
     by_name = {type(one).__name__: one for one in operations}
     assert operation in by_name, sorted(by_name)
     assert by_name[operation].survives_a_reboot is False
-    assert by_name["PrepareChroot"].survives_a_reboot is False
+
+
+def test_a_resume_remounts_the_chroot_but_keeps_the_resolver_seed_checkpoint() -> None:
+    """Cleanup removes the chroot mounts, while the copied resolver remains on
+    disk until the final system-stage replacement. A reboot checkpoint must
+    therefore rerun only the transient half of chroot preparation."""
+    from gentoo_install.plan import portage
+    from tests.unit.layouts import config
+
+    operations = portage.build(config(), mirror="https://distfiles.gentoo.org")
+    by_name = {type(one).__name__: one for one in operations}
+    assert by_name["MountChrootFilesystems"].survives_a_reboot is False
+    assert by_name["SeedResolver"].survives_a_reboot is True
 
 
 def test_every_kind_of_storage_that_needs_activation_has_a_fixture_here() -> None:


### PR DESCRIPTION
Transient mounts and the resolver seed have different lifetimes, so model them as separate operations and keep preflight aligned with the plan.