### PR TITLE
vm: move the overlay to the region a campaign rewrites

### DIFF
--- a/gentoo_install/model/mirrors.py
+++ b/gentoo_install/model/mirrors.py
@@ -247,6 +247,21 @@ def gentoozh(chosen: GentooZhMirror) -> Site:
     return _GENTOOZH[chosen]
 
 
+#: Which gentoo-zh site each Gentoo mirror region reaches fastest. Separate
+#: tables because the two repositories do not share a mirror set, and a
+#: machine choosing Chinese Gentoo mirrors cloning the overlay from GitHub is
+#: what this pairing exists to prevent.
+_GENTOOZH_BY_REGION: Final[dict[MirrorRegion, GentooZhMirror]] = {
+    MirrorRegion.CN: GentooZhMirror.CERNET,
+    MirrorRegion.GLOBAL: GentooZhMirror.UPSTREAM,
+}
+
+
+def gentoozh_for(region: MirrorRegion) -> GentooZhMirror:
+    """The gentoo-zh site that suits a Gentoo mirror region."""
+    return _GENTOOZH_BY_REGION[region]
+
+
 def gentoozh_binhost(
     chosen: GentooZhMirror, subarch: str = "x86-64", unstable: bool = False
 ) -> str:

--- a/tests/unit/test_harness.py
+++ b/tests/unit/test_harness.py
@@ -1492,3 +1492,22 @@ def test_a_console_that_keeps_printing_is_not_ended_by_the_ceiling() -> None:
         quiet.expect("MARK_1_DONE", timeout=1.0, idle=0.2)
     waited = clock.monotonic() - started
     assert waited < 0.6, f"silence ended it at {waited:.2f}s, not at the ceiling"
+
+
+def test_a_cn_run_clones_the_overlay_from_a_chinese_mirror(tmp_path: Path) -> None:
+    """github never connects from inside a cluster guest, and an overlay clone
+    that fails stops the whole install rather than degrading."""
+    from gentoo_install.model.config import MirrorRegion, Sync
+    from gentoo_install.exec.config import load
+    from tests.vm import cluster
+
+    source = Path(__file__).resolve().parents[1] / "fixtures" / "vm-zfs.toml"
+    assert "github.com" in load(source).portage.overlays[0].sync_uri
+    job = cluster.Job(name="vm-zfs", fixture=source)
+    written = cluster.rewrite_fixtures(
+        [job], tmp_path / "fixtures", MirrorRegion.CN, Sync.RSYNC
+    )
+    moved = load(written / source.name)
+    overlay = next(one for one in moved.portage.overlays if one.name == "gentoo-zh")
+    assert "github.com" not in overlay.sync_uri
+    assert overlay.sync_uri.startswith("https://mirrors.cernet.edu.cn/")

--- a/tests/vm/cluster.py
+++ b/tests/vm/cluster.py
@@ -47,6 +47,7 @@ from gentoo_install.model.device import (
     ZfsPool,
 )
 from gentoo_install.model.config import MirrorRegion, Sync
+from gentoo_install.model import mirrors
 from gentoo_install.exec.config import load
 from gentoo_install.model.serialise import to_toml
 from .console import (
@@ -818,12 +819,26 @@ def rewrite_fixtures(
     into.mkdir(parents=True, exist_ok=True)
     for job in jobs:
         config = load(job.fixture)
+        # The overlay moves with the region. A `cn` run that still cloned
+        # gentoo-zh from github stopped the install after two hundred seconds
+        # of `Could not connect to server`, while every other fetch in the same
+        # guest came from a Chinese mirror and worked.
+        chosen = mirrors.gentoozh_for(region)
+        where = mirrors.gentoozh(chosen).git
         moved = replace(
             config,
             portage=replace(
                 config.portage,
                 sync=sync,
-                mirrors=replace(config.portage.mirrors, region=region),
+                mirrors=replace(
+                    config.portage.mirrors, region=region, gentoo_zh=chosen
+                ),
+                overlays=tuple(
+                    replace(overlay, sync_uri=where)
+                    if overlay.name == "gentoo-zh"
+                    else overlay
+                    for overlay in config.portage.overlays
+                ),
             ),
         )
         (into / job.fixture.name).write_text(to_toml(moved))


### PR DESCRIPTION
`rewrite_fixtures` moved `portage.mirrors.region` but left each overlay's `sync_uri` as the fixture wrote it, so a `--region cn` run still cloned gentoo-zh from GitHub. The guest network reaches Chinese mirrors and not GitHub — the function's own docstring records that — so the clone spent 134 seconds failing and `emerge --sync gentoo-zh` exited 1, which stops the install outright.

The TUI already derives the overlay URI from `mirrors.gentoo_zh`; only the harness lagged. `model/mirrors.py` now pairs each region with the gentoo-zh site that suits it, in the one table that owns mirrors.

Found by `vm-zfs-encrypted` in `lab/run-c23`; the same cause failed an earlier run at `eee19ca2b`.