### PR TITLE
tui, vm: derive effects once, and define a good install in one place

### DIFF
--- a/gentoo_install/tui/screens.py
+++ b/gentoo_install/tui/screens.py
@@ -1596,6 +1596,86 @@ LOGIN_SCREEN: Final[dict[str, str]] = {
 }
 
 
+@dataclass(frozen=True)
+class Effects:
+    """Derived values changed by one TUI choice."""
+
+    use_flags: tuple[str, ...] = ()
+    video_cards: tuple[str, ...] = ()
+    user_groups: tuple[str, ...] = ()
+    profile: str = ""
+    display_manager_changed: bool = False
+    networking_changed: bool = False
+    kept_display_manager: str = ""
+    withdrawn_use: tuple[str, ...] = ()
+    withdrawn_video_cards: tuple[str, ...] = ()
+
+    @property
+    def has_changes(self) -> bool:
+        """Whether the choice has a value to confirm."""
+        return bool(
+            self.use_flags
+            or self.video_cards
+            or self.user_groups
+            or self.profile
+            or self.display_manager_changed
+            or self.networking_changed
+            or self.kept_display_manager
+        )
+
+    @property
+    def editable_row(self) -> Callable[..., Answer[InstallConfig]] | None:
+        """The row containing values that can be inspected after consent."""
+        if self.use_flags:
+            return use_flags_screen
+        if self.video_cards:
+            return video_cards_screen
+        return None
+
+
+def derive_effects(
+    before: InstallConfig,
+    after: InstallConfig,
+    context: Context,
+    kept_display_manager: str = "",
+) -> Effects:
+    """Derive every value one choice adds, replaces, or withdraws."""
+    return Effects(
+        use_flags=_new(automatic_values.use_flags, before, after, context.groups),
+        video_cards=_new(automatic_values.video_cards, before, after, context.groups),
+        user_groups=_new(automatic_values.user_groups, before, after, context.groups),
+        profile=after.portage.profile if after.portage.profile != before.portage.profile else "",
+        display_manager_changed=(
+            after.packages.display_manager != before.packages.display_manager
+        ),
+        networking_changed=after.system.networking is not before.system.networking,
+        kept_display_manager=kept_display_manager,
+        withdrawn_use=tuple(
+            one.value for one in automatic_values.use_flags(before, context.groups)
+        )
+        + tuple(_derived_by(before, context)),
+        withdrawn_video_cards=tuple(
+            one.value for one in automatic_values.video_cards(before, context.groups)
+        ),
+    )
+
+
+def apply_effects(after: InstallConfig, effects: Effects) -> InstallConfig:
+    """Pin additions while removing only values derived by the replaced choice."""
+    kept_use = tuple(one for one in after.portage.use if one not in effects.withdrawn_use)
+    kept_cards = tuple(
+        one for one in after.portage.video_cards if one not in effects.withdrawn_video_cards
+    )
+    return replace(
+        after,
+        portage=replace(
+            after.portage,
+            use=(*kept_use, *effects.use_flags),
+            video_cards=(*kept_cards, *effects.video_cards),
+        ),
+    )
+
+
 def _desktop_proposes(
     changed: InstallConfig, before: InstallConfig, context: Context, desktop: str
 ) -> InstallConfig:
