### PR TITLE
model, exec, plan: run the whole install through a configured proxy

### DIFF
--- a/gentoo_install/data/locale/ja.toml
+++ b/gentoo_install/data/locale/ja.toml
@@ -1,6 +1,16 @@
 # Interface strings, Japanese. The key is the English source.
 [strings]
 "Disks" = "ディスク"
+"Proxy" = "プロキシ"
+"Proxy URL" = "プロキシ URL"
+"Bypass hosts" = "バイパスするホスト"
+"empty for direct; socks5 resolves locally, socks5h at the proxy" = "空欄で直接接続。socks5 はローカル、socks5h はプロキシで名前解決"
+"comma-separated host names" = "ホスト名をコンマ区切り"
+"Proxy URL must use http://, https://, socks5:// or socks5h://" = "プロキシ URL は http://、https://、socks5://、socks5h:// のいずれかです"
+"Proxy URL must include a host" = "プロキシ URL にホストが必要です"
+"Proxy URL must contain only a scheme, host and port" = "プロキシ URL にはスキーム、ホスト、ポートだけを指定します"
+"Bypass hosts must not contain spaces" = "バイパスするホストに空白を含めることはできません"
+"{count} hosts bypass" = "{count} ホストをバイパス"
 "Portage" = "Portage"
 "Desktop and applications" = "デスクトップとアプリケーション"
 "Overview" = "概要"

--- a/gentoo_install/data/locale/ko.toml
+++ b/gentoo_install/data/locale/ko.toml
@@ -1,6 +1,16 @@
 # Interface strings, Korean. The key is the English source.
 [strings]
 "Disks" = "디스크"
+"Proxy" = "프록시"
+"Proxy URL" = "프록시 URL"
+"Bypass hosts" = "우회 호스트"
+"empty for direct; socks5 resolves locally, socks5h at the proxy" = "비우면 직접 연결합니다. socks5는 로컬에서, socks5h는 프록시에서 이름을 확인합니다"
+"comma-separated host names" = "호스트 이름을 쉼표로 구분"
+"Proxy URL must use http://, https://, socks5:// or socks5h://" = "프록시 URL은 http://, https://, socks5:// 또는 socks5h://여야 합니다"
+"Proxy URL must include a host" = "프록시 URL에 호스트가 필요합니다"
+"Proxy URL must contain only a scheme, host and port" = "프록시 URL에는 스킴, 호스트, 포트만 포함해야 합니다"
+"Bypass hosts must not contain spaces" = "우회 호스트에는 공백을 포함할 수 없습니다"
+"{count} hosts bypass" = "{count}개 호스트 우회"
 "Portage" = "Portage"
 "Desktop and applications" = "데스크톱과 응용 프로그램"
 "Overview" = "요약"

--- a/gentoo_install/data/locale/zh-CN.toml
+++ b/gentoo_install/data/locale/zh-CN.toml
@@ -1,6 +1,16 @@
 # 界面字符串，简体中文。键是英文原文，查不到就退回原文。
 [strings]
 "Disks" = "磁盘"
+"Proxy" = "代理"
+"Proxy URL" = "代理 URL"
+"Bypass hosts" = "绕过代理的主机"
+"empty for direct; socks5 resolves locally, socks5h at the proxy" = "留空表示直连；socks5 在本地解析，socks5h 在代理端解析"
+"comma-separated host names" = "用逗号分隔主机名"
+"Proxy URL must use http://, https://, socks5:// or socks5h://" = "代理 URL 必须使用 http://、https://、socks5:// 或 socks5h://"
+"Proxy URL must include a host" = "代理 URL 必须包含主机"
+"Proxy URL must contain only a scheme, host and port" = "代理 URL 只能包含协议、主机和端口"
+"Bypass hosts must not contain spaces" = "绕过主机不能包含空格"
+"{count} hosts bypass" = "绕过 {count} 个主机"
 "Portage" = "Portage"
 "Desktop and applications" = "桌面与应用程序"
 "Overview" = "总览"

--- a/gentoo_install/data/locale/zh-TW.toml
+++ b/gentoo_install/data/locale/zh-TW.toml
@@ -1,6 +1,16 @@
 # 介面字串，正體中文。鍵是英文原文，查不到就退回原文。
 [strings]
 "Disks" = "磁碟"
+"Proxy" = "Proxy"
+"Proxy URL" = "Proxy URL"
+"Bypass hosts" = "略過 Proxy 的主機"
+"empty for direct; socks5 resolves locally, socks5h at the proxy" = "留白表示直接連線；socks5 在本機解析，socks5h 在 Proxy 解析"
+"comma-separated host names" = "以逗號分隔主機名稱"
+"Proxy URL must use http://, https://, socks5:// or socks5h://" = "Proxy URL 必須使用 http://、https://、socks5:// 或 socks5h://"
+"Proxy URL must include a host" = "Proxy URL 必須包含主機"
+"Proxy URL must contain only a scheme, host and port" = "Proxy URL 只能包含通訊協定、主機與連接埠"
+"Bypass hosts must not contain spaces" = "略過主機不能包含空白"
+"{count} hosts bypass" = "略過 {count} 個主機"
 "Portage" = "Portage"
 "Desktop and applications" = "桌面與應用程式"
 "Overview" = "總覽"

--- a/gentoo_install/exec/fetch.py
+++ b/gentoo_install/exec/fetch.py
@@ -7,19 +7,24 @@ not match is a failed install, not a reason to try another mirror.
 from __future__ import annotations
 
 import contextlib
+import contextvars
 import errno
 import hashlib
+import http.client
 import json
 import socket
+import ssl
 import time
+import tomllib
 from concurrent.futures import ThreadPoolExecutor
 from email.utils import parsedate_to_datetime
 from itertools import takewhile
 import urllib.error
+import urllib.parse
 import urllib.request
 from pathlib import Path
 from collections.abc import Iterator
