### PR TITLE
portage: treat an unreadable keyserver policy as no override

### DIFF
--- a/gentoo_install/plan/portage.py
+++ b/gentoo_install/plan/portage.py
@@ -291,12 +291,14 @@ class WebrsyncRepository(Operation):
     def apply(self, context: Context) -> None:
         # Portage owns this policy in the stage3; overriding it can select a
         # server incompatible with the installed gemato configuration.
+        # `portageq` cannot answer before this operation runs, because
+        # `repos.conf` names `/var/db/repos/gentoo` and no snapshot has created
+        # it yet, so an unreadable policy means no override rather than a fault.
         policy = context.run_in_target(
             ["portageq", "envvar", "PORTAGE_GPG_KEY_SERVER"], check=False
         )
-        if not isinstance(policy, CommandOutput) or policy.returncode != 0:
-            raise ConfigError("portageq could not read the keyserver policy")
-        server = policy.strip()
+        readable = isinstance(policy, CommandOutput) and policy.returncode == 0
+        server = policy.strip() if readable else ""
         command = ["emerge-webrsync"]
         if server:
             command = ["env", f"PORTAGE_GPG_KEY_SERVER={server}", *command]

--- a/tests/unit/test_plan_portage.py
+++ b/tests/unit/test_plan_portage.py
@@ -1057,21 +1057,26 @@ def test_the_first_snapshot_keeps_portages_empty_keyserver_policy() -> None:
     assert recorder.in_target[-1] == ("emerge-webrsync",)
 
 
-def test_keyserver_policy_query_failure_stops_the_first_snapshot() -> None:
-    from gentoo_install.errors import ConfigError
+def test_an_unreadable_keyserver_policy_leaves_it_unset() -> None:
+    """`portageq` cannot answer before this operation has fetched a snapshot:
+    `repos.conf` names `/var/db/repos/gentoo` and nothing has created it, so it
+    exits 1. Treating that as a fault stopped every install at step 21 of 51.
+    """
     from gentoo_install.plan.operations import CommandOutput
     from gentoo_install.plan import portage as plan_portage
     from .recorder import Recorder
 
     def answer(argv: Sequence[str]) -> str | None:
         if tuple(argv[:3]) == ("portageq", "envvar", "PORTAGE_GPG_KEY_SERVER"):
-            return CommandOutput("query failed\n", 1)
+            return CommandOutput(
+                "!!! Invalid Repository Location (not a dir): '/var/db/repos/gentoo'\n", 1
+            )
         return None
 
     recorder = Recorder(answering=answer)
-    with pytest.raises(ConfigError, match="keyserver policy"):
-        plan_portage.WebrsyncRepository().apply(recorder)
-    assert not any(command[-1] == "emerge-webrsync" for command in recorder.in_target)
+    plan_portage.WebrsyncRepository().apply(recorder)
+    assert ("emerge-webrsync",) in recorder.in_target
+    assert not any(command[0] == "env" for command in recorder.in_target)
 
 
 def test_a_pinned_package_reaches_usepkg_exclude_without_its_version() -> None:


### PR DESCRIPTION
`WebrsyncRepository` queries `portageq envvar PORTAGE_GPG_KEY_SERVER` before it fetches the first snapshot, so `repos.conf` still names a `/var/db/repos/gentoo` that nothing has created and portageq exits 1 with `Invalid Repository Location`. `#236` read that exit status as a configuration fault, so every real install stopped at step 21 of 51; no unit test could see it because the query is answered by a recorder.

An unreadable policy now means no override, which is what Portage's own default does and what `#236` set out to preserve. The test that asserted the raise is replaced by one holding portageq's actual output.

The vm-btrfs guest that found this is in `lab/c17-btrfs`.