### PR TITLE
disk: force a pool export only for a holder it can name

### DIFF
--- a/gentoo_install/plan/disk.py
+++ b/gentoo_install/plan/disk.py
@@ -834,39 +834,52 @@ class UnmountTarget(Operation):
         already clear: Gig-OS failed there where gentoo-cjk did not.
         """
         listed = context.run(
-            ["zfs", "list", "-H", "-o", "name", "-r", pool], check=False
+            ["zfs", "list", "-H", "-o", "name,mounted", "-r", pool], check=False
         )
         if isinstance(listed, CommandOutput) and listed.returncode != 0:
             return
-        names = [one.strip() for one in str(listed).splitlines() if one.strip()]
+        names = [one.split("\t", 1)[0].strip() for one in str(listed).splitlines() if one.strip()]
         for name in sorted(names, key=lambda one: one.count("/"), reverse=True):
             context.run(["zfs", "unmount", name], check=False)
 
+    def _mounted_datasets(self, context: Context, pool: str) -> bool:
+        listed = context.run(
+            ["zfs", "list", "-H", "-o", "name,mounted", "-r", pool], check=False
+        )
+        if not isinstance(listed, CommandOutput) or listed.returncode != 0:
+            return False
+        return any(
+            separator and state.strip() == "yes"
+            for line in str(listed).splitlines()
+            for _, separator, state in [line.partition("\t")]
+        )
+
     def _export(self, context: Context, pool: str) -> None:
-        """`umount --lazy` detaches the tree and returns before the last
-        reference is dropped, so the export that follows it reads `cannot
-        export 'rpool': pool is busy` on a guest whose install had otherwise
-        finished. The references go within seconds; one that does not is a
-        reason to stop, because an unexported pool needs `zpool import -f` on
-        the next boot."""
+        """Export the pool, forcing only a holder this operation can name.
+
+        `umount --lazy` detaches the tree and returns before the last
+        reference is dropped, so the export that follows reads `pool is busy`
+        on a guest whose install had otherwise finished. Those references go
+        within seconds, which is what the retries are for. A pool still busy
+        with nothing of its own mounted is held by something else — `zed` in
+        a live environment is one — and forcing there hides it, so it is
+        reported instead. An unexported pool needs `zpool import -f` on the
+        next boot, so the failure has to say which case it is.
+        """
         last: CommandFailed | None = None
         for attempt in range(EXPORT_TRIES):
-            # The last attempt forces. A live environment running `zed` holds
-            # the pool open for as long as it runs, so waiting never clears it:
-            # Gig-OS failed all six plain attempts where the same fixture on a
-            # medium without `zed` succeeded on the second. Forcing is bounded
-            # here because the target tree was unmounted a moment ago and the
-            # only datasets left attached are the ones this run created.
-            forced = attempt + 1 == EXPORT_TRIES
             try:
-                context.run(["zpool", "export", *(["-f"] if forced else []), pool])
+                context.run(["zpool", "export", pool])
                 return
             except CommandFailed as failed:
                 last = failed
-                if not forced:
+                if attempt + 1 < EXPORT_TRIES:
                     context.run(["sleep", f"{EXPORT_PAUSE:g}"])
         assert last is not None
-        raise last
+        if self._mounted_datasets(context, pool):
+            context.run(["zpool", "export", "-f", pool])
+            return
+        raise CommandFailed(f"{pool} remains busy after dataset unmount; holder is unknown") from last
 
 
 def finish(config: InstallConfig) -> list[Operation]:

--- a/tests/unit/test_plan_disk.py
+++ b/tests/unit/test_plan_disk.py
@@ -764,16 +764,64 @@ def test_a_pool_still_busy_after_the_lazy_unmount_is_exported_on_a_later_try(
         unmounted[0] == "rpool/ROOT/gentoo" and unmounted[-1] == "rpool"
     ), unmounted
 
-    # A live environment running `zed` holds the pool for as long as it runs,
-    # so the last attempt forces rather than waiting again.
+    # A non-dataset holder is not released by the installer, so export stops.
     zed = Clean()
-    zed.refusals = disk.EXPORT_TRIES - 1
-    operation.apply(zed)
-    assert zed.commands[-1] == ("zpool", "export", "-f", "rpool"), zed.commands[-1]
+    zed.refusals = disk.EXPORT_TRIES
+    with pytest.raises(CommandFailed, match="holder is unknown"):
+        operation.apply(zed)
 
-    # A pool that refuses even that stops the install: an unexported pool needs
-    # `zpool import -f` on the next boot.
+    class MountedDataset(Clean):
+        def run(
+            self, argv: Sequence[str], *, check: bool = True, input_text: str | None = None
+        ) -> str:
+            if tuple(argv[:2]) == ("zfs", "list"):
+                return CommandOutput("rpool\tyes\n", 0)
+            return super().run(argv, check=check, input_text=input_text)
+
+    mounted = MountedDataset()
+    mounted.refusals = disk.EXPORT_TRIES
+    operation.apply(mounted)
+    assert mounted.commands[-1] == ("zpool", "export", "-f", "rpool")
+
+    # A pool that refuses every plain attempt stops the install.
     stubborn = Clean()
     stubborn.refusals = disk.EXPORT_TRIES
     with pytest.raises(CommandFailed):
         operation.apply(stubborn)
+
+
+def test_a_pool_busy_with_nothing_mounted_is_named_rather_than_forced(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Forcing an export hides whatever holds the pool. A dataset of its own
+    still mounted is a holder this operation can name, so that one is forced;
+    anything else — `zed` in a live environment is one — is reported.
+    """
+    from gentoo_install.errors import CommandFailed
+    from gentoo_install.plan.operations import CommandOutput
+
+    class Stuck(Recorder):
+        mounted_state = "no"
+
+        def run(
+            self, argv: Sequence[str], *, check: bool = True, input_text: str | None = None
+        ) -> str:
+            if tuple(argv[:2]) == ("zpool", "export") and "-f" not in argv:
+                raise CommandFailed("zpool export rpool exited 1: pool is busy")
+            if tuple(argv[:2]) == ("zfs", "list"):
+                return CommandOutput(f"rpool\t{self.mounted_state}\n", 0)
+            return super().run(argv, check=check, input_text=input_text)
+
+    monkeypatch.setattr(disk, "EXPORT_PAUSE", 0.0)
+    operation = disk.UnmountTarget(pools=("rpool",))
+
+    held = Stuck()
+    held.mounted_state = "yes"
+    operation.apply(held)
+    assert ["zpool", "export", "-f", "rpool"] in [list(one) for one in held.commands]
+
+    unknown = Stuck()
+    unknown.mounted_state = "no"
+    with pytest.raises(CommandFailed, match="holder is unknown"):
+        operation.apply(unknown)
+    assert not any("-f" in one for one in unknown.commands)


### PR DESCRIPTION
`zpool export` was forced on every busy pool, which hides whatever held it. A dataset of the pool's own still mounted is a holder this operation can name and can safely force; anything else — `zed` in a live environment is one — is reported instead, because an unexported pool needs `zpool import -f` on the next boot and the operator has to know which case it was.

The agent's version left `forced = False` assigned and then read, so `*(["-f"] if forced else [])` was dead, and replaced the docstring explaining why the retries exist with one line. Both are restored, and a test covers the classification in both directions.

Verification pending: this touches a ZFS disk operation, so it is not merged until a guest passes at this revision.

Closes H12.