### PR TITLE
portage, boot, vm: degrade a failed binary fetch, cover every mirror member

### DIFF
--- a/gentoo_install/model/compat.py
+++ b/gentoo_install/model/compat.py
@@ -10,7 +10,7 @@ from __future__ import annotations
 
 import re
 from dataclasses import dataclass
-from typing import Callable
+from typing import Callable, Final
 from enum import Enum
 from pathlib import PurePosixPath
 
@@ -53,6 +53,39 @@ from .device import (
 #: CJK on gives a console with no CJK glyphs, which is what the option exists
 #: to provide.
 CJK_FONT_SIZES = frozenset({ConsoleFontSize.SIZE_8X16})
+
+_KERNEL_PACKAGES: Final[dict[KernelSource, str]] = {
+    KernelSource.DIST_BIN: "sys-kernel/gentoo-kernel-bin",
+    KernelSource.DIST_SOURCE: "sys-kernel/gentoo-kernel",
+    KernelSource.CJK_BIN: "sys-kernel/gentoo-cjk-kernel-bin",
+    KernelSource.CJK: "sys-kernel/gentoo-cjk-kernel",
+}
+_CJK_KERNEL_PACKAGES: Final[frozenset[str]] = frozenset(
+    {"sys-kernel/gentoo-cjk-kernel", "sys-kernel/gentoo-cjk-kernel-bin"}
+)
+
+
+BINHOST_SUBARCH_REQUIREMENTS: Final[dict[str, frozenset[str]]] = {
+    "x86-64": frozenset(),
+    "x86-64-v3": frozenset({"avx2", "bmi1", "bmi2", "f16c", "fma"}),
+}
+
+
+def binhost_subarch_problems(config: InstallConfig) -> tuple[str, ...]:
+    """Reject an official binary host whose instruction set the CPU lacks."""
+    binhost = config.portage.binhost
+    if not binhost.official:
+        return ()
+    required = BINHOST_SUBARCH_REQUIREMENTS.get(binhost.subarch)
+    if required is None:
+        return (f"official binhost subarch {binhost.subarch!r} is not supported",)
+    missing = sorted(required.difference(config.portage.cpu_flags))
+    if missing:
+        return (
+            f"official binhost subarch {binhost.subarch!r} needs CPU flags "
+            f"{', '.join(missing)}, which this machine does not provide",
+        )
+    return ()
 
 
 class FilesystemLabelUnit(Enum):
@@ -373,7 +406,11 @@ def traits_of(
             and _encrypted_pool(graph, config.disk.root)
         ):
             found.add(Trait.NATIVE_ZFS_SYSTEM_INITRAMFS)
-    if config.kernel.source in (KernelSource.CJK_BIN, KernelSource.CJK):
+    package = config.kernel.package or _KERNEL_PACKAGES[config.kernel.source]
+    package_name = package.lstrip("=<>~!").split(":", 1)[0]
+    package_name = re.sub(r"-r\d+$", "", package_name)
+    package_name = re.sub(r"-\d[\w.]*$", "", package_name)
+    if package_name in _CJK_KERNEL_PACKAGES:
         found.add(Trait.CJK_KERNEL)
     else:
         found.add(Trait.KERNEL_WITHOUT_CJKTTY)

--- a/gentoo_install/model/validate.py
+++ b/gentoo_install/model/validate.py
@@ -170,6 +170,7 @@ def validate(
         *_unlock_problems(config, address_facts.remote_unlock),
         *_locale_problems(config),
         *_l10n_problems(config),
+        *compat.binhost_subarch_problems(config),
         *(rule.describe() for rule in compat.violations(config, storage_facts)),
     ]
     if problems:

--- a/gentoo_install/plan/bootloader.py
+++ b/gentoo_install/plan/bootloader.py
@@ -25,6 +25,7 @@ from ..model.device import (
     Mountpoint,
     Partition,
     PartitionRole,
+    PartitionTable,
     ZfsDataset,
     ZfsPool,
 )
@@ -75,8 +76,8 @@ class InstallGrub(Operation):
     stage: Stage = Stage.BOOTLOADER
     firmware: Firmware
     esp: PurePosixPath | None
-    #: Whose disk GRUB is written to on a BIOS machine: the one the root is on.
-    boot_device: DeviceId
+    #: Devices whose containing disks receive GRUB on a BIOS machine.
+    boot_devices: tuple[DeviceId, ...]
 
     def describe(self) -> str:
         where = f"the esp at {self.esp}" if self.esp is not None else "the boot disk"
@@ -90,9 +91,15 @@ class InstallGrub(Operation):
             # entry, and every firmware that never had one, boots only that.
             context.run_in_target([*efi, "--removable"])
         else:
-            context.run_in_target(
-                ["grub-install", "--target=i386-pc", context.containing_disk(self.boot_device)]
-            )
+            installed: set[str] = set()
+            for device in self.boot_devices:
+                disk = context.containing_disk(device)
+                if disk in installed:
+                    continue
+                installed.add(disk)
+                context.run_in_target(
+                    ["grub-install", "--target=i386-pc", disk]
+                )
         context.run_in_target(["grub-mkconfig", "--output", "/boot/grub/grub.cfg"])
         # grub-mkconfig exits 0 having found no kernel, and the machine then
         # drops back to the firmware menu with nothing to boot.
@@ -422,7 +429,9 @@ def build(config: InstallConfig) -> list[Operation]:
                 keymap=initramfs_keymap(config),
             ),
             InstallGrub(
-                firmware=config.bootloader.firmware, esp=esp, boot_device=config.disk.root
+                firmware=config.bootloader.firmware,
+                esp=esp,
+                boot_devices=_bios_boot_devices(config),
             ),
         ]
     elif kind is Bootloader.SYSTEMD_BOOT and esp is not None:
