### PR TITLE
portage: the first snapshot is tried again like every later sync

### DIFF
--- a/gentoo_install/plan/portage.py
+++ b/gentoo_install/plan/portage.py
@@ -461,9 +461,24 @@ class WebrsyncRepository(Operation):
         # falls back to a keyserver, and with none configured a WKD that does
         # not answer ends the install at `No keyserver available`.
         server = (policy.strip() if readable else "") or KEY_SERVER
-        context.run_in_target(
-            ["env", f"PORTAGE_GPG_KEY_SERVER={server}", "emerge-webrsync"]
-        )
+        # The same patience the later syncs get, and this one needs it more: it
+        # downloads the whole snapshot, looks the signing key up over WKD and
+        # refreshes it from a keyserver, and gemato lets a `ReadTimeout` in the
+        # WKD lookup out rather than falling back. `openrc-sdboot` ended a
+        # cluster round there with the tree never fetched.
+        last: CommandFailed | None = None
+        for attempt in range(SYNC_TRIES):
+            try:
+                context.run_in_target(
+                    ["env", f"PORTAGE_GPG_KEY_SERVER={server}", "emerge-webrsync"]
+                )
+                return
+            except CommandFailed as failed:
+                last = failed
+                if attempt + 1 < SYNC_TRIES:
+                    context.run(["sleep", f"{SYNC_PAUSE * (attempt + 1):g}"])
+        assert last is not None
+        raise last
 
 
 #: Records between the lines tar prints while unpacking. One every few

--- a/tests/unit/test_plan_portage.py
+++ b/tests/unit/test_plan_portage.py
@@ -1512,3 +1512,51 @@ def test_the_flag_variables_still_follow_common_flags() -> None:
     assert read_back[1] == "-O2 -pipe"
     # Not expanded: the fetcher substitutes these, long after the file is read.
     assert "${URI}" in read_back[2]
+
+
+def test_the_first_snapshot_is_tried_again_like_every_later_sync() -> None:
+    """It downloads the whole tree, looks the signing key up over WKD and
+    refreshes it from a keyserver, and gemato lets a `ReadTimeout` in the WKD
+    lookup out rather than falling back. The later syncs have had three
+    attempts since a mirror rewrote its Manifests mid-sync; this one had none,
+    and `openrc-sdboot` ended a cluster round with the tree never fetched."""
+    from gentoo_install.errors import CommandFailed
+    from gentoo_install.plan import portage as plan_portage
+    from .recorder import Recorder
+
+    tries = {"n": 0}
+
+    def answer(argv: Sequence[str]) -> str | None:
+        if "emerge-webrsync" in argv:
+            tries["n"] += 1
+            if tries["n"] < plan_portage.SYNC_TRIES:
+                raise CommandFailed("emerge-webrsync exited 1: requests.exceptions.ReadTimeout")
+        return None
+
+    recorder = Recorder(answering=answer)
+    plan_portage.WebrsyncRepository().apply(recorder)
+
+    assert tries["n"] == plan_portage.SYNC_TRIES
+    assert any("sleep" in one for one in recorder.commands)
+
+
+def test_a_snapshot_that_never_arrives_stops_the_install() -> None:
+    """Bounded, like the later syncs: a mirror that is down has to stop the
+    install rather than be walked around."""
+    from gentoo_install.errors import CommandFailed
+    from gentoo_install.plan import portage as plan_portage
+    from .recorder import Recorder
+
+    tries = {"n": 0}
+
+    def answer(argv: Sequence[str]) -> str | None:
+        if "emerge-webrsync" in argv:
+            tries["n"] += 1
+            raise CommandFailed("emerge-webrsync exited 1")
+        return None
+
+    recorder = Recorder(answering=answer)
+    with pytest.raises(CommandFailed):
+        plan_portage.WebrsyncRepository().apply(recorder)
+
+    assert tries["n"] == plan_portage.SYNC_TRIES


### PR DESCRIPTION
`openrc-sdboot` ended a cluster round eleven minutes in with `requests.exceptions.ReadTimeout` raised inside gemato's `refresh_keys_wkd`, and the tree never fetched. gemato lets that out rather than falling back to the keyserver `#277` gives it.

`SyncRepository` has retried three times with a growing pause since a mirror rewrote its Manifests mid-sync. `WebrsyncRepository` ran once — and it is the first sync always, because a stage3 has no `dev-vcs/git`, so the most fragile step in the install was the one with no patience: it downloads the whole snapshot, does a WKD lookup and refreshes a key from a keyserver.

Same three attempts, same growing pause, same bound: a mirror that is down still stops the install.