### PR TITLE
vm: answer SIGINT as well as SIGTERM when a schedule is ended

### DIFF
--- a/tests/unit/test_harness.py
+++ b/tests/unit/test_harness.py
@@ -2230,3 +2230,32 @@ def test_nothing_is_carried_when_it_was_not_asked_for() -> None:
     cluster.wait_for_network(cast(Any, Link()), 9300, "10.31.0.150")
 
     assert not any("/etc/hosts" in one for one in sent)
+
+
+def test_a_campaign_answers_every_signal_that_asks_it_to_stop() -> None:
+    """A campaign started in the background inherits `SIG_IGN` for SIGINT from
+    a shell without job control, and CPython keeps an inherited ignore: two
+    schedules ignored `kill -INT` entirely and kept seven guests on the cluster
+    until SIGTERM reached them."""
+    import signal as signals
+
+    from tests.vm.cluster import _leave_on_a_signal
+
+    before = {
+        one: signals.getsignal(one)
+        for one in (signals.SIGTERM, signals.SIGHUP, signals.SIGINT)
+    }
+    try:
+        _leave_on_a_signal()
+        installed = {one: signals.getsignal(one) for one in before}
+        # The same function for all three, which SIGINT's inherited handler is
+        # not: the interpreter's own raises `KeyboardInterrupt` as well.
+        assert len(set(map(id, installed.values()))) == 1, (
+            "a signal was left to the handler the campaign inherited"
+        )
+        for one, now in installed.items():
+            with pytest.raises(KeyboardInterrupt, match=f"signal {int(one)}"):
+                cast(Any, now)(int(one), None)
+    finally:
+        for one, was in before.items():
+            signals.signal(one, was)

--- a/tests/vm/cluster.py
+++ b/tests/vm/cluster.py
@@ -2266,11 +2266,15 @@ def fixtures(names: list[str]) -> list[Job]:
 
 
 def _leave_on_a_signal() -> None:
-    """Turn SIGTERM into the exception SIGINT already raises.
+    """Unwind on a signal so the closing path runs.
 
     Python's default handler for SIGTERM ends the process without unwinding,
     so no `finally` runs: `kill` on the scheduler left eight guests on the
     cluster with the closing path that removes them never reached.
+
+    SIGINT is claimed too. A shell without job control hands a background
+    campaign `SIG_IGN` for it, CPython keeps an inherited ignore, and
+    `kill -INT` on the schedule then does nothing at all.
     """
 
     def raised(number: int, frame: object) -> None:
@@ -2278,6 +2282,7 @@ def _leave_on_a_signal() -> None:
 
     signal.signal(signal.SIGTERM, raised)
     signal.signal(signal.SIGHUP, raised)
+    signal.signal(signal.SIGINT, raised)
 
 
 def main(argv: list[str] | None = None) -> int:


### PR DESCRIPTION
A shell without job control hands a background campaign `SIG_IGN` for SIGINT, and CPython keeps an inherited ignore rather than replacing it. Two schedules ignored `kill -INT` completely, kept seven guests on the cluster, and only unwound when SIGTERM reached them.