### PR TITLE
system: write the proxy environment only when there is a proxy

### DIFF
--- a/gentoo_install/plan/system.py
+++ b/gentoo_install/plan/system.py
@@ -76,10 +76,14 @@ class WriteProxyEnvironment(Operation):
     proxy: ProxyConfig
 
     def describe(self) -> str:
-        route = self.proxy.redacted_url if self.proxy.enabled else "direct connection"
-        return f"keep proxy environment for {route} in the installed system"
+        return f"keep proxy environment for {self.proxy.redacted_url} in the installed system"
 
     def apply(self, context: Context) -> None:
+        # `/etc/environment` is replaced, not appended to, so a run with no
+        # proxy left ten empty variables in every installed system and took
+        # whatever the file already held with them.
+        if not self.proxy.enabled:
+            return
         endpoint = _proxy_endpoint(self.proxy)
         bypass = ",".join(self.proxy.bypass)
         values = {
@@ -963,7 +967,7 @@ class EnableService(Operation):
 def build(config: InstallConfig) -> list[Operation]:
     system = config.system
     operations: list[Operation] = [
-        WriteProxyEnvironment(proxy=config.proxy),
+        *([WriteProxyEnvironment(proxy=config.proxy)] if config.proxy.enabled else []),
         GenerateLocales(locales=system.locales),
         SelectLocale(locale=system.locale, init=system.init),
         SetTimezone(timezone=system.timezone),

--- a/tests/golden/btrfs-luks.txt
+++ b/tests/golden/btrfs-luks.txt
@@ -55,7 +55,6 @@
   resolve app-admin/sudo net-misc/openssh sys-process/cronie sys-kernel/installkernel sys-apps/systemd sys-kernel/dracut sys-kernel/linux-firmware sys-fs/cryptsetup sys-fs/btrfs-progs sys-fs/dosfstools sys-kernel/gentoo-cjk-kernel-bin sys-boot/grub sys-boot/efibootmgr kde-plasma/plasma-meta x11-base/xorg-server kde-apps/konsole kde-apps/dolphin app-i18n/fcitx app-i18n/fcitx-gtk app-i18n/fcitx-qt app-i18n/fcitx-configtool app-i18n/fcitx-rime app-i18n/rime-data media-fonts/noto-cjk media-fonts/noto media-libs/fontconfig net-proxy/flclash-bin together before installing the requested packages
 
 [system]
-  keep proxy environment for direct connection in the installed system
   generate and verify locales en_US.UTF-8, zh_TW.UTF-8
   set the system locale to zh_TW.UTF-8
   set the timezone to Asia/Taipei

--- a/tests/golden/ext4-bios.txt
+++ b/tests/golden/ext4-bios.txt
@@ -34,7 +34,6 @@
   resolve net-misc/netifrc net-misc/dhcpcd app-admin/sysklogd sys-process/cronie sys-kernel/installkernel sys-kernel/dracut sys-kernel/linux-firmware sys-fs/e2fsprogs sys-kernel/gentoo-kernel-bin sys-boot/grub together before installing the requested packages
 
 [system]
-  keep proxy environment for direct connection in the installed system
   generate and verify locales en_US.UTF-8
   set the system locale to en_US.UTF-8
   set the timezone to UTC

--- a/tests/golden/mbr-edit.txt
+++ b/tests/golden/mbr-edit.txt
@@ -33,7 +33,6 @@
   resolve net-misc/netifrc net-misc/dhcpcd app-admin/sysklogd sys-process/cronie sys-kernel/installkernel sys-kernel/dracut sys-kernel/linux-firmware sys-fs/e2fsprogs sys-kernel/gentoo-kernel-bin sys-boot/grub together before installing the requested packages
 
 [system]
-  keep proxy environment for direct connection in the installed system
   generate and verify locales en_US.UTF-8
   set the system locale to en_US.UTF-8
   set the timezone to UTC

--- a/tests/golden/openrc-sdboot.txt
+++ b/tests/golden/openrc-sdboot.txt
@@ -38,7 +38,6 @@
   resolve net-misc/netifrc net-misc/dhcpcd app-admin/sysklogd sys-process/cronie sys-kernel/installkernel sys-kernel/dracut sys-kernel/linux-firmware sys-fs/dosfstools sys-fs/e2fsprogs sys-kernel/gentoo-kernel-bin sys-apps/systemd-utils together before installing the requested packages
 
 [system]
-  keep proxy environment for direct connection in the installed system
   generate and verify locales en_US.UTF-8
   set the system locale to en_US.UTF-8
   set the timezone to UTC

--- a/tests/golden/vm-binpkg.txt
+++ b/tests/golden/vm-binpkg.txt
@@ -37,7 +37,6 @@
   resolve net-misc/openssh sys-process/cronie sys-kernel/installkernel sys-kernel/dracut sys-kernel/linux-firmware sys-fs/dosfstools sys-fs/e2fsprogs sys-kernel/gentoo-kernel-bin sys-boot/grub sys-boot/efibootmgr together before installing the requested packages
 
 [system]
-  keep proxy environment for direct connection in the installed system
   generate and verify locales en_US.UTF-8
   set the system locale to en_US.UTF-8
   set the timezone to UTC

--- a/tests/golden/vm-bios-luks.txt
+++ b/tests/golden/vm-bios-luks.txt
@@ -40,7 +40,6 @@
   resolve net-misc/netifrc net-misc/dhcpcd app-admin/sysklogd sys-process/cronie sys-kernel/installkernel sys-kernel/dracut sys-kernel/linux-firmware sys-fs/cryptsetup sys-fs/e2fsprogs sys-kernel/gentoo-kernel-bin sys-boot/grub together before installing the requested packages
 
 [system]
-  keep proxy environment for direct connection in the installed system
   generate and verify locales en_US.UTF-8
   set the system locale to en_US.UTF-8
   set the timezone to UTC

--- a/tests/golden/vm-bios.txt
+++ b/tests/golden/vm-bios.txt
@@ -36,7 +36,6 @@
   resolve net-misc/netifrc net-misc/dhcpcd app-admin/sysklogd sys-process/cronie sys-kernel/installkernel sys-kernel/dracut sys-kernel/linux-firmware sys-fs/e2fsprogs sys-kernel/gentoo-kernel-bin sys-boot/grub together before installing the requested packages
 
 [system]
-  keep proxy environment for direct connection in the installed system
   generate and verify locales en_US.UTF-8
   set the system locale to en_US.UTF-8
   set the timezone to UTC

--- a/tests/golden/vm-btrfs.txt
+++ b/tests/golden/vm-btrfs.txt
@@ -40,7 +40,6 @@
   resolve sys-process/cronie sys-kernel/installkernel sys-kernel/dracut sys-kernel/linux-firmware sys-fs/btrfs-progs sys-fs/dosfstools sys-kernel/gentoo-kernel-bin sys-boot/grub sys-boot/efibootmgr together before installing the requested packages
 
 [system]
-  keep proxy environment for direct connection in the installed system
   generate and verify locales en_US.UTF-8, zh_TW.UTF-8
   set the system locale to zh_TW.UTF-8
   set the timezone to Asia/Taipei

--- a/tests/golden/vm-cjk-kernel.txt
+++ b/tests/golden/vm-cjk-kernel.txt
@@ -42,7 +42,6 @@
   resolve sys-process/cronie sys-kernel/installkernel sys-kernel/dracut sys-kernel/linux-firmware sys-fs/dosfstools sys-fs/e2fsprogs sys-kernel/gentoo-cjk-kernel-bin sys-boot/grub sys-boot/efibootmgr together before installing the requested packages
 
 [system]
-  keep proxy environment for direct connection in the installed system
   generate and verify locales en_US.UTF-8
   set the system locale to en_US.UTF-8
   set the timezone to UTC

--- a/tests/golden/vm-desktop.txt
+++ b/tests/golden/vm-desktop.txt
@@ -40,7 +40,6 @@
   resolve net-misc/openssh net-misc/networkmanager net-wireless/wpa_supplicant sys-process/cronie sys-kernel/installkernel sys-kernel/dracut sys-kernel/linux-firmware sys-fs/dosfstools sys-fs/e2fsprogs sys-kernel/gentoo-kernel-bin sys-boot/grub sys-boot/efibootmgr kde-plasma/plasma-meta x11-base/xorg-server kde-apps/konsole kde-apps/dolphin app-i18n/fcitx app-i18n/fcitx-gtk app-i18n/fcitx-qt app-i18n/fcitx-configtool app-i18n/fcitx-rime app-i18n/rime-data media-fonts/noto-cjk media-fonts/noto media-libs/fontconfig media-video/pipewire media-video/wireplumber together before installing the requested packages
 
 [system]
-  keep proxy environment for direct connection in the installed system
   generate and verify locales en_US.UTF-8
   set the system locale to en_US.UTF-8
   set the timezone to UTC

--- a/tests/golden/vm-f2fs.txt
+++ b/tests/golden/vm-f2fs.txt
@@ -37,7 +37,6 @@
   resolve net-misc/openssh sys-process/cronie sys-kernel/installkernel sys-kernel/dracut sys-kernel/linux-firmware sys-fs/dosfstools sys-fs/f2fs-tools sys-kernel/gentoo-kernel-bin sys-boot/grub sys-boot/efibootmgr together before installing the requested packages
 
 [system]
-  keep proxy environment for direct connection in the installed system
   generate and verify locales en_US.UTF-8
   set the system locale to en_US.UTF-8
   set the timezone to UTC

--- a/tests/golden/vm-gnome.txt
+++ b/tests/golden/vm-gnome.txt
@@ -39,7 +39,6 @@
   resolve net-misc/openssh net-misc/networkmanager net-wireless/wpa_supplicant sys-process/cronie sys-kernel/installkernel sys-kernel/dracut sys-kernel/linux-firmware sys-fs/dosfstools sys-fs/e2fsprogs sys-kernel/gentoo-kernel-bin sys-boot/grub sys-boot/efibootmgr gnome-base/gnome-light x11-base/xorg-server gnome-base/gdm media-fonts/noto-cjk media-fonts/noto media-libs/fontconfig media-video/pipewire media-video/wireplumber together before installing the requested packages
 
 [system]
-  keep proxy environment for direct connection in the installed system
   generate and verify locales en_US.UTF-8
   set the system locale to en_US.UTF-8
   set the timezone to UTC

--- a/tests/golden/vm-luks.txt
+++ b/tests/golden/vm-luks.txt
@@ -45,7 +45,6 @@
   resolve sys-process/cronie sys-kernel/installkernel sys-apps/systemd sys-kernel/dracut sys-kernel/linux-firmware sys-fs/cryptsetup sys-fs/btrfs-progs sys-fs/dosfstools sys-kernel/gentoo-kernel-bin sys-boot/grub sys-boot/efibootmgr together before installing the requested packages
 
 [system]
-  keep proxy environment for direct connection in the installed system
   generate and verify locales en_US.UTF-8, zh_TW.UTF-8
   set the system locale to zh_TW.UTF-8
   set the timezone to Asia/Taipei

--- a/tests/golden/vm-lvm.txt
+++ b/tests/golden/vm-lvm.txt
@@ -46,7 +46,6 @@
   resolve net-misc/netifrc net-misc/dhcpcd app-admin/sysklogd sys-process/cronie sys-kernel/installkernel sys-kernel/dracut sys-kernel/linux-firmware sys-fs/dosfstools sys-fs/e2fsprogs sys-fs/lvm2 sys-kernel/gentoo-kernel-bin sys-boot/grub sys-boot/efibootmgr together before installing the requested packages
 
 [system]
-  keep proxy environment for direct connection in the installed system
   generate and verify locales en_US.UTF-8
   set the system locale to en_US.UTF-8
   set the timezone to UTC

--- a/tests/golden/vm-mdraid.txt
+++ b/tests/golden/vm-mdraid.txt
@@ -45,7 +45,6 @@
   resolve sys-process/cronie sys-kernel/installkernel sys-kernel/dracut sys-kernel/linux-firmware sys-fs/mdadm sys-fs/dosfstools sys-fs/e2fsprogs sys-kernel/gentoo-kernel-bin sys-boot/grub sys-boot/efibootmgr together before installing the requested packages
 
 [system]
-  keep proxy environment for direct connection in the installed system
   generate and verify locales en_US.UTF-8
   set the system locale to en_US.UTF-8
   set the timezone to UTC

--- a/tests/golden/vm-openrc-desktop.txt
+++ b/tests/golden/vm-openrc-desktop.txt
@@ -39,7 +39,6 @@
   resolve net-misc/openssh net-misc/networkmanager net-wireless/wpa_supplicant app-admin/sysklogd sys-process/cronie sys-kernel/installkernel sys-kernel/dracut sys-kernel/linux-firmware sys-fs/dosfstools sys-fs/e2fsprogs sys-kernel/gentoo-kernel-bin sys-boot/grub sys-boot/efibootmgr xfce-base/xfce4-meta x11-base/xorg-server x11-misc/lightdm x11-misc/lightdm-gtk-greeter gui-libs/display-manager-init media-video/pipewire media-video/wireplumber sys-apps/dbus sys-auth/elogind together before installing the requested packages
 
 [system]
-  keep proxy environment for direct connection in the installed system
   generate and verify locales en_US.UTF-8
   set the system locale to en_US.UTF-8
   set the timezone to UTC

--- a/tests/golden/vm-raidz.txt
+++ b/tests/golden/vm-raidz.txt
@@ -55,7 +55,6 @@
   resolve sys-process/cronie sys-kernel/installkernel sys-kernel/dracut sys-kernel/linux-firmware sys-fs/dosfstools sys-kernel/gentoo-kernel-bin sys-fs/zfs sys-boot/zfsbootmenu sys-boot/efibootmgr sys-apps/systemd together before installing the requested packages
 
 [system]
-  keep proxy environment for direct connection in the installed system
   generate and verify locales en_US.UTF-8
   set the system locale to en_US.UTF-8
   set the timezone to UTC

--- a/tests/golden/vm-sdboot.txt
+++ b/tests/golden/vm-sdboot.txt
@@ -38,7 +38,6 @@
   resolve sys-process/cronie sys-kernel/installkernel sys-kernel/dracut sys-kernel/linux-firmware sys-fs/dosfstools sys-fs/e2fsprogs sys-kernel/gentoo-kernel-bin sys-apps/systemd together before installing the requested packages
 
 [system]
-  keep proxy environment for direct connection in the installed system
   generate and verify locales en_US.UTF-8
   set the system locale to en_US.UTF-8
   set the timezone to UTC

--- a/tests/golden/vm-unlock.txt
+++ b/tests/golden/vm-unlock.txt
@@ -46,7 +46,6 @@
   resolve net-misc/openssh sys-process/cronie sys-kernel/installkernel sys-apps/systemd sys-kernel/dracut sys-kernel/linux-firmware sys-kernel/dracut-crypt-ssh sys-fs/cryptsetup sys-fs/btrfs-progs sys-fs/dosfstools sys-kernel/gentoo-kernel-bin sys-boot/grub sys-boot/efibootmgr together before installing the requested packages
 
 [system]
-  keep proxy environment for direct connection in the installed system
   generate and verify locales en_US.UTF-8, zh_TW.UTF-8
   set the system locale to zh_TW.UTF-8
   set the timezone to Asia/Taipei

--- a/tests/golden/vm-xfs.txt
+++ b/tests/golden/vm-xfs.txt
@@ -37,7 +37,6 @@
   resolve net-misc/openssh sys-process/cronie sys-kernel/installkernel sys-kernel/dracut sys-kernel/linux-firmware sys-fs/dosfstools sys-fs/xfsprogs sys-kernel/gentoo-kernel-bin sys-boot/grub sys-boot/efibootmgr together before installing the requested packages
 
 [system]
-  keep proxy environment for direct connection in the installed system
   generate and verify locales en_US.UTF-8
   set the system locale to en_US.UTF-8
   set the timezone to UTC

--- a/tests/golden/vm-zfs-encrypted.txt
+++ b/tests/golden/vm-zfs-encrypted.txt
@@ -47,7 +47,6 @@
   resolve sys-process/cronie sys-kernel/installkernel sys-kernel/dracut sys-kernel/linux-firmware sys-fs/dosfstools sys-kernel/gentoo-kernel-bin sys-fs/zfs sys-boot/zfsbootmenu sys-boot/efibootmgr sys-apps/systemd together before installing the requested packages
 
 [system]
-  keep proxy environment for direct connection in the installed system
   generate and verify locales en_US.UTF-8
   set the system locale to en_US.UTF-8
   set the timezone to UTC

--- a/tests/golden/vm-zfs-mirror.txt
+++ b/tests/golden/vm-zfs-mirror.txt
@@ -51,7 +51,6 @@
   resolve sys-process/cronie sys-kernel/installkernel sys-kernel/dracut sys-kernel/linux-firmware sys-fs/dosfstools sys-kernel/gentoo-kernel-bin sys-fs/zfs sys-boot/zfsbootmenu sys-boot/efibootmgr sys-apps/systemd together before installing the requested packages
 
 [system]
-  keep proxy environment for direct connection in the installed system
   generate and verify locales en_US.UTF-8
   set the system locale to en_US.UTF-8
   set the timezone to UTC

--- a/tests/golden/vm-zfs.txt
+++ b/tests/golden/vm-zfs.txt
@@ -47,7 +47,6 @@
   resolve sys-process/cronie sys-kernel/installkernel sys-kernel/dracut sys-kernel/linux-firmware sys-fs/dosfstools sys-kernel/gentoo-kernel-bin sys-fs/zfs sys-boot/zfsbootmenu sys-boot/efibootmgr sys-apps/systemd together before installing the requested packages
 
 [system]
-  keep proxy environment for direct connection in the installed system
   generate and verify locales en_US.UTF-8
   set the system locale to en_US.UTF-8
   set the timezone to UTC

--- a/tests/golden/vm-zram.txt
+++ b/tests/golden/vm-zram.txt
@@ -37,7 +37,6 @@
   resolve sys-apps/zram-generator net-misc/openssh sys-process/cronie sys-kernel/installkernel sys-kernel/dracut sys-kernel/linux-firmware sys-fs/dosfstools sys-fs/xfsprogs sys-kernel/gentoo-kernel-bin sys-boot/grub sys-boot/efibootmgr together before installing the requested packages
 
 [system]
-  keep proxy environment for direct connection in the installed system
   generate and verify locales en_US.UTF-8
   set the system locale to en_US.UTF-8
   set the timezone to UTC

--- a/tests/golden/zfs-zbm.txt
+++ b/tests/golden/zfs-zbm.txt
@@ -53,7 +53,6 @@
   resolve app-admin/sudo net-misc/openssh sys-process/cronie sys-kernel/installkernel sys-kernel/dracut sys-kernel/linux-firmware sys-kernel/dracut-crypt-ssh sys-apps/iproute2 net-misc/dhcp net-misc/iputils sys-fs/dosfstools sys-kernel/gentoo-cjk-kernel-bin sys-fs/zfs sys-boot/zfsbootmenu sys-boot/efibootmgr sys-apps/systemd sys-apps/kbd app-editors/vim together before installing the requested packages
 
 [system]
-  keep proxy environment for direct connection in the installed system
   generate and verify locales en_US.UTF-8, zh_TW.UTF-8
   set the system locale to zh_TW.UTF-8
   set the timezone to Asia/Taipei

--- a/tests/unit/test_harness.py
+++ b/tests/unit/test_harness.py
@@ -1980,3 +1980,34 @@ def test_a_proxy_somewhere_else_is_not_checked_against_this_workstation() -> Non
             proxy=replace(installation.proxy, url=f"socks5h://192.0.2.9:{port}"),
         )
     )