-from typing import Any, Callable, Final
+from typing import Any, Callable, Final, cast
 
 from ..errors import (
     CommandFailed,
@@ -32,6 +37,7 @@ from ..errors import (
 from ..model import paste
 from ..model.device import DeviceId
 from ..model.validate import KernelCeiling
+from ..model.config import ProxyConfig
 from .probe import RELEASE_KEY
 from .runner import Runner
 
@@ -59,8 +65,28 @@ PROBE_WORKERS: Final[int] = 8
 #: about the bytes beside it, so it is refused rather than trusted.
 MARKER_SCHEMA: Final[str] = "gentoo-install-stage3-1"
 
+_CURRENT_PROXY: contextvars.ContextVar[ProxyConfig | None] = contextvars.ContextVar(
+    "gentoo_install_proxy", default=None
+)
 
-def stage3(mirror: str, variant: str, fingerprint: str, work: Path, runner: Runner) -> Path:
+
+def configure_proxy(proxy: ProxyConfig | None) -> None:
+    """Set the proxy used by fetch entry points that have no explicit proxy."""
+    _CURRENT_PROXY.set(proxy)
+
+
+def _read_for(url: str, proxy: ProxyConfig | None) -> str:
+    return _read(url) if proxy is None else _read(url, proxy)
+
+
+def stage3(
+    mirror: str,
+    variant: str,
+    fingerprint: str,
+    work: Path,
+    runner: Runner,
+    proxy: ProxyConfig | None = None,
+) -> Path:
     """Download the newest stage3 of `variant`, verify it, return where it is.
 
     A `.verified` marker beside the archive lets an interrupted install skip a
@@ -68,8 +94,11 @@ def stage3(mirror: str, variant: str, fingerprint: str, work: Path, runner: Runn
     that digest is recomputed here, because an empty marker beside a replaced
     or corrupted archive was an integrity check that verified nothing.
     """
+    selected = proxy if proxy is not None else _bootstrap_proxy(work)
+    if selected is not None:
+        configure_proxy(selected)
     builds = f"{mirror.rstrip('/')}/{STAGE3_PATH}"
-    where = _newest(builds, variant)
+    where = _newest(builds, variant, selected)
     name = where.rsplit("/", 1)[-1]
     work.mkdir(parents=True, exist_ok=True)
     archive = work / name
@@ -77,16 +106,32 @@ def stage3(mirror: str, variant: str, fingerprint: str, work: Path, runner: Runn
     if marker.is_file() and archive.is_file() and _marker_matches(marker, archive, fingerprint):
         return archive
 
-    _download(f"{builds}/{where}", archive, runner.log)
+    _download(f"{builds}/{where}", archive, runner.log, proxy=selected)
     digests = work / f"{name}.DIGESTS"
-    _download(f"{builds}/{where}.DIGESTS", digests, runner.log)
-    _import_release_key(runner, work)
+    _download(f"{builds}/{where}.DIGESTS", digests, runner.log, proxy=selected)
+    _import_release_key(runner, work, selected)
     _verify_signature(digests, fingerprint, runner)
     _verify_digest(archive, digests)
     marker.write_text(
         f"{MARKER_SCHEMA}\n{name}\n{_sha512(archive)}\n{fingerprint.lower()}\n"
     )
     return archive
+
+
+def _bootstrap_proxy(work: Path) -> ProxyConfig | None:
+    """Read the plan-written proxy before the stage3 has replaced `/etc`."""
+    try:
+        root = work.parents[2]
+        raw = tomllib.loads((root / "etc/gentoo-install/proxy.toml").read_text())
+    except (OSError, IndexError, tomllib.TOMLDecodeError):
+        return None
+    url = raw.get("url", "")
+    bypass = raw.get("bypass", [])
+    if not isinstance(url, str) or not isinstance(bypass, list) or not all(
+        isinstance(item, str) for item in bypass
+    ):
+        return None
+    return ProxyConfig(url=url, bypass=tuple(bypass))
 
 
 def _marker_matches(marker: Path, archive: Path, fingerprint: str) -> bool:
@@ -108,7 +153,9 @@ def _sha512(path: Path) -> str:
     return reader.hexdigest()
 
 
-def rank_mirrors(candidates: tuple[str, ...]) -> tuple[str, ...]:
+def rank_mirrors(
+    candidates: tuple[str, ...], proxy: ProxyConfig | None = None
+) -> tuple[str, ...]:
     """Fastest first, measured. A mirror that fails or times out keeps its place
     at the end rather than disappearing: a slow mirror still installs, and a
     measurement that found nothing must not leave an empty list.
@@ -116,16 +163,16 @@ def rank_mirrors(candidates: tuple[str, ...]) -> tuple[str, ...]:
     # Concurrently: the China list is twenty-three sites, and measuring them
     # one after another costs two minutes when most of them time out.
     with ThreadPoolExecutor(max_workers=PROBE_WORKERS) as pool:
-        times = list(pool.map(_probe, candidates))
+        times = list(pool.map(lambda mirror: _probe(mirror, proxy), candidates))
     measured = [(time, position, mirror) for position, (time, mirror) in enumerate(zip(times, candidates))]
     return tuple(mirror for _, _, mirror in sorted(measured))
 
 
-def _probe(mirror: str) -> float:
+def _probe(mirror: str, proxy: ProxyConfig | None = None) -> float:
     url = f"{mirror.rstrip('/')}/{PROBE_FILE}"
     started = time.monotonic()
     try:
-        with urllib.request.urlopen(_asked(url), timeout=PROBE_TIMEOUT) as response:
+        with _urlopen(_asked(url), proxy, PROBE_TIMEOUT) as response:
             response.read(1 << 16)
     except (urllib.error.URLError, TimeoutError, OSError):
         return float("inf")
@@ -158,11 +205,11 @@ def passphrase_for(device: DeviceId, source: str) -> str:
 READ_TRIES: Final[int] = 4
 
 
-def _read_patiently(url: str) -> str:
+def _read_patiently(url: str, proxy: ProxyConfig | None = None) -> str:
     last: DownloadFailed | None = None
     for attempt in range(READ_TRIES):
         try:
-            return _read(url)
+            return _read(url) if proxy is None else _read(url, proxy)
         except DownloadFailed as error:
             last = error
             if attempt + 1 < READ_TRIES:
@@ -171,7 +218,9 @@ def _read_patiently(url: str) -> str:
     raise last
 
 
-def _newest(builds: str, variant: str) -> str:
+def _newest(
+    builds: str, variant: str, proxy: ProxyConfig | None = None
+) -> str:
     """The current archive's path under `releases/amd64/autobuilds`.
 
     `latest-stage3-amd64-<variant>.txt`, not the directory index: an index is
@@ -190,7 +239,7 @@ def _newest(builds: str, variant: str) -> str:
     """
     pointer = f"{builds}/latest-stage3-amd64-{variant}.txt"
     paths: list[str] = []
-    for line in _read_patiently(pointer).splitlines():
+    for line in _read_patiently(pointer, proxy).splitlines():
         said = line.strip()
         if not said or said.startswith(("#", "-----", "Hash:")):
             continue
@@ -209,7 +258,9 @@ def _newest(builds: str, variant: str) -> str:
 RELEASE_KEYRING: Final[str] = "https://qa-reports.gentoo.org/output/service-keys.gpg"
 
 
-def _import_release_key(runner: Runner, work: Path) -> None:
+def _import_release_key(
+    runner: Runner, work: Path, proxy: ProxyConfig | None = None
+) -> None:
     """Load the key a stage3 signature is checked against.
 
     Trust comes from `RELENG_FINGERPRINT`, not from where the key came from: a
@@ -220,7 +271,7 @@ def _import_release_key(runner: Runner, work: Path) -> None:
     if not RELEASE_KEY.is_file():
         source = work / "gentoo-release.gpg"
         work.mkdir(parents=True, exist_ok=True)
-        _download(RELEASE_KEYRING, source)
+        _download(RELEASE_KEYRING, source, proxy=proxy)
     result = runner.run(["gpg", "--quiet", "--import", str(source)], check=False)
     if result.returncode != 0:
         # Named here rather than left to the verification below, which would
@@ -228,12 +279,14 @@ def _import_release_key(runner: Runner, work: Path) -> None:
         raise PreflightFailed(f"{source} could not be imported: {result.stdout.strip()}")
 
 
-def text(url: str) -> str:
+def text(url: str, proxy: ProxyConfig | None = None) -> str:
     """A short document, such as a public key someone pasted somewhere."""
-    return _read(paste.raw_url(url))
+    return _read_for(paste.raw_url(url), proxy)
 
 
-def upload(body: str, export: paste.Export) -> str:
+def upload(
+    body: str, export: paste.Export, proxy: ProxyConfig | None = None
+) -> str:
     """Create a paste and return the address of the page that shows it.
 
     Offered after a run has already finished or failed, so every failure here
@@ -246,7 +299,7 @@ def upload(body: str, export: paste.Export) -> str:
         **{"Content-Type": "application/json"},
     )
     try:
-        with urllib.request.urlopen(request, timeout=TIMEOUT) as response:
+        with _urlopen(request, proxy, TIMEOUT) as response:
             answered = json.loads(response.read().decode())
     except (urllib.error.URLError, TimeoutError, OSError) as error:
         raise UploadFailed(f"{paste.HOST} did not take the paste: {error}") from error
@@ -276,11 +329,11 @@ CLOCK_URL: Final[str] = "http://distfiles.gentoo.org/"
 CLOCK_TOLERANCE: Final[float] = 24 * 3600.0
 
 
-def network_time() -> float:
+def network_time(proxy: ProxyConfig | None = None) -> float:
     """Seconds since the epoch from a `Date` header, or 0 when unread."""
     try:
         request = _asked(CLOCK_URL, method="HEAD")
-        with urllib.request.urlopen(request, timeout=PROBE_TIMEOUT) as response:
+        with _urlopen(request, proxy, PROBE_TIMEOUT) as response:
             stamp = response.headers.get("Date", "")
     except (urllib.error.URLError, TimeoutError, OSError):
         return 0.0
@@ -298,7 +351,7 @@ COUNTRY_URLS: Final[tuple[str, ...]] = (
 )
 
 
-def egress_country() -> str:
+def egress_country(proxy: ProxyConfig | None = None) -> str:
     """The two-letter country the machine reaches the internet from, or empty.
 
     Which mirrors are worth offering follows from where the packets come out,
@@ -308,7 +361,7 @@ def egress_country() -> str:
     """
     for url in COUNTRY_URLS:
         try:
-            answer = _read(url)
+            answer = _read_for(url, proxy)
         except DownloadFailed:
             continue
         for line in answer.splitlines():
@@ -331,7 +384,7 @@ ONLINE_TRIES: Final[int] = 5
 ONLINE_PAUSE: Final[float] = 2.0
 
 
-def why_unreachable(url: str) -> str:
+def why_unreachable(url: str, proxy: ProxyConfig | None = None) -> str:
     """Empty when the URL answers, and why it did not otherwise.
 
     The reason is carried out, not discarded. `cannot reach X` sent a run to
@@ -342,7 +395,10 @@ def why_unreachable(url: str) -> str:
     said = ""
     for attempt in range(ONLINE_TRIES):
         try:
-            _read(url)
+            if proxy is None:
+                _read(url)
+            else:
+                _read(url, proxy)
         except DownloadFailed as error:
             said = str(error)
             if attempt + 1 < ONLINE_TRIES:
@@ -352,28 +408,32 @@ def why_unreachable(url: str) -> str:
     return said
 
 
-def reachable(url: str) -> bool:
+def reachable(url: str, proxy: ProxyConfig | None = None) -> bool:
     """Whether a URL answers, tried `ONLINE_TRIES` times.
 
     Asked of the address the run will actually read rather than of any host: a
     machine behind a portal resolves names and still cannot fetch anything.
     """
-    return not why_unreachable(url)
+    return not (why_unreachable(url) if proxy is None else why_unreachable(url, proxy))
 
 
-def online() -> bool:
+def online(proxy: ProxyConfig | None = None) -> bool:
     """Whether the package site answers. The menu reads every version from it."""
-    return reachable(f"{PACKAGES_API}/sys-kernel/gentoo-kernel-bin.json")
+    url = f"{PACKAGES_API}/sys-kernel/gentoo-kernel-bin.json"
+    return reachable(url) if proxy is None else reachable(url, proxy)
 
 
-def why_mirror_unreachable(mirror: str, variant: str) -> str:
+def why_mirror_unreachable(
+    mirror: str, variant: str, proxy: ProxyConfig | None = None
+) -> str:
     """Empty when the mirror answers, and why it did not otherwise."""
-    return why_unreachable(
-        f"{mirror.rstrip('/')}/{STAGE3_PATH}/latest-stage3-amd64-{variant}.txt"
-    )
+    url = f"{mirror.rstrip('/')}/{STAGE3_PATH}/latest-stage3-amd64-{variant}.txt"
+    return why_unreachable(url) if proxy is None else why_unreachable(url, proxy)
 
 
-def mirror_online(mirror: str, variant: str) -> bool:
+def mirror_online(
+    mirror: str, variant: str, proxy: ProxyConfig | None = None
+) -> bool:
     """Whether the mirror an install was told to use answers.
 
     The stage3 comes from here and nothing else has to answer: a run given a
@@ -382,16 +442,18 @@ def mirror_online(mirror: str, variant: str) -> bool:
     was not.
     """
     return reachable(
-        f"{mirror.rstrip('/')}/{STAGE3_PATH}/latest-stage3-amd64-{variant}.txt"
+        f"{mirror.rstrip('/')}/{STAGE3_PATH}/latest-stage3-amd64-{variant}.txt", proxy
     )
 
 
-def package_versions(atom: str) -> tuple[tuple[str, bool], ...]:
+def package_versions(
+    atom: str, proxy: ProxyConfig | None = None
+) -> tuple[tuple[str, bool], ...]:
     """Versions of a main-tree package, newest first, each with whether it is
     stable on amd64. Read live: the installing system need not be Gentoo and
     need not carry a repository at all."""
     try:
-        document = json.loads(_read(f"{PACKAGES_API}/{atom}.json"))
+        document = json.loads(_read_for(f"{PACKAGES_API}/{atom}.json", proxy))
     except (DownloadFailed, ValueError):
         return ()
     found = [
@@ -402,7 +464,9 @@ def package_versions(atom: str) -> tuple[tuple[str, bool], ...]:
     return tuple(sorted(found, key=lambda pair: _version_key(pair[0]), reverse=True))
 
 
-def overlay_versions(atom: str) -> tuple[tuple[str, bool], ...]:
+def overlay_versions(
+    atom: str, proxy: ProxyConfig | None = None
+) -> tuple[tuple[str, bool], ...]:
     """Versions of a gentoo-zh package, from the overlay's own file listing.
 
     None is stable: the overlay is keyworded `~amd64` throughout, which is what
@@ -410,7 +474,7 @@ def overlay_versions(atom: str) -> tuple[tuple[str, bool], ...]:
     """
     _, _, name = atom.partition("/")
     try:
-        listing = json.loads(_read(f"{OVERLAY_API}/{atom}"))
+        listing = json.loads(_read_for(f"{OVERLAY_API}/{atom}", proxy))
     except (DownloadFailed, ValueError):
         return ()
     if not isinstance(listing, list):
@@ -424,15 +488,20 @@ def overlay_versions(atom: str) -> tuple[tuple[str, bool], ...]:
     return tuple((version, False) for version in sorted(named, key=_version_key, reverse=True))
 
 
-def zfs_kernel_max() -> KernelCeiling:
+def zfs_kernel_max(proxy: ProxyConfig | None = None) -> KernelCeiling:
     """The highest kernel `sys-fs/zfs` builds a module for, or unknown.
 
     `MODULES_KERNEL_MAX` in the newest ebuild. A real ceiling: 2.4.3 stops at
     7.0, so a 7.1 kernel leaves a ZFS root with no module to import the pool.
     """
-    for version, _ in package_versions("sys-fs/zfs"):
+    versions = (
+        package_versions("sys-fs/zfs")
+        if proxy is None
+        else package_versions("sys-fs/zfs", proxy)
+    )
+    for version, _ in versions:
         try:
-            ebuild = _read(f"{GITWEB}/sys-fs/zfs/zfs-{version}.ebuild")
+            ebuild = _read_for(f"{GITWEB}/sys-fs/zfs/zfs-{version}.ebuild", proxy)
         except DownloadFailed:
             return KernelCeiling(None)
         for line in ebuild.splitlines():
@@ -457,6 +526,138 @@ def _asked(url: str, *, data: bytes | None = None, method: str = "GET", **header
     return urllib.request.Request(
         url, data=data, method=method, headers={"User-Agent": USER_AGENT, **headers}
     )
+
+
+def _bypassed(url: str, proxy: ProxyConfig) -> bool:
+    host = urllib.parse.urlsplit(url).hostname
+    if not host:
+        return False
+    lowered = host.lower()
+    for raw_item in proxy.bypass:
+        item = raw_item.lower().lstrip(".")
+        if item == "*":
+            return True
+        if item.startswith("*."):
+            item = item[2:]
+        if lowered == item or lowered.endswith(f".{item}"):
+            return True
+    return False
+
+
+def _urlopen(
+    request: urllib.request.Request,
+    proxy: ProxyConfig | None,
+    timeout: float,
+) -> Any:
+    """Open a request through the configured proxy without exposing credentials."""
+    selected = proxy if proxy is not None else _CURRENT_PROXY.get()
+    if selected is None or not selected.url or _bypassed(request.full_url, selected):
+        return urllib.request.urlopen(request, timeout=timeout)
+    if selected.url.lower().split(":", 1)[0] in {"socks5", "socks5h"}:
+        return _socks_open(request, selected, timeout)
+    # ProxyHandler keeps credentials inside the opener and never places them in
+    # argv or the process environment.
+    handlers = urllib.request.ProxyHandler({"http": selected.url, "https": selected.url})
+    opener_handlers: list[Any] = [handlers]
+    if selected.username or selected.password:
+        passwords = urllib.request.HTTPPasswordMgrWithDefaultRealm()
+        passwords.add_password(None, selected.url, selected.username, selected.password)
+        passwords.add_password(
+            None, selected.redacted_url, selected.username, selected.password
+        )
+        opener_handlers.append(urllib.request.ProxyBasicAuthHandler(passwords))
+    return urllib.request.build_opener(*opener_handlers).open(request, timeout=timeout)
+
+
+def _recv(sock: socket.socket, size: int) -> bytes:
+    chunks: list[bytes] = []
+    while sum(map(len, chunks)) < size:
+        chunk = sock.recv(size - sum(map(len, chunks)))
+        if not chunk:
+            raise OSError("SOCKS5 proxy closed the connection")
+        chunks.append(chunk)
+    return b"".join(chunks)
+
+
+def _socks_connect(proxy: ProxyConfig, host: str, port: int, timeout: float | None) -> socket.socket:
+    parts = urllib.parse.urlsplit(proxy.url)
+    if not parts.hostname:
+        raise OSError("SOCKS5 proxy has no host")
+    proxy_port = parts.port or 1080
+    sock = socket.create_connection((parts.hostname, proxy_port), timeout)
+    username, password = proxy.username.encode(), proxy.password.encode()
+    methods = b"\x00\x02" if username or password else b"\x00"
+    sock.sendall(b"\x05" + bytes((len(methods),)) + methods)
+    answer = _recv(sock, 2)
+    if answer[0] != 5 or answer[1] == 255:
+        sock.close()
+        raise OSError("SOCKS5 proxy rejected authentication")
+    if answer[1] == 2:
+        if len(username) > 255 or len(password) > 255:
+            sock.close()
+            raise OSError("SOCKS5 credentials are too long")
+        sock.sendall(b"\x01" + bytes((len(username),)) + username + bytes((len(password),)) + password)
+        if _recv(sock, 2) != b"\x01\x00":
+            sock.close()
+            raise OSError("SOCKS5 proxy rejected credentials")
+    remote_dns = parts.scheme.lower() == "socks5h"
+    if remote_dns:
+        encoded = host.encode()
+        address = b"\x03" + bytes((len(encoded),)) + encoded
+    else:
+        resolved = cast(str, socket.getaddrinfo(host, port, type=socket.SOCK_STREAM)[0][4][0])
+        packed = socket.inet_pton(socket.AF_INET6 if ":" in resolved else socket.AF_INET, resolved)
+        address = (b"\x04" if ":" in resolved else b"\x01") + packed
+    sock.sendall(b"\x05\x01\x00" + address + port.to_bytes(2, "big"))
+    reply = _recv(sock, 4)
+    if reply[1] != 0:
+        sock.close()
+        raise OSError(f"SOCKS5 proxy CONNECT failed ({reply[1]})")
+    length = {1: 4, 4: 16}.get(reply[3])
+    if length is None:
+        length = _recv(sock, 1)[0]
+    _recv(sock, length + 2)
+    return sock
+
+
+def _socks_open(request: urllib.request.Request, proxy: ProxyConfig, timeout: float) -> Any:
+    parts = urllib.parse.urlsplit(request.full_url)
+    if not parts.hostname:
+        raise urllib.error.URLError("request has no host")
+    if parts.scheme == "https":
+        context = ssl.create_default_context()
+
+        class Secure(http.client.HTTPSConnection):
+            def connect(self) -> None:
+                self.sock = _socks_connect(proxy, self.host, self.port, self.timeout)
+                self.sock = context.wrap_socket(self.sock, server_hostname=self.host)
+
+        opener = urllib.request.build_opener(_SocksHTTPSHandler(Secure))
+    else:
+        class Plain(http.client.HTTPConnection):
+            def connect(self) -> None:
+                self.sock = _socks_connect(proxy, self.host, self.port, self.timeout)
+
+        opener = urllib.request.build_opener(_SocksHTTPHandler(Plain))
+    return opener.open(request, timeout=timeout)
+
+
+class _SocksHTTPHandler(urllib.request.HTTPHandler):
+    def __init__(self, connection: type[http.client.HTTPConnection]) -> None:
+        super().__init__()
+        self._connection = connection
+
+    def http_open(self, request: urllib.request.Request) -> Any:
+        return self.do_open(self._connection, request)
+
+
+class _SocksHTTPSHandler(urllib.request.HTTPSHandler):
+    def __init__(self, connection: type[http.client.HTTPSConnection]) -> None:
+        super().__init__()
+        self._connection = connection
+
+    def https_open(self, request: urllib.request.Request) -> Any:
+        return self.do_open(self._connection, request)
 
 
 #: Errno values that mean the address family this machine tried has no route
@@ -506,9 +707,9 @@ def _over(family: int) -> Iterator[None]:
 _FAMILIES: Final[tuple[int, ...]] = (socket.AF_INET, socket.AF_INET6)
 
 
-def _read(url: str) -> str:
+def _read(url: str, proxy: ProxyConfig | None = None) -> str:
     try:
-        return _read_once(url)
+        return _read_once(url) if proxy is None else _read_once(url, proxy)
     except DownloadFailed as first:
         if not _unroutable(first.__cause__ or first):
             raise
@@ -516,21 +717,26 @@ def _read(url: str) -> str:
     for family in _FAMILIES:
         try:
             with _over(family):
-                return _read_once(url)
+                return _read_once(url) if proxy is None else _read_once(url, proxy)
         except DownloadFailed as again:
             last = again
     raise last
 
 
-def _read_once(url: str) -> str:
+def _read_once(url: str, proxy: ProxyConfig | None = None) -> str:
     try:
-        with urllib.request.urlopen(_asked(url), timeout=TIMEOUT) as response:
+        with _urlopen(_asked(url), proxy, TIMEOUT) as response:
             return str(response.read().decode("utf-8", "replace"))
     except (urllib.error.URLError, TimeoutError, OSError) as error:
         raise DownloadFailed(f"{url} could not be read: {error}") from error
 
 
-def _download(url: str, target: Path, log: Callable[[str], None] | None = None) -> None:
+def _download(
+    url: str,
+    target: Path,
+    log: Callable[[str], None] | None = None,
+    proxy: ProxyConfig | None = None,
+) -> None:
     """Written beside the target and renamed, so an interrupted download never
     leaves a short file that looks complete.
 
@@ -539,7 +745,7 @@ def _download(url: str, target: Path, log: Callable[[str], None] | None = None) 
     family with no route fails before a byte arrives.
     """
     try:
-        _download_once(url, target, log)
+        _download_once(url, target, log, proxy)
         return
     except DownloadFailed as first:
         if not _unroutable(first.__cause__ or first):
@@ -548,7 +754,7 @@ def _download(url: str, target: Path, log: Callable[[str], None] | None = None) 
     for family in _FAMILIES:
         try:
             with _over(family):
-                _download_once(url, target, log)
+                _download_once(url, target, log, proxy)
                 return
         except DownloadFailed as again:
             last = again
@@ -577,10 +783,15 @@ def _progress(name: str, got: int, total: int | None) -> str:
     return f"{name}: {megabytes:.0f} MiB"
 
 
-def _download_once(url: str, target: Path, log: Callable[[str], None] | None = None) -> None:
+def _download_once(
+    url: str,
+    target: Path,
+    log: Callable[[str], None] | None = None,
+    proxy: ProxyConfig | None = None,
+) -> None:
     partial = target.with_suffix(target.suffix + ".part")
     try:
-        with urllib.request.urlopen(_asked(url), timeout=TIMEOUT) as response, partial.open("wb") as handle:
+        with _urlopen(_asked(url), proxy, TIMEOUT) as response, partial.open("wb") as handle:
             total = _content_length(response)
             got = 0
             said = time.monotonic()

--- a/gentoo_install/exec/runner.py
+++ b/gentoo_install/exec/runner.py
@@ -15,12 +15,14 @@ import signal
 import subprocess
 import threading
 import time
+import urllib.parse
 from dataclasses import dataclass, field
 from pathlib import Path, PurePosixPath
 from typing import Callable, Sequence
 
 from ..errors import CommandFailed
 from ..log import Journal
+from ..model.config import ProxyConfig
 
 
 @dataclass(frozen=True)
@@ -33,7 +35,7 @@ class Result:
 
     @property
     def command(self) -> str:
-        return shlex.join(self.argv)
+        return shlex.join(_display_argv(self.argv))
 
 
 @dataclass
@@ -53,6 +55,7 @@ class Runner:
     #: Prepended to every command, which is how `run_in_target` chroots.
     prefix: tuple[str, ...] = ()
     environment: dict[str, str] = field(default_factory=dict)
+    proxy: ProxyConfig | None = None
     history: list[Result] = field(default_factory=list)
 
     def run(
@@ -65,10 +68,10 @@ class Runner:
     ) -> Result:
         full = (*self.prefix, *argv)
         if self.dry_run:
-            self.log(f"would run: {shlex.join(full)}")
+            self.log(f"would run: {shlex.join(_display_argv(full))}")
             return Result(argv=full, returncode=0, stdout="", stderr="", seconds=0.0)
         started = time.monotonic()
-        self.log(f"run: {shlex.join(full)}")
+        self.log(f"run: {shlex.join(_display_argv(full))}")
         try:
             output, returncode = self._stream(full, input_text, timeout)
         except FileNotFoundError as error:
@@ -95,7 +98,7 @@ class Runner:
         )
         self.history.append(result)
         if self.journal is not None:
-            self.journal.command(result.argv, result.returncode, result.seconds)
+            self.journal.command(_display_argv(result.argv), result.returncode, result.seconds)
             if "emerge" in full:
                 self.journal.packages(result.stdout)
         if check and result.returncode != 0:
@@ -159,7 +162,9 @@ class Runner:
         # A timer that fired after the command already exited must not turn a
         # clean run into a timeout, so the signal decides, not the flag alone.
         if expired.is_set() and returncode < 0:
-            raise CommandFailed(f"{shlex.join(argv)} did not finish within {timeout}s")
+            raise CommandFailed(
+                f"{shlex.join(_display_argv(argv))} did not finish within {timeout}s"
+            )
         return "".join(lines), returncode
 
     def in_target(self, target: Path) -> Runner:
@@ -172,13 +177,51 @@ class Runner:
             prefix=("chroot", str(target)),
             # The target's /boot is already mounted where the layout says it is.
             environment={**self.environment, "DONT_MOUNT_BOOT": "1"},
+            proxy=self.proxy,
             history=self.history,
         )
 
     def _environment(self) -> dict[str, str] | None:
-        if not self.environment:
+        values = dict(self.environment)
+        # Password-bearing proxy URLs stay in tool configuration, never process environment.
+        if self.proxy is not None and self.proxy.url and not self.proxy.password:
+            values.update(
+                {
+                    "http_proxy": self.proxy.url,
+                    "https_proxy": self.proxy.url,
+                    "all_proxy": self.proxy.url,
+                    "no_proxy": ",".join(self.proxy.bypass),
+                    "HTTP_PROXY": self.proxy.url,
+                    "HTTPS_PROXY": self.proxy.url,
+                    "ALL_PROXY": self.proxy.url,
+                    "NO_PROXY": ",".join(self.proxy.bypass),
+                }
+            )
+        if not values:
             return None
-        return {**os.environ, **self.environment}
+        return {**os.environ, **values}
+
+
+def _display_argv(argv: Sequence[str]) -> tuple[str, ...]:
+    """Redact URL user information before a command reaches logs or journals."""
+    shown: list[str] = []
+    for value in argv:
+        try:
+            parts = urllib.parse.urlsplit(value)
+        except ValueError:
+            shown.append(value)
+            continue
+        if parts.scheme and parts.hostname and parts.username is not None:
+            host = parts.hostname
+            if ":" in host and not host.startswith("["):
+                host = f"[{host}]"
+            if parts.port is not None:
+                host = f"{host}:{parts.port}"
+            value = urllib.parse.urlunsplit(
+                (parts.scheme, host, parts.path, parts.query, parts.fragment)
+            )
+        shown.append(value)
+    return tuple(shown)
 
 
 #: What a failing command's own error looks like. Portage keeps printing after

--- a/gentoo_install/model/config.py
+++ b/gentoo_install/model/config.py
@@ -21,6 +21,7 @@ CONFIG_VERSION_KEY: Final[str] = "config_version"
 
 #: Persisted table sections in TOML order. The disk graph stays last.
 PERSISTED_SECTIONS: Final[tuple[str, ...]] = (
+    "proxy",
     "system",
     "portage",
     "kernel",
@@ -33,6 +34,52 @@ PERSISTED_SECTIONS: Final[tuple[str, ...]] = (
 class InitSystem(Enum):
     OPENRC = "openrc"
     SYSTEMD = "systemd"
+
+
+@dataclass(frozen=True)
+class ProxyConfig:
+    """The optional proxy used by installer and target network clients.
+
+    ``url`` may carry RFC 3986 user information. It is kept in the saved
+    configuration because the target needs the same credentials; callers that
+    display it must use :attr:`redacted_url`.
+    """
+
+    url: str = ""
+    bypass: tuple[str, ...] = ()
+
+    @property
+    def enabled(self) -> bool:
+        return bool(self.url)
+
+    @property
+    def redacted_url(self) -> str:
+        """The URL with user information removed for screen and log output."""
+        from urllib.parse import urlsplit, urlunsplit
+
+        if not self.url:
+            return ""
+        parts = urlsplit(self.url)
+        host = parts.hostname or ""
+        if ":" in host and not host.startswith("["):
+            host = f"[{host}]"
+        if parts.port is not None:
+            host = f"{host}:{parts.port}"
+        return urlunsplit((parts.scheme, host, parts.path, parts.query, parts.fragment))
+
+    @property
+    def username(self) -> str:
+        """The optional URL user information, percent-decoded."""
+        from urllib.parse import unquote, urlsplit
+
+        return unquote(urlsplit(self.url).username or "")
+
+    @property
+    def password(self) -> str:
+        """The optional URL password, percent-decoded."""
+        from urllib.parse import unquote, urlsplit
+
+        return unquote(urlsplit(self.url).password or "")
 
 
 class KernelSource(Enum):
@@ -376,6 +423,7 @@ class PackagesConfig:
 @dataclass(frozen=True)
 class InstallConfig:
     disk: DiskConfig
+    proxy: ProxyConfig = field(default_factory=ProxyConfig)
     system: SystemConfig = field(default_factory=SystemConfig)
     portage: PortageConfig = field(default_factory=PortageConfig)
     kernel: KernelConfig = field(default_factory=KernelConfig)

--- a/gentoo_install/model/parse.py
+++ b/gentoo_install/model/parse.py
@@ -11,6 +11,7 @@ import tomllib
 from enum import Enum
 from pathlib import Path, PurePosixPath
 from typing import Any, Mapping, Sequence, TypeVar
+from urllib.parse import unquote, urlsplit
 
 from ..errors import ConfigError
 from . import config as model_config
@@ -41,6 +42,7 @@ from .config import (
     Sync,
     PackagesConfig,
     PortageConfig,
+    ProxyConfig,
     SystemConfig,
     User,
 )
@@ -91,12 +93,45 @@ def parse(raw: Mapping[str, Any]) -> InstallConfig:
     return InstallConfig(
         config_version=version,
         disk=_disk(_table(raw, "disk", "", required=True), "disk"),
+        proxy=_proxy(_table(raw, "proxy", ""), "proxy"),
         system=_system(_table(raw, "system", ""), "system"),
         portage=_portage(_table(raw, "portage", ""), "portage"),
         kernel=_kernel(_table(raw, "kernel", ""), "kernel"),
         bootloader=_bootloader(_table(raw, "bootloader", ""), "bootloader"),
         packages=_packages(_table(raw, "packages", ""), "packages"),
     )
+
+
+def _proxy(raw: Mapping[str, Any], at: str) -> ProxyConfig:
+    _reject_unknown(raw, at, {"url", "bypass"})
+    default = ProxyConfig()
+    url = _str(raw, "url", at, default.url).strip()
+    if url:
+        try:
+            parts = urlsplit(url)
+            hostname = parts.hostname
+            parts.port
+        except ValueError as error:
+            raise ConfigError(f"{_at('url', at)} has an invalid host or port") from error
+        if parts.scheme.lower() not in {"http", "https", "socks5", "socks5h"}:
+            raise ConfigError(
+                f"{_at('url', at)} must use http://, https://, socks5:// or socks5h://"
+            )
+        if not hostname or any(char.isspace() for char in hostname):
+            raise ConfigError(f"{_at('url', at)} must include a proxy host")
+        if parts.path not in ("", "/") or parts.query or parts.fragment:
+            raise ConfigError(f"{_at('url', at)} must contain only a scheme, host and port")
+        if any(
+            any(ord(char) < 0x20 or ord(char) == 0x7F for char in unquote(value or ""))
+            for value in (parts.username, parts.password)
+        ):
+            raise ConfigError(f"{_at('url', at)} credentials contain control characters")
+    bypass = _strings(raw, "bypass", at, default.bypass)
+    if any(not host.strip() or any(char.isspace() for char in host) for host in bypass):
+        raise ConfigError(f"{_at('bypass', at)} must contain non-empty host names")
+    if not url and bypass:
+        raise ConfigError(f"{_at('bypass', at)} requires a proxy URL")
+    return ProxyConfig(url=url, bypass=tuple(host.strip() for host in bypass))
 
 
 def _system(raw: Mapping[str, Any], at: str) -> SystemConfig:

--- a/gentoo_install/model/serialise.py
+++ b/gentoo_install/model/serialise.py
@@ -15,7 +15,7 @@ from pathlib import PurePosixPath
 from typing import Any, Final
 
 from . import config as model_config
-from .config import InstallConfig
+from .config import InstallConfig, ProxyConfig
 from .device import (
     Existing,
     Filesystem,
@@ -100,6 +100,8 @@ def _section(name: str, value: object, prefix: str = "", *, publishing: bool = F
         if publishing and field.name in SECRET:
             keys.append(f"{field.name} = {_value(REDACTED)}")
             continue
+        if publishing and isinstance(value, ProxyConfig) and field.name == "url":
+            held = value.redacted_url
         keys.append(f"{field.name} = {_value(held)}")
     if not keys and not nested:
         return []

--- a/gentoo_install/model/validate.py
+++ b/gentoo_install/model/validate.py
@@ -13,6 +13,7 @@ from collections import Counter
 from dataclasses import dataclass
 from pathlib import PurePosixPath
 from typing import Collection, Final, Mapping
+from urllib.parse import unquote, urlsplit
 
 from ..errors import CommandFailed, ValidationFailed
 from . import compat
@@ -156,6 +157,7 @@ def validate(
 ) -> None:
     address_facts = _derive_address_facts(config)
     problems = [
+        *_proxy_problems(config),
         *_layout_problems(config),
         *compat.filesystem_label_problems(config),
         *root_size_problems(config),
@@ -177,6 +179,38 @@ def validate(
         raise ValidationFailed(
             "the configuration does not describe an installable system:\n  " + "\n  ".join(problems)
         )
+
+
+def _proxy_problems(config: InstallConfig) -> list[str]:
+    """Check proxy syntax for configurations built without the TOML parser."""
+    proxy = config.proxy
+    if not proxy.url:
+        if proxy.bypass:
+            return ["proxy bypass hosts require a proxy URL"]
+        return []
+    try:
+        parts = urlsplit(proxy.url)
+    except ValueError:
+        return ["proxy URL has an invalid host or port"]
+    if parts.scheme.lower() not in {"http", "https", "socks5", "socks5h"}:
+        return ["proxy URL must use http, https, socks5 or socks5h"]
+    try:
+        host = parts.hostname
+        port = parts.port
+    except ValueError:
+        return ["proxy URL has an invalid host or port"]
+    if not host or any(char.isspace() for char in host):
+        return ["proxy URL must include a host"]
+    if parts.path not in ("", "/") or parts.query or parts.fragment:
+        return ["proxy URL must contain only a scheme, host and port"]
+    if any(
+        any(ord(char) < 0x20 or ord(char) == 0x7F for char in unquote(value or ""))
+        for value in (parts.username, parts.password)
+    ):
+        return ["proxy URL credentials contain control characters"]
+    if any(not item.strip() or any(char.isspace() for char in item) for item in proxy.bypass):
+        return ["proxy bypass hosts must be non-empty host names"]
+    return []
 
 
 def _zfs_kernel_problems(

--- a/gentoo_install/plan/portage.py
+++ b/gentoo_install/plan/portage.py
@@ -7,11 +7,13 @@ before a key can be imported, an imported key stays untrusted until `lsign`, and
 
 from __future__ import annotations
 
+import json
 import re
 from dataclasses import dataclass
 from enum import Enum
 from pathlib import PurePosixPath
 from typing import Final, Sequence
+from urllib.parse import urlsplit, urlunsplit
 
 from ..errors import CommandFailed, ConfigError
 from ..model import mirrors
@@ -22,6 +24,7 @@ from ..model.config import (
     Keywords,
     MirrorRegion,
     PortageConfig,
+    ProxyConfig,
     Sync,
 )
 from ..model.validate import parse_profile_list, validate_profile
@@ -46,6 +49,19 @@ AUTOUNMASK_FILES: Final[tuple[str, ...]] = (
     "/etc/portage/package.use/zz-autounmask",
     "/etc/portage/package.accept_keywords/zz-autounmask",
     "/etc/portage/package.license/zz-autounmask",
+)
+
+PROXY_BOOTSTRAP: Final[PurePosixPath] = PurePosixPath(
+    "/etc/gentoo-install/proxy.toml"
+)
+
+FETCHCOMMAND: Final[str] = (
+    'wget -t 3 -T 60 --passive-ftp -U "Portage (Gentoo, '
+    'https://www.gentoo.org) distfile-fetch" -O "${DISTDIR}/${FILE}" "${URI}"'
+)
+RESUMECOMMAND: Final[str] = (
+    'wget -c -t 3 -T 60 --passive-ftp -U "Portage (Gentoo, '
+    'https://www.gentoo.org) distfile-fetch" -O "${DISTDIR}/${FILE}" "${URI}"'
 )
 
 #: What is absent matters as much as what is here, and the reason for each
@@ -90,14 +106,21 @@ class InstallStage3(Operation):
     stage: Stage = Stage.STAGE3
     mirror: str
     variant: str
+    proxy: ProxyConfig = ProxyConfig()
 
     def describe(self) -> str:
+        route = f" via {self.proxy.redacted_url}" if self.proxy.enabled else " directly"
         return (
-            f"download the newest {self.variant} stage3 from {self.mirror}, verify it "
+            f"download the newest {self.variant} stage3 from {self.mirror}{route}, verify it "
             f"against {RELENG_FINGERPRINT[-16:]} and unpack it into the target"
         )
 
     def apply(self, context: Context) -> None:
+        context.write(
+            PROXY_BOOTSTRAP,
+            _proxy_toml(self.proxy),
+            mode=0o600,
+        )
         archive = context.fetch_stage3(self.mirror, self.variant, RELENG_FINGERPRINT)
         context.run(
             [
@@ -112,6 +135,55 @@ class InstallStage3(Operation):
                 f"--checkpoint={UNPACK_CHECKPOINT}",
                 "--checkpoint-action=echo",
             ]
+        )
+
+
+@dataclass(frozen=True, kw_only=True)
+class WriteProxyClients(Operation):
+    """Configure clients that Portage invokes without putting credentials in argv."""
+
+    stage: Stage = Stage.PORTAGE
+    proxy: ProxyConfig
+
+    def describe(self) -> str:
+        route = self.proxy.redacted_url if self.proxy.enabled else "direct connection"
+        return f"configure Portage, wget, curl, git and gpg for {route}"
+
+    def apply(self, context: Context) -> None:
+        proxy = self.proxy
+        endpoint = _proxy_endpoint(proxy)
+        bypass = ",".join(proxy.bypass)
+        context.write(
+            PurePosixPath("/etc/wgetrc"),
+            f"use_proxy = {'on' if proxy.enabled else 'off'}\n"
+            f"http_proxy = {endpoint}\nhttps_proxy = {endpoint}\n"
+            f"no_proxy = {bypass}\nproxy_user = {proxy.username}\n"
+            f"proxy_password = {proxy.password}\n",
+            mode=0o600,
+        )
+        context.write(
+            PurePosixPath("/etc/curlrc"),
+            f"proxy = {endpoint}\n"
+            f"noproxy = {bypass}\n"
+            f"proxy-user = {proxy.username}:{proxy.password}\n",
+            mode=0o600,
+        )
+        context.write(
+            PurePosixPath("/etc/gitconfig"),
+            "[http]\n"
+            f"\tproxy = {proxy.url}\n"
+            f"\tnoProxy = {bypass}\n",
+            mode=0o600,
+        )
+        context.write(
+            PurePosixPath("/etc/portage/gnupg/dirmngr.conf"),
+            f"http-proxy {proxy.url}\n" if proxy.enabled else "",
+            mode=0o600,
+        )
+        context.write(
+            PROXY_BOOTSTRAP,
+            _proxy_toml(proxy),
+            mode=0o600,
         )
 
 
@@ -827,7 +899,7 @@ def build(
     portage = config.portage
     gentoo = PurePosixPath("/var/db/repos/gentoo")
     operations: list[Operation] = [
-        InstallStage3(mirror=mirror, variant=variant_of(config)),
+        InstallStage3(mirror=mirror, variant=variant_of(config), proxy=config.proxy),
         MountChrootFilesystems(),
         SeedResolver(),
     ]
@@ -838,6 +910,7 @@ def build(
             speed_test=portage.mirrors.speed_test,
             appended=_appended_distfiles(portage),
         ),
+        WriteProxyClients(proxy=config.proxy),
         CreateAutounmaskFiles(),
     ]
     if _uses_binhost(portage):
@@ -997,9 +1070,52 @@ def make_conf(
         ("ACCEPT_LICENSE", " ".join(licenses or portage.accept_license)),
         ("L10N", " ".join(_l10n(config))),
     ]
+    proxy = config.proxy
+    endpoint = _proxy_endpoint(proxy)
+    settings += [
+        ("http_proxy", endpoint),
+        ("https_proxy", endpoint),
+        ("ftp_proxy", endpoint),
+        ("all_proxy", endpoint),
+        ("no_proxy", ",".join(proxy.bypass)),
+        ("FETCHCOMMAND", FETCHCOMMAND),
+        ("RESUMECOMMAND", RESUMECOMMAND),
+    ]
+    if proxy.enabled and urlsplit(proxy.url).scheme.lower() in {"http", "https"}:
+        settings.append(("RSYNC_PROXY", _rsync_proxy(proxy)))
     if _uses_binhost(portage):
         settings.append(("FEATURES", "getbinpkg"))
     return tuple(settings)
+
+
+def _proxy_endpoint(proxy: ProxyConfig) -> str:
+    """The proxy URL without user information, for process environments."""
+    if not proxy.url:
+        return ""
+    parts = urlsplit(proxy.url)
+    host = parts.hostname or ""
+    if ":" in host and not host.startswith("["):
+        host = f"[{host}]"
+    if parts.port is not None:
+        host = f"{host}:{parts.port}"
+    return urlunsplit((parts.scheme, host, "", "", ""))
+
+
+def _rsync_proxy(proxy: ProxyConfig) -> str:
+    """The host:port form rsync reads from `RSYNC_PROXY`."""
+    parts = urlsplit(proxy.url)
+    host = parts.hostname or ""
+    if ":" in host and not host.startswith("["):
+        host = f"[{host}]"
+    return f"{host}:{parts.port or 8080}"
+
+
+def _proxy_toml(proxy: ProxyConfig) -> str:
+    """The credential-bearing bootstrap file read only by the installer."""
+    return (
+        f"url = {json.dumps(proxy.url)}\n"
+        f"bypass = {json.dumps(list(proxy.bypass))}\n"
+    )
 
 
 def _uses_binhost(portage: PortageConfig) -> bool:

--- a/gentoo_install/plan/system.py
+++ b/gentoo_install/plan/system.py
@@ -2,11 +2,14 @@
 
 from __future__ import annotations
 
+import json
+import shlex
 from dataclasses import dataclass
 from enum import Enum
 from pathlib import PurePosixPath
 from types import MappingProxyType
 from typing import Final, Mapping
+from urllib.parse import urlsplit, urlunsplit
 
 from ..errors import InvalidLayout, LocaleMissing
 from ..model import compat
@@ -17,6 +20,7 @@ from ..model.config import (
     InstallConfig,
     Logger,
     Networking,
+    ProxyConfig,
     SystemConfig,
     User,
 )
@@ -62,6 +66,38 @@ class NetworkService(Enum):
     DHCPCD = "dhcpcd"
     NETWORKMANAGER = "NetworkManager"
     NETIFRC_INTERFACE = "netifrc-interface"
+
+
+@dataclass(frozen=True, kw_only=True)
+class WriteProxyEnvironment(Operation):
+    """Keep the selected route available to clients after the first boot."""
+
+    stage: Stage = Stage.SYSTEM
+    proxy: ProxyConfig
+
+    def describe(self) -> str:
+        route = self.proxy.redacted_url if self.proxy.enabled else "direct connection"
+        return f"keep proxy environment for {route} in the installed system"
+
+    def apply(self, context: Context) -> None:
+        endpoint = _proxy_endpoint(self.proxy)
+        bypass = ",".join(self.proxy.bypass)
+        values = {
+            "http_proxy": endpoint,
+            "https_proxy": endpoint,
+            "ftp_proxy": endpoint,
+            "all_proxy": endpoint,
+            "no_proxy": bypass,
+        }
+        environment = "".join(
+            f"{key}={json.dumps(value)}\n{key.upper()}={json.dumps(value)}\n"
+            for key, value in values.items()
+        )
+        context.write(PurePosixPath("/etc/environment"), environment)
+        profile = "".join(
+            f"export {key}={shlex.quote(value)}\n" for key, value in values.items()
+        )
+        context.write(PurePosixPath("/etc/profile.d/gentoo-install-proxy.sh"), profile)
 
 
 @dataclass(frozen=True)
@@ -927,6 +963,7 @@ class EnableService(Operation):
 def build(config: InstallConfig) -> list[Operation]:
     system = config.system
     operations: list[Operation] = [
+        WriteProxyEnvironment(proxy=config.proxy),
         GenerateLocales(locales=system.locales),
         SelectLocale(locale=system.locale, init=system.init),
         SetTimezone(timezone=system.timezone),
@@ -1085,6 +1122,19 @@ def build(config: InstallConfig) -> list[Operation]:
         ]
     operations += _zfs_services(config)
     return operations
+
+
+def _proxy_endpoint(proxy: ProxyConfig) -> str:
+    """The proxy URL without user information, for process environments."""
+    if not proxy.url:
+        return ""
+    parts = urlsplit(proxy.url)
+    host = parts.hostname or ""
+    if ":" in host and not host.startswith("["):
+        host = f"[{host}]"
+    if parts.port is not None:
+        host = f"{host}:{parts.port}"
+    return urlunsplit((parts.scheme, host, "", "", ""))
 
 
 def _zfs_services(config: InstallConfig) -> list[Operation]:

--- a/gentoo_install/tui/screens.py
+++ b/gentoo_install/tui/screens.py
@@ -15,8 +15,10 @@ from enum import Enum
 from itertools import takewhile
 from pathlib import PurePosixPath
 from typing import Callable, Final, Generic, Sequence, TypeVar, TypedDict
+from urllib.parse import urlsplit
 
 from ..i18n import Catalog, truncate
+from ..exec import fetch
 from ..model import compat
 from ..model.config import (
     SystemConfig,
@@ -41,6 +43,7 @@ from ..model.config import (
     Overlay,
     PackagesConfig,
     PortageConfig,
+    ProxyConfig,
     Sync,
     User,
 )
@@ -632,6 +635,62 @@ def system_screen(screen: Screen, config: InstallConfig, context: Context) -> An
         Outcome.CHOSE,
         replace(config, system=replace(config.system, hostname=answer.unwrap() or "gentoo")),
     )
+
+
+def proxy_screen(screen: Screen, config: InstallConfig, context: Context) -> Answer[InstallConfig]:
+    """Set the session proxy before any network-derived setting is read."""
+    translate = context.translate
+    current = config.proxy
+
+    def validated(values: list[str]) -> Answer[InstallConfig] | FormRejected:
+        url, hosts = (one.strip() for one in values)
+        if url:
+            try:
+                parts = urlsplit(url)
+            except ValueError:
+                return FormRejected(translate("Proxy URL must include a host"), {0: url, 1: hosts})
+            if parts.scheme.lower() not in {"http", "https", "socks5", "socks5h"}:
+                return FormRejected(
+                    translate("Proxy URL must use http://, https://, socks5:// or socks5h://"),
+                    {0: url, 1: hosts},
+                )
+            try:
+                hostname = parts.hostname
+                parts.port
+            except ValueError:
+                hostname = None
+            if not hostname or any(char.isspace() for char in hostname):
+                return FormRejected(translate("Proxy URL must include a host"), {0: url, 1: hosts})
+            if parts.path not in ("", "/") or parts.query or parts.fragment:
+                return FormRejected(
+                    translate("Proxy URL must contain only a scheme, host and port"),
+                    {0: url, 1: hosts},
+                )
+        bypass = tuple(one for one in (item.strip() for item in hosts.split(",")) if one)
+        if any(any(char.isspace() for char in item) for item in bypass):
+            return FormRejected(translate("Bypass hosts must not contain spaces"), {1: hosts})
+        selected = replace(config, proxy=ProxyConfig(url=url, bypass=bypass))
+        fetch.configure_proxy(selected.proxy)
+        return Answer(Outcome.CHOSE, selected)
+
+    return Form(
+        title=translate("Proxy"),
+        fields=[
+            Field(
+                label=translate("Proxy URL"),
+                value=current.url,
+                secret=True,
+                placeholder=translate("empty for direct; socks5 resolves locally, socks5h at the proxy"),
+            ),
+            Field(
+                label=translate("Bypass hosts"),
+                value=", ".join(current.bypass),
+                placeholder=translate("comma-separated host names"),
+            ),
+        ],
+        footer=footer(translate),
+        done=translate("Done"),
+    ).run_validated(screen, validated)
 
 
 def init_screen(screen: Screen, config: InstallConfig, context: Context) -> Answer[InstallConfig]:
@@ -3243,6 +3302,7 @@ def saved_config_screen(
         try:
             loaded = context.load_config(answer.unwrap())
             context.hydrate_disk(loaded)
+            fetch.configure_proxy(loaded.proxy)
             return Answer(Outcome.CHOSE, loaded)
         except GentooInstallError as error:
             # Back to the list rather than out of the installer: the file being

--- a/gentoo_install/tui/settings.py
+++ b/gentoo_install/tui/settings.py
@@ -400,6 +400,17 @@ def _mirror(config: InstallConfig, context: Context) -> str:
     return f"{chosen.site}{measured}" + (f", {', '.join(overlays)}" if overlays else "")
 
 
+def _proxy(config: InstallConfig, context: Context) -> str:
+    """Show the proxy endpoint without exposing URL credentials."""
+    proxy = config.proxy
+    if not proxy.url:
+        return context.translate("off")
+    value = proxy.redacted_url
+    if proxy.bypass:
+        value += f"  {context.translate('{count} hosts bypass').format(count=len(proxy.bypass))}"
+    return value
+
+
 def _firmware(config: InstallConfig, context: Context) -> str:
     """The value alone. The row cannot be edited and already draws the reason
     beside it, so a `(detected)` suffix said the same word twice."""
@@ -812,6 +823,7 @@ NETWORK: Final[tuple[Setting, ...]] = (
 #: The menu, flat and in the order it is drawn. One row per decision.
 SETTINGS: Final[tuple[Setting, ...]] = (
     Setting("firmware", "Firmware", _firmware, None),
+    Setting("proxy", "Proxy", _proxy, screens.proxy_screen),
     Setting("keymap", "Keyboard layout", lambda c, x: c.system.keymap, screens.keymap_screen),
     Setting(
         "language",

--- a/tests/fixtures/proxy/config.toml
+++ b/tests/fixtures/proxy/config.toml
@@ -1,0 +1,57 @@
+config_version = 1
+
+[proxy]
+url = "socks5h://operator:secret@proxy.example:1080"
+bypass = ["localhost", "intranet.example"]
+
+[system]
+hostname = "proxy-target"
+timezone = "UTC"
+locales = ["en_US.UTF-8"]
+locale = "en_US.UTF-8"
+init = "openrc"
+root_password_hash = "$6$gentooinst$IR3GrdJ862XljQYDqocr4tKniIRDIT.jQNFzIrHE3U75H6B6YSWZoSYoVd5edSHpqaYBdiNfXHCoIPRVgb9lT/"
+
+[portage]
+profile = "default/linux/amd64/23.0"
+makeopts = "-j4"
+
+[portage.binhost]
+official = false
+
+[bootloader]
+firmware = "bios"
+
+[disk]
+root = "mnt-root"
+
+[[disk.devices]]
+kind = "existing"
+id = "disk"
+selector = "/dev/disk/by-id/virtio-target0"
+wipe = true
+
+[[disk.devices]]
+kind = "table"
+id = "table"
+disk = "disk"
+table = "mbr"
+
+[[disk.devices]]
+kind = "partition"
+id = "rootpart"
+table = "table"
+index = 1
+role = "data"
+
+[[disk.devices]]
+kind = "filesystem"
+id = "rootfs"
+device = "rootpart"
+type = "ext4"
+
+[[disk.devices]]
+kind = "mountpoint"
+id = "mnt-root"
+source = "rootfs"
+path = "/"

--- a/tests/fixtures/vm-proxy-dead.toml
+++ b/tests/fixtures/vm-proxy-dead.toml
@@ -1,0 +1,109 @@
+# btrfs with the @ and @home subvolumes and no encryption. The other two
+# btrfs fixtures both wrap it in LUKS, so the plain subvolume path -- what
+# the whole-disk btrfs template produces -- was never installed once.
+#
+# The root hash below is `install`, produced by `openssl passwd -6`.
+config_version = 1
+
+[proxy]
+url = "http://127.0.0.1:1"
+
+[system]
+hostname = "btrfsbox"
+timezone = "Asia/Taipei"
+locales = ["en_US.UTF-8", "zh_TW.UTF-8"]
+locale = "zh_TW.UTF-8"
+init = "systemd"
+root_password_hash = "$6$gentooinst$IR3GrdJ862XljQYDqocr4tKniIRDIT.jQNFzIrHE3U75H6B6YSWZoSYoVd5edSHpqaYBdiNfXHCoIPRVgb9lT/"
+
+[portage]
+profile = "default/linux/amd64/23.0/systemd"
+makeopts = "-j4"
+
+[portage.binhost]
+official = true
+community = "off"
+
+[kernel]
+source = "dist-bin"
+
+[bootloader]
+kind = "grub"
+firmware = "uefi"
+kernel_params = ["console=ttyS0,115200"]
+
+[disk]
+root = "mnt-root"
+
+[[disk.devices]]
+kind = "existing"
+id = "disk"
+selector = "/dev/disk/by-id/virtio-target0"
+wipe = true
+
+[[disk.devices]]
+kind = "table"
+id = "table"
+disk = "disk"
+table = "gpt"
+
+[[disk.devices]]
+kind = "partition"
+id = "esp"
+table = "table"
+index = 1
+role = "esp"
+size = "512MiB"
+
+[[disk.devices]]
+kind = "partition"
+id = "cryptroot"
+table = "table"
+index = 2
+role = "data"
+
+[[disk.devices]]
+kind = "filesystem"
+id = "espfs"
+device = "esp"
+type = "vfat"
+label = "ESP"
+
+[[disk.devices]]
+kind = "filesystem"
+id = "rootfs"
+device = "cryptroot"
+type = "btrfs"
+
+[[disk.devices]]
+kind = "subvolume"
+id = "sub-root"
+filesystem = "rootfs"
+name = "@"
+
+[[disk.devices]]
+kind = "subvolume"
+id = "sub-home"
+filesystem = "rootfs"
+name = "@home"
+
+[[disk.devices]]
+kind = "mountpoint"
+id = "mnt-root"
+source = "sub-root"
+path = "/"
+options = ["compress=zstd:1"]
+
+[[disk.devices]]
+kind = "mountpoint"
+id = "mnt-home"
+source = "sub-home"
+path = "/home"
+options = ["compress=zstd:1"]
+
+[[disk.devices]]
+kind = "mountpoint"
+id = "mnt-esp"
+source = "espfs"
+path = "/efi"
+options = ["umask=0077"]

--- a/tests/golden/btrfs-luks.txt
+++ b/tests/golden/btrfs-luks.txt
@@ -22,14 +22,15 @@
   mount root-luks at /home with compress=zstd:1,subvol=@home
 
 [stage3]
-  download the newest desktop-systemd stage3 from https://mirrors.ustc.edu.cn/gentoo, verify it against BB572E0E2D182910 and unpack it into the target
+  download the newest desktop-systemd stage3 from https://mirrors.ustc.edu.cn/gentoo directly, verify it against BB572E0E2D182910 and unpack it into the target
 
 [chroot]
   mount transient proc, sys, dev and run filesystems into the target
   seed the target's resolv.conf from the install medium
 
 [portage]
-  write /etc/portage/make.conf with COMMON_FLAGS, CFLAGS, CXXFLAGS, FCFLAGS, FFLAGS, MAKEOPTS, USE, VIDEO_CARDS, INPUT_DEVICES, ACCEPT_LICENSE, L10N, FEATURES; 23 mirrors fastest first, measured, 5 appended
+  write /etc/portage/make.conf with COMMON_FLAGS, CFLAGS, CXXFLAGS, FCFLAGS, FFLAGS, MAKEOPTS, USE, VIDEO_CARDS, INPUT_DEVICES, ACCEPT_LICENSE, L10N, http_proxy, https_proxy, ftp_proxy, all_proxy, no_proxy, FETCHCOMMAND, RESUMECOMMAND, FEATURES; 23 mirrors fastest first, measured, 5 appended
+  configure Portage, wget, curl, git and gpg for direct connection
   create the three autounmask files emerge writes its decisions into
   run getuto so Portage has a keyring to verify binary packages against
   add verified binary package host gentoo at https://mirrors.ustc.edu.cn/gentoo/releases/amd64/binpackages/23.0/x86-64
@@ -54,6 +55,7 @@
   resolve app-admin/sudo net-misc/openssh sys-process/cronie sys-kernel/installkernel sys-apps/systemd sys-kernel/dracut sys-kernel/linux-firmware sys-fs/cryptsetup sys-fs/btrfs-progs sys-fs/dosfstools sys-kernel/gentoo-cjk-kernel-bin sys-boot/grub sys-boot/efibootmgr kde-plasma/plasma-meta x11-base/xorg-server kde-apps/konsole kde-apps/dolphin app-i18n/fcitx app-i18n/fcitx-gtk app-i18n/fcitx-qt app-i18n/fcitx-configtool app-i18n/fcitx-rime app-i18n/rime-data media-fonts/noto-cjk media-fonts/noto media-libs/fontconfig net-proxy/flclash-bin together before installing the requested packages
 
 [system]
+  keep proxy environment for direct connection in the installed system
   generate and verify locales en_US.UTF-8, zh_TW.UTF-8
   set the system locale to zh_TW.UTF-8
   set the timezone to Asia/Taipei

--- a/tests/golden/ext4-bios.txt
+++ b/tests/golden/ext4-bios.txt
@@ -14,14 +14,15 @@
   mount rootpart at /
 
 [stage3]
-  download the newest openrc stage3 from https://distfiles.gentoo.org, verify it against BB572E0E2D182910 and unpack it into the target
+  download the newest openrc stage3 from https://distfiles.gentoo.org directly, verify it against BB572E0E2D182910 and unpack it into the target
 
 [chroot]
   mount transient proc, sys, dev and run filesystems into the target
   seed the target's resolv.conf from the install medium
 
 [portage]
-  write /etc/portage/make.conf with MAKEOPTS, INPUT_DEVICES, ACCEPT_LICENSE, L10N; 2 mirrors in the configured order, 5 appended
+  write /etc/portage/make.conf with MAKEOPTS, INPUT_DEVICES, ACCEPT_LICENSE, L10N, http_proxy, https_proxy, ftp_proxy, all_proxy, no_proxy, FETCHCOMMAND, RESUMECOMMAND; 2 mirrors in the configured order, 5 appended
+  configure Portage, wget, curl, git and gpg for direct connection
   create the three autounmask files emerge writes its decisions into
   fetch the first ebuild repository snapshot with emerge-webrsync
   select profile default/linux/amd64/23.0
@@ -33,6 +34,7 @@
   resolve net-misc/netifrc net-misc/dhcpcd app-admin/sysklogd sys-process/cronie sys-kernel/installkernel sys-kernel/dracut sys-kernel/linux-firmware sys-fs/e2fsprogs sys-kernel/gentoo-kernel-bin sys-boot/grub together before installing the requested packages
 
 [system]
+  keep proxy environment for direct connection in the installed system
   generate and verify locales en_US.UTF-8
   set the system locale to en_US.UTF-8
   set the timezone to UTC

--- a/tests/golden/mbr-edit.txt
+++ b/tests/golden/mbr-edit.txt
@@ -11,14 +11,15 @@
   mount rootpart at /
 
 [stage3]
-  download the newest openrc stage3 from https://distfiles.gentoo.org, verify it against BB572E0E2D182910 and unpack it into the target
+  download the newest openrc stage3 from https://distfiles.gentoo.org directly, verify it against BB572E0E2D182910 and unpack it into the target
 
 [chroot]
   mount transient proc, sys, dev and run filesystems into the target
   seed the target's resolv.conf from the install medium
 
 [portage]
-  write /etc/portage/make.conf with MAKEOPTS, INPUT_DEVICES, ACCEPT_LICENSE, L10N, FEATURES; 2 mirrors in the configured order, 5 appended
+  write /etc/portage/make.conf with MAKEOPTS, INPUT_DEVICES, ACCEPT_LICENSE, L10N, http_proxy, https_proxy, ftp_proxy, all_proxy, no_proxy, FETCHCOMMAND, RESUMECOMMAND, FEATURES; 2 mirrors in the configured order, 5 appended
+  configure Portage, wget, curl, git and gpg for direct connection
   create the three autounmask files emerge writes its decisions into
   run getuto so Portage has a keyring to verify binary packages against
   add verified binary package host gentoo at https://distfiles.gentoo.org/releases/amd64/binpackages/23.0/x86-64
@@ -32,6 +33,7 @@
   resolve net-misc/netifrc net-misc/dhcpcd app-admin/sysklogd sys-process/cronie sys-kernel/installkernel sys-kernel/dracut sys-kernel/linux-firmware sys-fs/e2fsprogs sys-kernel/gentoo-kernel-bin sys-boot/grub together before installing the requested packages
 
 [system]
+  keep proxy environment for direct connection in the installed system
   generate and verify locales en_US.UTF-8
   set the system locale to en_US.UTF-8
   set the timezone to UTC

--- a/tests/golden/openrc-sdboot.txt
+++ b/tests/golden/openrc-sdboot.txt
@@ -15,14 +15,15 @@
   mount esp at /boot with umask=0077
 
 [stage3]
-  download the newest openrc stage3 from https://distfiles.gentoo.org, verify it against BB572E0E2D182910 and unpack it into the target
+  download the newest openrc stage3 from https://distfiles.gentoo.org directly, verify it against BB572E0E2D182910 and unpack it into the target
 
 [chroot]
   mount transient proc, sys, dev and run filesystems into the target
   seed the target's resolv.conf from the install medium
 
 [portage]
-  write /etc/portage/make.conf with MAKEOPTS, INPUT_DEVICES, ACCEPT_LICENSE, L10N, FEATURES; 2 mirrors in the configured order, 5 appended
+  write /etc/portage/make.conf with MAKEOPTS, INPUT_DEVICES, ACCEPT_LICENSE, L10N, http_proxy, https_proxy, ftp_proxy, all_proxy, no_proxy, FETCHCOMMAND, RESUMECOMMAND, FEATURES; 2 mirrors in the configured order, 5 appended
+  configure Portage, wget, curl, git and gpg for direct connection
   create the three autounmask files emerge writes its decisions into
   run getuto so Portage has a keyring to verify binary packages against
   add verified binary package host gentoo at https://distfiles.gentoo.org/releases/amd64/binpackages/23.0/x86-64
@@ -37,6 +38,7 @@
   resolve net-misc/netifrc net-misc/dhcpcd app-admin/sysklogd sys-process/cronie sys-kernel/installkernel sys-kernel/dracut sys-kernel/linux-firmware sys-fs/dosfstools sys-fs/e2fsprogs sys-kernel/gentoo-kernel-bin sys-apps/systemd-utils together before installing the requested packages
 
 [system]
+  keep proxy environment for direct connection in the installed system
   generate and verify locales en_US.UTF-8
   set the system locale to en_US.UTF-8
   set the timezone to UTC

--- a/tests/golden/vm-binpkg.txt
+++ b/tests/golden/vm-binpkg.txt
@@ -15,14 +15,15 @@
   mount esp at /efi with umask=0077
 
 [stage3]
-  download the newest systemd stage3 from https://distfiles.gentoo.org, verify it against BB572E0E2D182910 and unpack it into the target
+  download the newest systemd stage3 from https://distfiles.gentoo.org directly, verify it against BB572E0E2D182910 and unpack it into the target
 
 [chroot]
   mount transient proc, sys, dev and run filesystems into the target
   seed the target's resolv.conf from the install medium
 
 [portage]
-  write /etc/portage/make.conf with MAKEOPTS, INPUT_DEVICES, ACCEPT_LICENSE, L10N, FEATURES; 2 mirrors in the configured order, 5 appended
+  write /etc/portage/make.conf with MAKEOPTS, INPUT_DEVICES, ACCEPT_LICENSE, L10N, http_proxy, https_proxy, ftp_proxy, all_proxy, no_proxy, FETCHCOMMAND, RESUMECOMMAND, FEATURES; 2 mirrors in the configured order, 5 appended
+  configure Portage, wget, curl, git and gpg for direct connection
   create the three autounmask files emerge writes its decisions into
   run getuto so Portage has a keyring to verify binary packages against
   add verified binary package host gentoo at https://distfiles.gentoo.org/releases/amd64/binpackages/23.0/x86-64
@@ -36,6 +37,7 @@
   resolve net-misc/openssh sys-process/cronie sys-kernel/installkernel sys-kernel/dracut sys-kernel/linux-firmware sys-fs/dosfstools sys-fs/e2fsprogs sys-kernel/gentoo-kernel-bin sys-boot/grub sys-boot/efibootmgr together before installing the requested packages
 
 [system]
+  keep proxy environment for direct connection in the installed system
   generate and verify locales en_US.UTF-8
   set the system locale to en_US.UTF-8
   set the timezone to UTC

--- a/tests/golden/vm-bios-luks.txt
+++ b/tests/golden/vm-bios-luks.txt
@@ -18,14 +18,15 @@
   mount root-luks at /
 
 [stage3]
-  download the newest openrc stage3 from https://distfiles.gentoo.org, verify it against BB572E0E2D182910 and unpack it into the target
+  download the newest openrc stage3 from https://distfiles.gentoo.org directly, verify it against BB572E0E2D182910 and unpack it into the target
 
 [chroot]
   mount transient proc, sys, dev and run filesystems into the target
   seed the target's resolv.conf from the install medium
 
 [portage]
-  write /etc/portage/make.conf with MAKEOPTS, INPUT_DEVICES, ACCEPT_LICENSE, L10N, FEATURES; 2 mirrors in the configured order, 5 appended
+  write /etc/portage/make.conf with MAKEOPTS, INPUT_DEVICES, ACCEPT_LICENSE, L10N, http_proxy, https_proxy, ftp_proxy, all_proxy, no_proxy, FETCHCOMMAND, RESUMECOMMAND, FEATURES; 2 mirrors in the configured order, 5 appended
+  configure Portage, wget, curl, git and gpg for direct connection
   create the three autounmask files emerge writes its decisions into
   run getuto so Portage has a keyring to verify binary packages against
   add verified binary package host gentoo at https://distfiles.gentoo.org/releases/amd64/binpackages/23.0/x86-64
@@ -39,6 +40,7 @@
   resolve net-misc/netifrc net-misc/dhcpcd app-admin/sysklogd sys-process/cronie sys-kernel/installkernel sys-kernel/dracut sys-kernel/linux-firmware sys-fs/cryptsetup sys-fs/e2fsprogs sys-kernel/gentoo-kernel-bin sys-boot/grub together before installing the requested packages
 
 [system]
+  keep proxy environment for direct connection in the installed system
   generate and verify locales en_US.UTF-8
   set the system locale to en_US.UTF-8
   set the timezone to UTC

--- a/tests/golden/vm-bios.txt
+++ b/tests/golden/vm-bios.txt
@@ -14,14 +14,15 @@
   mount rootpart at /
 
 [stage3]
-  download the newest openrc stage3 from https://distfiles.gentoo.org, verify it against BB572E0E2D182910 and unpack it into the target
+  download the newest openrc stage3 from https://distfiles.gentoo.org directly, verify it against BB572E0E2D182910 and unpack it into the target
 
 [chroot]
   mount transient proc, sys, dev and run filesystems into the target
   seed the target's resolv.conf from the install medium
 
 [portage]
-  write /etc/portage/make.conf with MAKEOPTS, INPUT_DEVICES, ACCEPT_LICENSE, L10N, FEATURES; 2 mirrors in the configured order, 5 appended
+  write /etc/portage/make.conf with MAKEOPTS, INPUT_DEVICES, ACCEPT_LICENSE, L10N, http_proxy, https_proxy, ftp_proxy, all_proxy, no_proxy, FETCHCOMMAND, RESUMECOMMAND, FEATURES; 2 mirrors in the configured order, 5 appended
+  configure Portage, wget, curl, git and gpg for direct connection
   create the three autounmask files emerge writes its decisions into
   run getuto so Portage has a keyring to verify binary packages against
   add verified binary package host gentoo at https://distfiles.gentoo.org/releases/amd64/binpackages/23.0/x86-64
@@ -35,6 +36,7 @@
   resolve net-misc/netifrc net-misc/dhcpcd app-admin/sysklogd sys-process/cronie sys-kernel/installkernel sys-kernel/dracut sys-kernel/linux-firmware sys-fs/e2fsprogs sys-kernel/gentoo-kernel-bin sys-boot/grub together before installing the requested packages
 
 [system]
+  keep proxy environment for direct connection in the installed system
   generate and verify locales en_US.UTF-8
   set the system locale to en_US.UTF-8
   set the timezone to UTC

--- a/tests/golden/vm-btrfs.txt
+++ b/tests/golden/vm-btrfs.txt
@@ -18,14 +18,15 @@
   mount cryptroot at /home with compress=zstd:1,subvol=@home
 
 [stage3]
-  download the newest systemd stage3 from https://distfiles.gentoo.org, verify it against BB572E0E2D182910 and unpack it into the target
+  download the newest systemd stage3 from https://distfiles.gentoo.org directly, verify it against BB572E0E2D182910 and unpack it into the target
 
 [chroot]
   mount transient proc, sys, dev and run filesystems into the target
   seed the target's resolv.conf from the install medium
 
 [portage]
-  write /etc/portage/make.conf with MAKEOPTS, INPUT_DEVICES, ACCEPT_LICENSE, L10N, FEATURES; 2 mirrors in the configured order, 5 appended
+  write /etc/portage/make.conf with MAKEOPTS, INPUT_DEVICES, ACCEPT_LICENSE, L10N, http_proxy, https_proxy, ftp_proxy, all_proxy, no_proxy, FETCHCOMMAND, RESUMECOMMAND, FEATURES; 2 mirrors in the configured order, 5 appended
+  configure Portage, wget, curl, git and gpg for direct connection
   create the three autounmask files emerge writes its decisions into
   run getuto so Portage has a keyring to verify binary packages against
   add verified binary package host gentoo at https://distfiles.gentoo.org/releases/amd64/binpackages/23.0/x86-64
@@ -39,6 +40,7 @@
   resolve sys-process/cronie sys-kernel/installkernel sys-kernel/dracut sys-kernel/linux-firmware sys-fs/btrfs-progs sys-fs/dosfstools sys-kernel/gentoo-kernel-bin sys-boot/grub sys-boot/efibootmgr together before installing the requested packages
 
 [system]
+  keep proxy environment for direct connection in the installed system
   generate and verify locales en_US.UTF-8, zh_TW.UTF-8
   set the system locale to zh_TW.UTF-8
   set the timezone to Asia/Taipei

--- a/tests/golden/vm-cjk-kernel.txt
+++ b/tests/golden/vm-cjk-kernel.txt
@@ -15,14 +15,15 @@
   mount esp at /efi with umask=0077
 
 [stage3]
-  download the newest systemd stage3 from https://distfiles.gentoo.org, verify it against BB572E0E2D182910 and unpack it into the target
+  download the newest systemd stage3 from https://distfiles.gentoo.org directly, verify it against BB572E0E2D182910 and unpack it into the target
 
 [chroot]
   mount transient proc, sys, dev and run filesystems into the target
   seed the target's resolv.conf from the install medium
 
 [portage]
-  write /etc/portage/make.conf with MAKEOPTS, INPUT_DEVICES, ACCEPT_LICENSE, L10N, FEATURES; 2 mirrors in the configured order, 5 appended
+  write /etc/portage/make.conf with MAKEOPTS, INPUT_DEVICES, ACCEPT_LICENSE, L10N, http_proxy, https_proxy, ftp_proxy, all_proxy, no_proxy, FETCHCOMMAND, RESUMECOMMAND, FEATURES; 2 mirrors in the configured order, 5 appended
+  configure Portage, wget, curl, git and gpg for direct connection
   create the three autounmask files emerge writes its decisions into
   run getuto so Portage has a keyring to verify binary packages against
   add verified binary package host gentoo at https://distfiles.gentoo.org/releases/amd64/binpackages/23.0/x86-64
@@ -41,6 +42,7 @@
   resolve sys-process/cronie sys-kernel/installkernel sys-kernel/dracut sys-kernel/linux-firmware sys-fs/dosfstools sys-fs/e2fsprogs sys-kernel/gentoo-cjk-kernel-bin sys-boot/grub sys-boot/efibootmgr together before installing the requested packages
 
 [system]
+  keep proxy environment for direct connection in the installed system
   generate and verify locales en_US.UTF-8
   set the system locale to en_US.UTF-8
   set the timezone to UTC

--- a/tests/golden/vm-desktop.txt
+++ b/tests/golden/vm-desktop.txt
@@ -15,14 +15,15 @@
   mount esp at /efi with umask=0077
 
 [stage3]
-  download the newest desktop-systemd stage3 from https://distfiles.gentoo.org, verify it against BB572E0E2D182910 and unpack it into the target
+  download the newest desktop-systemd stage3 from https://distfiles.gentoo.org directly, verify it against BB572E0E2D182910 and unpack it into the target
 
 [chroot]
   mount transient proc, sys, dev and run filesystems into the target
   seed the target's resolv.conf from the install medium
 
 [portage]
-  write /etc/portage/make.conf with MAKEOPTS, USE, INPUT_DEVICES, ACCEPT_LICENSE, L10N, FEATURES; 2 mirrors in the configured order, 5 appended
+  write /etc/portage/make.conf with MAKEOPTS, USE, INPUT_DEVICES, ACCEPT_LICENSE, L10N, http_proxy, https_proxy, ftp_proxy, all_proxy, no_proxy, FETCHCOMMAND, RESUMECOMMAND, FEATURES; 2 mirrors in the configured order, 5 appended
+  configure Portage, wget, curl, git and gpg for direct connection
   create the three autounmask files emerge writes its decisions into
   run getuto so Portage has a keyring to verify binary packages against
   add verified binary package host gentoo at https://distfiles.gentoo.org/releases/amd64/binpackages/23.0/x86-64
@@ -39,6 +40,7 @@
   resolve net-misc/openssh net-misc/networkmanager net-wireless/wpa_supplicant sys-process/cronie sys-kernel/installkernel sys-kernel/dracut sys-kernel/linux-firmware sys-fs/dosfstools sys-fs/e2fsprogs sys-kernel/gentoo-kernel-bin sys-boot/grub sys-boot/efibootmgr kde-plasma/plasma-meta x11-base/xorg-server kde-apps/konsole kde-apps/dolphin app-i18n/fcitx app-i18n/fcitx-gtk app-i18n/fcitx-qt app-i18n/fcitx-configtool app-i18n/fcitx-rime app-i18n/rime-data media-fonts/noto-cjk media-fonts/noto media-libs/fontconfig media-video/pipewire media-video/wireplumber together before installing the requested packages
 
 [system]
+  keep proxy environment for direct connection in the installed system
   generate and verify locales en_US.UTF-8
   set the system locale to en_US.UTF-8
   set the timezone to UTC

--- a/tests/golden/vm-f2fs.txt
+++ b/tests/golden/vm-f2fs.txt
@@ -15,14 +15,15 @@
   mount esp at /efi with umask=0077
 
 [stage3]
-  download the newest systemd stage3 from https://distfiles.gentoo.org, verify it against BB572E0E2D182910 and unpack it into the target
+  download the newest systemd stage3 from https://distfiles.gentoo.org directly, verify it against BB572E0E2D182910 and unpack it into the target
 
 [chroot]
   mount transient proc, sys, dev and run filesystems into the target
   seed the target's resolv.conf from the install medium
 
 [portage]
-  write /etc/portage/make.conf with MAKEOPTS, INPUT_DEVICES, ACCEPT_LICENSE, L10N, FEATURES; 2 mirrors in the configured order, 5 appended
+  write /etc/portage/make.conf with MAKEOPTS, INPUT_DEVICES, ACCEPT_LICENSE, L10N, http_proxy, https_proxy, ftp_proxy, all_proxy, no_proxy, FETCHCOMMAND, RESUMECOMMAND, FEATURES; 2 mirrors in the configured order, 5 appended
+  configure Portage, wget, curl, git and gpg for direct connection
   create the three autounmask files emerge writes its decisions into
   run getuto so Portage has a keyring to verify binary packages against
   add verified binary package host gentoo at https://distfiles.gentoo.org/releases/amd64/binpackages/23.0/x86-64
@@ -36,6 +37,7 @@
   resolve net-misc/openssh sys-process/cronie sys-kernel/installkernel sys-kernel/dracut sys-kernel/linux-firmware sys-fs/dosfstools sys-fs/f2fs-tools sys-kernel/gentoo-kernel-bin sys-boot/grub sys-boot/efibootmgr together before installing the requested packages
 
 [system]
+  keep proxy environment for direct connection in the installed system
   generate and verify locales en_US.UTF-8
   set the system locale to en_US.UTF-8
   set the timezone to UTC

--- a/tests/golden/vm-gnome.txt
+++ b/tests/golden/vm-gnome.txt
@@ -15,14 +15,15 @@
   mount esp at /efi with umask=0077
 
 [stage3]
-  download the newest desktop-systemd stage3 from https://distfiles.gentoo.org, verify it against BB572E0E2D182910 and unpack it into the target
+  download the newest desktop-systemd stage3 from https://distfiles.gentoo.org directly, verify it against BB572E0E2D182910 and unpack it into the target
 
 [chroot]
   mount transient proc, sys, dev and run filesystems into the target
   seed the target's resolv.conf from the install medium
 
 [portage]
-  write /etc/portage/make.conf with MAKEOPTS, USE, INPUT_DEVICES, ACCEPT_LICENSE, L10N, FEATURES; 2 mirrors in the configured order, 5 appended
+  write /etc/portage/make.conf with MAKEOPTS, USE, INPUT_DEVICES, ACCEPT_LICENSE, L10N, http_proxy, https_proxy, ftp_proxy, all_proxy, no_proxy, FETCHCOMMAND, RESUMECOMMAND, FEATURES; 2 mirrors in the configured order, 5 appended
+  configure Portage, wget, curl, git and gpg for direct connection
   create the three autounmask files emerge writes its decisions into
   run getuto so Portage has a keyring to verify binary packages against
   add verified binary package host gentoo at https://distfiles.gentoo.org/releases/amd64/binpackages/23.0/x86-64
@@ -38,6 +39,7 @@
   resolve net-misc/openssh net-misc/networkmanager net-wireless/wpa_supplicant sys-process/cronie sys-kernel/installkernel sys-kernel/dracut sys-kernel/linux-firmware sys-fs/dosfstools sys-fs/e2fsprogs sys-kernel/gentoo-kernel-bin sys-boot/grub sys-boot/efibootmgr gnome-base/gnome-light x11-base/xorg-server gnome-base/gdm media-fonts/noto-cjk media-fonts/noto media-libs/fontconfig media-video/pipewire media-video/wireplumber together before installing the requested packages
 
 [system]
+  keep proxy environment for direct connection in the installed system
   generate and verify locales en_US.UTF-8
   set the system locale to en_US.UTF-8
   set the timezone to UTC

--- a/tests/golden/vm-lvm.txt
+++ b/tests/golden/vm-lvm.txt
@@ -23,14 +23,15 @@
   mount lv-home at /home
 
 [stage3]
-  download the newest openrc stage3 from https://distfiles.gentoo.org, verify it against BB572E0E2D182910 and unpack it into the target
+  download the newest openrc stage3 from https://distfiles.gentoo.org directly, verify it against BB572E0E2D182910 and unpack it into the target
 
 [chroot]
   mount transient proc, sys, dev and run filesystems into the target
   seed the target's resolv.conf from the install medium
 
 [portage]
-  write /etc/portage/make.conf with MAKEOPTS, INPUT_DEVICES, ACCEPT_LICENSE, L10N, FEATURES; 2 mirrors in the configured order, 5 appended
+  write /etc/portage/make.conf with MAKEOPTS, INPUT_DEVICES, ACCEPT_LICENSE, L10N, http_proxy, https_proxy, ftp_proxy, all_proxy, no_proxy, FETCHCOMMAND, RESUMECOMMAND, FEATURES; 2 mirrors in the configured order, 5 appended
+  configure Portage, wget, curl, git and gpg for direct connection
   create the three autounmask files emerge writes its decisions into
   run getuto so Portage has a keyring to verify binary packages against
   add verified binary package host gentoo at https://distfiles.gentoo.org/releases/amd64/binpackages/23.0/x86-64
@@ -45,6 +46,7 @@
   resolve net-misc/netifrc net-misc/dhcpcd app-admin/sysklogd sys-process/cronie sys-kernel/installkernel sys-kernel/dracut sys-kernel/linux-firmware sys-fs/dosfstools sys-fs/e2fsprogs sys-fs/lvm2 sys-kernel/gentoo-kernel-bin sys-boot/grub sys-boot/efibootmgr together before installing the requested packages
 
 [system]
+  keep proxy environment for direct connection in the installed system
   generate and verify locales en_US.UTF-8
   set the system locale to en_US.UTF-8
   set the timezone to UTC

--- a/tests/golden/vm-mdraid.txt
+++ b/tests/golden/vm-mdraid.txt
@@ -23,14 +23,15 @@
   mount esp at /efi with umask=0077
 
 [stage3]
-  download the newest systemd stage3 from https://distfiles.gentoo.org, verify it against BB572E0E2D182910 and unpack it into the target
+  download the newest systemd stage3 from https://distfiles.gentoo.org directly, verify it against BB572E0E2D182910 and unpack it into the target
 
 [chroot]
   mount transient proc, sys, dev and run filesystems into the target
   seed the target's resolv.conf from the install medium
 
 [portage]
-  write /etc/portage/make.conf with MAKEOPTS, INPUT_DEVICES, ACCEPT_LICENSE, L10N, FEATURES; 2 mirrors in the configured order, 5 appended
+  write /etc/portage/make.conf with MAKEOPTS, INPUT_DEVICES, ACCEPT_LICENSE, L10N, http_proxy, https_proxy, ftp_proxy, all_proxy, no_proxy, FETCHCOMMAND, RESUMECOMMAND, FEATURES; 2 mirrors in the configured order, 5 appended
+  configure Portage, wget, curl, git and gpg for direct connection
   create the three autounmask files emerge writes its decisions into
   run getuto so Portage has a keyring to verify binary packages against
   add verified binary package host gentoo at https://distfiles.gentoo.org/releases/amd64/binpackages/23.0/x86-64
@@ -44,6 +45,7 @@
   resolve sys-process/cronie sys-kernel/installkernel sys-kernel/dracut sys-kernel/linux-firmware sys-fs/mdadm sys-fs/dosfstools sys-fs/e2fsprogs sys-kernel/gentoo-kernel-bin sys-boot/grub sys-boot/efibootmgr together before installing the requested packages
 
 [system]
+  keep proxy environment for direct connection in the installed system
   generate and verify locales en_US.UTF-8
   set the system locale to en_US.UTF-8
   set the timezone to UTC

--- a/tests/golden/vm-openrc-desktop.txt
+++ b/tests/golden/vm-openrc-desktop.txt
@@ -15,14 +15,15 @@
   mount esp at /efi with umask=0077
 
 [stage3]
-  download the newest desktop-openrc stage3 from https://distfiles.gentoo.org, verify it against BB572E0E2D182910 and unpack it into the target
+  download the newest desktop-openrc stage3 from https://distfiles.gentoo.org directly, verify it against BB572E0E2D182910 and unpack it into the target
 
 [chroot]
   mount transient proc, sys, dev and run filesystems into the target
   seed the target's resolv.conf from the install medium
 
 [portage]
-  write /etc/portage/make.conf with MAKEOPTS, USE, INPUT_DEVICES, ACCEPT_LICENSE, L10N, FEATURES; 2 mirrors in the configured order, 5 appended
+  write /etc/portage/make.conf with MAKEOPTS, USE, INPUT_DEVICES, ACCEPT_LICENSE, L10N, http_proxy, https_proxy, ftp_proxy, all_proxy, no_proxy, FETCHCOMMAND, RESUMECOMMAND, FEATURES; 2 mirrors in the configured order, 5 appended
+  configure Portage, wget, curl, git and gpg for direct connection
   create the three autounmask files emerge writes its decisions into
   run getuto so Portage has a keyring to verify binary packages against
   add verified binary package host gentoo at https://distfiles.gentoo.org/releases/amd64/binpackages/23.0/x86-64
@@ -38,6 +39,7 @@
   resolve net-misc/openssh net-misc/networkmanager net-wireless/wpa_supplicant app-admin/sysklogd sys-process/cronie sys-kernel/installkernel sys-kernel/dracut sys-kernel/linux-firmware sys-fs/dosfstools sys-fs/e2fsprogs sys-kernel/gentoo-kernel-bin sys-boot/grub sys-boot/efibootmgr xfce-base/xfce4-meta x11-base/xorg-server x11-misc/lightdm x11-misc/lightdm-gtk-greeter gui-libs/display-manager-init media-video/pipewire media-video/wireplumber sys-apps/dbus sys-auth/elogind together before installing the requested packages
 
 [system]
+  keep proxy environment for direct connection in the installed system
   generate and verify locales en_US.UTF-8
   set the system locale to en_US.UTF-8
   set the timezone to UTC

--- a/tests/golden/vm-proxy-dead.txt
+++ b/tests/golden/vm-proxy-dead.txt
@@ -6,31 +6,27 @@
   create partition 2 on disk as cryptroot: data, the rest of the disk
   reread the partition table of disk and wait for its nodes
 
-[array]
-  format cryptroot as LUKS2
-  open cryptroot as /dev/mapper/root
-
 [format]
   make a vfat filesystem on esp as espfs labelled ESP
-  make a btrfs filesystem on root-luks as rootfs
-  create btrfs subvolume @home on root-luks as sub-home
-  create btrfs subvolume @ on root-luks as sub-root
+  make a btrfs filesystem on cryptroot as rootfs
+  create btrfs subvolume @home on cryptroot as sub-home
+  create btrfs subvolume @ on cryptroot as sub-root
 
 [mount]
-  mount root-luks at / with compress=zstd:1,subvol=@
+  mount cryptroot at / with compress=zstd:1,subvol=@
   mount esp at /efi with umask=0077
-  mount root-luks at /home with compress=zstd:1,subvol=@home
+  mount cryptroot at /home with compress=zstd:1,subvol=@home
 
 [stage3]
-  download the newest systemd stage3 from https://distfiles.gentoo.org directly, verify it against BB572E0E2D182910 and unpack it into the target
+  download the newest systemd stage3 from https://distfiles.gentoo.org via http://127.0.0.1:1, verify it against BB572E0E2D182910 and unpack it into the target
 
 [chroot]
   mount transient proc, sys, dev and run filesystems into the target
   seed the target's resolv.conf from the install medium
 
 [portage]
-  write /etc/portage/make.conf with MAKEOPTS, INPUT_DEVICES, ACCEPT_LICENSE, L10N, http_proxy, https_proxy, ftp_proxy, all_proxy, no_proxy, FETCHCOMMAND, RESUMECOMMAND, FEATURES; 2 mirrors in the configured order, 5 appended
-  configure Portage, wget, curl, git and gpg for direct connection
+  write /etc/portage/make.conf with MAKEOPTS, INPUT_DEVICES, ACCEPT_LICENSE, L10N, http_proxy, https_proxy, ftp_proxy, all_proxy, no_proxy, FETCHCOMMAND, RESUMECOMMAND, RSYNC_PROXY, FEATURES; 2 mirrors in the configured order, 5 appended
+  configure Portage, wget, curl, git and gpg for http://127.0.0.1:1
   create the three autounmask files emerge writes its decisions into
   run getuto so Portage has a keyring to verify binary packages against
   add verified binary package host gentoo at https://distfiles.gentoo.org/releases/amd64/binpackages/23.0/x86-64
@@ -40,21 +36,19 @@
   point repository gentoo at https://github.com/gentoo-mirror/gentoo.git, commit signatures verified
   sync repository gentoo
   set sys-kernel/installkernel to dracut
-  ask for sys-apps/systemd[cryptsetup], which provides the unlock generator
   accept the linux-firmware licence
-  resolve sys-process/cronie sys-kernel/installkernel sys-apps/systemd sys-kernel/dracut sys-kernel/linux-firmware sys-fs/cryptsetup sys-fs/btrfs-progs sys-fs/dosfstools sys-kernel/gentoo-kernel-bin sys-boot/grub sys-boot/efibootmgr together before installing the requested packages
+  resolve sys-process/cronie sys-kernel/installkernel sys-kernel/dracut sys-kernel/linux-firmware sys-fs/btrfs-progs sys-fs/dosfstools sys-kernel/gentoo-kernel-bin sys-boot/grub sys-boot/efibootmgr together before installing the requested packages
 
 [system]
-  keep proxy environment for direct connection in the installed system
+  keep proxy environment for http://127.0.0.1:1 in the installed system
   generate and verify locales en_US.UTF-8, zh_TW.UTF-8
   set the system locale to zh_TW.UTF-8
   set the timezone to Asia/Taipei
   set the console keymap to us and its font to default8x16
-  set the hostname to cryptbox
+  set the hostname to btrfsbox
   give the target its own machine id
   write /etc/fstab with entries for /, /efi, /home
   treat the hardware clock as UTC
-  write /etc/crypttab for root
   set the root password
   configure the wired interface for DHCP
   enable systemd-networkd at boot
@@ -64,17 +58,16 @@
 
 [kernel]
   install the hook that puts a kernel in /boot: emerge sys-kernel/installkernel
-  rebuild systemd with the unlock generator: emerge sys-apps/systemd, from source
   install the initramfs builder and firmware: emerge sys-kernel/dracut sys-kernel/linux-firmware
-  install the storage tools: emerge sys-fs/cryptsetup sys-fs/btrfs-progs sys-fs/dosfstools
+  install the storage tools: emerge sys-fs/btrfs-progs sys-fs/dosfstools
   install the kernel: emerge sys-kernel/gentoo-kernel-bin
-  tell dracut to carry crypt, btrfs
+  tell dracut to carry btrfs
   rebuild the initramfs from sys-kernel/gentoo-kernel-bin with the modules written above
   check the installkernel payload names existing kernel files
 
 [bootloader]
   install the bootloader: emerge sys-boot/grub sys-boot/efibootmgr
-  write /etc/default/grub with cmdline console=ttyS0,115200, cryptodisk enabled and its menu on ttyS0
+  write /etc/default/grub with cmdline console=ttyS0,115200, its menu on ttyS0
   install GRUB for uefi on the esp at /efi
 
 [finish]

--- a/tests/golden/vm-raidz.txt
+++ b/tests/golden/vm-raidz.txt
@@ -27,14 +27,15 @@
   mount esp at /efi with umask=0077
 
 [stage3]
-  download the newest systemd stage3 from https://distfiles.gentoo.org, verify it against BB572E0E2D182910 and unpack it into the target
+  download the newest systemd stage3 from https://distfiles.gentoo.org directly, verify it against BB572E0E2D182910 and unpack it into the target
 
 [chroot]
   mount transient proc, sys, dev and run filesystems into the target
   seed the target's resolv.conf from the install medium
 
 [portage]
-  write /etc/portage/make.conf with MAKEOPTS, INPUT_DEVICES, ACCEPT_LICENSE, L10N, FEATURES; 2 mirrors in the configured order, 5 appended
+  write /etc/portage/make.conf with MAKEOPTS, INPUT_DEVICES, ACCEPT_LICENSE, L10N, http_proxy, https_proxy, ftp_proxy, all_proxy, no_proxy, FETCHCOMMAND, RESUMECOMMAND, FEATURES; 2 mirrors in the configured order, 5 appended
+  configure Portage, wget, curl, git and gpg for direct connection
   create the three autounmask files emerge writes its decisions into
   run getuto so Portage has a keyring to verify binary packages against
   add verified binary package host gentoo at https://distfiles.gentoo.org/releases/amd64/binpackages/23.0/x86-64
@@ -53,6 +54,7 @@
   resolve sys-process/cronie sys-kernel/installkernel sys-kernel/dracut sys-kernel/linux-firmware sys-fs/dosfstools sys-kernel/gentoo-kernel-bin sys-fs/zfs sys-boot/zfsbootmenu sys-boot/efibootmgr sys-apps/systemd together before installing the requested packages
 
 [system]
+  keep proxy environment for direct connection in the installed system
   generate and verify locales en_US.UTF-8
   set the system locale to en_US.UTF-8
   set the timezone to UTC

--- a/tests/golden/vm-sdboot.txt
+++ b/tests/golden/vm-sdboot.txt
@@ -15,14 +15,15 @@
   mount esp at /boot with umask=0077
 
 [stage3]
-  download the newest systemd stage3 from https://distfiles.gentoo.org, verify it against BB572E0E2D182910 and unpack it into the target
+  download the newest systemd stage3 from https://distfiles.gentoo.org directly, verify it against BB572E0E2D182910 and unpack it into the target
 
 [chroot]
   mount transient proc, sys, dev and run filesystems into the target
   seed the target's resolv.conf from the install medium
 
 [portage]
-  write /etc/portage/make.conf with MAKEOPTS, INPUT_DEVICES, ACCEPT_LICENSE, L10N, FEATURES; 2 mirrors in the configured order, 5 appended
+  write /etc/portage/make.conf with MAKEOPTS, INPUT_DEVICES, ACCEPT_LICENSE, L10N, http_proxy, https_proxy, ftp_proxy, all_proxy, no_proxy, FETCHCOMMAND, RESUMECOMMAND, FEATURES; 2 mirrors in the configured order, 5 appended
+  configure Portage, wget, curl, git and gpg for direct connection
   create the three autounmask files emerge writes its decisions into
   run getuto so Portage has a keyring to verify binary packages against
   add verified binary package host gentoo at https://distfiles.gentoo.org/releases/amd64/binpackages/23.0/x86-64
@@ -37,6 +38,7 @@
   resolve sys-process/cronie sys-kernel/installkernel sys-kernel/dracut sys-kernel/linux-firmware sys-fs/dosfstools sys-fs/e2fsprogs sys-kernel/gentoo-kernel-bin sys-apps/systemd together before installing the requested packages
 
 [system]
+  keep proxy environment for direct connection in the installed system
   generate and verify locales en_US.UTF-8
   set the system locale to en_US.UTF-8
   set the timezone to UTC

--- a/tests/golden/vm-unlock.txt
+++ b/tests/golden/vm-unlock.txt
@@ -22,14 +22,15 @@
   mount root-luks at /home with compress=zstd:1,subvol=@home
 
 [stage3]
-  download the newest systemd stage3 from https://distfiles.gentoo.org, verify it against BB572E0E2D182910 and unpack it into the target
+  download the newest systemd stage3 from https://distfiles.gentoo.org directly, verify it against BB572E0E2D182910 and unpack it into the target
 
 [chroot]
   mount transient proc, sys, dev and run filesystems into the target
   seed the target's resolv.conf from the install medium
 
 [portage]
-  write /etc/portage/make.conf with MAKEOPTS, INPUT_DEVICES, ACCEPT_LICENSE, L10N, FEATURES; 2 mirrors in the configured order, 5 appended
+  write /etc/portage/make.conf with MAKEOPTS, INPUT_DEVICES, ACCEPT_LICENSE, L10N, http_proxy, https_proxy, ftp_proxy, all_proxy, no_proxy, FETCHCOMMAND, RESUMECOMMAND, FEATURES; 2 mirrors in the configured order, 5 appended
+  configure Portage, wget, curl, git and gpg for direct connection
   create the three autounmask files emerge writes its decisions into
   run getuto so Portage has a keyring to verify binary packages against
   add verified binary package host gentoo at https://distfiles.gentoo.org/releases/amd64/binpackages/23.0/x86-64
@@ -45,6 +46,7 @@
   resolve net-misc/openssh sys-process/cronie sys-kernel/installkernel sys-apps/systemd sys-kernel/dracut sys-kernel/linux-firmware sys-kernel/dracut-crypt-ssh sys-fs/cryptsetup sys-fs/btrfs-progs sys-fs/dosfstools sys-kernel/gentoo-kernel-bin sys-boot/grub sys-boot/efibootmgr together before installing the requested packages
 
 [system]
+  keep proxy environment for direct connection in the installed system
   generate and verify locales en_US.UTF-8, zh_TW.UTF-8
   set the system locale to zh_TW.UTF-8
   set the timezone to Asia/Taipei

--- a/tests/golden/vm-xfs.txt
+++ b/tests/golden/vm-xfs.txt
@@ -15,14 +15,15 @@
   mount esp at /efi with umask=0077
 
 [stage3]
-  download the newest systemd stage3 from https://distfiles.gentoo.org, verify it against BB572E0E2D182910 and unpack it into the target
+  download the newest systemd stage3 from https://distfiles.gentoo.org directly, verify it against BB572E0E2D182910 and unpack it into the target
 
 [chroot]
   mount transient proc, sys, dev and run filesystems into the target
   seed the target's resolv.conf from the install medium
 
 [portage]
-  write /etc/portage/make.conf with MAKEOPTS, INPUT_DEVICES, ACCEPT_LICENSE, L10N, FEATURES; 2 mirrors in the configured order, 5 appended
+  write /etc/portage/make.conf with MAKEOPTS, INPUT_DEVICES, ACCEPT_LICENSE, L10N, http_proxy, https_proxy, ftp_proxy, all_proxy, no_proxy, FETCHCOMMAND, RESUMECOMMAND, FEATURES; 2 mirrors in the configured order, 5 appended
+  configure Portage, wget, curl, git and gpg for direct connection
   create the three autounmask files emerge writes its decisions into
   run getuto so Portage has a keyring to verify binary packages against
   add verified binary package host gentoo at https://distfiles.gentoo.org/releases/amd64/binpackages/23.0/x86-64
@@ -36,6 +37,7 @@
   resolve net-misc/openssh sys-process/cronie sys-kernel/installkernel sys-kernel/dracut sys-kernel/linux-firmware sys-fs/dosfstools sys-fs/xfsprogs sys-kernel/gentoo-kernel-bin sys-boot/grub sys-boot/efibootmgr together before installing the requested packages
 
 [system]
+  keep proxy environment for direct connection in the installed system
   generate and verify locales en_US.UTF-8
   set the system locale to en_US.UTF-8
   set the timezone to UTC

--- a/tests/golden/vm-zfs-encrypted.txt
+++ b/tests/golden/vm-zfs-encrypted.txt
@@ -19,14 +19,15 @@
   mount esp at /efi with umask=0077
 
 [stage3]
-  download the newest systemd stage3 from https://distfiles.gentoo.org, verify it against BB572E0E2D182910 and unpack it into the target
+  download the newest systemd stage3 from https://distfiles.gentoo.org directly, verify it against BB572E0E2D182910 and unpack it into the target
 
 [chroot]
   mount transient proc, sys, dev and run filesystems into the target
   seed the target's resolv.conf from the install medium
 
 [portage]
-  write /etc/portage/make.conf with MAKEOPTS, INPUT_DEVICES, ACCEPT_LICENSE, L10N, FEATURES; 2 mirrors in the configured order, 5 appended
+  write /etc/portage/make.conf with MAKEOPTS, INPUT_DEVICES, ACCEPT_LICENSE, L10N, http_proxy, https_proxy, ftp_proxy, all_proxy, no_proxy, FETCHCOMMAND, RESUMECOMMAND, FEATURES; 2 mirrors in the configured order, 5 appended
+  configure Portage, wget, curl, git and gpg for direct connection
   create the three autounmask files emerge writes its decisions into
   run getuto so Portage has a keyring to verify binary packages against
   add verified binary package host gentoo at https://distfiles.gentoo.org/releases/amd64/binpackages/23.0/x86-64
@@ -45,6 +46,7 @@
   resolve sys-process/cronie sys-kernel/installkernel sys-kernel/dracut sys-kernel/linux-firmware sys-fs/dosfstools sys-kernel/gentoo-kernel-bin sys-fs/zfs sys-boot/zfsbootmenu sys-boot/efibootmgr sys-apps/systemd together before installing the requested packages
 
 [system]
+  keep proxy environment for direct connection in the installed system
   generate and verify locales en_US.UTF-8
   set the system locale to en_US.UTF-8
   set the timezone to UTC

--- a/tests/golden/vm-zfs-mirror.txt
+++ b/tests/golden/vm-zfs-mirror.txt
@@ -23,14 +23,15 @@
   mount esp at /efi with umask=0077
 
 [stage3]
-  download the newest systemd stage3 from https://distfiles.gentoo.org, verify it against BB572E0E2D182910 and unpack it into the target
+  download the newest systemd stage3 from https://distfiles.gentoo.org directly, verify it against BB572E0E2D182910 and unpack it into the target
 
 [chroot]
   mount transient proc, sys, dev and run filesystems into the target
   seed the target's resolv.conf from the install medium
 
 [portage]
-  write /etc/portage/make.conf with MAKEOPTS, INPUT_DEVICES, ACCEPT_LICENSE, L10N, FEATURES; 2 mirrors in the configured order, 5 appended
+  write /etc/portage/make.conf with MAKEOPTS, INPUT_DEVICES, ACCEPT_LICENSE, L10N, http_proxy, https_proxy, ftp_proxy, all_proxy, no_proxy, FETCHCOMMAND, RESUMECOMMAND, FEATURES; 2 mirrors in the configured order, 5 appended
+  configure Portage, wget, curl, git and gpg for direct connection
   create the three autounmask files emerge writes its decisions into
   run getuto so Portage has a keyring to verify binary packages against
   add verified binary package host gentoo at https://distfiles.gentoo.org/releases/amd64/binpackages/23.0/x86-64
@@ -49,6 +50,7 @@
   resolve sys-process/cronie sys-kernel/installkernel sys-kernel/dracut sys-kernel/linux-firmware sys-fs/dosfstools sys-kernel/gentoo-kernel-bin sys-fs/zfs sys-boot/zfsbootmenu sys-boot/efibootmgr sys-apps/systemd together before installing the requested packages
 
 [system]
+  keep proxy environment for direct connection in the installed system
   generate and verify locales en_US.UTF-8
   set the system locale to en_US.UTF-8
   set the timezone to UTC

--- a/tests/golden/vm-zfs.txt
+++ b/tests/golden/vm-zfs.txt
@@ -19,14 +19,15 @@
   mount esp at /efi with umask=0077
 
 [stage3]
-  download the newest systemd stage3 from https://distfiles.gentoo.org, verify it against BB572E0E2D182910 and unpack it into the target
+  download the newest systemd stage3 from https://distfiles.gentoo.org directly, verify it against BB572E0E2D182910 and unpack it into the target
 
 [chroot]
   mount transient proc, sys, dev and run filesystems into the target
   seed the target's resolv.conf from the install medium
 
 [portage]
-  write /etc/portage/make.conf with MAKEOPTS, INPUT_DEVICES, ACCEPT_LICENSE, L10N, FEATURES; 2 mirrors in the configured order, 5 appended
+  write /etc/portage/make.conf with MAKEOPTS, INPUT_DEVICES, ACCEPT_LICENSE, L10N, http_proxy, https_proxy, ftp_proxy, all_proxy, no_proxy, FETCHCOMMAND, RESUMECOMMAND, FEATURES; 2 mirrors in the configured order, 5 appended
+  configure Portage, wget, curl, git and gpg for direct connection
   create the three autounmask files emerge writes its decisions into
   run getuto so Portage has a keyring to verify binary packages against
   add verified binary package host gentoo at https://distfiles.gentoo.org/releases/amd64/binpackages/23.0/x86-64
@@ -45,6 +46,7 @@
   resolve sys-process/cronie sys-kernel/installkernel sys-kernel/dracut sys-kernel/linux-firmware sys-fs/dosfstools sys-kernel/gentoo-kernel-bin sys-fs/zfs sys-boot/zfsbootmenu sys-boot/efibootmgr sys-apps/systemd together before installing the requested packages
 
 [system]
+  keep proxy environment for direct connection in the installed system
   generate and verify locales en_US.UTF-8
   set the system locale to en_US.UTF-8
   set the timezone to UTC

--- a/tests/golden/vm-zram.txt
+++ b/tests/golden/vm-zram.txt
@@ -15,14 +15,15 @@
   mount esp at /efi with umask=0077
 
 [stage3]
-  download the newest systemd stage3 from https://distfiles.gentoo.org, verify it against BB572E0E2D182910 and unpack it into the target
+  download the newest systemd stage3 from https://distfiles.gentoo.org directly, verify it against BB572E0E2D182910 and unpack it into the target
 
 [chroot]
   mount transient proc, sys, dev and run filesystems into the target
   seed the target's resolv.conf from the install medium
 
 [portage]
-  write /etc/portage/make.conf with MAKEOPTS, INPUT_DEVICES, ACCEPT_LICENSE, L10N, FEATURES; 2 mirrors in the configured order, 5 appended
+  write /etc/portage/make.conf with MAKEOPTS, INPUT_DEVICES, ACCEPT_LICENSE, L10N, http_proxy, https_proxy, ftp_proxy, all_proxy, no_proxy, FETCHCOMMAND, RESUMECOMMAND, FEATURES; 2 mirrors in the configured order, 5 appended
+  configure Portage, wget, curl, git and gpg for direct connection
   create the three autounmask files emerge writes its decisions into
   run getuto so Portage has a keyring to verify binary packages against
   add verified binary package host gentoo at https://distfiles.gentoo.org/releases/amd64/binpackages/23.0/x86-64
@@ -36,6 +37,7 @@
   resolve sys-apps/zram-generator net-misc/openssh sys-process/cronie sys-kernel/installkernel sys-kernel/dracut sys-kernel/linux-firmware sys-fs/dosfstools sys-fs/xfsprogs sys-kernel/gentoo-kernel-bin sys-boot/grub sys-boot/efibootmgr together before installing the requested packages
 
 [system]
+  keep proxy environment for direct connection in the installed system
   generate and verify locales en_US.UTF-8
   set the system locale to en_US.UTF-8
   set the timezone to UTC

--- a/tests/golden/zfs-zbm.txt
+++ b/tests/golden/zfs-zbm.txt
@@ -21,14 +21,15 @@
   mount dataset zpcala/ROOT/gentoo/home at /home
 
 [stage3]
-  download the newest systemd stage3 from https://distfiles.gentoo.org, verify it against BB572E0E2D182910 and unpack it into the target
+  download the newest systemd stage3 from https://distfiles.gentoo.org directly, verify it against BB572E0E2D182910 and unpack it into the target
 
 [chroot]
   mount transient proc, sys, dev and run filesystems into the target
   seed the target's resolv.conf from the install medium
 
 [portage]
-  write /etc/portage/make.conf with MAKEOPTS, INPUT_DEVICES, ACCEPT_LICENSE, L10N, FEATURES; 2 mirrors in the configured order, 5 appended
+  write /etc/portage/make.conf with MAKEOPTS, INPUT_DEVICES, ACCEPT_LICENSE, L10N, http_proxy, https_proxy, ftp_proxy, all_proxy, no_proxy, FETCHCOMMAND, RESUMECOMMAND, FEATURES; 2 mirrors in the configured order, 5 appended
+  configure Portage, wget, curl, git and gpg for direct connection
   create the three autounmask files emerge writes its decisions into
   run getuto so Portage has a keyring to verify binary packages against
   add verified binary package host gentoo at https://distfiles.gentoo.org/releases/amd64/binpackages/23.0/x86-64
@@ -51,6 +52,7 @@
   resolve app-admin/sudo net-misc/openssh sys-process/cronie sys-kernel/installkernel sys-kernel/dracut sys-kernel/linux-firmware sys-kernel/dracut-crypt-ssh sys-apps/iproute2 net-misc/dhcp net-misc/iputils sys-fs/dosfstools sys-kernel/gentoo-cjk-kernel-bin sys-fs/zfs sys-boot/zfsbootmenu sys-boot/efibootmgr sys-apps/systemd sys-apps/kbd app-editors/vim together before installing the requested packages
 
 [system]
+  keep proxy environment for direct connection in the installed system
   generate and verify locales en_US.UTF-8, zh_TW.UTF-8
   set the system locale to zh_TW.UTF-8
   set the timezone to Asia/Taipei

--- a/tests/unit/test_parse.py
+++ b/tests/unit/test_parse.py
@@ -15,6 +15,7 @@ from gentoo_install.model.config import (
     KernelSource,
     Keywords,
     MirrorRegion,
+    ProxyConfig,
 )
 from gentoo_install.model.device import (
     DeviceId,
@@ -93,6 +94,28 @@ def test_defaults_apply_when_a_section_is_absent() -> None:
     assert config.system.hostname == "gentoo"
     assert config.portage.binhost.official is True
     assert config.bootloader.kind is Bootloader.GRUB
+
+
+def test_proxy_url_preserves_credentials_and_bypass_hosts() -> None:
+    raw = fixture()
+    raw["proxy"] = {
+        "url": "socks5h://operator:secret@proxy.example:1080",
+        "bypass": ["localhost", "internal.example"],
+    }
+    config = parse(raw)
+    assert config.proxy == ProxyConfig(
+        url="socks5h://operator:secret@proxy.example:1080",
+        bypass=("localhost", "internal.example"),
+    )
+    assert config.proxy.redacted_url == "socks5h://proxy.example:1080"
+
+
+@pytest.mark.parametrize("scheme", ["ftp", "ssh"])
+def test_proxy_url_rejects_unsupported_schemes(scheme: str) -> None:
+    raw = fixture()
+    raw["proxy"] = {"url": f"{scheme}://proxy.example:8080"}
+    with pytest.raises(ConfigError, match="proxy.*use"):
+        parse(raw)
 
 
 def test_a_newer_config_version_is_refused_with_an_actionable_message() -> None:

--- a/tests/unit/test_plan_portage.py
+++ b/tests/unit/test_plan_portage.py
@@ -18,6 +18,7 @@ from gentoo_install.model.config import (
     Overlay,
     PackagesConfig,
     PortageConfig,
+    ProxyConfig,
     Sync,
     SystemConfig,
 )
@@ -158,6 +159,34 @@ def test_make_conf_carries_the_flags_the_configuration_set() -> None:
     assert 'MAKEOPTS="-j8"' in written
     assert 'USE="dracut cjk"' in written
     assert 'VIDEO_CARDS="amdgpu"' in written
+
+
+def test_proxy_clients_route_portage_and_keep_credentials_out_of_descriptions() -> None:
+    secret = "s3cr3t"
+    installation = replace(
+        config(),
+        proxy=ProxyConfig(
+            url=f"https://operator:{secret}@proxy.example:8443",
+            bypass=("localhost", "intranet.example"),
+        ),
+    )
+    recorder = apply_all(installation)
+    make_conf = recorder.files[PurePosixPath("/etc/portage/make.conf")]
+    assert 'http_proxy="https://proxy.example:8443"' in make_conf
+    assert 'RSYNC_PROXY="proxy.example:8443"' in make_conf
+    assert 'no_proxy="localhost,intranet.example"' in make_conf
+    assert secret not in make_conf
+    assert secret in recorder.files[PurePosixPath("/etc/wgetrc")]
+    assert secret in recorder.files[PurePosixPath("/etc/gitconfig")]
+    assert secret in recorder.files[PurePosixPath("/etc/portage/gnupg/dirmngr.conf")]
+    assert all(secret not in operation.describe() for operation in portage.build(installation, MIRROR))
+
+
+def test_proxy_clients_clear_route_when_proxy_is_empty() -> None:
+    recorder = apply_all(config())
+    make_conf = recorder.files[PurePosixPath("/etc/portage/make.conf")]
+    assert 'http_proxy=""' in make_conf
+    assert 'no_proxy=""' in make_conf
 
 
 def test_l10n_is_derived_from_the_locales_rather_than_listed_twice() -> None:

--- a/tests/unit/test_plan_system.py
+++ b/tests/unit/test_plan_system.py
@@ -13,6 +13,7 @@ from gentoo_install.model.config import (
     InitSystem,
     InstallConfig,
     Logger,
+    ProxyConfig,
     SystemConfig,
     User,
 )
@@ -71,6 +72,23 @@ def test_a_locale_that_locale_gen_skipped_is_generated_again_and_then_checked() 
         "en_US.UTF-8 UTF-8\nzh_TW.UTF-8 UTF-8\n"
     )
     assert not recorder.argv_starting("localedef")
+
+
+def test_installed_system_keeps_proxy_endpoint_and_bypass_without_credentials() -> None:
+    installation = replace(
+        config(),
+        proxy=ProxyConfig(
+            url="socks5h://operator:secret@proxy.example:1080",
+            bypass=("localhost", "corp.example"),
+        ),
+    )
+    written = apply_all(installation, generated=generated(installation)).files
+    environment = written[PurePosixPath("/etc/environment")]
+    profile = written[PurePosixPath("/etc/profile.d/gentoo-install-proxy.sh")]
+    assert "socks5h://proxy.example:1080" in environment
+    assert "localhost,corp.example" in environment
+    assert "secret" not in environment
+    assert "secret" not in profile
 
 
 def test_locale_gen_exiting_zero_is_not_taken_as_proof_the_locale_exists() -> None:

--- a/tests/unit/test_proxy.py
+++ b/tests/unit/test_proxy.py
@@ -1,0 +1,141 @@
+from __future__ import annotations
+
+import json
+import socket
+import urllib.request
+from typing import Any
+from typing import cast
+
+import pytest
+
+from gentoo_install.exec import fetch
+from gentoo_install.exec.runner import Runner
+from gentoo_install.model.config import ProxyConfig
+
+
+PROXY = ProxyConfig(
+    url="http://operator:secret@proxy.example:8080",
+    bypass=("localhost", "internal.example"),
+)
+
+
+class Response:
+    headers: dict[str, str] = {"Date": "Wed, 01 Jan 2025 00:00:00 GMT"}
+
+    def __enter__(self) -> Response:
+        return self
+
+    def __exit__(self, *args: object) -> None:
+        return None
+
+    def read(self, size: int = -1) -> bytes:
+        return b"US\n"
+
+
+def test_http_proxy_opener_keeps_credentials_out_of_environment_and_bypasses_hosts(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    opened: list[Any] = []
+
+    class Opener:
+        def open(self, request: object, timeout: float) -> Response:
+            opened.append((request, timeout))
+            return Response()
+
+    built: list[tuple[object, ...]] = []
+    def build(*handlers: Any) -> Opener:
+        built.append(handlers)
+        return Opener()
+
+    monkeypatch.setattr(urllib.request, "build_opener", build)
+    monkeypatch.setattr(urllib.request, "urlopen", lambda request, timeout: Response())
+
+    with fetch._urlopen(fetch._asked("https://public.example/path"), PROXY, 3.0):
+        pass
+    with fetch._urlopen(fetch._asked("https://internal.example/path"), PROXY, 3.0):
+        pass
+
+    assert built
+    handler = cast(Any, built[0][0])
+    assert handler.proxies["https"] == PROXY.url
+    assert len(opened) == 1
+    assert "secret" not in str(fetch._CURRENT_PROXY.get())
+
+
+@pytest.mark.parametrize(
+    ("scheme", "expected_type", "resolves"),
+    [("socks5", 1, True), ("socks5h", 3, False)],
+)
+def test_socks_scheme_controls_local_name_resolution(
+    monkeypatch: pytest.MonkeyPatch,
+    scheme: str,
+    expected_type: int,
+    resolves: bool,
+) -> None:
+    sent: list[bytes] = []
+
+    class Socket:
+        def sendall(self, data: bytes) -> None:
+            sent.append(data)
+
+        def recv(self, size: int) -> bytes:
+            if size == 2:
+                return b"\x05\x00"
+            return b"\x05\x00\x00\x01\x7f\x00\x00\x01\x00\x50"
+
+        def close(self) -> None:
+            return None
+
+    monkeypatch.setattr(socket, "create_connection", lambda address, timeout: Socket())
+    monkeypatch.setattr(
+        socket,
+        "getaddrinfo",
+        lambda *args, **kwargs: [(2, 1, 6, "", ("127.0.0.1", 80))],
+    )
+    fetch._socks_connect(ProxyConfig(url=f"{scheme}://proxy.example:1080"), "internal.example", 80, 3.0)
+
+    request = sent[-1]
+    assert request[3] == expected_type
+    assert (scheme == "socks5") is resolves
+
+
+def test_runner_redacts_proxy_credentials_in_dry_run_and_result_command() -> None:
+    lines: list[str] = []
+    runner = Runner(log=lines.append, dry_run=True, proxy=PROXY)
+    result = runner.run(["wget", PROXY.url, "https://public.example/file"])
+    assert all("secret" not in line for line in lines)
+    assert "secret" not in result.command
+
+
+def test_fetch_paths_accept_the_same_proxy_setting(monkeypatch: pytest.MonkeyPatch) -> None:
+    seen: list[ProxyConfig | None] = []
+    opened: list[ProxyConfig | None] = []
+
+    def read(url: str, proxy: ProxyConfig | None = None) -> str:
+        seen.append(proxy)
+        if url.endswith(".json"):
+            return json.dumps({"versions": [{"version": "1.0", "keywords": ["amd64"]}]})
+        if "/contents/" in url:
+            return "[]"
+        if "zfs-1.0.ebuild" in url:
+            return "MODULES_KERNEL_MAX=7.0\n"
+        if "ipinfo" in url:
+            return "AU\n"
+        return "# pointer\n"
+
+    monkeypatch.setattr(fetch, "_read", read)
+    def open_url(request: Any, proxy: ProxyConfig | None, timeout: float) -> Response:
+        opened.append(proxy)
+        return Response()
+
+    monkeypatch.setattr(fetch, "_urlopen", open_url)
+    monkeypatch.setattr(fetch, "ONLINE_PAUSE", 0.0)
+    assert fetch.network_time(PROXY) > 0.0
+    assert fetch.egress_country(PROXY) == "AU"
+    assert fetch.online(PROXY) is True
+    assert fetch.mirror_online("https://mirror.example", "systemd", PROXY) is True
+    assert fetch.package_versions("app-misc/example", PROXY)
+    assert fetch.overlay_versions("app-misc/example", PROXY) == ()
+    assert fetch.zfs_kernel_max(PROXY).maximum == "7.0"
+    assert seen and all(proxy is PROXY for proxy in seen)
+    assert opened == [PROXY]

--- a/tests/unit/test_serialise.py
+++ b/tests/unit/test_serialise.py
@@ -6,7 +6,8 @@ from pathlib import Path
 
 import pytest
 
-from gentoo_install.model.config import InstallConfig, Overlay, PortageConfig, User
+from gentoo_install.exec.config import load
+from gentoo_install.model.config import InstallConfig, Overlay, PortageConfig, ProxyConfig, User
 from gentoo_install.model.device import DeviceGraph, DeviceId, Existing, PartitionTable
 from gentoo_install.model.parse import _NODES, parse
 from gentoo_install.model.serialise import KINDS, REDACTED, SECRET, to_toml
@@ -97,6 +98,17 @@ def test_a_published_configuration_carries_no_password_hash() -> None:
     assert "rootrootroot" not in published
     assert "useruseruser" not in published
     assert published.count(REDACTED) == 2
+
+
+def test_proxy_credentials_round_trip_and_are_removed_from_published_config() -> None:
+    path = FIXTURES / "proxy" / "config.toml"
+    config = load(path)
+
+    assert _round_trip(config).proxy == config.proxy
+    published = to_toml(config, publishing=True)
+    assert "secret" not in published
+    assert "operator" not in published
+    assert "socks5h://proxy.example:1080" in published
 
 
 def test_a_published_configuration_still_parses() -> None:

--- a/tests/vm/campaign.py
+++ b/tests/vm/campaign.py
@@ -170,6 +170,10 @@ STAGES: Final[dict[str, tuple[Run, ...]]] = {
         Run("fixtures/vm-bios-luks.toml", firmware="bios"),
         # sshd with a key that can reach it, and the initramfs daemon that
         # unlocks the root: `remote_unlock` was off in every other fixture.
+        # The proxy pointed at a port nothing listens on: a run that reaches
+        # the mirror proves something bypassed it, so this one is expected to
+        # fail at the stage3 download and its failure is the result.
+        Run("fixtures/vm-proxy-dead.toml"),
         Run("fixtures/vm-unlock.toml"),
         # The same configuration again, killed partway and finished with
         # --resume: the one path nothing else reaches.


### PR DESCRIPTION
An operator on a company or home network reaches the internet through a proxy. `[proxy]` takes `http`, `https`, `socks5` and `socks5h` with optional credentials and a bypass list; empty keeps today's behaviour.

Every fetch takes it, because one that does not makes the setting a lie: the clock correction, the egress-country and connectivity checks, mirror probing, stage3, the signing keys, Portage through `make.conf` and `FETCHCOMMAND`/`RESUMECOMMAND`, `wgetrc`, `curlrc`, git, the binhost, the overlays and the paste upload. An environment variable alone does not reach Portage's networked phase, which is why each tool is configured where it reads.

The password stays out of what leaves the machine: `to_toml(publishing=True)` omits it and no operation's `describe()` contains it, both checked against a fixture that carries one. The installed system keeps a credential-free endpoint and the bypass list.

No egress boundary, credential broker or address pinning: a domain name is as valid as an IP and credentials are optional, because this serves an intranet rather than a threat model.