### PR TITLE
portage: name a keyserver for the first snapshot's signature check

### DIFF
--- a/gentoo_install/plan/portage.py
+++ b/gentoo_install/plan/portage.py
@@ -51,6 +51,9 @@ AUTOUNMASK_FILES: Final[tuple[str, ...]] = (
     "/etc/portage/package.license/zz-autounmask",
 )
 
+#: Where Gentoo publishes the keys gemato refreshes.
+KEY_SERVER: Final[str] = "hkps://keys.gentoo.org"
+
 PROXY_BOOTSTRAP: Final[PurePosixPath] = PurePosixPath(
     "/etc/gentoo-install/proxy.toml"
 )
@@ -420,11 +423,13 @@ class WebrsyncRepository(Operation):
             ["portageq", "envvar", "PORTAGE_GPG_KEY_SERVER"], check=False
         )
         readable = isinstance(policy, CommandOutput) and policy.returncode == 0
-        server = policy.strip() if readable else ""
-        command = ["emerge-webrsync"]
-        if server:
-            command = ["env", f"PORTAGE_GPG_KEY_SERVER={server}", *command]
-        context.run_in_target(command)
+        # Gentoo's own when the stage3 names none: gemato tries WKD first and
+        # falls back to a keyserver, and with none configured a WKD that does
+        # not answer ends the install at `No keyserver available`.
+        server = (policy.strip() if readable else "") or KEY_SERVER
+        context.run_in_target(
+            ["env", f"PORTAGE_GPG_KEY_SERVER={server}", "emerge-webrsync"]
+        )
 
 
 #: Records between the lines tar prints while unpacking. One every few

--- a/tests/unit/test_plan_portage.py
+++ b/tests/unit/test_plan_portage.py
@@ -1169,7 +1169,10 @@ def test_the_first_snapshot_uses_portages_keyserver_policy() -> None:
     )
 
 
-def test_the_first_snapshot_keeps_portages_empty_keyserver_policy() -> None:
+def test_an_empty_keyserver_policy_still_names_one() -> None:
+    """gemato tries WKD and falls back to a keyserver. A stage3 configures
+    none, so a WKD that does not answer ended the install at `No keyserver
+    available` with the snapshot already downloaded."""
     from gentoo_install.plan.operations import CommandOutput
     from gentoo_install.plan import portage as plan_portage
     from .recorder import Recorder
@@ -1181,13 +1184,16 @@ def test_the_first_snapshot_keeps_portages_empty_keyserver_policy() -> None:
 
     recorder = Recorder(answering=answer)
     plan_portage.WebrsyncRepository().apply(recorder)
-    assert recorder.in_target[-1] == ("emerge-webrsync",)
+    assert recorder.in_target[-1] == (
+        "env", f"PORTAGE_GPG_KEY_SERVER={plan_portage.KEY_SERVER}", "emerge-webrsync"
+    )
 
 
-def test_an_unreadable_keyserver_policy_leaves_it_unset() -> None:
+def test_an_unreadable_keyserver_policy_falls_back_to_gentoos_own() -> None:
     """`portageq` cannot answer before this operation has fetched a snapshot:
     `repos.conf` names `/var/db/repos/gentoo` and nothing has created it, so it
-    exits 1. Treating that as a fault stopped every install at step 21 of 51.
+    exits 1. Treating that as a fault stopped every install at step 21 of 51,
+    and treating it as `no keyserver` stopped every one of them at gemato.
     """
     from gentoo_install.plan.operations import CommandOutput
     from gentoo_install.plan import portage as plan_portage
@@ -1202,8 +1208,9 @@ def test_an_unreadable_keyserver_policy_leaves_it_unset() -> None:
 
     recorder = Recorder(answering=answer)
     plan_portage.WebrsyncRepository().apply(recorder)
-    assert ("emerge-webrsync",) in recorder.in_target
-    assert not any(command[0] == "env" for command in recorder.in_target)
+    assert recorder.in_target[-1] == (
+        "env", f"PORTAGE_GPG_KEY_SERVER={plan_portage.KEY_SERVER}", "emerge-webrsync"
+    )
 
 
 def test_a_pinned_package_reaches_usepkg_exclude_without_its_version() -> None:


### PR DESCRIPTION
A stage3 configures no `PORTAGE_GPG_KEY_SERVER`, and gemato tries WKD before falling back to a keyserver. With none configured, a WKD that does not answer ends the install at `gpg: keyserver refresh failed: No keyserver available` with the 49 MB snapshot already downloaded and verified by digest.

Two guests died there in a regression sweep on `master`, and every fixture reaches it: the first sync is always `emerge-webrsync` whatever `sync` says. Reading the stage3's policy stays; an empty answer now means Gentoo's own keyserver rather than none.