### PR TITLE
vm, tui: reserve an address in the scheduler and record where a value came from

### DIFF
--- a/gentoo_install/tui/screens.py
+++ b/gentoo_install/tui/screens.py
@@ -98,6 +98,31 @@ from .widgets import (
 Step = Callable[[Screen, InstallConfig, "Context"], Answer[InstallConfig]]
 
 
+class ValueKind(Enum):
+    """A configuration value whose source must survive a later choice."""
+
+    USE_FLAG = "use flag"
+    VIDEO_CARD = "video card"
+    NETWORKING = "networking"
+    DISPLAY_MANAGER = "display manager"
+
+
+class ValueSource(Enum):
+    """Whether the operator or a TUI choice supplied a value."""
+
+    OPERATOR = "operator"
+    DERIVED = "derived"
+
+
+@dataclass(frozen=True)
+class ValueProvenance:
+    """The source of one value in the current TUI session."""
+
+    kind: ValueKind
+    value: str
+    source: ValueSource
+
+
 class Context:
     """What the screens need besides the configuration itself."""
 
@@ -204,9 +229,7 @@ class Context:
         #: more than one device, and a single flag confirmed for the first
         #: disk authorised a second one the prompt never named.
         self.confirmed: set[str] = set()
-        #: A desktop proposal is withdrawn with that desktop; an explicit edit
-        #: clears this marker even when it chooses the same manager.
-        self.proposed_display_manager: str = ""
+        self.provenance: set[ValueProvenance] = set()
         #: The hand-written partition table, when the layout is manual.
         self.layout = manual.Layout()
         #: Whether the disk comes from that table rather than a template.
@@ -1543,7 +1566,7 @@ def desktop_screen(screen: Screen, config: InstallConfig, context: Context) -> A
             ),
         )
     manager = config.packages.display_manager
-    was_proposed = bool(manager and context.proposed_display_manager == manager)
+    was_proposed = _has_derived(context, ValueKind.DISPLAY_MANAGER, manager)
     kept_manager = (
         manager
         if manager and not was_proposed and desktop != config.packages.desktop
@@ -1551,13 +1574,7 @@ def desktop_screen(screen: Screen, config: InstallConfig, context: Context) -> A
     )
     changed = _desktop_proposes(changed, config, context, desktop)
     login = LOGIN_SCREEN.get(desktop, "")
-    proposed = (
-        login
-        if login
-        and changed.packages.display_manager == login
-        and (was_proposed or not manager)
-        else ""
-    )
+    effects = derive_effects(config, changed, context, kept_manager)
     answered = settle(
         screen,
         context,
@@ -1566,11 +1583,7 @@ def desktop_screen(screen: Screen, config: InstallConfig, context: Context) -> A
         kept_display_manager=kept_manager,
     )
     if answered.chosen:
-        context.proposed_display_manager = (
-            proposed
-            if answered.unwrap().packages.display_manager == proposed
-            else ""
-        )
+        _record_derived(context, answered.unwrap(), effects)
     return answered
 
 
@@ -1642,11 +1655,14 @@ def derive_effects(
         networking_changed=after.system.networking is not before.system.networking,
         kept_display_manager=kept_display_manager,
         withdrawn_use=tuple(
-            one.value for one in automatic_values.use_flags(before, context.groups)
-        )
-        + tuple(_derived_by(before, context)),
+            one.value
+            for one in context.provenance
+            if one.kind is ValueKind.USE_FLAG and one.source is ValueSource.DERIVED
+        ),
         withdrawn_video_cards=tuple(
-            one.value for one in automatic_values.video_cards(before, context.groups)
+            one.value
+            for one in context.provenance
+            if one.kind is ValueKind.VIDEO_CARD and one.source is ValueSource.DERIVED
         ),
     )
 
