### PR TITLE
vm: bound the console buffer and the result archive at the tail

### DIFF
--- a/tests/unit/test_harness.py
+++ b/tests/unit/test_harness.py
@@ -631,6 +631,39 @@ def test_a_worker_that_ends_without_reporting_becomes_an_error() -> None:
     assert _unanswered({"vm-lvm": ended}, nothing_queued=True) == ["vm-lvm"]
 
 
+def test_console_buffer_keeps_the_tail_of_long_output() -> None:
+    from io import BytesIO
+
+    from tests.vm.console import ConsoleTimeout, SerialConsole
+
+    class Channel:
+        closed = False
+
+        def __init__(self) -> None:
+            self.chunks = [b"old output", b"current failure"]
+
+        def recv(self, size: int) -> bytes:
+            return self.chunks.pop(0) if self.chunks else b""
+
+        def sendall(self, data: bytes) -> None:
+            return None
+
+        def close(self) -> None:
+            return None
+
+    console = SerialConsole(Channel(), BytesIO(), buffer_limit=len(b"current failure"))
+    with pytest.raises(ConsoleTimeout, match="current failure"):
+        console.expect(r"never appears", timeout=0.1)
+
+
+def test_result_archive_rejects_data_above_its_bound() -> None:
+    from tests.vm.results import RESULT_BUFFER_BYTES, ResultError, read_console
+
+    said = b"x" * (RESULT_BUFFER_BYTES + 1)
+    with pytest.raises(ResultError, match="size limit"):
+        read_console(said)
+
+
 def test_unknown_telemetry_does_not_make_a_quiet_guest_stuck(tmp_path: Path) -> None:
     """Three failed API reads were treated as three proofs that counters were flat."""
     from tests.vm.cluster import WATCH_STRIKES, Watchdog

--- a/tests/vm/cluster.py
+++ b/tests/vm/cluster.py
@@ -74,7 +74,13 @@ from .proxmox import (
     append_to_cmdline,
     append_to_cmdline_blind,
 )
-from .results import CONSOLE_CLOSE, ResultError, console_command, read_console
+from .results import (
+    CONSOLE_CLOSE,
+    RESULT_BUFFER_BYTES,
+    ResultError,
+    console_command,
+    read_console,
+)
 from .workdir import WorkdirError, confined
 
 REPOSITORY: Final[Path] = Path(__file__).resolve().parents[2]
@@ -1574,6 +1580,9 @@ class Reconnecting:
             # a prompt, and ordinary shell waits below are looking for text.
             self.console.send("")
 
