### PR TITLE
vm: a task that ends with warnings did its work

### DIFF
--- a/tests/unit/test_proxmox.py
+++ b/tests/unit/test_proxmox.py
@@ -3093,3 +3093,35 @@ def test_a_stop_still_stops_this_runs_machine() -> None:
 
     assert stopped == ["/nodes/node/qemu/9302/status/stop"]
     assert not guest._booted
+
+
+def test_a_task_that_finished_with_warnings_finished(capsys: pytest.CaptureFixture[str]) -> None:
+    """Proxmox writes `WARNINGS: n` for a task that did its work and logged
+    something on the way. Three `qmdestroy` tasks ended that way and the
+    schedule printed `the guest was not removed` for machines that were gone."""
+    from tests.vm.proxmox import Api
+
+    class Answering(Api):
+        def __init__(self) -> None:
+            pass
+
+        def call(self, method: str, path: str, **fields: object) -> dict[str, object]:
+            return {"status": "stopped", "exitstatus": "WARNINGS: 2"}
+
+    Answering().wait("infra-node6", "UPID:infra-node6:0:0:0:qmdestroy:9300:zakk@pve:")
+
+    assert "WARNINGS: 2" in capsys.readouterr().err
+
+
+def test_a_task_that_failed_is_still_a_failure() -> None:
+    from tests.vm.proxmox import Api, ProxmoxError
+
+    class Refusing(Api):
+        def __init__(self) -> None:
+            pass
+
+        def call(self, method: str, path: str, **fields: object) -> dict[str, object]:
+            return {"status": "stopped", "exitstatus": "unable to open disk image"}
+
+    with pytest.raises(ProxmoxError, match="unable to open disk image"):
+        Refusing().wait("infra-node6", "UPID:infra-node6:0:0:0:qmdestroy:9300:zakk@pve:")

--- a/tests/vm/proxmox.py
+++ b/tests/vm/proxmox.py
@@ -20,6 +20,7 @@ from __future__ import annotations
 import json
 import re
 import ssl
+import sys
 import time
 import urllib.error
 import urllib.parse
@@ -69,6 +70,10 @@ ISO_STORAGE: Final[str] = "local"
 #: node that stopped answering does not hold the whole campaign.
 API_TIMEOUT: Final[float] = 60.0
 TASK_POLL: Final[float] = 2.0
+
+#: What Proxmox writes as a task's exit status when it finished its work
+#: and logged a warning while doing it.
+TASK_WARNED: Final[str] = "WARNINGS:"
 CLEANUP_PAUSE: Final[float] = 2.0
 CLEANUP_PATIENCE: Final[float] = 300.0
 
@@ -248,7 +253,15 @@ class Api:
                 time.sleep(min(TASK_POLL, max(0.0, deadline - time.monotonic())))
                 continue
             if status.get("status") == "stopped":
-                exit_status = status.get("exitstatus", "")
+                exit_status = str(status.get("exitstatus", ""))
+                if exit_status.startswith(TASK_WARNED):
+                    # Proxmox says `WARNINGS: n` for a task that did its work
+                    # and logged something: a `qmdestroy` that could not reach
+                    # one disk still removed the guest, and reading it as a
+                    # failure printed `the guest was not removed` for three
+                    # machines that were gone.
+                    print(f"{upid} {exit_status}", file=sys.stderr)
+                    return
                 if exit_status != "OK":
                     raise ProxmoxError(f"{upid} ended with {exit_status!r}")
                 return


### PR DESCRIPTION
Proxmox writes `WARNINGS: n` as a task exit status when the task finished and logged something on the way, and `Api.wait` read anything other than `OK` as a failure. Three `qmdestroy` tasks ended with warnings in one round and the schedule reported `the guest was not removed` for three guests the cluster no longer had.

The warning line is printed rather than swallowed.