### PR TITLE
tui: make the ZFS pool own its passphrase

### DIFF
--- a/gentoo_install/model/manual.py
+++ b/gentoo_install/model/manual.py
@@ -160,7 +160,7 @@ class Slice:
     mountpoint: str = ""
     label: str = ""
     #: A path on the installing system, never the passphrase. Non-empty puts
-    #: LUKS between the partition and its filesystem, or encrypts the pool.
+    #: LUKS between the partition and its filesystem.
     passphrase_file: str = ""
     status: SliceStatus = SliceStatus.CREATE
     #: The path `exec/probe.py` listed, for a row that is already on the disk.
@@ -238,6 +238,9 @@ class Layout:
     array: Array = field(default_factory=Array)
     #: The pool every slice marked as a pool member joins, on any disk.
     pool: str = "rpool"
+    #: A path on the installing system, never the passphrase. Non-empty
+    #: encrypts the pool.
+    passphrase_file: str = ""
     #: How those members are joined. Only asked once more than one is marked:
     #: a single member has nothing to mirror.
     topology: ZfsTopology = ZfsTopology.STRIPE
@@ -413,7 +416,6 @@ def build(layout: Layout) -> tuple[DeviceGraph, DeviceId]:
     members: list[DeviceId] = []
     #: Pool members with a mount point, each with the id prefix of its disk.
     datasets: list[tuple[str, Slice]] = []
-    pool_passphrase = ""
     for position, disk in enumerate(layout.disks, start=1):
         prefix = f"disk{position}"
         nodes += _table_nodes(disk, prefix)
@@ -439,7 +441,6 @@ def build(layout: Layout) -> tuple[DeviceGraph, DeviceId]:
                 # The pool encrypts its own datasets, so a member is never
                 # wrapped in LUKS as well.
                 vdevs.append(part)
-                pool_passphrase = pool_passphrase or entry.passphrase_file
                 if entry.mountpoint:
                     datasets.append((prefix, entry))
                 continue
@@ -499,8 +500,8 @@ def build(layout: Layout) -> tuple[DeviceGraph, DeviceId]:
                 vdevs=tuple(vdevs),
                 name=layout.pool,
                 topology=layout.topology,
-                encrypted=bool(pool_passphrase),
-                passphrase_file=pool_passphrase,
+                encrypted=bool(layout.passphrase_file),
+                passphrase_file=layout.passphrase_file,
             )
         )
         for prefix, entry in datasets:

--- a/gentoo_install/tui/screens.py
+++ b/gentoo_install/tui/screens.py
@@ -3464,6 +3464,7 @@ class _RowKind(Enum):
     ADD_PARTITION = "add-partition"
     ADD_DISK = "add-disk"
     TOPOLOGY = "topology"
+    POOL_ENCRYPTION = "pool-encryption"
     ARRAY = "array"
     DONE = "done"
 
@@ -3581,6 +3582,14 @@ def _partition_rows(context: Context) -> list[Item[_Row]]:
             ),
         )
     )
