### PR TITLE
tui: keep Back and Cancelled apart in nested editors

### DIFF
--- a/gentoo_install/tui/screens.py
+++ b/gentoo_install/tui/screens.py
@@ -2660,18 +2660,26 @@ def timezone_screen(screen: Screen, config: InstallConfig, context: Context) -> 
         return Answer(
             Outcome.CHOSE, replace(config, system=replace(config.system, timezone=area))
         )
-    city: Menu[str] = Menu(
-        title=area,
-        items=[Item(label=zone.split("/", 1)[1], value=zone) for zone in within],
-        footer=footer(translate),
-        current=config.system.timezone,
-    )
-    answer = city.run(screen)
-    if not answer.chosen:
+    while True:
+        city: Menu[str] = Menu(
+            title=area,
+            items=[Item(label=zone.split("/", 1)[1], value=zone) for zone in within],
+            footer=footer(translate),
+            current=config.system.timezone,
+        )
+        answer = city.run(screen)
+        if answer.chosen:
+            return Answer(
+                Outcome.CHOSE, replace(config, system=replace(config.system, timezone=answer.unwrap()))
+            )
+        if answer.outcome is Outcome.BACK:
+            picked = chosen_area.run(screen)
+            if not picked.chosen:
+                return Answer(picked.outcome)
+            area = picked.unwrap()
+            within = [zone for zone in zones if zone.split("/", 1)[0] == area]
+            continue
         return Answer(answer.outcome)
-    return Answer(
-        Outcome.CHOSE, replace(config, system=replace(config.system, timezone=answer.unwrap()))
-    )
 
 
 def encryption_screen(screen: Screen, config: InstallConfig, context: Context) -> Answer[InstallConfig]:
@@ -2797,14 +2805,15 @@ def _ask_password(screen: Screen, context: Context, title: str) -> Answer[str]:
     ).run_validated(screen, validated)
 
 
-def _say(screen: Screen, context: Context, message: str) -> None:
+def _say(screen: Screen, context: Context, message: str) -> Answer[None]:
     """One line the operator has to acknowledge, so a rejected entry is not
     silently redrawn as an empty field."""
-    Menu(
+    answer = Menu(
         title=message,
         items=[Item(label=context.translate("Continue"), value=0)],
         footer=footer(context.translate),
     ).run(screen)
+    return Answer(answer.outcome)
 
 
 def swap_screen(screen: Screen, config: InstallConfig, context: Context) -> Answer[InstallConfig]:
@@ -2999,7 +3008,7 @@ def sshd_screen(screen: Screen, config: InstallConfig, context: Context) -> Answ
         return Answer(answer.outcome)
     running, password = answer.unwrap()
     if running and config.system.firewall is Firewall.NONE:
-        _say(
+        acknowledged = _say(
             screen,
             context,
             translate(
@@ -3008,6 +3017,8 @@ def sshd_screen(screen: Screen, config: InstallConfig, context: Context) -> Answ
                 "writes no rules, so the policy stays the operator's."
             ),
         )
+        if not acknowledged.chosen:
+            return Answer(acknowledged.outcome)
     return Answer(
         Outcome.CHOSE,
         replace(
@@ -3442,7 +3453,7 @@ def firewall_screen(
         return Answer(answer.outcome)
     chosen = answer.unwrap()
     if chosen is not Firewall.NONE:
-        _say(
+        acknowledged = _say(
             screen,
             context,
             translate(
@@ -3451,6 +3462,8 @@ def firewall_screen(
                 "over SSH would then need a console to be reached at all."
             ),
         )
+        if not acknowledged.chosen:
+            return Answer(acknowledged.outcome)
     return Answer(
         Outcome.CHOSE, replace(config, system=replace(config.system, firewall=chosen))
     )
@@ -4223,7 +4236,9 @@ def extra_packages_screen(
             return Answer(typed.outcome)
         good, bad = atoms.split(typed.unwrap())
         if bad:
-            _say(screen, context, f"{translate('Not a package name')}: {' '.join(bad)}")
+            informed = _say(screen, context, f"{translate('Not a package name')}: {' '.join(bad)}")
+            if not informed.chosen:
+                return Answer(informed.outcome)
             continue
         return Answer(
             Outcome.CHOSE, replace(config, packages=replace(config.packages, extra=good))
@@ -4280,10 +4295,12 @@ def _typed_beside_automatic(
             footer=footer(translate),
         ).run(screen)
         if not entered.chosen:
-            continue
+            return Answer(entered.outcome)
         good, bad = accepts(entered.unwrap())
         if bad:
-            _say(screen, context, f"{rejected}: {' '.join(bad)}")
+            informed = _say(screen, context, f"{rejected}: {' '.join(bad)}")
+            if not informed.chosen:
+                return Answer(informed.outcome)
             continue
         return Answer(Outcome.CHOSE, good)
 

--- a/tests/unit/test_tui_app.py
+++ b/tests/unit/test_tui_app.py
@@ -236,6 +236,34 @@ def test_the_timezone_list_is_every_zone_the_machine_knows() -> None:
     assert answer.unwrap().system.timezone == "Asia/Taipei"
 
 
+@pytest.mark.parametrize("leaving", ["KEY_LEFT", "q"])
+def test_firewall_dialog_leaving_does_not_commit(leaving: str) -> None:
+    start = config()
+    answer = screens.firewall_screen(
+        FakeScreen(keys=["KEY_DOWN", "\n", leaving]), start, context()
+    )
+    assert answer.outcome is (Outcome.BACK if leaving == "KEY_LEFT" else Outcome.CANCELLED)
+    assert answer.value is None
+
+
+def test_invalid_extra_package_dialog_cancellation_reaches_caller() -> None:
+    answer = screens.extra_packages_screen(
+        FakeScreen(keys=[*"bad!", "\n", "q"]), config(), context()
+    )
+    assert answer.outcome is Outcome.CANCELLED
+
+
+def test_timezone_back_reopens_area_and_cancel_exits_city() -> None:
+    changed = screens.timezone_screen(
+        FakeScreen(keys=["\n", "KEY_LEFT", "KEY_DOWN", "\n", "\n"]),
+        config(),
+        context(),
+    )
+    assert changed.unwrap().system.timezone == "Europe/London"
+    cancelled = screens.timezone_screen(FakeScreen(keys=["\n", "\x1b"]), config(), context())
+    assert cancelled.outcome is Outcome.CANCELLED
+
+
 def test_reopening_the_timezone_and_accepting_keeps_it() -> None:
     """Two menus, and both used to start at their first row: reopening a
     configured timezone and pressing enter twice moved the machine to UTC."""


### PR DESCRIPTION
`Back` moves up a level with the work kept; `Cancelled` discards it. An informational dialog dropped its cancel result entirely, so the firewall choice was committed after the operator refused it, a rejected package name could not be withdrawn, and the timezone city stage treated `Back` as an exit rather than reopening the area it came from.

The agent also added an `Answer.__getattr__` forwarding attribute access to the unwrapped value. It was removed: `mypy` and the whole suite pass without it, and it would have made every attribute read on an `Answer` untyped, hiding exactly the distinction this change restores.

Closes D18, D19, D21.