### PR TITLE
vm: install ibus somewhere, not only fcitx

### DIFF
--- a/tests/fixtures/vm-gnome.toml
+++ b/tests/fixtures/vm-gnome.toml
@@ -99,4 +99,7 @@ options = ["umask=0077"]
 [packages]
 desktop = "gnome"
 display_manager = "gdm"
-applications = ["noto-cjk", "pipewire"]
+# ibus, not fcitx: twelve ibus groups were in the catalog and no fixture had
+# ever installed one, so only the fcitx half of `framework_conflict()` and of
+# `INPUT_ENVIRONMENT` had ever reached a machine.
+applications = ["ibus", "ibus-pinyin", "noto-cjk", "pipewire"]

--- a/tests/golden/vm-gnome.txt
+++ b/tests/golden/vm-gnome.txt
@@ -36,7 +36,7 @@
   accept the linux-firmware licence
   ask for gnome-base/gdm systemd; sys-auth/pambase systemd for the gdm group
   ask for media-video/pipewire sound-server for the pipewire group
-  resolve net-misc/openssh net-misc/networkmanager net-wireless/wpa_supplicant sys-process/cronie sys-kernel/installkernel sys-kernel/dracut sys-kernel/linux-firmware sys-fs/dosfstools sys-fs/e2fsprogs sys-kernel/gentoo-kernel-bin sys-boot/grub sys-boot/efibootmgr gnome-base/gnome-light x11-base/xorg-server gnome-base/gdm media-fonts/noto-cjk media-fonts/noto media-libs/fontconfig media-video/pipewire media-video/wireplumber together before installing the requested packages
+  resolve net-misc/openssh net-misc/networkmanager net-wireless/wpa_supplicant sys-process/cronie sys-kernel/installkernel sys-kernel/dracut sys-kernel/linux-firmware sys-fs/dosfstools sys-fs/e2fsprogs sys-kernel/gentoo-kernel-bin sys-boot/grub sys-boot/efibootmgr gnome-base/gnome-light x11-base/xorg-server gnome-base/gdm app-i18n/ibus app-i18n/ibus-libpinyin media-fonts/noto-cjk media-fonts/noto media-libs/fontconfig media-video/pipewire media-video/wireplumber together before installing the requested packages
 
 [system]
   generate and verify locales en_US.UTF-8
@@ -75,9 +75,13 @@
   install the gnome group: emerge gnome-base/gnome-light x11-base/xorg-server
   install the gdm group: emerge gnome-base/gdm
   enable gdm at boot
+  install the ibus group: emerge app-i18n/ibus
+  install the ibus-pinyin group: emerge app-i18n/ibus-libpinyin
   install the noto-cjk group: emerge media-fonts/noto-cjk media-fonts/noto media-libs/fontconfig
   install the pipewire group: emerge media-video/pipewire media-video/wireplumber
   enable pipewire.socket, pipewire-pulse.socket, wireplumber.service for every user
+  set XMODIFIERS, GTK_IM_MODULE, QT_IM_MODULE in /etc/environment for ibus
+  write the GNOME dconf default with libpinyin
 
 [finish]
   delete the downloaded stage3 from /var/cache/gentoo-install

--- a/tests/unit/test_harness.py
+++ b/tests/unit/test_harness.py
@@ -2005,9 +2005,16 @@ def test_the_input_method_check_names_something_the_file_can_hold() -> None:
 
 
 def test_no_input_method_asks_for_no_environment() -> None:
+    """Built here rather than named: this test pointed at `vm-gnome` until that
+    fixture was given ibus, and a fixture is free to change what it installs."""
+    from dataclasses import replace
+
     from gentoo_install.exec.config import load
     from tests.vm.installed import checks
 
-    installation = load(Path("tests/fixtures/vm-gnome.toml"))
+    chosen = load(Path("tests/fixtures/vm-gnome.toml"))
+    installation = replace(
+        chosen, packages=replace(chosen.packages, applications=())
+    )
 
     assert [one for one in checks(installation) if one.name == "inputmethod"] == []


### PR DESCRIPTION
Twelve of the catalog's thirty input groups are ibus. No fixture had installed one, so half of `framework_conflict()`, the three ibus rows of `INPUT_ENVIRONMENT` and the GNOME dconf default had never reached a machine. `vm-gnome` selected no input method at all, so it carries this at no extra run.

Not a new fixture: a GNOME install takes twenty-five minutes and a slot, and making an existing run prove more costs neither.

Noticed while writing it and not changed here: the three ibus rows all set `GTK_IM_MODULE`, including both Wayland ones, while the fcitx rows deliberately omit it on Wayland and cite the Fcitx documentation for why. A VM cannot settle that one; it needs somebody typing into a Gtk application.