### PR TITLE
vm: capacity counts cores as well as memory

### DIFF
--- a/tests/unit/test_cluster.py
+++ b/tests/unit/test_cluster.py
@@ -48,7 +48,7 @@ class FakeApi:
         self.created: dict[int, str] = {}
 
     def nodes(self) -> list[Node]:
-        return [Node("node", 64 * 1024**3, 16)]
+        return [Node("node", 64 * 1024**3, 16, free_cores=16.0)]
 
     def free_vmid(self, held: frozenset[int] = frozenset()) -> int:
         vmid = next(
@@ -173,6 +173,7 @@ def test_non_double_memory_reservation_is_admitted_in_exact_bytes(
         "node",
         cluster.NODE_HEADROOM_BYTES + reservation,
         16,
+        free_cores=16.0,
     )
 
     class CapacityApi:

--- a/tests/unit/test_proxmox.py
+++ b/tests/unit/test_proxmox.py
@@ -801,9 +801,9 @@ def test_a_node_offers_a_slot_for_every_guest_it_can_hold() -> None:
     class Counted(Api):
         def nodes(self) -> list[Node]:
             return [
-                Node(name="big", free_bytes=NODE_HEADROOM_BYTES + guest * 3, cores=4),
-                Node(name="one", free_bytes=NODE_HEADROOM_BYTES + guest, cores=4),
-                Node(name="none", free_bytes=NODE_HEADROOM_BYTES + guest - 1, cores=4),
+                Node(name="big", free_bytes=NODE_HEADROOM_BYTES + guest * 3, cores=4, free_cores=64.0),
+                Node(name="one", free_bytes=NODE_HEADROOM_BYTES + guest, cores=4, free_cores=64.0),
+                Node(name="none", free_bytes=NODE_HEADROOM_BYTES + guest - 1, cores=4, free_cores=64.0),
             ]
 
     names = [node.name for node in free_slots(Counted(host="nowhere.invalid"))]
@@ -1037,7 +1037,7 @@ def test_guests_already_placed_are_subtracted_from_what_a_node_reports() -> None
 
     class Lagging(Api):
         def nodes(self) -> list[Node]:
-            return [Node(name="one", free_bytes=NODE_HEADROOM_BYTES + guest * 3, cores=4)]
+            return [Node(name="one", free_bytes=NODE_HEADROOM_BYTES + guest * 3, cores=4, free_cores=64.0)]
 
     api = Lagging(host="nowhere.invalid")
     assert len(free_slots(api)) == 3
@@ -1754,6 +1754,7 @@ def test_a_node_with_one_light_slot_left_is_not_given_a_heavy_guest() -> None:
         name="infra-node1",
         free_bytes=NODE_HEADROOM_BYTES + GUEST_MEMORY_MIB * 1024**2,
         cores=4,
+            free_cores=64.0,
     )
     assert room_for(one_slot, light)
     assert not room_for(one_slot, heavy)
@@ -1762,6 +1763,7 @@ def test_a_node_with_one_light_slot_left_is_not_given_a_heavy_guest() -> None:
         name="infra-node2",
         free_bytes=NODE_HEADROOM_BYTES + 2 * GUEST_MEMORY_MIB * 1024**2,
         cores=4,
+            free_cores=64.0,
     )
     assert room_for(two_slots, heavy)
 
@@ -2774,6 +2776,7 @@ def test_slots_are_offered_one_node_at_a_time() -> None:
             name=name,
             free_bytes=NODE_HEADROOM_BYTES + guests * GUEST_MEMORY_MIB * 1024**2,
             cores=4,
+            free_cores=64.0,
         )
 
     class Cluster(Api):
@@ -3125,3 +3128,66 @@ def test_a_task_that_failed_is_still_a_failure() -> None:
 
     with pytest.raises(ProxmoxError, match="unable to open disk image"):
         Refusing().wait("infra-node6", "UPID:infra-node6:0:0:0:qmdestroy:9300:zakk@pve:")
