### PR TITLE
boot: give a native ZFS unlock the initramfs keymap it was told

### DIFF
--- a/gentoo_install/plan/bootloader.py
+++ b/gentoo_install/plan/bootloader.py
@@ -684,7 +684,15 @@ def initramfs_keymap(config: InstallConfig) -> str:
     """Only when an encrypted device asks for a passphrase before the console
     keymap is loaded, and only when it differs from the default."""
     wanted = config.system.keymap_initramfs or config.system.keymap
-    if wanted == "us" or not compat.early_containers(config.disk.graph):
+    graph = config.disk.graph
+    native_encrypted_root = any(
+        pool.encrypted
+        for pool in graph.of_type(ZfsPool)
+        if pool.id in graph.ancestors_of(config.disk.root)
+    )
+    if wanted == "us" or (
+        not compat.early_containers(graph) and not native_encrypted_root
+    ):
         return ""
     return wanted
 

--- a/tests/unit/test_plan_bootloader.py
+++ b/tests/unit/test_plan_bootloader.py
@@ -93,6 +93,25 @@ def test_zfsbootmenu_carries_remote_access_in_its_own_image() -> None:
     assert "network" not in kernel.dracut_modules(installation)
 
 
+def test_native_zfs_unlock_uses_the_initramfs_keymap() -> None:
+    encrypted = load(Path("tests/fixtures/vm-zfs-encrypted.toml"))
+    encrypted = replace(
+        encrypted,
+        system=replace(encrypted.system, keymap_initramfs="de"),
+    )
+    plaintext = load(Path("tests/fixtures/vm-zfs.toml"))
+    plaintext = replace(
+        plaintext,
+        system=replace(plaintext.system, keymap_initramfs="de"),
+    )
+
+    assert bootloader.initramfs_keymap(encrypted) == "de"
+    assert bootloader.initramfs_keymap(plaintext) == ""
+    assert bootloader.initramfs_keymap(
+        replace(encrypted, system=replace(encrypted.system, keymap_initramfs="us"))
+    ) == ""
+
+
 def test_a_systemd_boot_machine_shows_its_menu() -> None:
     """`bootctl install` writes no `loader.conf`, and systemd-boot's documented
     default for `timeout` is 0: "no menu is shown and the default entry will be


### PR DESCRIPTION
The initramfs keymap was carried for an early LUKS container and for nothing else, so a native encrypted ZFS root got `us` whatever the operator chose. They then typed the passphrase they had set, on a console with no way to see the layout, and it was refused.

Verification pending: this touches the bootloader, so it is not merged until `vm-zfs-encrypted` passes at this revision.

Closes C23.