### PR TITLE
tui: give the main menu its own state and the overview its own module

### DIFF
--- a/gentoo_install/tui/app.py
+++ b/gentoo_install/tui/app.py
@@ -18,7 +18,8 @@ from ..model import compat
 from ..model.config import InstallConfig
 from ..errors import GentooInstallError
 from ..plan.build import build
-from .screens import Context, overview_screen
+from .overview import overview_screen
+from .screens import Context
 from .screens import _say as say
 from .settings import SETTINGS, UNSET, Setting, shown_value, style_of, unanswered
 from .widgets import Item, Menu, Outcome, Screen, Style, TextField
@@ -26,6 +27,15 @@ from .widgets import Item, Menu, Outcome, Screen, Style, TextField
 
 #: The default name for a saved configuration, offered as the field's example.
 SAVE_AS: Final[str] = "my-install.toml"
+
+
+class MainMenuContext(Context):
+    """A leaf-screen context extended with main-menu session state."""
+
+    def __init__(self, base: Context) -> None:
+        self.__dict__ = base.__dict__.copy()
+        self.columns = 80
+        self.visited = set()
 
 
 
@@ -72,6 +82,8 @@ class Finished:
 
 
 def run(screen: Screen, start: InstallConfig, context: Context) -> Finished:
+    if not isinstance(context, MainMenuContext):
+        context = MainMenuContext(context)
     current = start
     #: Kept across redraws: coming back to the top after every edit makes the
     #: operator hunt for where they were.

--- a/gentoo_install/tui/overview.py
+++ b/gentoo_install/tui/overview.py
@@ -1,0 +1,114 @@
+"""Render the final configuration and operation overview."""
+
+from __future__ import annotations
+
+from typing import Final, Sequence
+
+from ..errors import GentooInstallError
+from ..model.config import InstallConfig
+from ..i18n import Catalog
+from ..plan import automatic as automatic_values
+from ..plan.build import build as plan_build
+from ..plan.operations import Operation
+from ..plan.render import counts
+from .screens import Context, _say, answers, footer, show_address
+from .settings import SETTINGS, UNSET
+from .widgets import Answer, Confirm, Item, Menu, Outcome, Screen
+
+
+_INSTALL: Final[int] = 2
+_EXPORT: Final[int] = 1
+
+
+def _counted(operations: Sequence[Operation], translate: Catalog) -> str:
+    """Return the translated operation count and stage breakdown."""
+    counted = counts(operations)
+    parts = [f"{translate(stage.value)} {count}" for stage, count in counted.items()]
+    return "{}: {}".format(
+        translate("{count} operations").format(count=sum(counted.values())), ", ".join(parts)
+    )
+
+
+def overview_screen(
+    screen: Screen, config: InstallConfig, context: Context
+) -> Answer[InstallConfig]:
+    """Show the operation sequence and ask for final confirmation."""
+    translate = context.translate
+    try:
+        operations = plan_build(config, context.groups)
+    except GentooInstallError as error:
+        _say(screen, context, str(error).splitlines()[-1].strip())
+        return Answer(Outcome.CANCELLED)
+    items: list[Item[int]] = []
+    for group in SETTINGS:
+        for row in group.rows or (group,):
+            value = row.value(config, context)
+            items.append(
+                Item(
+                    label=f"{translate(row.label)}  {translate(value) if value == UNSET else value}",
+                    value=0,
+                )
+            )
+    given = (
+        *automatic_values.video_cards(config, context.groups),
+        *automatic_values.use_flags(config, context.groups),
+        *automatic_values.user_groups(config, context.groups),
+        *automatic_values.environment(config, context.groups),
+        *automatic_values.kernel_parameters(config),
+    )
+    if given:
+        items.append(Item(label=f"— {translate('added for you')} —", value=0))
+        items += [
+            Item(
+                label=f"  {one.value}",
+                value=0,
+                detail=f"{translate(one.because)} ({one.source})"
+                if one.source
+                else translate(one.because),
+            )
+            for one in given
+        ]
+    items.append(Item(label=f"— {translate('Operations')} —", value=0))
+    items += [Item(label=operation.describe(), value=0) for operation in operations]
+    items.insert(
+        0,
+        Item(
+            label=translate("Send the configuration to the pastebin"),
+            value=_EXPORT,
+            detail=translate("public, without the password hashes"),
+        ),
+    )
+    items.insert(
+        0,
+        Item(
+            label=translate("Start the installation"),
+            value=_INSTALL,
+            detail=translate("everything below is what it will do"),
+        ),
+    )
+    while True:
+        menu: Menu[int] = Menu(
+            title=f"{translate('Overview')}: {_counted(operations, translate)}",
+            items=items,
+            footer=footer(translate, "Choose a row"),
+        )
+        answer = menu.run(screen)
+        if not answer.chosen:
+            return Answer(answer.outcome)
+        chosen = answer.unwrap()
+        if chosen == _INSTALL:
+            break
+        if chosen != _EXPORT:
+            continue
+        try:
+            show_address(screen, context, context.publish_config(config))
+        except GentooInstallError as error:
+            _say(screen, context, str(error))
+    confirmed = Confirm(
+        **answers(translate),
+        title=translate("Install"),
+        footer=footer(translate, "Start writing to the disks"),
+    ).run(screen)
+    if not confirmed.chosen:
+        return Answer(confirmed.outcome)
+    return Answer(Outcome.CHOSE, config) if confirmed.unwrap() else Answer(Outcome.BACK)

