### PR TITLE
vm: a fixture meant to stop passes by stopping

### DIFF
--- a/tests/unit/test_harness.py
+++ b/tests/unit/test_harness.py
@@ -2018,3 +2018,36 @@ def test_no_input_method_asks_for_no_environment() -> None:
     )
 
     assert [one for one in checks(installation) if one.name == "inputmethod"] == []
+
+
+def test_a_fixture_meant_to_fail_passes_by_failing() -> None:
+    """`vm-proxy-dead` points the proxy at a port nothing listens on, so an
+    install that finishes proves the setting was bypassed. Reported as a
+    failure every round, it taught everyone to read past red."""
+    from tests.vm.campaign import Outcome, Run, mark_for
+
+    dead = Run("fixtures/vm-proxy-dead.toml", expect_failure=True)
+    log = Path(__file__).resolve().parents[1] / "fixtures" / "vm-proxy-dead.toml"
+
+    assert Outcome(dead, 4, 1.0, log).passed
+    assert not Outcome(dead, 0, 1.0, log).passed
+    assert mark_for(Outcome(dead, 0, 1.0, log)) == "BYPASS"
+
+    ordinary = Run("fixtures/vm-btrfs.toml")
+    assert Outcome(ordinary, 0, 1.0, log).passed
+    assert not Outcome(ordinary, 4, 1.0, log).passed
+
+
+def test_the_campaign_expects_exactly_the_fixtures_that_cannot_finish() -> None:
+    """A second fixture marked this way would be a fixture nobody notices
+    failing, so the set is named here as well as there."""
+    from tests.vm.campaign import STAGES
+
+    named = {
+        Path(run.config).stem
+        for runs in STAGES.values()
+        for run in runs
+        if run.expect_failure
+    }
+
+    assert named == {"vm-proxy-dead"}

--- a/tests/vm/campaign.py
+++ b/tests/vm/campaign.py
@@ -102,6 +102,12 @@ class Run:
     #: at zero for a run that installs binary packages: more cores do nothing
     #: for a download, and they would be taken from a run that is compiling.
     cpus: int = 0
+    #: Whether the install is meant to stop. `vm-proxy-dead` points the proxy
+    #: at a port nothing listens on, so an install that finishes proves the
+    #: setting was bypassed: its failure is the result. Reported as `ok` when it
+    #: fails and as a failure when it does not, because a fixture that is always
+    #: red teaches everyone to read past red.
+    expect_failure: bool = False
     #: What this costs the machine, against `CAPACITY`. Two for a run that
     #: compiles a kernel or a desktop: those saturate their vCPUs for half an
     #: hour, and packing them beside each other makes every one of them slower
@@ -173,7 +179,7 @@ STAGES: Final[dict[str, tuple[Run, ...]]] = {
         # The proxy pointed at a port nothing listens on: a run that reaches
         # the mirror proves something bypassed it, so this one is expected to
         # fail at the stage3 download and its failure is the result.
-        Run("fixtures/vm-proxy-dead.toml"),
+        Run("fixtures/vm-proxy-dead.toml", expect_failure=True),
         # The direction that matters to an operator on an intranet, and the one
         # nothing covered: the proxy answers and the install completes through
         # it. It needs a SOCKS5 listener on the workstation, so `run.py` refuses
@@ -211,7 +217,7 @@ class Outcome:
 
     @property
     def passed(self) -> bool:
-        return self.returncode == 0
+        return (self.returncode != 0) if self.run.expect_failure else (self.returncode == 0)
 
 
 def perform(run: Run) -> Outcome:
@@ -245,6 +251,10 @@ def mark_for(outcome: Outcome) -> str:
     if outcome.passed:
         return "ok  "
     said = outcome.log.read_text(errors="replace")
+    if outcome.run.expect_failure:
+        # It finished, and finishing is the defect: the fetch reached the mirror
+        # with a proxy that cannot carry it.
+        return "BYPASS"
     if HOST_KILLED in said:
         return "HOST"
     return "LOCK" if ALREADY_RUNNING in said else "FAIL"


### PR DESCRIPTION
`vm-proxy-dead` exists to prove a fetch cannot bypass the proxy setting: it points the proxy at a port nothing listens on, so an install that *finishes* is the defect. The campaign reported it `FAIL` every round, which is a red line nobody can act on and a habit of reading past red.

It now reports `ok` when it stops and `BYPASS` when it does not. A second test names the set of fixtures marked this way, so a fixture nobody notices failing cannot be added quietly.