### PR TITLE
vm: a node the cluster proxy cannot reach is a transient failure

### DIFF
--- a/tests/unit/test_proxmox.py
+++ b/tests/unit/test_proxmox.py
@@ -312,6 +312,9 @@ def _refusing_api(
         ("GET", "/nodes", 502),
         ("GET", "/nodes", 503),
         ("GET", "/nodes", 504),
+        # The cluster proxy could not reach the node. `infra-node3` answered
+        # this while restarting and ended a campaign at its first dispatch.
+        ("GET", "/nodes/node/qemu/9306/status", 595),
         ("POST", "/nodes/node/qemu/9300/termproxy", 500),
         ("GET", "/nodes/node/tasks/UPID%3Anode%3Atask/status", 500),
     ],
@@ -2968,3 +2971,24 @@ def test_the_blind_edit_presses_before_the_menu_boots_itself() -> None:
     # Not so early that the firmware has not reached GRUB either: SeaBIOS and
     # the medium's own search take a few seconds before the menu is drawn.
     assert BIOS_MENU_DELAY >= 4.0
+
+
+def test_a_refusal_from_the_node_itself_is_not_transient() -> None:
+    """`403` is an answer, and retrying it wastes the window a real failure
+    needs."""
+    import io
+    import urllib.error
+
+    from tests.vm.proxmox import ProxmoxError, ProxmoxTransientError, _http_exception
+
+    error = urllib.error.HTTPError(
+        "https://pve.invalid/api2/json/nodes/infra-node3/qemu/9306/status",
+        403,
+        "Permission check failed",
+        Message(),
+        io.BytesIO(b""),
+    )
+    classified = _http_exception("GET", "/nodes/infra-node3/qemu/9306/status", error)
+
+    assert isinstance(classified, ProxmoxError)
+    assert not isinstance(classified, ProxmoxTransientError)

--- a/tests/vm/proxmox.py
+++ b/tests/vm/proxmox.py
@@ -127,7 +127,10 @@ def _http_exception(method: str, path: str, error: urllib.error.HTTPError) -> Pr
         re.fullmatch(r"/nodes/[^/]+/qemu/\d+/termproxy(?:\?.*)?", path) is not None
         or re.fullmatch(r"/nodes/[^/]+/tasks/[^/]+/status(?:\?.*)?", path) is not None
     )
-    if error.code in (429, 502, 503, 504) or retryable_500:
+    # 595 is the cluster proxy saying it could not reach the node, not the node
+    # saying no: `infra-node3` answered it four times while restarting, and the
+    # fourth ended a twenty-two guest campaign at its first dispatch.
+    if error.code in (429, 502, 503, 504, 595) or retryable_500:
         return ProxmoxTransientError(message)
     return ProxmoxError(message)
 


### PR DESCRIPTION
A twenty-two guest campaign ended at its first dispatch with `GET /nodes/infra-node3/tasks/.../status answered 595 Connection refused`. `595` is the cluster proxy reporting that it could not reach the node — pvedaemon restarting, the node rebooting — and not the node answering no, so it joins the codes the API layer already retries. The classification is all that was needed: every call site retries what `_transient` accepts.

It goes in the table `test_documented_http_failures_are_transient` already walks rather than in a test of its own, and `403` keeps a test proving a real refusal is not retried.