### PR TITLE
vm: unlock the installed root over ssh before the console login

### DIFF
--- a/tests/unit/test_harness.py
+++ b/tests/unit/test_harness.py
@@ -34,6 +34,92 @@ def test_a_run_that_installed_and_collected_no_exit_code_is_a_failure() -> None:
     assert verdict({"install.rc": b"0\n"}, None, installed=True) == 0
 
 
+def test_remote_unlock_failure_is_not_a_console_fallback() -> None:
+    assert verdict({"remote-unlock.rc": b"1\n"}, None) == 1
+
+
+def test_remote_unlock_replaces_fixture_values_without_mutating_fixture() -> None:
+    from gentoo_install.exec.config import load
+    from tests.vm.run import remote_config
+
+    fixture = Path("tests/fixtures/zfs-zbm.toml")
+    before = fixture.read_bytes()
+    substituted = remote_config(load(fixture), "ssh-ed25519 AAAA harness")
+    assert substituted.system.authorized_keys == ("ssh-ed25519 AAAA harness",)
+    assert substituted.kernel.remote_unlock.address == ""
+    assert fixture.read_bytes() == before
+
+
+@pytest.mark.parametrize(
+    ("fixture", "command", "proof"),
+    [
+        ("vm-unlock.toml", "unlock", None),
+        (
+            "zfs-zbm.toml",
+            "zfs load-key -a",
+            "zfs get -H -o value keystatus zpcala/ROOT/gentoo/root",
+        ),
+    ],
+)
+def test_remote_unlock_command_comes_from_fixture(
+    fixture: str, command: str, proof: str | None
+) -> None:
+    from gentoo_install.exec.config import load
+    from tests.vm.run import remote_unlock_commands
+
+    commands = remote_unlock_commands(load(Path("tests/fixtures") / fixture))
+    assert commands is not None
+    actual_command, actual_proof = commands
+    assert actual_command == command
+    assert actual_proof == proof
+
+
+def test_zfs_remote_unlock_proof_changes_when_pool_is_renamed() -> None:
+    from dataclasses import replace
+
+    from gentoo_install.exec.config import load
+    from gentoo_install.model.device import ZfsPool
+    from tests.vm.run import remote_unlock_commands
+
+    installation = load(Path("tests/fixtures/zfs-zbm.toml"))
+    pool = installation.disk.graph.of_type(ZfsPool)[0]
+    nodes = [
+        replace(node, name="renamed") if node.id == pool.id and isinstance(node, ZfsPool) else node
+        for node in installation.disk.graph.nodes.values()
+    ]
+    renamed = replace(installation, disk=replace(installation.disk, graph=type(installation.disk.graph)(nodes)))
+    commands = remote_unlock_commands(renamed)
+    assert commands is not None
+    _, proof = commands
+    assert proof is not None and "renamed/" in proof and "zpcala/" not in proof
+
+
+def test_disabled_remote_unlock_produces_no_command() -> None:
+    from dataclasses import replace
+
+    from gentoo_install.exec.config import load
+    from tests.vm.run import remote_unlock_commands
+
+    installation = load(Path("tests/fixtures/zfs-zbm.toml"))
+    disabled = replace(
+        installation,
+        kernel=replace(installation.kernel, remote_unlock=replace(installation.kernel.remote_unlock, enabled=False)),
+    )
+    assert remote_unlock_commands(disabled) is None
+
+
+def test_unlock_forward_is_only_added_when_remote_unlock_is_requested() -> None:
+    from tests.vm.media import MEDIA
+    from tests.vm.qemu import Vm, VmSpec
+
+    ordinary = Vm(VmSpec(MEDIA["official-minimal"], Path("/tmp"), ssh_port=2200))._netdev()
+    remote = Vm(
+        VmSpec(MEDIA["official-minimal"], Path("/tmp"), ssh_port=2200, remote_unlock_port=2201)
+    )._netdev()
+    assert "hostfwd=tcp::2201-:2222" not in ordinary
+    assert "hostfwd=tcp::2201-:2222" in remote
+
+
 def test_every_configuration_the_campaign_names_exists() -> None:
     """A stage naming a fixture that was renamed fails half an hour in, after
     the medium has booted, rather than at the first line."""

