### PR TITLE
plan: write every Portage fragment through one typed operation

### DIFF
--- a/gentoo_install/plan/bootloader.py
+++ b/gentoo_install/plan/bootloader.py
@@ -30,7 +30,7 @@ from ..model.device import (
     ZfsPool,
 )
 from .operations import Context, Operation, Stage
-from .portage import Emerge, InstallMode
+from .portage import Emerge, InstallMode, PortageConfigKind, WritePortageConfig
 
 BOOTLOADER_PACKAGES: Final[dict[Bootloader, tuple[str, ...]]] = {
     Bootloader.GRUB: ("sys-boot/grub",),
@@ -193,10 +193,11 @@ class RequestBootctl(Operation):
         return f"ask for {self.package}[{','.join(self.FLAGS)}], which is what provides bootctl"
 
     def apply(self, context: Context) -> None:
-        context.write(
-            PurePosixPath("/etc/portage/package.use/systemd-boot"),
-            f"{self.package} {' '.join(self.FLAGS)}\n",
-        )
+        WritePortageConfig(
+            kind=PortageConfigKind.USE,
+            name="systemd-boot",
+            lines=(f"{self.package} {' '.join(self.FLAGS)}",),
+        ).apply(context)
 
 
 @dataclass(frozen=True, kw_only=True)

--- a/gentoo_install/plan/kernel.py
+++ b/gentoo_install/plan/kernel.py
@@ -36,7 +36,13 @@ from .bootloader import GenerateHostId
 from .bootloader import initramfs_keymap as bootloader_keymap
 from .bootloader import unlock_parameters
 from .operations import Context, Operation, Stage
-from .portage import Emerge, InstallMode, SourcePolicy
+from .portage import (
+    Emerge,
+    InstallMode,
+    PortageConfigKind,
+    SourcePolicy,
+    WritePortageConfig,
+)
 
 #: The package that provides each kernel choice.
 KERNEL_PACKAGES: Final[dict[KernelSource, str]] = {
@@ -162,10 +168,11 @@ class ConfigureInstallKernel(Operation):
         # Only this package's flags. What `bootctl` comes from is
         # `RequestBootctl`'s to say, and writing it here as well put one
         # package's USE in two files that neither named the other.
-        context.write(
-            PurePosixPath("/etc/portage/package.use/installkernel"),
-            f"sys-kernel/installkernel {' '.join(self._flags())}\n",
-        )
+        WritePortageConfig(
+            kind=PortageConfigKind.USE,
+            name="installkernel",
+            lines=(f"sys-kernel/installkernel {' '.join(self._flags())}",),
+        ).apply(context)
         if self.boot_root:
             # A drop-in, never `/etc/kernel/install.conf`. kernel-install(8):
             # "The first of the files that is found will be used", so writing
@@ -230,10 +237,11 @@ class RequestSystemdCryptsetup(Operation):
         return "ask for sys-apps/systemd[cryptsetup], which provides the unlock generator"
 
     def apply(self, context: Context) -> None:
-        context.write(
-            PurePosixPath("/etc/portage/package.use/cryptsetup"),
-            "sys-apps/systemd cryptsetup\n",
-        )
+        WritePortageConfig(
+            kind=PortageConfigKind.USE,
+            name="cryptsetup",
+            lines=("sys-apps/systemd cryptsetup",),
+        ).apply(context)
 
 
 @dataclass(frozen=True, kw_only=True)
@@ -248,8 +256,11 @@ class RequestStorageUse(Operation):
         return f"ask for {listed}, which dracut needs and the default build lacks"
 
     def apply(self, context: Context) -> None:
-        lines = "".join(f"{atom} {' '.join(flags)}\n" for atom, flags in self.entries)
-        context.write(PurePosixPath("/etc/portage/package.use/storage"), lines)
+        WritePortageConfig(
+            kind=PortageConfigKind.USE,
+            name="storage",
+            lines=tuple(f"{atom} {' '.join(flags)}" for atom, flags in self.entries),
+        ).apply(context)
 
 
 @dataclass(frozen=True, kw_only=True)
@@ -262,10 +273,11 @@ class RequestZfsBootMenuNetworkTools(Operation):
         return "ask for dhclient and arping, which ZFSBootMenu networking requires"
 
     def apply(self, context: Context) -> None:
-        context.write(
-            PurePosixPath("/etc/portage/package.use/zfsbootmenu-network"),
-            "net-misc/dhcp client -server\nnet-misc/iputils arping\n",
-        )
+        WritePortageConfig(
+            kind=PortageConfigKind.USE,
+            name="zfsbootmenu-network",
+            lines=("net-misc/dhcp client -server", "net-misc/iputils arping"),
+        ).apply(context)
 
 
 @dataclass(frozen=True, kw_only=True)
@@ -329,10 +341,11 @@ class AcceptFirmwareLicence(Operation):
         return "accept the linux-firmware licence"
 
     def apply(self, context: Context) -> None:
-        context.write(
-            PurePosixPath("/etc/portage/package.license/linux-firmware"),
-            "sys-kernel/linux-firmware linux-fw-redistributable no-source-code\n",
-        )
+        WritePortageConfig(
+            kind=PortageConfigKind.LICENSE,
+            name="linux-firmware",
+            lines=("sys-kernel/linux-firmware linux-fw-redistributable no-source-code",),
+        ).apply(context)
 
 
 @dataclass(frozen=True, kw_only=True)
@@ -354,10 +367,11 @@ class ConfigureRemoteUnlock(Operation):
         return f"configure remote unlock over ssh on port {self.port}"
 
     def apply(self, context: Context) -> None:
-        context.write(
-            PurePosixPath("/etc/portage/package.accept_keywords/dracut-crypt-ssh"),
-            f"{REMOTE_UNLOCK_PACKAGE} ~amd64\n",
-        )
+        WritePortageConfig(
+            kind=PortageConfigKind.KEYWORDS,
+            name="dracut-crypt-ssh",
+            lines=(f"{REMOTE_UNLOCK_PACKAGE} ~amd64",),
+        ).apply(context)
         if not self.system_initramfs:
             context.write(
                 PurePosixPath("/etc/dracut.conf.d/crypt-ssh.conf"),
@@ -404,10 +418,11 @@ class UnmaskCjkDistKernel(Operation):
         return f"unmask {CJK_MASKED}, which the cjk kernel depends on by revision"
 
     def apply(self, context: Context) -> None:
-        context.write(
-            PurePosixPath("/etc/portage/package.unmask/cjk-kernel"),
-            f"{CJK_MASKED}\n",
-        )
+        WritePortageConfig(
+            kind=PortageConfigKind.UNMASK,
+            name="cjk-kernel",
+            lines=(CJK_MASKED,),
+        ).apply(context)
 
 
 @dataclass(frozen=True, kw_only=True)
@@ -427,10 +442,11 @@ class AcceptKernelVersion(Operation):
         return f"accept {self.package}-{self.version} as testing"
 
     def apply(self, context: Context) -> None:
-        context.write(
-            PurePosixPath("/etc/portage/package.accept_keywords/kernel-version"),
-            f"={self.package}-{self.version} ~amd64\n",
-        )
+        WritePortageConfig(
+            kind=PortageConfigKind.KEYWORDS,
+            name="kernel-version",
+            lines=(f"={self.package}-{self.version} ~amd64",),
+        ).apply(context)
 
 
 @dataclass(frozen=True, kw_only=True)
@@ -449,15 +465,17 @@ class RequestCjkKernel(Operation):
         return f"accept {self.package} as testing, with cjk {'on' if self.cjk else 'off'}"
 
     def apply(self, context: Context) -> None:
-        context.write(
-            PurePosixPath("/etc/portage/package.accept_keywords/cjk-kernel"),
-            f"{self.package} ~amd64\n",
-        )
+        WritePortageConfig(
+            kind=PortageConfigKind.KEYWORDS,
+            name="cjk-kernel",
+            lines=(f"{self.package} ~amd64",),
+        ).apply(context)
         if not self.cjk:
-            context.write(
-                PurePosixPath("/etc/portage/package.use/cjk-kernel"),
-                f"{self.package} -{CJK_USE}\n",
-            )
+            WritePortageConfig(
+                kind=PortageConfigKind.USE,
+                name="cjk-kernel",
+                lines=(f"{self.package} -{CJK_USE}",),
+            ).apply(context)
 
 
 @dataclass(frozen=True, kw_only=True)
@@ -605,8 +623,11 @@ class RequestDistKernelModules(Operation):
         return f"tell {', '.join(self.packages)} to build against the dist-kernel"
 
     def apply(self, context: Context) -> None:
-        lines = "".join(f"{package} dist-kernel\n" for package in self.packages)
-        context.write(PurePosixPath("/etc/portage/package.use/dist-kernel-modules"), lines)
+        WritePortageConfig(
+            kind=PortageConfigKind.USE,
+            name="dist-kernel-modules",
+            lines=tuple(f"{package} dist-kernel" for package in self.packages),
+        ).apply(context)
 
 
 def build(config: InstallConfig) -> list[Operation]:

--- a/gentoo_install/plan/portage.py
+++ b/gentoo_install/plan/portage.py
@@ -516,10 +516,11 @@ class AcceptOverlayKeywords(Operation):
         return f"accept ~amd64 for packages from {self.repository} only"
 
     def apply(self, context: Context) -> None:
-        context.write(
-            PurePosixPath(f"/etc/portage/package.accept_keywords/{self.repository}"),
-            f"*/*::{self.repository} ~amd64\n",
-        )
+        WritePortageConfig(
+            kind=PortageConfigKind.KEYWORDS,
+            name=self.repository,
+            lines=(f"*/*::{self.repository} ~amd64",),
+        ).apply(context)
 
 
 @dataclass(frozen=True, kw_only=True)
@@ -795,8 +796,11 @@ class AcceptTestingPackages(Operation):
         return f"accept ~amd64 for {' '.join(self.packages)} and nothing else"
 
     def apply(self, context: Context) -> None:
-        lines = "".join(f"{atom} ~amd64\n" for atom in self.packages)
-        context.write(PurePosixPath("/etc/portage/package.accept_keywords/user"), lines)
+        WritePortageConfig(
+            kind=PortageConfigKind.KEYWORDS,
+            name="user",
+            lines=tuple(f"{atom} ~amd64" for atom in self.packages),
+        ).apply(context)
 
 
 @dataclass(frozen=True, kw_only=True)

--- a/gentoo_install/plan/system.py
+++ b/gentoo_install/plan/system.py
@@ -34,7 +34,7 @@ from ..model.device import (
 from .bootloader import serial_console
 from .mounts import resolve_mounts
 from .operations import Context, Operation, Stage
-from .portage import Emerge
+from .portage import Emerge, PortageConfigKind, WritePortageConfig
 
 #: Console fonts `sys-apps/kbd` installs, by the cell size they draw.
 CONSOLE_FONTS: Final[dict[ConsoleFontSize, str]] = {
@@ -435,10 +435,11 @@ class RequestNetworkUse(Operation):
         return f"ask for {'; '.join(self.lines)}"
 
     def apply(self, context: Context) -> None:
-        context.write(
-            PurePosixPath("/etc/portage/package.use/network"),
-            "".join(f"{line}\n" for line in self.lines),
-        )
+        WritePortageConfig(
+            kind=PortageConfigKind.USE,
+            name="network",
+            lines=self.lines,
+        ).apply(context)
 
 
 @dataclass(frozen=True, kw_only=True)

--- a/tests/unit/test_plan_portage.py
+++ b/tests/unit/test_plan_portage.py
@@ -74,6 +74,29 @@ def test_named_portage_fragments_share_one_path_and_writer() -> None:
     assert recorder.files[operation.path] == "app-misc/example foo\n"
 
 
+@pytest.mark.parametrize("kind", tuple(portage.PortageConfigKind))
+def test_portage_config_kinds_use_the_same_typed_writer(
+    kind: portage.PortageConfigKind,
+) -> None:
+    operation = portage.WritePortageConfig(kind=kind, name="example", lines=("one", "two"))
+    recorder = Recorder()
+
+    operation.apply(recorder)
+
+    # The directory is named, not derived from `kind.value`: deriving both
+    # sides from the same source cannot fail when a kind names the wrong file.
+    directories = {
+        portage.PortageConfigKind.USE: "package.use",
+        portage.PortageConfigKind.KEYWORDS: "package.accept_keywords",
+        portage.PortageConfigKind.LICENSE: "package.license",
+        portage.PortageConfigKind.UNMASK: "package.unmask",
+    }
+    assert set(directories) == set(portage.PortageConfigKind)
+    assert len(set(directories.values())) == len(directories)
+    assert operation.path == PurePosixPath(f"/etc/portage/{directories[kind]}/example")
+    assert recorder.files[operation.path] == "one\ntwo\n"
+
+
 def test_the_chroot_gets_proc_rbinds_and_a_slave_run() -> None:
     recorder = Recorder()
 


### PR DESCRIPTION
The kernel, bootloader, system and package plans each built their own `/etc/portage` write, so a change to how a fragment is written reached some of them and not the others. `WritePortageConfig` and `PortageConfigKind` are the single writer now.

The test the agent added derived the expected path from `kind.value`, so both sides moved together and it could not fail when a kind named the wrong file — renaming `LICENSE` to `package.use` kept it green. It names the four directories explicitly and asserts they are distinct and cover the enum.

Closes C15.