### PR TITLE
portage: escape make.conf values so bash reads them back whole

### DIFF
--- a/gentoo_install/plan/portage.py
+++ b/gentoo_install/plan/portage.py
@@ -307,6 +307,18 @@ class WritePortageConfig(Operation):
         context.write(self.path, "".join(f"{line}\n" for line in self.lines))
 
 
+def quoted(value: str) -> str:
+    """One make.conf value, as bash reads it back literally.
+
+    Portage sources the file, so an unescaped `"` ends the value early and an
+    unescaped `$` expands there instead of when the command runs. `FETCHCOMMAND`
+    holds both, and writing it plainly gave wget no URL at all; make.globals
+    escapes the same three characters.
+    """
+    escaped = value.replace("\\", "\\\\").replace('"', '\\"').replace("$", "\\$")
+    return f'"{escaped}"'
+
+
 def merge(existing: str, wanted: Sequence[tuple[str, str]]) -> str:
     """Replace the keys this installer sets and keep the rest of the file.
 
@@ -320,11 +332,11 @@ def merge(existing: str, wanted: Sequence[tuple[str, str]]) -> str:
     for line in existing.splitlines():
         key = line.split("=", 1)[0].strip() if "=" in line and not line.lstrip().startswith("#") else ""
         if key in replacing:
-            kept.append(f'{key}="{replacing[key]}"')
+            kept.append(f"{key}={quoted(replacing[key])}")
             seen.add(key)
             continue
         kept.append(line)
-    added = [f'{key}="{value}"' for key, value in wanted if key not in seen]
+    added = [f"{key}={quoted(value)}" for key, value in wanted if key not in seen]
     if added:
         if kept and kept[-1].strip():
             kept.append("")

--- a/tests/unit/test_plan_portage.py
+++ b/tests/unit/test_plan_portage.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+import subprocess
+
 import pytest
 
 from dataclasses import fields, replace
@@ -1295,3 +1297,25 @@ def test_unpacking_a_stage3_says_it_is_still_unpacking() -> None:
     ran = next(one for one in recorder.commands if one and one[0] == "tar")
     assert f"--checkpoint={plan_portage.UNPACK_CHECKPOINT}" in ran, ran
     assert "--checkpoint-action=echo" in ran, ran
+
+
+def test_make_conf_values_survive_being_sourced_by_portage() -> None:
+    """`FETCHCOMMAND` carries both a quote and a `$`, and writing it plainly
+    ended the value at the first quote, so `emerge-webrsync` ran a wget with no
+    URL and no tree ever arrived."""
+    from gentoo_install.plan.portage import FETCHCOMMAND, RESUMECOMMAND, merge
+
+    written = merge("", (("FETCHCOMMAND", FETCHCOMMAND), ("RESUMECOMMAND", RESUMECOMMAND)))
+    for line in written.splitlines():
+        if not line.startswith(("FETCHCOMMAND=", "RESUMECOMMAND=")):
+            continue
+        key, _, value = line.partition("=")
+        # bash reads the file, so bash decides what the value is.
+        read_back = subprocess.run(
+            ["bash", "-c", f'{line}\nprintf %s "${{{key}}}"'],
+            capture_output=True,
+            text=True,
+            check=True,
+        ).stdout
+        assert read_back == (FETCHCOMMAND if key == "FETCHCOMMAND" else RESUMECOMMAND)
+        assert "${URI}" in read_back


### PR DESCRIPTION
Portage sources `make.conf`, so the value has to survive bash. `merge()` wrapped each one in double quotes and escaped nothing, and `FETCHCOMMAND` carries both a quote and a `$`: the value ended at the first inner quote and `\${URI}` expanded to nothing there, so `emerge-webrsync` ran a wget with no URL.

The first install through a working proxy stopped at exactly that. The written line is now byte-for-byte what Portage's own `make.globals` holds. The test reads each value back with bash rather than comparing strings, because bash is what decides.