### PR TITLE
tui: give the screen a full-width band to draw with

### DIFF
--- a/gentoo_install/tui/widgets.py
+++ b/gentoo_install/tui/widgets.py
@@ -121,6 +121,24 @@ class Screen(Protocol):
         """Block until a key press and return its name."""
 
 
+def band(screen: Screen, line: int, left: str, right: str = "") -> None:
+    """One full-width reversed row, `left` at the margin and `right` at the end.
+
+    Reverse video is an attribute rather than a glyph, so a console with no
+    colour and no line-drawing font still shows the edge; a box drawn from
+    `U+2500` would be a row of question marks on the medium's own font.
+
+    `right` is dropped rather than truncated when the two cannot both fit: half
+    a count reads as a different count.
+    """
+    _, columns = screen.size()
+    head = truncate(left, columns)
+    room = columns - width(head) - 1
+    tail = right if right and width(right) <= room else ""
+    padding = columns - width(head) - width(tail)
+    screen.write(line, 0, f"{head}{' ' * padding}{tail}", highlight=True)
+
+
 @dataclass(frozen=True)
 class Item(Generic[V]):
     """One row of a menu."""

--- a/tests/unit/test_tui_widgets.py
+++ b/tests/unit/test_tui_widgets.py
@@ -475,3 +475,47 @@ def test_a_window_that_grows_while_a_widget_waits_is_read_again() -> None:
     drawn = [len([row for row in frame if "row" in row]) for frame in screen.frames]
     assert len(drawn) >= 2, screen.frames
     assert drawn[-1] > drawn[0], drawn
+
+
+def test_a_band_fills_the_row_so_the_reverse_video_reaches_both_edges() -> None:
+    """A header that stops where its text stops is a highlighted word, not a
+    band, and the screen still reads as a printout."""
+    from gentoo_install.tui.widgets import band
+
+    screen = FakeScreen(columns=40)
+    band(screen, 0, "gentoo-install", "6/22 answered")
+    drawn = screen.frames[-1][0] if screen.frames else screen._current[0]
+
+    assert len(drawn) == 40
+    assert drawn.startswith("gentoo-install")
+    assert drawn.endswith("6/22 answered")
+    assert drawn in screen.highlighted
+
+
+def test_a_band_drops_the_right_side_rather_than_cutting_it() -> None:
+    """Half a count reads as a different count."""
+    from gentoo_install.tui.widgets import band
+
+    screen = FakeScreen(columns=20)
+    band(screen, 0, "gentoo-install", "6/22 answered")
+    drawn = screen._current[0]
+
+    assert len(drawn) == 20
+    # Whole or absent. A truncating band leaves `6/22 `, which reads as a
+    # different count rather than as a missing one.
+    assert "6/22" not in drawn
+    assert drawn.rstrip() == "gentoo-install"
+
+
+def test_a_band_counts_cells_not_characters() -> None:
+    """A CJK title takes two cells each, and a band measured in characters
+    runs past the last column: `FakeScreen` refuses that, and so does curses."""
+    from gentoo_install.tui.widgets import band
+    from gentoo_install.i18n import width
+
+    screen = FakeScreen(columns=30)
+    # Two wide characters each: four cells, not two. Written as escapes
+    # because a literal here would be unreadable to half the contributors.
+    band(screen, 0, "\u5b89\u88dd", "\u5b8c\u6210")
+
+    assert width(screen._current[0]) == 30


### PR DESCRIPTION
First of four steps on the interface, and the only one that changes no pixel: nothing calls it yet. `Screen` is unchanged — `write` already carries `highlight`, so a band is a padded row drawn with it, and neither the curses screen nor the fake needed a line.

Reverse video rather than `U+2500`: the box would be a row of question marks in the medium's own console font, and a band that carries no meaning is decoration a console without it can lose. The right-hand text is dropped rather than truncated when both cannot fit, because half a count reads as a different count.