+
+
+def test_a_node_out_of_cores_offers_no_slot_however_much_memory_it_has() -> None:
+    """`infra-node1` sat at 100% of its four cores with 7 GiB free while the
+    schedule counted memory alone, and the cluster proxy answered 595 for the
+    node beside it. Cores are measured rather than derived: the cluster runs
+    other people's machines and their load is not in `cores`."""
+    from tests.vm.cluster import GUEST_MEMORY_MIB, NODE_HEADROOM_BYTES, free_slots
+    from tests.vm.proxmox import Api, Node
+
+    guest = GUEST_MEMORY_MIB * 1024**2
+
+    class Saturated(Api):
+        def __init__(self) -> None:
+            pass
+
+        def nodes(self) -> list[Node]:
+            return [
+                Node(
+                    name="busy",
+                    free_bytes=NODE_HEADROOM_BYTES + guest * 4,
+                    cores=4,
+                    free_cores=0.2,
+                ),
+                Node(
+                    name="idle",
+                    free_bytes=NODE_HEADROOM_BYTES + guest * 4,
+                    cores=4,
+                    free_cores=3.2,
+                ),
+            ]
+
+    offered = [node.name for node in free_slots(Saturated())]
+
+    assert "busy" not in offered
+    assert offered == ["idle"], "one two-core guest on a node with 3.2 cores free"
+
+
+def test_cores_this_schedule_has_placed_are_subtracted_too() -> None:
+    """A guest's load takes minutes to show in what the node reports, the same
+    lag the memory reservation exists for."""
+    from tests.vm.cluster import GUEST_CORES, GUEST_MEMORY_MIB, NODE_HEADROOM_BYTES, free_slots
+    from tests.vm.proxmox import Api, Node
+
+    guest = GUEST_MEMORY_MIB * 1024**2
+
+    class Idle(Api):
+        def __init__(self) -> None:
+            pass
+
+        def nodes(self) -> list[Node]:
+            return [
+                Node(
+                    name="one",
+                    free_bytes=NODE_HEADROOM_BYTES + guest * 8,
+                    cores=8,
+                    free_cores=7.0,
+                )
+            ]
+
+    assert len(free_slots(Idle())) == 3
+    assert len(free_slots(Idle(), None, {"one": GUEST_CORES * 2})) == 1
+    assert free_slots(Idle(), None, {"one": GUEST_CORES * 3}) == []

--- a/tests/vm/cluster.py
+++ b/tests/vm/cluster.py
@@ -164,6 +164,11 @@ HEAVY_CORES: Final[int] = 4
 #: spare stops answering, and this cluster runs other people's machines.
 NODE_HEADROOM_BYTES: Final[int] = 2 * 1024**3
 
+#: Cores left to the node itself. `pveproxy` answers 595 through the
+#: cluster proxy when a node is saturated, and a node carrying four
+#: two-core guests on four cores has nothing left to answer with.
+NODE_HEADROOM_CORES: Final[float] = 1.0
+
 #: How often the watchdog looks, and how many quiet looks end a guest. Ten
 #: minutes because a stage3 extract and a kernel build both write progress more
 #: often than that, and half an hour of silence is not a slow mirror.
@@ -1062,7 +1067,11 @@ def trusted_revision(identity: str) -> bool:
     return bool(identity) and (dirty is None or dirty.group(1) == "0")
 
 
-def free_slots(api: Api, placed: Mapping[str, int] | None = None) -> list[Node]:
+def free_slots(
+    api: Api,
+    placed: Mapping[str, int] | None = None,
+    cores_placed: Mapping[str, int] | None = None,
+) -> list[Node]:
     """One entry per guest the cluster can still hold, most free node first.
 
     A node appears as many times as it has room for, not once: returning one
@@ -1077,10 +1086,17 @@ def free_slots(api: Api, placed: Mapping[str, int] | None = None) -> list[Node]:
     """
     need = GUEST_MEMORY_MIB * 1024**2
     held = placed or {}
+    cores_held = cores_placed or {}
     per_node: list[list[Node]] = []
     for node in api.nodes():
         room = node.free_bytes - NODE_HEADROOM_BYTES - held.get(node.name, 0)
