### PR TITLE
exec: unlock with the passphrase preflight approved

### DIFF
--- a/gentoo_install/exec/apply.py
+++ b/gentoo_install/exec/apply.py
@@ -33,6 +33,7 @@ from ..log import Journal
 from ..plan.disk import STAGE3_CACHE
 from ..plan.operations import CommandOutput, Operation
 from . import fetch, packages
+from .preflight import SecretStore
 from .probe import Probe
 from .runner import Runner, open_in_target, under, write_file
 
@@ -47,6 +48,7 @@ class Machine:
     work: Path
     mountpoint: Path = Path("/mnt/gentoo")
     keys: dict[DeviceId, PurePosixPath] = field(default_factory=dict)
+    secrets: SecretStore | None = None
     given_up: set[str] = field(default_factory=set)
 
     @property
@@ -142,9 +144,16 @@ class Machine:
 
     def passphrase(self, device: DeviceId) -> str:
         """The passphrase itself, for a command that reads one on stdin."""
-        node = self.config.disk.graph[device]
-        source = node.passphrase_file if isinstance(node, (Luks, ZfsPool)) else ""
-        return fetch.passphrase_for(device, source)
+        try:
+            return self._secret_path(device).read_text()
+        except OSError as error:
+            raise InvalidLayout(f"approved passphrase for {device} cannot be read: {error}") from error
+
+    def _secret_path(self, device: DeviceId) -> Path:
+        return (self.secrets or SecretStore(self.work)).path(device)
+
+    def cleanup_secrets(self) -> None:
+        (self.secrets or SecretStore(self.work)).cleanup()
 
     def key_file(self, device: DeviceId) -> PurePosixPath:
         """Where the passphrase is staged, as a path on the installing system.
@@ -157,11 +166,9 @@ class Machine:
         known = self.keys.get(device)
         if known is not None:
             return known
-        node = self.config.disk.graph[device]
-        source = node.passphrase_file if isinstance(node, (Luks, ZfsPool)) else ""
-        path = self.work / "keys" / str(device)
-        path.parent.mkdir(parents=True, exist_ok=True, mode=0o700)
-        write_file(path, fetch.passphrase_for(device, source), 0o600)
+        path = self._secret_path(device)
+        if not path.is_file():
+            raise InvalidLayout(f"approved passphrase for {device} was not staged")
         staged = PurePosixPath(path)
         self.keys[device] = staged
         return staged
@@ -342,23 +349,26 @@ def apply(
     """
     total = len(operations)
     opened = time.monotonic()
-    for position, operation in enumerate(operations):
-        counted = f"[{position + 1}/{total} {_elapsed(time.monotonic() - opened)}]"
-        if operation.survives_a_reboot and (position, identity(operation)) in finished:
-            machine.runner.log(
-                f"{counted} [{operation.stage.value}] done earlier: {operation.describe()}"
-            )
-            continue
-        if on_start is not None:
-            on_start(operation)
-        machine.runner.log(f"{counted} [{operation.stage.value}] {operation.describe()}")
-        started = time.monotonic()
-        try:
-            operation.apply(machine)
-        except GentooInstallError:
-            _record(machine, operation, started, "failed", position)
-            raise
-        _record(machine, operation, started, "done", position)
+    try:
+        for position, operation in enumerate(operations):
+            counted = f"[{position + 1}/{total} {_elapsed(time.monotonic() - opened)}]"
+            if operation.survives_a_reboot and (position, identity(operation)) in finished:
+                machine.runner.log(
+                    f"{counted} [{operation.stage.value}] done earlier: {operation.describe()}"
+                )
+                continue
+            if on_start is not None:
+                on_start(operation)
+            machine.runner.log(f"{counted} [{operation.stage.value}] {operation.describe()}")
+            started = time.monotonic()
+            try:
+                operation.apply(machine)
+            except GentooInstallError:
+                _record(machine, operation, started, "failed", position)
+                raise
+            _record(machine, operation, started, "done", position)
+    finally:
+        machine.cleanup_secrets()
 
 
 def _elapsed(seconds: float) -> str:

--- a/gentoo_install/exec/preflight.py
+++ b/gentoo_install/exec/preflight.py
@@ -35,6 +35,7 @@ from ..plan.disk import MKFS
 from ..plan.operations import Operation
 from ..plan.portage import InstallStage3, MountChrootFilesystems, SyncRepository
 from .probe import RELEASE_KEY, Machine, Probe
+from .runner import write_file
 
 # These are used while preflight inspects disks, before any operation runs.
 PREFLIGHT_ONLY: Final[tuple[str, ...]] = ("lsblk", "swapon")