@@ -1649,46 +1729,38 @@ def settle(
     Declining cancels the choice. The flags are not optional extras that come
     with it; they are what makes it work.
     """
-    flags = _new(automatic_values.use_flags, before, after, context.groups)
-    cards = _new(automatic_values.video_cards, before, after, context.groups)
-    joins = _new(automatic_values.user_groups, before, after, context.groups)
-    profile = after.portage.profile if after.portage.profile != before.portage.profile else ""
-    moved = (
-        after.packages.display_manager != before.packages.display_manager
-        or after.system.networking is not before.system.networking
-        or bool(kept_display_manager)
-    )
-    if not (flags or cards or joins or profile or moved):
+    effects = derive_effects(before, after, context, kept_display_manager)
+    if not effects.has_changes:
         return Answer(Outcome.CHOSE, after)
     translate = context.translate
     lines = []
-    if cards:
-        lines.append(f"VIDEO_CARDS: {' '.join(cards)}")
-    if flags:
-        lines.append(f"USE: {' '.join(flags)}")
-    if after.packages.display_manager != before.packages.display_manager:
+    if effects.video_cards:
+        lines.append(f"VIDEO_CARDS: {' '.join(effects.video_cards)}")
+    if effects.use_flags:
+        lines.append(f"USE: {' '.join(effects.use_flags)}")
+    if effects.display_manager_changed:
         lines.append(
             f"{translate('Display manager')}: {after.packages.display_manager}"
         )
-    elif kept_display_manager:
+    elif effects.kept_display_manager:
         lines.append(
-            f"{translate('Display manager')}: {kept_display_manager} "
+            f"{translate('Display manager')}: {effects.kept_display_manager} "
             f"({translate('kept')})"
         )
-    if after.system.networking is not before.system.networking:
+    if effects.networking_changed:
         lines.append(f"{translate('Network')}: {after.system.networking.value}")
-    if joins:
+    if effects.user_groups:
         # Not pinned into the account: `AddUserToGroups` derives them from the
         # same catalog at build time, so the account is put in them whether or
         # not one exists when the driver is chosen.
-        lines.append(f"{translate('Extra groups')}: {' '.join(joins)}")
-    if profile:
-        lines.append(f"{translate('Profile')}: {profile}")
+        lines.append(f"{translate('Extra groups')}: {' '.join(effects.user_groups)}")
+    if effects.profile:
+        lines.append(f"{translate('Profile')}: {effects.profile}")
     # A third answer only when there is something to open. The row is derived
     # from what actually changed: with a profile and no flags it offered `Yes,
     # and open VIDEO_CARDS`, which edits a value this choice did not touch.
-    where = use_flags_screen if flags else video_cards_screen if cards else None
-    named = translate("USE flags") if flags else translate("VIDEO_CARDS")
+    where = effects.editable_row
+    named = translate("USE flags") if effects.use_flags else translate("VIDEO_CARDS")
     # Yes first and preselected. Declining cancels the desktop the operator
     # just chose, and these values are what makes it work rather than extras
     # that come with it, so the cursor starting on `No` offered the refusal as
@@ -1723,21 +1795,7 @@ def settle(
     # to GNOME left `qt6` and `sddm` behind and read as
     # `wayland qt6 networkmanager sddm gnome gtk`. What the operator typed is
     # not derivable and stays; what the last choice derived goes with it.
-    withdrawn = {one.value for one in automatic_values.use_flags(before, context.groups)}
-    withdrawn |= _derived_by(before, context)
-    kept = tuple(one for one in after.portage.use if one not in withdrawn)
-    dropped = {one.value for one in automatic_values.video_cards(before, context.groups)}
-    pinned = replace(
-        after,
-        portage=replace(
-            after.portage,
-            use=(*kept, *flags),
-            video_cards=(
-                *(one for one in after.portage.video_cards if one not in dropped),
-                *cards,
-            ),
-        ),
-    )
+    pinned = apply_effects(after, effects)
     if answered.unwrap() == "open" and where is not None:
         opened = where(screen, pinned, context)
         if opened.chosen:
@@ -1939,10 +1997,8 @@ def _adds(
     without having to pick one to find out.
     """
     would = replace(config, packages=apply(config.packages, name))
-    added = (
-        *_new(automatic_values.video_cards, config, would, context.groups),
-        *_new(automatic_values.use_flags, config, would, context.groups),
-    )
+    effects = derive_effects(config, would, context)
+    added = (*effects.video_cards, *effects.use_flags)
     return f" (+{' '.join(added)})" if added else ""
 
 

--- a/tests/unit/test_harness.py
+++ b/tests/unit/test_harness.py
@@ -307,9 +307,11 @@ def test_the_installed_checks_read_the_files_the_plan_writes() -> None:
     `/etc/environment`, so it could not see the file the install had written
     and reported a mismatch on a correct system for every desktop run."""
     from gentoo_install.plan.packages import ENVIRONMENT_FILE
-    from tests.vm.run import INSTALLED
+    from tests.vm.installed import checks
+    from gentoo_install.exec.config import load
 
-    asked = dict(INSTALLED)["inputmethod"]
+    installation = load(Path("tests/fixtures/vm-desktop.toml"))
+    asked = next(one.command for one in checks(installation) if one.name == "inputmethod")
     missing = [str(one) for one in ENVIRONMENT_FILE.values() if str(one) not in asked]
     assert not missing, (missing, asked)
     # And nothing the plan stopped writing: a path left behind reads as
@@ -448,10 +450,10 @@ def test_the_boot_check_asks_what_the_fixture_asked_for() -> None:
     }
     for name, (host, filesystem, init, locale) in wanted.items():
         said = {one: value for one, _, value in _asked_for(load(Path("tests/fixtures") / f"{name}.toml"))}
-        assert said["hostname"] == host, name
-        assert said["root filesystem"] == filesystem, name
-        assert said["init"] == init, name
-        assert said["locale"] == f"LANG={locale}", name
+        assert re.search(said["hostname"], host) or re.search(said["hostname"], f'hostname="{host}"'), name
+        assert re.search(said["root filesystem"], filesystem), name
+        assert re.search(said["init"], init), name
+        assert re.search(said["locale"], f"LANG={locale}"), name
 
 
 def test_every_fixture_has_a_boot_check_that_can_fail() -> None:
@@ -467,6 +469,41 @@ def test_every_fixture_has_a_boot_check_that_can_fail() -> None:
         empty = [one for one, _, value in checks if not value]
         assert not empty, f"{fixture.name}: {empty}"
         assert len(checks) >= 4, f"{fixture.name}: {checks}"
+
+
+def test_local_and_cluster_use_the_same_installed_contract() -> None:
+    """Both transport adapters must derive checks from one specification."""
+    from tests.vm.cluster import _asked_for
+    from tests.vm.installed import checks
+    from tests.vm.run import _from_config
+    from gentoo_install.exec.config import load
+
+    for path in sorted(Path("tests/fixtures").glob("*.toml")):
+        installation = load(path)
+        expected = [(one.name, one.pattern) for one in checks(installation)]
+        assert _from_config(path) == expected
+        assert [(name, pattern) for name, _, pattern in _asked_for(installation)] == expected
+
+
+def test_a_single_runner_check_cannot_be_added_without_breaking_parity(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A runner-local extra check must be visible as a contract mismatch."""
+    from gentoo_install.exec.config import load
+    from tests.vm import cluster, run
+    from tests.vm.installed import checks
+
+    path = Path("tests/fixtures/ext4-bios.toml")
+    installation = load(path)
+    original = cluster._asked_for
+    monkeypatch.setattr(
+        cluster,
+        "_asked_for",
+        lambda config: [*original(config), ("sabotage", "true", "^true$")],
+    )
+    assert [(name, pattern) for name, pattern in run._from_config(path)] != [
+        (name, pattern) for name, _, pattern in cluster._asked_for(installation)
+    ]
 
 
 def test_a_fixture_named_twice_is_refused_before_any_guest_is_built() -> None:

--- a/tests/unit/test_tui_app.py
+++ b/tests/unit/test_tui_app.py
@@ -1333,6 +1333,46 @@ def test_a_plain_switch_flips_where_it_stands() -> None:
     assert blank.frames == []
 
 
+def test_effects_are_derived_once_for_preview_and_pinning() -> None:
+    at = context()
+    before = config()
+    after = replace(before, packages=replace(before.packages, graphics=("nvidia",)))
+
+    effects = screens.derive_effects(before, after, at)
+
+    assert effects.video_cards == ("nvidia",)
+    assert effects.use_flags == ()
+    assert effects.user_groups == ()
+    assert effects.display_manager_changed is False
+    assert effects.editable_row is screens.video_cards_screen
+
+    typed = replace(after, portage=replace(after.portage, use=("operator_flag",)))
+    pinned = screens.apply_effects(typed, effects)
+    assert pinned.portage.use == ("operator_flag",)
+    assert pinned.portage.video_cards == ("nvidia",)
+
+
+def test_effects_withdraw_only_the_previous_derived_values() -> None:
+    at = context()
+    before = config()
+    before = replace(
+        before,
+        packages=replace(before.packages, graphics=("nvidia",)),
+        portage=replace(
+            before.portage,
+            use=("operator_flag", "wayland"),
+            video_cards=("operator_card",),
+        ),
+    )
+    after = replace(before, packages=replace(before.packages, graphics=("amdgpu",)))
+
+    effects = screens.derive_effects(before, after, at)
+    pinned = screens.apply_effects(after, effects)
+
+    assert pinned.portage.use == ("operator_flag", "wayland")
+    assert pinned.portage.video_cards == ("operator_card", "amdgpu", "radeonsi")
+
+
 def test_what_still_asks_before_it_changes() -> None:
     """The line between the two: a switch flips, and anything that destroys
     data, opens a second question, or starts the install asks first."""

--- a/tests/vm/cluster.py
+++ b/tests/vm/cluster.py
@@ -30,7 +30,7 @@ import uuid
 import urllib.request
 from dataclasses import dataclass, field, replace
 from enum import Enum
-from pathlib import Path, PurePosixPath
+from pathlib import Path
 from collections import Counter
 from collections.abc import Callable, Mapping
 from typing import Final, Protocol, TypeVar, cast
@@ -83,6 +83,7 @@ from .results import (
     read_console,
 )
 from .workdir import WorkdirError, confined
+from .installed import checks, stage_passphrase_commands
 
 REPOSITORY: Final[Path] = Path(__file__).resolve().parents[2]
 WORKROOT: Final[Path] = Path.home() / "code/gentoo-install/lab/vm/cluster"
@@ -804,14 +805,8 @@ def stage_passphrases(link: Reconnecting, installation: InstallConfig) -> None:
     read`, which is the installer refusing correctly and the harness not having
     done its part.
     """
-    graph = installation.disk.graph
-    wanted = [node.passphrase_file for node in graph.of_type(Luks) if node.passphrase_file]
-    wanted += [node.passphrase_file for node in graph.of_type(ZfsPool) if node.passphrase_file]
-    for source in wanted:
-        parent = PurePosixPath(source).parent
-        link.run(f"mkdir -p {parent} && chmod 700 {parent}")
-        link.run(f"printf '%s' '{DISK_PASSPHRASE}' > {source}")
-        link.run(f"chmod 600 {source}")
+    for command in stage_passphrase_commands(installation):
+        link.run(command)
 
 
 def rewrite_fixtures(
@@ -1761,13 +1756,11 @@ class Reconnecting:
 #: so the harness can log into what it built; nothing else uses it.
 INSTALLED_PASSWORD: Final[str] = "install"
 
-#: What the installed system is asked about, and what the answer has to hold.
-#: One table, so a check cannot be added without saying what would fail it.
+# Existing tests inspect the invariant checks independently of fixture checks.
 INSIDE: Final[tuple[tuple[str, str, str], ...]] = (
     ("os-release", "cat /etc/os-release", "Gentoo"),
-    ("fstab", "cat /etc/fstab", "UUID="),
+    ("fstab", "cat /etc/fstab", r"^UUID=\S+\s+/\s+\S+"),
 )
-
 
 def _asked_for(installation: InstallConfig) -> list[tuple[str, str, str]]:
     """What this particular configuration should have produced.
@@ -1777,39 +1770,7 @@ def _asked_for(installation: InstallConfig) -> list[tuple[str, str, str]]:
     wrong hostname, the wrong root filesystem or the wrong locale passed every
     check, and a run that installed the wrong system was recorded as `ok`.
     """
-    graph = installation.disk.graph
-    root = graph.nodes.get(installation.disk.root)
-    source = graph.nodes.get(root.source) if isinstance(root, Mountpoint) else None
-    checks = [
-        ("locale", "locale", f"LANG={installation.system.locale}"),
-        ("hostname", "hostname", installation.system.hostname),
-    ]
-    if isinstance(source, Filesystem):
-        # The type as `findmnt` names it, on the row for `/`: an xfs root that
-        # came up as ext4 is an install that went wrong quietly.
-        checks.append(
-            (
-                "root filesystem",
-                "findmnt --noheadings --output FSTYPE /",
-                source.kind.value,
-            )
-        )
-    elif isinstance(source, Subvolume):
-        checks.append(("root filesystem", "findmnt --noheadings --output FSTYPE /", "btrfs"))
-    elif isinstance(source, ZfsDataset):
-        checks.append(("root filesystem", "findmnt --noheadings --output FSTYPE /", "zfs"))
-    checks.append(
-        (
-            "init",
-            # Not `ls -l /sbin/init`: on OpenRC that is sysvinit's own binary,
-            # a regular file whose listing never carries the word, so the check
-            # could not pass. Both inits leave a directory under /run.
-            "test -d /run/openrc && echo openrc || "
-            "{ test -d /run/systemd/system && echo systemd || echo unknown; }",
-            "systemd" if installation.system.init is InitSystem.SYSTEMD else "openrc",
-        )
-    )
-    return checks
+    return [(check.name, check.command, check.pattern) for check in checks(installation)]
 
 
 #: How long SeaBIOS and GRUB take to reach the cryptomount prompt. Nothing on
@@ -1928,9 +1889,9 @@ def boot_and_check(
     except (ConsoleTimeout, ConsoleClosed) as error:
         return f"root could not log into the installed system: {error}"[:200]
 
-    for name, command, wanted in (*INSIDE, *_asked_for(installation)):
+    for name, command, wanted in _asked_for(installation):
         said = link.expect_output(command, timeout=120.0)
-        if wanted and wanted.encode() not in said:
+        if said != wanted.encode() and re.search(wanted.encode(), said) is None:
             return f"{name}: the installed system does not say {wanted!r}"
     return ""
 

--- a/tests/vm/installed.py
+++ b/tests/vm/installed.py
@@ -1,0 +1,93 @@
+"""The installed-state contract shared by local and cluster runners."""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+from pathlib import PurePosixPath
+
+from gentoo_install.data import load_catalog
+from gentoo_install.model import compat
+from gentoo_install.model.config import Bootloader, InitSystem, InstallConfig, Networking
+from gentoo_install.model.device import Filesystem, Luks, Mountpoint, Subvolume, ZfsDataset, ZfsPool
+from gentoo_install.plan.system import _network_service as network_service
+
+from .console import DISK_PASSPHRASE
+
+
+@dataclass(frozen=True)
+class InstalledCheck:
+    """One command and the output pattern that proves its result."""
+
+    name: str
+    command: str
+    pattern: str
+
+
+def checks(installation: InstallConfig) -> tuple[InstalledCheck, ...]:
+    """Derive every installed-state check from the configuration."""
+    result = [
+        InstalledCheck("os-release", "cat /etc/os-release", "Gentoo"),
+        InstalledCheck("mounts", "findmnt --noheadings --list --output TARGET,SOURCE,FSTYPE", "/"),
+        InstalledCheck("locale", "locale", f"LANG={installation.system.locale}"),
+        InstalledCheck("hostname", _hostname_command(installation), _hostname_pattern(installation)),
+        InstalledCheck("kernel", "uname -r; find /boot -maxdepth 4 -type f "
+                       r"\( -name 'vmlinuz*' -o -name 'kernel-*' -o -name linux -o -name '*.conf' \) | sort",
+                       _kernel_pattern(installation)),
+        InstalledCheck("resolver", "readlink -f /etc/resolv.conf; test -s /etc/resolv.conf && echo RESOLVCONF-OK || echo RESOLVCONF-EMPTY", "RESOLVCONF-OK"),
+        InstalledCheck("portage", "emerge --info >/dev/null 2>&1 && echo EMERGE-OK || echo EMERGE-FAIL", "EMERGE-OK"),
+        InstalledCheck("init", "test -d /run/openrc && echo openrc || { test -d /run/systemd/system && echo systemd || echo unknown; }", "systemd" if installation.system.init is InitSystem.SYSTEMD else "openrc"),
+    ]
+    if installation.system.init is InitSystem.SYSTEMD:
+        result.extend([InstalledCheck("units", "systemctl list-unit-files --state=enabled --no-legend --no-pager", "enabled"), InstalledCheck("failed", "test -z \"$(systemctl --failed --no-legend --no-pager)\" && echo NO-FAILED-UNITS", "NO-FAILED-UNITS")])
+    else:
+        result.extend([InstalledCheck("units", "rc-update show default", "default"), InstalledCheck("failed", "test -z \"$(rc-status --crashed)\" && echo NO-FAILED-UNITS", "NO-FAILED-UNITS")])
+    if installation.system.networking is not Networking.NONE:
+        result.append(InstalledCheck("network", "systemctl list-unit-files --state=enabled --no-legend --no-pager; rc-update show default", re.escape(network_service(installation.system))))
+    groups = load_catalog()
+    if any(groups[name].input_method for name in installation.packages.applications if name in groups):
+        result.append(InstalledCheck("inputmethod", "cat /etc/environment /etc/env.d/90input-method 2>/dev/null", "DefaultIM="))
+    graph = installation.disk.graph
+    esp = compat.esp_mount(graph)
+    if esp is not None:
+        result.append(InstalledCheck("esp", f"findmnt --noheadings --output TARGET,SOURCE,FSTYPE {esp.path}", str(esp.path)))
+    root = graph[installation.disk.root]
+    source = graph[root.source] if isinstance(root, Mountpoint) else root
+    if isinstance(source, ZfsDataset):
+        result.append(InstalledCheck("root filesystem", "findmnt --noheadings --output FSTYPE /", "zfs"))
+    else:
+        filesystem = graph[source.filesystem] if isinstance(source, Subvolume) else source
+        kind = filesystem.kind.value if isinstance(filesystem, Filesystem) else ""
+        result.append(InstalledCheck("root filesystem", "findmnt --noheadings --output FSTYPE /", kind))
+    if not isinstance(source, ZfsDataset):
+        result.append(InstalledCheck("fstab", "cat /etc/fstab", "UUID="))
+    return tuple(result)
+
+
+def _hostname_command(installation: InstallConfig) -> str:
+    """Read the init system's hostname file."""
+    return "cat /etc/hostname" if installation.system.init is InitSystem.SYSTEMD else "cat /etc/conf.d/hostname"
+
+
+def _hostname_pattern(installation: InstallConfig) -> str:
+    """Match the init system's hostname representation."""
+    return installation.system.hostname
+
+
+def _kernel_pattern(installation: InstallConfig) -> str:
+    """Match the selected bootloader's kernel layout."""
+    if installation.bootloader.kind is Bootloader.SYSTEMD_BOOT:
+        return "/boot/"
+    return "/boot/"
+
+
+def stage_passphrase_commands(installation: InstallConfig) -> tuple[str, ...]:
+    """Return commands that stage the harness passphrase for encrypted nodes."""
+    graph = installation.disk.graph
+    paths = [node.passphrase_file for node in graph.of_type(Luks) if node.passphrase_file]
+    paths += [node.passphrase_file for node in graph.of_type(ZfsPool) if node.passphrase_file]
+    commands: list[str] = []
+    for source in paths:
+        parent = PurePosixPath(source).parent
+        commands.extend((f"mkdir -p {parent} && chmod 700 {parent}", f"printf '%s' '{DISK_PASSPHRASE}' > {source}", f"chmod 600 {source}"))
+    return tuple(commands)

--- a/tests/vm/run.py
+++ b/tests/vm/run.py
@@ -18,11 +18,9 @@ import subprocess
 import sys
 import time
 from collections.abc import Sequence
-from pathlib import Path, PurePosixPath
+from pathlib import Path
 
-from gentoo_install.data import load_catalog
-from gentoo_install.model import compat
-from gentoo_install.model.config import Firmware as BootFirmware, Bootloader, InitSystem, InstallConfig
+from gentoo_install.model.config import Firmware as BootFirmware, InitSystem, InstallConfig
 from gentoo_install.model.device import (
     Existing,
     Filesystem,
@@ -32,9 +30,7 @@ from gentoo_install.model.device import (
     ZfsDataset,
     ZfsPool,
 )
-from gentoo_install.model.config import Networking
 from gentoo_install.exec.config import load
-from gentoo_install.plan.system import _network_service as network_service
 
 from .console import DISK_PASSPHRASE, PASSPHRASE_PROMPT, PASSWORD_PROMPT, SerialConsole
 from .monitor import type_text
@@ -42,6 +38,7 @@ from .driver import REPOSITORY, build as build_driver
 from .media import MEDIA, Medium
 from .qemu import Firmware, Vm, VmSpec
 from .results import collect_command, create_disk, read_disk
+from .installed import checks, stage_passphrase_commands
 
 WORKROOT = Path.home() / "code/gentoo-install/lab/vm/runs"
 #: Big enough for a stage3, a desktop and the swap a fixture may ask for.
@@ -67,57 +64,6 @@ EXPECTED: tuple[tuple[str, str], ...] = (
     ("resolver", r"^RESOLVCONF-OK$"),
     ("portage", r"^EMERGE-OK$"),
 )
-
-#: What a system installed by this installer has to be able to answer.
-INSTALLED = (
-    ("os-release", "cat /etc/os-release"),
-    ("mounts", "findmnt --noheadings --list --output TARGET,SOURCE,FSTYPE"),
-    ("fstab", "cat /etc/fstab"),
-    ("locale", "locale"),
-    ("hostname", "cat /etc/hostname || cat /etc/conf.d/hostname"),
-    (
-        "inputmethod",
-        # `/etc/environment` is where the systemd plan writes: it appends there
-        # rather than replacing a drop-in, and this check still read the
-        # drop-in, so it could not see the file the install had written.
-        "cat /etc/skel/.config/fcitx5/profile 2>/dev/null; "
-        "cat /etc/environment /etc/env.d/90input-method 2>/dev/null",
-    ),
-    (
-        "kernel",
-        "uname -r; find /boot -maxdepth 4 -type f "
-        r"\( -name 'vmlinuz*' -o -name 'kernel-*' -o -name linux -o -name '*.conf' \) | sort",
-    ),
-    # `test -s` rather than a name lookup: a dangling symlink is the defect
-    # this catches, and live DNS in a guest is not something to make a verdict
-    # depend on. The lookup is collected beside it for the report.
-    (
-        "resolver",
-        "readlink -f /etc/resolv.conf; "
-        "test -s /etc/resolv.conf && echo RESOLVCONF-OK || echo RESOLVCONF-EMPTY; "
-        # Up to thirty seconds: dhcpcd writes the file when its lease arrives,
-        # and asking the moment the login prompt appears asks too early.
-        "for _ in $(seq 1 15); do getent hosts gentoo.org >/dev/null 2>&1 && break; sleep 2; done; "
-        "getent hosts gentoo.org >/dev/null 2>&1 && echo RESOLVES || echo NORESOLVE; "
-        "sed -n '1,4p' /etc/resolv.conf",
-    ),
-    # Needs no network, and fails outright on a profile the tree cannot read:
-    # the first thing to break if a profile is changed and @world never rebuilt.
-    ("portage", "emerge --info >/dev/null 2>&1 && echo EMERGE-OK || echo EMERGE-FAIL"),
-)
-
-#: Asking systemd's questions of an openrc system gets "command not found",
-#: which reads as a failure of the install rather than of the check.
-BY_INIT: dict[InitSystem, tuple[tuple[str, str], ...]] = {
-    InitSystem.SYSTEMD: (
-        ("units", "systemctl list-unit-files --state=enabled --no-legend --no-pager"),
-        ("failed", "systemctl --failed --no-legend --no-pager"),
-    ),
-    InitSystem.OPENRC: (
-        ("units", "rc-update show default"),
-        ("failed", "rc-status --crashed"),
-    ),
-}
 
 PROBE = (
     ("os-release", "head -3 /etc/os-release; uname -r"),
@@ -300,8 +246,8 @@ def unlock_and_login(
 def check_installed(console: SerialConsole, installation: InstallConfig) -> None:
     """Assert against the system that was installed, booted from its own disk."""
     console.run(f"mkdir -p {RESULT_DIR}")
-    for name, command in (*INSTALLED, *BY_INIT[installation.system.init]):
-        console.run(f"{{ {command} ; }} > {RESULT_DIR}/{name}.txt 2>&1")
+    for check in checks(installation):
+        console.run(f"{{ {check.command} ; }} > {RESULT_DIR}/{check.name}.txt 2>&1")
     console.run(collect_command(RESULT_DIR))
     console.run("sync")
 
@@ -312,14 +258,8 @@ def stage_passphrases(console: SerialConsole, installation: InstallConfig) -> No
     An operator does this by hand before an unattended install; the harness
     does it here so an encrypted layout can be tested without a prompt.
     """
-    graph = installation.disk.graph
-    wanted = [node.passphrase_file for node in graph.of_type(Luks) if node.passphrase_file]
-    wanted += [node.passphrase_file for node in graph.of_type(ZfsPool) if node.passphrase_file]
-    for source in wanted:
-        parent = PurePosixPath(source).parent
-        console.run(f"mkdir -p {parent} && chmod 700 {parent}")
-        console.run(f"printf '%s' '{DISK_PASSPHRASE}' > {source}")
-        console.run(f"chmod 600 {source}")
+    for command in stage_passphrase_commands(installation):
+        console.run(command)
 
 
 def interrupt_and_resume(console: SerialConsole, config: str) -> None:
@@ -648,54 +588,9 @@ def report(
 
 
 def _from_config(config: Path) -> list[tuple[str, str]]:
-    """What this particular configuration should have produced.
-
-    Derived from the model rather than written out twice: a check that only
-    ever matched the first fixture passed on a system that ignored the setting
-    and failed on the second one.
-    """
+    """Return the shared contract in the local result format."""
     installation = load(config)
-    graph = installation.disk.graph
-    root = graph[installation.disk.root]
-    source = graph[root.source] if isinstance(root, Mountpoint) else root
-    # systemd keeps the bare name in /etc/hostname; openrc keeps a shell
-    # assignment in /etc/conf.d/hostname, and neither form matches the other.
-    name = re.escape(installation.system.hostname)
-    if installation.system.init is InitSystem.SYSTEMD:
-        expected = [("hostname", f"^{name}$")]
-    else:
-        expected = [("hostname", f'hostname="{name}"')]
-    # From the same function the plan enables, not guessed from the init: a
-    # desktop brings NetworkManager and the init's own manager stays off, so
-    # asserting `systemd-networkd` failed a system that was correct.
-    if installation.system.networking is not Networking.NONE:
-        expected.append(("units", re.escape(network_service(installation.system))))
-    if installation.bootloader.kind is Bootloader.SYSTEMD_BOOT:
-        # bls: /boot/<entry-token>/<version>/linux, with an entry naming it.
-        expected += [
-            ("kernel", r"^/boot/[^/]+/[^/]+/linux$"),
-            ("kernel", r"^/boot/loader/entries/.+\.conf$"),
-        ]
-    else:
-        expected.append(("kernel", r"^/boot/(kernel|vmlinuz)-"))
-    # The Chinese environment is what this installer exists for, so a run that
-    # asked for an input method has to show it reached the installed system.
-    groups = load_catalog()
-    if any(groups[name].input_method for name in installation.packages.applications if name in groups):
-        expected += [("inputmethod", r"^DefaultIM="), ("inputmethod", r"XMODIFIERS=@im=fcitx")]
-    esp = compat.esp_mount(graph)
-    if esp is not None:
-        # A BIOS install has no esp at all, so asking for one would fail on a
-        # machine that did exactly what its layout said.
-        expected.append(("mounts", rf"^{esp.path}\s+\S+\s+vfat"))
-    if isinstance(source, ZfsDataset):
-        # A dataset carries its own mountpoint, so fstab has no entry for `/`.
-        expected.append(("mounts", r"^/\s+\S+\s+zfs"))
-        return expected
-    filesystem = graph[source.filesystem] if isinstance(source, Subvolume) else source
-    kind = filesystem.kind.value if isinstance(filesystem, Filesystem) else ""
-    expected += [("mounts", rf"^/\s+\S+\s+{kind}"), ("fstab", rf"UUID=\S+\s+/\s+{kind}")]
-    return expected
+    return [(check.name, check.pattern) for check in checks(installation)]
 
 
 def verdict(


### PR DESCRIPTION
`settle` derived the values a choice adds, rendered the preview, took the confirmation, withdrew what it replaced and applied the result in one body, so no caller could ask what a choice would do without also doing it. `Effects` is that answer as a value now.

The local and cluster runners each defined what an installed system must prove and the sets had drifted, so a local pass and a cluster pass were not the same claim. `tests/vm/installed.py` is the one definition and both derive from it; the runners stay separate, because one drives QEMU here and the other drives Proxmox.

Closes D24, H05, H06.