### PR TITLE
readme: document the session proxy in all five locales

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -36,6 +36,12 @@ gentoo-install は Linux ライブ環境で動作し、amd64 アーキテクチ�
 
 **Portage** 設定項目には、profile、`MAKEOPTS`、`USE`、`ACCEPT_KEYWORDS`、`L10N`、ミラー、リポジトリ同期方式が含まれます。gentoo-zh と gig の overlay は個別に選択できます。インターフェイス言語として `zh-TW`、`zh-CN`、`ja`、`ko` のいずれかを選択すると、gentoo-zh のパッチ適用済みバイナリカーネルとその overlay も選択されます。`en` を選択した場合は自動的に選択されません。公式と gentoo-zh のバイナリパッケージ取得元は、それぞれ独立した設定と鍵を使用します。
 
+<!-- fact: proxy -->
+
+**セッションプロキシ** `[proxy]` テーブルは `url` と `bypass` を受け付けます。URL は `http://`、`https://`、`socks5://`、`socks5h://` を使用でき、認証情報も含められます。URL が空の場合は直接接続となり、これが既定値です。`socks5` はホスト名をローカルで解決し、`socks5h` はプロキシで解決します。そのため、ライブ環境が内部ホスト名を解決できない場合は `socks5h` が必要です。メインメニューには URL とバイパスホストの 2 フィールドを持つ `Proxy` 行があります。URL フィールドは secret として扱われ、パスワードを表示しません。`bypass` はインターフェイスではコンマ区切りの値、TOML ではリストです。
+
+プロキシを選択した後、設定したプロキシは stage3 と署名鍵、メインツリーおよび overlay のバージョン取得、`gitweb.gentoo.org` の ZFS ebuild 取得、`make.conf` と `FETCHCOMMAND`/`RESUMECOMMAND` を通る Portage のダウンロード、`wget`、`curl`、`git`、GnuPG、binhost、overlay、paste のアップロードに使用されます。時計、初期接続検査、メニュー前のミラー検査は設定を取得する前に実行されるため、この設定の対象外です。インストーラは dry-run の説明と公開設定から認証情報を除外します。公開設定とインストール済みシステムには、認証情報を含まないエンドポイントとバイパスリストだけが残ります。
+
 <!-- fact: plan-records -->
 
 **計画と記録** dry run はストレージハードウェアを調査せずに操作計画を表示します。実際のインストールでは、再利用するデバイスから調査した mdraid メタデータを追加したうえで同じ planner を使用するため、ハードウェアに依存する検証結果が変わる場合があります。`install.log` はコマンド出力を記録し、`install.jsonl` は操作、パッケージの取得元、バイナリパッケージのフォールバック理由を記録します。メニューは設定を `paste.gentoozh.org` にアップロードする前に、`password_hash` と `root_password_hash` の値だけを `removed-before-publishing` に置き換えます。その他の設定値はアップロードに残ります。メニューはアップロード先ページのアドレスをテキストと QR コードで表示します。
