### PR TITLE
vm: wait for the initramfs ssh daemon instead of racing it

### DIFF
--- a/gentoo_install/plan/kernel.py
+++ b/gentoo_install/plan/kernel.py
@@ -345,7 +345,7 @@ class ConfigureRemoteUnlock(Operation):
 
     def describe(self) -> str:
         if not self.system_initramfs:
-            return "write /etc/dracut.conf.d/crypt-ssh.conf to omit ssh from the system initramfs"
+            return "write /etc/dracut.conf.d/99-gentoo-install-crypt-ssh.conf to omit ssh from the system initramfs"
         return f"configure remote unlock over ssh on port {self.port}"
 
     def apply(self, context: Context) -> None:
@@ -356,7 +356,7 @@ class ConfigureRemoteUnlock(Operation):
         ).apply(context)
         if not self.system_initramfs:
             context.write(
-                PurePosixPath("/etc/dracut.conf.d/crypt-ssh.conf"),
+                PurePosixPath("/etc/dracut.conf.d/99-gentoo-install-crypt-ssh.conf"),
                 'omit_dracutmodules+=" crypt-ssh "\n',
             )
             return
@@ -372,7 +372,7 @@ class ConfigureRemoteUnlock(Operation):
             'install_items+=" /sbin/cryptsetup "',
         ]
         context.write(
-            PurePosixPath("/etc/dracut.conf.d/crypt-ssh.conf"),
+            PurePosixPath("/etc/dracut.conf.d/99-gentoo-install-crypt-ssh.conf"),
             "".join(f"{line}\n" for line in lines),
         )
 

--- a/tests/golden/zfs-zbm.txt
+++ b/tests/golden/zfs-zbm.txt
@@ -45,7 +45,7 @@
   verify the selected kernel against the target sys-fs/zfs ceiling
   accept the linux-firmware licence
   ask for dhclient and arping, which ZFSBootMenu networking requires
-  write /etc/dracut.conf.d/crypt-ssh.conf to omit ssh from the system initramfs
+  write /etc/dracut.conf.d/99-gentoo-install-crypt-ssh.conf to omit ssh from the system initramfs
   accept sys-kernel/gentoo-cjk-kernel-bin as testing, with cjk on
   unmask virtual/dist-kernel, which the cjk kernel depends on by revision
   tell sys-fs/zfs to build against the dist-kernel

--- a/tests/unit/test_harness.py
+++ b/tests/unit/test_harness.py
@@ -10,6 +10,7 @@ import re
 from io import BytesIO
 from pathlib import Path
 from types import SimpleNamespace
+from typing import Callable
 from typing import Any, cast
 
 import pytest
@@ -2308,3 +2309,95 @@ def test_a_worker_cannot_hold_the_interpreter_open_after_the_schedule_ends() -> 
     assert daemons, "a worker thread is started without saying whether it is a daemon"
     for value in daemons:
         assert isinstance(value, ast.Constant) and value.value is True