@@ -474,6 +483,26 @@ def build(config: InstallConfig) -> list[Operation]:
             ),
         ]
     return operations
+
+
+def _bios_boot_devices(config: InstallConfig) -> tuple[DeviceId, ...]:
+    """Return physical graph leaves that can contain a BIOS boot sector."""
+    graph = config.disk.graph
+    candidates = {
+        node.id
+        for node in (
+            graph[config.disk.root],
+            *(graph[ancestor] for ancestor in graph.ancestors_of(config.disk.root)),
+        )
+        if isinstance(node, Existing)
+    }
+    disks = {
+        table.disk
+        for table in graph.of_type(PartitionTable)
+        if table.disk in candidates
+    }
+    selected = disks or candidates
+    return tuple(sorted(selected))
 
 
 def luks_parameters(context: Context, devices: tuple[DeviceId, ...]) -> tuple[str, ...]:

--- a/gentoo_install/plan/portage.py
+++ b/gentoo_install/plan/portage.py
@@ -550,26 +550,63 @@ class Emerge(Operation):
         return self.source.built_from(self.packages)
 
     def apply(self, context: Context) -> None:
+        command = self._argv(context, source_only=context.degraded(BINARY_PACKAGES))
+        try:
+            result = context.run_in_target(command, check=False)
+        except CommandFailed as error:
+            marker = _binpkg_failure(str(error))
+            if marker is None or context.degraded(BINARY_PACKAGES):
+                raise
+            context.degrade(BINARY_PACKAGES, f"selected binary package failed: {marker}")
+            retry_result = context.run_in_target(self._argv(context, source_only=True), check=False)
+            if isinstance(retry_result, CommandOutput) and retry_result.returncode != 0:
+                raise CommandFailed(
+                    f"source retry failed with exit {retry_result.returncode}: "
+                    f"{str(retry_result).strip()}"
+                )
+            return
+        if not isinstance(result, CommandOutput) or result.returncode == 0:
+            return
+        if not _binpkg_failure(str(result)) or context.degraded(BINARY_PACKAGES):
+            raise CommandFailed(f"emerge failed with exit {result.returncode}: {str(result).strip()}")
+        reason = f"selected binary package failed: {_binpkg_failure(str(result))}"
+        context.degrade(BINARY_PACKAGES, reason)
+        retry = self._argv(context, source_only=True)
+        retry_result = context.run_in_target(retry, check=False)
+        if isinstance(retry_result, CommandOutput) and retry_result.returncode != 0:
+            raise CommandFailed(
+                f"source retry failed with exit {retry_result.returncode}: {str(retry_result).strip()}"
+            )
+
+    def _argv(self, context: Context, *, source_only: bool) -> list[str]:
         argv = ["emerge", *EMERGE_OPTIONS]
         if self.mode.value:
             argv.append(self.mode.value)
-        if context.degraded(BINARY_PACKAGES):
-            # `FEATURES=getbinpkg` in make.conf keeps fetching remote binaries
-            # under `--usepkg=n`, so both are needed to reach the source path
-            # a degraded binhost has to fall back to.
+        if source_only:
             argv += ["--usepkg=n", "--getbinpkg=n"]
         elif built := self._built_here():
