### PR TITLE
tui, plan, vm: withdraw stale consents, resolve groups once, isolate driver images

### DIFF
--- a/gentoo_install/plan/build.py
+++ b/gentoo_install/plan/build.py
@@ -75,19 +75,20 @@ def build(
     """Validate, then derive the whole install. Nothing here touches a machine."""
     facts = storage_facts if storage_facts is not None else StorageFacts()
     validate(config, storage_facts=facts)
+    chosen = packages.groups(config, catalog)
     operations: list[Operation] = [
         *disk.build(config, facts),
         *portage.build(
             config,
             stage3_mirror(config, mirror),
-            packages.required_use(config, catalog),
-            packages.required_video_cards(config, catalog),
-            packages.required_licenses(config, catalog),
+            packages._required_use(chosen),
+            packages._required_video_cards(config, chosen),
+            packages._required_licenses(config, chosen),
         ),
         *system.build(config),
         *kernel.build(config),
         *bootloader.build(config),
-        *packages.build(config, catalog),
+        *packages._build(config, catalog, chosen),
         *fonts.build(config, catalog),
         *portage.finish(config),
         # Last of all: the keyword change above still has to reach make.conf in

--- a/gentoo_install/plan/packages.py
+++ b/gentoo_install/plan/packages.py
@@ -23,7 +23,7 @@ from typing import Final, Mapping, Protocol, Sequence, runtime_checkable
 from ..errors import CommandFailed, ConfigError, ValidationFailed
 from ..model.config import InitSystem, InstallConfig
 from .operations import Context, Operation, Stage
-from .portage import Emerge
+from .portage import Emerge, PortageConfigKind, WritePortageConfig
 from .system import CONSOLE_FONTS, EnableService
 
 
@@ -426,42 +426,38 @@ KWIN_DEFAULTS: Final[PurePosixPath] = PurePosixPath("/etc/xdg/kwinrc")
 SKELETON: Final[PurePosixPath] = PurePosixPath("/etc/skel")
 
 
-@dataclass(frozen=True, kw_only=True)
-class WriteGroupKeywords(Operation):
+@dataclass(frozen=True, kw_only=True, init=False)
+class WriteGroupKeywords(WritePortageConfig):
     """Written in the portage phase, for the same reason as the USE flags."""
 
-    stage: Stage = Stage.PORTAGE
-    group: str
-    lines: tuple[str, ...]
+    def __init__(self, *, group: str, lines: tuple[str, ...]) -> None:
+        object.__setattr__(self, "kind", PortageConfigKind.KEYWORDS)
+        object.__setattr__(self, "name", group)
+        object.__setattr__(self, "lines", lines)
+
+    @property
+    def group(self) -> str:
+        return self.name
 
     def describe(self) -> str:
         return f"accept {'; '.join(self.lines)} for the {self.group} group"
 
-    def apply(self, context: Context) -> None:
-        context.write(
-            PurePosixPath(f"/etc/portage/package.accept_keywords/{self.group}"),
-            "".join(f"{line}\n" for line in self.lines),
-        )
-
-
-@dataclass(frozen=True, kw_only=True)
-class WriteGroupUse(Operation):
+@dataclass(frozen=True, kw_only=True, init=False)
+class WriteGroupUse(WritePortageConfig):
     """Written in the portage phase: the flags have to be set before the
     packages that need them are merged."""
 
-    stage: Stage = Stage.PORTAGE
-    group: str
-    lines: tuple[str, ...]
+    def __init__(self, *, group: str, lines: tuple[str, ...]) -> None:
+        object.__setattr__(self, "kind", PortageConfigKind.USE)
+        object.__setattr__(self, "name", group)
+        object.__setattr__(self, "lines", lines)
+
+    @property
+    def group(self) -> str:
+        return self.name
 
     def describe(self) -> str:
         return f"ask for {'; '.join(self.lines)} for the {self.group} group"
-
-    def apply(self, context: Context) -> None:
-        context.write(
-            PurePosixPath(f"/etc/portage/package.use/{self.group}"),
-            "".join(f"{line}\n" for line in self.lines),
-        )
-
 
 @dataclass(frozen=True, kw_only=True)
 class EnableUserUnits(Operation):
@@ -854,6 +850,12 @@ def _group_file_operations(
 
 def build(config: InstallConfig, catalog: Catalog) -> list[Operation]:
     chosen = groups(config, catalog)
+    return _build(config, catalog, chosen)
+
+
+def _build(
+    config: InstallConfig, catalog: Catalog, chosen: tuple[Group, ...]
+) -> list[Operation]:
     _check_repositories(config, chosen)
     conflict = _framework_conflict(chosen) or _driver_conflict(config, chosen)
     if conflict:
@@ -1013,8 +1015,12 @@ def _required_user_groups(chosen: tuple[Group, ...]) -> tuple[str, ...]:
 
 
 def required_use(config: InstallConfig, catalog: Catalog) -> tuple[str, ...]:
+    return _required_use(groups(config, catalog))
+
+
+def _required_use(chosen: Sequence[Group]) -> tuple[str, ...]:
     wanted: list[str] = []
-    for group in groups(config, catalog):
+    for group in chosen:
         for flag in group.use:
             if flag not in wanted:
                 wanted.append(flag)
@@ -1022,9 +1028,13 @@ def required_use(config: InstallConfig, catalog: Catalog) -> tuple[str, ...]:
 
 
 def required_video_cards(config: InstallConfig, catalog: Catalog) -> tuple[str, ...]:
+    return _required_video_cards(config, groups(config, catalog))
+
+
+def _required_video_cards(config: InstallConfig, chosen: Sequence[Group]) -> tuple[str, ...]:
     """What the configuration asks for, then what a driver group adds."""
     wanted = list(config.portage.video_cards)
-    for group in groups(config, catalog):
+    for group in chosen:
         for card in group.video_cards:
             if card not in wanted:
                 wanted.append(card)
@@ -1137,9 +1147,13 @@ def _display_manager(name: str, packages: Sequence[str], init: InitSystem) -> li
 
 
 def required_licenses(config: InstallConfig, catalog: Catalog) -> tuple[str, ...]:
+    return _required_licenses(config, groups(config, catalog))
+
+
+def _required_licenses(config: InstallConfig, chosen: Sequence[Group]) -> tuple[str, ...]:
     """What the configuration accepts, widened by what a chosen group needs."""
     wanted = list(config.portage.accept_license)
-    for group in groups(config, catalog):
+    for group in chosen:
         for licence in group.accept_license:
             if licence not in wanted:
                 wanted.append(licence)

--- a/gentoo_install/plan/portage.py
+++ b/gentoo_install/plan/portage.py
@@ -182,6 +182,33 @@ class WriteMakeConf(Operation):
         context.write(PurePosixPath("/etc/portage/make.conf"), merge(existing, wanted))
 
 
+class PortageConfigKind(Enum):
+    USE = "package.use"
+    KEYWORDS = "package.accept_keywords"
+    LICENSE = "package.license"
+    UNMASK = "package.unmask"
+
+
+@dataclass(frozen=True, kw_only=True)
+class WritePortageConfig(Operation):
+    """Write one named Portage configuration fragment."""
+
+    stage: Stage = Stage.PORTAGE
+    kind: PortageConfigKind
+    name: str
+    lines: tuple[str, ...]
+
+    @property
+    def path(self) -> PurePosixPath:
+        return PurePosixPath(f"/etc/portage/{self.kind.value}/{self.name}")
+
+    def describe(self) -> str:
+        return f"write {self.path}"
+
+    def apply(self, context: Context) -> None:
+        context.write(self.path, "".join(f"{line}\n" for line in self.lines))
+
+
 def merge(existing: str, wanted: Sequence[tuple[str, str]]) -> str:
     """Replace the keys this installer sets and keep the rest of the file.
 

--- a/gentoo_install/tui/screens.py
+++ b/gentoo_install/tui/screens.py
@@ -1475,6 +1475,8 @@ def desktop_screen(screen: Screen, config: InstallConfig, context: Context) -> A
         return Answer(answer.outcome)
     desktop = answer.unwrap()
     changed = replace(config, packages=replace(config.packages, desktop=desktop))
+    if desktop != config.packages.desktop:
+        changed = _set_input_configuration(changed, context.groups, None)
     if not _profile_was_chosen(config, context.groups):
         # Only while the profile is still the one the last desktop implied.
         # Overwriting it regardless threw away a profile the operator had
@@ -2555,10 +2557,10 @@ def locale_screen(screen: Screen, config: InstallConfig, context: Context) -> An
     generated = config.system.locales
     if chosen not in generated:
         generated = (*generated, chosen)
-    return Answer(
-        Outcome.CHOSE,
-        replace(config, system=replace(config.system, locale=chosen, locales=generated)),
-    )
+    changed = replace(config, system=replace(config.system, locale=chosen, locales=generated))
+    if CjkFontconfigLocale.selected(chosen) is None:
+        changed = _set_font_configuration(changed, context.groups, None)
+    return Answer(Outcome.CHOSE, changed)
 
 
 def additional_locales_screen(
@@ -2689,7 +2691,19 @@ def encryption_screen(screen: Screen, config: InstallConfig, context: Context) -
     )
     if edited.chosen:
         context.choice = replace(context.choice, passphrase_file=edited.unwrap())
-    return edited.map(lambda _: _rebuild(config, context))
+    def rebuilt(_: str) -> InstallConfig:
+        changed = _rebuild(config, context)
+        if not context.choice.passphrase_file:
+            changed = replace(
+                changed,
+                kernel=replace(
+                    changed.kernel,
+                    remote_unlock=replace(changed.kernel.remote_unlock, enabled=False),
+                ),
+            )
+        return changed
+
+    return edited.map(rebuilt)
 
 
 def _edit_passphrase(
@@ -4730,9 +4744,18 @@ def authorized_keys_screen(
             keys.pop(-chosen - 1)
             continue
         if chosen == 3:
+            changed_keys = tuple(keys)
+            if not changed_keys:
+                config = replace(
+                    config,
+                    kernel=replace(
+                        config.kernel,
+                        remote_unlock=replace(config.kernel.remote_unlock, enabled=False),
+                    ),
+                )
             return Answer(
                 Outcome.CHOSE,
-                replace(config, system=replace(config.system, authorized_keys=tuple(keys))),
+                replace(config, system=replace(config.system, authorized_keys=changed_keys)),
             )
         added = _ADD_A_KEY[chosen](screen, context)
         if added:

--- a/tests/unit/test_harness.py
+++ b/tests/unit/test_harness.py
@@ -752,6 +752,26 @@ def test_driver_identity_changes_with_the_packaged_bytes(tmp_path: Path) -> None
     assert first != second
 
 
+def test_campaign_driver_paths_are_content_addressed(tmp_path: Path) -> None:
+    """Two revisions retain separate images in one campaign work directory."""
+    from tests.vm.cluster import retain_driver
+    from tests.vm.driver import remote_name
+
+    first = tmp_path / "first.iso"
+    second = tmp_path / "second.iso"
+    first.write_bytes(b"revision-a")
+    second.write_bytes(b"revision-b")
+
+    first_path = retain_driver(tmp_path, first)
+    second_path = retain_driver(tmp_path, second)
+
+    assert first_path != second_path
+    assert first_path.name == remote_name(first_path)
+    assert second_path.name == remote_name(second_path)
+    assert first_path.read_bytes() == b"revision-a"
+    assert second_path.read_bytes() == b"revision-b"
+
+
 def test_a_revisionless_success_is_not_counted_as_passed(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:

--- a/tests/unit/test_plan_portage.py
+++ b/tests/unit/test_plan_portage.py
@@ -62,6 +62,18 @@ def test_stage3_is_unpacked_with_xattrs_because_capabilities_would_be_lost() -> 
     assert "--preserve-permissions" in argv
 
 
+def test_named_portage_fragments_share_one_path_and_writer() -> None:
+    operation = portage.WritePortageConfig(
+        kind=portage.PortageConfigKind.USE,
+        name="example",
+        lines=("app-misc/example foo",),
+    )
+    recorder = Recorder()
+    operation.apply(recorder)
+    assert operation.path == PurePosixPath("/etc/portage/package.use/example")
+    assert recorder.files[operation.path] == "app-misc/example foo\n"
+
+
 def test_the_chroot_gets_proc_rbinds_and_a_slave_run() -> None:
     recorder = apply_all(config())
     mounts = recorder.argv_starting("mount")

--- a/tests/unit/test_tui_app.py
+++ b/tests/unit/test_tui_app.py
@@ -2152,6 +2152,39 @@ def test_remote_unlock_is_offered_once_both_hold() -> None:
     assert "Unlock the root over SSH" in "\n".join(screen.frames[0])
 
 
+def test_disabling_encryption_withdraws_remote_unlock_consent() -> None:
+    at = context()
+    wanted = replace(
+        config(encrypted_root()),
+        kernel=replace(config().kernel, remote_unlock=replace(config().kernel.remote_unlock, enabled=True)),
+        system=replace(config().system, authorized_keys=(GOOD_KEY,)),
+    )
+    answer = screens.encryption_screen(FakeScreen(keys=["KEY_UP", "\n"]), wanted, at)
+    assert not answer.unwrap().kernel.remote_unlock.enabled
+
+
+def test_changing_desktop_withdraws_input_configuration_consent() -> None:
+    at = context()
+    groups = screens.configuration_groups(at.groups)
+    wanted = replace(config(), packages=replace(config().packages, desktop="plasma", applications=(*groups,)))
+    answer = screens.desktop_screen(FakeScreen(keys=["KEY_UP", "\n", "\n"], lines=30), wanted, at)
+    applications = answer.unwrap().packages.applications
+    assert groups[2] not in applications and groups[3] not in applications
+
+
+def test_changing_to_non_cjk_locale_withdraws_font_consent() -> None:
+    at = context()
+    groups = screens.configuration_groups(at.groups)
+    wanted = replace(
+        config(),
+        system=replace(config().system, locale="zh_CN.UTF-8"),
+        packages=replace(config().packages, applications=(*groups,)),
+    )
+    answer = screens.locale_screen(FakeScreen(keys=["KEY_DOWN", "\n"]), wanted, at)
+    applications = answer.unwrap().packages.applications
+    assert groups[0] not in applications and groups[1] not in applications
+
+
 def test_the_main_menu_reads_the_same_precondition_the_nested_one_does() -> None:
     """`nested()` consults `Setting.unavailable` when drawing and again before
     dispatching; the top-level loop read it in neither place, so every fix that

--- a/tests/vm/cluster.py
+++ b/tests/vm/cluster.py
@@ -933,6 +933,14 @@ def revision_identity(driver: Path) -> str:
     return f"{described} dirty={changed} driver-sha256={driver_digest(driver)}"
 
 
+def retain_driver(workdir: Path, built: Path) -> Path:
+    """Move a completed driver to its content-derived campaign path."""
+    target = workdir / remote_name(built)
+    if built != target:
+        built.replace(target)
+    return target
+
+
 def trusted_revision(identity: str) -> bool:
     """Whether an outcome identifies a clean tree or an explicit test identity."""
     dirty = re.search(r"(?:^| )dirty=(\d+)(?: |$)", identity)
@@ -1308,13 +1316,15 @@ def run(
     workdir.mkdir(parents=True, exist_ok=True)
     reconcile(api, workdir)
     # Packed: the ingress refuses the 1.4 MiB loose-file CD with `413`.
-    driver_path = build_driver(
-        workdir / "driver.iso",
+    staging = workdir / f".driver-{uuid.uuid4().hex}.iso"
+    built_path = build_driver(
+        staging,
         packed=True,
         fixtures=rewrite_fixtures(jobs, workdir / "fixtures", region, sync),
     )
+    driver_path = retain_driver(workdir, built_path)
+    driver = driver_path.name
     revision = revision_identity(driver_path)
-    driver = remote_name(driver_path)
     medium, urls, medium_sha512 = current_minimal()
     prepared: set[str] = set()
     done: queue.Queue[Outcome] = queue.Queue()


### PR DESCRIPTION
A consent is the operator's answer to a question. Remote unlock stayed enabled after encryption was switched off, and the input and font consents survived the desktop or locale change that raised them, so a stored answer described a configuration that no longer existed.

`plan.build()` resolved the package groups in each of four phases, so one configuration was resolved four times and a catalog change could reach one phase and not another.

Two campaigns sharing a work directory wrote the same `driver.iso`, so each measured a revision it had not built.

Closes D15, D16, D17, C16, H03.