### PR TITLE
tui: a field refuses the characters it can never hold

### DIFF
--- a/gentoo_install/data/locale/ja.toml
+++ b/gentoo_install/data/locale/ja.toml
@@ -11,7 +11,6 @@
 "comma-separated host names" = "ホスト名をコンマ区切り"
 "Proxy host is required when proxy fields are set" = "プロキシの項目を指定した場合はホストが必要です"
 "Proxy port must be between 1 and 65535" = "プロキシのポートは 1 から 65535 の範囲で指定します"
-"Proxy password contains control characters" = "プロキシのパスワードに制御文字があります"
 "Bypass hosts must not contain spaces" = "バイパスするホストに空白を含めることはできません"
 "{count} hosts bypass" = "{count} ホストをバイパス"
 "Portage" = "Portage"

--- a/gentoo_install/data/locale/ko.toml
+++ b/gentoo_install/data/locale/ko.toml
@@ -11,7 +11,6 @@
 "comma-separated host names" = "호스트 이름을 쉼표로 구분"
 "Proxy host is required when proxy fields are set" = "프록시 항목을 지정하면 호스트가 필요합니다"
 "Proxy port must be between 1 and 65535" = "프록시 포트는 1에서 65535 사이여야 합니다"
-"Proxy password contains control characters" = "프록시 비밀번호에 제어 문자가 있습니다"
 "Bypass hosts must not contain spaces" = "우회 호스트에는 공백을 포함할 수 없습니다"
 "{count} hosts bypass" = "{count}개 호스트 우회"
 "Portage" = "Portage"

--- a/gentoo_install/data/locale/zh-CN.toml
+++ b/gentoo_install/data/locale/zh-CN.toml
@@ -11,7 +11,6 @@
 "comma-separated host names" = "用逗号分隔主机名"
 "Proxy host is required when proxy fields are set" = "设置代理字段时必须填写代理主机"
 "Proxy port must be between 1 and 65535" = "代理端口必须在 1 到 65535 之间"
-"Proxy password contains control characters" = "代理密码包含控制字符"
 "Bypass hosts must not contain spaces" = "绕过主机不能包含空格"
 "{count} hosts bypass" = "绕过 {count} 个主机"
 "Portage" = "Portage"

--- a/gentoo_install/data/locale/zh-TW.toml
+++ b/gentoo_install/data/locale/zh-TW.toml
@@ -11,7 +11,6 @@
 "comma-separated host names" = "以逗號分隔主機名稱"
 "Proxy host is required when proxy fields are set" = "設定 Proxy 欄位時必須填寫 Proxy 主機"
 "Proxy port must be between 1 and 65535" = "Proxy 連接埠必須介於 1 與 65535 之間"
-"Proxy password contains control characters" = "Proxy 密碼包含控制字元"
 "Bypass hosts must not contain spaces" = "略過主機不能包含空白"
 "{count} hosts bypass" = "略過 {count} 個主機"
 "Portage" = "Portage"