-        per_node.append([node] * max(0, int(room // need)))
+        by_memory = max(0, int(room // need))
+        # A node that is out of cores is out of slots whatever its memory says:
+        # `infra-node1` sat at 100% of four cores with 7 GiB free, and the
+        # cluster proxy answered 595 for the node next to it.
+        spare = node.free_cores - NODE_HEADROOM_CORES - cores_held.get(node.name, 0)
+        by_cores = max(0, int(spare // GUEST_CORES))
+        per_node.append([node] * min(by_memory, by_cores))
     # One from each node in turn, rather than a node's whole share before the
     # next one is touched: five guests went onto `infra-node5` and left the
     # other five idle, so one node carried every build while the shared
@@ -1093,7 +1109,12 @@ def free_slots(api: Api, placed: Mapping[str, int] | None = None) -> list[Node]:
     return slots
 
 
-def room_for(node: Node, job: Job, placed: Mapping[str, int] | None = None) -> bool:
+def room_for(
+    node: Node,
+    job: Job,
+    placed: Mapping[str, int] | None = None,
+    cores_placed: Mapping[str, int] | None = None,
+) -> bool:
     """Whether this node can carry this job now.
 
     A slot list built from the light size does not answer for a larger job:
@@ -1102,7 +1123,10 @@ def room_for(node: Node, job: Job, placed: Mapping[str, int] | None = None) -> b
     """
     held = (placed or {}).get(node.name, 0)
     room = node.free_bytes - NODE_HEADROOM_BYTES - held
-    return room >= job.reservation_bytes
+    spare = (
+        node.free_cores - NODE_HEADROOM_CORES - (cores_placed or {}).get(node.name, 0)
+    )
+    return room >= job.reservation_bytes and spare >= job.cores
 
 
 class Stoppable(Protocol):
@@ -1207,6 +1231,17 @@ def _reserved_bytes(scheduled: Mapping[str, Job]) -> Counter[str]:
         if job.node is None or job.execution is None:
             raise ProxmoxError(f"{job.name} holds resources without an execution")
         held[job.node] += job.execution.reservation_bytes
+    return held
+
+
+def _reserved_cores(scheduled: Mapping[str, Job]) -> Counter[str]:
+    held: Counter[str] = Counter()
+    for job in scheduled.values():
+        if not job.holds_resources:
+            continue
+        if job.node is None:
+            raise ProxmoxError(f"{job.name} holds resources without a node")
+        held[job.node] += job.cores
     return held
 
 
@@ -1504,7 +1539,8 @@ def run(
             waiting = [job for job in scheduled.values() if job.status is JobStatus.WAITING]
             running = [job for job in scheduled.values() if job.running]
             placed = _reserved_bytes(scheduled)
-            slots = free_slots(api, placed)
+            cores_placed = _reserved_cores(scheduled)
+            slots = free_slots(api, placed, cores_placed)
             if limit:
                 slots = slots[: max(0, limit - len(running))]
             if waiting and not running and not slots:
@@ -1528,7 +1564,11 @@ def run(
                 # node with one light slot left is how the hypervisor came to
                 # kill it. A light job behind it still goes now.
                 index = next(
-                    (at for at, one in enumerate(waiting) if room_for(slots[0], one, placed)),
+                    (
+                        at
+                        for at, one in enumerate(waiting)
+                        if room_for(slots[0], one, placed, cores_placed)
+                    ),
                     None,
                 )
                 if index is None:

--- a/tests/vm/proxmox.py
+++ b/tests/vm/proxmox.py
@@ -167,6 +167,9 @@ class Node:
     name: str
     free_bytes: int
     cores: int
+    #: Cores this node is not already using, measured rather than derived: the
+    #: cluster runs other people's machines and their load is not in `cores`.
+    free_cores: float = 0.0
 
 
 class Api:
@@ -274,6 +277,7 @@ class Api:
                 name=one["node"],
                 free_bytes=int(one.get("maxmem", 0)) - int(one.get("mem", 0)),
                 cores=int(one.get("maxcpu", 0)),
+                free_cores=int(one.get("maxcpu", 0)) * (1.0 - float(one.get("cpu", 0.0))),
             )
             for one in self.call("GET", "/nodes")
             if one.get("status") == "online"


### PR DESCRIPTION
The schedule offered one slot per free 4 GiB and never read a core. `infra-node1` measured 100% of four cores with 7 GiB still free while the campaign kept dispatching, and the cluster proxy answered 595 for the node beside it.

Free cores come from what the node reports rather than from `maxcpu`, because the load of the machines this harness cannot see is in the measurement and not in the count. One core is left to the node itself.