@@ -159,12 +160,36 @@ TMPFS_MINIMUM: Final[int] = 8 * 1024**3
 
 
 @dataclass(frozen=True)
+class SecretStore:
+    """Approved passphrases staged under the run's volatile work directory."""
+
+    work: Path
+
+    def path(self, device: DeviceId) -> Path:
+        return self.work / "keys" / "approved" / str(device)
+
+    def stage(self, device: DeviceId, passphrase: str) -> None:
+        write_file(self.path(device), passphrase, 0o600)
+
+    def cleanup(self) -> None:
+        keys = self.work / "keys" / "approved"
+        if not keys.is_dir():
+            return
+        for path in keys.iterdir():
+            if path.is_file():
+                path.unlink()
+
+
+@dataclass(frozen=True)
 class Report:
     fatal: tuple[str, ...]
     warnings: tuple[str, ...]
+    secrets: SecretStore | None = None
 
     def raise_if_fatal(self) -> None:
         if self.fatal:
+            if self.secrets is not None:
+                self.secrets.cleanup()
             raise PreflightFailed(
                 "this machine cannot run the install:\n  " + "\n  ".join(self.fatal)
             )
@@ -242,7 +267,9 @@ def _disks_at_risk(graph: DeviceGraph) -> list[Existing]:
     return list(compat.destroyed(graph))
 
 