+
+
+def test_the_input_method_check_names_something_the_file_can_hold() -> None:
+    """`DefaultIM=` was asserted against `/etc/environment` for three weeks. It
+    lives in the user's `fcitx5/profile`, so the check could only ever fail,
+    and `vm-desktop` was the first fixture to reach it."""
+    from gentoo_install.exec.config import load
+    from gentoo_install.plan.packages import INPUT_ENVIRONMENT
+    from tests.vm.installed import checks
+
+    installation = load(Path("tests/fixtures/vm-desktop.toml"))
+    named = [one for one in checks(installation) if one.name == "inputmethod"]
+    assert named, "a configuration with an input method has no check for it"
+
+    written = {
+        line
+        for (framework, _), lines in INPUT_ENVIRONMENT.items()
+        for line in lines
+    }
+    for check in named:
+        wanted = check.pattern.replace("\\", "")
+        assert any(wanted in line for line in written), wanted
+
+
+def test_no_input_method_asks_for_no_environment() -> None:
+    from gentoo_install.exec.config import load
+    from tests.vm.installed import checks
+
+    installation = load(Path("tests/fixtures/vm-gnome.toml"))
+
+    assert [one for one in checks(installation) if one.name == "inputmethod"] == []

--- a/tests/unit/test_plan_system.py
+++ b/tests/unit/test_plan_system.py
@@ -1246,3 +1246,33 @@ def test_the_unlock_key_always_reaches_root() -> None:
     assert "root" not in {name for name, _ in key_accounts(system)}
     assert "root" in {name for name, _ in key_accounts(system, unlocking=True)}
     assert KernelConfig().remote_unlock == RemoteUnlock()
