### PR TITLE
vm: end a guest whose hypervisor stops answering

### DIFF
--- a/tests/unit/test_harness.py
+++ b/tests/unit/test_harness.py
@@ -2051,3 +2051,41 @@ def test_the_campaign_expects_exactly_the_fixtures_that_cannot_finish() -> None:
     }
 
     assert named == {"vm-proxy-dead"}
+
+
+def test_a_hypervisor_that_stops_answering_is_not_a_living_guest(tmp_path: Path) -> None:
+    """`vm-desktop` sat for sixty-eight minutes on a node that had stopped
+    answering, its console silent and its counters unreadable, and every look
+    called it alive. One unanswered request is noise; a run of them is the
+    watchdog going blind, and a blind watchdog must end the guest rather than
+    wait out the ceiling."""
+    from tests.vm.cluster import BLIND_SAMPLES, Watchdog
+
+    log = tmp_path / "guest.log"
+    log.write_text("")
+    watchdog = Watchdog(log=log, counters=lambda: None)
+
+    for _ in range(BLIND_SAMPLES - 1):
+        assert watchdog.moved(), "one unreadable sample alone is not proof"
+        assert not watchdog.stuck
+    assert not watchdog.moved()
+
+    assert watchdog.stuck
+    assert "did not answer" in (watchdog.idle_reason() or "")
+
+
+def test_a_guest_still_printing_survives_an_unreadable_counter(tmp_path: Path) -> None:
+    """The counters go unreadable for a node under load while the guest is
+    fine, and the console is the other half of the answer."""
+    from tests.vm.cluster import BLIND_SAMPLES, Watchdog
+
+    log = tmp_path / "guest.log"
+    log.write_text("")
+    watchdog = Watchdog(log=log, counters=lambda: None)
+
+    for step in range(BLIND_SAMPLES * 3):
+        log.write_text("x" * (step + 1) * 4096)
+        assert watchdog.moved()
+
+    assert not watchdog.stuck
+    assert watchdog.idle_reason() is None

--- a/tests/vm/cluster.py
+++ b/tests/vm/cluster.py
@@ -168,6 +168,8 @@ NODE_HEADROOM_BYTES: Final[int] = 2 * 1024**3
 #: often than that, and half an hour of silence is not a slow mirror.
 WATCH_EVERY: Final[float] = 600.0
 WATCH_STRIKES: Final[int] = 3
+#: Samples the hypervisor may refuse before its silence is the guest's.
+BLIND_SAMPLES: Final[int] = WATCH_STRIKES * 2
 
 #: Between starting one guest and the next. They all reach for the same mirror
 #: in their first minute, and twelve starting together each failed the
@@ -403,6 +405,8 @@ class Watchdog:
     _moved: int = field(default=0, init=False)
     _counter_before: int = field(default=0, init=False)
     _counter_after: int = field(default=0, init=False)
+    #: Consecutive samples the hypervisor would not answer.
+    _blind: int = field(default=0, init=False)
     _lock: threading.Lock = field(default_factory=threading.Lock, init=False, repr=False)
 
     def moved(self) -> bool:
@@ -415,9 +419,17 @@ class Watchdog:
     def _observe(self, talking: bool) -> bool:
         traffic = self.counters()
         if traffic is None:
+            # One unanswered request is not evidence about the guest. A run of
+            # them is: `vm-desktop` sat on a node that had stopped answering
+            # for sixty-eight minutes with the console silent and the counters
+            # unreadable, and the watchdog called that alive every time.
             if talking:
                 self.strikes = 0
-            return True
+                self._blind = 0
+                return True
+            self._blind += 1
+            return self._blind < BLIND_SAMPLES
+        self._blind = 0
         self._counter_before = self._moved
         self._counter_after = traffic
         working = traffic - self._moved >= QUIET_BYTES
@@ -432,6 +444,12 @@ class Watchdog:
         with self._lock:
             if self._observe(talking=False):
                 return None
+            if self._blind:
+                minutes = self._blind * WATCH_EVERY / 60
+                return (
+                    f"the hypervisor did not answer for {minutes:.0f}m "
+                    "and the console said nothing"
+                )
             return (
                 "counters were flat "
                 f"({self._counter_before} -> {self._counter_after} bytes)"
@@ -439,7 +457,7 @@ class Watchdog:
 
     @property
     def stuck(self) -> bool:
-        return self.strikes >= WATCH_STRIKES
+        return self.strikes >= WATCH_STRIKES or self._blind >= BLIND_SAMPLES
 
 
 def _download(url: str, target: Path) -> None:


### PR DESCRIPTION
An unreadable counter reset no strike and returned "alive", so a guest on a node that had stopped answering sat sixty-eight minutes with a silent console and never produced a verdict. `Watchdog` now separates "cannot read" from "no traffic": six refused samples with a silent console end the guest, one hiccup still does not.