-def _passphrase_problems(config: InstallConfig, probe: Probe) -> list[str]:
+def _passphrase_problems(
+    config: InstallConfig, probe: Probe, secrets: SecretStore | None = None
+) -> list[str]:
     """Read every passphrase file before the first disk is touched.
 
     `zpool create` rejects a short passphrase only once the pool's vdevs have
@@ -277,6 +304,8 @@ def _passphrase_problems(config: InstallConfig, probe: Probe) -> list[str]:
                 f"{device}: {source} holds {len(passphrase)} characters and zfs takes at "
                 f"least {minimum}"
             )
+        elif secrets is not None:
+            secrets.stage(DeviceId(device), passphrase)
     return problems
 
 
@@ -466,7 +495,8 @@ def inspect(
         if unusable:
             fatal.append(f"{unusable}, and this configuration makes a pool")
 
-    fatal += _passphrase_problems(config, probe)
+    secrets = SecretStore(probe.work)
+    fatal += _passphrase_problems(config, probe, secrets)
     fatal += _capacity_problems(config, probe)
 
     if not machine.release_key:
@@ -488,4 +518,4 @@ def inspect(
         warnings.append(
             f"{Size(machine.memory_bytes)} of memory: build in /var/tmp rather than a tmpfs"
         )
-    return Report(fatal=tuple(fatal), warnings=tuple(warnings))
+    return Report(fatal=tuple(fatal), warnings=tuple(warnings), secrets=secrets)

--- a/tests/unit/test_exec.py
+++ b/tests/unit/test_exec.py
@@ -21,10 +21,10 @@ from gentoo_install.exec.probe import Machine as ProbedMachine
 from gentoo_install.exec.probe import Probe
 from gentoo_install.exec.runner import Result, Runner, under
 from gentoo_install.model.config import Bootloader, BootloaderConfig, Firmware, InstallConfig
-from gentoo_install.model.device import DeviceId, Existing, Node
+from gentoo_install.model.device import DeviceId, Existing, Luks, Node
 from gentoo_install.plan.operations import CommandOutput
 
-from .layouts import config, encrypted_root, ext4_on_gpt, i
+from .layouts import config, encrypted_root, ext4_on_gpt, i, zfs_root
 
 
 def runner(tmp_path: Path) -> Runner:
@@ -592,28 +592,127 @@ def test_the_measured_order_is_used_only_when_the_configuration_asks() -> None:
     assert not plain.argv_starting("rank-mirrors")
 
 
-def test_no_passphrase_is_invented_when_none_was_supplied() -> None:
-    """A configuration error, not an integrity one: exit code 3 says the data
-    could not be trusted, and a missing passphrase is not that."""
-    with pytest.raises(ConfigError, match="names no passphrase_file"):
-        fetch.passphrase_for(DeviceId("crypt"), "")
-
-
-def test_a_passphrase_comes_from_the_file_the_layout_names(tmp_path: Path) -> None:
-    """A path, never the passphrase: the configuration is copied into the
-    target and the log is what people paste into bug reports."""
-    source = tmp_path / "key"
-    source.write_text("open sesame\n")
-    assert fetch.passphrase_for(DeviceId("crypt"), str(source)) == "open sesame"
-
-
 def test_an_empty_or_missing_passphrase_file_is_named(tmp_path: Path) -> None:
-    empty = tmp_path / "empty"
-    empty.write_text("")
-    with pytest.raises(ConfigError, match="is empty"):
-        fetch.passphrase_for(DeviceId("crypt"), str(empty))
-    with pytest.raises(ConfigError, match="cannot be read"):
-        fetch.passphrase_for(DeviceId("crypt"), str(tmp_path / "absent"))
+    from gentoo_install.exec.preflight import SecretStore
+
+    source = tmp_path / "key"
+    source.write_text("")
+    store = SecretStore(tmp_path / "work")
+    problems = preflight._passphrase_problems(
+        config(
+            [
+                replace(node, passphrase_file=str(source))
+                if isinstance(node, Luks)
+                else node
+                for node in encrypted_root()
+            ]
+        ),
+        probe_of(tmp_path),
+        store,
+    )
+    assert "is empty" in problems[0]
+    source.unlink()
+    problems = preflight._passphrase_problems(
+        config(
+            [
+                replace(node, passphrase_file=str(source))
+                if isinstance(node, Luks)
+                else node
+                for node in encrypted_root()
+            ]
+        ),
+        probe_of(tmp_path),
+        store,
+    )
+    assert "cannot be read" in problems[0]
+
+
+def test_apply_uses_the_preflight_approved_passphrase_after_source_mutation(
+    tmp_path: Path,
+) -> None:
+    from gentoo_install.exec.preflight import SecretStore
+    from gentoo_install.model.device import ZfsPool
+    from gentoo_install.plan.disk import CreateZpool
+    from .layouts import zfs_root
+
+    source = tmp_path / "key"
+    source.write_text("approved-passphrase")
+    installation = config(
+        [
+            replace(node, passphrase_file=str(source)) if isinstance(node, ZfsPool) else node
+            for node in zfs_root()
+        ]
+    )
+    store = SecretStore(tmp_path / "work")
+    assert preflight._passphrase_problems(installation, probe_of(tmp_path), store) == []
+    source.write_text("changed-after-preflight")
+
+    class Capturing(Runner):
+        input_text: str | None = None
+
+        def run(
+            self,
+            argv: Sequence[str],
+            *,
+            check: bool = True,
+            input_text: str | None = None,
+            timeout: float | None = None,
+        ) -> Result:
+            self.input_text = input_text
+            return Result(tuple(argv), 0, "", "", 0.0)
+
+    class Echoing(Probe):
+        def resolve(self, device: DeviceId, selector: str) -> str:
+            return selector
+
+        def wait_for(self, path: str, seconds: float = 15.0) -> str:
+            return path
+
+    answering = Capturing(log=lambda line: None)
+    machine = apply.Machine(
+        config=installation,
+        runner=answering,
+        probe=Echoing(runner=answering, work=tmp_path),
+        work=tmp_path / "work",
+        secrets=store,
+    )
+    pool = next(one for one in installation.disk.graph.of_type(ZfsPool))
+    CreateZpool(
+        pool=pool.id,
+        vdevs=pool.vdevs,
+        name=pool.name,
+        topology=pool.topology,
+        encrypted=True,
+    ).apply(machine)
+    assert answering.input_text == "approved-passphrase"
+    store.cleanup()
+    assert not store.path(pool.id).exists()
+
+
+def test_apply_uses_the_approved_passphrase_after_source_disappearance(tmp_path: Path) -> None:
+    from gentoo_install.exec.preflight import SecretStore
+    from gentoo_install.model.device import ZfsPool
+
+    source = tmp_path / "key"
+    source.write_text("approved-passphrase")
+    installation = config(
+        [
+            replace(node, passphrase_file=str(source)) if isinstance(node, ZfsPool) else node
+            for node in zfs_root()
+        ]
+    )
+    store = SecretStore(tmp_path / "work")
+    assert preflight._passphrase_problems(installation, probe_of(tmp_path), store) == []
+    source.unlink()
+    machine = apply.Machine(
+        config=installation,
+        runner=runner(tmp_path),
+        probe=probe_of(tmp_path),
+        work=tmp_path / "work",
+        secrets=store,
+    )
+    pool = next(one for one in installation.disk.graph.of_type(ZfsPool))
+    assert machine.passphrase(pool.id) == "approved-passphrase"
 
 
 def test_a_medium_without_the_release_key_fetches_one_rather_than_stopping(tmp_path: Path) -> None:


### PR DESCRIPTION
Preflight approves what it read, and apply then reopened the configured source file. A passphrase that changed in between — or disappeared — reached `cryptsetup` without anyone approving it, and by that point the partition table has been written.

Preflight stages each approved value in the exec-owned secret store and apply reads only that. Two tests cover the source changing and the source disappearing.

Verification pending: this touches the encryption path, so it is not merged until `vm-luks` passes at this revision.