+
+
+def test_no_proxy_writes_no_proxy_environment() -> None:
+    """`/etc/environment` is replaced rather than appended to, so an install
+    with no proxy left ten empty variables there and discarded whatever the
+    file already carried."""
+    from gentoo_install.plan import system as plan_system
+
+    written = [
+        one for one in plan_system.build(config())
+        if isinstance(one, plan_system.WriteProxyEnvironment)
+    ]
+
+    assert written == []
+
+
+def test_a_configured_proxy_still_reaches_the_installed_system() -> None:
+    from gentoo_install.model.config import ProxyConfig
+    from gentoo_install.plan import system as plan_system
+
+    installation = replace(
+        config(), proxy=ProxyConfig(url="http://operator:secret@proxy.example:8080")
+    )
+    written = [
+        one for one in plan_system.build(installation)
+        if isinstance(one, plan_system.WriteProxyEnvironment)
+    ]
+
+    assert len(written) == 1
+    assert "secret" not in written[0].describe()

--- a/tests/vm/installed.py
+++ b/tests/vm/installed.py
@@ -45,8 +45,23 @@ def checks(installation: InstallConfig) -> tuple[InstalledCheck, ...]:
     if installation.system.networking is not Networking.NONE:
         result.append(InstalledCheck("network", "systemctl list-unit-files --state=enabled --no-legend --no-pager; rc-update show default", re.escape(network_service(installation.system))))
     groups = load_catalog()
