### PR TITLE
plan: derive the boot facts once for the kernel and the bootloader

### DIFF
--- a/gentoo_install/plan/bootloader.py
+++ b/gentoo_install/plan/bootloader.py
@@ -15,12 +15,13 @@ from dataclasses import dataclass
 from pathlib import PurePosixPath
 from typing import Final
 
-from ..errors import ConfigError, NothingToBoot
+from ..errors import ConfigError, InvalidLayout, NothingToBoot
 from ..model import compat
 from ..model.config import Bootloader, Firmware, InitSystem, InstallConfig, RemoteUnlock
 from ..model.device import (
     Existing,
     DeviceId,
+    Filesystem,
     MdRaid,
     Mountpoint,
     Partition,
@@ -28,6 +29,7 @@ from ..model.device import (
     PartitionTable,
     ZfsDataset,
     ZfsPool,
+    Subvolume,
 )
 from .operations import CommandOutput, Context, Operation, Stage
 from .portage import Emerge, InstallMode, PortageConfigKind, WritePortageConfig
@@ -90,6 +92,21 @@ EFI_PACKAGE: Final[str] = "sys-boot/efibootmgr"
 #: It names the image after the kernel, so the name is looked up, not assumed.
 ZBM_DIRECTORY: Final[str] = "EFI/zbm"
 FALLBACK_IMAGE: Final[str] = "EFI/BOOT/BOOTX64.EFI"
+
+
+@dataclass(frozen=True, kw_only=True)
+class BootFacts:
+    """Boot inputs derived once from the device graph and configuration."""
+
+    root: DeviceId | None
+    dataset: str
+    root_parameters: tuple[str, ...]
+    containers: tuple[DeviceId, ...]
+    arrays: tuple[DeviceId, ...]
+    keymap: str
+    unlock_parameters: tuple[str, ...]
+    pool: str
+    pool_dataset: str
 
 #: ZFSBootMenu's dracut tree is separate from the installed system's tree.
 ZBM_REMOTE_CONFIG: Final[PurePosixPath] = PurePosixPath(
@@ -441,6 +458,7 @@ class InstallZfsBootMenu(Operation):
 
 def build(config: InstallConfig) -> list[Operation]:
     kind = config.bootloader.kind
+    facts = boot_facts(config)
     mount = compat.esp_mount(config.disk.graph)
     esp = mount.path if mount is not None else None
     esp_device = _esp_partition(config)
@@ -457,12 +475,12 @@ def build(config: InstallConfig) -> list[Operation]:
     if kind is Bootloader.GRUB:
         operations += [
             WriteGrubDefaults(
-                kernel_params=(*unlock_parameters(config), *config.bootloader.kernel_params),
+                kernel_params=(*facts.unlock_parameters, *config.bootloader.kernel_params),
                 cryptodisk=compat.boot_is_encrypted(config.disk.graph),
                 serial=serial_console(config),
-                luks=initramfs_devices(config)[0],
-                arrays=initramfs_devices(config)[1],
-                keymap=initramfs_keymap(config),
+                luks=facts.containers,
+                arrays=facts.arrays,
+                keymap=facts.keymap,
             ),
             InstallGrub(
                 firmware=config.bootloader.firmware,
@@ -490,7 +508,6 @@ def build(config: InstallConfig) -> list[Operation]:
             ShowTheBootMenu(esp=esp),
         ]
     elif kind is Bootloader.ZFSBOOTMENU and esp is not None and esp_device is not None:
-        pool, dataset = _root_pool_and_dataset(config)
         operations += [
             # Without the stub systemd ships behind its `boot` flag,
             # generate-zbm writes loose components and no bootable image.
@@ -510,8 +527,8 @@ def build(config: InstallConfig) -> list[Operation]:
             )
         operations += [
             InstallZfsBootMenu(
-                pool=pool,
-                dataset=dataset,
+                pool=facts.pool,
+                dataset=facts.pool_dataset,
                 esp=esp,
                 esp_device=esp_device,
                 kernel_params=config.bootloader.kernel_params,
@@ -519,6 +536,52 @@ def build(config: InstallConfig) -> list[Operation]:
             ),
         ]
     return operations
+
+
+def boot_facts(config: InstallConfig) -> BootFacts:
+    """Derive every root and initramfs input shared by boot planners."""
+    graph = config.disk.graph
+    root = graph[config.disk.root]
+    source = graph[root.source] if isinstance(root, Mountpoint) else root
+    if isinstance(source, ZfsDataset):
+        pool = graph[source.pool]
+        if not isinstance(pool, ZfsPool):
+            raise InvalidLayout(f"{source.id} does not refer to a ZFS pool")
+        root_device: DeviceId | None = None
+        dataset = f"{pool.name}/{source.name}"
+        root_parameters: tuple[str, ...] = ()
+        pool_name = pool.name
+        pool_dataset = dataset
+    elif isinstance(source, Subvolume):
+        filesystem = graph[source.filesystem]
+        if not isinstance(filesystem, Filesystem):
+            raise InvalidLayout(f"{source.id} does not refer to a filesystem")
+        root_device = filesystem.device
+        dataset = ""
+        root_parameters = (f"rootflags=subvol={source.name}",)
+        pool_name = ""
+        pool_dataset = ""
+    elif isinstance(source, Filesystem):
+        root_device = source.device
+        dataset = ""
+        root_parameters = ()
+        pool_name = ""
+        pool_dataset = ""
+    else:
+        raise InvalidLayout(f"{config.disk.root} is not something a boot entry can mount")
+    containers = tuple(node.backing for node in compat.early_containers(graph))
+    arrays = tuple(node.id for node in graph.of_type(MdRaid))
+    return BootFacts(
+        root=root_device,
+        dataset=dataset,
+        root_parameters=root_parameters,
+        containers=containers,
+        arrays=arrays,
+        keymap=initramfs_keymap(config),
+        unlock_parameters=unlock_parameters(config),
+        pool=pool_name,
+        pool_dataset=pool_dataset,
+    )
 
 
 def _bios_boot_devices(config: InstallConfig) -> tuple[DeviceId, ...]:
@@ -608,10 +671,8 @@ def initramfs_devices(config: InstallConfig) -> tuple[tuple[DeviceId, ...], tupl
     One function for both command line writers: deriving it twice is how
     systemd-boot came to omit the arrays that GRUB was given.
     """
-    graph = config.disk.graph
-    containers = tuple(node.backing for node in compat.early_containers(graph))
-    arrays = tuple(node.id for node in graph.of_type(MdRaid))
-    return containers, arrays
+    facts = boot_facts(config)
+    return facts.containers, facts.arrays
 
 
 def array_parameters(context: Context, devices: tuple[DeviceId, ...]) -> tuple[str, ...]:
@@ -665,25 +726,3 @@ def _esp_partition(config: InstallConfig) -> DeviceId | None:
         if isinstance(graph[parent], Existing):
             return graph[parent].id
     return None
-
-
-def _root_pool_and_dataset(config: InstallConfig) -> tuple[str, str]:
-    """The pool `/` is on and the dataset that holds it, from one graph edge.
-
-    Both were read separately, and the pool was whichever `ZfsPool` came first
-    in the graph: a layout with a data pool beside the root pool had
-    `bootfs=tank/ROOT/gentoo` set on `tank`, a dataset no pool has, and the
-    install stopped at the bootloader with everything else already written.
-    Reordering two equivalent `disk.devices` entries changed the answer.
-    """
-    graph = config.disk.graph
-    root = graph.nodes.get(config.disk.root)
-    if not isinstance(root, Mountpoint):
-        return "", ""
-    dataset = graph.nodes.get(root.source)
-    if not isinstance(dataset, ZfsDataset):
-        return "", ""
-    pool = graph.nodes.get(dataset.pool)
-    if not isinstance(pool, ZfsPool):
-        return "", ""
-    return pool.name, f"{pool.name}/{dataset.name}"

--- a/gentoo_install/plan/kernel.py
+++ b/gentoo_install/plan/kernel.py
@@ -21,21 +21,11 @@ from ..model.device import (
     FilesystemType,
     Luks,
     MdRaid,
-    Mountpoint,
-    Subvolume,
     VolumeGroup,
-    ZfsDataset,
     ZfsPool,
 )
-from .bootloader import (
-    array_parameters,
-    initramfs_devices,
-    keymap_parameters,
-    luks_parameters,
-)
+from .bootloader import array_parameters, boot_facts, keymap_parameters, luks_parameters
 from .bootloader import GenerateHostId
-from .bootloader import initramfs_keymap as bootloader_keymap
-from .bootloader import unlock_parameters
 from .operations import Context, Operation, Stage
 from .portage import (
     Emerge,
@@ -660,17 +650,17 @@ def build(config: InstallConfig) -> list[Operation]:
     if graph.of_type(ZfsPool):
         operations.append(VerifyZfsKernelCompatibility(version=config.kernel.version))
     if entries:
-        root, dataset, extra = _root_parameters(config)
+        facts = boot_facts(config)
         operations.append(
             WriteKernelCmdline(
-                root=root,
-                dataset=dataset,
-                luks=initramfs_devices(config)[0],
-                arrays=initramfs_devices(config)[1],
-                keymap=bootloader_keymap(config),
+                root=facts.root,
+                dataset=facts.dataset,
+                luks=facts.containers,
+                arrays=facts.arrays,
+                keymap=facts.keymap,
                 kernel_params=(
-                    *extra,
-                    *unlock_parameters(config),
+                    *facts.root_parameters,
+                    *facts.unlock_parameters,
                     *config.bootloader.kernel_params,
                 ),
             )
@@ -926,25 +916,3 @@ def storage_packages(
         if package not in wanted:
             wanted.append(package)
     return tuple(wanted)
-
-
-def _root_parameters(config: InstallConfig) -> tuple[DeviceId | None, str, tuple[str, ...]]:
-    """What a boot entry needs to find the root: a device, or a dataset name.
-
-    A subvolume root also needs `rootflags`, because the initramfs mounts the
-    filesystem's default subvolume otherwise.
-    """
-    graph = config.disk.graph
-    mount = graph[config.disk.root]
-    source = graph[mount.source] if isinstance(mount, Mountpoint) else mount
-    if isinstance(source, ZfsDataset):
-        pool = graph[source.pool]
-        name = pool.name if isinstance(pool, ZfsPool) else ""
-        return None, f"{name}/{source.name}", ()
-    if isinstance(source, Subvolume):
-        filesystem = graph[source.filesystem]
-        if isinstance(filesystem, Filesystem):
-            return filesystem.device, "", (f"rootflags=subvol={source.name}",)
-    if isinstance(source, Filesystem):
-        return source.device, "", ()
-    raise InvalidLayout(f"{config.disk.root} is not something a boot entry can mount")

--- a/tests/unit/test_plan_boot.py
+++ b/tests/unit/test_plan_boot.py
@@ -393,7 +393,8 @@ def test_the_boot_entry_names_the_root_the_layout_actually_has() -> None:
         ("tests/fixtures/zfs-zbm.toml", "root=ZFS="),
     ):
         installation = load(Path(fixture))
-        root, dataset, extra = kernel._root_parameters(installation)
+        facts = bootloader.boot_facts(installation)
+        root, dataset, extra = facts.root, facts.dataset, facts.root_parameters
         recorder = Recorder()
         kernel.WriteKernelCmdline(root=root, dataset=dataset, kernel_params=extra).apply(
             recorder
@@ -964,6 +965,46 @@ def test_zfsbootmenu_configures_the_pool_the_root_is_on() -> None:
         if isinstance(operation, InstallZfsBootMenu)
     ]
     assert (alone[0].pool, alone[0].dataset) == (installed[0].pool, installed[0].dataset)
+
+
+def test_kernel_and_zfsbootmenu_use_the_same_root_facts() -> None:
+    """A data pool before the root pool cannot change either boot input."""
+    from gentoo_install.model.config import Bootloader
+    from gentoo_install.model.device import DeviceId, Existing
+    from gentoo_install.plan.bootloader import InstallZfsBootMenu
+    from gentoo_install.plan.kernel import WriteKernelCmdline
+
+    installation = zfs_installation()
+    nodes = [
+        Existing(id=DeviceId("datadisk"), selector="/dev/disk/by-id/virtio-data", wipe=True),
+        ZfsPool(id=DeviceId("tank"), vdevs=(DeviceId("datadisk"),), name="tank"),
+        *installation.disk.graph.nodes.values(),
+    ]
+    installation = replace(
+        installation,
+        disk=replace(installation.disk, graph=DeviceGraph.build(nodes)),
+    )
+    expected_pool = "zpcala"
+    expected_dataset = "zpcala/ROOT/gentoo/root"
+    facts = bootloader.boot_facts(installation)
+
+    zbm = next(
+        one
+        for one in bootloader.build(installation)
+        if isinstance(one, InstallZfsBootMenu)
+    )
+    systemd_boot = replace(
+        installation,
+        bootloader=replace(installation.bootloader, kind=Bootloader.SYSTEMD_BOOT),
+    )
+    cmdline = next(
+        one
+        for one in kernel.build(systemd_boot)
+        if isinstance(one, WriteKernelCmdline)
+    )
+    assert (facts.pool, facts.pool_dataset) == (expected_pool, expected_dataset)
+    assert (zbm.pool, zbm.dataset) == (facts.pool, facts.pool_dataset)
+    assert (cmdline.root, cmdline.dataset) == (facts.root, facts.dataset)
 
 
 def test_the_dropbear_port_written_is_the_port_the_configuration_asked_for() -> None:


### PR DESCRIPTION
The kernel plan and the bootloader plan each derived the root device, its dataset, the encrypted containers, the arrays, the keymap and the unlock parameters from the configuration. A change reached one and not the other, and the kernel command line then disagreed with what the bootloader had installed.

`BootFacts` is that derivation, once. The test compares what both use and fails when they diverge.

Verification pending: this touches the bootloader, so it is not merged until a guest passes at this revision.

Closes C13.