--- a/gentoo_install/tui/screens.py
+++ b/gentoo_install/tui/screens.py
@@ -83,6 +83,7 @@ from ..plan.packages import INPUT_CONFIGURATION_DISABLED, INPUT_CONFIGURATION_EN
 from ..plan.packages import driver_conflict, framework_conflict
 from ..plan import system as plan_system
 from .widgets import (
+    Accepts,
     band,
     MINIMUM_COLUMNS,
     Answer,
@@ -659,8 +660,6 @@ def proxy_screen(screen: Screen, config: InstallConfig, context: Context) -> Ans
             return FormRejected(translate("Proxy host is required when proxy fields are set"), {0: host})
         if port and (not port.isdecimal() or not 1 <= int(port) <= 65535):
             return FormRejected(translate("Proxy port must be between 1 and 65535"), {1: port})
-        if any(ord(char) < 0x20 or ord(char) == 0x7F for char in password):
-            return FormRejected(translate("Proxy password contains control characters"), {3: password})
         bypass = tuple(one for one in (item.strip() for item in hosts.split(",")) if one)
         if any(any(char.isspace() for char in item) for item in bypass):
             return FormRejected(translate("Bypass hosts must not contain spaces"), {1: hosts})
@@ -674,13 +673,26 @@ def proxy_screen(screen: Screen, config: InstallConfig, context: Context) -> Ans
     return Form(
         title=translate("Proxy"),
         fields=[
-            Field(label=translate("Proxy host"), value=current.host),
-            Field(label=translate("Proxy port"), value=str(current.port) if current.port else ""),
-            Field(label=translate("Proxy username"), value=current.username),
+            Field(
+                label=translate("Proxy host"),
+                value=current.host,
+                accepts=Accepts.NO_SPACE,
+            ),
+            Field(
+                label=translate("Proxy port"),
+                value=str(current.port) if current.port else "",
+                accepts=Accepts.DIGITS,
+            ),
+            Field(
+                label=translate("Proxy username"),
+                value=current.username,
+                accepts=Accepts.NO_SPACE,
+            ),
             Field(label=translate("Proxy password"), value=current.password, secret=True),
             Field(
                 label=translate("Bypass hosts"),
                 value=", ".join(current.bypass),
+                accepts=Accepts.NO_SPACE,
                 placeholder=translate("comma-separated host names"),
             ),
         ],

--- a/gentoo_install/tui/widgets.py
+++ b/gentoo_install/tui/widgets.py
@@ -475,12 +475,36 @@ class Confirm:
         return Answer(Outcome.CHOSE, answer.unwrap())
 
 
+class Accepts(Enum):
+    """What a field takes at a keystroke.
+
+    Rejecting a submitted form tells the operator they were wrong; refusing the
+    key tells them before they are. A host name can never hold a space, so the
+    space is simply not typed.
+    """
+
+    ANYTHING = "anything"
+    #: Host names, bypass lists and user names.
+    NO_SPACE = "no space"
+    #: Ports. The range stays a rejection: `70000` is five valid keystrokes.
+    DIGITS = "digits"
+
+    def holds(self, character: str) -> bool:
+        if self is Accepts.NO_SPACE:
+            return not character.isspace()
+        if self is Accepts.DIGITS:
+            return character.isdigit()
+        return True
+
+
 @dataclass
 class Field:
     """One line of a `Form`."""
 
     label: str
     value: str = ""
+    #: What this field takes, from the table above.
+    accepts: Accepts = Accepts.ANYTHING
     #: Drawn inside the box while it is empty.
     placeholder: str = ""
     #: Drawn as asterisks. A password read over a shoulder is the reason, and
@@ -575,6 +599,7 @@ class Form:
                 and pressed.isprintable()
                 and cursor < len(self.fields)
                 and not self.fields[cursor].toggle
+                and self.fields[cursor].accepts.holds(pressed)
             ):
                 typed[cursor].append(pressed)
                 touched = True

--- a/tests/unit/test_tui_widgets.py
+++ b/tests/unit/test_tui_widgets.py
@@ -519,3 +519,42 @@ def test_a_band_counts_cells_not_characters() -> None:
     band(screen, 0, "\u5b89\u88dd", "\u5b8c\u6210")
 
     assert width(screen._current[0]) == 30
+
+
+def test_a_field_refuses_a_character_it_can_never_hold() -> None:
+    """Rejecting the submitted form tells the operator they were wrong; the
+    field can tell them before they are. A host name never holds a space."""
+    from gentoo_install.tui.widgets import Accepts, Field, Form
+
+    screen = FakeScreen(keys=["a", " ", "b", "\t", "\n"], lines=20, columns=60)
+    answered = Form(
+        title="Proxy",
+        fields=[Field(label="host", accepts=Accepts.NO_SPACE)],
+        footer="",
+    ).run(screen)
+
+    assert answered.unwrap() == ["ab"]
+
+
+def test_a_port_field_takes_digits_and_nothing_else() -> None:
+    from gentoo_install.tui.widgets import Accepts, Field, Form
+
+    screen = FakeScreen(keys=["8", "o", "0", "-", "8", "\t", "\n"], lines=20, columns=60)
+    answered = Form(
+        title="Proxy",
+        fields=[Field(label="port", accepts=Accepts.DIGITS)],
+        footer="",
+    ).run(screen)
+
+    assert answered.unwrap() == ["808"]
+
+
+def test_a_field_with_no_rule_takes_what_it_is_given() -> None:
+    """Most fields hold prose; a table that refused by default would be a rule
+    nobody asked for."""
+    from gentoo_install.tui.widgets import Field, Form
+
+    screen = FakeScreen(keys=["a", " ", "b", "\t", "\n"], lines=20, columns=60)
+    answered = Form(title="Any", fields=[Field(label="free")], footer="").run(screen)
+
+    assert answered.unwrap() == ["a b"]


### PR DESCRIPTION
Measured against subiquity's own rule — "prevent invalid use if that makes sense (e.g. unix usernames can never contain spaces, so you simply can't enter spaces in that box)" — this interface rejected after the fact in fourteen places. `Accepts` is one table with three entries, and the proxy screen's host, port, username and bypass fields now take only what they can hold. A range check stays a rejection: `70000` is five valid keystrokes.

One rejection is gone rather than converted. `Proxy password contains control characters` could never fire: the key handler takes only `isprintable()` characters, and `parse._proxy` refuses a control character in a saved configuration — I checked both. An entry that never fires reads as coverage and is not.