### PR TITLE
portage: write nothing for a machine with no proxy

### DIFF
--- a/gentoo_install/plan/portage.py
+++ b/gentoo_install/plan/portage.py
@@ -151,6 +151,9 @@ class WriteProxyClients(Operation):
 
     def apply(self, context: Context) -> None:
         proxy = self.proxy
+        # A machine with no proxy keeps the files its distribution shipped.
+        if not proxy.enabled:
+            return
         endpoint = _proxy_endpoint(proxy)
         bypass = ",".join(proxy.bypass)
         context.write(
@@ -1070,19 +1073,23 @@ def make_conf(
         ("ACCEPT_LICENSE", " ".join(licenses or portage.accept_license)),
         ("L10N", " ".join(_l10n(config))),
     ]
+    # Only when a proxy is configured: `emerge-webrsync` runs `FETCHCOMMAND`
+    # for a snapshot whose URL it supplies itself, and the wget line written
+    # here has none, so it answered `missing URL` and no tree arrived.
     proxy = config.proxy
-    endpoint = _proxy_endpoint(proxy)
-    settings += [
-        ("http_proxy", endpoint),
-        ("https_proxy", endpoint),
-        ("ftp_proxy", endpoint),
-        ("all_proxy", endpoint),
-        ("no_proxy", ",".join(proxy.bypass)),
-        ("FETCHCOMMAND", FETCHCOMMAND),
-        ("RESUMECOMMAND", RESUMECOMMAND),
-    ]
-    if proxy.enabled and urlsplit(proxy.url).scheme.lower() in {"http", "https"}:
-        settings.append(("RSYNC_PROXY", _rsync_proxy(proxy)))
+    if proxy.enabled:
+        endpoint = _proxy_endpoint(proxy)
+        settings += [
+            ("http_proxy", endpoint),
+            ("https_proxy", endpoint),
+            ("ftp_proxy", endpoint),
+            ("all_proxy", endpoint),
+            ("no_proxy", ",".join(proxy.bypass)),
+            ("FETCHCOMMAND", FETCHCOMMAND),
+            ("RESUMECOMMAND", RESUMECOMMAND),
+        ]
+        if urlsplit(proxy.url).scheme.lower() in {"http", "https"}:
+            settings.append(("RSYNC_PROXY", _rsync_proxy(proxy)))
     if _uses_binhost(portage):
         settings.append(("FEATURES", "getbinpkg"))
     return tuple(settings)

--- a/tests/golden/btrfs-luks.txt
+++ b/tests/golden/btrfs-luks.txt
@@ -29,7 +29,7 @@
   seed the target's resolv.conf from the install medium
 
 [portage]
-  write /etc/portage/make.conf with COMMON_FLAGS, CFLAGS, CXXFLAGS, FCFLAGS, FFLAGS, MAKEOPTS, USE, VIDEO_CARDS, INPUT_DEVICES, ACCEPT_LICENSE, L10N, http_proxy, https_proxy, ftp_proxy, all_proxy, no_proxy, FETCHCOMMAND, RESUMECOMMAND, FEATURES; 23 mirrors fastest first, measured, 5 appended
+  write /etc/portage/make.conf with COMMON_FLAGS, CFLAGS, CXXFLAGS, FCFLAGS, FFLAGS, MAKEOPTS, USE, VIDEO_CARDS, INPUT_DEVICES, ACCEPT_LICENSE, L10N, FEATURES; 23 mirrors fastest first, measured, 5 appended
   configure Portage, wget, curl, git and gpg for direct connection
   create the three autounmask files emerge writes its decisions into
   run getuto so Portage has a keyring to verify binary packages against

--- a/tests/golden/ext4-bios.txt
+++ b/tests/golden/ext4-bios.txt
@@ -21,7 +21,7 @@
   seed the target's resolv.conf from the install medium
 
 [portage]
-  write /etc/portage/make.conf with MAKEOPTS, INPUT_DEVICES, ACCEPT_LICENSE, L10N, http_proxy, https_proxy, ftp_proxy, all_proxy, no_proxy, FETCHCOMMAND, RESUMECOMMAND; 2 mirrors in the configured order, 5 appended
+  write /etc/portage/make.conf with MAKEOPTS, INPUT_DEVICES, ACCEPT_LICENSE, L10N; 2 mirrors in the configured order, 5 appended
   configure Portage, wget, curl, git and gpg for direct connection
   create the three autounmask files emerge writes its decisions into
   fetch the first ebuild repository snapshot with emerge-webrsync

--- a/tests/golden/mbr-edit.txt
+++ b/tests/golden/mbr-edit.txt
@@ -18,7 +18,7 @@
   seed the target's resolv.conf from the install medium
 
 [portage]
-  write /etc/portage/make.conf with MAKEOPTS, INPUT_DEVICES, ACCEPT_LICENSE, L10N, http_proxy, https_proxy, ftp_proxy, all_proxy, no_proxy, FETCHCOMMAND, RESUMECOMMAND, FEATURES; 2 mirrors in the configured order, 5 appended
+  write /etc/portage/make.conf with MAKEOPTS, INPUT_DEVICES, ACCEPT_LICENSE, L10N, FEATURES; 2 mirrors in the configured order, 5 appended
   configure Portage, wget, curl, git and gpg for direct connection
   create the three autounmask files emerge writes its decisions into
   run getuto so Portage has a keyring to verify binary packages against

--- a/tests/golden/openrc-sdboot.txt
+++ b/tests/golden/openrc-sdboot.txt
@@ -22,7 +22,7 @@
   seed the target's resolv.conf from the install medium
 
 [portage]
-  write /etc/portage/make.conf with MAKEOPTS, INPUT_DEVICES, ACCEPT_LICENSE, L10N, http_proxy, https_proxy, ftp_proxy, all_proxy, no_proxy, FETCHCOMMAND, RESUMECOMMAND, FEATURES; 2 mirrors in the configured order, 5 appended
+  write /etc/portage/make.conf with MAKEOPTS, INPUT_DEVICES, ACCEPT_LICENSE, L10N, FEATURES; 2 mirrors in the configured order, 5 appended
   configure Portage, wget, curl, git and gpg for direct connection
   create the three autounmask files emerge writes its decisions into
   run getuto so Portage has a keyring to verify binary packages against

--- a/tests/golden/vm-binpkg.txt
+++ b/tests/golden/vm-binpkg.txt
@@ -22,7 +22,7 @@
   seed the target's resolv.conf from the install medium
 
 [portage]
-  write /etc/portage/make.conf with MAKEOPTS, INPUT_DEVICES, ACCEPT_LICENSE, L10N, http_proxy, https_proxy, ftp_proxy, all_proxy, no_proxy, FETCHCOMMAND, RESUMECOMMAND, FEATURES; 2 mirrors in the configured order, 5 appended
+  write /etc/portage/make.conf with MAKEOPTS, INPUT_DEVICES, ACCEPT_LICENSE, L10N, FEATURES; 2 mirrors in the configured order, 5 appended
   configure Portage, wget, curl, git and gpg for direct connection
   create the three autounmask files emerge writes its decisions into
   run getuto so Portage has a keyring to verify binary packages against

--- a/tests/golden/vm-bios-luks.txt
+++ b/tests/golden/vm-bios-luks.txt
@@ -25,7 +25,7 @@
   seed the target's resolv.conf from the install medium
 
 [portage]
-  write /etc/portage/make.conf with MAKEOPTS, INPUT_DEVICES, ACCEPT_LICENSE, L10N, http_proxy, https_proxy, ftp_proxy, all_proxy, no_proxy, FETCHCOMMAND, RESUMECOMMAND, FEATURES; 2 mirrors in the configured order, 5 appended
+  write /etc/portage/make.conf with MAKEOPTS, INPUT_DEVICES, ACCEPT_LICENSE, L10N, FEATURES; 2 mirrors in the configured order, 5 appended
   configure Portage, wget, curl, git and gpg for direct connection
   create the three autounmask files emerge writes its decisions into
   run getuto so Portage has a keyring to verify binary packages against

--- a/tests/golden/vm-bios.txt
+++ b/tests/golden/vm-bios.txt
@@ -21,7 +21,7 @@
   seed the target's resolv.conf from the install medium
 
 [portage]
-  write /etc/portage/make.conf with MAKEOPTS, INPUT_DEVICES, ACCEPT_LICENSE, L10N, http_proxy, https_proxy, ftp_proxy, all_proxy, no_proxy, FETCHCOMMAND, RESUMECOMMAND, FEATURES; 2 mirrors in the configured order, 5 appended
+  write /etc/portage/make.conf with MAKEOPTS, INPUT_DEVICES, ACCEPT_LICENSE, L10N, FEATURES; 2 mirrors in the configured order, 5 appended
   configure Portage, wget, curl, git and gpg for direct connection
   create the three autounmask files emerge writes its decisions into
   run getuto so Portage has a keyring to verify binary packages against

--- a/tests/golden/vm-btrfs.txt
+++ b/tests/golden/vm-btrfs.txt
@@ -25,7 +25,7 @@
   seed the target's resolv.conf from the install medium
 
 [portage]
-  write /etc/portage/make.conf with MAKEOPTS, INPUT_DEVICES, ACCEPT_LICENSE, L10N, http_proxy, https_proxy, ftp_proxy, all_proxy, no_proxy, FETCHCOMMAND, RESUMECOMMAND, FEATURES; 2 mirrors in the configured order, 5 appended
+  write /etc/portage/make.conf with MAKEOPTS, INPUT_DEVICES, ACCEPT_LICENSE, L10N, FEATURES; 2 mirrors in the configured order, 5 appended
   configure Portage, wget, curl, git and gpg for direct connection
   create the three autounmask files emerge writes its decisions into
   run getuto so Portage has a keyring to verify binary packages against

--- a/tests/golden/vm-cjk-kernel.txt
+++ b/tests/golden/vm-cjk-kernel.txt
@@ -22,7 +22,7 @@
   seed the target's resolv.conf from the install medium
 
 [portage]
-  write /etc/portage/make.conf with MAKEOPTS, INPUT_DEVICES, ACCEPT_LICENSE, L10N, http_proxy, https_proxy, ftp_proxy, all_proxy, no_proxy, FETCHCOMMAND, RESUMECOMMAND, FEATURES; 2 mirrors in the configured order, 5 appended
+  write /etc/portage/make.conf with MAKEOPTS, INPUT_DEVICES, ACCEPT_LICENSE, L10N, FEATURES; 2 mirrors in the configured order, 5 appended
   configure Portage, wget, curl, git and gpg for direct connection
   create the three autounmask files emerge writes its decisions into
   run getuto so Portage has a keyring to verify binary packages against

--- a/tests/golden/vm-desktop.txt
+++ b/tests/golden/vm-desktop.txt
@@ -22,7 +22,7 @@
   seed the target's resolv.conf from the install medium
 
 [portage]
-  write /etc/portage/make.conf with MAKEOPTS, USE, INPUT_DEVICES, ACCEPT_LICENSE, L10N, http_proxy, https_proxy, ftp_proxy, all_proxy, no_proxy, FETCHCOMMAND, RESUMECOMMAND, FEATURES; 2 mirrors in the configured order, 5 appended
+  write /etc/portage/make.conf with MAKEOPTS, USE, INPUT_DEVICES, ACCEPT_LICENSE, L10N, FEATURES; 2 mirrors in the configured order, 5 appended
   configure Portage, wget, curl, git and gpg for direct connection
   create the three autounmask files emerge writes its decisions into
   run getuto so Portage has a keyring to verify binary packages against

--- a/tests/golden/vm-f2fs.txt
+++ b/tests/golden/vm-f2fs.txt
@@ -22,7 +22,7 @@
   seed the target's resolv.conf from the install medium
 
 [portage]
-  write /etc/portage/make.conf with MAKEOPTS, INPUT_DEVICES, ACCEPT_LICENSE, L10N, http_proxy, https_proxy, ftp_proxy, all_proxy, no_proxy, FETCHCOMMAND, RESUMECOMMAND, FEATURES; 2 mirrors in the configured order, 5 appended
+  write /etc/portage/make.conf with MAKEOPTS, INPUT_DEVICES, ACCEPT_LICENSE, L10N, FEATURES; 2 mirrors in the configured order, 5 appended
   configure Portage, wget, curl, git and gpg for direct connection
   create the three autounmask files emerge writes its decisions into
   run getuto so Portage has a keyring to verify binary packages against

--- a/tests/golden/vm-gnome.txt
+++ b/tests/golden/vm-gnome.txt
@@ -22,7 +22,7 @@
   seed the target's resolv.conf from the install medium
 
 [portage]
-  write /etc/portage/make.conf with MAKEOPTS, USE, INPUT_DEVICES, ACCEPT_LICENSE, L10N, http_proxy, https_proxy, ftp_proxy, all_proxy, no_proxy, FETCHCOMMAND, RESUMECOMMAND, FEATURES; 2 mirrors in the configured order, 5 appended
+  write /etc/portage/make.conf with MAKEOPTS, USE, INPUT_DEVICES, ACCEPT_LICENSE, L10N, FEATURES; 2 mirrors in the configured order, 5 appended
   configure Portage, wget, curl, git and gpg for direct connection
   create the three autounmask files emerge writes its decisions into
   run getuto so Portage has a keyring to verify binary packages against

--- a/tests/golden/vm-luks.txt
+++ b/tests/golden/vm-luks.txt
@@ -29,7 +29,7 @@
   seed the target's resolv.conf from the install medium
 
 [portage]
-  write /etc/portage/make.conf with MAKEOPTS, INPUT_DEVICES, ACCEPT_LICENSE, L10N, http_proxy, https_proxy, ftp_proxy, all_proxy, no_proxy, FETCHCOMMAND, RESUMECOMMAND, FEATURES; 2 mirrors in the configured order, 5 appended
+  write /etc/portage/make.conf with MAKEOPTS, INPUT_DEVICES, ACCEPT_LICENSE, L10N, FEATURES; 2 mirrors in the configured order, 5 appended
   configure Portage, wget, curl, git and gpg for direct connection
   create the three autounmask files emerge writes its decisions into
   run getuto so Portage has a keyring to verify binary packages against

--- a/tests/golden/vm-lvm.txt
+++ b/tests/golden/vm-lvm.txt
@@ -30,7 +30,7 @@
   seed the target's resolv.conf from the install medium
 
 [portage]
-  write /etc/portage/make.conf with MAKEOPTS, INPUT_DEVICES, ACCEPT_LICENSE, L10N, http_proxy, https_proxy, ftp_proxy, all_proxy, no_proxy, FETCHCOMMAND, RESUMECOMMAND, FEATURES; 2 mirrors in the configured order, 5 appended
+  write /etc/portage/make.conf with MAKEOPTS, INPUT_DEVICES, ACCEPT_LICENSE, L10N, FEATURES; 2 mirrors in the configured order, 5 appended
   configure Portage, wget, curl, git and gpg for direct connection
   create the three autounmask files emerge writes its decisions into
   run getuto so Portage has a keyring to verify binary packages against

--- a/tests/golden/vm-mdraid.txt
+++ b/tests/golden/vm-mdraid.txt
@@ -30,7 +30,7 @@
   seed the target's resolv.conf from the install medium
 
 [portage]
-  write /etc/portage/make.conf with MAKEOPTS, INPUT_DEVICES, ACCEPT_LICENSE, L10N, http_proxy, https_proxy, ftp_proxy, all_proxy, no_proxy, FETCHCOMMAND, RESUMECOMMAND, FEATURES; 2 mirrors in the configured order, 5 appended
+  write /etc/portage/make.conf with MAKEOPTS, INPUT_DEVICES, ACCEPT_LICENSE, L10N, FEATURES; 2 mirrors in the configured order, 5 appended
   configure Portage, wget, curl, git and gpg for direct connection
   create the three autounmask files emerge writes its decisions into
   run getuto so Portage has a keyring to verify binary packages against

--- a/tests/golden/vm-openrc-desktop.txt
+++ b/tests/golden/vm-openrc-desktop.txt
@@ -22,7 +22,7 @@
   seed the target's resolv.conf from the install medium
 
 [portage]
-  write /etc/portage/make.conf with MAKEOPTS, USE, INPUT_DEVICES, ACCEPT_LICENSE, L10N, http_proxy, https_proxy, ftp_proxy, all_proxy, no_proxy, FETCHCOMMAND, RESUMECOMMAND, FEATURES; 2 mirrors in the configured order, 5 appended
+  write /etc/portage/make.conf with MAKEOPTS, USE, INPUT_DEVICES, ACCEPT_LICENSE, L10N, FEATURES; 2 mirrors in the configured order, 5 appended
   configure Portage, wget, curl, git and gpg for direct connection
   create the three autounmask files emerge writes its decisions into
   run getuto so Portage has a keyring to verify binary packages against

--- a/tests/golden/vm-raidz.txt
+++ b/tests/golden/vm-raidz.txt
@@ -34,7 +34,7 @@
   seed the target's resolv.conf from the install medium
 
 [portage]
-  write /etc/portage/make.conf with MAKEOPTS, INPUT_DEVICES, ACCEPT_LICENSE, L10N, http_proxy, https_proxy, ftp_proxy, all_proxy, no_proxy, FETCHCOMMAND, RESUMECOMMAND, FEATURES; 2 mirrors in the configured order, 5 appended
+  write /etc/portage/make.conf with MAKEOPTS, INPUT_DEVICES, ACCEPT_LICENSE, L10N, FEATURES; 2 mirrors in the configured order, 5 appended
   configure Portage, wget, curl, git and gpg for direct connection
   create the three autounmask files emerge writes its decisions into
   run getuto so Portage has a keyring to verify binary packages against

--- a/tests/golden/vm-sdboot.txt
+++ b/tests/golden/vm-sdboot.txt
@@ -22,7 +22,7 @@
   seed the target's resolv.conf from the install medium
 
 [portage]
-  write /etc/portage/make.conf with MAKEOPTS, INPUT_DEVICES, ACCEPT_LICENSE, L10N, http_proxy, https_proxy, ftp_proxy, all_proxy, no_proxy, FETCHCOMMAND, RESUMECOMMAND, FEATURES; 2 mirrors in the configured order, 5 appended
+  write /etc/portage/make.conf with MAKEOPTS, INPUT_DEVICES, ACCEPT_LICENSE, L10N, FEATURES; 2 mirrors in the configured order, 5 appended
   configure Portage, wget, curl, git and gpg for direct connection
   create the three autounmask files emerge writes its decisions into
   run getuto so Portage has a keyring to verify binary packages against

--- a/tests/golden/vm-unlock.txt
+++ b/tests/golden/vm-unlock.txt
@@ -29,7 +29,7 @@
   seed the target's resolv.conf from the install medium
 
 [portage]
-  write /etc/portage/make.conf with MAKEOPTS, INPUT_DEVICES, ACCEPT_LICENSE, L10N, http_proxy, https_proxy, ftp_proxy, all_proxy, no_proxy, FETCHCOMMAND, RESUMECOMMAND, FEATURES; 2 mirrors in the configured order, 5 appended
+  write /etc/portage/make.conf with MAKEOPTS, INPUT_DEVICES, ACCEPT_LICENSE, L10N, FEATURES; 2 mirrors in the configured order, 5 appended
   configure Portage, wget, curl, git and gpg for direct connection
   create the three autounmask files emerge writes its decisions into
   run getuto so Portage has a keyring to verify binary packages against

--- a/tests/golden/vm-xfs.txt
+++ b/tests/golden/vm-xfs.txt
@@ -22,7 +22,7 @@
   seed the target's resolv.conf from the install medium
 
 [portage]
-  write /etc/portage/make.conf with MAKEOPTS, INPUT_DEVICES, ACCEPT_LICENSE, L10N, http_proxy, https_proxy, ftp_proxy, all_proxy, no_proxy, FETCHCOMMAND, RESUMECOMMAND, FEATURES; 2 mirrors in the configured order, 5 appended
+  write /etc/portage/make.conf with MAKEOPTS, INPUT_DEVICES, ACCEPT_LICENSE, L10N, FEATURES; 2 mirrors in the configured order, 5 appended
   configure Portage, wget, curl, git and gpg for direct connection
   create the three autounmask files emerge writes its decisions into
   run getuto so Portage has a keyring to verify binary packages against

--- a/tests/golden/vm-zfs-encrypted.txt
+++ b/tests/golden/vm-zfs-encrypted.txt
@@ -26,7 +26,7 @@
   seed the target's resolv.conf from the install medium
 
 [portage]
-  write /etc/portage/make.conf with MAKEOPTS, INPUT_DEVICES, ACCEPT_LICENSE, L10N, http_proxy, https_proxy, ftp_proxy, all_proxy, no_proxy, FETCHCOMMAND, RESUMECOMMAND, FEATURES; 2 mirrors in the configured order, 5 appended
+  write /etc/portage/make.conf with MAKEOPTS, INPUT_DEVICES, ACCEPT_LICENSE, L10N, FEATURES; 2 mirrors in the configured order, 5 appended
   configure Portage, wget, curl, git and gpg for direct connection
   create the three autounmask files emerge writes its decisions into
   run getuto so Portage has a keyring to verify binary packages against

--- a/tests/golden/vm-zfs-mirror.txt
+++ b/tests/golden/vm-zfs-mirror.txt
@@ -30,7 +30,7 @@
   seed the target's resolv.conf from the install medium
 
 [portage]
-  write /etc/portage/make.conf with MAKEOPTS, INPUT_DEVICES, ACCEPT_LICENSE, L10N, http_proxy, https_proxy, ftp_proxy, all_proxy, no_proxy, FETCHCOMMAND, RESUMECOMMAND, FEATURES; 2 mirrors in the configured order, 5 appended
+  write /etc/portage/make.conf with MAKEOPTS, INPUT_DEVICES, ACCEPT_LICENSE, L10N, FEATURES; 2 mirrors in the configured order, 5 appended
   configure Portage, wget, curl, git and gpg for direct connection
   create the three autounmask files emerge writes its decisions into
   run getuto so Portage has a keyring to verify binary packages against

--- a/tests/golden/vm-zfs.txt
+++ b/tests/golden/vm-zfs.txt
@@ -26,7 +26,7 @@
   seed the target's resolv.conf from the install medium
 
 [portage]
-  write /etc/portage/make.conf with MAKEOPTS, INPUT_DEVICES, ACCEPT_LICENSE, L10N, http_proxy, https_proxy, ftp_proxy, all_proxy, no_proxy, FETCHCOMMAND, RESUMECOMMAND, FEATURES; 2 mirrors in the configured order, 5 appended
+  write /etc/portage/make.conf with MAKEOPTS, INPUT_DEVICES, ACCEPT_LICENSE, L10N, FEATURES; 2 mirrors in the configured order, 5 appended
   configure Portage, wget, curl, git and gpg for direct connection
   create the three autounmask files emerge writes its decisions into
   run getuto so Portage has a keyring to verify binary packages against

--- a/tests/golden/vm-zram.txt
+++ b/tests/golden/vm-zram.txt
@@ -22,7 +22,7 @@
   seed the target's resolv.conf from the install medium
 
 [portage]
-  write /etc/portage/make.conf with MAKEOPTS, INPUT_DEVICES, ACCEPT_LICENSE, L10N, http_proxy, https_proxy, ftp_proxy, all_proxy, no_proxy, FETCHCOMMAND, RESUMECOMMAND, FEATURES; 2 mirrors in the configured order, 5 appended
+  write /etc/portage/make.conf with MAKEOPTS, INPUT_DEVICES, ACCEPT_LICENSE, L10N, FEATURES; 2 mirrors in the configured order, 5 appended
   configure Portage, wget, curl, git and gpg for direct connection
   create the three autounmask files emerge writes its decisions into
   run getuto so Portage has a keyring to verify binary packages against

--- a/tests/golden/zfs-zbm.txt
+++ b/tests/golden/zfs-zbm.txt
@@ -28,7 +28,7 @@
   seed the target's resolv.conf from the install medium
 
 [portage]
-  write /etc/portage/make.conf with MAKEOPTS, INPUT_DEVICES, ACCEPT_LICENSE, L10N, http_proxy, https_proxy, ftp_proxy, all_proxy, no_proxy, FETCHCOMMAND, RESUMECOMMAND, FEATURES; 2 mirrors in the configured order, 5 appended
+  write /etc/portage/make.conf with MAKEOPTS, INPUT_DEVICES, ACCEPT_LICENSE, L10N, FEATURES; 2 mirrors in the configured order, 5 appended
   configure Portage, wget, curl, git and gpg for direct connection
   create the three autounmask files emerge writes its decisions into
   run getuto so Portage has a keyring to verify binary packages against

--- a/tests/unit/test_plan_portage.py
+++ b/tests/unit/test_plan_portage.py
@@ -182,11 +182,19 @@ def test_proxy_clients_route_portage_and_keep_credentials_out_of_descriptions() 
     assert all(secret not in operation.describe() for operation in portage.build(installation, MIRROR))
 
 
-def test_proxy_clients_clear_route_when_proxy_is_empty() -> None:
+def test_no_proxy_leaves_every_client_as_the_distribution_shipped_it() -> None:
+    """Writing an empty proxy is not the same as writing nothing.
+    `FETCHCOMMAND` reached `make.conf` on a machine with no proxy, and
+    `emerge-webrsync` runs it for a snapshot whose URL it supplies itself, so
+    wget answered `missing URL` and the install stopped with no tree.
+    """
     recorder = apply_all(config())
     make_conf = recorder.files[PurePosixPath("/etc/portage/make.conf")]
-    assert 'http_proxy=""' in make_conf
-    assert 'no_proxy=""' in make_conf
+    for name in ("http_proxy", "https_proxy", "ftp_proxy", "all_proxy", "no_proxy",
+                 "FETCHCOMMAND", "RESUMECOMMAND", "RSYNC_PROXY"):
+        assert name not in make_conf
+    for path in ("/etc/wgetrc", "/etc/curlrc", "/etc/gitconfig"):
+        assert PurePosixPath(path) not in recorder.files
 
 
 def test_l10n_is_derived_from_the_locales_rather_than_listed_twice() -> None:


### PR DESCRIPTION
`#257` wrote the proxy settings unconditionally, so a machine with no proxy still got `http_proxy=""`, `FETCHCOMMAND`, `RESUMECOMMAND` and a replacement `/etc/wgetrc`, `/etc/curlrc` and `/etc/gitconfig`.

`emerge-webrsync` runs `FETCHCOMMAND` for a snapshot whose URL it supplies itself. The line written here carries no URL, so wget answered `missing URL` and the install stopped with no ebuild tree — `vm-sdboot` failed at 2.7 minutes.

An empty proxy now writes nothing at all, which is what the machine had before the setting existed. The test that asserted `http_proxy=""` reached `make.conf` encoded the fault; it asserts the opposite.