### PR TITLE
portage: let the flag variables expand again

### DIFF
--- a/gentoo_install/plan/portage.py
+++ b/gentoo_install/plan/portage.py
@@ -320,14 +320,23 @@ class WritePortageConfig(Operation):
         context.write(self.path, "".join(f"{line}\n" for line in self.lines))
 
 
-def quoted(value: str) -> str:
-    """One make.conf value, as bash reads it back literally.
+#: Values bash has to expand when it sources make.conf rather than read back as
+#: text. `CFLAGS="${COMMON_FLAGS}"` is the stage3's own idiom, and escaping it
+#: handed gcc the literal `${COMMON_FLAGS}` as a filename: every source build
+#: stopped at `linker input file not found`.
+EXPANDED: Final[frozenset[str]] = frozenset({"CFLAGS", "CXXFLAGS", "FCFLAGS", "FFLAGS"})
+
+
+def quoted(key: str, value: str) -> str:
+    """One make.conf value, as bash reads it back.
 
     Portage sources the file, so an unescaped `"` ends the value early and an
     unescaped `$` expands there instead of when the command runs. `FETCHCOMMAND`
-    holds both, and writing it plainly gave wget no URL at all; make.globals
-    escapes the same three characters.
+    holds both and needs the escaping make.globals gives it; make.globals leaves
+    the four flag variables unescaped for the same reason this does.
     """
+    if key in EXPANDED:
+        return f'"{value}"'
     escaped = value.replace("\\", "\\\\").replace('"', '\\"').replace("$", "\\$")
     return f'"{escaped}"'
 
@@ -345,11 +354,11 @@ def merge(existing: str, wanted: Sequence[tuple[str, str]]) -> str:
     for line in existing.splitlines():
         key = line.split("=", 1)[0].strip() if "=" in line and not line.lstrip().startswith("#") else ""
         if key in replacing:
-            kept.append(f"{key}={quoted(replacing[key])}")
+            kept.append(f"{key}={quoted(key, replacing[key])}")
             seen.add(key)
             continue
         kept.append(line)
-    added = [f"{key}={quoted(value)}" for key, value in wanted if key not in seen]
+    added = [f"{key}={quoted(key, value)}" for key, value in wanted if key not in seen]
     if added:
         if kept and kept[-1].strip():
             kept.append("")

--- a/tests/unit/test_plan_portage.py
+++ b/tests/unit/test_plan_portage.py
@@ -1475,3 +1475,40 @@ def test_git_reaches_the_proxy_with_the_password_it_demands() -> None:
     )
 
     assert "secret" in apply_all(installation).files[PurePosixPath("/etc/gitconfig")]
+
+
+def test_the_flag_variables_still_follow_common_flags() -> None:
+    """The stage3 writes `CFLAGS="${COMMON_FLAGS}"` and this installer keeps
+    that idiom. Escaping the `$` handed gcc the literal `${COMMON_FLAGS}` as a
+    filename, and every source build stopped at `linker input file not found`.
+    """
+    import subprocess
+
+    from gentoo_install.plan.portage import FETCHCOMMAND, merge
+
+    written = merge(
+        "",
+        (
+            ("COMMON_FLAGS", "-O2 -pipe"),
+            ("CFLAGS", "${COMMON_FLAGS}"),
+            ("CXXFLAGS", "${COMMON_FLAGS}"),
+            ("FETCHCOMMAND", FETCHCOMMAND),
+        ),
+    )
+    read_back = subprocess.run(
+        [
+            "bash",
+            "-c",
+            'source /dev/stdin; printf "%s\\n%s\\n%s" "$CFLAGS" "$CXXFLAGS" "$FETCHCOMMAND"',
+        ],
+        input=written,
+        text=True,
+        capture_output=True,
+        check=True,
+    ).stdout.split("\n")
+
+    # Expanded, because bash is what expands them when Portage sources the file.
+    assert read_back[0] == "-O2 -pipe"
+    assert read_back[1] == "-O2 -pipe"
+    # Not expanded: the fetcher substitutes these, long after the file is read.
+    assert "${URI}" in read_back[2]


### PR DESCRIPTION
`#278` escaped `$` in every make.conf value so `FETCHCOMMAND`'s `\${URI}` would survive being sourced. The installer also writes `CFLAGS="\${COMMON_FLAGS}"`, the stage3's own idiom, and that one has to expand: gcc was handed the literal `\${COMMON_FLAGS}` as a filename and answered `linker input file not found`. Every install that compiles anything from source has been broken since `#278` merged.

`btrfs-luks` caught it in the local matrix; the binary-package fixtures did not, which is why the suite stayed green. Portage's own `make.globals` draws the same line, escaping `FETCHCOMMAND` and leaving the four flag variables alone.

The test reads the values back through bash rather than comparing strings, and asserts both halves: the flags expand, `\${URI}` does not.