### PR TITLE
vm: wait for the serial signal a BIOS medium prints before GRUB

### DIFF
--- a/tests/unit/test_harness.py
+++ b/tests/unit/test_harness.py
@@ -1428,19 +1428,38 @@ def test_a_bios_guest_whose_grub_speaks_is_read_before_it_is_typed_at_blind(
             reset.append("reset")
 
     class Link:
-        def reopen(self) -> None:
-            reset.append("reopen")
+        def reopen(self, *, solicit_prompt: bool = True) -> None:
+            reset.append(f"reopen:{solicit_prompt}")
 
-    from tests.vm.console import ConsoleTimeout
+    from tests.vm.proxmox import GrubNotReadable
 
     def silent(link: object, extra: str) -> None:
-        raise ConsoleTimeout("never matched")
+        raise GrubNotReadable("the menu is VGA-only")
 
     read.clear()
     monkeypatch.setattr(cluster, "append_to_cmdline", silent)
     cluster._edit_bios_cmdline(cast("Any", Guest()), cast("Any", Link()))
     assert read == ["blind"]
-    assert reset == ["reset", "reopen"]
+    assert reset == ["reset", "reopen:False"]
+
+
+def test_bios_grub_serial_start_signal_stops_the_countdown() -> None:
+    from typing import Any, cast
+
+    from tests.vm import proxmox
+
+    sent: list[str] = []
+
+    class Console:
+        def expect(self, pattern: str, timeout: float, idle: float = 0.0) -> bytes:
+            assert "starting serial terminal on interface serial0" in pattern
+            return b"starting serial terminal on interface serial0"
+
+        def send_raw(self, keys: str) -> None:
+            sent.append(keys)
+
+    proxmox.hold_the_menu(cast(Any, Console()), timeout=1.0)
+    assert sent == [proxmox.GRUB_HOLD]
 
 
 def test_run_refuses_a_repeated_job_name_before_it_touches_the_cluster() -> None:

--- a/tests/vm/cluster.py
+++ b/tests/vm/cluster.py
@@ -66,6 +66,7 @@ from .proxmox import (
     CreateConflict,
     Guest,
     GuestSpec,
+    GrubNotReadable,
     Node,
     ProxmoxError,
     VMID_FIRST,
@@ -2030,12 +2031,12 @@ def _edit_bios_cmdline(guest: Guest, link: "Reconnecting") -> None:
     try:
         append_to_cmdline(link, EXTRA_CMDLINE)
         return
-    except (ProxmoxError, ConsoleTimeout, ConsoleClosed):
+    except GrubNotReadable:
         pass
-    # The half-finished edit goes with the reset, so the blind attempt starts
-    # from a menu nobody has touched.
+    # The unreadable menu may have counted down while the serial wait ran, so
+    # reset before timing the blind attempt from a fresh boot.
     guest.reset()
-    link.reopen()
+    link.reopen(solicit_prompt=False)
     append_to_cmdline_blind(guest, link, EXTRA_CMDLINE)
 
 

--- a/tests/vm/proxmox.py
+++ b/tests/vm/proxmox.py
@@ -77,6 +77,10 @@ class ProxmoxError(Exception):
     """The cluster refused a call, or a task it accepted did not finish."""
 
 
+class GrubNotReadable(ProxmoxError):
+    """GRUB produced no serial output that identifies a readable menu."""
+
+
 class ProxmoxNotFound(ProxmoxError):
     """The requested cluster object no longer exists."""
 
@@ -749,7 +753,10 @@ GRUB_HOLD: Final[str] = "\x0e\x10"
 #: draws the entries by cursor position and prints nothing else worth matching.
 #: Matching an entry title instead matched `Booting \`Boot LiveCD'`, which is
 #: printed after the countdown has already run out.
-GRUB_COUNTDOWN: Final[str] = r"highlighted entry|GNU GRUB|Minimal BASH-like"
+GRUB_COUNTDOWN: Final[str] = (
+    r"starting serial terminal on interface serial0|"
+    r"highlighted entry|GNU GRUB|Minimal BASH-like"
+)
 
 
 def hold_the_menu(console: Line, timeout: float = 300.0) -> bytes:
@@ -759,7 +766,10 @@ def hold_the_menu(console: Line, timeout: float = 300.0) -> bytes:
     drawn is consumed the moment it appears, the countdown never prints, and
     there is then nothing to match on.
     """
-    seen = console.expect(GRUB_COUNTDOWN, timeout=timeout)
+    try:
+        seen = console.expect(GRUB_COUNTDOWN, timeout=timeout)
+    except (ConsoleTimeout, ConsoleClosed) as error:
+        raise GrubNotReadable(str(error)) from error
     console.send_raw(GRUB_HOLD)
     return seen
 
@@ -778,8 +788,11 @@ def append_to_cmdline(console: Line, extra: str, timeout: float = 30.0) -> None:
     landed on it, and the entry booted unchanged with a broken search line.
     """
     hold_the_menu(console)
-    screen = _editor_screen(console, timeout)
-    down = _line_of_linux(screen)
+    try:
+        screen = _editor_screen(console, timeout)
+        down = _line_of_linux(screen)
+    except ProxmoxError as error:
+        raise GrubNotReadable(str(error)) from error
     console.send_raw(GRUB_NEXT_LINE * down + GRUB_END_OF_LINE)
     time.sleep(0.5)
     console.send_raw(f" {extra}")
@@ -855,7 +868,7 @@ def append_to_cmdline_blind(
             # new one: the first guest to take a second attempt reported `the
             # guest closed the serial connection` a minute in.
             guest.reset()
-            link.reopen()
+            link.reopen(solicit_prompt=False)
             console = link.console
     raise ProxmoxError(f"the kernel never spoke after editing GRUB blind: {last}")
 
@@ -886,7 +899,7 @@ class Reopenable(Protocol):
 
     console: Line
 
-    def reopen(self) -> None: ...
+    def reopen(self, *, solicit_prompt: bool = True) -> None: ...
 
 
 #: How long an escape is left alone before the next key, so the two are not


### PR DESCRIPTION
The install medium prints `starting serial terminal on interface serial0` and then shows a GRUB menu that stays on VGA, so a harness listening on the serial port typed its edit into nothing. No BIOS guest reached a shell all day: three runs ended with `never matched 'livecd .*#|Load keymap'` or `the kernel never spoke after editing GRUB blind`.

The consequence was that no BIOS change could be verified at all — the mirrored-root GRUB fix in `#250` carries no guest evidence for that reason.

Verified on the cluster: `vm-bios` installed, rebooted and passed the installed-system checks in 21.9 minutes at this revision, the first BIOS guest to do so.