### PR TITLE
fetch: wait longer when a name does not resolve

### DIFF
--- a/gentoo_install/exec/fetch.py
+++ b/gentoo_install/exec/fetch.py
@@ -738,6 +738,20 @@ def _read_once(url: str, proxy: ProxyConfig | None = None) -> str:
 DOWNLOAD_TRIES: Final[int] = 3
 
 
+#: How long a name may stay unresolvable before the install gives up. A
+#: resolver that answers intermittently is the common case on the networks this
+#: installer is used from, and `Temporary failure in name resolution` says so;
+#: six seconds of retry ended installs a resolver would have served a minute
+#: later. `SYNC_PAUSE` waits this long for a mirror rewriting its Manifests.
+UNRESOLVED_PAUSE: Final[float] = 30.0
+
+
+def _unresolved(error: BaseException) -> bool:
+    """Whether the name did not resolve, rather than the host refusing."""
+    reason = getattr(error, "reason", error)
+    return isinstance(reason, socket.gaierror) and reason.errno == socket.EAI_AGAIN
+
+
 def _permanent(error: BaseException) -> bool:
     """Whether trying again cannot help. A missing archive stays missing; a
     timeout, a reset, or `429 Too Many Requests` is a moment rather than an
@@ -767,7 +781,10 @@ def _download(
                 raise
             last = error
             if attempt + 1 < DOWNLOAD_TRIES:
-                time.sleep(ONLINE_PAUSE * 2**attempt)
+                cause = error.__cause__ or error
+                time.sleep(
+                    UNRESOLVED_PAUSE if _unresolved(cause) else ONLINE_PAUSE * 2**attempt
+                )
     assert last is not None
     raise last
 

--- a/tests/unit/test_exec.py
+++ b/tests/unit/test_exec.py
@@ -2186,3 +2186,60 @@ def test_a_missing_stage3_is_not_asked_for_again(
     with pytest.raises(DownloadFailed):
         fetch._download("https://distfiles.invalid/gone.tar.xz", tmp_path / "gone.tar.xz")
     assert tries["n"] == 1
+
+
+def test_a_name_that_does_not_resolve_is_waited_out(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """`Temporary failure in name resolution` says the resolver may answer in a
+    minute, and six seconds of retry ended installs on a network whose only
+    resolver answers intermittently."""
+    import socket as network
+
+    from gentoo_install.exec import fetch
+    from gentoo_install.errors import DownloadFailed
+
+    waited: list[float] = []
+    tries = {"n": 0}
+
+    def flaky(url: str, target: Path, log: object = None, proxy: object = None) -> None:
+        tries["n"] += 1
+        if tries["n"] < 2:
+            cause = network.gaierror(network.EAI_AGAIN, "Temporary failure in name resolution")
+            raise DownloadFailed(f"{url} could not be fetched: {cause}") from cause
+        target.write_bytes(b"stage3")
+
+    monkeypatch.setattr(fetch, "_download_over_any_family", flaky)
+    import time as clock
+
+    monkeypatch.setattr(clock, "sleep", waited.append)
+    fetch._download("https://distfiles.invalid/stage3.tar.xz", tmp_path / "stage3.tar.xz")
+
+    assert waited == [fetch.UNRESOLVED_PAUSE]
+
+
+def test_a_refused_connection_is_not_waited_out_as_long(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """A host that answers `Connection refused` is answering; only the resolver
+    earns the long pause."""
+    from gentoo_install.exec import fetch
+    from gentoo_install.errors import DownloadFailed
+
+    waited: list[float] = []
+    tries = {"n": 0}
+
+    def flaky(url: str, target: Path, log: object = None, proxy: object = None) -> None:
+        tries["n"] += 1
+        if tries["n"] < 2:
+            cause = ConnectionRefusedError("Connection refused")
+            raise DownloadFailed(f"{url} could not be fetched: {cause}") from cause
+        target.write_bytes(b"stage3")
+
+    monkeypatch.setattr(fetch, "_download_over_any_family", flaky)
+    import time as clock
+
+    monkeypatch.setattr(clock, "sleep", waited.append)
+    fetch._download("https://distfiles.invalid/stage3.tar.xz", tmp_path / "stage3.tar.xz")
+
+    assert waited == [fetch.ONLINE_PAUSE]


### PR DESCRIPTION
`#279` retries a stage3 three times with two and four seconds between them. A resolver that answers intermittently takes longer than six seconds to come back, and eight guests in one campaign stopped at `DownloadFailed: ... [Errno -3] Temporary failure in name resolution` two minutes in, with the disk already written.

EAI_AGAIN is the resolver saying to ask again, so it gets `SYNC_PAUSE`'s thirty seconds rather than the short backoff. A refused connection is a host answering, and keeps the short one.