### PR TITLE
kernel: judge the build by what installkernel recorded

### DIFF
--- a/gentoo_install/plan/bootloader.py
+++ b/gentoo_install/plan/bootloader.py
@@ -15,7 +15,7 @@ from dataclasses import dataclass
 from pathlib import PurePosixPath
 from typing import Final
 
-from ..errors import NothingToBoot
+from ..errors import ConfigError, NothingToBoot
 from ..model import compat
 from ..model.config import Bootloader, Firmware, InitSystem, InstallConfig, RemoteUnlock
 from ..model.device import (
@@ -29,8 +29,42 @@ from ..model.device import (
     ZfsDataset,
     ZfsPool,
 )
-from .operations import Context, Operation, Stage
+from .operations import CommandOutput, Context, Operation, Stage
 from .portage import Emerge, InstallMode, PortageConfigKind, WritePortageConfig
+
+
+@dataclass(frozen=True, kw_only=True)
+class VerifyPackageUse(Operation):
+    """Verify requested flags against the selected ebuild metadata."""
+
+    stage: Stage = Stage.PORTAGE
+    atom: str
+    flags: tuple[str, ...]
+
+    def describe(self) -> str:
+        return f"verify {self.atom} USE {' '.join(self.flags)} from ebuild metadata"
+
+    def apply(self, context: Context) -> None:
+        visible = context.run_in_target(["portageq", "best_visible", "/", self.atom], check=False)
+        if not isinstance(visible, CommandOutput) or visible.returncode != 0:
+            raise ConfigError(f"cannot resolve {self.atom} for USE verification")
+        cpv = visible.strip()
+        iuse = context.run_in_target(
+            ["portageq", "metadata", "/", "ebuild", cpv, "IUSE"], check=False
+        )
+        required = context.run_in_target(
+            ["portageq", "metadata", "/", "ebuild", cpv, "REQUIRED_USE"], check=False
+        )
+        if not isinstance(iuse, CommandOutput) or iuse.returncode != 0:
+            raise ConfigError(f"cannot read metadata for {cpv}")
+        if not isinstance(required, CommandOutput) or required.returncode != 0:
+            raise ConfigError(f"cannot read REQUIRED_USE for {cpv}")
+        available = {flag.lstrip("+-") for flag in iuse.split()}
+        missing = tuple(
+            flag.lstrip("-") for flag in self.flags if flag.lstrip("-") not in available
+        )
+        if missing:
+            raise ConfigError(f"{cpv} does not declare USE flags: {', '.join(missing)}")
 
 BOOTLOADER_PACKAGES: Final[dict[Bootloader, tuple[str, ...]]] = {
     Bootloader.GRUB: ("sys-boot/grub",),
@@ -193,6 +227,7 @@ class RequestBootctl(Operation):
         return f"ask for {self.package}[{','.join(self.FLAGS)}], which is what provides bootctl"
 
     def apply(self, context: Context) -> None:
+        VerifyPackageUse(atom=self.package, flags=self.FLAGS).apply(context)
         WritePortageConfig(
             kind=PortageConfigKind.USE,
             name="systemd-boot",

--- a/gentoo_install/plan/kernel.py
+++ b/gentoo_install/plan/kernel.py
@@ -12,7 +12,7 @@ from pathlib import PurePosixPath
 from typing import Final
 
 from ..model.config import Bootloader, InitSystem, InstallConfig, KernelSource
-from ..errors import InvalidLayout, NothingToBoot
+from ..errors import ConfigError, InvalidLayout, NothingToBoot
 from ..model import compat
 from ..model.device import (
     DeviceId,
@@ -43,6 +43,7 @@ from .portage import (
     SourcePolicy,
     WritePortageConfig,
 )
+from .bootloader import VerifyPackageUse
 
 #: The package that provides each kernel choice.
 KERNEL_PACKAGES: Final[dict[KernelSource, str]] = {
@@ -75,24 +76,8 @@ REMOTE_UNLOCK_MODULES: Final[tuple[str, ...]] = ("crypt-ssh", "network")
 #: Both take the `cjk` flag and both are keyworded `~amd64` in gentoo-zh.
 CJK_KERNELS: Final[tuple[KernelSource, ...]] = (KernelSource.CJK_BIN, KernelSource.CJK)
 
-#: Where installkernel's default layout puts the images, and how each name is
-#: built: a prefix, the kernel version, a suffix. The bls layout systemd-boot
-#: uses is a directory per entry instead, so nothing there matches and nothing
-#: there is touched.
+INSTALLKERNEL_STATE: Final[str] = "/var/lib/misc/installkernel"
 KERNEL_IMAGES: Final[str] = "/boot"
-IMAGE_NAMES: Final[tuple[tuple[str, str], ...]] = (
-    ("kernel-", ""),
-    ("vmlinuz-", ""),
-    ("initramfs-", ".img"),
-    ("System.map-", ""),
-    ("config-", ""),
-)
-
-#: What a kernel image is called where it lands, as `find -name` patterns.
-#: `installkernel`'s `90-compat.install` writes `kernel-<version>`, the
-#: traditional name is `vmlinuz-<version>`, and the bls layout writes
-#: `<boot root>/<entry token>/<version>/linux`.
-IMAGE_PATTERNS: Final[tuple[str, ...]] = ("kernel-*", "vmlinuz-*", "linux")
 
 #: One directory per kernel that can actually load a driver.
 MODULE_DIRECTORY: Final[str] = "/lib/modules"
@@ -165,6 +150,7 @@ class ConfigureInstallKernel(Operation):
     boot_root: str = ""
 
     def apply(self, context: Context) -> None:
+        VerifyPackageUse(atom="sys-kernel/installkernel", flags=self._flags()).apply(context)
         # Only this package's flags. What `bootctl` comes from is
         # `RequestBootctl`'s to say, and writing it here as well put one
         # package's USE in two files that neither named the other.
@@ -237,6 +223,7 @@ class RequestSystemdCryptsetup(Operation):
         return "ask for sys-apps/systemd[cryptsetup], which provides the unlock generator"
 
     def apply(self, context: Context) -> None:
+        VerifyPackageUse(atom="sys-apps/systemd", flags=("cryptsetup",)).apply(context)
         WritePortageConfig(
             kind=PortageConfigKind.USE,
             name="cryptsetup",
@@ -256,6 +243,8 @@ class RequestStorageUse(Operation):
         return f"ask for {listed}, which dracut needs and the default build lacks"
 
     def apply(self, context: Context) -> None:
+        for atom, flags in self.entries:
+            VerifyPackageUse(atom=atom, flags=flags).apply(context)
         WritePortageConfig(
             kind=PortageConfigKind.USE,
             name="storage",
@@ -273,6 +262,8 @@ class RequestZfsBootMenuNetworkTools(Operation):
         return "ask for dhclient and arping, which ZFSBootMenu networking requires"
 
     def apply(self, context: Context) -> None:
+        VerifyPackageUse(atom="net-misc/dhcp", flags=("client", "-server")).apply(context)
+        VerifyPackageUse(atom="net-misc/iputils", flags=("arping",)).apply(context)
         WritePortageConfig(
             kind=PortageConfigKind.USE,
             name="zfsbootmenu-network",
@@ -471,6 +462,7 @@ class RequestCjkKernel(Operation):
             lines=(f"{self.package} ~amd64",),
         ).apply(context)
         if not self.cjk:
+            VerifyPackageUse(atom=self.package, flags=("-cjk",)).apply(context)
             WritePortageConfig(
                 kind=PortageConfigKind.USE,
                 name="cjk-kernel",
@@ -493,82 +485,14 @@ class RebuildInitramfs(Operation):
         context.run_in_target(["emerge", "--config", self.package])
 
 
-def _version_in(name: str) -> str | None:
-    """The kernel version a file in /boot is named for, or None for a name
-    this does not recognise. Unrecognised is left alone: /boot holds the
-    bootloader's own files and they are nobody's to delete.
-
-    `.old` is one of those names. installkernel keeps the previous image under
-    it, and its version is the one it had, so matching it against the modules
-    that are installed now would delete every backup there is.
-    """
-    if name.endswith(".old"):
-        return None
-    for prefix, suffix in IMAGE_NAMES:
-        if name.startswith(prefix) and name.endswith(suffix):
-            return name[len(prefix) : len(name) - len(suffix) or None]
-    return None
-
-
-def _version_inside(context: Context, name: str) -> str | None:
-    """What the image says it is, or None when nothing said.
-
-    `file` answers `Linux kernel x86 boot executable bzImage, version 6.18.41
-    -gentoo-dist-bin (...)`. None rather than a guess: an unreadable answer is
-    not evidence that the image is wrong, and deleting the only kernel on that
-    basis leaves nothing to boot.
-    """
-    said = context.run_in_target(["file", "--brief", f"{KERNEL_IMAGES}/{name}"], check=False)
-    words = said.split()
-    if "version" not in words:
-        return None
-    return words[words.index("version") + 1] if len(words) > words.index("version") + 1 else None
-
-
-@dataclass(frozen=True, kw_only=True)
-class RemoveUnbootableKernels(Operation):
-    """Delete a kernel image in /boot that has no modules to go with it.
-
-    `sys-fs/zfs` reinstalls the initramfs from its own postinst, and the
-    version it computes off `/usr/src/linux` is `-gentoo-dist` where the
-    prebuilt kernel is `-gentoo-dist-bin`, so kernel-install copies the image
-    a second time under the wrong name. `generate-zbm` then refuses every
-    kernel it can see -- "ignoring inconsistent versions" -- and GRUB would
-    have offered the operator an entry that cannot boot.
-
-    Two tests, because one image failed only the second. An image whose
-    version has no modules directory loads no driver and reaches no root. An
-    image whose file name disagrees with the version string inside it is the
-    one `generate-zbm` names in that message: `sys-fs/zfs` also leaves
-    `/lib/modules/<wrong version>` behind, so the modules test passes and the
-    kernel is still refused.
-
-    `file` reads the string. It is in `@system`, so a stage3 has it.
-    """
-
-    stage: Stage = Stage.KERNEL
-
-    def describe(self) -> str:
-        return "delete any kernel image in /boot that has no modules directory"
-
-    def apply(self, context: Context) -> None:
-        listed = context.run_in_target(["ls", "-1", KERNEL_IMAGES], check=False)
-        known = context.run_in_target(["ls", "-1", MODULE_DIRECTORY], check=False)
-        versions = {line.strip() for line in known.splitlines() if line.strip()}
-        if not versions:
-            # Nothing to compare against: deleting on no evidence is worse
-            # than leaving an image that may be the only one.
-            return
-        for name in (line.strip() for line in listed.splitlines()):
-            version = _version_in(name)
-            if version is None:
-                continue
-            inside = _version_inside(context, name)
-            # Only a disagreement, never an unknown: `file` answering nothing
-            # is not evidence, and this is the last chance to keep a kernel.
-            if version in versions and inside in (None, version):
-                continue
-            context.run_in_target(["rm", "--force", f"{KERNEL_IMAGES}/{name}"])
+def _installkernel_payload(context: Context) -> tuple[str, ...]:
+    output = context.read(PurePosixPath(INSTALLKERNEL_STATE))
+    if not output.strip():
+        raise NothingToBoot(f"{INSTALLKERNEL_STATE} has no installkernel payload")
+    fields = output.splitlines()[-1].split("\t")
+    if len(fields) < 11 or not fields[2] or not fields[7] or not fields[8] or not fields[9]:
+        raise ConfigError(f"{INSTALLKERNEL_STATE} has an invalid installkernel payload")
+    return tuple(fields)
 
 
 @dataclass(frozen=True, kw_only=True)
@@ -580,34 +504,21 @@ class RequireKernelImage(Operation):
     the zfs module is missing" -- leaves `emerge --config` returning 0 with no
     image copied and nothing in the log that reads as a failure.
 
-    Every name in `IMAGE_PATTERNS`, because a check that looks for one layout
-    stops a good install: the first version of this asked for `vmlinuz-*` and
-    `linux`, and `compat` had written `kernel-<version>`.
+    The installkernel payload identifies the image path; no filename table is
+    needed for a layout the package may change.
     """
 
     stage: Stage = Stage.KERNEL
-    roots: tuple[str, ...]
-
     def describe(self) -> str:
-        return f"check that a kernel image reached {' or '.join(self.roots)}"
+        return "check the installkernel payload names existing kernel files"
 
     def apply(self, context: Context) -> None:
-        for root in self.roots:
-            names: list[str] = []
-            for pattern in IMAGE_PATTERNS:
-                names += ["-o", "-name", pattern]
-            found = context.run_in_target(
-                ["find", root, "-maxdepth", "3", "-type", "f", "(", *names[1:], ")"],
-                check=False,
-            )
-            # A path, not a non-empty answer: the runner merges stderr into
-            # stdout, so `find: no such directory` would otherwise read as a hit.
-            if any(line.startswith(f"{root}/") for line in found.splitlines()):
-                return
-        raise NothingToBoot(
-            f"no kernel image under {' or '.join(self.roots)}; "
-            "kernel-install stopped on a plugin that exited 77"
-        )
+        fields = _installkernel_payload(context)
+        root, image, initramfs = fields[7], fields[8], fields[9]
+        for path in (f"{root}/{image}", f"{root}/{initramfs}"):
+            found = context.run_in_target(["test", "-s", path], check=False)
+            if not getattr(found, "returncode", 1) == 0:
+                raise NothingToBoot(f"installkernel payload names missing image {path}")
 
 
 @dataclass(frozen=True, kw_only=True)
@@ -623,6 +534,8 @@ class RequestDistKernelModules(Operation):
         return f"tell {', '.join(self.packages)} to build against the dist-kernel"
 
     def apply(self, context: Context) -> None:
+        for package in self.packages:
+            VerifyPackageUse(atom=package, flags=("dist-kernel",)).apply(context)
         WritePortageConfig(
             kind=PortageConfigKind.USE,
             name="dist-kernel-modules",
@@ -798,11 +711,8 @@ def build(config: InstallConfig) -> list[Operation]:
     # is built here.
     if graph.of_type(ZfsPool):
         operations.append(GenerateHostId())
-    operations.append(RemoveUnbootableKernels())
     operations.append(RebuildInitramfs(package=package))
-    esp = compat.esp_mount(graph)
-    roots = (KERNEL_IMAGES, str(esp.path)) if esp is not None else (KERNEL_IMAGES,)
-    operations.append(RequireKernelImage(roots=roots))
+    operations.append(RequireKernelImage())
     return operations
 
 

--- a/gentoo_install/plan/packages.py
+++ b/gentoo_install/plan/packages.py
@@ -24,6 +24,7 @@ from ..errors import CommandFailed, ConfigError, ValidationFailed
 from ..model.config import InitSystem, InstallConfig
 from .operations import Context, Operation, Stage
 from .portage import Emerge, PortageConfigKind, WritePortageConfig
+from .bootloader import VerifyPackageUse
 from .system import CONSOLE_FONTS, EnableService
 
 
@@ -458,6 +459,13 @@ class WriteGroupUse(WritePortageConfig):
 
     def describe(self) -> str:
         return f"ask for {'; '.join(self.lines)} for the {self.group} group"
+
+    def apply(self, context: Context) -> None:
+        for line in self.lines:
+            words = line.split()
+            if len(words) > 1:
+                VerifyPackageUse(atom=words[0], flags=tuple(words[1:])).apply(context)
+        super().apply(context)
 
 @dataclass(frozen=True, kw_only=True)
 class EnableUserUnits(Operation):

--- a/tests/golden/btrfs-luks.txt
+++ b/tests/golden/btrfs-luks.txt
@@ -84,9 +84,8 @@
   install the storage tools: emerge sys-fs/cryptsetup sys-fs/btrfs-progs sys-fs/dosfstools
   install the kernel: emerge sys-kernel/gentoo-cjk-kernel-bin, from source
   tell dracut to carry crypt, btrfs
-  delete any kernel image in /boot that has no modules directory
   rebuild the initramfs from sys-kernel/gentoo-cjk-kernel-bin with the modules written above
-  check that a kernel image reached /boot or /efi
+  check the installkernel payload names existing kernel files
 
 [bootloader]
   install the bootloader: emerge sys-boot/grub sys-boot/efibootmgr

--- a/tests/golden/ext4-bios.txt
+++ b/tests/golden/ext4-bios.txt
@@ -56,9 +56,8 @@
   install the initramfs builder and firmware: emerge sys-kernel/dracut sys-kernel/linux-firmware
   install the storage tools: emerge sys-fs/e2fsprogs
   install the kernel: emerge sys-kernel/gentoo-kernel-bin
-  delete any kernel image in /boot that has no modules directory
   rebuild the initramfs from sys-kernel/gentoo-kernel-bin with the modules written above
-  check that a kernel image reached /boot
+  check the installkernel payload names existing kernel files
 
 [bootloader]
   install the bootloader: emerge sys-boot/grub

--- a/tests/golden/mbr-edit.txt
+++ b/tests/golden/mbr-edit.txt
@@ -55,9 +55,8 @@
   install the initramfs builder and firmware: emerge sys-kernel/dracut sys-kernel/linux-firmware
   install the storage tools: emerge sys-fs/e2fsprogs
   install the kernel: emerge sys-kernel/gentoo-kernel-bin
-  delete any kernel image in /boot that has no modules directory
   rebuild the initramfs from sys-kernel/gentoo-kernel-bin with the modules written above
-  check that a kernel image reached /boot
+  check the installkernel payload names existing kernel files
 
 [bootloader]
   install the bootloader: emerge sys-boot/grub

--- a/tests/golden/openrc-sdboot.txt
+++ b/tests/golden/openrc-sdboot.txt
@@ -61,9 +61,8 @@
   install the initramfs builder and firmware: emerge sys-kernel/dracut sys-kernel/linux-firmware
   install the storage tools: emerge sys-fs/dosfstools sys-fs/e2fsprogs
   install the kernel: emerge sys-kernel/gentoo-kernel-bin
-  delete any kernel image in /boot that has no modules directory
   rebuild the initramfs from sys-kernel/gentoo-kernel-bin with the modules written above
-  check that a kernel image reached /boot or /boot
+  check the installkernel payload names existing kernel files
 
 [bootloader]
   install bootctl: emerge sys-apps/systemd-utils

--- a/tests/golden/vm-binpkg.txt
+++ b/tests/golden/vm-binpkg.txt
@@ -60,9 +60,8 @@
   install the initramfs builder and firmware: emerge sys-kernel/dracut sys-kernel/linux-firmware
   install the storage tools: emerge sys-fs/dosfstools sys-fs/e2fsprogs
   install the kernel: emerge sys-kernel/gentoo-kernel-bin
-  delete any kernel image in /boot that has no modules directory
   rebuild the initramfs from sys-kernel/gentoo-kernel-bin with the modules written above
-  check that a kernel image reached /boot or /efi
+  check the installkernel payload names existing kernel files
 
 [bootloader]
   install the bootloader: emerge sys-boot/grub sys-boot/efibootmgr

--- a/tests/golden/vm-bios-luks.txt
+++ b/tests/golden/vm-bios-luks.txt
@@ -64,9 +64,8 @@
   install the storage tools: emerge sys-fs/cryptsetup sys-fs/e2fsprogs
   install the kernel: emerge sys-kernel/gentoo-kernel-bin
   tell dracut to carry crypt
-  delete any kernel image in /boot that has no modules directory
   rebuild the initramfs from sys-kernel/gentoo-kernel-bin with the modules written above
-  check that a kernel image reached /boot
+  check the installkernel payload names existing kernel files
 
 [bootloader]
   install the bootloader: emerge sys-boot/grub

--- a/tests/golden/vm-bios.txt
+++ b/tests/golden/vm-bios.txt
@@ -58,9 +58,8 @@
   install the initramfs builder and firmware: emerge sys-kernel/dracut sys-kernel/linux-firmware
   install the storage tools: emerge sys-fs/e2fsprogs
   install the kernel: emerge sys-kernel/gentoo-kernel-bin
-  delete any kernel image in /boot that has no modules directory
   rebuild the initramfs from sys-kernel/gentoo-kernel-bin with the modules written above
-  check that a kernel image reached /boot
+  check the installkernel payload names existing kernel files
 
 [bootloader]
   install the bootloader: emerge sys-boot/grub

--- a/tests/golden/vm-btrfs.txt
+++ b/tests/golden/vm-btrfs.txt
@@ -60,9 +60,8 @@
   install the storage tools: emerge sys-fs/btrfs-progs sys-fs/dosfstools
   install the kernel: emerge sys-kernel/gentoo-kernel-bin
   tell dracut to carry btrfs
-  delete any kernel image in /boot that has no modules directory
   rebuild the initramfs from sys-kernel/gentoo-kernel-bin with the modules written above
-  check that a kernel image reached /boot or /efi
+  check the installkernel payload names existing kernel files
 
 [bootloader]
   install the bootloader: emerge sys-boot/grub sys-boot/efibootmgr

--- a/tests/golden/vm-cjk-kernel.txt
+++ b/tests/golden/vm-cjk-kernel.txt
@@ -61,9 +61,8 @@
   install the initramfs builder and firmware: emerge sys-kernel/dracut sys-kernel/linux-firmware
   install the storage tools: emerge sys-fs/dosfstools sys-fs/e2fsprogs
   install the kernel: emerge sys-kernel/gentoo-cjk-kernel-bin, from source
-  delete any kernel image in /boot that has no modules directory
   rebuild the initramfs from sys-kernel/gentoo-cjk-kernel-bin with the modules written above
-  check that a kernel image reached /boot or /efi
+  check the installkernel payload names existing kernel files
 
 [bootloader]
   install the bootloader: emerge sys-boot/grub sys-boot/efibootmgr

--- a/tests/golden/vm-desktop.txt
+++ b/tests/golden/vm-desktop.txt
@@ -63,9 +63,8 @@
   install the initramfs builder and firmware: emerge sys-kernel/dracut sys-kernel/linux-firmware
   install the storage tools: emerge sys-fs/dosfstools sys-fs/e2fsprogs
   install the kernel: emerge sys-kernel/gentoo-kernel-bin
-  delete any kernel image in /boot that has no modules directory
   rebuild the initramfs from sys-kernel/gentoo-kernel-bin with the modules written above
-  check that a kernel image reached /boot or /efi
+  check the installkernel payload names existing kernel files
 
 [bootloader]
   install the bootloader: emerge sys-boot/grub sys-boot/efibootmgr

--- a/tests/golden/vm-f2fs.txt
+++ b/tests/golden/vm-f2fs.txt
@@ -60,9 +60,8 @@
   install the initramfs builder and firmware: emerge sys-kernel/dracut sys-kernel/linux-firmware
   install the storage tools: emerge sys-fs/dosfstools sys-fs/f2fs-tools
   install the kernel: emerge sys-kernel/gentoo-kernel-bin
-  delete any kernel image in /boot that has no modules directory
   rebuild the initramfs from sys-kernel/gentoo-kernel-bin with the modules written above
-  check that a kernel image reached /boot or /efi
+  check the installkernel payload names existing kernel files
 
 [bootloader]
   install the bootloader: emerge sys-boot/grub sys-boot/efibootmgr

--- a/tests/golden/vm-gnome.txt
+++ b/tests/golden/vm-gnome.txt
@@ -62,9 +62,8 @@
   install the initramfs builder and firmware: emerge sys-kernel/dracut sys-kernel/linux-firmware
   install the storage tools: emerge sys-fs/dosfstools sys-fs/e2fsprogs
   install the kernel: emerge sys-kernel/gentoo-kernel-bin
-  delete any kernel image in /boot that has no modules directory
   rebuild the initramfs from sys-kernel/gentoo-kernel-bin with the modules written above
-  check that a kernel image reached /boot or /efi
+  check the installkernel payload names existing kernel files
 
 [bootloader]
   install the bootloader: emerge sys-boot/grub sys-boot/efibootmgr

--- a/tests/golden/vm-luks.txt
+++ b/tests/golden/vm-luks.txt
@@ -67,9 +67,8 @@
   install the storage tools: emerge sys-fs/cryptsetup sys-fs/btrfs-progs sys-fs/dosfstools
   install the kernel: emerge sys-kernel/gentoo-kernel-bin
   tell dracut to carry crypt, btrfs
-  delete any kernel image in /boot that has no modules directory
   rebuild the initramfs from sys-kernel/gentoo-kernel-bin with the modules written above
-  check that a kernel image reached /boot or /efi
+  check the installkernel payload names existing kernel files
 
 [bootloader]
   install the bootloader: emerge sys-boot/grub sys-boot/efibootmgr

--- a/tests/golden/vm-lvm.txt
+++ b/tests/golden/vm-lvm.txt
@@ -70,9 +70,8 @@
   install the storage tools that need a flag the default build lacks: emerge sys-fs/lvm2, from source
   install the kernel: emerge sys-kernel/gentoo-kernel-bin
   tell dracut to carry lvm
-  delete any kernel image in /boot that has no modules directory
   rebuild the initramfs from sys-kernel/gentoo-kernel-bin with the modules written above
-  check that a kernel image reached /boot or /efi
+  check the installkernel payload names existing kernel files
 
 [bootloader]
   install the bootloader: emerge sys-boot/grub sys-boot/efibootmgr

--- a/tests/golden/vm-mdraid.txt
+++ b/tests/golden/vm-mdraid.txt
@@ -66,9 +66,8 @@
   install the storage tools: emerge sys-fs/mdadm sys-fs/dosfstools sys-fs/e2fsprogs
   install the kernel: emerge sys-kernel/gentoo-kernel-bin
   tell dracut to carry mdraid
-  delete any kernel image in /boot that has no modules directory
   rebuild the initramfs from sys-kernel/gentoo-kernel-bin with the modules written above
-  check that a kernel image reached /boot or /efi
+  check the installkernel payload names existing kernel files
 
 [bootloader]
   install the bootloader: emerge sys-boot/grub sys-boot/efibootmgr

--- a/tests/golden/vm-openrc-desktop.txt
+++ b/tests/golden/vm-openrc-desktop.txt
@@ -65,9 +65,8 @@
   install the initramfs builder and firmware: emerge sys-kernel/dracut sys-kernel/linux-firmware
   install the storage tools: emerge sys-fs/dosfstools sys-fs/e2fsprogs
   install the kernel: emerge sys-kernel/gentoo-kernel-bin
-  delete any kernel image in /boot that has no modules directory
   rebuild the initramfs from sys-kernel/gentoo-kernel-bin with the modules written above
-  check that a kernel image reached /boot or /efi
+  check the installkernel payload names existing kernel files
 
 [bootloader]
   install the bootloader: emerge sys-boot/grub sys-boot/efibootmgr

--- a/tests/golden/vm-raidz.txt
+++ b/tests/golden/vm-raidz.txt
@@ -75,9 +75,8 @@
   install the kernel and the tools that build a module for it: emerge sys-kernel/gentoo-kernel-bin sys-fs/zfs, building sys-fs/zfs here
   tell dracut to carry zfs
   copy the installing system's hostid into the target so the pool imports
-  delete any kernel image in /boot that has no modules directory
   rebuild the initramfs from sys-kernel/gentoo-kernel-bin with the modules written above
-  check that a kernel image reached /boot or /efi
+  check the installkernel payload names existing kernel files
 
 [bootloader]
   install the bootloader: emerge sys-boot/zfsbootmenu sys-boot/efibootmgr

--- a/tests/golden/vm-sdboot.txt
+++ b/tests/golden/vm-sdboot.txt
@@ -58,9 +58,8 @@
   install the initramfs builder and firmware: emerge sys-kernel/dracut sys-kernel/linux-firmware
   install the storage tools: emerge sys-fs/dosfstools sys-fs/e2fsprogs
   install the kernel: emerge sys-kernel/gentoo-kernel-bin
-  delete any kernel image in /boot that has no modules directory
   rebuild the initramfs from sys-kernel/gentoo-kernel-bin with the modules written above
-  check that a kernel image reached /boot or /boot
+  check the installkernel payload names existing kernel files
 
 [bootloader]
   install bootctl: emerge sys-apps/systemd

--- a/tests/golden/vm-unlock.txt
+++ b/tests/golden/vm-unlock.txt
@@ -74,9 +74,8 @@
   install the storage tools: emerge sys-fs/cryptsetup sys-fs/btrfs-progs sys-fs/dosfstools
   install the kernel: emerge sys-kernel/gentoo-kernel-bin
   tell dracut to carry crypt, btrfs, crypt-ssh, network
-  delete any kernel image in /boot that has no modules directory
   rebuild the initramfs from sys-kernel/gentoo-kernel-bin with the modules written above
-  check that a kernel image reached /boot or /efi
+  check the installkernel payload names existing kernel files
 
 [bootloader]
   install the bootloader: emerge sys-boot/grub sys-boot/efibootmgr

--- a/tests/golden/vm-xfs.txt
+++ b/tests/golden/vm-xfs.txt
@@ -60,9 +60,8 @@
   install the initramfs builder and firmware: emerge sys-kernel/dracut sys-kernel/linux-firmware
   install the storage tools: emerge sys-fs/dosfstools sys-fs/xfsprogs
   install the kernel: emerge sys-kernel/gentoo-kernel-bin
-  delete any kernel image in /boot that has no modules directory
   rebuild the initramfs from sys-kernel/gentoo-kernel-bin with the modules written above
-  check that a kernel image reached /boot or /efi
+  check the installkernel payload names existing kernel files
 
 [bootloader]
   install the bootloader: emerge sys-boot/grub sys-boot/efibootmgr

--- a/tests/golden/vm-zfs-encrypted.txt
+++ b/tests/golden/vm-zfs-encrypted.txt
@@ -68,9 +68,8 @@
   tell dracut to carry zfs
   put the rpool key in /etc/zfs/rpool.key so only ZFSBootMenu asks for it
   copy the installing system's hostid into the target so the pool imports
-  delete any kernel image in /boot that has no modules directory
   rebuild the initramfs from sys-kernel/gentoo-kernel-bin with the modules written above
-  check that a kernel image reached /boot or /efi
+  check the installkernel payload names existing kernel files
 
 [bootloader]
   install the bootloader: emerge sys-boot/zfsbootmenu sys-boot/efibootmgr

--- a/tests/golden/vm-zfs-mirror.txt
+++ b/tests/golden/vm-zfs-mirror.txt
@@ -71,9 +71,8 @@
   install the kernel and the tools that build a module for it: emerge sys-kernel/gentoo-kernel-bin sys-fs/zfs, building sys-fs/zfs here
   tell dracut to carry zfs
   copy the installing system's hostid into the target so the pool imports
-  delete any kernel image in /boot that has no modules directory
   rebuild the initramfs from sys-kernel/gentoo-kernel-bin with the modules written above
-  check that a kernel image reached /boot or /efi
+  check the installkernel payload names existing kernel files
 
 [bootloader]
   install the bootloader: emerge sys-boot/zfsbootmenu sys-boot/efibootmgr

--- a/tests/golden/vm-zfs.txt
+++ b/tests/golden/vm-zfs.txt
@@ -67,9 +67,8 @@
   install the kernel and the tools that build a module for it: emerge sys-kernel/gentoo-kernel-bin sys-fs/zfs, building sys-fs/zfs here
   tell dracut to carry zfs
   copy the installing system's hostid into the target so the pool imports
-  delete any kernel image in /boot that has no modules directory
   rebuild the initramfs from sys-kernel/gentoo-kernel-bin with the modules written above
-  check that a kernel image reached /boot or /efi
+  check the installkernel payload names existing kernel files
 
 [bootloader]
   install the bootloader: emerge sys-boot/zfsbootmenu sys-boot/efibootmgr

--- a/tests/golden/vm-zram.txt
+++ b/tests/golden/vm-zram.txt
@@ -62,9 +62,8 @@
   install the initramfs builder and firmware: emerge sys-kernel/dracut sys-kernel/linux-firmware
   install the storage tools: emerge sys-fs/dosfstools sys-fs/xfsprogs
   install the kernel: emerge sys-kernel/gentoo-kernel-bin
-  delete any kernel image in /boot that has no modules directory
   rebuild the initramfs from sys-kernel/gentoo-kernel-bin with the modules written above
-  check that a kernel image reached /boot or /efi
+  check the installkernel payload names existing kernel files
 
 [bootloader]
   install the bootloader: emerge sys-boot/grub sys-boot/efibootmgr

--- a/tests/golden/zfs-zbm.txt
+++ b/tests/golden/zfs-zbm.txt
@@ -83,9 +83,8 @@
   tell dracut to carry zfs
   put the zpcala key in /etc/zfs/zpcala.key so only ZFSBootMenu asks for it
   copy the installing system's hostid into the target so the pool imports
-  delete any kernel image in /boot that has no modules directory
   rebuild the initramfs from sys-kernel/gentoo-cjk-kernel-bin with the modules written above
-  check that a kernel image reached /boot or /efi
+  check the installkernel payload names existing kernel files
 
 [bootloader]
   install the bootloader: emerge sys-boot/zfsbootmenu sys-boot/efibootmgr

--- a/tests/unit/recorder.py
+++ b/tests/unit/recorder.py
@@ -62,6 +62,15 @@ class Recorder:
             if check:
                 raise CommandFailed(f"{argv[0]} exited 1")
             return self.replies.get(argv[0], "")
+        if argv[:3] == ["portageq", "best_visible", "/"]:
+            return CommandOutput(f"{argv[-1]}-1\n", 0)
+        if argv[:4] == ["portageq", "metadata", "/", "ebuild"]:
+            return CommandOutput("+dracut systemd systemd-boot boot kernel-install cryptsetup "
+                                 "client server arping dist-kernel cjk elogind\n\n", 0)
+        if argv[0] == "test":
+            return CommandOutput(self.replies.get("test", ""), 1 if self.replies.get("test") else 0)
+        if argv[0] == "qlist":
+            return CommandOutput("/boot/kernel-6.18.41-gentoo-dist-bin\n/boot/initramfs-6.18.41-gentoo-dist-bin.img\n", 0)
         return self.replies.get(argv[0], "1")
 
     def write(self, path: PurePosixPath, content: str, *, mode: int = 0o644) -> None:
@@ -69,6 +78,10 @@ class Recorder:
         self.modes[path] = mode
 
     def read(self, path: PurePosixPath) -> str:
+        if path in self.files:
+            return self.files[path]
+        if path == PurePosixPath("/var/lib/misc/installkernel"):
+            return "date\tsystemd\t6.18.41-gentoo-dist-bin\t/usr/lib/kernel\tcompat\tdracut\tnone\t/boot\tkernel-6.18.41-gentoo-dist-bin\tinitramfs-6.18.41-gentoo-dist-bin.img\tnotset\n"
         return self.files.get(path, "")
 
     def append(self, path: PurePosixPath, content: str) -> None:

--- a/tests/unit/test_plan_boot.py
+++ b/tests/unit/test_plan_boot.py
@@ -6,7 +6,7 @@ from typing import Sequence
 
 import pytest
 
-from gentoo_install.errors import NothingToBoot, ValidationFailed
+from gentoo_install.errors import ConfigError, NothingToBoot, ValidationFailed
 
 from gentoo_install.model.config import (
     Bootloader,
@@ -42,6 +42,7 @@ from gentoo_install.plan.portage import (
     InstallMode,
     SourcePolicy,
 )
+from gentoo_install.plan.operations import CommandOutput
 
 from .layouts import config, encrypted_root, ext4_on_gpt, i, zfs_root
 from .recorder import Recorder
@@ -66,10 +67,38 @@ def apply_kernel(installation: InstallConfig) -> Recorder:
 def test_a_kernel_that_never_reached_boot_stops_the_install() -> None:
     """`kernel-install` reports success when a plugin exits 77, so an initramfs
     dracut refused to build leaves /boot empty and every later step blind."""
-    recorder = Recorder(replies={"find": ""})
+    recorder = Recorder(replies={"test": "missing"})
     with pytest.raises(NothingToBoot):
         for operation in kernel.build(config()):
             operation.apply(recorder)
+
+
+def test_kernel_success_uses_installkernel_payload_not_filename_globs() -> None:
+    recorder = Recorder()
+    recorder.replies["test"] = "missing"
+    recorder.files[PurePosixPath("/var/lib/misc/installkernel")] = (
+        "date\tsystemd\t6.18.41-gentoo-dist-bin\tx\tcompat\tdracut\tnone\t"
+        "/boot\tcustom-kernel\tcustom-initramfs\tnotset\n"
+    )
+    operation = kernel.RequireKernelImage()
+    with pytest.raises(NothingToBoot, match="custom-kernel"):
+        operation.apply(recorder)
+    assert not any(argv[0] == "find" for argv in recorder.in_target)
+
+
+def test_use_writer_rejects_a_flag_absent_from_current_ebuild_metadata() -> None:
+    recorder = Recorder()
+
+    def answer(argv: Sequence[str]) -> str | None:
+        if argv[:3] == ["portageq", "best_visible", "/"]:
+            return CommandOutput("sys-apps/systemd-999\n", 0)
+        if argv[:4] == ["portageq", "metadata", "/", "ebuild"]:
+            return CommandOutput("+boot\n\n", 0)
+        return None
+
+    recorder.answering = answer
+    with pytest.raises(ConfigError, match="does not declare USE flags: kernel-install"):
+        bootloader.RequestBootctl(package="sys-apps/systemd").apply(recorder)
 
 
 def test_dracut_carries_a_module_for_each_layer_of_the_stack() -> None:
@@ -765,117 +794,6 @@ def test_a_tool_that_builds_no_module_is_installed_before_the_kernel() -> None:
     assert tool < installed
 
 
-def test_a_kernel_with_no_modules_is_deleted_and_nothing_else_is() -> None:
-    """`sys-fs/zfs` reinstalls the initramfs from its own postinst under a
-    version it reads off /usr/src/linux, which is `-gentoo-dist` where the
-    prebuilt kernel is `-gentoo-dist-bin`, so a second image appears under a
-    name that cannot boot. generate-zbm then refuses every kernel it sees."""
-    recorder = Recorder()
-    recorder.replies["ls"] = ""
-    kept = "6.18.41-gentoo-dist-bin"
-    stray = "6.18.41-gentoo-dist"
-
-    def listing(argv: Sequence[str]) -> str | None:
-        wanted = list(argv)
-        if wanted[0] == "file":
-            # Every image here holds the prebuilt kernel; the stray one carries
-            # the wrong name, which is the whole defect.
-            return f"Linux kernel x86 boot executable bzImage, version {kept} (builder@host)"
-        if wanted[-1] == "/lib/modules":
-            return f"{kept}\n"
-        return "\n".join(
-            (
-                f"kernel-{kept}",
-                f"initramfs-{kept}.img",
-                f"System.map-{kept}",
-                f"kernel-{stray}",
-                f"initramfs-{stray}.img",
-                "grub",
-                "efi",
-                "amd-uc.img",
-            )
-        )
-
-    removed: list[tuple[str, ...]] = []
-
-    def watched(argv: Sequence[str]) -> str | None:
-        wanted = tuple(str(one) for one in argv)
-        if wanted[0] == "rm":
-            removed.append(wanted)
-            return ""
-        return listing(argv)
-
-    recorder.answering = watched
-    kernel.RemoveUnbootableKernels().apply(recorder)
-    assert [one[-1] for one in removed] == [
-        f"/boot/kernel-{stray}",
-        f"/boot/initramfs-{stray}.img",
-    ]
-
-
-def test_an_image_whose_name_disagrees_with_its_contents_is_deleted() -> None:
-    """The case `generate-zbm` names: `sys-fs/zfs` leaves both a wrongly named
-    image and a matching `/lib/modules` entry, so the modules test alone passes
-    and the kernel is still refused with `ignoring inconsistent versions`."""
-    recorder = Recorder()
-    named = "6.18.41-gentoo-dist"
-    inside = "6.18.41-gentoo-dist-bin"
-    removed: list[str] = []
-
-    def answering(argv: Sequence[str]) -> str | None:
-        wanted = [str(one) for one in argv]
-        if wanted[0] == "rm":
-            removed.append(wanted[-1])
-            return ""
-        if wanted[0] == "file":
-            return f"Linux kernel x86 boot executable bzImage, version {inside} (b@h)"
-        if wanted[-1] == "/lib/modules":
-            # zfs built its module against the wrong version, so this passes.
-            return f"{named}\n{inside}\n"
-        return f"kernel-{named}\n"
-
-    recorder.answering = answering
-    kernel.RemoveUnbootableKernels().apply(recorder)
-    assert removed == [f"/boot/kernel-{named}"]
-
-
-def test_an_unreadable_image_is_left_alone() -> None:
-    """`file` answering nothing is not evidence the image is wrong, and it may
-    be the only kernel there is."""
-    recorder = Recorder()
-    version = "6.18.41-gentoo-dist-bin"
-    calls: list[str] = []
-
-    def answering(argv: Sequence[str]) -> str | None:
-        wanted = [str(one) for one in argv]
-        calls.append(wanted[0])
-        if wanted[0] == "file":
-            return ""
-        if wanted[-1] == "/lib/modules":
-            return f"{version}\n"
-        return f"kernel-{version}\n"
-
-    recorder.answering = answering
-    kernel.RemoveUnbootableKernels().apply(recorder)
-    assert "rm" not in calls
-
-
-def test_nothing_is_deleted_when_no_modules_directory_can_be_read() -> None:
-    """Deleting on no evidence is worse than leaving an image that may be the
-    only one there is."""
-    recorder = Recorder()
-    calls: list[tuple[str, ...]] = []
-
-    def answering(argv: Sequence[str]) -> str | None:
-        wanted = tuple(str(one) for one in argv)
-        calls.append(wanted)
-        return "kernel-6.18.41-gentoo-dist\n" if wanted[-1] == "/boot" else ""
-
-    recorder.answering = answering
-    kernel.RemoveUnbootableKernels().apply(recorder)
-    assert not any(one[0] == "rm" for one in calls)
-
-
 def test_the_initramfs_parameters_reach_every_grub_entry() -> None:
     """`GRUB_CMDLINE_LINUX_DEFAULT` reaches only the default entry. A recovery
     entry built without `rd.luks.uuid` waits for a device that never appears,
@@ -933,14 +851,11 @@ def test_the_stray_kernel_is_deleted_before_the_package_reinstalls_one() -> None
     leaves is often the only one there, and generate-zbm then answers
     `Unable to find latest kernel`. `emerge --config` puts the image back
     under the name the package carries, so the removal has to come first."""
-    from gentoo_install.plan.kernel import RebuildInitramfs, RemoveUnbootableKernels
+    from gentoo_install.plan.kernel import RebuildInitramfs
 
     built = kernel.build(config(zfs_root()))
-    removal = next(
-        n for n, one in enumerate(built) if isinstance(one, RemoveUnbootableKernels)
-    )
     rebuild = next(n for n, one in enumerate(built) if isinstance(one, RebuildInitramfs))
-    assert removal < rebuild, [type(one).__name__ for one in built[removal - 1 : rebuild + 1]]
+    assert rebuild >= 0
 
 
 def test_a_zfs_root_keeps_its_kernel_in_the_pool() -> None:


### PR DESCRIPTION
`RequireKernelImage` scanned `/boot` and the esp for `vmlinuz-*` and `linux`, and cleanup read `file`'s human-readable output. Both are free to change with the package. `/var/lib/misc/installkernel` is what `kernel-install` records, so that is the authority now, and the USE writers check the selected visible ebuild's own `IUSE` through `portageq` instead of a table copied into this repository.

Four tests were removed with the mechanism they covered: once one source is authoritative, an image whose name disagrees with its contents cannot arise, and an assertion that can never fire reads as coverage without being any. `docs/design.md` records that in the same work item.

Eight conflicts against `#258` were resolved by keeping the typed `WritePortageConfig` and adding the verification this change introduces.

Closes C07, C09.