-            # These packages only. Turning binaries off wholesale builds the
-            # whole dependency tree here too: `sys-apps/systemd` pulled in
-            # gtk+, cups and 21 more, and died on a circular dependency.
-            # `--usepkg-exclude` also blocks the remote copy under `-g`.
             argv += [
                 *BINPKG_OPTIONS[:-1],
                 f"{BINPKG_EXCLUDED} {' '.join(_unversioned(one) for one in built)}",
             ]
         else:
             argv += BINPKG_OPTIONS
-        context.run_in_target([*argv, "--", *self.packages])
+        return [*argv, "--", *self.packages]
+
+
+def _binpkg_failure(output: str) -> str | None:
+    """Return a Portage marker that proves the failure was a binary fetch."""
+    for line in output.splitlines():
+        if any(
+            marker in line
+            for marker in (
+                "Fetching Binary failed",
+                "Binary package is not usable",
+                "Fetching Binary",
+            )
+        ):
+            return line.strip()
+    return None
 
 
 @dataclass(frozen=True, kw_only=True)
@@ -658,7 +695,8 @@ class ConfigureBinhost(Operation):
             f"verify-signature = {'true' if self.verify else 'false'}\n"
             f"location = /var/cache/binhost/{self.name}\n"
         )
-        context.write(PurePosixPath(f"/etc/portage/binrepos.conf/{self.name}.conf"), stanza)
+        filename = "gentoobinhost.conf" if self.name == "gentoo" else f"{self.name}.conf"
+        context.write(PurePosixPath(f"/etc/portage/binrepos.conf/{filename}"), stanza)
 
 
 @dataclass(frozen=True, kw_only=True)

--- a/tests/unit/test_compat.py
+++ b/tests/unit/test_compat.py
@@ -331,6 +331,20 @@ def test_a_plain_uefi_install_breaks_no_rule() -> None:
     assert violations(config()) == ()
 
 
