### PR TITLE
tui: say why the interface stopped answering

### DIFF
--- a/gentoo_install/data/locale/ja.toml
+++ b/gentoo_install/data/locale/ja.toml
@@ -531,3 +531,4 @@
 "no user password and no authorised ssh key usable by sshd" = "ユーザーのパスワードがなく、sshd が使える authorized な ssh 鍵もありません"
 "the root password hash is empty, locked, or malformed, and no user password or usable ssh key can log into the installed system" = "root のパスワードハッシュが空、ロック済み、または不正な形式で、インストール後のシステムにログインできるユーザーのパスワードも使用可能な ssh 鍵もありません"
 "the separate /boot is encrypted or not vfat, so systemd-boot cannot read its kernels or entries" = "独立した /boot が暗号化されているか vfat ではないため、systemd-boot はカーネルもエントリーも読み取れません"
+"reading the versions this package offers" = "このパッケージが提供するバージョンを読み込んでいます"

--- a/gentoo_install/data/locale/ko.toml
+++ b/gentoo_install/data/locale/ko.toml
@@ -531,3 +531,4 @@
 "no user password and no authorised ssh key usable by sshd" = "사용자 비밀번호가 없고 sshd 가 사용할 수 있는 승인된 ssh 키도 없습니다"
 "the root password hash is empty, locked, or malformed, and no user password or usable ssh key can log into the installed system" = "root 비밀번호 해시가 비어 있거나 잠겨 있거나 형식이 잘못되었고, 설치된 시스템에 로그인할 수 있는 사용자 비밀번호나 사용 가능한 ssh 키도 없습니다"
 "the separate /boot is encrypted or not vfat, so systemd-boot cannot read its kernels or entries" = "별도의 /boot 가 암호화되어 있거나 vfat 이 아니므로 systemd-boot 가 커널과 항목을 읽을 수 없습니다"
+"reading the versions this package offers" = "이 패키지가 제공하는 버전을 읽는 중"

--- a/gentoo_install/data/locale/zh-CN.toml
+++ b/gentoo_install/data/locale/zh-CN.toml
@@ -532,3 +532,4 @@
 "no user password and no authorised ssh key usable by sshd" = "没有用户密码，也没有 sshd 用得上的授权 ssh 密钥"
 "the root password hash is empty, locked, or malformed, and no user password or usable ssh key can log into the installed system" = "root 密码哈希是空的、已锁定或格式错误，而且没有任何用户密码或可用的 ssh 密钥能登录安装完成的系统"
 "the separate /boot is encrypted or not vfat, so systemd-boot cannot read its kernels or entries" = "独立的 /boot 已加密或不是 vfat，因此 systemd-boot 无法读取其中的内核与启动项"
+"reading the versions this package offers" = "正在读取这个软件包提供的版本"

--- a/gentoo_install/data/locale/zh-TW.toml
+++ b/gentoo_install/data/locale/zh-TW.toml
@@ -532,3 +532,4 @@
 "no user password and no authorised ssh key usable by sshd" = "沒有使用者密碼，也沒有 sshd 用得上的授權 ssh 金鑰"
 "the root password hash is empty, locked, or malformed, and no user password or usable ssh key can log into the installed system" = "root 密碼雜湊是空的、已鎖定或格式錯誤，而且沒有任何使用者密碼或可用的 ssh 金鑰能登入安裝完成的系統"
 "the separate /boot is encrypted or not vfat, so systemd-boot cannot read its kernels or entries" = "獨立的 /boot 已加密或不是 vfat，因此 systemd-boot 無法讀取其中的核心與開機項目"
+"reading the versions this package offers" = "正在讀取這個套件提供的版本"