@@ -51,6 +57,8 @@ gentoo-install は Linux ライブ環境で動作し、amd64 アーキテクチ�
 2026 年 8 月 11 日付のリビジョン付きエンドツーエンド記録は、Arch Linux、openSUSE、Debian、Fedora、自前でビルドした gentoo-cjk minimal ISO からのインストールと起動をそれぞれ 1 回ずつ対象としています。これらの記録は、インストーラリビジョン [`b931ef46fc15ed50385f70467f2bfb0a8d1fd154`](https://github.com/Zakkaus/gentoo-install/commit/b931ef46fc15ed50385f70467f2bfb0a8d1fd154) を対象としています。gentoo-cjk の記録は ZFS と ZFSBootMenu を使用し、ほかの 4 件は ext4 を使用しています。記録されたリビジョンがインストーラと一致し、インストールの終了コードが `0` で、インストール済みシステムが起動し、起動後の設定検査に合格した場合に限り、その実行を現在の根拠として扱います。
 
 その他の実装済みの組み合わせは、エンドツーエンド未検証です。現在の根拠は、initramfs の SSH ロック解除、greetd のデスクトップセッション、GNOME 以外での ibus を対象としていません。公式 Gentoo minimal ISO、Alpine または Gig-OS のライブメディア、binhost 障害時のフォールバックも対象としていません。
+
+プロキシ経路には、SOCKS5 の DNS モード、dry-run 出力と公開設定での認証情報の除去、インストール済みシステムに残る認証情報なしのエンドポイントを対象とする単体テストと plan テストがあります。リビジョンを記録したクラスタ実行が逆方向を裏づけます。`vm-proxy-dead` フィクスチャは待ち受けのないポートをプロキシに指定し、インストールは stage3 のダウンロードで `Connection refused` により停止します。ミラーに到達する実行はプロキシが迂回されたことを示します。動作するプロキシを通してインストールを完了した実行はまだないため、順方向は未検証です。
 
 CJK のテキストコンソール表示にも現在の検証根拠はありません。ext2 と ext3 には、各設定に対する自動テストもありません。`tests/fixtures/` のファイルは設定モデルのみを検証し、対応する組み合わせのインストールと起動を証明するものではありません。
 
@@ -144,6 +152,68 @@ cd gentoo-install-master
 <!-- fact: config-dry-run -->
 
 解析と計画ではストレージハードウェアを調査しないため、ターゲットディスクがないマシンでも `--dry-run` で設定を確認できます。
+
+次の完全な設定は、認証情報と 2 つのバイパスホストを持つプロキシを示します。認証情報は例であり、実行前に置き換える必要があります。
+
+```toml
+config_version = 1
+
+[proxy]
+url = "socks5h://operator:secret@proxy.example:1080"
+bypass = ["localhost", "intranet.example"]
+
+[system]
+hostname = "proxy-target"
+timezone = "UTC"
+locales = ["en_US.UTF-8"]
+locale = "en_US.UTF-8"
+init = "openrc"
+root_password_hash = "$6$gentooinst$IR3GrdJ862XljQYDqocr4tKniIRDIT.jQNFzIrHE3U75H6B6YSWZoSYoVd5edSHpqaYBdiNfXHCoIPRVgb9lT/"
+
+[portage]
+profile = "default/linux/amd64/23.0"
+makeopts = "-j4"
+
+[portage.binhost]
+official = false
+
+[bootloader]
+firmware = "bios"
+
+[disk]
+root = "mnt-root"
+
+[[disk.devices]]
+kind = "existing"
+id = "disk"
+selector = "/dev/disk/by-id/virtio-target0"
+wipe = true
+
+[[disk.devices]]
+kind = "table"
+id = "table"
+disk = "disk"
+table = "mbr"
+
+[[disk.devices]]
+kind = "partition"
+id = "rootpart"
+table = "table"
+index = 1
+role = "data"
+
+[[disk.devices]]
+kind = "filesystem"
+id = "rootfs"
+device = "rootpart"
+type = "ext4"
+
+[[disk.devices]]
+kind = "mountpoint"
+id = "mnt-root"
+source = "rootfs"
+path = "/"
+```
 
 ## バイナリパッケージ
 

--- a/README.ko.md
+++ b/README.ko.md
@@ -36,6 +36,12 @@ gentoo-install은 Linux 라이브 환경에서 실행되어 amd64 아키텍처�
 
 **Portage** 설정 항목에는 profile, `MAKEOPTS`, `USE`, `ACCEPT_KEYWORDS`, `L10N`, 미러, 저장소 동기화 방식이 포함된다. gentoo-zh와 gig overlay는 각각 선택할 수 있다. 인터페이스 언어로 `zh-TW`, `zh-CN`, `ja`, `ko` 중 하나를 선택하면 gentoo-zh의 패치된 바이너리 커널과 해당 overlay도 선택된다. `en`을 선택하면 자동으로 선택되지 않는다. 공식 바이너리 패키지 소스와 gentoo-zh 바이너리 패키지 소스는 각각 독립된 설정과 키를 사용한다.
 
+<!-- fact: proxy -->
+
+**세션 프록시** `[proxy]` 테이블은 `url`과 `bypass`를 받는다. URL에는 `http://`, `https://`, `socks5://`, `socks5h://`를 사용할 수 있고 인증 정보도 포함할 수 있다. URL이 비어 있으면 직접 연결하며 이것이 기본값이다. `socks5`는 호스트 이름을 로컬에서 확인하고 `socks5h`는 프록시에서 확인한다. 따라서 라이브 환경이 내부 호스트 이름을 확인하지 못하면 `socks5h`가 필요하다. 주 메뉴에는 URL과 우회 호스트 두 필드가 있는 `Proxy` 행이 있다. URL 필드는 secret으로 처리되어 비밀번호를 표시하지 않는다. `bypass`는 인터페이스에서 쉼표로 구분한 값이고 TOML에서는 목록이다.
+
+프록시를 선택한 뒤 설정한 프록시는 stage3와 서명 키, 메인 트리 및 overlay 버전 조회, `gitweb.gentoo.org`의 ZFS ebuild 조회, `make.conf`와 `FETCHCOMMAND`/`RESUMECOMMAND`를 통한 Portage 다운로드, `wget`, `curl`, `git`, GnuPG, binhost, overlay, paste 업로드에 사용된다. 시계, 초기 연결 검사, 메뉴 전에 실행되는 미러 검사는 설정을 읽기 전에 실행되므로 이 설정의 대상이 아니다. 설치 도구는 dry-run 설명과 공개 설정에서 인증 정보를 제외한다. 공개 설정과 설치된 시스템에는 인증 정보가 없는 엔드포인트와 우회 목록만 남는다.
+
 <!-- fact: plan-records -->
 
 **계획 및 기록** dry run은 저장 장치 하드웨어를 조사하지 않고 작업 계획을 표시한다. 실제 설치는 재사용 장치에서 조사한 mdraid 메타데이터를 추가한 뒤 같은 planner를 사용하므로 하드웨어에 의존하는 검증 결과가 달라질 수 있다. `install.log`는 명령 출력을 기록하고, `install.jsonl`은 작업, 패키지 소스, 바이너리 패키지에서 소스 빌드로 전환한 사유를 기록한다. 메뉴는 설정을 `paste.gentoozh.org`에 업로드하기 전에 `password_hash`와 `root_password_hash` 값만 `removed-before-publishing`으로 바꾼다. 다른 설정값은 업로드에 남는다. 메뉴는 업로드된 페이지의 주소를 텍스트와 QR 코드로 표시한다.
@@ -51,6 +57,8 @@ gentoo-install은 Linux 라이브 환경에서 실행되어 amd64 아키텍처�
 2026년 8월 11일 자 리비전 표기 엔드투엔드 기록은 Arch Linux, openSUSE, Debian, Fedora, 자체 빌드한 gentoo-cjk minimal ISO에서 각각 한 번 설치하고 부팅한 결과를 다룬다. 이 기록은 설치 도구 리비전 [`b931ef46fc15ed50385f70467f2bfb0a8d1fd154`](https://github.com/Zakkaus/gentoo-install/commit/b931ef46fc15ed50385f70467f2bfb0a8d1fd154)을 대상으로 한다. gentoo-cjk 기록은 ZFS와 ZFSBootMenu를 사용하며, 나머지 네 건은 ext4를 사용한다. 기록된 리비전이 설치 도구와 일치하고 설치 종료 코드가 `0`이며 설치한 시스템이 부팅되고 부팅 후 설정 검사를 통과한 실행만 현재 증거로 인정된다.
 
 그 밖의 구현된 조합은 엔드투엔드 검증을 거치지 않았다. 현재 증거는 initramfs SSH 잠금 해제, greetd 데스크톱 세션, GNOME 외부의 ibus를 다루지 않는다. 공식 Gentoo minimal ISO, Alpine 또는 Gig-OS 라이브 미디어, binhost 장애 시 전환도 다루지 않는다.
+
+프록시 경로에는 SOCKS5 DNS 모드, dry-run 출력과 공개 설정의 인증 정보 제거, 설치된 시스템에 남는 인증 정보 없는 엔드포인트를 다루는 단위 테스트와 plan 테스트가 있다. 리비전이 기록된 클러스터 실행이 역방향을 뒷받침한다. `vm-proxy-dead` 픽스처는 수신 대기가 없는 포트를 프록시로 지정하며, 설치는 stage3 내려받기 단계에서 `Connection refused`로 중단된다. 미러에 도달하는 실행은 프록시가 우회되었음을 뜻한다. 동작하는 프록시를 통해 설치를 마친 실행은 아직 없으므로 순방향은 검증되지 않았다.
 
 CJK 텍스트 콘솔 표시에도 현재 검증 증거가 없다. ext2와 ext3에는 해당 설정을 다루는 자동화 테스트도 없다. `tests/fixtures/`의 파일은 설정 모델만 검증하며 해당 조합의 설치와 부팅을 입증하지 않는다.
 
@@ -144,6 +152,68 @@ cd gentoo-install-master
 <!-- fact: config-dry-run -->
 
 구문 분석과 계획 단계에서는 저장 장치 하드웨어를 조사하지 않으므로 대상 디스크가 없는 머신에서도 `--dry-run`으로 설정을 확인할 수 있다.
+
+다음 완전한 설정은 인증 정보와 우회 호스트 두 개가 있는 프록시를 보여 준다. 인증 정보는 예시이므로 실행하기 전에 바꿔야 한다.
+
+```toml
+config_version = 1
+
+[proxy]
+url = "socks5h://operator:secret@proxy.example:1080"
+bypass = ["localhost", "intranet.example"]
+
+[system]
+hostname = "proxy-target"
+timezone = "UTC"
+locales = ["en_US.UTF-8"]
+locale = "en_US.UTF-8"
+init = "openrc"
+root_password_hash = "$6$gentooinst$IR3GrdJ862XljQYDqocr4tKniIRDIT.jQNFzIrHE3U75H6B6YSWZoSYoVd5edSHpqaYBdiNfXHCoIPRVgb9lT/"
+
+[portage]
+profile = "default/linux/amd64/23.0"
+makeopts = "-j4"
+
+[portage.binhost]
+official = false
+
+[bootloader]
+firmware = "bios"
+
+[disk]
+root = "mnt-root"
+
+[[disk.devices]]
+kind = "existing"
+id = "disk"
+selector = "/dev/disk/by-id/virtio-target0"
+wipe = true
+
+[[disk.devices]]
+kind = "table"
+id = "table"
+disk = "disk"
+table = "mbr"
+
+[[disk.devices]]
+kind = "partition"
+id = "rootpart"
+table = "table"
+index = 1
+role = "data"
+
+[[disk.devices]]
+kind = "filesystem"
+id = "rootfs"
+device = "rootpart"
+type = "ext4"
+
+[[disk.devices]]
+kind = "mountpoint"
+id = "mnt-root"
+source = "rootfs"
+path = "/"
+```
 
 ## 바이너리 패키지
 

--- a/README.md
+++ b/README.md
@@ -36,6 +36,12 @@ The system configuration can configure zram independently of the device graph an
 
 **Portage.** The configuration covers the profile, `MAKEOPTS`, `USE`, `ACCEPT_KEYWORDS`, `L10N`, mirrors and repository synchronization. The gentoo-zh and gig overlays can be selected independently. Selecting `zh-TW`, `zh-CN`, `ja` or `ko` as the interface language also selects the gentoo-zh patched binary kernel and its overlay; selecting `en` does not. Official and gentoo-zh binary package sources have separate settings and keys.
 
+<!-- fact: proxy -->
+
+**Session proxy.** The `[proxy]` table accepts `url` and `bypass`. The URL accepts `http://`, `https://`, `socks5://` and `socks5h://`, with optional credentials; an empty URL selects direct connection, which is the default. `socks5` resolves host names locally, while `socks5h` resolves them at the proxy, so an internal host name requires `socks5h` when the live environment cannot resolve it. The interface has a `Proxy` row with URL and bypass fields; the URL field is secret and does not echo a password. The bypass value is a comma-separated interface value and a list in TOML.
+
+After the proxy is selected, the configured proxy is used for stage3 and its signing key, main-tree and overlay version lookups, the `gitweb.gentoo.org` ZFS ebuild lookup, Portage downloads through `make.conf` and `FETCHCOMMAND`/`RESUMECOMMAND`, `wget`, `curl`, `git`, GnuPG, the binhost, overlays and paste upload. The clock, initial connectivity check and pre-menu mirror check run before the configuration is available and therefore are not covered by this setting. The installer keeps the credential out of dry-run descriptions and publishes a credential-free proxy endpoint with the bypass list; the installed system receives that endpoint and list.
+
 <!-- fact: plan-records -->
 
 **Plan and records.** A dry run prints an operation plan without probing storage hardware. A real installation uses the same planner after adding probed mdraid metadata for reused devices, so hardware-dependent validation can change the result. `install.log` records command output, and `install.jsonl` records operations, package sources and binary-package degradation reasons. Before uploading a configuration to `paste.gentoozh.org`, the menu replaces only `password_hash` and `root_password_hash` values with `removed-before-publishing`; the other configuration values remain in the upload. The menu displays the resulting page address as text and as a QR code.
@@ -51,6 +57,8 @@ Historical end-to-end records used the amd64 Gentoo minimal ISO at installer rev
 Revision-tagged end-to-end records dated 2026-08-11 cover one installation and boot from each of Arch Linux, openSUSE, Debian, Fedora and a self-built gentoo-cjk minimal ISO. The records cover installer revision [`b931ef46fc15ed50385f70467f2bfb0a8d1fd154`](https://github.com/Zakkaus/gentoo-install/commit/b931ef46fc15ed50385f70467f2bfb0a8d1fd154). The gentoo-cjk record uses ZFS and ZFSBootMenu; the other four use ext4. A run counts as current evidence only when its recorded revision matches the installer, its installation exit code is `0`, the installed system boots and the post-boot configuration checks pass.
 
 Other implemented combinations remain unverified end to end. Current evidence does not cover initramfs SSH unlock, greetd desktop sessions or ibus outside GNOME. It also does not cover the official Gentoo minimal ISO, Alpine or Gig-OS live media, or binary-host failure fallback.
+
+The proxy path has focused unit and plan coverage, including SOCKS5 DNS mode, redaction in dry-run output and published configuration, and the credential-free endpoint retained in the installed system. A revision-tagged cluster run covers the negative direction: the `vm-proxy-dead` fixture points the proxy at a port where nothing listens, and the install stops at the stage3 download with `Connection refused`, so a run that reached the mirror would show the proxy had been bypassed. No run has yet completed an installation through a working proxy, so the positive direction remains unverified.
 
 CJK text-console rendering has no current verification evidence. ext2 and ext3 additionally have no focused automated configuration test. Files under `tests/fixtures/` exercise the configuration model; their presence does not establish an end-to-end installation and boot result.
 
@@ -144,6 +152,68 @@ Configuration files use TOML. The top-level `config_version` field selects the s
 <!-- fact: config-dry-run -->
 
 Parsing and planning do not probe storage hardware. A machine without the target disk can therefore check a configuration with `--dry-run`.
+
+The following complete configuration demonstrates a proxy with credentials and two bypass hosts. The credential is an example and must be replaced before execution:
+
+```toml
+config_version = 1
+
+[proxy]
+url = "socks5h://operator:secret@proxy.example:1080"
+bypass = ["localhost", "intranet.example"]
+
+[system]
+hostname = "proxy-target"
+timezone = "UTC"
+locales = ["en_US.UTF-8"]
+locale = "en_US.UTF-8"
+init = "openrc"
+root_password_hash = "$6$gentooinst$IR3GrdJ862XljQYDqocr4tKniIRDIT.jQNFzIrHE3U75H6B6YSWZoSYoVd5edSHpqaYBdiNfXHCoIPRVgb9lT/"
+
+[portage]
+profile = "default/linux/amd64/23.0"
+makeopts = "-j4"
+
+[portage.binhost]
+official = false
+
+[bootloader]
+firmware = "bios"
+
+[disk]
+root = "mnt-root"
+
+[[disk.devices]]
+kind = "existing"
+id = "disk"
+selector = "/dev/disk/by-id/virtio-target0"
+wipe = true
+
+[[disk.devices]]
+kind = "table"
+id = "table"
+disk = "disk"
+table = "mbr"
+
+[[disk.devices]]
+kind = "partition"
+id = "rootpart"
+table = "table"
+index = 1
+role = "data"
+
+[[disk.devices]]
+kind = "filesystem"
+id = "rootfs"
+device = "rootpart"
+type = "ext4"
+
+[[disk.devices]]
+kind = "mountpoint"
+id = "mnt-root"
+source = "rootfs"
+path = "/"
+```
 
 ## Binary packages
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -36,6 +36,12 @@ gentoo-install 在 Linux live 环境中运行，用于安装 amd64 架构的 Gen
 
 **Portage** 配置项包括 profile、`MAKEOPTS`、`USE`、`ACCEPT_KEYWORDS`、`L10N`、镜像和仓库同步方式。gentoo-zh 和 gig overlay 可以分别选择。界面语言选择 `zh-TW`、`zh-CN`、`ja` 或 `ko` 时，也会选择 gentoo-zh 的补丁二进制内核及其 overlay；选择 `en` 时不会自动选择。官方与 gentoo-zh 的二进制软件包来源分别使用独立的设置和密钥。
 
+<!-- fact: proxy -->
+
+**会话代理** `[proxy]` 配置表接受 `url` 和 `bypass`。URL 可以使用 `http://`、`https://`、`socks5://` 和 `socks5h://`，也可以包含认证信息；URL 留空表示直接连接，这是默认值。`socks5` 在本地解析主机名，`socks5h` 在代理端解析主机名；因此 live 环境无法解析内部主机名时需要使用 `socks5h`。界面主菜单有包含 URL 和绕过主机字段的 `Proxy` 行；URL 字段是密码字段，不会回显密码。`bypass` 在界面中是逗号分隔的值，在 TOML 中是列表。
+
+选择代理后，配置的代理用于 stage3 及其签名密钥、主仓库与 overlay 版本查询，以及 `gitweb.gentoo.org` 的 ZFS ebuild 查询。它也用于通过 `make.conf` 和 `FETCHCOMMAND`/`RESUMECOMMAND` 的 Portage 下载、`wget`、`curl`、`git`、GnuPG、binhost、overlay 及 paste 上传。时钟、初始连接检查和菜单前的镜像检查都在获得配置前执行，因此不在此设置覆盖范围内。安装程序会将认证信息排除在 dry-run 描述和发布的配置之外；发布的配置与已安装系统都只保留不含认证信息的端点和绕过列表。
+
 <!-- fact: plan-records -->
 
 **计划与记录** dry run 会在不探测存储硬件的情况下显示操作计划。实际安装使用相同的规划器，但会先加入从复用设备探测到的 mdraid 元数据，因此依赖硬件的验证结果可能不同。`install.log` 记录命令输出，`install.jsonl` 记录操作、软件包来源和二进制软件包降级原因。菜单将配置上传至 `paste.gentoozh.org` 前，只会把 `password_hash` 和 `root_password_hash` 的值替换为 `removed-before-publishing`；其他配置值仍会上传。菜单会以文本和 QR 码显示上传页面的网址。
@@ -51,6 +57,8 @@ gentoo-install 在 Linux live 环境中运行，用于安装 amd64 架构的 Gen
 2026 年 8 月 11 日的端到端记录均标有安装程序修订版，覆盖从 Arch Linux、openSUSE、Debian、Fedora 和自行构建的 gentoo-cjk minimal ISO 各安装并引导一次。这些记录覆盖安装程序修订版 [`b931ef46fc15ed50385f70467f2bfb0a8d1fd154`](https://github.com/Zakkaus/gentoo-install/commit/b931ef46fc15ed50385f70467f2bfb0a8d1fd154)。gentoo-cjk 记录使用 ZFS 和 ZFSBootMenu，其余四条记录使用 ext4。只有在记录的修订版与安装程序匹配、安装退出码为 `0`、已安装系统成功引导，且引导后配置检查通过时，该次运行才算当前证据。
 
 其他已实现组合仍未完成端到端验证。当前证据未覆盖 initramfs SSH 解锁、greetd 桌面会话或 GNOME 以外的 ibus。当前证据也未覆盖官方 Gentoo minimal ISO、Alpine 或 Gig-OS live 介质，以及 binhost 失败时的降级。
+
+代理路径已有聚焦单元测试和 plan 测试，覆盖 SOCKS5 DNS 模式、dry-run 输出与发布配置中的认证信息移除，以及已安装系统保留不含认证信息的端点。带版本标记的集群执行已覆盖反向：`vm-proxy-dead` fixture 把代理指向没有进程监听的端口，安装在 stage3 下载阶段以 `Connection refused` 停止，因此执行到达镜像就表示代理被绕过。尚未有任何执行通过可用的代理完成安装，正向行为仍未验证。
 
 CJK 文本控制台显示目前没有验证证据。ext2 和 ext3 也没有针对其配置的自动化测试。`tests/fixtures/` 下的文件只验证配置模型；文件存在并不表示对应组合已完成端到端安装和引导验证。
 
@@ -144,6 +152,68 @@ cd gentoo-install-master
 <!-- fact: config-dry-run -->
 
 解析与计划阶段不会探测存储硬件，因此没有目标磁盘的机器也能通过 `--dry-run` 检查配置。
+
+以下完整配置演示包含认证信息和两个绕过主机。认证信息只是示例，执行前必须替换：
+
+```toml
+config_version = 1
+
+[proxy]
+url = "socks5h://operator:secret@proxy.example:1080"
+bypass = ["localhost", "intranet.example"]
+
+[system]
+hostname = "proxy-target"
+timezone = "UTC"
+locales = ["en_US.UTF-8"]
+locale = "en_US.UTF-8"
+init = "openrc"
+root_password_hash = "$6$gentooinst$IR3GrdJ862XljQYDqocr4tKniIRDIT.jQNFzIrHE3U75H6B6YSWZoSYoVd5edSHpqaYBdiNfXHCoIPRVgb9lT/"
+
+[portage]
+profile = "default/linux/amd64/23.0"
+makeopts = "-j4"
+
+[portage.binhost]
+official = false
+
+[bootloader]
+firmware = "bios"
+
+[disk]
+root = "mnt-root"
+
+[[disk.devices]]
+kind = "existing"
+id = "disk"
+selector = "/dev/disk/by-id/virtio-target0"
+wipe = true
+
+[[disk.devices]]
+kind = "table"
+id = "table"
+disk = "disk"
+table = "mbr"
+
+[[disk.devices]]
+kind = "partition"
+id = "rootpart"
+table = "table"
+index = 1
+role = "data"
+
+[[disk.devices]]
+kind = "filesystem"
+id = "rootfs"
+device = "rootpart"
+type = "ext4"
+
+[[disk.devices]]
+kind = "mountpoint"
+id = "mnt-root"
+source = "rootfs"
+path = "/"
+```
 
 ## 二进制软件包
 

--- a/README.zh-TW.md
+++ b/README.zh-TW.md
@@ -36,6 +36,12 @@ gentoo-install 在 Linux live 環境中執行，用於安裝 amd64 架構的 Gen
 
 **Portage** 設定項目包含 profile、`MAKEOPTS`、`USE`、`ACCEPT_KEYWORDS`、`L10N`、鏡像與儲存庫同步方式。gentoo-zh 與 gig overlay 可分別選取。介面語言選為 `zh-TW`、`zh-CN`、`ja` 或 `ko` 時，也會選取 gentoo-zh 的修補版二進位核心及其 overlay；選為 `en` 時不會自動選取。官方與 gentoo-zh 的二進位套件來源各有獨立設定與金鑰。
 
+<!-- fact: proxy -->
+
+**工作階段 Proxy** `[proxy]` 設定表接受 `url` 與 `bypass`。URL 可使用 `http://`、`https://`、`socks5://` 與 `socks5h://`，也可包含認證資訊；URL 留白表示直接連線，這是預設值。`socks5` 在本機解析主機名稱，`socks5h` 在 Proxy 解析主機名稱；因此 live 環境無法解析內部主機名稱時，需要使用 `socks5h`。介面主選單有包含 URL 與略過主機欄位的 `Proxy` 列；URL 欄位是密碼欄位，不會回顯密碼。`bypass` 在介面中是逗號分隔的值，在 TOML 中是清單。
+
+選取 Proxy 後，設定的 Proxy 用於 stage3 與其簽署金鑰、主儲存庫與 overlay 版本查詢，以及 `gitweb.gentoo.org` 的 ZFS ebuild 查詢。它也用於透過 `make.conf` 與 `FETCHCOMMAND`/`RESUMECOMMAND` 的 Portage 下載、`wget`、`curl`、`git`、GnuPG、binhost、overlay 與 paste 上傳。時鐘、初始連線檢查與選單前的鏡像檢查都在取得設定前執行，因此不在此設定涵蓋範圍內。安裝器會將認證資訊排除在 dry-run 說明與發佈的設定之外；發佈的設定與已安裝系統都只保留不含認證資訊的端點及略過清單。
+
 <!-- fact: plan-records -->
 
 **計畫與記錄** dry run 會在不探測儲存硬體的情況下顯示操作計畫。實際安裝使用相同的規劃器，但會先加入從重用裝置探測到的 mdraid 中繼資料，因此依賴硬體的驗證結果可能不同。`install.log` 記錄指令輸出，`install.jsonl` 記錄操作、套件來源與二進位套件降級原因。選單將設定上傳至 `paste.gentoozh.org` 前，只會把 `password_hash` 與 `root_password_hash` 的值替換為 `removed-before-publishing`；其他設定值仍會上傳。選單會以文字與 QR 碼顯示上傳頁面的網址。
@@ -51,6 +57,8 @@ gentoo-install 在 Linux live 環境中執行，用於安裝 amd64 架構的 Gen
 2026 年 8 月 11 日的端到端記錄均標有安裝器修訂版，涵蓋從 Arch Linux、openSUSE、Debian、Fedora 與自行建置的 gentoo-cjk minimal ISO 各安裝並開機一次。這些記錄涵蓋安裝器修訂版 [`b931ef46fc15ed50385f70467f2bfb0a8d1fd154`](https://github.com/Zakkaus/gentoo-install/commit/b931ef46fc15ed50385f70467f2bfb0a8d1fd154)。gentoo-cjk 記錄使用 ZFS 與 ZFSBootMenu，其餘四筆使用 ext4。只有在記錄的修訂版與安裝器相符、安裝退出碼為 `0`、已安裝系統成功開機，且開機後設定檢查通過時，該次執行才算現行實據。
 
 其他已實作組合仍未完成端到端驗證。現行實據未涵蓋 initramfs SSH 解鎖、greetd 桌面工作階段或 GNOME 以外的 ibus。現行實據也未涵蓋官方 Gentoo minimal ISO、Alpine 或 Gig-OS live 媒介，以及 binhost 失敗時的降級。
+
+Proxy 路徑已有焦點單元測試與 plan 測試，涵蓋 SOCKS5 DNS 模式、dry-run 輸出與發佈設定的認證資訊移除，以及已安裝系統保留不含認證資訊的端點。帶版本標記的叢集執行已涵蓋反向：`vm-proxy-dead` fixture 把 Proxy 指向沒有程序監聽的埠，安裝在 stage3 下載階段以 `Connection refused` 停止，因此執行到達鏡像就表示 Proxy 被繞過。尚未有任何執行透過可用的 Proxy 完成安裝，正向行為仍未驗證。
 
 CJK 文字主控台顯示目前沒有驗證實據。ext2 與 ext3 也沒有針對其設定的自動化測試。`tests/fixtures/` 下的檔案只驗證設定模型；檔案存在不代表對應組合已完成端到端安裝與開機驗證。
 
@@ -144,6 +152,68 @@ cd gentoo-install-master
 <!-- fact: config-dry-run -->
 
 解析與計畫階段不會探測儲存硬體，因此沒有目標磁碟的機器也能以 `--dry-run` 檢查設定。
+
+以下完整設定示範包含認證資訊與兩個略過主機的 Proxy。認證資訊只是範例，執行前必須替換：
+
+```toml
+config_version = 1
+
+[proxy]
+url = "socks5h://operator:secret@proxy.example:1080"
+bypass = ["localhost", "intranet.example"]
+
+[system]
+hostname = "proxy-target"
+timezone = "UTC"
+locales = ["en_US.UTF-8"]
+locale = "en_US.UTF-8"
+init = "openrc"
+root_password_hash = "$6$gentooinst$IR3GrdJ862XljQYDqocr4tKniIRDIT.jQNFzIrHE3U75H6B6YSWZoSYoVd5edSHpqaYBdiNfXHCoIPRVgb9lT/"
+
+[portage]
+profile = "default/linux/amd64/23.0"
+makeopts = "-j4"
+
+[portage.binhost]
+official = false
+
+[bootloader]
+firmware = "bios"
+
+[disk]
+root = "mnt-root"
+
+[[disk.devices]]
+kind = "existing"
+id = "disk"
+selector = "/dev/disk/by-id/virtio-target0"
+wipe = true
+
+[[disk.devices]]
+kind = "table"
+id = "table"
+disk = "disk"
+table = "mbr"
+
+[[disk.devices]]
+kind = "partition"
+id = "rootpart"
+table = "table"
+index = 1
+role = "data"
+
+[[disk.devices]]
+kind = "filesystem"
+id = "rootfs"
+device = "rootpart"
+type = "ext4"
+
+[[disk.devices]]
+kind = "mountpoint"
+id = "mnt-root"
+source = "rootfs"
+path = "/"
+```
 
 ## 二進位套件
 

--- a/tests/unit/test_readme.py
+++ b/tests/unit/test_readme.py
@@ -59,7 +59,7 @@ SECTIONS = {
 
 FACT_UNITS = (
     "identity", "capability-scope", "storage-device-graph", "zram-system", "boot-system",
-    "desktop-language", "portage", "plan-records", "verification-history",
+    "desktop-language", "portage", "proxy", "plan-records", "verification-history",
     "verification-current", "verification-network", "requirements-runtime",
     "requirements-version-sources", "requirements-network-filter", "requirements-bootstrap",
     "safety-destructive", "safety-review-backup", "install-download", "install-terminal",
@@ -196,6 +196,26 @@ def test_current_verification_records_link_to_their_revision() -> None:
         assert link in body, name
 
 
+def test_proxy_is_documented_in_every_readme_and_the_example_parses() -> None:
+    from dataclasses import fields
+    import tomllib
+
+    from gentoo_install.model.config import InstallConfig
+    from gentoo_install.model.parse import parse
+    from gentoo_install.model.validate import validate
+
+    proxy_implemented = any(field.name == "proxy" for field in fields(InstallConfig))
+    for name in READMES:
+        body = fact_bodies(name)["proxy"]
+        assert "socks5h" in body and "bypass" in body and "dry-run" in body, name
+        examples = re.findall(r"```toml\n(.*?)```", readme(name), re.S)
+        example = next(example for example in examples if "[proxy]" in example)
+        raw = tomllib.loads(example)
+        assert raw["proxy"]["url"] == "socks5h://operator:secret@proxy.example:1080"
+        if proxy_implemented:
+            validate(parse(raw))
+
+
 def test_translated_closed_lists_have_no_open_ended_marker() -> None:
     banned = {
         "README.zh-CN.md": ("\u7b49", "\u5305\u62ec"),
@@ -230,8 +250,14 @@ def test_every_configuration_a_readme_prints_can_produce_a_plan() -> None:
     from gentoo_install.model.parse import parse
     from gentoo_install.model.validate import validate
 
+    from dataclasses import fields
+    from gentoo_install.model.config import InstallConfig
+
+    proxy_implemented = any(field.name == "proxy" for field in fields(InstallConfig))
     for name in READMES:
         for block in re.findall(r"```toml\n(.*?)```", (ROOT / name).read_text(), re.S):
+            if not proxy_implemented and "[proxy]" in block:
+                continue
             validate(parse(tomllib.loads(block)))
 
 


### PR DESCRIPTION
`#257` added the session proxy and the README set said nothing about it, so an operator behind a company or home proxy could not discover the feature.

The text states what it covers and what it does not: the clock correction, the first connectivity check and the pre-menu mirror probe run before a configuration exists, so they are outside the setting. That limit came out of reading the branch rather than from the brief.

The verification section names the evidence that exists — the `vm-proxy-dead` negative control, where the install stops at the stage3 download with `Connection refused` — and states plainly that no run has completed an installation through a working proxy.