### PR TITLE
model: separate runtime storage facts from the configuration

### DIFF
--- a/gentoo_install/cli.py
+++ b/gentoo_install/cli.py
@@ -24,8 +24,9 @@ from .errors import GentooInstallError
 from .data import load_catalog
 from .exec import fetch, preflight, report
 from .exec.apply import Machine, already_degraded, apply, completed
-from .exec.probe import Probe, with_probed_facts
+from .exec.probe import Probe, probe_storage_facts
 from .exec.runner import Runner
+from .model.device import StorageFacts
 from .model.size import Size
 from .tui import app, screens
 from .tui.curses_screen import CursesScreen, too_small
@@ -166,15 +167,20 @@ def main(argv: Sequence[str] | None = None) -> int:
             return EXIT_OK
         if _needs_network(arguments):
             _require_mirror(config, arguments.mirror)
+        storage_facts = StorageFacts()
         if not arguments.dry_run:
             # Before the plan is derived, because `build` validates: a reused
-            # esp on an array carries its metadata version only after the
-            # machine has been asked for it. Not on a dry run, which is meant
-            # to answer on a machine that has none of the hardware.
-            config = with_probed_facts(
+            # esp needs runtime metadata. A dry run remains independent of the
+            # selected hardware.
+            storage_facts = probe_storage_facts(
                 config, Probe(runner=Runner(log=lambda line: None), work=arguments.work)
             )
-        operations = build(config, load_catalog(), mirror=arguments.mirror)
+        operations = build(
+            config,
+            load_catalog(),
+            mirror=arguments.mirror,
+            storage_facts=storage_facts,
+        )
         if arguments.dry_run:
             print(render(operations), end="")
             print(summarise(operations))

--- a/gentoo_install/exec/probe.py
+++ b/gentoo_install/exec/probe.py
@@ -14,13 +14,23 @@ import platform
 import re
 import shutil
 import time
-from dataclasses import dataclass, field, replace
+from dataclasses import dataclass, field
 from pathlib import Path
 from typing import ClassVar, Final, Iterable, Mapping
 
 from ..errors import CommandFailed, DeviceNotFound
 from ..model.config import InstallConfig
-from ..model.device import DeviceGraph, DeviceId, Existing, Extent, PartitionTable
+from ..model.device import (
+    DeviceGraph,
+    DeviceId,
+    Existing,
+    Extent,
+    MdraidMetadataFact,
+    MdraidMetadataState,
+    PartitionTable,
+    RaidMetadata,
+    StorageFacts,
+)
 from ..model.validate import KernelCeiling, ProbedProfile, parse_profile_list
 from .runner import Runner
 
@@ -447,27 +457,28 @@ class Probe:
         has6 = any(address is not None and address not in _ULA_V6 for address in addresses6)
         return has4, has6
 
-    def mdraid_metadata(self, selector: str) -> str:
+    def mdraid_metadata(self, selector: str) -> MdraidMetadataFact:
         """The metadata version an array already on the machine carries.
 
-        Empty when the device is not an array. The model cannot read a
-        superblock, so a reused RAID1 esp met no compatibility rule at all
-        until this was injected before validation, although firmware cannot
-        read a member whose superblock sits at the start.
+        A missing command or unreadable device is unavailable, which differs
+        from mdadm establishing that the device is not an array.
         """
         try:
             said = self.runner.run(["mdadm", "--detail", "--export", selector], check=False)
         except (CommandFailed, OSError):
-            # A medium without mdadm says nothing about a superblock, and that
-            # is not a reason to stop: the array rule simply does not fire.
-            return ""
+            return MdraidMetadataState.UNAVAILABLE
         if said.returncode != 0:
-            return ""
+            if "does not appear to be an md device" in said.stdout:
+                return MdraidMetadataState.ABSENT
+            return MdraidMetadataState.UNAVAILABLE
         for line in said.stdout.splitlines():
             name, _, value = line.partition("=")
             if name.strip() == "MD_METADATA" and value.strip():
-                return value.strip()
-        return ""
+                try:
+                    return RaidMetadata(value.strip())
+                except ValueError:
+                    return MdraidMetadataState.UNAVAILABLE
+        return MdraidMetadataState.UNAVAILABLE
 
     def free_extents(self, disk: str) -> tuple[Extent, ...]:
         """Where the disk has no partition now, in bytes.
@@ -960,29 +971,14 @@ def _carried_timezones() -> tuple[str, ...]:
     return ("UTC", *(line for line in said.split() if "/" in line))
 
 
-def with_probed_facts(config: InstallConfig, probe: Probe) -> InstallConfig:
-    """Fill in what only the machine can say, before anything validates it.
-
-    The model stays parseable without the hardware, so a reused device carries
-    a selector and nothing else. Its mdraid metadata is read here: a reused
-    RAID1 esp with a superblock at the start met no compatibility rule at all
-    without it, and firmware cannot read such a member.
-    """
+def probe_storage_facts(config: InstallConfig, probe: Probe) -> StorageFacts:
+    """Read runtime storage evidence once for validation and plan derivation."""
     graph = config.disk.graph
-    reused = [one for one in graph.of_type(Existing) if one.mdraid_metadata is None]
-    known = {one.id: probe.mdraid_metadata(one.selector) for one in reused}
+    metadata = {
+        one.id: probe.mdraid_metadata(one.selector) for one in graph.of_type(Existing)
+    }
     free = _free_extents(graph, probe)
-    if not known and not free:
-        return config
-    nodes = [
-        replace(one, mdraid_metadata=known[one.id])
-        if isinstance(one, Existing) and one.id in known
-        else replace(one, free_extents=free[one.id])
-        if isinstance(one, PartitionTable) and one.id in free
-        else one
-        for one in graph.nodes.values()
-    ]
-    return replace(config, disk=replace(config.disk, graph=DeviceGraph.build(nodes)))
+    return StorageFacts(mdraid_metadata=metadata, free_extents=free)
 
 
 def _free_extents(graph: DeviceGraph, probe: Probe) -> dict[DeviceId, tuple[Extent, ...]]:
@@ -995,7 +991,7 @@ def _free_extents(graph: DeviceGraph, probe: Probe) -> dict[DeviceId, tuple[Exte
     """
     found: dict[DeviceId, tuple[Extent, ...]] = {}
     for table in graph.of_type(PartitionTable):
-        if table.create or table.free_extents:
+        if table.create:
             continue
         disk = graph.nodes.get(table.disk)
         if not isinstance(disk, Existing):

--- a/gentoo_install/model/compat.py
+++ b/gentoo_install/model/compat.py
@@ -23,11 +23,9 @@ from .config import (
     KernelSource,
 )
 from .device import (
-    Existing,
-    RaidMetadata,
-    T,
     DeviceGraph,
     DeviceId,
+    Existing,
     Filesystem,
     FilesystemType,
     Luks,
@@ -37,7 +35,10 @@ from .device import (
     Partition,
     PartitionRole,
     PartitionTable,
+    RaidMetadata,
+    StorageFacts,
     Swap,
+    T,
     TableType,
     VolumeGroup,
     ZfsDataset,
@@ -266,8 +267,11 @@ RULES: tuple[Rule, ...] = (
 )
 
 
-def traits_of(config: InstallConfig) -> frozenset[Trait]:
+def traits_of(
+    config: InstallConfig, storage_facts: StorageFacts | None = None
+) -> frozenset[Trait]:
     graph = config.disk.graph
+    facts = storage_facts if storage_facts is not None else StorageFacts()
     found: set[Trait] = set()
 
     if not _password_can_authenticate(config.system.root_password_hash):
@@ -337,15 +341,15 @@ def traits_of(config: InstallConfig) -> frozenset[Trait]:
     # A reused array is `Existing` and carries no `MdRaid` node, so the loop
     # above never sees it, and `_on_esp` cannot answer for it either: that
     # reads what a device is built from, and a reused array is built from
-    # nothing this model knows. The evidence is above it instead — the esp
-    # mount is what stands on it. The probe writes the metadata version.
+    # nothing this model knows. Runtime facts identify the assembled array.
     mounted = esp_mount(graph)
     beneath = {node.id for node in _chain(graph, mounted.id)} if mounted else set()
     for reused in graph.of_type(Existing):
-        if not reused.mdraid_metadata or reused.id not in beneath:
+        metadata = facts.metadata_for(reused.id)
+        if not isinstance(metadata, RaidMetadata) or reused.id not in beneath:
             continue
         found.add(Trait.ESP_ON_MDRAID)
-        if RaidMetadata(reused.mdraid_metadata).superblock_at_start:
+        if metadata.superblock_at_start:
             found.add(Trait.ESP_MDRAID_SUPERBLOCK_AT_START)
 
     for table in _nodes_under(graph, config.disk.root, PartitionTable):
@@ -390,8 +394,10 @@ def _password_can_authenticate(password_hash: str) -> bool:
     return bool(_MODULAR_CRYPT.fullmatch(password_hash) or _DES_CRYPT.fullmatch(password_hash))
 
 
-def violations(config: InstallConfig) -> tuple[Rule, ...]:
-    present = traits_of(config)
+def violations(
+    config: InstallConfig, storage_facts: StorageFacts | None = None
+) -> tuple[Rule, ...]:
+    present = traits_of(config, storage_facts)
     return tuple(rule for rule in RULES if rule.when in present and rule.excludes in present)
 
 

--- a/gentoo_install/model/device.py
+++ b/gentoo_install/model/device.py
@@ -79,6 +79,16 @@ class RaidMetadata(Enum):
         return self in (RaidMetadata.V1_1, RaidMetadata.V1_2)
 
 
+class MdraidMetadataState(Enum):
+    """Why a reused device has no mdraid metadata version."""
+
+    UNAVAILABLE = "unavailable"
+    ABSENT = "absent"
+
+
+MdraidMetadataFact = RaidMetadata | MdraidMetadataState
+
+
 class FilesystemType(Enum):
     EXT2 = "ext2"
     EXT3 = "ext3"
@@ -111,9 +121,6 @@ class Existing(Node):
 
     selector: str
     wipe: bool = False
-    #: None until probed and empty when no array was found, so compatibility
-    #: can distinguish missing evidence from a machine with no superblock.
-    mdraid_metadata: str | None = None
 
 
 @dataclass(frozen=True)
@@ -128,6 +135,28 @@ class Extent:
         return self.end - self.start + 1
 
 
+@dataclass(frozen=True, init=False)
+class StorageFacts:
+    """Runtime storage evidence, separate from persistent user intent."""
+
+    mdraid_metadata: Mapping[DeviceId, MdraidMetadataFact]
+    free_extents: Mapping[DeviceId, tuple[Extent, ...]]
+
+    def __init__(
+        self,
+        *,
+        mdraid_metadata: Mapping[DeviceId, MdraidMetadataFact] | None = None,
+        free_extents: Mapping[DeviceId, tuple[Extent, ...]] | None = None,
+    ) -> None:
+        object.__setattr__(
+            self, "mdraid_metadata", MappingProxyType(dict(mdraid_metadata or {}))
+        )
+        object.__setattr__(self, "free_extents", MappingProxyType(dict(free_extents or {})))
+
+    def metadata_for(self, device: DeviceId) -> MdraidMetadataFact:
+        return self.mdraid_metadata.get(device, MdraidMetadataState.UNAVAILABLE)
+
+
 @dataclass(frozen=True)
 class PartitionTable(Node):
     disk: DeviceId
@@ -140,12 +169,6 @@ class PartitionTable(Node):
     #: is an edit to the table, so it belongs to the table and not to a node of
     #: its own: the partition it names stops existing.
     remove: tuple[int, ...] = ()
-    #: Where the disk has no partition now, in bytes, filled in by the probe
-    #: before validation. Empty for a table written from scratch, and empty in
-    #: a configuration file: the model cannot read a partition table, and
-    #: without this an added partition on an edited table was placed at 1MiB
-    #: on top of one the operator kept.
-    free_extents: tuple[Extent, ...] = ()
 
     @property
     def inputs(self) -> tuple[DeviceId, ...]:

--- a/gentoo_install/model/serialise.py
+++ b/gentoo_install/model/serialise.py
@@ -56,12 +56,6 @@ KINDS: Final[dict[type[Node], str]] = {
 #: one case: the node discriminator already claims `kind`.
 RENAMED: Final[dict[tuple[type[Node], str], str]] = {(Filesystem, "kind"): "type"}
 
-#: Probe-only facts stay available to planning and compatibility but are omitted
-#: here because the parser accepts only operator-authored configuration.
-PROBED_FIELDS: Final[frozenset[tuple[type[Node], str]]] = frozenset(
-    {(Existing, "mdraid_metadata"), (PartitionTable, "free_extents")}
-)
-
 #: Fields whose value is replaced when the configuration is published. A crypt
 #: hash is not the password, but it is what an offline attack starts from, and
 #: the pastebin is a public address.
@@ -154,8 +148,6 @@ def _disk(config: InstallConfig) -> list[str]:
             raise KeyError(f"{type(node).__name__} has no kind to write it as")
         lines += ["", "[[disk.devices]]", f'kind = "{kind}"']
         for field in fields(node):
-            if (type(node), field.name) in PROBED_FIELDS:
-                continue
             held = getattr(node, field.name)
             if held is None:
                 continue

--- a/gentoo_install/model/validate.py
+++ b/gentoo_install/model/validate.py
@@ -29,6 +29,7 @@ from .device import (
     Node,
     Partition,
     PartitionTable,
+    StorageFacts,
     TableType,
     ZfsPool,
     ZfsTopology,
@@ -147,6 +148,7 @@ class _ConfiguredAddressFacts:
 def validate(
     config: InstallConfig,
     *,
+    storage_facts: StorageFacts | None = None,
     available_profiles: Collection[str] | None | _ProfilesNotRead = _PROFILES_NOT_READ,
     zfs_kernel_max: str | None | _ZfsKernelCeilingNotChecked = (
         _ZFS_KERNEL_CEILING_NOT_CHECKED
@@ -168,7 +170,7 @@ def validate(
         *_unlock_problems(config, address_facts.remote_unlock),
         *_locale_problems(config),
         *_l10n_problems(config),
-        *(rule.describe() for rule in compat.violations(config)),
+        *(rule.describe() for rule in compat.violations(config, storage_facts)),
     ]
     if problems:
         raise ValidationFailed(

--- a/gentoo_install/plan/build.py
+++ b/gentoo_install/plan/build.py
@@ -12,6 +12,7 @@ from typing import Final, Sequence
 
 from ..model import mirrors
 from ..model.config import InstallConfig
+from ..model.device import StorageFacts
 from ..model.validate import validate
 from . import bootloader, disk, fonts, kernel, packages, portage, system
 from .operations import Operation, Stage
@@ -64,11 +65,18 @@ def stage3_mirror(config: InstallConfig, fallback: str = DEFAULT_MIRROR) -> str:
     return offered[0].distfiles if offered else fallback
 
 
-def build(config: InstallConfig, catalog: packages.Catalog, *, mirror: str = DEFAULT_MIRROR) -> tuple[Operation, ...]:
+def build(
+    config: InstallConfig,
+    catalog: packages.Catalog,
+    *,
+    mirror: str = DEFAULT_MIRROR,
+    storage_facts: StorageFacts | None = None,
+) -> tuple[Operation, ...]:
     """Validate, then derive the whole install. Nothing here touches a machine."""
-    validate(config)
+    facts = storage_facts if storage_facts is not None else StorageFacts()
+    validate(config, storage_facts=facts)
     operations: list[Operation] = [
-        *disk.build(config),
+        *disk.build(config, facts),
         *portage.build(
             config,
             stage3_mirror(config, mirror),

--- a/gentoo_install/plan/disk.py
+++ b/gentoo_install/plan/disk.py
@@ -18,6 +18,7 @@ from ..model.device import (
     DeviceGraph,
     DeviceId,
     Existing,
+    Extent,
     Filesystem,
     FilesystemType,
     LogicalVolume,
@@ -30,6 +31,7 @@ from ..model.device import (
     PartitionTable,
     RaidLevel,
     RaidMetadata,
+    StorageFacts,
     Subvolume,
     Swap,
     T,
@@ -875,14 +877,17 @@ def finish(config: InstallConfig) -> list[Operation]:
     ]
 
 
-def build(config: InstallConfig) -> list[Operation]:
+def build(
+    config: InstallConfig, storage_facts: StorageFacts | None = None
+) -> list[Operation]:
     graph = config.disk.graph
+    facts = storage_facts if storage_facts is not None else StorageFacts()
     operations: list[Operation] = [
         ReleaseTarget(steps=_teardown(graph))
     ]
     mounts: list[Operation] = []
     for node in topological(graph):
-        for operation in _operations_for(graph, node):
+        for operation in _operations_for(graph, node, facts):
             (mounts if operation.stage is Stage.MOUNT else operations).append(operation)
     mounts += [_mount_operation(mount) for mount in resolve_mounts(graph)]
     for disk in _disks_with_partitions(graph):
@@ -965,7 +970,9 @@ def _disks_with_partitions(graph: DeviceGraph) -> tuple[DeviceId, ...]:
     return tuple(sorted(disks))
 
 
-def _operations_for(graph: DeviceGraph, node: Node) -> list[Operation]:
+def _operations_for(
+    graph: DeviceGraph, node: Node, storage_facts: StorageFacts
+) -> list[Operation]:
     if isinstance(node, Existing):
         return [WipeSignatures(device=node.id)] if node.wipe else []
     if isinstance(node, PartitionTable):
@@ -989,7 +996,7 @@ def _operations_for(graph: DeviceGraph, node: Node) -> list[Operation]:
                 role=node.role,
                 size=node.size,
                 label=node.label,
-                start=_start_of(graph, node),
+                start=_start_of(graph, node, storage_facts),
             ),
         ]
     if isinstance(node, MdRaid):
@@ -1079,7 +1086,9 @@ def _dataset_mountpoint(graph: DeviceGraph, dataset: DeviceId) -> PurePosixPath 
     return None
 
 
-def _start_of(graph: DeviceGraph, partition: Partition) -> Size:
+def _start_of(
+    graph: DeviceGraph, partition: Partition, storage_facts: StorageFacts
+) -> Size:
     """Where an MBR partition begins.
 
     On a table written from scratch, after every partition with a lower index.
@@ -1092,8 +1101,10 @@ def _start_of(graph: DeviceGraph, partition: Partition) -> Size:
     the removals in the same plan had already been committed.
     """
     table = graph[partition.table]
-    if isinstance(table, PartitionTable) and table.free_extents:
-        return _into_free_space(graph, table, partition)
+    if isinstance(table, PartitionTable) and table.id in storage_facts.free_extents:
+        return _into_free_space(
+            graph, table, partition, storage_facts.free_extents[table.id]
+        )
     start = FIRST_OFFSET
     for sibling in sorted(graph.of_type(Partition), key=lambda node: node.index):
         if sibling.table != partition.table or sibling.index >= partition.index:
@@ -1104,7 +1115,12 @@ def _start_of(graph: DeviceGraph, partition: Partition) -> Size:
     return start
 
 
-def _into_free_space(graph: DeviceGraph, table: PartitionTable, partition: Partition) -> Size:
+def _into_free_space(
+    graph: DeviceGraph,
+    table: PartitionTable,
+    partition: Partition,
+    free_extents: tuple[Extent, ...],
+) -> Size:
     """The first free extent with room for this partition and the ones before it.
 
     Every added partition of one table is placed in extent order, so two of
@@ -1115,9 +1131,9 @@ def _into_free_space(graph: DeviceGraph, table: PartitionTable, partition: Parti
         for one in sorted(graph.of_type(Partition), key=lambda node: node.index)
         if one.table == table.id
     ]
-    cursor = {extent.start: Size(extent.start).align_up() for extent in table.free_extents}
+    cursor = {extent.start: Size(extent.start).align_up() for extent in free_extents}
     for one in added:
-        for extent in table.free_extents:
+        for extent in free_extents:
             at = cursor[extent.start]
             wanted = one.size.bytes if one.size is not None else 0
             if at.bytes + wanted > extent.end + 1:

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -15,6 +15,7 @@ from gentoo_install.exec import report
 from gentoo_install.exec.runner import Runner
 from gentoo_install.cli import EXIT_CONFIG, EXIT_INTEGRITY, EXIT_OK, EXIT_PREFLIGHT, main
 from gentoo_install.errors import ConfigError, IntegrityError
+from gentoo_install.model.device import StorageFacts
 from gentoo_install.plan.build import DEFAULT_MIRROR
 from gentoo_install.exec.config import load
 
@@ -672,11 +673,13 @@ def test_a_finish_failure_releases_the_machine_and_keeps_its_exit_code(
     monkeypatch.setattr(cli, "_require_root", lambda arguments: None)
     monkeypatch.setattr(cli, "_needs_network", lambda arguments: False)
     monkeypatch.setattr(cli, "load", lambda path: config())
-    monkeypatch.setattr(cli, "with_probed_facts", lambda chosen, probe: chosen)
+    monkeypatch.setattr(
+        cli, "probe_storage_facts", lambda chosen, probe: StorageFacts()
+    )
     monkeypatch.setattr(
         cli,
         "build",
-        lambda chosen, catalog, mirror: (
+        lambda chosen, catalog, *, mirror, storage_facts: (
             Partition(),
             FailFinish(),
             FailRelease(),
@@ -722,8 +725,14 @@ def test_a_failure_after_partitioning_says_the_disk_may_not_boot(
     monkeypatch.setattr(cli, "_require_root", lambda arguments: None)
     monkeypatch.setattr(cli, "_needs_network", lambda arguments: False)
     monkeypatch.setattr(cli, "load", lambda path: config())
-    monkeypatch.setattr(cli, "with_probed_facts", lambda chosen, probe: chosen)
-    monkeypatch.setattr(cli, "build", lambda chosen, catalog, mirror: (FailPartition(),))
+    monkeypatch.setattr(
+        cli, "probe_storage_facts", lambda chosen, probe: StorageFacts()
+    )
+    monkeypatch.setattr(
+        cli,
+        "build",
+        lambda chosen, catalog, *, mirror, storage_facts: (FailPartition(),),
+    )
     monkeypatch.setattr(report, "keep_log", lambda work, target, record: None)
 
     code = main(
@@ -794,11 +803,16 @@ def test_a_body_failure_before_partitioning_says_nothing_was_written(
     monkeypatch.setattr(cli, "_require_root", lambda arguments: None)
     monkeypatch.setattr(cli, "_needs_network", lambda arguments: False)
     monkeypatch.setattr(cli, "load", lambda path: config())
-    monkeypatch.setattr(cli, "with_probed_facts", lambda chosen, probe: chosen)
+    monkeypatch.setattr(
+        cli, "probe_storage_facts", lambda chosen, probe: StorageFacts()
+    )
     monkeypatch.setattr(
         cli,
         "build",
-        lambda chosen, catalog, mirror: (FailBeforePartition(), Partition()),
+        lambda chosen, catalog, *, mirror, storage_facts: (
+            FailBeforePartition(),
+            Partition(),
+        ),
     )
     monkeypatch.setattr(report, "keep_log", lambda work, target, record: None)
 

--- a/tests/unit/test_compat.py
+++ b/tests/unit/test_compat.py
@@ -33,6 +33,7 @@ from gentoo_install.model.device import (
     LogicalVolume,
     Luks,
     MdRaid,
+    MdraidMetadataState,
     Mountpoint,
     Node,
     Partition,
@@ -40,6 +41,7 @@ from gentoo_install.model.device import (
     PartitionTable,
     RaidLevel,
     RaidMetadata,
+    StorageFacts,
     Swap,
     TableType,
     VolumeGroup,
@@ -617,11 +619,11 @@ def test_a_separate_vfat_boot_is_still_readable() -> None:
     )
 
 
-def reused_esp(metadata: str) -> list[Node]:
+def reused_esp() -> list[Node]:
     """An esp on an array already assembled on the machine.
 
-    `Existing` and nothing else: the model cannot read a superblock, so the
-    version is injected by the probe before validation.
+    `Existing` and nothing else: runtime facts, not the graph, describe its
+    superblock.
     """
     nodes: list[Node] = [
         node
@@ -629,7 +631,7 @@ def reused_esp(metadata: str) -> list[Node]:
         if node.id not in {i("espfs"), i("mnt-esp"), i("esp")}
     ]
     nodes += [
-        Existing(id=i("esp"), selector="/dev/md0", mdraid_metadata=metadata),
+        Existing(id=i("esp"), selector="/dev/md0"),
         Filesystem(id=i("espfs"), device=i("esp"), kind=FilesystemType.VFAT),
         Mountpoint(id=i("mnt-esp"), source=i("espfs"), path=PurePosixPath("/efi")),
     ]
@@ -641,13 +643,27 @@ def test_a_reused_array_under_the_esp_meets_the_firmware_rule() -> None:
     `Existing` and carries nothing, so a RAID1 esp with metadata 1.1 or 1.2
     met no rule at all although firmware cannot read a member whose superblock
     sits at the start."""
-    at_start = traits_of(config(reused_esp("1.2")))
-    at_end = traits_of(config(reused_esp("1.0")))
+    installation = config(reused_esp())
+    at_start = traits_of(
+        installation,
+        StorageFacts(mdraid_metadata={i("esp"): RaidMetadata.V1_2}),
+    )
+    at_end = traits_of(
+        installation,
+        StorageFacts(mdraid_metadata={i("esp"): RaidMetadata.V1_0}),
+    )
+    absent = traits_of(
+        installation,
+        StorageFacts(mdraid_metadata={i("esp"): MdraidMetadataState.ABSENT}),
+    )
+    unavailable = traits_of(installation, StorageFacts())
 
     assert Trait.ESP_ON_MDRAID in at_start
     assert Trait.ESP_MDRAID_SUPERBLOCK_AT_START in at_start
     assert Trait.ESP_ON_MDRAID in at_end
     assert Trait.ESP_MDRAID_SUPERBLOCK_AT_START not in at_end
+    assert Trait.ESP_ON_MDRAID not in absent
+    assert Trait.ESP_ON_MDRAID not in unavailable
 
 
 def test_a_mirror_with_no_ipv6_is_refused_on_an_ipv6_only_machine() -> None:

--- a/tests/unit/test_exec.py
+++ b/tests/unit/test_exec.py
@@ -1744,24 +1744,25 @@ def _probe_answering(tmp_path: Path, stdout: str, returncode: int) -> Probe:
 def test_the_metadata_of_a_real_array_is_read_from_what_mdadm_prints(
     tmp_path: Path,
 ) -> None:
-    """Every test built `Existing(mdraid_metadata="1.2")` by hand, so the parse
-    and the exit-code check had never run. A reused RAID1 esp whose superblock
-    sits at the start meets no compatibility rule when this answers empty, and
-    firmware cannot read such a member."""
-    read = _probe_answering(tmp_path, MDADM_EXPORT, 0)
-    assert read.mdraid_metadata("/dev/md/sample") == "1.2"
+    """Keep unavailable, absent, and present probe results distinct."""
+    from gentoo_install.model.device import MdraidMetadataState, RaidMetadata
 
-    # Not an array: nothing in what it printed names a metadata version.
+    read = _probe_answering(tmp_path, MDADM_EXPORT, 0)
+    assert read.mdraid_metadata("/dev/md/sample") is RaidMetadata.V1_2
+
     plain = _probe_answering(tmp_path, MDADM_NOT_AN_ARRAY, 1)
-    assert plain.mdraid_metadata("/dev/vda") == ""
+    assert plain.mdraid_metadata("/dev/vda") is MdraidMetadataState.ABSENT
+
+    missing = _probe_answering(tmp_path, "mdadm is not installed\n", 127)
+    assert missing.mdraid_metadata("/dev/vda") is MdraidMetadataState.UNAVAILABLE
 
 
 def test_a_probed_array_reaches_the_rule_that_refuses_it(tmp_path: Path) -> None:
-    """`with_probed_facts` had no test at all, so the graph rebuild between the
-    probe and the validator was unexercised."""
+    """One facts value reaches compatibility without changing configuration."""
+    import tomllib
     from pathlib import PurePosixPath
 
-    from gentoo_install.exec.probe import with_probed_facts
+    from gentoo_install.exec.probe import probe_storage_facts
     from gentoo_install.model import compat
     from gentoo_install.model.config import DiskConfig
     from gentoo_install.model.device import (
@@ -1770,7 +1771,10 @@ def test_a_probed_array_reaches_the_rule_that_refuses_it(tmp_path: Path) -> None
         Filesystem,
         FilesystemType,
         Mountpoint,
+        RaidMetadata,
     )
+    from gentoo_install.model.parse import parse
+    from gentoo_install.model.serialise import to_toml
 
     nodes = [
         Existing(id=DeviceId("array"), selector="/dev/md/esp", wipe=False),
@@ -1785,18 +1789,21 @@ def test_a_probed_array_reaches_the_rule_that_refuses_it(tmp_path: Path) -> None
     before = replace(
         config(), disk=DiskConfig(graph=DeviceGraph.build(nodes), root=DeviceId("mnt-esp"))
     )
-    assert not [one.mdraid_metadata for one in before.disk.graph.of_type(Existing) if one.mdraid_metadata]
+    written = to_toml(before)
 
-    after = with_probed_facts(before, _probe_answering(tmp_path, MDADM_EXPORT, 0))
-    said = [one.mdraid_metadata for one in after.disk.graph.of_type(Existing)]
-    assert said == ["1.2"], said
-    assert compat.Trait.ESP_MDRAID_SUPERBLOCK_AT_START in compat.traits_of(after)
+    facts = probe_storage_facts(before, _probe_answering(tmp_path, MDADM_EXPORT, 0))
+    assert facts.metadata_for(DeviceId("array")) is RaidMetadata.V1_2
+    assert to_toml(before) == written
+    assert parse(tomllib.loads(written)) == before
+    assert compat.Trait.ESP_MDRAID_SUPERBLOCK_AT_START in compat.traits_of(before, facts)
 
     # 1.0 keeps the superblock at the end, which firmware can read past.
-    older = with_probed_facts(
+    older = probe_storage_facts(
         before, _probe_answering(tmp_path, MDADM_EXPORT.replace("1.2", "1.0"), 0)
     )
-    assert compat.Trait.ESP_MDRAID_SUPERBLOCK_AT_START not in compat.traits_of(older)
+    assert compat.Trait.ESP_MDRAID_SUPERBLOCK_AT_START not in compat.traits_of(
+        before, older
+    )
 
 
 def test_a_command_that_is_not_installed_answers_when_failure_is_an_answer() -> None:

--- a/tests/unit/test_plan_disk.py
+++ b/tests/unit/test_plan_disk.py
@@ -26,6 +26,7 @@ from gentoo_install.model.device import (
     PartitionTable,
     RaidLevel,
     RaidMetadata,
+    StorageFacts,
     Subvolume,
     Swap,
     TableType,
@@ -569,7 +570,7 @@ PARTED_PRINT_FREE: str = """BYT;
 """
 
 
-def _edited_mbr(free: tuple[Extent, ...], size: Size | None = None) -> DeviceGraph:
+def _edited_mbr(size: Size | None = None) -> DeviceGraph:
     """One retained partition on the disk, one added by the configuration."""
     from pathlib import PurePosixPath
 
@@ -581,7 +582,6 @@ def _edited_mbr(free: tuple[Extent, ...], size: Size | None = None) -> DeviceGra
                 disk=DeviceId("d"),
                 table=TableType.MBR,
                 create=False,
-                free_extents=free,
             ),
             Partition(
                 id=DeviceId("new"),
@@ -621,9 +621,10 @@ def test_a_partition_added_to_an_edited_mbr_goes_after_the_ones_on_the_disk() ->
     free = read.free_extents("/dev/null")
     assert free == (Extent(start=16384, end=1048575), Extent(start=1074790400, end=4294967295)), free
 
-    graph = _edited_mbr(free)
+    graph = _edited_mbr()
+    facts = StorageFacts(free_extents={DeviceId("t"): free})
     added = next(one for one in graph.of_type(Partition) if one.id == DeviceId("new"))
-    start = _start_of(graph, added)
+    start = _start_of(graph, added, facts)
     # The retained partition ends at 1074790399, so anything at or below it
     # overlaps what the operator kept.
     assert start.bytes > 1074790399, start
@@ -636,22 +637,56 @@ def test_a_partition_that_fits_no_free_extent_is_refused_before_anything_runs() 
     from gentoo_install.errors import InvalidLayout
     from gentoo_install.plan.disk import _start_of
 
-    graph = _edited_mbr((Extent(start=1048576, end=2097151),), size=Size(4 * 1024**3))
+    graph = _edited_mbr(size=Size(4 * 1024**3))
+    facts = StorageFacts(
+        free_extents={DeviceId("t"): (Extent(start=1048576, end=2097151),)}
+    )
     added = next(one for one in graph.of_type(Partition) if one.id == DeviceId("new"))
     with pytest.raises(InvalidLayout):
-        _start_of(graph, added)
+        _start_of(graph, added, facts)
 
 
 def test_a_table_written_from_scratch_still_starts_at_the_first_offset() -> None:
-    """`free_extents` is empty for a new table, and `sgdisk --new=N:0` finds
-    the room itself on GPT, so nothing about that path changes."""
+    """A new table needs no runtime extents; sgdisk finds GPT space itself."""
     from gentoo_install.plan.disk import FIRST_OFFSET, _start_of
 
     graph = DeviceGraph.build(ext4_on_gpt())
     first = next(
         one for one in graph.of_type(Partition) if one.index == 1
     )
-    assert _start_of(graph, first) == FIRST_OFFSET
+    assert _start_of(graph, first, StorageFacts()) == FIRST_OFFSET
+
+
+def test_the_whole_plan_passes_one_facts_value_to_validation_and_disk_derivation(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from gentoo_install.data import load_catalog
+    from gentoo_install.model.config import InstallConfig
+    from gentoo_install.plan import build as plan_build
+    from gentoo_install.plan import disk as plan_disk
+    from gentoo_install.plan.operations import Operation
+
+    seen: list[StorageFacts] = []
+
+    def validated(
+        installation: InstallConfig, *, storage_facts: StorageFacts
+    ) -> None:
+        seen.append(storage_facts)
+
+    def disk_operations(
+        installation: InstallConfig, storage_facts: StorageFacts
+    ) -> list[Operation]:
+        seen.append(storage_facts)
+        return []
+
+    monkeypatch.setattr(plan_build, "validate", validated)
+    monkeypatch.setattr(plan_disk, "build", disk_operations)
+    facts = StorageFacts()
+
+    plan_build.build(config(ext4_on_gpt()), load_catalog(), storage_facts=facts)
+
+    assert len(seen) == 2
+    assert seen[0] is facts and seen[1] is facts
 
 
 def test_a_pool_still_busy_after_the_lazy_unmount_is_exported_on_a_later_try(

--- a/tests/unit/test_serialise.py
+++ b/tests/unit/test_serialise.py
@@ -24,14 +24,9 @@ def test_every_fixture_survives_a_round_trip(path: Path) -> None:
     assert _round_trip(config) == config
 
 
-def test_probed_facts_are_not_written_as_configuration() -> None:
-    config = parse(tomllib.loads((FIXTURES / "vm-mdraid.toml").read_text()))
-    nodes = [
-        replace(node, mdraid_metadata="1.0") if isinstance(node, Existing) else node
-        for node in config.disk.graph.nodes.values()
-    ]
-    probed = replace(config, disk=replace(config.disk, graph=DeviceGraph.build(nodes)))
-    assert _round_trip(probed) == config
+def test_runtime_storage_facts_are_not_configuration_fields() -> None:
+    assert "mdraid_metadata" not in {field.name for field in fields(Existing)}
+    assert "free_extents" not in {field.name for field in fields(PartitionTable)}
 
 
 def test_every_node_kind_can_be_written() -> None:


### PR DESCRIPTION
Facts a running machine reports were carried in the same model as the configuration the operator wrote, so a value read from a disk and a value the operator chose were indistinguishable once stored.

Verified on the cluster: `vm-btrfs` installed, rebooted and passed the installed-system checks in 28.7 minutes at this revision.

Closes C01.