--- a/tests/unit/test_proxmox.py
+++ b/tests/unit/test_proxmox.py
@@ -1220,6 +1220,7 @@ def test_installed_boot_attaches_before_reset_without_sending_a_line(
 ) -> None:
     """A late termproxy has no GRUB scrollback, while a blank line submitted at
     the hidden passphrase prompt is an empty key rather than a harmless probe."""
+    from gentoo_install.exec.config import load
     from tests.vm import cluster
 
     events: list[str] = []
@@ -1250,7 +1251,10 @@ def test_installed_boot_attaches_before_reset_without_sending_a_line(
 
     monkeypatch.setattr(cluster, "_unlock", unlock)
     refused = cluster.boot_and_check(
-        cast(Any, Guest()), cast(Any, Link()), Path("unused"), cast(Any, object())
+        cast(Any, Guest()),
+        cast(Any, Link()),
+        Path("unused"),
+        load(Path("tests/fixtures/vm-btrfs.toml")),
     )
 
     assert refused == "stop after observing boot order"

--- a/tests/vm/cluster.py
+++ b/tests/vm/cluster.py
@@ -88,6 +88,7 @@ from .results import (
 )
 from .workdir import WorkdirError, confined
 from .installed import checks, stage_passphrase_commands
+from .run import remote_config, remote_unlock, ssh_keypair
 
 REPOSITORY: Final[Path] = Path(__file__).resolve().parents[2]
 WORKROOT: Final[Path] = Path.home() / "code/gentoo-install/lab/vm/cluster"
@@ -269,6 +270,7 @@ class Job:
     #: Read from the fixture rather than listed beside it: what makes a run
     #: long is compiling, and the configuration is what says whether it does.
     heavy: bool = False
+    remote_unlock: bool = False
     status: JobStatus = JobStatus.WAITING
     vmid: int = 0
     node: str | None = None
@@ -816,7 +818,7 @@ def stage_passphrases(link: Reconnecting, installation: InstallConfig) -> None:
 
 
 def rewrite_fixtures(
-    jobs: list[Job], into: Path, region: MirrorRegion, sync: Sync
+    jobs: list[Job], into: Path, region: MirrorRegion, sync: Sync, public_key: str = ""
 ) -> Path:
     """Write each fixture out again with its mirror region and sync replaced.
 
@@ -848,7 +850,7 @@ def rewrite_fixtures(
         chosen = mirrors.gentoozh_for(region)
         where = mirrors.gentoozh(chosen).git
         moved = replace(
-            config,
+            remote_config(config, public_key) if public_key else config,
             portage=replace(
                 config.portage,
                 sync=sync,
@@ -865,6 +867,11 @@ def rewrite_fixtures(
         )
         (into / job.fixture.name).write_text(to_toml(moved))
     return into
+
+
+def _requests_remote_unlock(path: Path) -> bool:
+    """Read the typed configuration so schema changes fail at the boundary."""
+    return load(path).kernel.remote_unlock.enabled
 
 
 @dataclass(frozen=True)
@@ -1179,6 +1186,7 @@ def install_one(
     nonce: str = "",
     revision: str = "",
     execution: Running | None = None,
+    remote_key: Path | None = None,
 ) -> Outcome:
     """Build a guest, install into it, read the result, delete the guest."""
     started = time.monotonic()
@@ -1249,7 +1257,7 @@ def install_one(
         # the machine it produced comes up and carries what was asked for, and
         # nothing in the log above can answer that.
         phase = Phase.BOOT_INSTALLED
-        wrong = boot_and_check(guest, link, log, load(job.fixture))
+        wrong = boot_and_check(guest, link, log, load(job.fixture), remote_key, held.address)
         if wrong:
             outcome = Outcome(
                 job.name,
@@ -1319,6 +1327,7 @@ def answer_once(
     nonce: str = "",
     revision: str = "",
     execution: Running | None = None,
+    remote_key: Path | None = None,
 ) -> None:
     """Run one job and put exactly one outcome on the queue, whatever happens.
 
@@ -1339,6 +1348,7 @@ def answer_once(
             nonce,
             revision,
             execution,
+            remote_key,
         )
         outcome = replace(outcome, vmid=outcome.vmid or vmid)
         done.put(outcome)
@@ -1377,13 +1387,16 @@ def run(
     workdir.mkdir(parents=True, exist_ok=True)
     reconcile(api, workdir)
     addresses = AddressPool(ADDRESS_POOL_ROOT, _address_is_taken)
+    remote_key = ssh_keypair(workdir) if any(job.remote_unlock for job in jobs) else None
+    public_key = remote_key.with_suffix(".pub").read_text().strip() if remote_key else ""
     # Packed: the ingress refuses the 1.4 MiB loose-file CD with `413`.
     staging = workdir / f".driver-{uuid.uuid4().hex}.iso"
-    built_path = build_driver(
-        staging,
-        packed=True,
-        fixtures=rewrite_fixtures(jobs, workdir / "fixtures", region, sync),
-    )
+    fixture_dir = workdir / "fixtures"
+    if public_key:
+        rewritten = rewrite_fixtures(jobs, fixture_dir, region, sync, public_key)
+    else:
+        rewritten = rewrite_fixtures(jobs, fixture_dir, region, sync)
+    built_path = build_driver(staging, packed=True, fixtures=rewritten)
     driver_path = retain_driver(workdir, built_path)
     driver = driver_path.name
     revision = revision_identity(driver_path)
@@ -1484,6 +1497,7 @@ def run(
                         nonce,
                         revision,
                         execution,
+                        remote_key,
                     ),
                     daemon=False,
                 )
@@ -1843,7 +1857,10 @@ class UnlockResult:
 
 
 def _unlock(
-    guest: Typeable, link: Reconnecting, installation: InstallConfig
+    guest: Typeable,
+    link: Reconnecting,
+    installation: InstallConfig,
+    remotely_unlocked: bool = False,
 ) -> UnlockResult:
     """Answer every passphrase prompt on the way to a login.
 
@@ -1861,6 +1878,8 @@ def _unlock(
     )
     if not encrypted:
         return UnlockResult(InstalledBootState.WAIT_LOGIN)
+    if remotely_unlocked:
+        return UnlockResult(InstalledBootState.LOGIN_READY)
     if installation.bootloader.firmware is BootFirmware.BIOS:
         time.sleep(GRUB_PROMPT_SECONDS)
         guest.send_keys([*keys_for(DISK_PASSPHRASE), "ret"])
@@ -1891,7 +1910,12 @@ def _unlock(
 
 
 def boot_and_check(
-    guest: Guest, link: Reconnecting, log: Path, installation: InstallConfig
+    guest: Guest,
+    link: Reconnecting,
+    log: Path,
+    installation: InstallConfig,
+    remote_key: Path | None = None,
+    remote_host: str = "127.0.0.1",
 ) -> str:
     """Boot the newly written disk and read the system back.
 
@@ -1908,7 +1932,18 @@ def boot_and_check(
     # here submitted an empty GRUB passphrase before the reader was ready.
     link.reopen(solicit_prompt=False)
     guest.reset()
-    unlocked = _unlock(guest, link, installation)
+    remotely_unlocked = False
+    unlock = installation.kernel.remote_unlock
+    if unlock.enabled:
+        if remote_key is None:
+            return "remote unlock is enabled but the harness has no key"
+        try:
+            remote_unlock(remote_key, unlock.port, installation, host=remote_host)
+        except RuntimeError as error:
+            return f"remote unlock failed: {error}"[:200]
+        remotely_unlocked = True
+        print("installed root unlocked by remote SSH session", flush=True)
+    unlocked = _unlock(guest, link, installation, remotely_unlocked)
     if unlocked.refused:
         return unlocked.refused
     if unlocked.state is InstalledBootState.WAIT_LOGIN:
@@ -2123,6 +2158,7 @@ def fixtures(names: list[str]) -> list[Job]:
                 uefi=config.bootloader.firmware.value != "bios",
                 disks=max(1, len(config.disk.graph.of_type(Existing))),
                 heavy=_compiles(config),
+                remote_unlock=_requests_remote_unlock(path),
             )
         )
     return found