+    def set_buffer_limit(self, limit: int) -> None:
+        cast(SerialConsole, self.console).set_buffer_limit(limit)
+
     def expect(self, pattern: str, timeout: float, idle: float = 0.0) -> bytes:
         return self._with_reconnect(
             timeout,
@@ -1935,6 +1944,7 @@ def collect(guest: Guest, link: "Reconnecting", log: Path) -> dict[str, bytes]:
     it, so the answer is another console, not another install.
     """
     last: Exception | None = None
+    link.set_buffer_limit(RESULT_BUFFER_BYTES)
     for attempt in range(COLLECT_TRIES):
         try:
             link.run(f"cp /run/gentoo-install/install.jsonl {RESULT_DIR}/ 2>/dev/null || true")
@@ -1947,6 +1957,7 @@ def collect(guest: Guest, link: "Reconnecting", log: Path) -> dict[str, bytes]:
             if attempt + 1 == COLLECT_TRIES:
                 break
             link.reopen()
+            link.set_buffer_limit(RESULT_BUFFER_BYTES)
     raise ResultError(f"the results could not be read back: {last}")
 
 

--- a/tests/vm/console.py
+++ b/tests/vm/console.py
@@ -17,6 +17,8 @@ _ANSI = re.compile(
     rb"|\x1b[=>]"
 )
 
+CONSOLE_BUFFER_BYTES = 4 * 1024 * 1024
+
 
 class ConsoleTimeout(Exception):
     """A pattern did not appear on the console within its deadline."""
@@ -114,7 +116,15 @@ class _Socket:
 class SerialConsole:
     """Reads and writes a serial port, with expect semantics."""
 
-    def __init__(self, sock: Channel, log: IO[bytes], errors: Path | None = None) -> None:
+    def __init__(
+        self,
+        sock: Channel,
+        log: IO[bytes],
+        errors: Path | None = None,
+        buffer_limit: int = CONSOLE_BUFFER_BYTES,
+    ) -> None:
+        if buffer_limit <= 0:
+            raise ValueError("console buffer limit must be positive")
         self._sock = sock
         self._log = log
         #: Where qemu wrote its own stderr. It names whatever killed it, and
@@ -122,6 +132,8 @@ class SerialConsole:
         #: hung: three rounds were diagnosed by inference instead.
         self._errors = errors
         self._buffer = b""
+        self._last_chunk = b""
+        self._buffer_limit = buffer_limit
         self._tokens: Iterator[int] = itertools.count(1)
 
     @classmethod
@@ -236,6 +248,7 @@ class SerialConsole:
         self.expect(prompt, timeout=60.0)
 
     def _read_once(self) -> None:
+        self._last_chunk = b""
         chunk = self._sock.recv(4096)
         if not chunk:
             # Empty means nothing arrived before the read timed out, which is
@@ -246,7 +259,15 @@ class SerialConsole:
             return
         self._log.write(chunk)
         self._log.flush()
-        self._buffer += chunk
+        self._last_chunk = chunk
+        self._buffer = (self._buffer + chunk)[-self._buffer_limit :]
+
+    def set_buffer_limit(self, limit: int) -> None:
+        """Set the retained tail size for the next reads."""
+        if limit <= 0:
+            raise ValueError("console buffer limit must be positive")
+        self._buffer_limit = limit
+        self._buffer = self._buffer[-limit:]
 
     def _why_closed(self) -> str:
         transport_reason = getattr(self._sock, "why_closed", "")
@@ -278,12 +299,11 @@ class SerialConsole:
         got = bytearray(self._buffer)
         deadline = time.monotonic() + seconds
         while time.monotonic() < deadline:
-            before = len(self._buffer)
             try:
                 self._read_once()
+                got += self._last_chunk
             except ConsoleClosed:
                 break
-            got += self._buffer[before:]
         self._buffer = b""
         return bytes(got)
 

--- a/tests/vm/results.py
+++ b/tests/vm/results.py
@@ -14,6 +14,7 @@ import tarfile
 from pathlib import Path
 
 DEFAULT_SIZE_MIB = 64
+RESULT_BUFFER_BYTES = 64 * 1024 * 1024
 
 
 class ResultError(Exception):
@@ -60,6 +61,8 @@ def console_command(directory: str) -> str:
 
 def read_console(said: bytes) -> dict[str, bytes]:
     """The archive out of what the console printed."""
+    if len(said) > RESULT_BUFFER_BYTES:
+        raise ResultError("the console result exceeds the configured size limit")
     opened = said.rfind(CONSOLE_OPEN.encode())
     closed = said.rfind(CONSOLE_CLOSE.encode())
     if opened < 0 or closed < opened:
@@ -72,14 +75,19 @@ def read_console(said: bytes) -> dict[str, bytes]:
     except (binascii.Error, ValueError) as error:
         raise ResultError(f"the console result is not base64: {error}") from error
     files: dict[str, bytes] = {}
+    total = 0
     try:
         with tarfile.open(fileobj=io.BytesIO(packed), mode="r:gz") as archive:
             for member in archive:
                 if not member.isfile():
                     continue
+                if member.size > RESULT_BUFFER_BYTES - total:
+                    raise ResultError("the console result files exceed the configured size limit")
                 extracted = archive.extractfile(member)
                 if extracted is not None:
-                    files[member.name.removeprefix("./")] = extracted.read()
+                    data = extracted.read()
+                    total += len(data)
+                    files[member.name.removeprefix("./")] = data
     except (tarfile.TarError, EOFError) as error:
         raise ResultError(f"the console result is not a tar archive: {error}") from error
     if not files:


### PR DESCRIPTION
An install prints for an hour and both the live console buffer and the collected archive grew with it, so a long run held all of it in memory and a campaign of a dozen guests held a dozen copies.

The bound keeps the tail: a failure is diagnosed from what was printed last, so dropping the beginning costs nothing a verdict needs.

Closes H07.