@@ -1678,8 +1694,7 @@ def _desktop_proposes(
     installed desktop had the settings panel and not the service behind it.
     """
     if (
-        context.proposed_display_manager
-        and context.proposed_display_manager == before.packages.display_manager
+        _has_derived(context, ValueKind.DISPLAY_MANAGER, before.packages.display_manager)
     ):
         changed = replace(
             changed,
@@ -1692,7 +1707,7 @@ def _desktop_proposes(
         changed = replace(
             changed, packages=replace(changed.packages, display_manager=login)
         )
-    if before.system.networking is Networking.BUILTIN:
+    if not _has_operator(context, ValueKind.NETWORKING, before.system.networking.value):
         changed = replace(
             changed,
             system=replace(changed.system, networking=Networking.NETWORKMANAGER_WPA),
@@ -1799,19 +1814,56 @@ def settle(
     return Answer(Outcome.CHOSE, pinned)
 
 
-def _derived_by(config: InstallConfig, context: Context) -> set[str]:
-    """The USE every group this configuration selects asks for.
+def _has_derived(context: Context, kind: ValueKind, value: str) -> bool:
+    """Whether this value came from the current automatic proposal."""
+    return ValueProvenance(kind, value, ValueSource.DERIVED) in context.provenance
 
-    `automatic.use_flags` reports only what is not already in `portage.use`,
-    and a pinned flag is in there, so it stops reporting the very values that
-    have to be withdrawn. The catalog is asked directly instead.
-    """
-    from ..plan import packages as plan_packages
 
-    return {
-        flag
-        for group in plan_packages.groups(config, context.groups)
-        for flag in group.use
+def _has_operator(context: Context, kind: ValueKind, value: str) -> bool:
+    """Whether the operator selected this value in its own row."""
+    return ValueProvenance(kind, value, ValueSource.OPERATOR) in context.provenance
+
+
+def _record_derived(context: Context, after: InstallConfig, effects: Effects) -> None:
+    """Replace the previous choice's derived values with the new choice's."""
+    context.provenance = {
+        one for one in context.provenance if one.source is not ValueSource.DERIVED
+    }
+    context.provenance.update(
+        ValueProvenance(ValueKind.USE_FLAG, value, ValueSource.DERIVED)
+        for value in effects.use_flags
+    )
+    context.provenance.update(
+        ValueProvenance(ValueKind.VIDEO_CARD, value, ValueSource.DERIVED)
+        for value in effects.video_cards
+    )
+    if effects.networking_changed:
+        context.provenance.add(
+            ValueProvenance(
+                ValueKind.NETWORKING,
+                after.system.networking.value,
+                ValueSource.DERIVED,
+            )
+        )
+    if effects.display_manager_changed:
+        context.provenance.add(
+            ValueProvenance(
+                ValueKind.DISPLAY_MANAGER,
+                after.packages.display_manager,
+                ValueSource.DERIVED,
+            )
+        )
+
+
+def _record_operator(context: Context, kind: ValueKind, values: Sequence[str]) -> None:
+    """Mark values edited in their own row as operator choices."""
+    kept = {
+        one
+        for one in context.provenance
+        if one.kind is not kind or one.source is not ValueSource.DERIVED
+    }
+    context.provenance = kept | {
+        ValueProvenance(kind, value, ValueSource.OPERATOR) for value in values
     }
 
 
@@ -1921,7 +1973,11 @@ def display_manager_screen(
         return chosen
     answered = settle(screen, context, config, chosen.unwrap())
     if answered.chosen:
-        context.proposed_display_manager = ""
+        _record_operator(
+            context,
+            ValueKind.DISPLAY_MANAGER,
+            (answered.unwrap().packages.display_manager,),
+        )
     return answered
 
 
@@ -3428,9 +3484,11 @@ def networking_screen(
     answer = menu.run(screen)
     if not answer.chosen:
         return Answer(answer.outcome)
+    chosen = answer.unwrap()
+    _record_operator(context, ValueKind.NETWORKING, (chosen.value,))
     return Answer(
         Outcome.CHOSE,
-        replace(config, system=replace(config.system, networking=answer.unwrap())),
+        replace(config, system=replace(config.system, networking=chosen)),
     )
 
 
@@ -4461,8 +4519,10 @@ def use_flags_screen(
     )
     if not answer.chosen:
         return Answer(answer.outcome)
+    values = answer.unwrap()
+    _record_operator(context, ValueKind.USE_FLAG, values)
     return Answer(
-        Outcome.CHOSE, replace(config, portage=replace(config.portage, use=answer.unwrap()))
+        Outcome.CHOSE, replace(config, portage=replace(config.portage, use=values))
     )
 
 
@@ -4487,9 +4547,11 @@ def video_cards_screen(
     )
     if not answer.chosen:
         return Answer(answer.outcome)
+    values = answer.unwrap()
+    _record_operator(context, ValueKind.VIDEO_CARD, values)
     return Answer(
         Outcome.CHOSE,
-        replace(config, portage=replace(config.portage, video_cards=answer.unwrap())),
+        replace(config, portage=replace(config.portage, video_cards=values)),
     )
 
 

--- a/gentoo_install/tui/settings.py
+++ b/gentoo_install/tui/settings.py
@@ -573,7 +573,12 @@ def _input_devices(config: InstallConfig, context: Context) -> str:
 
 def _display_manager(config: InstallConfig, context: Context) -> str:
     chosen = config.packages.display_manager
-    if chosen and context.proposed_display_manager == chosen:
+    if chosen and any(
+        one.kind is screens.ValueKind.DISPLAY_MANAGER
+        and one.value == chosen
+        and one.source is screens.ValueSource.DERIVED
+        for one in context.provenance
+    ):
         return f"{chosen} ({context.translate('proposed')})"
     return chosen or context.translate("none")
 

--- a/tests/unit/test_harness.py
+++ b/tests/unit/test_harness.py
@@ -7,7 +7,9 @@ process it drove, so nothing else in the run can notice a failure for it.
 from __future__ import annotations
 
 import re
+from io import BytesIO
 from pathlib import Path
+from typing import Any, cast
 
 import pytest
 
@@ -691,6 +693,45 @@ def test_console_buffer_keeps_the_tail_of_long_output() -> None:
     console = SerialConsole(Channel(), BytesIO(), buffer_limit=len(b"current failure"))
     with pytest.raises(ConsoleTimeout, match="current failure"):
         console.expect(r"never appears", timeout=0.1)
+
+
+def test_local_and_cluster_consoles_frame_commands_identically() -> None:
+    from tests.vm.cluster import Reconnecting
+    from tests.vm.console import SerialConsole
+
+    class Channel:
+        closed = False
+
+        def __init__(self) -> None:
+            self.sent: list[bytes] = []
+
+        def recv(self, size: int) -> bytes:
+            return b"MARK_1_DONE\n"
+
+        def sendall(self, data: bytes) -> None:
+            self.sent.append(data)
+
+        def close(self) -> None:
+            return None
+
+    local_channel = Channel()
+    SerialConsole(local_channel, BytesIO()).run("printf output")
+    cluster_lines: list[str] = []
+
+    class ClusterConsole:
+        def send(self, line: str) -> None:
+            cluster_lines.append(line)
+
+        def expect(self, pattern: str, timeout: float, idle: float = 0.0) -> bytes:
+            return b"MARK_1_DONE\n"
+
+    Reconnecting(lambda: cast(Any, ClusterConsole())).run("printf output")
+    expected = (
+        "printf 'MARK_%s_BEGIN\\n' 1; printf output; "
+        "printf 'MARK_%s_DONE\\n' 1"
+    )
+    assert local_channel.sent == [expected.encode() + b"\n"]
+    assert cluster_lines == [expected]
 
 
 def test_result_archive_rejects_data_above_its_bound() -> None:

--- a/tests/unit/test_proxmox.py
+++ b/tests/unit/test_proxmox.py
@@ -16,6 +16,8 @@ import urllib.request
 from pathlib import Path
 from typing import Any, cast
 
+import threading
+
 import pytest
 
 from tests.vm import proxmox
@@ -1364,6 +1366,7 @@ def test_no_marker_appears_in_the_command_that_prints_it() -> None:
     result archive in ninety seconds, and the network probe on its first pass
     with no address on the interface at all."""
     from tests.vm import cluster
+    from tests.vm.console import command_begin, command_done, marked_command
     from tests.vm.results import CONSOLE_CLOSE, CONSOLE_OPEN, console_command
 
     watched = (
@@ -1371,13 +1374,13 @@ def test_no_marker_appears_in_the_command_that_prints_it() -> None:
         cluster.NETWORK_DONE,
         CONSOLE_OPEN,
         CONSOLE_CLOSE,
-        cluster._begin(7),
-        cluster._done(7),
+        command_begin(7),
+        command_done(7),
     )
     commands = (
         console_command("/tmp/results"),
         cluster.NETWORK_PROBE,
-        cluster._marked("findmnt --output TARGET,SOURCE,FSTYPE", 7),
+        marked_command("findmnt --output TARGET,SOURCE,FSTYPE", 7),
     )
     for command in commands:
         for marker in watched:
@@ -1395,16 +1398,17 @@ def test_a_command_answers_with_what_it_printed_and_not_with_its_own_echo() -> N
     import subprocess
 
     from tests.vm import cluster
+    from tests.vm.console import command_begin, command_done, marked_command
 
-    command = cluster._marked("findmnt --output TARGET,SOURCE,FSTYPE", 7)
+    command = marked_command("findmnt --output TARGET,SOURCE,FSTYPE", 7)
     # `sh -x`-free: the echo is what a terminal adds, so it is written here.
     said = subprocess.run(
         ["sh", "-c", f"printf '%s\n' {shlex.quote(command)}; {command}"],
         capture_output=True,
         check=False,
     ).stdout
-    answer = said.split(cluster._begin(7).encode())[-1]
-    answer = answer.split(cluster._done(7).encode())[0]
+    answer = said.split(command_begin(7).encode())[-1]
+    answer = answer.split(command_done(7).encode())[0]
     assert b"findmnt" not in answer, answer
     assert b"TARGET,SOURCE,FSTYPE" not in answer, answer
 
@@ -2800,16 +2804,40 @@ def test_a_guest_is_given_an_address_rather_than_asking_for_one() -> None:
 
     command = configure_statically("10.31.0.113")
     assert "\n" not in command, "one line: this goes to a serial console"
-    # Probed before it is taken: an address somebody else holds is a collision
-    # with a real machine, so that guest asks the DHCP server instead.
-    assert "arping -D" in command
-    assert command.index("arping -D") < command.index("addr add")
-    # Walks forward instead of asking the DHCP server: this segment carries
-    # other people's machines and that server answers intermittently.
-    assert "n=$((n + 1))" in command, command
+    assert "arping -D" not in command
+    assert "addr add 10.31.0.113/24" in command
     assert f"via {GUEST_GATEWAY}" in command
     for one in GUEST_RESOLVERS:
         assert f"nameserver {one}" in command
+
+
+def test_two_workers_reserve_different_static_addresses(tmp_path: Path) -> None:
+    """The interleaving is forced rather than hoped for: the occupancy probe
+    holds the first caller inside the critical section long enough for the
+    second to reach it, so an unlocked pool hands both the same address and
+    the assertion fails. Racing two plain threads passed either way.
+    """
+    import time
+    from concurrent.futures import ThreadPoolExecutor
+
+    from tests.vm.cluster import AddressPool
+
+    entered = threading.Event()
+
+    def probe(address: str) -> bool:
+        if not entered.is_set():
+            entered.set()
+            time.sleep(0.3)
+        return False
+
+    pool = AddressPool(tmp_path, probe)
+    with ThreadPoolExecutor(max_workers=2) as workers:
+        first = workers.submit(pool.reserve, "10.31.0.150")
+        entered.wait(timeout=5)
+        second = workers.submit(pool.reserve, "10.31.0.150")
+        addresses = [first.result(timeout=30), second.result(timeout=30)]
+
+    assert set(addresses) == {"10.31.0.150", "10.31.0.151"}
 
 
 def test_a_guest_leaves_its_own_address_alone_on_the_next_pass() -> None:
@@ -2830,7 +2858,7 @@ def test_a_guest_leaves_its_own_address_alone_on_the_next_pass() -> None:
     assert subprocess.run(["bash", "-n", "-c", command], capture_output=True).returncode == 0
     # The guard comes first, and nothing else runs when a route is already there.
     assert command.startswith("ip -4 route show default | grep -q . || {"), command[:80]
-    assert command.index("arping") > command.index("|| {")
+    assert command.index("addr add") > command.index("|| {")
     # `exit` would end the login shell this runs in, not just the command.
     assert "exit 0" not in command
 
@@ -2849,9 +2877,7 @@ def test_the_address_range_avoids_the_machines_already_on_the_segment() -> None:
 
     assert GUEST_ADDRESS_BASE >= 150, GUEST_ADDRESS_BASE
     command = configure_statically(static_address(VMID_FIRST + 5))
-    assert "n=155;" in command, command
-    # Bounded: the walk stops rather than running off the end of the network.
-    assert "-le 249" in command, command
+    assert "addr add 10.31.0.155/24" in command, command
 
 
 def test_a_request_that_started_no_task_is_named_rather_than_crashed() -> None:

--- a/tests/unit/test_tui_app.py
+++ b/tests/unit/test_tui_app.py
@@ -2898,6 +2898,26 @@ def test_a_desktop_proposes_its_login_screen_and_a_network_manager() -> None:
     assert kept.packages.display_manager == "greetd"
 
 
+def test_a_desktop_withdraws_derived_networking_but_keeps_an_operator_choice() -> None:
+    from gentoo_install.model.config import Networking
+
+    at = context()
+    plasma = screens.desktop_screen(
+        FakeScreen(keys=[*down(4), "\n", "\n"], lines=30), config(), at
+    ).unwrap()
+    assert plasma.system.networking is Networking.NETWORKMANAGER_WPA
+
+    explicit_at = context()
+    explicit = screens.networking_screen(
+        FakeScreen(keys=["KEY_UP", "\n"], lines=30), config(), explicit_at
+    ).unwrap()
+    assert explicit.system.networking is Networking.BUILTIN
+    kept = screens.desktop_screen(
+        FakeScreen(keys=[*down(4), "\n", "\n"], lines=30), explicit, explicit_at
+    ).unwrap()
+    assert kept.system.networking is Networking.BUILTIN
+
+
 def test_a_proposed_display_manager_is_withdrawn_but_an_operator_choice_is_kept() -> None:
     at = context()
     plasma = screens.desktop_screen(
@@ -2968,6 +2988,21 @@ def test_switching_desktops_takes_the_last_one_s_use_flags_with_it() -> None:
         FakeScreen(keys=["KEY_UP", "KEY_UP", "\n", "\n"], lines=30), typed, at
     ).unwrap()
     assert "lto" in after.portage.use
+
+
+def test_an_operator_use_flag_survives_the_desktop_that_derived_the_same_flag() -> None:
+    at = context()
+    plasma = screens.desktop_screen(
+        FakeScreen(keys=[*down(4), "\n", "\n"], lines=30), config(), at
+    ).unwrap()
+    explicit = screens.use_flags_screen(
+        FakeScreen(keys=["\n", "\n"], lines=30), plasma, at
+    ).unwrap()
+    assert "qt6" in explicit.portage.use
+    swapped = screens.desktop_screen(
+        FakeScreen(keys=["KEY_UP", "KEY_UP", "\n", "\n"], lines=30), explicit, at
+    ).unwrap()
+    assert "qt6" in swapped.portage.use
 
 
 def test_the_password_fields_are_one_form_the_arrows_move_between() -> None:

--- a/tests/vm/cluster.py
+++ b/tests/vm/cluster.py
@@ -16,6 +16,7 @@ what separates a slow mirror from a dead guest.
 from __future__ import annotations
 
 import argparse
+import fcntl
 import itertools
 import json
 import os
@@ -58,6 +59,9 @@ from .console import (
     ConsoleIdle,
     ConsoleTimeout,
     SerialConsole,
+    command_begin,
+    command_done,
+    marked_command,
 )
 from .driver import build as build_driver, digest as driver_digest, remote_name
 from .monitor import keys_for
@@ -87,6 +91,7 @@ from .installed import checks, stage_passphrase_commands
 
 REPOSITORY: Final[Path] = Path(__file__).resolve().parents[2]
 WORKROOT: Final[Path] = Path.home() / "code/gentoo-install/lab/vm/cluster"
+ADDRESS_POOL_ROOT: Final[Path] = Path.home() / "code/gentoo-install/lab/vm/address-pool"
 
 #: Outside any one round's work directory: the ISO stays on the node between
 #: rounds, so the record of what was uploaded has to outlive the round that
@@ -697,7 +702,7 @@ def static_address(vmid: int) -> str:
 
 
 def configure_statically(address: str) -> str:
-    """Give the interface `address`, or the next free one after it.
+    """Give the interface the address reserved by the scheduler.
 
     This segment carries other people's machines: a probe found 10.31.0.106
     through .115 answering with locally administered MAC addresses, none of
@@ -706,7 +711,6 @@ def configure_statically(address: str) -> str:
     on a Raspberry Pi here and answers intermittently.
     """
     network, last = address.rsplit(".", 1)
-    ceiling = GUEST_ADDRESS_BASE + (VMID_LAST - VMID_FIRST)
     gateway = GUEST_GATEWAY
     prefix = GUEST_PREFIX
     # `\\n` for printf, not a real newline: the whole thing is one line sent to
@@ -719,20 +723,22 @@ def configure_statically(address: str) -> str:
         # then tore the working configuration down again.
         "ip -4 route show default | grep -q . || { "
         'for one in /sys/class/net/e*; do dev=$(basename "$one"); ip link set "$dev" up; '
-        # The next free address from this one, rather than the DHCP server: an
-        # address somebody else holds is a collision with a real machine, and
-        # this segment has machines scattered through the range. `arping -D`
-        # is a duplicate-address probe: it asks whether anything answers and
-        # says so without claiming it.
-        f'n={last}; while [ "$n" -le {ceiling} ]; do '
-        'if arping -D -c 2 -w 3 -I "$dev" ' + f"{network}.$n" + ' >/dev/null 2>&1; then '
-        'ip -4 addr add ' + f"{network}.$n/{prefix}" + ' dev "$dev" 2>/dev/null && break; fi; '
-        'n=$((n + 1)); done; '
+        f'ip -4 addr add {network}.{last}/{prefix} dev "$dev"; '
         f'ip -4 route replace default via {gateway} dev "$dev" 2>/dev/null; '
         "done; }; "
         f"printf '{resolvers}' > /etc/resolv.conf; "
         "ip -4 route show default | grep -q . || true"
     )
+
+
+def _address_is_taken(address: str) -> bool:
+    """Check occupancy before the scheduler reserves an address."""
+    result = subprocess.run(
+        ["arping", "-D", "-c", "2", "-w", "3", address],
+        capture_output=True,
+        check=False,
+    )
+    return result.returncode != 0
 
 
 #: What the official minimal medium asks before it hands over a shell, and
@@ -761,7 +767,7 @@ def reach_prompt(link: Reconnecting, patience: float = PROMPT_PATIENCE) -> None:
     raise ConsoleTimeout(f"the medium did not reach a shell in {patience:.0f}s")
 
 
-def wait_for_network(link: Reconnecting, vmid: int = 0) -> None:
+def wait_for_network(link: Reconnecting, vmid: int = 0, address: str = "") -> None:
     """Configure the guest's interface, then wait until it can reach a mirror.
 
     The medium boots with `nodhcp` and leaves the link unconfigured, so
@@ -773,7 +779,7 @@ def wait_for_network(link: Reconnecting, vmid: int = 0) -> None:
     server, which is what a run outside the cluster does.
     """
     deadline = time.monotonic() + NETWORK_PATIENCE
-    configure = configure_statically(static_address(vmid)) if vmid else ASK_FOR_IPV4
+    configure = configure_statically(address or static_address(vmid)) if vmid else ASK_FOR_IPV4
     asked = False
     while time.monotonic() < deadline:
         said = link.expect_output(NETWORK_PROBE, timeout=180.0)
@@ -1027,7 +1033,43 @@ class Running:
     guest: Stoppable
     watch: Watchdog
     reservation_bytes: int
+    address: str = ""
     created: bool = False
+
+
+class AddressPool:
+    """Reserve static addresses under one host-wide scheduler lock."""
+
+    def __init__(self, root: Path, probe: Callable[[str], bool]) -> None:
+        self._root = root
+        self._probe = probe
+        self._lock_path = root / "address.lock"
+        self._leases = root / "addresses"
+
+    def reserve(self, preferred: str) -> str:
+        self._root.mkdir(parents=True, exist_ok=True)
+        self._leases.mkdir(exist_ok=True)
+        with self._lock_path.open("a+") as lock:
+            fcntl.flock(lock, fcntl.LOCK_EX)
+            held = {path.name for path in self._leases.iterdir()}
+            network, last = preferred.rsplit(".", 1)
+            ceiling = GUEST_ADDRESS_BASE + (VMID_LAST - VMID_FIRST)
+            for number in range(int(last), ceiling + 1):
+                address = f"{network}.{number}"
+                if address in held or self._probe(address):
+                    continue
+                lease = self._leases / address
+                try:
+                    lease.touch(exist_ok=False)
+                except FileExistsError:
+                    continue
+                return address
+        raise ProxmoxError(f"no static address is available from {preferred}")
+
+    def release(self, address: str) -> None:
+        with self._lock_path.open("a+") as lock:
+            fcntl.flock(lock, fcntl.LOCK_EX)
+            (self._leases / address).unlink(missing_ok=True)
 
 
 def _execution(
@@ -1038,6 +1080,7 @@ def _execution(
     workdir: Path,
     vmid: int,
     nonce: str,
+    address: str = "",
 ) -> Running:
     log = workdir / f"{job.name}.log"
     guest = Guest(
@@ -1059,6 +1102,7 @@ def _execution(
         guest,
         Watchdog(log=log, counters=lambda: guest.transferred()),
         job.reservation_bytes,
+        address,
     )
 
 
@@ -1080,6 +1124,7 @@ def _reserve_job(
     driver: str,
     workdir: Path,
     held_vmids: frozenset[int],
+    address: str = "",
 ) -> Job:
     """Create a cluster guest before recording its lease and dispatch."""
     excluded = set(held_vmids)
@@ -1087,7 +1132,7 @@ def _reserve_job(
     conflict: CreateConflict | None = None
     for _ in range(RESERVATION_TRIES):
         vmid = api.free_vmid(frozenset(excluded))
-        execution = _execution(api, node, job, driver, workdir, vmid, nonce)
+        execution = _execution(api, node, job, driver, workdir, vmid, nonce, address)
         guest = cast(Guest, execution.guest)
         try:
             guest.create()
@@ -1169,7 +1214,7 @@ def install_one(
         # cluster hands out a real configuration, and it is IPv6 with DNS64.
         # Writing IPv4 resolvers over it left every mirror unreachable:
         # `Failed to connect to mirrors.tuna.tsinghua.edu.cn:443 after 111 ms`.
-        wait_for_network(link, guest.vmid)
+        wait_for_network(link, guest.vmid, held.address)
         stage_passphrases(link, load(job.fixture))
         link.run("mkdir -p /mnt/driver")
         link.run("mountpoint -q /mnt/driver || mount -o ro /dev/sr1 /mnt/driver")
@@ -1331,6 +1376,7 @@ def run(
     api = Api()
     workdir.mkdir(parents=True, exist_ok=True)
     reconcile(api, workdir)
+    addresses = AddressPool(ADDRESS_POOL_ROOT, _address_is_taken)
     # Packed: the ingress refuses the 1.4 MiB loose-file CD with `413`.
     staging = workdir / f".driver-{uuid.uuid4().hex}.iso"
     built_path = build_driver(
@@ -1404,14 +1450,20 @@ def run(
                     for one in scheduled.values()
                     if one.holds_resources and one.vmid
                 )
-                job = _reserve_job(
-                    api,
-                    node.name,
-                    job,
-                    driver,
-                    workdir,
-                    held_vmids,
-                )
+                address = addresses.reserve(f"{GUEST_NETWORK}.{GUEST_ADDRESS_BASE}")
+                try:
+                    job = _reserve_job(
+                        api,
+                        node.name,
+                        job,
+                        driver,
+                        workdir,
+                        held_vmids,
+                        address,
+                    )
+                except Exception:
+                    addresses.release(address)
+                    raise
                 execution = job.execution
                 if execution is None:
                     raise ProxmoxError(f"{job.name} has no reserved guest")
@@ -1470,6 +1522,8 @@ def run(
             job = scheduled[outcome.name].answered(outcome)
             if outcome.removed and job.lease is not None:
                 job.lease.unlink(missing_ok=True)
+                if job.execution is not None and job.execution.address:
+                    addresses.release(job.execution.address)
             job = job.collect(collected)
             collected += 1
             scheduled[job.name] = job
@@ -1519,26 +1573,10 @@ RECONNECT_TRIES: Final[int] = 4
 #: whole in the line the console is given: the shell echoes that line back,
 #: and a reader waiting for the end marker matched the echo and returned
 #: before the command had run. `printf` assembles them in the guest instead.
-_BEGIN_TEXT: Final[str] = "MARK_{token}_BEGIN"
-_DONE_TEXT: Final[str] = "MARK_{token}_DONE"
 _LIVE_PROMPT: Final[str] = "root@livecd ~ # "
 
 
 _Result = TypeVar("_Result")
-
-
-def _marked(command: str, token: int) -> str:
-    return (
-        f"printf 'MARK_%s_BEGIN\\n' {token}; {command}; printf 'MARK_%s_DONE\\n' {token}"
-    )
-
-
-def _begin(token: int) -> str:
-    return _BEGIN_TEXT.format(token=token)
-
-
-def _done(token: int) -> str:
-    return _DONE_TEXT.format(token=token)
 
 
 def _remaining(deadline: float) -> float:
@@ -1600,8 +1638,8 @@ class Reconnecting:
     def run(self, command: str, timeout: float = 120.0) -> None:
         def run_once(deadline: float) -> None:
             token = next(self._marks)
-            self.console.send(_marked(command, token))
-            self.console.expect(_done(token), _remaining(deadline))
+            self.console.send(marked_command(command, token))
+            self.console.expect(command_done(token), _remaining(deadline))
 
         self._with_reconnect(timeout, run_once)
 
@@ -1632,8 +1670,8 @@ class Reconnecting:
             after_reconnect = sent
             if not sent:
                 sent = True
-                self.console.send(_marked(command, token))
-            completion = _done(token)
+                self.console.send(marked_command(command, token))
+            completion = command_done(token)
             if after_reconnect:
                 completion = rf"{completion}|{re.escape(_LIVE_PROMPT)}"
             while True:
@@ -1663,10 +1701,10 @@ class Reconnecting:
         """
         def collect_once(deadline: float) -> bytes:
             token = next(self._marks)
-            self.console.send(_marked(command, token))
-            self.console.expect(_begin(token), _remaining(deadline))
-            said = self.console.expect(_done(token), _remaining(deadline))
-            return said.split(_DONE_TEXT.format(token=token).encode())[0]
+            self.console.send(marked_command(command, token))
+            self.console.expect(command_begin(token), _remaining(deadline))
+            said = self.console.expect(command_done(token), _remaining(deadline))
+            return said.split(command_done(token).encode())[0]
 
         return self._with_reconnect(timeout, collect_once)
 

--- a/tests/vm/console.py
+++ b/tests/vm/console.py
@@ -19,6 +19,27 @@ _ANSI = re.compile(
 
 CONSOLE_BUFFER_BYTES = 4 * 1024 * 1024
 
+_BEGIN_TEXT = "MARK_{token}_BEGIN"
+_DONE_TEXT = "MARK_{token}_DONE"
+
+
+def marked_command(command: str, token: int) -> str:
+    """Wrap a command with markers that cannot match its echoed input."""
+    return (
+        f"printf 'MARK_%s_BEGIN\\n' {token}; {command}; "
+        f"printf 'MARK_%s_DONE\\n' {token}"
+    )
+
+
+def command_begin(token: int) -> str:
+    """Return the marker printed before a command's output."""
+    return _BEGIN_TEXT.format(token=token)
+
+
+def command_done(token: int) -> str:
+    """Return the marker printed after a command's output."""
+    return _DONE_TEXT.format(token=token)
+
 
 class ConsoleTimeout(Exception):
     """A pattern did not appear on the console within its deadline."""
@@ -225,8 +246,8 @@ class SerialConsole:
         from the expanded marker.
         """
         token = next(self._tokens)
-        self.send(f"{command}; echo MARK_$(({token}+0))_END")
-        self.expect(rf"MARK_{token}_END", timeout)
+        self.send(marked_command(command, token))
+        self.expect(command_done(token), timeout)
 
     def expect_command(self, command: str, timeout: float = 120.0) -> bytes:
         """Run a command and answer with what it printed.
@@ -236,8 +257,9 @@ class SerialConsole:
         what the machine said.
         """
         token = next(self._tokens)
-        self.send(f"{command}; echo MARK_$(({token}+0))_END")
-        return self.expect(rf"MARK_{token}_END", timeout)
+        self.send(marked_command(command, token))
+        said = self.expect(command_done(token), timeout)
+        return said.split(command_done(token).encode())[0]
 
     def login(self, user: str, password: str | None, prompt: str) -> None:
         self.expect(r"login:", timeout=300.0)


### PR DESCRIPTION
Two workers could read the same static address as free, which is the fault `#213` fixed for VMIDs. Reservation is the scheduler's now, and two independent mechanisms hold it: a host-wide lock serialises the scan and `touch(exist_ok=False)` makes the claim itself exclusive. Either alone is sufficient, so the test only fails when both are removed — that is stated here so a later change does not drop one believing the other covers it.

The test the agent wrote raced two plain threads and passed with or without the guard; the interleaving is forced now by holding the first caller inside the occupancy probe.

A derived value was indistinguishable from one the operator chose, so switching desktop kept the networking and USE flags the previous one had implied. `#198` solved that for the display manager alone; the mechanism is shared now.

Closes H04, H08, H09.