### PR TITLE
vm: quote the path a check writes its output to

### DIFF
--- a/tests/unit/test_harness.py
+++ b/tests/unit/test_harness.py
@@ -1790,3 +1790,31 @@ def test_a_cn_run_clones_the_overlay_from_a_chinese_mirror(tmp_path: Path) -> No
     overlay = next(one for one in moved.portage.overlays if one.name == "gentoo-zh")
     assert "github.com" not in overlay.sync_uri
     assert overlay.sync_uri.startswith("https://mirrors.cernet.edu.cn/")
+
+
+def test_a_check_whose_name_has_a_space_is_written_to_one_file() -> None:
+    """`root filesystem` is a check name, and an unquoted redirection split it
+    into two words: bash answered `syntax error near unexpected token` and the
+    Alpine run ended there with the install already finished.
+    """
+    import subprocess
+
+    from tests.vm import run as vm_run
+
+    class Recording:
+        def __init__(self) -> None:
+            self.commands: list[str] = []
+
+        def run(self, command: str, timeout: float = 120.0) -> None:
+            self.commands.append(command)
+
+    from gentoo_install.exec.config import load
+
+    console = Recording()
+    installation = load(Path(__file__).resolve().parents[1] / "fixtures" / "vm-btrfs.toml")
+    vm_run.check_installed(console, installation)  # type: ignore[arg-type]
+    assert any("root filesystem" in one for one in console.commands)
+    for command in console.commands:
+        assert subprocess.run(
+            ["bash", "-n", "-c", command], capture_output=True
+        ).returncode == 0, command

--- a/tests/vm/run.py
+++ b/tests/vm/run.py
@@ -13,6 +13,7 @@ import fcntl
 import io
 import os
 import re
+import shlex
 import socket
 import subprocess
 import sys
@@ -247,7 +248,7 @@ def check_installed(console: SerialConsole, installation: InstallConfig) -> None
     """Assert against the system that was installed, booted from its own disk."""
     console.run(f"mkdir -p {RESULT_DIR}")
     for check in checks(installation):
-        console.run(f"{{ {check.command} ; }} > {RESULT_DIR}/{check.name}.txt 2>&1")
+        console.run(f"{{ {check.command} ; }} > {shlex.quote(f'{RESULT_DIR}/{check.name}.txt')} 2>&1")
     console.run(collect_command(RESULT_DIR))
     console.run("sync")
 
@@ -337,7 +338,7 @@ def run_installer(console: SerialConsole, config: str, extra: str = "") -> None:
 def probe(console: SerialConsole) -> None:
     console.run(f"mkdir -p {RESULT_DIR}")
     for name, command in PROBE:
-        console.run(f"{{ {command} ; }} > {RESULT_DIR}/{name}.txt 2>&1")
+        console.run(f"{{ {command} ; }} > {shlex.quote(f'{RESULT_DIR}/{name}.txt')} 2>&1")
     console.run(collect_command(RESULT_DIR))
     console.run("sync")
 


### PR DESCRIPTION
`#264` gave both runners one definition of what an installed system must prove, and one of its checks is named `root filesystem`. The redirection that writes each check's output was unquoted, so bash split the name into two words:

```
> /run/vm-result/root filesystem.txt
-bash: syntax error near unexpected token `filesystem.txt'
```

The install had already finished; the run ended while reading the result back. Found by the first Alpine medium run.

The test drives `check_installed` against a real fixture and runs `bash -n` over every command it produces, so a name with a space cannot come back unquoted.