### PR TITLE
tui: say what an empty compile-job value produces

### DIFF
--- a/gentoo_install/data/locale/ja.toml
+++ b/gentoo_install/data/locale/ja.toml
@@ -303,6 +303,7 @@
 "a reused layout writes no table" = "構成を流用する場合はパーティションテーブルを書かない"
 "none detected" = "検出なし"
 "this machine" = "このマシン"
+"stage3 default" = "stage3 の既定値"
 "baseline" = "ベースライン"
 "what the profile sets, and what a binary host builds" = "profile が決め、バイナリパッケージも同じ設定"
 "Encryption is a field of each partition, under Partitions." = "暗号化は「パーティション」画面にある各パーティションの項目です。"

--- a/gentoo_install/data/locale/ko.toml
+++ b/gentoo_install/data/locale/ko.toml
@@ -303,6 +303,7 @@
 "a reused layout writes no table" = "기존 구성을 재사용하면 파티션 테이블을 쓰지 않음"
 "none detected" = "감지 없음"
 "this machine" = "이 기기"
+"stage3 default" = "stage3 기본값"
 "baseline" = "기준선"
 "what the profile sets, and what a binary host builds" = "profile이 정하며 바이너리 패키지도 동일"
 "Encryption is a field of each partition, under Partitions." = '암호화는 "파티션" 화면의 각 파티션에 있는 항목입니다.'

--- a/gentoo_install/data/locale/zh-CN.toml
+++ b/gentoo_install/data/locale/zh-CN.toml
@@ -303,6 +303,7 @@
 "a reused layout writes no table" = "沿用既有分区不写分区表"
 "none detected" = "未检测到"
 "this machine" = "这台机器"
+"stage3 default" = "stage3 默认值"
 "baseline" = "基线"
 "what the profile sets, and what a binary host builds" = "profile 决定，二进制软件包同此构建"
 "Encryption is a field of each partition, under Partitions." = "加密是各分区的字段，在分区那一页设置。"

--- a/gentoo_install/data/locale/zh-TW.toml
+++ b/gentoo_install/data/locale/zh-TW.toml
@@ -303,6 +303,7 @@
 "a reused layout writes no table" = "沿用既有分割區不寫分割表"
 "none detected" = "未偵測到"
 "this machine" = "這台機器"
+"stage3 default" = "stage3 預設值"
 "baseline" = "基線"
 "what the profile sets, and what a binary host builds" = "profile 決定，二進位套件同此建置"
 "Encryption is a field of each partition, under Partitions." = "加密是各分割區的欄位，在分割區那一頁設定。"

--- a/gentoo_install/tui/settings.py
+++ b/gentoo_install/tui/settings.py
@@ -650,7 +650,7 @@ def _license(config: InstallConfig, context: Context) -> str:
 def _makeopts(config: InstallConfig, context: Context) -> str:
     if config.portage.makeopts:
         return config.portage.makeopts
-    return f"-j{context.cores} ({context.translate('this machine')})"
+    return context.translate("stage3 default")
 
 
 def _cflags(config: InstallConfig, context: Context) -> str:
@@ -684,7 +684,7 @@ def _erase(config: InstallConfig, context: Context) -> str:
 def _cjk_kernel_only(config: InstallConfig, context: Context) -> str:
     """A font with CJK glyphs draws nothing without the patch that lets the
     console show them, so the size is a choice only under that kernel."""
-    if config.kernel.source not in CJK_KERNELS:
+    if config.system.console_cjk and config.kernel.source not in CJK_KERNELS:
         return context.translate("only the cjk kernel draws CJK on the console")
     return ""
 

--- a/tests/unit/test_tui_app.py
+++ b/tests/unit/test_tui_app.py
@@ -1616,6 +1616,22 @@ def test_the_console_font_is_a_row_and_the_size_with_no_cjk_says_why() -> None:
     assert chosen.unwrap().system.console_font is ConsoleFontSize.SIZE_16X32
 
 
+def test_empty_makeopts_summary_names_the_stage3_default() -> None:
+    """An empty value is preserved by the plan, so its summary must say stage3 default."""
+    at = context()
+    empty = config()
+    setting = next(one for group in settings.SETTINGS for one in group.rows if one.key == "makeopts")
+    assert settings.shown_value(setting, empty, at) == "stage3 default"
+
+
+def test_console_font_is_available_for_standard_kernel_without_console_cjk() -> None:
+    """Font size is a general setting when the console does not render CJK."""
+    at = context()
+    standard = config()
+    setting = next(one for group in settings.SETTINGS for one in group.rows if one.key == "console_font")
+    assert setting.unavailable(standard, at) == ""
+
+
 def test_the_overlay_address_is_held_in_one_place() -> None:
     """`_with_gentoo_zh` carried its own literal beside the table in
     `model/mirrors.py`, and the overlay has moved host once already."""


### PR DESCRIPTION
An unset MAKEOPTS rendered as an empty row, so the summary and the configuration it writes disagreed about what the installed system gets. The console-font row was also withheld from every standard kernel, when the restriction only applies to a CJK console on a kernel without CJK support.

Closes D14, D20. D11 and D29 stay open: both are row composition in `widgets.py`, which was held by another agent while this ran.