+def test_the_unlock_waits_for_the_daemon_rather_than_racing_it(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """The harness connected the moment qemu started, and qemu's user-mode
+    network accepts a forwarded connection whether or not anything listens
+    behind it: the client waited out `ConnectTimeout` and reported
+    `Connection timed out during banner exchange` for a daemon seconds from
+    starting."""
+    import subprocess as commands
+
+    from tests.vm import run as vm_run
+
+    attempts = {"n": 0}
+
+    def answering(argv: object, **rest: object) -> commands.CompletedProcess[str]:
+        attempts["n"] += 1
+        if attempts["n"] < 3:
+            return commands.CompletedProcess(
+                [], 255, "", "kex_exchange_identification: Connection reset by peer"
+            )
+        return commands.CompletedProcess([], 255, "", "Permission denied (publickey).")
+
+    monkeypatch.setattr("subprocess.run", answering)
+    monkeypatch.setattr("time.sleep", lambda seconds: None)
+    vm_run.wait_for_unlock_daemon(tmp_path / "key", 2222)
+
+    assert attempts["n"] == 3
+
+
+def test_a_port_nothing_ever_answers_stops_the_run(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """Bounded: a daemon that never starts must end the run rather than hold
+    it open for the whole campaign."""
+    import subprocess as commands
+
+    from tests.vm import run as vm_run
+
+    def refusing(argv: object, **rest: object) -> commands.CompletedProcess[str]:
+        return commands.CompletedProcess([], 255, "", "Connection refused")
+
+    monkeypatch.setattr("subprocess.run", refusing)
+    monkeypatch.setattr("time.sleep", lambda seconds: None)
+    monkeypatch.setattr("time.monotonic", _ticking())
+
+    with pytest.raises(RuntimeError, match="no ssh daemon"):
+        vm_run.wait_for_unlock_daemon(tmp_path / "key", 2222, patience=10.0)
+
+
+def _ticking() -> Callable[[], float]:
+    """A clock that advances a second each time it is read, so a bounded wait
+    ends without the test waiting for it."""
+    ticks = {"at": 0.0}
+
+    def now() -> float:
+        ticks["at"] += 1.0
+        return ticks["at"]
+
+    return now
+
+
+def test_the_unlock_asks_for_the_daemon_before_it_speaks(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """A helper nothing calls is a helper that fixes nothing: the wait has to
+    happen inside `remote_unlock`, before the passphrase is offered."""
+    import subprocess as commands
+
+    from gentoo_install.exec.config import load
+    from tests.vm import run as vm_run
+
+    order: list[str] = []
+
+    def waited(key: object, port: object, **rest: object) -> None:
+        order.append("waited")
+
+    class Spoke:
+        returncode = 0
+
+        def communicate(self, text: object = None, timeout: object = None) -> tuple[str, str]:
+            order.append("spoke")
+            return "", ""
+
+    monkeypatch.setattr(vm_run, "wait_for_unlock_daemon", waited)
+    monkeypatch.setattr("subprocess.Popen", lambda *argv, **rest: Spoke())
+    monkeypatch.setattr(
+        vm_run, "ssh", lambda *argv, **rest: commands.CompletedProcess([], 0, "available", "")
+    )
+    installation = load(Path("tests/fixtures/vm-unlock.toml"))
+    vm_run.remote_unlock(tmp_path / "key", 2222, installation)
+
+    assert order == ["waited", "spoke"]

--- a/tests/unit/test_plan_boot.py
+++ b/tests/unit/test_plan_boot.py
@@ -619,7 +619,9 @@ def test_the_unlock_daemon_is_keyworded_and_told_where_to_read_its_keys() -> Non
         PurePosixPath("/etc/portage/package.accept_keywords/dracut-crypt-ssh")
     ]
     assert keywords == "sys-kernel/dracut-crypt-ssh ~amd64\n"
-    written = recorder.files[PurePosixPath("/etc/dracut.conf.d/crypt-ssh.conf")]
+    written = recorder.files[
+        PurePosixPath("/etc/dracut.conf.d/99-gentoo-install-crypt-ssh.conf")
+    ]
     assert 'dropbear_port="222"' in written
     # The `unlock` helper runs cryptsetup and the module does not pull it in.
     assert "/sbin/cryptsetup" in written
@@ -1032,7 +1034,9 @@ def test_the_dropbear_port_written_is_the_port_the_configuration_asked_for() -> 
             operation.apply(recorder)
             ran += 1
     assert ran == 1, "the fixture enables remote unlock, so exactly one is planned"
-    written = recorder.files[PurePosixPath("/etc/dracut.conf.d/crypt-ssh.conf")]
+    written = recorder.files[
+        PurePosixPath("/etc/dracut.conf.d/99-gentoo-install-crypt-ssh.conf")
+    ]
     assert f'dropbear_port="{asked}"' in written, written
 
 

--- a/tests/unit/test_plan_bootloader.py
+++ b/tests/unit/test_plan_bootloader.py
@@ -86,7 +86,9 @@ def test_zfsbootmenu_carries_remote_access_in_its_own_image() -> None:
     for operation in kernel.build(installation):
         if isinstance(operation, kernel.ConfigureRemoteUnlock):
             operation.apply(kernel_recorder)
-    assert kernel_recorder.files[PurePosixPath("/etc/dracut.conf.d/crypt-ssh.conf")] == (
+    assert kernel_recorder.files[
+        PurePosixPath("/etc/dracut.conf.d/99-gentoo-install-crypt-ssh.conf")
+    ] == (
         'omit_dracutmodules+=" crypt-ssh "\n'
     )
     assert "crypt-ssh" not in kernel.dracut_modules(installation)

--- a/tests/unit/test_plan_kernel.py
+++ b/tests/unit/test_plan_kernel.py
@@ -32,7 +32,9 @@ def test_grub_remote_unlock_keeps_the_system_dracut_path() -> None:
     recorder = Recorder()
     operation.apply(recorder)
 
-    written = recorder.files[PurePosixPath("/etc/dracut.conf.d/crypt-ssh.conf")]
+    written = recorder.files[
+        PurePosixPath("/etc/dracut.conf.d/99-gentoo-install-crypt-ssh.conf")
+    ]
     assert 'dropbear_port="2222"' in written
     assert 'dropbear_rsa_key="SYSTEM"' in written
     assert 'install_items+=" /sbin/cryptsetup "' in written

--- a/tests/vm/run.py
+++ b/tests/vm/run.py
@@ -226,6 +226,50 @@ def push_config(key: Path, port: int, path: str, contents: str) -> None:
         raise RuntimeError(f"the live SSH configuration push failed: {result.stderr.strip()}")
 
 
+#: How long the initramfs is given to reach its ssh daemon. The guest has to
+#: POST, load a bootloader and unpack an initramfs first, and the harness used
+#: to connect the moment qemu started: user-mode networking accepts the
+#: forwarded connection whether or not anything listens behind it, so the
+#: client waited out `ConnectTimeout` and reported
+#: `Connection timed out during banner exchange` for a daemon that was seconds
+#: from starting. The reset the ZFSBootMenu fixture answered is the same race
+#: caught a moment earlier.
+DAEMON_PATIENCE: Final[float] = 180.0
+DAEMON_PAUSE: Final[float] = 3.0
+
+
+def wait_for_unlock_daemon(
+    key: Path, port: int, *, host: str = "127.0.0.1", patience: float = DAEMON_PATIENCE
+) -> None:
+    """Block until the initramfs answers on the forwarded port.
+
+    `ssh -O check`-style probing is not available for a host that has never
+    been connected, so this asks for the banner and nothing else: exit code 255
+    with no shell is what a working daemon returns for `BatchMode` without a
+    key it trusts, and a refused or silent port is what it does not.
+    """
+    deadline = time.monotonic() + patience
+    last = ""
+    while time.monotonic() < deadline:
+        probe = subprocess.run(
+            [
+                "ssh", "-p", str(port), "-i", str(key),
+                "-o", "StrictHostKeyChecking=no", "-o", "UserKnownHostsFile=/dev/null",
+                "-o", "BatchMode=yes", "-o", "ConnectTimeout=5",
+                f"root@{host}", "true",
+            ],
+            capture_output=True,
+            text=True,
+            timeout=30,
+        )
+        said = f"{probe.stdout}{probe.stderr}"
+        if probe.returncode == 0 or "Permission denied" in said:
+            return
+        last = said.strip()[-200:]
+        time.sleep(DAEMON_PAUSE)
+    raise RuntimeError(f"no ssh daemon on port {port} after {patience:.0f}s: {last}")
+
+
 def remote_unlock(
     key: Path,
     port: int,
@@ -239,6 +283,7 @@ def remote_unlock(
     if commands is None:
         raise RuntimeError("remote unlock is disabled")
     command, proof = commands
+    wait_for_unlock_daemon(key, port, host=host)
     process = subprocess.Popen(
         [
             "ssh", "-p", str(port), "-i", str(key),


### PR DESCRIPTION
Two fixtures failed the unlock in the local matrix and failed it differently: `vm-unlock` with `Connection timed out during banner exchange`, `zfs-zbm` with `kex_exchange_identification: read: Connection reset by peer`. Both installs completed and rebooted; only the unlock failed.

The harness called `remote_unlock()` the moment qemu started, before the guest had POSTed, loaded a bootloader or unpacked an initramfs. qemu's user-mode network accepts a forwarded connection whether or not anything listens behind it, so the client waited out `ConnectTimeout` against a daemon seconds from starting; the reset is the same race caught a moment earlier. It now asks for the banner until the daemon answers, bounded so a daemon that never starts ends the run.

The guest logs also show `sys-kernel/dracut-crypt-ssh` installing its own `/etc/dracut.conf.d/crypt-ssh.conf` over the one `ConfigureRemoteUnlock` wrote. Config protection kept ours, so it did not cause these failures, but it left a `._cfg0000_` pending in every install and one `etc-update` would reverse it; the installer's file is now `99-gentoo-install-crypt-ssh.conf`.

Not verified on a guest yet: the matrix that found this is queued behind a cluster run.