### PR TITLE
vm: the closing path owns removal, not the worker thread

### DIFF
--- a/tests/unit/test_harness.py
+++ b/tests/unit/test_harness.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 import re
 from io import BytesIO
 from pathlib import Path
+from types import SimpleNamespace
 from typing import Any, cast
 
 import pytest
@@ -1286,12 +1287,36 @@ def test_a_schedule_that_ends_early_stops_the_guests_it_left_running() -> None:
 
 
 def test_scheduler_workers_are_owned_by_the_scheduler() -> None:
-    import inspect
-
+    """No guest outlives the process. The worker's own `finally` cannot carry
+    that, because a daemon thread wedged on a console is cut short at
+    interpreter shutdown, so the closing path removes every guest the schedule
+    built rather than only the ones a job still counts as running."""
     from tests.vm import cluster
 
-    source = inspect.getsource(cluster.run)
-    assert "daemon=False" in source
+    class Machine:
+        def __init__(self) -> None:
+            self.removed = False
+
+        def stop(self) -> None:
+            pass
+
+        def destroy(self, patience: float = 0.0) -> None:
+            self.removed = True
+
+    finished, wedged = Machine(), Machine()
+    jobs = {
+        name: cluster.Job(
+            name=name,
+            fixture=Path(f"{name}.toml"),
+            execution=cast(Any, SimpleNamespace(guest=machine)),
+            thread=None,
+        )
+        for name, machine in (("done", finished), ("stuck", wedged))
+    }
+
+    cluster._abandon_jobs(jobs)
+
+    assert finished.removed and wedged.removed
 
 
 def test_a_removed_guest_gives_its_vmid_back(monkeypatch: pytest.MonkeyPatch) -> None:
@@ -2259,3 +2284,27 @@ def test_a_campaign_answers_every_signal_that_asks_it_to_stop() -> None:
     finally:
         for one, was in before.items():
             signals.signal(one, was)
+
+
+def test_a_worker_cannot_hold_the_interpreter_open_after_the_schedule_ends() -> None:
+    """Two schedules ended by SIGTERM removed every guest and then hung at
+    interpreter shutdown, joining workers still reading the consoles of guests
+    that no longer existed. `_abandon` already destroys what a timed-out worker
+    was holding, which is why its docstring says the workers are daemons."""
+    import ast
+
+    root = Path(__file__).resolve().parents[1]
+    source = (root / "vm" / "cluster.py").read_text()
+    daemons = [
+        keyword.value
+        for node in ast.walk(ast.parse(source))
+        if isinstance(node, ast.Call)
+        and isinstance(node.func, ast.Attribute)
+        and node.func.attr == "Thread"
+        for keyword in node.keywords
+        if keyword.arg == "daemon"
+    ]
+
+    assert daemons, "a worker thread is started without saying whether it is a daemon"
+    for value in daemons:
+        assert isinstance(value, ast.Constant) and value.value is True

--- a/tests/vm/cluster.py
+++ b/tests/vm/cluster.py
@@ -1591,7 +1591,10 @@ def run(
                         remote_key,
                         pinned,
                     ),
-                    daemon=False,
+                    # A worker reading the console of a guest the closing path
+                    # already removed never returns, and a schedule ended by a
+                    # signal then hangs at interpreter shutdown joining it.
+                    daemon=True,
                 )
                 scheduled[job.name] = job.started(thread)
                 placed[node.name] += execution.reservation_bytes
@@ -2108,7 +2111,7 @@ def _abandon(
 ) -> None:
     """Stop and remove every guest still running when the schedule ends.
 
-    The workers stay daemon threads, so one wedged on a console cannot hold the
+    The workers are daemon threads, so one wedged on a console cannot hold the
     interpreter open; that makes this the only path that reclaims their guests.
     Without it a scheduler that raised in `free_slots`, `prepare` or the
     bookkeeping left its guests running and holding memory the cluster's own
@@ -2151,6 +2154,17 @@ def _abandon_jobs(scheduled: Mapping[str, Job]) -> None:
         if job.running and job.thread is not None
     }
     _abandon(inflight, running)
+    # The workers are daemons, so what guarantees no guest outlives the process
+    # is here rather than in a thread: every guest this schedule built, not only
+    # the ones a job still counts as running. `destroy` checks the tag and the
+    # nonce, and returns on a guest that is already gone.
+    for name, job in scheduled.items():
+        if job.execution is None:
+            continue
+        try:
+            job.execution.guest.destroy()
+        except ProxmoxError as error:
+            print(f"  {name} outlived the schedule: {error}", file=sys.stderr)
 
 
 def _edit_bios_cmdline(guest: Guest, link: "Reconnecting") -> None:


### PR DESCRIPTION
A worker reading the console of a guest the closing path already removed never returns. The workers were not daemons, so two schedules ended by SIGTERM removed their guests, printed their traceback, and then hung at interpreter shutdown joining threads that would never finish.

What `daemon=False` was protecting — no guest outliving the process — moves to the closing path, which now removes every guest the schedule built rather than only the ones a job still counts as running. `destroy` already checks the tag and the nonce.