+def test_cjk_compatibility_uses_the_effective_kernel_package() -> None:
+    custom = replace(
+        config(),
+        system=replace(config().system, console_cjk=True),
+        kernel=KernelConfig(
+            source=KernelSource.DIST_BIN,
+            package="sys-kernel/gentoo-cjk-kernel-bin",
+        ),
+    )
+    present = traits_of(custom)
+    assert Trait.CJK_KERNEL in present
+    assert Trait.KERNEL_WITHOUT_CJKTTY not in present
+
+
 def test_zfs_with_zfsbootmenu_and_the_kernel_in_the_pool_breaks_no_rule() -> None:
     installable = replace(
         boots(config(zfs_root()), Bootloader.ZFSBOOTMENU, Firmware.UEFI),

--- a/tests/unit/test_harness.py
+++ b/tests/unit/test_harness.py
@@ -1088,6 +1088,15 @@ def test_a_schedule_that_ends_early_stops_the_guests_it_left_running() -> None:
     assert wedged.stopped and wedged.removed, "the closing path removes it"
 
 
+def test_scheduler_workers_are_owned_by_the_scheduler() -> None:
+    import inspect
+
+    from tests.vm import cluster
+
+    source = inspect.getsource(cluster.run)
+    assert "daemon=False" in source
+
+
 def test_a_removed_guest_gives_its_vmid_back(monkeypatch: pytest.MonkeyPatch) -> None:
     """`handed` only ever grew, so a campaign of more than a hundred jobs
     stopped at `no free vmid` with the whole range unoccupied. The outcome has

--- a/tests/unit/test_plan_bootloader.py
+++ b/tests/unit/test_plan_bootloader.py
@@ -6,7 +6,7 @@ from dataclasses import replace
 from pathlib import Path, PurePosixPath
 
 from gentoo_install.exec.config import load
-from gentoo_install.model.config import InstallConfig, RemoteUnlock
+from gentoo_install.model.config import Bootloader, BootloaderConfig, Firmware, InstallConfig, RemoteUnlock
 from gentoo_install.plan import bootloader, kernel
 
 from .recorder import Recorder
@@ -117,6 +117,28 @@ def test_a_grub_machine_writes_no_loader_conf() -> None:
     installation = load(Path("tests/fixtures/vm-btrfs.toml"))
     operations = bootloader.build(installation)
     assert not [one for one in operations if isinstance(one, bootloader.ShowTheBootMenu)]
+
+
+def test_bios_grub_targets_every_mirrored_root_member() -> None:
+    installation = replace(
+        load(Path("tests/fixtures/vm-mdraid.toml")),
+        bootloader=BootloaderConfig(kind=Bootloader.GRUB, firmware=Firmware.BIOS),
+    )
+    operation = next(
+        one for one in bootloader.build(installation) if isinstance(one, bootloader.InstallGrub)
+    )
+    assert operation.boot_devices == ("disk0", "disk1")
+
+    class MirroredRecorder(Recorder):
+        def containing_disk(self, device: str) -> str:
+            return f"/dev/{device}"
+
+    recorder = MirroredRecorder()
+    operation.apply(recorder)
+    assert recorder.argv_starting("grub-install", "--target=i386-pc") == (
+        ("grub-install", "--target=i386-pc", "/dev/disk0"),
+        ("grub-install", "--target=i386-pc", "/dev/disk1"),
+    )
 
 
 def test_every_zfsbootmenu_host_key_can_be_written_in_the_format_asked_for() -> None:

--- a/tests/unit/test_plan_portage.py
+++ b/tests/unit/test_plan_portage.py
@@ -557,10 +557,40 @@ def test_a_failed_community_key_leaves_the_official_host_alone() -> None:
     )
     written = set(recorder.files)
     assert PurePosixPath("/etc/portage/binrepos.conf/gentoo-zh.conf") not in written
-    assert PurePosixPath("/etc/portage/binrepos.conf/gentoo.conf") in written
+    assert PurePosixPath("/etc/portage/binrepos.conf/gentoobinhost.conf") in written
 
     portage.Emerge(packages=("sys-boot/grub",), summary="install the bootloader").apply(recorder)
     assert "--getbinpkg=y" in next(argv for argv in recorder.in_target if argv[0] == "emerge")
+
+
+def test_a_selected_binary_fetch_failure_retries_from_source() -> None:
+    recorder = Recorder()
+    recorder.answering = lambda argv: (
+        CommandOutput("Fetching Binary failed: mirror refused the connection", 1)
+        if argv[0] == "emerge" and "--usepkg=n" not in argv
+        else CommandOutput("[ebuild] app-editors/nano-8", 0)
+    )
+
+    portage.Emerge(
+        packages=("app-editors/nano",), summary="install the editor"
+    ).apply(recorder)
+
+    emerges = [argv for argv in recorder.in_target if argv[0] == "emerge"]
+    assert len(emerges) == 2
+    assert "--getbinpkg=n" in emerges[-1] and "--usepkg=n" in emerges[-1]
+    assert recorder.degraded(portage.BINARY_PACKAGES)
+
+
+def test_an_unrelated_emerge_failure_is_not_misclassified_as_a_binhost_failure() -> None:
+    recorder = Recorder()
+    recorder.answering = lambda argv: CommandOutput("compile failed", 1)
+
+    with pytest.raises(CommandFailed, match="emerge failed"):
+        portage.Emerge(
+            packages=("app-editors/nano",), summary="install the editor"
+        ).apply(recorder)
+
+    assert not recorder.degraded(portage.BINARY_PACKAGES)
 
 
 def test_named_atoms_are_accepted_without_opening_the_whole_system() -> None:

--- a/tests/unit/test_proxmox.py
+++ b/tests/unit/test_proxmox.py
@@ -2246,13 +2246,14 @@ def test_install_media_cache_name_contains_its_signed_digest() -> None:
 def test_an_existing_install_iso_needs_its_matching_verification_record(
     tmp_path: Path,
 ) -> None:
-    """A same-name remote ISO was reused without evidence that its bytes were checked."""
+    """A same-name remote ISO is replaced when its record is missing."""
     from tests.vm.cluster import prepare
     from tests.vm.driver import digest as driver_digest
 
     class Existing(Api):
         def __init__(self) -> None:
-            pass
+            self.removed: list[str] = []
+            self.fetched: list[str] = []
 
         def isos(self, node: str) -> list[str]:
             return ["minimal-a.iso", "driver.iso"]
@@ -2260,41 +2261,119 @@ def test_an_existing_install_iso_needs_its_matching_verification_record(
         def upload_iso(self, node: str, path: Path, name: str) -> str:
             return name
 
+        def remove_iso(self, node: str, name: str) -> str:
+            self.removed.append(name)
+            return ""
+
+        def fetch_iso(self, node: str, url: str, filename: str, sha512: str) -> None:
+            self.fetched.append(filename)
+
     api = Existing()
     driver = tmp_path / "driver.iso"
     driver.write_bytes(b"driver")
-    with pytest.raises(ProxmoxError, match="signed SHA-512 record"):
-        prepare(
-            api,
-            "node",
-            "minimal-a.iso",
-            ("https://mirror.invalid/install.iso",),
-            "a" * 128,
-            tmp_path / "trust",
-            driver,
-            "driver.iso",
-        )
-
-    stamp = tmp_path / "trust" / "remote" / "node" / "minimal-a.iso.sha512"
-    stamp.parent.mkdir(parents=True)
-    stamp.write_text("a" * 128)
-    with pytest.raises(ProxmoxError, match="driver SHA-256 record"):
-        prepare(
-            api,
-            "node",
-            "minimal-a.iso",
-            ("https://mirror.invalid/install.iso",),
-            "a" * 128,
-            tmp_path / "trust",
-            driver,
-            "driver.iso",
-        )
-    driver_stamp = tmp_path / "trust" / "remote" / "node" / "driver.iso.sha256"
-    driver_stamp.write_text(driver_digest(driver))
     prepare(
         api,
         "node",
         "minimal-a.iso",
+        ("https://mirror.invalid/install.iso",),
+        "a" * 128,
+        tmp_path / "trust",
+        driver,
+        "driver.iso",
+    )
+    assert api.removed == ["minimal-a.iso", "driver.iso"]
+    assert api.fetched == ["minimal-a.iso"]
+
+
+def test_an_existing_install_iso_replaces_a_mismatched_record(tmp_path: Path) -> None:
+    from tests.vm.cluster import prepare
+    from tests.vm.driver import digest as driver_digest
+
+    class Existing(Api):
+        def __init__(self) -> None:
+            self.removed: list[str] = []
+            self.fetched: list[str] = []
+
+        def isos(self, node: str) -> list[str]:
+            return ["minimal-a.iso", "driver.iso"]
+
+        def upload_iso(self, node: str, path: Path, name: str) -> str:
+            return name
+
+        def remove_iso(self, node: str, name: str) -> str:
+            self.removed.append(name)
+            return ""
+
+        def fetch_iso(self, node: str, url: str, filename: str, sha512: str) -> None:
+            self.fetched.append(filename)
+
+    driver = tmp_path / "driver.iso"
+    driver.write_bytes(b"driver")
+    trust = tmp_path / "trust" / "remote" / "node"
+    trust.mkdir(parents=True)
+    (trust / "minimal-a.iso.sha512").write_text("b" * 128)
+    (trust / "driver.iso.sha256").write_text(driver_digest(driver))
+    api = Existing()
+    prepare(
+        api,
+        "node",
+        "minimal-a.iso",
+        ("https://mirror.invalid/install.iso",),
+        "a" * 128,
+        tmp_path / "trust",
+        driver,
+        "driver.iso",
+    )
+    assert api.removed == ["minimal-a.iso"]
+    assert api.fetched == ["minimal-a.iso"]
+
+
+def test_iso_listing_without_checksum_does_not_mark_recorded_media_corrupt(
+    tmp_path: Path,
+) -> None:
+    from tests.vm.cluster import prepare
+    from tests.vm.driver import digest as driver_digest
+
+    listing = [
+        {
+            "volid": "local:iso/install-a.iso",
+            "format": "iso",
+            "content": "iso",
+            "size": 123,
+            "ctime": 456,
+        },
+        {
+            "volid": "local:iso/driver.iso",
+            "format": "iso",
+            "content": "iso",
+            "size": 3,
+            "ctime": 456,
+        },
+    ]
+
+    class Listing(Api):
+        def call(self, method: str, path: str, **form: Any) -> Any:
+            return listing
+
+        def remove_iso(self, node: str, name: str) -> str:
+            raise AssertionError("recorded media should not be removed")
+
+        def fetch_iso(self, node: str, url: str, filename: str, sha512: str) -> None:
+            raise AssertionError("recorded media should not be fetched")
+
+        def upload_iso(self, node: str, path: Path, name: str) -> str:
+            raise AssertionError("recorded media should not be uploaded")
+
+    driver = tmp_path / "driver.iso"
+    driver.write_bytes(b"drv")
+    stamps = tmp_path / "trust" / "remote" / "node"
+    stamps.mkdir(parents=True)
+    (stamps / "install-a.iso.sha512").write_text("a" * 128)
+    (stamps / "driver.iso.sha256").write_text(driver_digest(driver))
+    prepare(
+        Listing(),
+        "node",
+        "install-a.iso",
         ("https://mirror.invalid/install.iso",),
         "a" * 128,
         tmp_path / "trust",

--- a/tests/unit/test_validate.py
+++ b/tests/unit/test_validate.py
@@ -297,6 +297,35 @@ def test_a_root_with_room_passes() -> None:
     validate(config(nodes))
 
 
+def test_an_official_v3_binhost_requires_the_cpu_flags_it_serves() -> None:
+    base = config()
+    selected = replace(
+        base,
+        portage=replace(
+            base.portage,
+            cpu_flags=("sse2",),
+            binhost=replace(base.portage.binhost, subarch="x86-64-v3"),
+        ),
+    )
+
+    with pytest.raises(ValidationFailed, match="x86-64-v3.*avx2"):
+        validate(selected)
+
+
+def test_an_official_v3_binhost_passes_with_the_required_cpu_flags() -> None:
+    base = config()
+    selected = replace(
+        base,
+        portage=replace(
+            base.portage,
+            cpu_flags=("avx2", "bmi1", "bmi2", "f16c", "fma"),
+            binhost=replace(base.portage.binhost, subarch="x86-64-v3"),
+        ),
+    )
+
+    validate(selected)
+
+
 def test_a_profile_that_disagrees_with_the_init_is_refused() -> None:
     """The profile decides what packages are built against, so one that does
     not match leaves a system whose packages expect the other init."""

--- a/tests/vm/cluster.py
+++ b/tests/vm/cluster.py
@@ -552,9 +552,20 @@ def prepare(
         except OSError:
             recorded = ""
         if recorded != sha512:
-            raise ProxmoxError(
-                f"{medium} already exists on {node} without its signed SHA-512 record"
-            )
+            reason = api.remove_iso(node, medium)
+            if reason:
+                raise ProxmoxError(f"{medium} could not be replaced on {node}: {reason}")
+            last = ""
+            for url in urls:
+                try:
+                    api.fetch_iso(node, url, medium, sha512)
+                    break
+                except ProxmoxError as error:
+                    last = str(error)
+            else:
+                raise ProxmoxError(f"no mirror served {medium} to {node}: {last}")
+            stamp.parent.mkdir(parents=True, exist_ok=True)
+            stamp.write_text(sha512)
     else:
         last = ""
         for url in urls:
@@ -575,9 +586,12 @@ def prepare(
         except OSError:
             recorded_driver = ""
         if recorded_driver != driver_sha256:
-            raise ProxmoxError(
-                f"{driver} already exists on {node} without its driver SHA-256 record"
-            )
+            reason = api.remove_iso(node, driver)
+            if reason:
+                raise ProxmoxError(f"{driver} could not be replaced on {node}: {reason}")
+            api.upload_iso(node, driver_path, driver)
+            driver_stamp.parent.mkdir(parents=True, exist_ok=True)
+            driver_stamp.write_text(driver_sha256)
     else:
         api.upload_iso(node, driver_path, driver)
         driver_stamp.parent.mkdir(parents=True, exist_ok=True)
@@ -1417,7 +1431,7 @@ def run(
                         revision,
                         execution,
                     ),
-                    daemon=True,
+                    daemon=False,
                 )
                 scheduled[job.name] = job.started(thread)
                 placed[node.name] += execution.reservation_bytes
@@ -1968,9 +1982,8 @@ def _abandon(
     deadline = time.monotonic() + ABANDON_PATIENCE
     for thread in running.values():
         thread.join(timeout=max(0.0, deadline - time.monotonic()))
-    # After the join, not before: a worker that was going to remove its own
-    # guest has had its chance, and what is left is what nothing else will
-    # remove. Reporting it and walking away left guests running on the cluster.
+    # A timed-out worker no longer owns cleanup: destroy establishes the
+    # terminal guest state before the scheduler releases its reservation.
     for name, one in list(inflight.items()):
         try:
             one.guest.destroy()


### PR DESCRIPTION
A binary-package transport failure stopped the merge instead of compiling from source, which the repository requires as the guaranteed fallback. The official host also competed with the filename the stage3 inherits rather than replacing it, and a `x86-64-v3` host could be selected by a CPU without the flags it serves.

BIOS GRUB went to the disk holding the root device alone, so a mirrored root lost the member carrying the bootloader and stopped booting.

A scheduler worker could outlive cleanup and leave its guest running. Proxmox reports no checksum for a stored ISO — its content listing carries `volid`, `format`, `content`, `size` and `ctime` and nothing else — so a cached file is compared against the digest this harness recorded when it uploaded it.

Closes C18, C19, C21, C22, C24, H01, H02.