+    if pool:
+        items.append(
+            Item(
+                label=f"ZFS {translate('Encryption')}",
+                value=_Row(_RowKind.POOL_ENCRYPTION),
+                detail=translate("on") if context.layout.passphrase_file else translate("off"),
+            )
+        )
     array = len(_array_members(context))
     items.append(
         Item(
@@ -3608,6 +3617,9 @@ def _act_on(screen: Screen, context: Context, row: _Row) -> None:
         picked = _pool_topology(screen, context, len(_pool_members(context)))
         if picked is not None:
             context.layout.topology = picked
+        return
+    if row.kind is _RowKind.POOL_ENCRYPTION:
+        _edit_pool_encryption(screen, context)
         return
     if row.kind is _RowKind.ARRAY:
         _edit_array(screen, context)
@@ -3911,6 +3923,18 @@ def _pool_topology(
     return answer.unwrap() if answer.chosen else None
 
 
+def _edit_pool_encryption(screen: Screen, context: Context) -> Answer[str]:
+    edited = _edit_passphrase(
+        screen,
+        context,
+        context.layout.passphrase_file,
+        context.translate("Encrypt the pool?"),
+    )
+    if edited.chosen:
+        context.layout.passphrase_file = edited.unwrap()
+    return edited
+
+
 def _layout_problem(context: Context, config: InstallConfig) -> str:
     """What the validator says about the table as it stands."""
     try:
@@ -4002,18 +4026,23 @@ def _slice_fields(
             ),
         ),
         Item(label=translate("Label"), value=_LABEL, detail=entry.label or "-"),
-        Item(
-            label=translate("Encryption"),
-            value=_ENCRYPTION,
-            detail=translate("on") if entry.passphrase_file else translate("off"),
-            # Refused here rather than at the Install row: firmware reads the
-            # esp itself and cannot open a container, so the layout never boots
-            # and there is no reason to let it be built one partition at a time.
-            disabled_because=(
-                translate("firmware cannot open a container to read the esp")
-                if purpose.role is PartitionRole.ESP
-                else ""
-            ),
+        *(
+            [
+                Item(
+                    label=translate("Encryption"),
+                    value=_ENCRYPTION,
+                    detail=translate("on") if entry.passphrase_file else translate("off"),
+                    # Firmware reads the esp itself and cannot open a container,
+                    # so an encrypted esp never boots.
+                    disabled_because=(
+                        translate("firmware cannot open a container to read the esp")
+                        if purpose.role is PartitionRole.ESP
+                        else ""
+                    ),
+                )
+            ]
+            if purpose.role is not PartitionRole.ZFS
+            else []
         ),
         Item(
             label=translate("What happens to it"),
@@ -4158,6 +4187,7 @@ def _apply_purpose(entry: manual.Slice, purpose: manual.Purpose) -> manual.Slice
         role=purpose.role,
         filesystem=entry.filesystem if purpose.chooses_filesystem else purpose.filesystem,
         mountpoint=entry.mountpoint if purpose.asks_mountpoint else purpose.mountpoint,
+        passphrase_file=("" if purpose.role is PartitionRole.ZFS else entry.passphrase_file),
     )
 
 
@@ -4169,11 +4199,7 @@ def _edit_slice_encryption(
         screen,
         context,
         entry.passphrase_file,
-        (
-            translate("Encrypt the pool?")
-            if purpose.role is PartitionRole.ZFS
-            else translate("Encrypt this partition?")
-        ),
+        translate("Encrypt this partition?"),
     ).map(lambda staged_path: replace(entry, passphrase_file=staged_path)).value
 
 

--- a/tests/unit/test_tui_app.py
+++ b/tests/unit/test_tui_app.py
@@ -447,6 +447,37 @@ def test_array_encryption_replaces_its_staged_passphrase_after_success() -> None
     assert STAGED == ["replacement"]
 
 
+@pytest.mark.parametrize(
+    ("leave", "outcome"),
+    [("KEY_BACKSPACE", Outcome.BACK), ("\x1b", Outcome.CANCELLED)],
+)
+def test_reopening_pool_encryption_preserves_its_passphrase_on_child_exit(
+    leave: str, outcome: Outcome,
+) -> None:
+    at = context()
+    at.layout.passphrase_file = "/run/keys/old"
+
+    answer = screens._edit_pool_encryption(FakeScreen(keys=["\n", leave]), at)
+
+    assert answer.outcome is outcome
+    assert at.layout.passphrase_file == "/run/keys/old"
+    assert STAGED == []
+
+
+def test_pool_encryption_replaces_its_staged_passphrase_after_success() -> None:
+    at = context()
+    at.layout.passphrase_file = "/run/keys/old"
+    typed = list("replacement")
+
+    answer = screens._edit_pool_encryption(
+        FakeScreen(keys=["\n", *typed, "\n", *typed, "\n"]), at
+    )
+
+    assert answer.outcome is Outcome.CHOSE
+    assert at.layout.passphrase_file == "/run/keys/tui"
+    assert STAGED == ["replacement"]
+
+
 def encrypted_partition() -> manual.Slice:
     return manual.Slice(
         index=1,

--- a/tests/unit/test_tui_partitions.py
+++ b/tests/unit/test_tui_partitions.py
@@ -226,7 +226,45 @@ def test_two_pool_members_make_one_pool() -> None:
     assert sorted(node.name for node in graph.of_type(ZfsDataset)) == ["ROOT/gentoo", "home"]
 
 
-def test_a_pool_member_is_never_wrapped_in_luks() -> None:
+@pytest.mark.parametrize(
+    ("reverse_disks", "reverse_rows"),
+    [(False, False), (True, False), (False, True), (True, True)],
+)
+def test_pool_encryption_comes_from_the_layout_for_every_member_order(
+    reverse_disks: bool, reverse_rows: bool
+) -> None:
+    disks = [
+        manual.Disk(
+            selector=f"/dev/vd{letter}",
+            slices=[
+                manual.Slice(
+                    index=index,
+                    role=PartitionRole.ZFS,
+                    size=None,
+                    mountpoint="/" if (letter, index) == ("a", 1) else "",
+                    passphrase_file=f"/run/keys/member-{letter}{index}",
+                )
+                for index in (1, 2)
+            ],
+        )
+        for letter in ("a", "b")
+    ]
+    if reverse_rows:
+        for disk in disks:
+            disk.slices = [replace(entry, index=3 - entry.index) for entry in disk.slices]
+    if reverse_disks:
+        disks.reverse()
+    layout = manual.Layout(disks=disks, passphrase_file="/run/keys/pool")
+
+    graph, _ = manual.build(layout)
+
+    pool = graph.of_type(ZfsPool)[0]
+    assert pool.passphrase_file == "/run/keys/pool"
+    assert pool.encrypted
+    assert len(pool.vdevs) == 4
+
+
+def test_pool_encryption_off_ignores_stale_member_passphrases() -> None:
     """The pool encrypts its own datasets; LUKS underneath as well would ask
     for two passphrases to reach one filesystem."""
     layout = one_disk(slices=[
@@ -237,7 +275,27 @@ def test_a_pool_member_is_never_wrapped_in_luks() -> None:
     ])
     graph, _ = manual.build(layout)
     assert not graph.of_type(Luks)
-    assert graph.of_type(ZfsPool)[0].encrypted
+    pool = graph.of_type(ZfsPool)[0]
+    assert not pool.encrypted
+    assert pool.passphrase_file == ""
+
+
+def test_partition_luks_remains_per_slice() -> None:
+    layout = one_disk(slices=[
+        manual.Slice(index=1, role=PartitionRole.DATA, size=Size.parse("30GiB"),
+                     filesystem=FilesystemType.EXT4, mountpoint="/",
+                     passphrase_file="/run/keys/root"),
+        manual.Slice(index=2, role=PartitionRole.DATA, size=None,
+                     filesystem=FilesystemType.XFS, mountpoint="/home",
+                     passphrase_file="/run/keys/home"),
+    ])
+
+    graph, _ = manual.build(layout)
+
+    assert [node.passphrase_file for node in graph.of_type(Luks)] == [
+        "/run/keys/root",
+        "/run/keys/home",
+    ]
 
 
 def test_every_field_of_a_partition_is_visible_with_its_value() -> None:
@@ -252,6 +310,41 @@ def test_every_field_of_a_partition_is_visible_with_its_value() -> None:
     assert shown["Filesystem"] == "ext4"
     assert shown["Mount point"] == "/"
     assert "Encryption" in shown and "Size" in shown and "Label" in shown
+
+
+def test_a_zfs_member_has_no_partition_encryption_field() -> None:
+    entry = manual.Slice(index=2, role=PartitionRole.ZFS, size=None, mountpoint="/")
+    fields = screens._slice_fields(entry, manual.purpose_of(entry), opened().translate)
+    assert "Encryption" not in {item.label for item in fields}
+
+
+def test_exactly_one_pool_encryption_row_is_shown_only_when_a_pool_exists() -> None:
+    at = opened()
+    assert not [item for item in screens._partition_rows(at) if item.label == "ZFS Encryption"]
+
+    at.layout = one_disk(
+        slices=[manual.Slice(index=1, role=PartitionRole.ZFS, size=None, mountpoint="/")]
+    )
+    at.layout.passphrase_file = "/run/keys/pool"
+    rows = [item for item in screens._partition_rows(at) if item.label == "ZFS Encryption"]
+
+    assert len(rows) == 1
+    assert rows[0].detail == "on"
+
+
+def test_changing_an_encrypted_partition_to_zfs_drops_its_luks_path() -> None:
+    entry = manual.Slice(
+        index=2,
+        role=PartitionRole.DATA,
+        size=None,
+        filesystem=FilesystemType.EXT4,
+        mountpoint="/",
+        passphrase_file="/run/keys/partition",
+    )
+
+    changed = screens._apply_purpose(entry, manual.purpose_for("zfs"))
+
+    assert changed.passphrase_file == ""
 
 
 def test_a_field_that_does_not_apply_says_why() -> None:


### PR DESCRIPTION
A pool's passphrase was stored on each member row and read back by taking the first non-empty one, so two members carrying different values produced a pool whose passphrase depended on the order the rows were built.

Verified on the cluster: `vm-zfs` installed, rebooted and passed the installed-system checks in 58.7 minutes at this revision.

Closes C04.