### PR TITLE
portage: fetch through a SOCKS proxy with curl, which can use one

### DIFF
--- a/gentoo_install/model/config.py
+++ b/gentoo_install/model/config.py
@@ -53,6 +53,21 @@ class ProxyConfig:
         return bool(self.url)
 
     @property
+    def over_socks(self) -> bool:
+        """Whether the fetchers have to be ones that speak SOCKS.
+
+        `validate.py` names the four schemes an operator may write; this
+        divides them, so a caller never carries its own set of scheme names.
+        """
+        from urllib.parse import urlsplit
+
+        return urlsplit(self.url).scheme.lower() in {"socks5", "socks5h"}
+
+    @property
+    def over_http(self) -> bool:
+        return self.enabled and not self.over_socks
+
+    @property
     def redacted_url(self) -> str:
         """The URL with user information removed for screen and log output."""
         from urllib.parse import urlsplit, urlunsplit

--- a/gentoo_install/plan/portage.py
+++ b/gentoo_install/plan/portage.py
@@ -57,6 +57,9 @@ KEY_SERVER: Final[str] = "hkps://keys.gentoo.org"
 PROXY_BOOTSTRAP: Final[PurePosixPath] = PurePosixPath(
     "/etc/gentoo-install/proxy.toml"
 )
+CURL_PROXY_CONFIG: Final[PurePosixPath] = PurePosixPath(
+    "/etc/gentoo-install/curl-proxy.conf"
+)
 
 FETCHCOMMAND: Final[str] = (
     'wget -t 3 -T 60 --passive-ftp -U "Portage (Gentoo, '
@@ -65,6 +68,19 @@ FETCHCOMMAND: Final[str] = (
 RESUMECOMMAND: Final[str] = (
     'wget -c -t 3 -T 60 --passive-ftp -U "Portage (Gentoo, '
     'https://www.gentoo.org) distfile-fetch" -O "${DISTDIR}/${FILE}" "${URI}"'
+)
+#: `-K` rather than the command line: `/proc/<pid>/cmdline` is world readable
+#: and the file this names carries the proxy's password. curl treats a missing
+#: file as an error, and `WriteProxyClients` writes it before the first fetch.
+CURL_FETCHCOMMAND: Final[str] = (
+    f'curl -K {CURL_PROXY_CONFIG} --fail --location --retry 3 '
+    '--connect-timeout 60 --output '
+    '"${DISTDIR}/${FILE}" "${URI}"'
+)
+CURL_RESUMECOMMAND: Final[str] = (
+    f'curl -K {CURL_PROXY_CONFIG} --fail --location --retry 3 '
+    '--connect-timeout 60 --continue-at - --output '
+    '"${DISTDIR}/${FILE}" "${URI}"'
 )
 
 #: What is absent matters as much as what is here, and the reason for each
@@ -161,17 +177,20 @@ class WriteProxyClients(Operation):
         bypass = ",".join(proxy.bypass)
         context.write(
             PurePosixPath("/etc/wgetrc"),
-            f"use_proxy = {'on' if proxy.enabled else 'off'}\n"
-            f"http_proxy = {endpoint}\nhttps_proxy = {endpoint}\n"
-            f"no_proxy = {bypass}\nproxy_user = {proxy.username}\n"
-            f"proxy_password = {proxy.password}\n",
+            (
+                f"use_proxy = on\nhttp_proxy = {endpoint}\nhttps_proxy = {endpoint}\n"
+                f"no_proxy = {bypass}\nproxy_user = {proxy.username}\n"
+                f"proxy_password = {proxy.password}\n"
+                if proxy.over_http
+                else "use_proxy = off\n"
+            ),
             mode=0o600,
         )
         context.write(
-            PurePosixPath("/etc/curlrc"),
-            f"proxy = {endpoint}\n"
-            f"noproxy = {bypass}\n"
-            f"proxy-user = {proxy.username}:{proxy.password}\n",
+            CURL_PROXY_CONFIG,
+            f'proxy = "{endpoint}"\n'
+            f'noproxy = "{bypass}"\n'
+            f'proxy-user = "{proxy.username}:{proxy.password}"\n',
             mode=0o600,
         )
         context.write(
@@ -179,11 +198,6 @@ class WriteProxyClients(Operation):
             "[http]\n"
             f"\tproxy = {proxy.url}\n"
             f"\tnoProxy = {bypass}\n",
-            mode=0o600,
-        )
-        context.write(
-            PurePosixPath("/etc/portage/gnupg/dirmngr.conf"),
-            f"http-proxy {proxy.url}\n" if proxy.enabled else "",
             mode=0o600,
         )
         context.write(
@@ -1096,20 +1110,44 @@ def make_conf(
     proxy = config.proxy
     if proxy.enabled:
         endpoint = _proxy_endpoint(proxy)
+        fetchcommand = CURL_FETCHCOMMAND if proxy.over_socks else FETCHCOMMAND
+        resumecommand = CURL_RESUMECOMMAND if proxy.over_socks else RESUMECOMMAND
+        # `http_proxy` names an HTTP proxy and nothing else. `getuto` writes
+        # `honor-http-proxy` into its own dirmngr.conf, so a SOCKS URL there
+        # made the tree's signature check answer `keyserver refresh failed:
+        # Invalid URI`. dirmngr cannot use SOCKS at all; `all_proxy` is the
+        # one curl reads and dirmngr ignores.
+        named = ("all_proxy",) if proxy.over_socks else (
+            "http_proxy", "https_proxy", "ftp_proxy", "all_proxy"
+        )
+        settings += [(name, endpoint) for name in named]
         settings += [
-            ("http_proxy", endpoint),
-            ("https_proxy", endpoint),
-            ("ftp_proxy", endpoint),
-            ("all_proxy", endpoint),
             ("no_proxy", ",".join(proxy.bypass)),
-            ("FETCHCOMMAND", FETCHCOMMAND),
-            ("RESUMECOMMAND", RESUMECOMMAND),
+            ("FETCHCOMMAND", fetchcommand),
+            ("RESUMECOMMAND", resumecommand),
         ]
-        if urlsplit(proxy.url).scheme.lower() in {"http", "https"}:
+        if proxy.over_http:
             settings.append(("RSYNC_PROXY", _rsync_proxy(proxy)))
-    if _uses_binhost(portage):
-        settings.append(("FEATURES", "getbinpkg"))
+    features = _features(config)
+    if features:
+        settings.append(("FEATURES", " ".join(features)))
     return tuple(settings)
+
+
+def _features(config: InstallConfig) -> tuple[str, ...]:
+    """One `FEATURES` value, because two would leave two lines and bash keeps
+    the last.
+
+    `userfetch` is Portage's own default and it drops the fetch to the
+    `portage` user, which cannot read the `0600` files holding the proxy's
+    password: curl answered `cannot read config from` for every distfile.
+    """
+    wanted: list[str] = []
+    if _uses_binhost(config.portage):
+        wanted.append("getbinpkg")
+    if config.proxy.enabled and (config.proxy.over_socks or config.proxy.username):
+        wanted.append("-userfetch")
+    return tuple(wanted)
 
 
 def _proxy_endpoint(proxy: ProxyConfig) -> str:

--- a/tests/fixtures/vm-proxy.toml
+++ b/tests/fixtures/vm-proxy.toml
@@ -1,15 +1,19 @@
-# The negative direction of the proxy option: every fetch is pointed at a port
-# nothing listens on, so the install must stop rather than reach the network
-# directly. `vm-proxy` is the same layout with a proxy that works.
+# Every fetch goes through a SOCKS5 proxy that demands a password. `vm-proxy-dead`
+# proves the failure direction; nothing had ever proved that an install completes
+# when the proxy works, which is what an operator on an intranet actually needs.
+#
+# `10.0.2.2` is the workstation as qemu's user-mode network presents it, so this
+# fixture runs under `tests/vm/run.py` and not on the cluster.
 #
 # The root hash below is `install`, produced by `openssl passwd -6`.
 config_version = 1
 
 [proxy]
-url = "http://127.0.0.1:1"
+url = "socks5h://installer:secret@10.0.2.2:1080"
+bypass = ["localhost", "127.0.0.1"]
 
 [system]
-hostname = "btrfsbox"
+hostname = "proxybox"
 timezone = "Asia/Taipei"
 locales = ["en_US.UTF-8", "zh_TW.UTF-8"]
 locale = "zh_TW.UTF-8"

--- a/tests/golden/vm-proxy.txt
+++ b/tests/golden/vm-proxy.txt
@@ -1,0 +1,76 @@
+[partition]
+  release anything a previous run of this configuration left mounted or open
+  wipe existing signatures from disk
+  create a gpt partition table on disk as table
+  create partition 1 on disk as esp: esp, 512MiB
+  create partition 2 on disk as cryptroot: data, the rest of the disk
+  reread the partition table of disk and wait for its nodes
+
+[format]
+  make a vfat filesystem on esp as espfs labelled ESP
+  make a btrfs filesystem on cryptroot as rootfs
+  create btrfs subvolume @home on cryptroot as sub-home
+  create btrfs subvolume @ on cryptroot as sub-root
+
+[mount]
+  mount cryptroot at / with compress=zstd:1,subvol=@
+  mount esp at /efi with umask=0077
+  mount cryptroot at /home with compress=zstd:1,subvol=@home
+
+[stage3]
+  download the newest systemd stage3 from https://distfiles.gentoo.org via socks5h://10.0.2.2:1080, verify it against BB572E0E2D182910 and unpack it into the target
+
+[chroot]
+  mount transient proc, sys, dev and run filesystems into the target
+  seed the target's resolv.conf from the install medium
+
+[portage]
+  write /etc/portage/make.conf with MAKEOPTS, INPUT_DEVICES, ACCEPT_LICENSE, L10N, all_proxy, no_proxy, FETCHCOMMAND, RESUMECOMMAND, FEATURES; 2 mirrors in the configured order, 5 appended
+  configure Portage, wget, curl, git and gpg for socks5h://10.0.2.2:1080
+  create the three autounmask files emerge writes its decisions into
+  run getuto so Portage has a keyring to verify binary packages against
+  add verified binary package host gentoo at https://distfiles.gentoo.org/releases/amd64/binpackages/23.0/x86-64
+  fetch the first ebuild repository snapshot with emerge-webrsync
+  select profile default/linux/amd64/23.0/systemd
+  install git, which every later repository sync needs: emerge dev-vcs/git
+  point repository gentoo at https://github.com/gentoo-mirror/gentoo.git, commit signatures verified
+  sync repository gentoo
+  set sys-kernel/installkernel to dracut
+  accept the linux-firmware licence
+  resolve sys-process/cronie sys-kernel/installkernel sys-kernel/dracut sys-kernel/linux-firmware sys-fs/btrfs-progs sys-fs/dosfstools sys-kernel/gentoo-kernel-bin sys-boot/grub sys-boot/efibootmgr together before installing the requested packages
+
+[system]
+  keep proxy environment for socks5h://10.0.2.2:1080 in the installed system
+  generate and verify locales en_US.UTF-8, zh_TW.UTF-8
+  set the system locale to zh_TW.UTF-8
+  set the timezone to Asia/Taipei
+  set the console keymap to us and its font to default8x16
+  set the hostname to proxybox
+  give the target its own machine id
+  write /etc/fstab with entries for /, /efi, /home
+  treat the hardware clock as UTC
+  set the root password
+  configure the wired interface for DHCP
+  enable systemd-networkd at boot
+  enable systemd-resolved at boot
+  install cron: emerge sys-process/cronie
+  enable cronie at boot
+
+[kernel]
+  install the hook that puts a kernel in /boot: emerge sys-kernel/installkernel
+  install the initramfs builder and firmware: emerge sys-kernel/dracut sys-kernel/linux-firmware
+  install the storage tools: emerge sys-fs/btrfs-progs sys-fs/dosfstools
+  install the kernel: emerge sys-kernel/gentoo-kernel-bin
+  tell dracut to carry btrfs
+  rebuild the initramfs from sys-kernel/gentoo-kernel-bin with the modules written above
+  check the installkernel payload names existing kernel files
+
+[bootloader]
+  install the bootloader: emerge sys-boot/grub sys-boot/efibootmgr
+  write /etc/default/grub with cmdline console=ttyS0,115200, its menu on ttyS0
+  install GRUB for uefi on the esp at /efi
+
+[finish]
+  point /etc/resolv.conf at systemd-resolved rather than the install medium's
+  delete the downloaded stage3 from /var/cache/gentoo-install
+  unmount everything under the target

--- a/tests/unit/test_harness.py
+++ b/tests/unit/test_harness.py
@@ -1927,3 +1927,56 @@ def test_a_healthy_init_is_judged_by_the_marker_it_prints() -> None:
     broken = dict(healthy)
     broken["failed.txt"] = b"cronie.service loaded failed failed\n"
     assert check_expected(broken, fixture) != 0
+
+
+def test_a_proxy_on_the_workstation_must_be_listening_before_the_run() -> None:
+    """The install fails at the stage3 fetch when it is not, and that reads as
+    a defect in the proxy support the fixture exists to prove."""
+    import socket
+    from dataclasses import replace
+
+    from gentoo_install.exec.config import load
+    from tests.vm.run import GATEWAY, require_proxy
+
+    root = Path(__file__).resolve().parents[1]
+    installation = load(root / "fixtures" / "vm-proxy.toml")
+    with socket.socket() as listener:
+        listener.bind(("127.0.0.1", 0))
+        listener.listen(1)
+        port = listener.getsockname()[1]
+        require_proxy(
+            replace(
+                installation,
+                proxy=replace(installation.proxy, url=f"socks5h://{GATEWAY}:{port}"),
+            )
+        )
+    with pytest.raises(SystemExit) as refused:
+        require_proxy(
+            replace(
+                installation,
+                proxy=replace(installation.proxy, url=f"socks5h://{GATEWAY}:{port}"),
+            )
+        )
+    assert str(port) in str(refused.value)
+
+
+def test_a_proxy_somewhere_else_is_not_checked_against_this_workstation() -> None:
+    """An operator's own intranet proxy is unreachable from here by design, and
+    refusing the run on that would refuse every real configuration."""
+    from dataclasses import replace
+
+    from gentoo_install.exec.config import load
+    from tests.vm.run import free_port, require_proxy
+
+    root = Path(__file__).resolve().parents[1]
+    installation = load(root / "fixtures" / "vm-proxy.toml")
+    # A port nothing holds, so dropping the address check would make this
+    # raise. `1080` would not: the workstation runs a proxy there during a
+    # proxy run, and the test would pass for the wrong reason.
+    port = free_port()
+    require_proxy(
+        replace(
+            installation,
+            proxy=replace(installation.proxy, url=f"socks5h://192.0.2.9:{port}"),
+        )
+    )

--- a/tests/unit/test_plan_portage.py
+++ b/tests/unit/test_plan_portage.py
@@ -179,9 +179,58 @@ def test_proxy_clients_route_portage_and_keep_credentials_out_of_descriptions() 
     assert 'no_proxy="localhost,intranet.example"' in make_conf
     assert secret not in make_conf
     assert secret in recorder.files[PurePosixPath("/etc/wgetrc")]
+    assert secret in recorder.files[portage.CURL_PROXY_CONFIG]
     assert secret in recorder.files[PurePosixPath("/etc/gitconfig")]
-    assert secret in recorder.files[PurePosixPath("/etc/portage/gnupg/dirmngr.conf")]
+    # Not dirmngr.conf: `getuto` rebuilds /etc/portage/gnupg from a staging
+    # directory afterwards, so anything written there is thrown away. It reaches
+    # the proxy through its own `honor-http-proxy` and `http_proxy` instead.
     assert all(secret not in operation.describe() for operation in portage.build(installation, MIRROR))
+
+
+def test_socks_proxy_uses_curl_for_portage_and_leaves_wget_and_dirmngr_direct() -> None:
+    installation = replace(
+        config(), proxy=ProxyConfig(url="socks5h://installer:secret@proxy.example:1080")
+    )
+
+    recorder = apply_all(installation)
+    make_conf = recorder.files[PurePosixPath("/etc/portage/make.conf")]
+
+    assert 'FETCHCOMMAND="curl ' in make_conf
+    assert 'RESUMECOMMAND="curl ' in make_conf
+    assert f'FETCHCOMMAND="curl -K {portage.CURL_PROXY_CONFIG}' in make_conf
+    assert f'RESUMECOMMAND="curl -K {portage.CURL_PROXY_CONFIG}' in make_conf
+    assert "wget" not in make_conf.split('FETCHCOMMAND="', 1)[1].split('"', 1)[0]
+    assert "RSYNC_PROXY" not in make_conf
+    assert "proxy = \"socks5h://proxy.example:1080\"" in recorder.files[portage.CURL_PROXY_CONFIG]
+    assert 'proxy-user = "installer:secret"' in recorder.files[portage.CURL_PROXY_CONFIG]
+    assert "installer:secret" not in make_conf
+    assert "installer:secret" not in portage.CURL_FETCHCOMMAND
+    assert "installer:secret" not in portage.CURL_RESUMECOMMAND
+    assert recorder.files[PurePosixPath("/etc/wgetrc")] == "use_proxy = off\n"
+    # `getuto` rebuilds /etc/portage/gnupg from a staging directory after this
+    # runs, so nothing written there survives; its own dirmngr.conf carries
+    # `honor-http-proxy`, and a SOCKS URL in `http_proxy` made the tree's
+    # signature check answer `Invalid URI`.
+    assert PurePosixPath("/etc/portage/gnupg/dirmngr.conf") not in recorder.files
+    assert "http_proxy" not in make_conf
+    assert "https_proxy" not in make_conf
+    assert "ftp_proxy" not in make_conf
+    assert 'all_proxy="socks5h://proxy.example:1080"' in make_conf
+
+
+def test_http_proxy_keeps_wget_for_portage_and_configures_wget_and_dirmngr() -> None:
+    installation = replace(config(), proxy=ProxyConfig(url="http://installer:secret@proxy.example:8080"))
+
+    recorder = apply_all(installation)
+    make_conf = recorder.files[PurePosixPath("/etc/portage/make.conf")]
+
+    assert 'FETCHCOMMAND="wget ' in make_conf
+    assert 'RESUMECOMMAND="wget ' in make_conf
+    assert "http_proxy = http://proxy.example:8080" in recorder.files[PurePosixPath("/etc/wgetrc")]
+    # dirmngr reaches the proxy through `honor-http-proxy` and the environment
+    # `http_proxy`, which is why an HTTP proxy needs no file of its own.
+    assert 'http_proxy="http://proxy.example:8080"' in make_conf
+    assert PurePosixPath("/etc/portage/gnupg/dirmngr.conf") not in recorder.files
 
 
 def test_no_proxy_leaves_every_client_as_the_distribution_shipped_it() -> None:
@@ -195,8 +244,9 @@ def test_no_proxy_leaves_every_client_as_the_distribution_shipped_it() -> None:
     for name in ("http_proxy", "https_proxy", "ftp_proxy", "all_proxy", "no_proxy",
                  "FETCHCOMMAND", "RESUMECOMMAND", "RSYNC_PROXY"):
         assert name not in make_conf
-    for path in ("/etc/wgetrc", "/etc/curlrc", "/etc/gitconfig"):
+    for path in ("/etc/wgetrc", "/etc/gitconfig"):
         assert PurePosixPath(path) not in recorder.files
+    assert portage.CURL_PROXY_CONFIG not in recorder.files
 
 
 def test_l10n_is_derived_from_the_locales_rather_than_listed_twice() -> None:
@@ -910,6 +960,30 @@ def test_a_key_the_file_already_has_is_replaced_in_place() -> None:
     assert 'MAKEOPTS="-j8"' in merged
 
 
+def test_make_conf_values_survive_being_sourced_by_portage() -> None:
+    installation = replace(
+        config(),
+        proxy=ProxyConfig(url='socks5h://user:pass@proxy.example:1080'),
+        portage=replace(
+            config().portage,
+            makeopts='-j8 "quoted" $expanded \\literal',
+        ),
+    )
+    written = apply_all(installation).files[PurePosixPath("/etc/portage/make.conf")]
+    result = subprocess.run(
+        ["bash", "-c", "source /dev/stdin; printf '%s' \"$MAKEOPTS\""],
+        input=written,
+        text=True,
+        capture_output=True,
+        check=True,
+    )
+
+    assert result.stdout == '-j8 "quoted" $expanded \\literal'
+    assert '\\"' in written
+    assert "\\$" in written
+    assert "\\\\" in written
+
+
 def test_common_flags_are_left_alone_unless_they_were_changed() -> None:
     """The default is the stage3's own value, so writing it would only add a
     line that says what the file already said."""
@@ -1299,7 +1373,7 @@ def test_unpacking_a_stage3_says_it_is_still_unpacking() -> None:
     assert "--checkpoint-action=echo" in ran, ran
 
 
-def test_make_conf_values_survive_being_sourced_by_portage() -> None:
+def test_an_awkward_make_conf_value_survives_the_whole_plan() -> None:
     """`FETCHCOMMAND` carries both a quote and a `$`, and writing it plainly
     ended the value at the first quote, so `emerge-webrsync` ran a wget with no
     URL and no tree ever arrived."""
@@ -1319,3 +1393,28 @@ def test_make_conf_values_survive_being_sourced_by_portage() -> None:
         ).stdout
         assert read_back == (FETCHCOMMAND if key == "FETCHCOMMAND" else RESUMECOMMAND)
         assert "${URI}" in read_back
+
+
+def test_a_proxy_with_a_private_file_turns_userfetch_off() -> None:
+    """Portage's own default drops the fetch to the `portage` user, which
+    cannot read the `0600` file holding the password: curl answered `cannot
+    read config from /etc/gentoo-install/curl-proxy.conf` for every distfile
+    and the install stopped at `linux-firmware`."""
+    installation = replace(
+        config(), proxy=ProxyConfig(url="socks5h://installer:secret@proxy.example:1080")
+    )
+
+    make_conf = apply_all(installation).files[PurePosixPath("/etc/portage/make.conf")]
+    features = [line for line in make_conf.splitlines() if line.startswith("FEATURES=")]
+
+    # One line: two would each be a whole assignment and bash keeps the last.
+    assert len(features) == 1
+    assert "-userfetch" in features[0]
+
+
+def test_no_proxy_leaves_userfetch_alone() -> None:
+    """It is a Portage default and this installer has no opinion on it; the
+    only reason to name it is a file the fetching user cannot read."""
+    make_conf = apply_all(config()).files[PurePosixPath("/etc/portage/make.conf")]
+
+    assert "userfetch" not in make_conf

--- a/tests/vm/campaign.py
+++ b/tests/vm/campaign.py
@@ -174,6 +174,11 @@ STAGES: Final[dict[str, tuple[Run, ...]]] = {
         # the mirror proves something bypassed it, so this one is expected to
         # fail at the stage3 download and its failure is the result.
         Run("fixtures/vm-proxy-dead.toml"),
+        # The direction that matters to an operator on an intranet, and the one
+        # nothing covered: the proxy answers and the install completes through
+        # it. It needs a SOCKS5 listener on the workstation, so `run.py` refuses
+        # the run rather than reporting a proxy defect the fixture cannot show.
+        Run("fixtures/vm-proxy.toml"),
         Run("fixtures/vm-unlock.toml"),
         # The same configuration again, killed partway and finished with
         # --resume: the one path nothing else reaches.

--- a/tests/vm/run.py
+++ b/tests/vm/run.py
@@ -21,6 +21,8 @@ import time
 from collections.abc import Sequence
 from dataclasses import replace
 from pathlib import Path
+from typing import Final
+from urllib.parse import urlsplit
 
 from gentoo_install.model.config import Bootloader, Firmware as BootFirmware, InitSystem, InstallConfig
 from gentoo_install.model.device import (
@@ -95,11 +97,38 @@ def claim(workdir: Path) -> int:
     return handle
 
 
+#: qemu's user-mode network puts the workstation here, so a fixture that
+#: names a proxy on the host names this address.
+GATEWAY: Final[str] = "10.0.2.2"
+
+
 def free_port() -> int:
     with socket.socket() as probe:
         probe.bind(("127.0.0.1", 0))
         port: int = probe.getsockname()[1]
     return port
+
+
+def require_proxy(installation: InstallConfig) -> None:
+    """Refuse a run whose proxy is not listening, before anything is built.
+
+    A fixture reaches the workstation at qemu's user-mode gateway, which is
+    `127.0.0.1` from here. Without this the install fails at the stage3 fetch
+    and reads exactly like a defect in the proxy support it was meant to prove.
+    """
+    url = installation.proxy.url
+    if not url:
+        return
+    parsed = urlsplit(url)
+    if parsed.hostname != GATEWAY or parsed.port is None:
+        return
+    with socket.socket() as probe:
+        probe.settimeout(5.0)
+        if probe.connect_ex(("127.0.0.1", parsed.port)) != 0:
+            raise SystemExit(
+                f"{url} names this workstation, and nothing is listening on "
+                f"port {parsed.port}; start the proxy before the run"
+            )
 
 
 def _target_paths(workdir: Path, installation: InstallConfig) -> tuple[Path, ...]:
@@ -570,7 +599,11 @@ def _perform(args: argparse.Namespace, medium: Medium, workdir: Path) -> int:
     ssh_port = args.ssh_port or free_port()
     key = ssh_keypair(workdir)
     requested = load(REPOSITORY / "tests" / args.install) if args.install else None
-    remote_port = free_port() if requested is not None and requested.kernel.remote_unlock.enabled else None
+    if requested is not None:
+        require_proxy(requested)
+    remote_port = (
+        free_port() if requested is not None and requested.kernel.remote_unlock.enabled else None
+    )
     result_disk = create_disk(workdir / "result.img")
     driver_iso = build_driver(workdir / "driver.iso") if args.install and not args.boot_installed else None
     targets: tuple[Path, ...] = ()


### PR DESCRIPTION
The option is documented as supporting SOCKS5, and no run had ever used one. The first that did stopped four times, each on a different mechanism: wget answers `Unsupported scheme` to every `socks5h://` URL; dirmngr answers `Invalid URI` to one in `http_proxy`, which `getuto` makes it honour; `userfetch` drops the fetch to the `portage` user, which cannot open the `0600` file holding the password; and `merge()` ended a `FETCHCOMMAND` at its first inner quote.

So SOCKS now fetches with curl, reading its credentials from a file through `-K` rather than from argv, sets only `all_proxy`, and turns `userfetch` off. `tests/fixtures/vm-proxy.toml` is the direction nothing covered; `vm-proxy-dead` only ever proved a fetch cannot bypass the setting.

Verified: an install through a real authenticated SOCKS5 listener completed, 57 operations, 93 packages from a binary host and 14 compiled. dirmngr has no SOCKS support at all, so gemato's key refresh still needs a direct route to the keyserver; `docs/design.md` names that boundary.