### PR TITLE
vm: stopping a guest checks whose machine it is

### DIFF
--- a/tests/unit/test_proxmox.py
+++ b/tests/unit/test_proxmox.py
@@ -2506,6 +2506,9 @@ def test_a_stop_task_failure_does_not_mark_the_guest_stopped() -> None:
         def call(self, method: str, path: str, **form: Any) -> Any:
             if path.endswith("/status/current"):
                 return {"status": "running"}
+            # The ownership check reads this before anything is stopped.
+            if path.endswith("/config"):
+                return {"tags": TAG}
             return "UPID:node:stop"
 
         def wait(self, node: str, upid: str, patience: float = 1800.0) -> None:
@@ -2992,3 +2995,54 @@ def test_a_refusal_from_the_node_itself_is_not_transient() -> None:
 
     assert isinstance(classified, ProxmoxError)
     assert not isinstance(classified, ProxmoxTransientError)
+
+
+def test_a_stop_refuses_a_machine_that_is_not_this_runs() -> None:
+    """`destroy` has checked the tag since a VMID was found not to be proof of
+    ownership; `stop` had no check at all, and three call sites reach it without
+    going through `destroy`. VMIDs are recycled between fixtures inside one
+    campaign: 9302 carried three guests in seventy minutes."""
+    stopped: list[str] = []
+
+    class Someone(Api):
+        def call(self, method: str, path: str, **form: Any) -> Any:
+            if path.endswith("/status/current"):
+                return {"status": "running"}
+            if path.endswith("/config"):
+                return {"tags": "somebody-else"}
+            stopped.append(path)
+            return "UPID:node:stop"
+
+        def wait(self, node: str, upid: str, patience: float = 1800.0) -> None:
+            return None
+
+    guest = Guest(Someone(), "node", 9302, GuestSpec(name="x", iso="x"))
+    guest._booted = True
+    with pytest.raises(ProxmoxError, match="not this run's machine"):
+        guest.stop()
+
+    assert stopped == []
+    assert guest._booted
+
+
+def test_a_stop_still_stops_this_runs_machine() -> None:
+    stopped: list[str] = []
+
+    class Ours(Api):
+        def call(self, method: str, path: str, **form: Any) -> Any:
+            if path.endswith("/status/current"):
+                return {"status": "running"}
+            if path.endswith("/config"):
+                return {"tags": f"other;{TAG}"}
+            stopped.append(path)
+            return "UPID:node:stop"
+
+        def wait(self, node: str, upid: str, patience: float = 1800.0) -> None:
+            return None
+
+    guest = Guest(Ours(), "node", 9302, GuestSpec(name="x", iso="x"))
+    guest._booted = True
+    guest.stop()
+
+    assert stopped == ["/nodes/node/qemu/9302/status/stop"]
+    assert not guest._booted

--- a/tests/vm/proxmox.py
+++ b/tests/vm/proxmox.py
@@ -569,6 +569,14 @@ class Guest:
             time.sleep(self.KEY_PAUSE)
 
     def stop(self) -> None:
+        """Stop the machine this run created, and only that one.
+
+        `destroy` has checked the tag since a VMID was found not to be proof of
+        ownership; this did not, and three call sites reach it without going
+        through `destroy`. VMIDs are recycled between fixtures inside one
+        campaign — 9302 carried three guests in seventy minutes — so a stale
+        `Guest` had nothing between it and another run's machine.
+        """
         try:
             status = self.api.call(
                 "GET", f"/nodes/{self.node}/qemu/{self.vmid}/status/current"
@@ -579,12 +587,30 @@ class Guest:
         if str(status.get("status")) != "running":
             self._booted = False
             return
+        if not self._is_ours():
+            raise ProxmoxError(
+                f"vm {self.vmid} on {self.node} is not this run's machine; not stopping it"
+            )
         self.api.wait(
             self.node,
             self.api.call("POST", f"/nodes/{self.node}/qemu/{self.vmid}/status/stop"),
             patience=180.0,
         )
         self._booted = False
+
+    def _is_ours(self) -> bool:
+        """Whether the machine at this VMID still carries this harness's tag.
+
+        A VMID is not proof: the range already held a production template, and
+        within one campaign a failed run's VMID is handed straight to the next.
+        """
+        if not VMID_FIRST <= self.vmid <= VMID_LAST:
+            return False
+        try:
+            config = self.api.call("GET", f"/nodes/{self.node}/qemu/{self.vmid}/config")
+        except ProxmoxNotFound:
+            return False
+        return TAG in str(config.get("tags", "")).split(";")
 
     def destroy(self, patience: float = CLEANUP_PATIENCE) -> None:
         """Remove the machine and its disks.


### PR DESCRIPTION
`Guest.destroy` refuses a machine that does not carry this harness's tag and this run's nonce, and its comment says why: a VMID is not proof of ownership, and this range already held `prod-debian-12-server-template`. `Guest.stop` read the status and stopped whatever was running, with no check at all.

Nothing has been observed going wrong through that hole. I opened this claiming it powered off `vm-desktop`'s guest mid-run; the node's task history says otherwise — `qmstop` at 19:27:17 and `qmdestroy` six seconds later, which is that guest's own closing path after its verdict at 67.9 minutes. `destroy` checks the tag and the nonce before it calls `stop`, so a foreign guest never reaches it by that route.

What remains is that three call sites in `cluster.py` call `stop` directly, VMIDs are recycled between fixtures within a single campaign — 9302 carried three different guests in seventy minutes — and the only thing standing between a stale `Guest` object and somebody else's machine was that nobody had written that code path yet.