### PR TITLE
fetch: try the stage3 again when a read times out

### DIFF
--- a/gentoo_install/exec/fetch.py
+++ b/gentoo_install/exec/fetch.py
@@ -731,7 +731,48 @@ def _read_once(url: str, proxy: ProxyConfig | None = None) -> str:
         raise DownloadFailed(f"{url} could not be read: {error}") from error
 
 
+#: A stage3 is a quarter of a gigabyte over whatever link the operator has, so
+#: one timed-out read part way through is the transient case. `_read_patiently`
+#: already covers the pointer file beside it; the archive had no retry at all,
+#: and `The read operation timed out` ended an install two minutes in.
+DOWNLOAD_TRIES: Final[int] = 3
+
+
+def _permanent(error: BaseException) -> bool:
+    """Whether trying again cannot help. A missing archive stays missing; a
+    timeout, a reset, or `429 Too Many Requests` is a moment rather than an
+    answer."""
+    return (
+        isinstance(error, urllib.error.HTTPError)
+        and 400 <= error.code < 500
+        and error.code not in {408, 429}
+    )
+
+
 def _download(
+    url: str,
+    target: Path,
+    log: Callable[[str], None] | None = None,
+    proxy: ProxyConfig | None = None,
+) -> None:
+    """Retried with a growing pause, because a stage3 is the longest fetch a
+    run makes and a link that dropped one read usually carries the next."""
+    last: DownloadFailed | None = None
+    for attempt in range(DOWNLOAD_TRIES):
+        try:
+            _download_over_any_family(url, target, log, proxy)
+            return
+        except DownloadFailed as error:
+            if _permanent(error.__cause__ or error):
+                raise
+            last = error
+            if attempt + 1 < DOWNLOAD_TRIES:
+                time.sleep(ONLINE_PAUSE * 2**attempt)
+    assert last is not None
+    raise last
+
+
+def _download_over_any_family(
     url: str,
     target: Path,
     log: Callable[[str], None] | None = None,

--- a/tests/unit/test_exec.py
+++ b/tests/unit/test_exec.py
@@ -2122,3 +2122,67 @@ def test_a_long_download_says_it_is_still_downloading() -> None:
     assert said, "the download reported nothing"
     assert "stage3.tar.xz" in said[0], said
     assert "MiB" in said[0], said
+
+
+def test_a_timed_out_stage3_read_is_tried_again(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """The pointer file beside the archive already retried; the archive itself
+    retried only when the address family had no route, so one
+    `The read operation timed out` ended an install two minutes in."""
+    from gentoo_install.exec import fetch
+    from gentoo_install.errors import DownloadFailed
+
+    tries = {"n": 0}
+
+    def flaky(url: str, target: Path, log: object = None, proxy: object = None) -> None:
+        tries["n"] += 1
+        if tries["n"] < 3:
+            raise DownloadFailed(f"{url} could not be fetched: The read operation timed out")
+        target.write_bytes(b"stage3")
+
+    monkeypatch.setattr(fetch, "_download_over_any_family", flaky)
+    import time as clock
+
+    monkeypatch.setattr(clock, "sleep", lambda seconds: None)
+    archive = tmp_path / "stage3.tar.xz"
+    fetch._download("https://distfiles.invalid/stage3.tar.xz", archive)
+    assert archive.read_bytes() == b"stage3"
+    assert tries["n"] == 3
+
+    # Bounded: a mirror that never answers stops the install rather than
+    # holding it open.
+    tries["n"] = 0
+
+    def dead(url: str, target: Path, log: object = None, proxy: object = None) -> None:
+        tries["n"] += 1
+        raise DownloadFailed(f"{url} could not be fetched: The read operation timed out")
+
+    monkeypatch.setattr(fetch, "_download_over_any_family", dead)
+    with pytest.raises(DownloadFailed):
+        fetch._download("https://distfiles.invalid/stage3.tar.xz", archive)
+    assert tries["n"] == fetch.DOWNLOAD_TRIES
+
+
+def test_a_missing_stage3_is_not_asked_for_again(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """A mirror that answers `404` answers it every time, and three of them
+    with a growing pause is a minute spent proving what the first one said."""
+    import urllib.error
+    from email.message import Message
+
+    from gentoo_install.exec import fetch
+    from gentoo_install.errors import DownloadFailed
+
+    tries = {"n": 0}
+
+    def missing(url: str, target: Path, log: object = None, proxy: object = None) -> None:
+        tries["n"] += 1
+        cause = urllib.error.HTTPError(url, 404, "Not Found", Message(), None)
+        raise DownloadFailed(f"{url} could not be fetched: {cause}") from cause
+
+    monkeypatch.setattr(fetch, "_download_over_any_family", missing)
+    with pytest.raises(DownloadFailed):
+        fetch._download("https://distfiles.invalid/gone.tar.xz", tmp_path / "gone.tar.xz")
+    assert tries["n"] == 1


### PR DESCRIPTION
`_download` retried only when the failure was an address family with no route. Everything else — a reset, a timeout part way through a quarter of a gigabyte — raised at once, and `vm-sdboot` stopped at `DownloadFailed: ... The read operation timed out` two and a half minutes into a cluster run.

The pointer file beside the archive has retried four times since a `Connection reset by peer` ended an install the same way; the archive, which is a thousand times larger and the longest fetch a run makes, had none.

A `404` is still asked for once: a missing archive stays missing, and `408` and `429` are the two 4xx that are a moment rather than an answer.