--- a/tests/vm/qemu.py
+++ b/tests/vm/qemu.py
@@ -47,6 +47,7 @@ class VmSpec:
     #: six guests at once.
     cpus: int = 5
     ssh_port: int = 2222
+    remote_unlock_port: int | None = None
     disks: tuple[Path, ...] = ()
     #: Built from the working tree each run and mounted as the second CD.
     driver_iso: Path | None = None
@@ -166,6 +167,8 @@ class Vm:
             parts.append("ipv6-net=fd00:5:5::/64")
         if wants4:
             parts.append(f"hostfwd=tcp::{self.spec.ssh_port}-:22")
+            if self.spec.remote_unlock_port is not None:
+                parts.append(f"hostfwd=tcp::{self.spec.remote_unlock_port}-:2222")
         return ",".join(parts)
 
     def _ovmf_args(self) -> list[str]:

--- a/tests/vm/run.py
+++ b/tests/vm/run.py
@@ -19,9 +19,10 @@ import subprocess
 import sys
 import time
 from collections.abc import Sequence
+from dataclasses import replace
 from pathlib import Path
 
-from gentoo_install.model.config import Firmware as BootFirmware, InitSystem, InstallConfig
+from gentoo_install.model.config import Bootloader, Firmware as BootFirmware, InitSystem, InstallConfig
 from gentoo_install.model.device import (
     Existing,
     Filesystem,
@@ -32,6 +33,8 @@ from gentoo_install.model.device import (
     ZfsPool,
 )
 from gentoo_install.exec.config import load
+from gentoo_install.model.serialise import to_toml
+from gentoo_install.model.manual import dataset_for
 
 from .console import DISK_PASSPHRASE, PASSPHRASE_PROMPT, PASSWORD_PROMPT, SerialConsole
 from .monitor import type_text
@@ -162,7 +165,9 @@ def install_key(console: SerialConsole, public_key: str) -> None:
     console.run("chmod 600 /root/.ssh/authorized_keys")
 
 
-def ssh(key: Path, port: int, command: str) -> subprocess.CompletedProcess[str]:
+def ssh(
+    key: Path, port: int, command: str, *, host: str = "127.0.0.1"
+) -> subprocess.CompletedProcess[str]:
     return subprocess.run(
         [
             "ssh", "-p", str(port), "-i", str(key),
@@ -170,11 +175,100 @@ def ssh(key: Path, port: int, command: str) -> subprocess.CompletedProcess[str]:
             "-o", "UserKnownHostsFile=/dev/null",
             "-o", "BatchMode=yes",
             "-o", "ConnectTimeout=10",
-            "root@127.0.0.1", command,
+            f"root@{host}", command,
         ],
         capture_output=True,
         text=True,
         timeout=120,
+    )
+
+
+def push_config(key: Path, port: int, path: str, contents: str) -> None:
+    """Push the substituted configuration through the live SSH channel."""
+    result = subprocess.run(
+        [
+            "ssh", "-p", str(port), "-i", str(key),
+            "-o", "StrictHostKeyChecking=no", "-o", "UserKnownHostsFile=/dev/null",
+            "-o", "BatchMode=yes", "-o", "ConnectTimeout=10", "root@127.0.0.1",
+            f"cat > {path}",
+        ], input=contents, capture_output=True, text=True, timeout=120,
+    )
+    if result.returncode != 0:
+        raise RuntimeError(f"the live SSH configuration push failed: {result.stderr.strip()}")
+
+
+def remote_unlock(
+    key: Path,
+    port: int,
+    installation: InstallConfig,
+    *,
+    host: str = "127.0.0.1",
+    timeout: float = 300.0,
+) -> str:
+    """Unlock the configured root and verify the mechanism's own result."""
+    commands = remote_unlock_commands(installation)
+    if commands is None:
+        raise RuntimeError("remote unlock is disabled")
+    command, proof = commands
+    process = subprocess.Popen(
+        [
+            "ssh", "-p", str(port), "-i", str(key),
+            "-o", "StrictHostKeyChecking=no", "-o", "UserKnownHostsFile=/dev/null",
+            "-o", "BatchMode=yes", "-o", "ConnectTimeout=10", f"root@{host}",
+            command,
+        ], stdin=subprocess.PIPE, stdout=subprocess.PIPE, stderr=subprocess.STDOUT,
+        text=True,
+    )
+    try:
+        output, _ = process.communicate(f"{DISK_PASSPHRASE}\n", timeout=timeout)
+    except subprocess.TimeoutExpired as error:
+        process.kill()
+        process.communicate()
+        raise RuntimeError(f"remote unlock timed out after {timeout:.0f}s") from error
+    if process.returncode != 0:
+        raise RuntimeError(f"remote unlock failed: {output.strip()[-300:]}")
+    if proof is None:
+        return "unlocked"
+    checked = ssh(key, port, proof, host=host)
+    status = checked.stdout.strip()
+    if checked.returncode != 0 or status != "available":
+        raise RuntimeError(f"remote ZFS unlock reported keystatus {status!r}")
+    return status
+
+
+def remote_unlock_commands(installation: InstallConfig) -> tuple[str, str | None] | None:
+    """Return the remote client command and its configuration-derived proof."""
+    if not installation.kernel.remote_unlock.enabled:
+        return None
+    if installation.bootloader.kind is Bootloader.ZFSBOOTMENU:
+        root = next(
+            mount.source
+            for mount in installation.disk.graph.of_type(Mountpoint)
+            if str(mount.path) == "/"
+        )
+        dataset = installation.disk.graph[root]
+        if not isinstance(dataset, ZfsDataset) or not dataset.name.startswith(dataset_for("/")):
+            raise RuntimeError("ZFSBootMenu root is not a configured root dataset")
+        pool = installation.disk.graph[dataset.pool]
+        if not isinstance(pool, ZfsPool):
+            raise RuntimeError("ZFSBootMenu root dataset has no configured pool")
+        full_name = f"{pool.name}/{dataset.name}"
+        return "zfs load-key -a", f"zfs get -H -o value keystatus {full_name}"
+    return "unlock", None
+
+
+def remote_config(installation: InstallConfig, public_key: str) -> InstallConfig:
+    """Replace fixture-only remote credentials with values owned by this run."""
+    unlock = installation.kernel.remote_unlock
+    if not unlock.enabled:
+        return installation
+    return replace(
+        installation,
+        system=replace(installation.system, authorized_keys=(public_key,)),
+        kernel=replace(
+            installation.kernel,
+            remote_unlock=replace(unlock, address=""),
+        ),
     )
 
 
@@ -206,8 +300,11 @@ def pin_resolver(console: SerialConsole) -> None:
 
 
 def unlock_and_login(
-    console: SerialConsole, installation: InstallConfig, monitor: Path | None = None
-) -> None:
+    console: SerialConsole,
+    installation: InstallConfig,
+    monitor: Path | None = None,
+    remote_unlocked: bool = False,
+) -> str:
     """Answer every passphrase prompt on the way to a login.
 
     `monitor` is qemu's monitor socket. GRUB unlocks an encrypted BIOS disk
@@ -223,7 +320,14 @@ def unlock_and_login(
     )
     if not encrypted:
         console.login("root", INSTALLED_PASSWORD, r"# ")
-        return
+        return "console"
+    if remote_unlocked:
+        console.expect(r"login:", timeout=300.0)
+        console.send("root")
+        console.expect(PASSWORD_PROMPT, timeout=60.0)
+        console.send(INSTALLED_PASSWORD)
+        console.expect(r"# ", timeout=60.0)
+        return "remote"
     # Bounded: a wrong passphrase makes the prompt come back, and each one
     # re-arms the timeout, so an unbounded loop would never fail.
     if monitor is not None and installation.bootloader.firmware is BootFirmware.BIOS:
@@ -239,7 +343,7 @@ def unlock_and_login(
             console.expect(PASSWORD_PROMPT, timeout=60.0)
             console.send(INSTALLED_PASSWORD)
             console.expect(r"# ", timeout=60.0)
-            return
+            return "console"
         console.send(DISK_PASSPHRASE)
     raise SystemExit("the disk kept asking for a passphrase; it is not the one installed")
 
@@ -333,6 +437,23 @@ def run_installer(console: SerialConsole, config: str, extra: str = "") -> None:
     console.run(f"cp /run/gentoo-install/install.jsonl {RESULT_DIR}/ 2>/dev/null || true")
     console.run(collect_command(RESULT_DIR))
     console.run("sync")
+
+
+def install_remote_config(
+    console: SerialConsole,
+    key: Path,
+    ssh_port: int,
+    installation: InstallConfig,
+    config: str,
+) -> str:
+    """Publish run-owned remote-unlock values and return the bootstrap path."""
+    if not installation.kernel.remote_unlock.enabled:
+        return config
+    public_key = key.with_suffix(".pub").read_text().strip()
+    substituted = remote_config(installation, public_key)
+    remote_path = f"/tmp/{Path(config).name}"
+    push_config(key, ssh_port, remote_path, to_toml(substituted))
+    return remote_path
 
 
 def probe(console: SerialConsole) -> None:
@@ -448,6 +569,8 @@ def main(argv: list[str] | None = None) -> int:
 def _perform(args: argparse.Namespace, medium: Medium, workdir: Path) -> int:
     ssh_port = args.ssh_port or free_port()
     key = ssh_keypair(workdir)
+    requested = load(REPOSITORY / "tests" / args.install) if args.install else None
+    remote_port = free_port() if requested is not None and requested.kernel.remote_unlock.enabled else None
     result_disk = create_disk(workdir / "result.img")
     driver_iso = build_driver(workdir / "driver.iso") if args.install and not args.boot_installed else None
     targets: tuple[Path, ...] = ()
@@ -472,6 +595,7 @@ def _perform(args: argparse.Namespace, medium: Medium, workdir: Path) -> int:
         **({"cpus": args.cpus} if args.cpus else {}),
         firmware=Firmware(args.firmware),
         ssh_port=ssh_port,
+        remote_unlock_port=remote_port,
         disks=(result_disk,),
         driver_iso=driver_iso,
         targets=targets,
@@ -483,8 +607,22 @@ def _perform(args: argparse.Namespace, medium: Medium, workdir: Path) -> int:
         with SerialConsole.connect(vm.serial_socket, vm.serial_log) as console:
             if args.boot_installed:
                 expected = load(REPOSITORY / "tests" / args.install)
-                unlock_and_login(console, expected, vm.monitor_socket)
-                print(f"[{time.monotonic() - started:5.1f}s] logged into the installed system")
+                unlocked_remotely = False
+                if expected.kernel.remote_unlock.enabled:
+                    if remote_port is None:
+                        raise RuntimeError("remote unlock is enabled without a forwarded port")
+                    try:
+                        remote_unlock(key, remote_port, expected)
+                    except RuntimeError as error:
+                        print(f"FAIL remote unlock: {error}", file=sys.stderr)
+                        power_off(console, vm)
+                        return 1
+                    unlocked_remotely = True
+                    print("installed root unlocked by remote SSH session")
+                method = unlock_and_login(
+                    console, expected, vm.monitor_socket, remote_unlocked=unlocked_remotely
+                )
+                print(f"[{time.monotonic() - started:5.1f}s] logged into the installed system ({method})")
                 check_installed(console, expected)
                 power_off(console, vm)
                 code = report(
@@ -517,8 +655,10 @@ def _perform(args: argparse.Namespace, medium: Medium, workdir: Path) -> int:
                 stage_passphrases(console, load(REPOSITORY / "tests" / args.install))
                 interrupt_and_resume(console, args.install)
             elif args.install:
+                installation = load(REPOSITORY / "tests" / args.install)
+                config = install_remote_config(console, key, ssh_port, installation, args.install)
                 stage_passphrases(console, load(REPOSITORY / "tests" / args.install))
-                run_installer(console, args.install, "--dry-run" if args.dry_run else "")
+                run_installer(console, config, "--dry-run" if args.dry_run else "")
             else:
                 probe(console)
             power_off(console, vm)
@@ -600,6 +740,10 @@ def verdict(
     """Turn everything the run left behind into one exit code."""
     code = check_expected(results, assertions) if assertions is not None else 0
     installer = results.get("install.rc", b"").decode("utf-8", "replace").strip()
+    remote = results.get("remote-unlock.rc", b"").decode("utf-8", "replace").strip()
+    if remote not in ("", "0"):
+        print(f"FAIL remote unlock exited {remote}", file=sys.stderr)
+        code = 1
     # The installer's own exit code, which the collected output does not carry:
     # a run that stopped at the bootloader printed its failure and exited 0.
     if installer not in ("", "0"):


### PR DESCRIPTION
The fixture reserves a passphrase the console answers, so no run ever exercised the initramfs ssh daemon the installer sets up. The harness now unlocks over the forwarded port and falls through to the console only when `remote_unlock` is off.

The command follows the configuration rather than one fixture: `zfs load-key` and a keystatus check on the configured pool under ZFSBootMenu, dracut-crypt-ssh's `unlock` otherwise. The LUKS fixture would have failed against the ZFS-only first version.

The cluster scheduler still boots through the console; only the local QEMU path forwards the unlock port, so this is not claimed as verified on real hardware.