### PR TITLE
vm: wait for a drawn TUI screen rather than a command echo

### DIFF
--- a/tests/unit/test_harness.py
+++ b/tests/unit/test_harness.py
@@ -1151,6 +1151,64 @@ def test_the_walk_does_not_escape_out_of_a_row_that_never_opened(
     class Console:
         def __init__(self) -> None:
             self.sent: list[str] = []
+            self.snapshots = 0
+
+        def run(self, line: str, timeout: float = 0.0) -> str:
+            return ""
+
+        def send_raw(self, keys: str) -> None:
+            self.sent.append(keys)
+
+        def snapshot(self, seconds: float) -> bytes:
+            self.snapshots += 1
+            if self.snapshots % 2:
+                return (
+                    b"\x1b[2J\x1b[1;1Hgentoo-install"
+                    b"\x1b[3;3Hstorage"
+                    b"\x1b[24;1H[enter] Continue"
+                )
+            # Different redraw bytes, but the same stable screen: Enter did
+            # not open the row and Escape must therefore stay unsent.
+            return (
+                b"\x1b[2Jgentoo-install"
+                b"\x1b[2B\r  storage"
+                b"\x1b[21B\r[enter] Continue"
+            )
+
+    import time as clock
+
+    monkeypatch.setattr(clock, "sleep", lambda seconds: None)
+    monkeypatch.setattr(tui, "_ROWS", 3)
+    console = Console()
+    seen = tui.walk(cast("Any", console), "en")
+
+    assert "\x1b" not in console.sent, console.sent
+    assert any("opened nothing" in one.what for one in seen.findings), seen.findings
+
+
+def test_the_walk_waits_for_a_drawn_menu_after_the_echoed_launch_command(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The launch command already contains the program name. It is not a
+    screen, so navigation must wait until curses has drawn the menu."""
+    from typing import Any, cast
+
+    from tests.vm import tui
+
+    menu = (
+        b"\x1b[2J\x1b[1;1Hgentoo-install"
+        b"\x1b[3;3Hstorage"
+        b"\x1b[24;1H[enter] Continue"
+    )
+    launch = (
+        "cd /tmp/driver && TERM=vt220 LINES=24 COLUMNS=80 "
+        "python3 -m gentoo_install --lang en\n"
+    )
+
+    class Console:
+        def __init__(self) -> None:
+            self.sent: list[str] = []
+            self.snapshots = 0
             self.asked = 0
 
         def run(self, line: str, timeout: float = 0.0) -> str:
@@ -1161,22 +1219,55 @@ def test_the_walk_does_not_escape_out_of_a_row_that_never_opened(
 
         def expect(self, pattern: str, timeout: float, idle: float = 0.0) -> bytes:
             self.asked += 1
-            return b"gentoo-install"
+            return b"python3 -m gentoo_install # gentoo-install\r\n"
 
         def snapshot(self, seconds: float) -> bytes:
-            # The same screen every time: the row never opens.
-            return b"gentoo-install\r\nstorage\r\n"
+            self.snapshots += 1
+            if self.snapshots <= 2:
+                assert self.sent == [launch], "navigation reached the echoed command"
+            if self.snapshots == 1:
+                return b"python3 -m gentoo_install # gentoo-install\r\n"
+            return menu
 
     import time as clock
 
     monkeypatch.setattr(clock, "sleep", lambda seconds: None)
-    monkeypatch.setattr(tui, "_ROWS", 3)
+    monkeypatch.setattr(tui, "_ROWS", 1)
     console = Console()
-    seen = tui.walk(cast("Any", console), "en")
+    tui.walk(cast("Any", console), "en")
 
-    assert console.asked == 1, "the menu is waited for, not slept through"
-    assert "\x1b" not in console.sent, console.sent
-    assert any("opened nothing" in one.what for one in seen.findings), seen.findings
+    assert console.snapshots >= 4
+    assert console.asked == 0, "readiness fell back to echoed console text"
+    assert console.sent[:3] == [launch, "\x1b[B", "\x1b[A"]
+
+
+def test_menu_readiness_keeps_one_deadline_and_reports_the_last_screen(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    import time as clock
+    from typing import Any, cast
+
+    from tests.vm import tui
+    from tests.vm.console import ConsoleTimeout
+
+    class Console:
+        def __init__(self) -> None:
+            self.windows: list[float] = []
+
+        def snapshot(self, seconds: float) -> bytes:
+            self.windows.append(seconds)
+            return b"still only the echoed gentoo-install command"
+
+    moments = iter((10.0, 10.0, 12.5, 13.0))
+    monkeypatch.setattr(tui, "MENU_PATIENCE", 3.0)
+    monkeypatch.setattr(clock, "monotonic", lambda: next(moments))
+    console = Console()
+
+    with pytest.raises(ConsoleTimeout, match="last rendered state") as refused:
+        tui._wait_for_menu(cast("Any", console))
+
+    assert console.windows == [2.0, 0.5]
+    assert "still only the echoed gentoo-install command" in str(refused.value)
 
 
 def test_a_screen_is_replayed_into_a_grid_rather_than_flattened() -> None:

--- a/tests/vm/tui.py
+++ b/tests/vm/tui.py
@@ -22,7 +22,7 @@ from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Final
 
-from .console import SerialConsole
+from .console import ConsoleTimeout, SerialConsole
 from .driver import build as build_driver
 from .run import create_target
 from .media import MEDIA
@@ -120,6 +120,43 @@ def rendered(said: bytes) -> list[str]:
     return ["".join(line).rstrip() for line in grid]
 
 
+@dataclass(frozen=True)
+class ScreenState:
+    """The small part of terminal state the walk needs to make safe choices.
+
+    Keeping replay behind this boundary lets the pending stateful VT work
+    replace `rendered()` without spreading terminal parsing into the walk.
+    """
+
+    lines: tuple[str, ...]
+
+    @classmethod
+    def replay(cls, said: bytes) -> ScreenState:
+        return cls(tuple(rendered(said)))
+
+    @property
+    def title(self) -> str:
+        return self.lines[0] if self.lines else ""
+
+    @property
+    def drawn(self) -> bool:
+        """Whether this has the geometry every curses menu screen draws."""
+        return bool(
+            len(self.lines) == LINES
+            and self.title
+            and any(line.strip() for line in self.lines[1:-1])
+            and self.lines[-1].strip()
+        )
+
+    @property
+    def main_menu(self) -> bool:
+        return self.drawn and self.title == "gentoo-install"
+
+    def opened_from(self, previous: ScreenState) -> bool:
+        """Whether Enter replaced the main menu with a complete row screen."""
+        return previous.main_menu and self.drawn and self.title != previous.title
+
+
 @dataclass
 class Finding:
     where: str
@@ -151,6 +188,21 @@ def cells(line: str) -> int:
 MENU_PATIENCE: Final[float] = 180.0
 
 
+def _wait_for_menu(console: SerialConsole) -> ScreenState:
+    deadline = time.monotonic() + MENU_PATIENCE
+    last = ScreenState(())
+    while True:
+        remaining = deadline - time.monotonic()
+        if remaining <= 0:
+            break
+        last = ScreenState.replay(console.snapshot(min(REDRAW_SECONDS, remaining)))
+        if last.main_menu:
+            return last
+    raise ConsoleTimeout(
+        f"menu was not drawn before timeout; last rendered state was {last.lines!r}"
+    )
+
+
 def _open_menu(console: SerialConsole, lang: str) -> None:
     console.run("mkdir -p /mnt/driver")
     console.run("mountpoint -q /mnt/driver || mount -o ro /dev/sr1 /mnt/driver")
@@ -172,15 +224,14 @@ def walk(console: SerialConsole, lang: str) -> Walk:
     # a timer had them land on the shell, and the escape that followed reached
     # the main menu, where escape means leave. The recording then held one
     # screen and the review of it reported nothing.
-    console.expect(r"gentoo-install", timeout=MENU_PATIENCE)
-    console.snapshot(REDRAW_SECONDS)
+    _wait_for_menu(console)
     console.send_raw("\x1b[B")
     time.sleep(0.5)
     console.send_raw("\x1b[A")
     time.sleep(0.5)
     for step in range(_ROWS):
-        drawn = rendered(console.snapshot(REDRAW_SECONDS))
-        body = [line for line in drawn if line.strip()]
+        drawn = ScreenState.replay(console.snapshot(REDRAW_SECONDS))
+        body = [line for line in drawn.lines if line.strip()]
         if not body:
             seen.note(f"row {step}", "the row drew nothing")
         else:
@@ -191,14 +242,14 @@ def walk(console: SerialConsole, lang: str) -> Walk:
         # Enter opens the row, then escape leaves it, then down moves on.
         console.send_raw("\r")
         time.sleep(1.0)
-        opened = rendered(console.snapshot(REDRAW_SECONDS))
-        for line in opened:
+        opened = ScreenState.replay(console.snapshot(REDRAW_SECONDS))
+        for line in opened.lines:
             if cells(line) > COLUMNS:
                 seen.note(f"row {step} opened", f"{cells(line)} cells: {line!r}")
         # Only when the row actually opened. Escape on the main menu leaves the
         # installer, so sending it after a press that opened nothing ends the
         # walk on its first row.
-        if opened != drawn:
+        if opened.opened_from(drawn):
             console.send_raw("\x1b")
             time.sleep(0.5)
         else:


### PR DESCRIPTION
The harness accepted the echo of the command that starts the interface as evidence that curses had finished drawing, and treated any difference between raw frames as a row transition, so a TUI assertion could pass against a screen that was still being painted.

Verified on the cluster: `vm-xfs` installed, rebooted and passed the installed-system checks in 30.1 minutes at this revision.

Closes H10.