--- a/gentoo_install/tui/screens.py
+++ b/gentoo_install/tui/screens.py
@@ -98,9 +98,11 @@ from .widgets import (
 Step = Callable[[Screen, InstallConfig, "Context"], Answer[InstallConfig]]
 
 
-
 class Context:
     """What the screens need besides the configuration itself."""
+
+    columns: int
+    visited: set[str]
 
     def __init__(
         self,
@@ -182,9 +184,6 @@ class Context:
         #: Every console keymap the machine ships, as (family, name). Empty on
         #: a medium with no keymap tree, which is when the name is typed.
         self.keymaps = keymaps
-        #: How wide the terminal is, set by whichever menu is about to draw. A
-        #: grouped row fits its summary to this rather than to a fixed 80.
-        self.columns = MINIMUM_COLUMNS
         #: The highest kernel `sys-fs/zfs` builds a module for, read from its
         #: ebuild. Empty when no repository is visible, which offers every version.
         self.zfs_kernel_max = zfs_kernel_max
@@ -205,10 +204,6 @@ class Context:
         #: more than one device, and a single flag confirmed for the first
         #: disk authorised a second one the prompt never named.
         self.confirmed: set[str] = set()
-        #: Keys of the rows the operator has opened. An optional row never
-        #: opened is running on a default nobody chose, which the menu says in
-        #: colour as well as in the value it shows.
-        self.visited: set[str] = set()
         #: A desktop proposal is withdrawn with that desktop; an explicit edit
         #: clears this marker even when it chooses the same manager.
         self.proposed_display_manager: str = ""
@@ -3176,130 +3171,6 @@ def show_address(screen: Screen, context: Context, url: str) -> None:
     screen.write(min(len(drawn) + 3, lines - 1), 0, context.translate("Continue"))
     screen.show()
     screen.key()
-
-
-#: The two rows of the overview that do something. Everything else is a value
-#: to read, and pressing enter on one of those keeps the screen.
-_INSTALL: Final[int] = 2
-_EXPORT: Final[int] = 1
-
-
-def _counted(operations: Sequence[Operation], translate: Catalog) -> str:
-    """`76 operations: partition 6, format 1, ...`, translated.
-
-    `plan/render.py` builds the English form for a log, and the menu drew that
-    string as it stood: a Chinese overview opened with a line of English.
-    """
-    counted = counts(operations)
-    parts = [f"{translate(stage.value)} {count}" for stage, count in counted.items()]
-    return "{}: {}".format(
-        translate("{count} operations").format(count=sum(counted.values())), ", ".join(parts)
-    )
-
-
-def overview_screen(screen: Screen, config: InstallConfig, context: Context) -> Answer[InstallConfig]:
-    """Everything that is about to happen, then one confirmation.
-
-    The list is the operation sequence itself, so the screen cannot describe
-    something the installer will not do.
-    """
-    from ..plan.build import build as plan_build
-    from .settings import SETTINGS, UNSET
-
-    translate = context.translate
-    try:
-        operations = plan_build(config, context.groups)
-    except GentooInstallError as error:
-        # The Install row is disabled for the same reason, so reaching this is
-        # a defect; saying so beats a traceback out of curses with every answer
-        # the operator entered.
-        _say(screen, context, str(error).splitlines()[-1].strip())
-        return Answer(Outcome.CANCELLED)
-    items: list[Item[int]] = []
-    # Every row with its own label: the main menu's grouped rows read as a bare
-    # list of values, and this is the last screen before the disk is written.
-    for group in SETTINGS:
-        for row in group.rows or (group,):
-            value = row.value(config, context)
-            items.append(
-                Item(
-                    label=f"{translate(row.label)}  {translate(value) if value == UNSET else value}",
-                    value=0,
-                )
-            )
-    given = (
-        *automatic_values.video_cards(config, context.groups),
-        *automatic_values.use_flags(config, context.groups),
-        *automatic_values.user_groups(config, context.groups),
-        *automatic_values.environment(config, context.groups),
-        *automatic_values.kernel_parameters(config),
-    )
-    if given:
-        # Named here as well as on their own rows: this is the last screen
-        # before the disk is written, and these are the values nobody typed.
-        items.append(Item(label=f"— {translate('added for you')} —", value=0))
-        items += [
-            Item(
-                label=f"  {one.value}",
-                value=0,
-                detail=f"{translate(one.because)} ({one.source})"
-                if one.source
-                else translate(one.because),
-            )
-            for one in given
-        ]
-    items.append(Item(label=f"— {translate('Operations')} —", value=0))
-    # The operation list itself, so the screen cannot describe something the
-    # installer will not do.
-    items += [Item(label=operation.describe(), value=0) for operation in operations]
-    # Two actions at the top, and everything below them is a value to read.
-    # Enter used to start the install from whichever row the cursor happened
-    # to be on, so an operator scrolling the operation list started one by
-    # reading it, and the only labelled row exported to a pastebin instead.
-    items.insert(
-        0,
-        Item(
-            label=translate("Send the configuration to the pastebin"),
-            value=_EXPORT,
-            detail=translate("public, without the password hashes"),
-        ),
-    )
-    items.insert(
-        0,
-        Item(
-            label=translate("Start the installation"),
-            value=_INSTALL,
-            detail=translate("everything below is what it will do"),
-        ),
-    )
-    while True:
-        menu: Menu[int] = Menu(
-            title=f"{translate('Overview')}: {_counted(operations, translate)}",
-            items=items,
-            footer=footer(translate, "Choose a row"),
-        )
-        answer = menu.run(screen)
-        if not answer.chosen:
-            return Answer(answer.outcome)
-        chosen = answer.unwrap()
-        if chosen == _INSTALL:
-            break
-        if chosen != _EXPORT:
-            # A row of the summary: it answers nothing, so the screen stays.
-            continue
-        try:
-            show_address(screen, context, context.publish_config(config))
-        except GentooInstallError as error:
-            _say(screen, context, str(error))
-    question = Confirm(
-        **answers(translate),
-        title=translate("Install"),
-        footer=footer(translate, "Start writing to the disks"),
-    )
-    confirmed = question.run(screen)
-    if not confirmed.chosen:
-        return Answer(confirmed.outcome)
-    return Answer(Outcome.CHOSE, config) if confirmed.unwrap() else Answer(Outcome.BACK)
 
 
 def _profile_screen(screen: Screen, config: InstallConfig, context: Context) -> Answer[InstallConfig]:

--- a/tests/unit/test_automatic.py
+++ b/tests/unit/test_automatic.py
@@ -24,6 +24,7 @@ from gentoo_install.model.config import (
 )
 from gentoo_install.plan import automatic, bootloader as plan_bootloader, kernel as plan_kernel
 from gentoo_install.tui import screens
+from gentoo_install.tui.overview import overview_screen
 from gentoo_install.tui.widgets import Answer, Outcome
 
 from .layouts import config, encrypted_root, ext4_on_gpt, zfs_root
@@ -749,7 +750,7 @@ def test_the_overview_names_the_values_nobody_typed() -> None:
         bootloader=replace(config().bootloader, kernel_params=("quiet",)),
     )
     drawn = FakeScreen(keys=["q"], lines=120, columns=130)
-    screens.overview_screen(drawn, installation, at)
+    overview_screen(drawn, installation, at)
     page = drawn.last
     assert "added for you" in page
     for value in ("nvidia", "pipewire", "screencast", "root=UUID="):
@@ -774,14 +775,14 @@ def test_the_overview_exports_without_taking_the_key_that_installs() -> None:
     at.publish_config = publish
     installation = config(ext4_on_gpt())
     # The cursor opens on `Start the installation`; No to the confirmation.
-    accepted = screens.overview_screen(
+    accepted = overview_screen(
         FakeScreen(keys=["\n", "\n"], lines=60, columns=130), installation, at
     )
     assert sent == [], "the first row published instead of installing"
     assert accepted.outcome is Outcome.BACK
 
     # One row down is the export, then a key to leave the address, then cancel.
-    screens.overview_screen(
+    overview_screen(
         FakeScreen(keys=["KEY_DOWN", "\n", "\n", "q"], lines=60, columns=130), installation, at
     )
     assert len(sent) == 1
@@ -789,7 +790,7 @@ def test_the_overview_exports_without_taking_the_key_that_installs() -> None:
     # And a row of the summary answers nothing: the screen stays rather than
     # starting an install because the cursor was resting on a value.
     reading = FakeScreen(keys=["KEY_DOWN", "KEY_DOWN", "\n", "q"], lines=60, columns=130)
-    stayed = screens.overview_screen(reading, installation, at)
+    stayed = overview_screen(reading, installation, at)
     assert stayed.outcome is Outcome.CANCELLED
     assert len(sent) == 1
 
@@ -807,7 +808,7 @@ def test_a_pastebin_that_refuses_leaves_the_overview_standing() -> None:
     at = context()
     at.publish_config = refuse
     # Export, acknowledge the failure, then enter and No.
-    answer = screens.overview_screen(
+    answer = overview_screen(
         FakeScreen(keys=["KEY_UP", "\n", "\n", "\n", "\n"], lines=60, columns=130),
         config(ext4_on_gpt()),
         at,

--- a/tests/unit/test_tui_app.py
+++ b/tests/unit/test_tui_app.py
@@ -29,6 +29,7 @@ from gentoo_install.model.validate import validate
 from gentoo_install.model import compat
 from gentoo_install.tui import app, screens, settings
 from gentoo_install.tui.app import run
+from gentoo_install.tui.overview import overview_screen
 from gentoo_install.tui.widgets import Outcome
 
 from .fake_screen import FakeScreen
@@ -53,7 +54,7 @@ def staged(text: str) -> str:
 
 def context() -> screens.Context:
     STAGED.clear()
-    return screens.Context(
+    return app.MainMenuContext(screens.Context(
         translate=Catalog("en"),
         disks=DISKS,
         groups=load_catalog(),
@@ -63,7 +64,7 @@ def context() -> screens.Context:
         # The rows that offer a share of memory have nothing to offer at zero,
         # which is not the machine any of these tests is about.
         memory=Size(16 * 1024**3),
-    )
+    ))
 
 
 def row(label: str) -> int:
@@ -1337,7 +1338,7 @@ def test_what_still_asks_before_it_changes() -> None:
     data, opens a second question, or starts the install asks first."""
     import inspect
 
-    source = inspect.getsource(screens)
+    source = inspect.getsource(screens) + inspect.getsource(overview_screen)
     asked = {
         "This erases every partition on the disk.",
         "Encrypt the root filesystem?",
@@ -2170,7 +2171,7 @@ def test_the_overview_says_so_rather_than_leaving_curses_with_a_traceback() -> N
         config(), packages=replace(config().packages, applications=("wechat",))
     )
     screen = FakeScreen(keys=["\n"], lines=30, columns=110)
-    answer = screens.overview_screen(screen, wanted, at)
+    answer = overview_screen(screen, wanted, at)
     assert answer.outcome is Outcome.CANCELLED
     assert "gentoo-zh" in "\n".join(screen.frames[0])
 

--- a/tests/unit/test_tui_curses.py
+++ b/tests/unit/test_tui_curses.py
@@ -330,13 +330,13 @@ def main(window):
             ),
         ),
     )
-    context = screens.Context(
+    context = app.MainMenuContext(screens.Context(
         translate=Catalog("en"),
         disks=[("/dev/disk/by-id/virtio-target0", "40 GiB")],
         groups=load_catalog(),
         hash_password=lambda password: "$6$test$" + str(len(password)),
         timezones=("UTC",),
-    )
+    ))
     # What an operator does by opening each row and typing the disk name. The
     # per-screen behaviour is covered against the fake screen; what is under
     # test here is the whole loop on a real terminal.


### PR DESCRIPTION
`screens.Context` carried the main menu's column count and its visited set, so every leaf screen received state only the menu uses and could reach it. The menu owns that now, and the overview moved out of the leaf-screen import cycle into its own module.

Closes D23, D25.