-    if any(groups[name].input_method for name in installation.packages.applications if name in groups):
-        result.append(InstalledCheck("inputmethod", "cat /etc/environment /etc/env.d/90input-method 2>/dev/null", "DefaultIM="))
+    frameworks = {
+        groups[name].input_framework
+        for name in installation.packages.applications
+        if name in groups and groups[name].input_method
+    }
+    for framework in sorted(one for one in frameworks if one):
+        # What the environment file actually carries. `DefaultIM=` was asserted
+        # here for three weeks and lives in the user's `fcitx5/profile`, so the
+        # check could only ever fail; `vm-desktop` was the first fixture to
+        # reach it and it did have a working input method.
+        result.append(
+            InstalledCheck(
+                "inputmethod",
+                "cat /etc/environment /etc/env.d/90input-method 2>/dev/null",
+                re.escape(f"XMODIFIERS=@im={framework}"),
+            )
+        )
     graph = installation.disk.graph
     esp = compat.esp_mount(graph)
     if esp is not None:


### PR DESCRIPTION
`WriteProxyEnvironment` ran on every install. It replaces `/etc/environment` rather than appending to it, so a machine with no proxy got ten empty variables there, lost whatever the file already held, and a `/etc/profile.d` script exporting the same emptiness. The plan announced it as `keep proxy environment for direct connection`, which is a decision nobody made. Twenty-five goldens lose that line.

The second commit is what found it. `vm-desktop`'s installed-system check asserted `DefaultIM=` against `/etc/environment`; that key lives in the user's `fcitx5/profile`, so the check could only ever fail, and `vm-desktop` was the first fixture to reach it. The check now derives `XMODIFIERS=@im=<framework>` from the same table the plan writes from, so a key that file cannot hold fails a unit test rather than a 25-minute install.