--- a/gentoo_install/tui/screens.py
+++ b/gentoo_install/tui/screens.py
@@ -83,6 +83,7 @@ from ..plan.packages import INPUT_CONFIGURATION_DISABLED, INPUT_CONFIGURATION_EN
 from ..plan.packages import driver_conflict, framework_conflict
 from ..plan import system as plan_system
 from .widgets import (
+    band,
     MINIMUM_COLUMNS,
     Answer,
     Confirm,
@@ -1362,6 +1363,23 @@ KERNELS: tuple[tuple[KernelSource, str], ...] = (
 )
 
 
+def _while_reading(
+    screen: Screen, context: Context, package: str
+) -> tuple[tuple[str, bool], ...]:
+    """Read the versions with the reason for the pause on the screen.
+
+    The lookup is a network request and the interface stopped answering keys
+    while it ran, with nothing to say why: on a slow link that reads as a
+    program that has died. Drawn before the call and left there, because the
+    call is what returns.
+    """
+    screen.clear()
+    band(screen, 0, context.translate("Kernel"), package)
+    screen.write(2, 2, context.translate("reading the versions this package offers"))
+    screen.show()
+    return context.kernel_versions(package)
+
+
 def _within(
     offered: tuple[tuple[str, bool], ...], ceiling: str
 ) -> tuple[tuple[str, bool], ...]:
@@ -1398,7 +1416,7 @@ def kernel_version_screen(
     translate = context.translate
     package = config.kernel.package or KERNEL_PACKAGES[config.kernel.source]
     ceiling = context.zfs_kernel_max if config.disk.graph.of_type(ZfsPool) else ""
-    offered = _within(context.kernel_versions(package), ceiling)
+    offered = _within(_while_reading(screen, context, package), ceiling)
     if not offered:
         typed = TextField(
             title=f"{package}  {translate('version')}",

--- a/tests/unit/test_tui_app.py
+++ b/tests/unit/test_tui_app.py
@@ -1303,8 +1303,10 @@ def test_the_version_list_is_read_from_the_machine_and_not_held_here() -> None:
     screen = FakeScreen(keys=["KEY_DOWN", "\n"], lines=20, columns=100)
     answer = screens.kernel_version_screen(screen, config(), at)
     assert answer.unwrap().kernel.version == "7.1.7"
-    assert "~amd64" in screen.frames[0][3]
-    assert "amd64" in "\n".join(screen.frames[0])
+    # Whichever frame carries the list: a screen drawn before it, to say why
+    # the network lookup is pausing, is not the one under test.
+    assert any("~amd64" in line for frame in screen.frames for line in frame)
+    assert any("amd64" in "\n".join(frame) for frame in screen.frames)
 
 
 def test_a_medium_with_no_repository_asks_for_the_version_instead() -> None:
@@ -3046,3 +3048,26 @@ def test_a_row_names_its_state_beside_the_label() -> None:
     for label, shown in named.items():
         assert shown != ctx.translate(label)
         assert shown.endswith("]")
+
+
+def test_the_interface_says_why_it_stopped_answering() -> None:
+    """The version lookup is a network request, and the interface stopped
+    answering keys while it ran with nothing on screen to say why. On a slow
+    link that reads as a program that has died."""
+    at = context()
+    drawn: list[list[str]] = []
+
+    def slow(atom: str) -> tuple[tuple[str, bool], ...]:
+        # Whatever is on the screen when the request starts is what the
+        # operator looks at for as long as it takes.
+        drawn.append([line for line in screen.frames[-1] if line.strip()])
+        return (("7.1.7", False),)
+
+    at.kernel_versions = slow
+    screen = FakeScreen(keys=["\n"], lines=20, columns=100)
+    screens.kernel_version_screen(screen, config(), at)
+
+    assert drawn, "the lookup ran before anything was drawn"
+    said = "\n".join(drawn[0])
+    assert "reading the versions" in said
+    assert "sys-kernel/" in said


### PR DESCRIPTION
Opening the kernel row calls `fetch.package_versions()`, which is a network request. The interface answered no keys while it ran and had nothing on screen to say why; on the slow links this installer is used from, that reads as a program that has died.

It now draws the package and one line — `reading the versions this package offers` — before the call. Subiquity's own rule is that the UI never blocks and anything past 0.1s runs in the background with an indication; this is the indication, not the background, and the background half is worth doing separately.

Found by measuring this interface against that document rather than by taste. Two other findings from the same pass are not in this PR: fourteen places reject input after the fact where the field could refuse the character, and five of eighty-three screens say what they are for.