### PR TITLE
tui: keep the footer keys and the legend apart

### DIFF
--- a/gentoo_install/tui/app.py
+++ b/gentoo_install/tui/app.py
@@ -53,13 +53,12 @@ def _labelled(setting: Setting, current: InstallConfig, context: Context) -> str
     return f"{label} [{context.translate(named)}]" if named else label
 
 
-def _menu_footer(context: Context, config: InstallConfig) -> str:
+def _menu_footer(context: Context) -> str:
     """Label the main-menu action by what Enter opens."""
     return "  ".join(
         (
             f"[enter] {context.translate('Open')}",
             f"[q] {context.translate('Cancel')}",
-            _legend(config, context),
         )
     )
 
@@ -117,7 +116,8 @@ def run(screen: Screen, start: InstallConfig, context: Context) -> Finished:
             title="gentoo-install",
             items=items,
             cursor=cursor,
-            footer=_menu_footer(context, current),
+            footer=_menu_footer(context),
+            legend=_legend(current, context),
         )
         answer = menu.run(screen)
         cursor = menu.cursor

--- a/gentoo_install/tui/widgets.py
+++ b/gentoo_install/tui/widgets.py
@@ -121,22 +121,28 @@ class Screen(Protocol):
         """Block until a key press and return its name."""
 
 
+def spread(left: str, right: str, columns: int) -> str:
+    """`left` at the margin and `right` at the end of one row that wide.
+
+    `right` is dropped rather than truncated when the two cannot both fit: half
+    a count reads as a different count, and half a legend explains a mark the
+    reader can no longer see named.
+    """
+    head = truncate(left, columns)
+    room = columns - width(head) - 1
+    tail = right if right and width(right) <= room else ""
+    return f"{head}{' ' * (columns - width(head) - width(tail))}{tail}"
+
+
 def band(screen: Screen, line: int, left: str, right: str = "") -> None:
-    """One full-width reversed row, `left` at the margin and `right` at the end.
+    """One full-width reversed row.
 
     Reverse video is an attribute rather than a glyph, so a console with no
     colour and no line-drawing font still shows the edge; a box drawn from
     `U+2500` would be a row of question marks on the medium's own font.
-
-    `right` is dropped rather than truncated when the two cannot both fit: half
-    a count reads as a different count.
     """
     _, columns = screen.size()
-    head = truncate(left, columns)
-    room = columns - width(head) - 1
-    tail = right if right and width(right) <= room else ""
-    padding = columns - width(head) - width(tail)
-    screen.write(line, 0, f"{head}{' ' * padding}{tail}", highlight=True)
+    screen.write(line, 0, spread(left, right, columns), highlight=True)
 
 
 @dataclass(frozen=True)
@@ -187,6 +193,9 @@ class _Menu(Generic[V, A]):
     #: keeps the binary behavior unless it opts in.
     tri_state: bool = False
     footer: str = ""
+    #: What the marks in the body mean, kept at the end of the footer line so
+    #: it does not read as one more key.
+    legend: str = ""
     #: Lines drawn between the title and the rows. For a question whose
     #: subject is a list: the title is one line and truncated to the width.
     preamble: tuple[str, ...] = ()
@@ -315,8 +324,11 @@ class _Menu(Generic[V, A]):
                 highlight=index == cursor,
                 style=item.style,
             )
-        if self.footer:
-            screen.write(lines - 1, 0, truncate(self.footer, columns))
+        if self.footer or self.legend:
+            # Held apart rather than run together: the keys and what the marks
+            # mean are two things to read, and one line of `[enter] open
+            # [q] cancel * required ~ never opened` reads as neither.
+            screen.write(lines - 1, 0, spread(self.footer, self.legend, columns))
         screen.show()
 
     def _display_rows(self, columns: int) -> list[tuple[int | None, str]]:
@@ -371,6 +383,9 @@ class TextField:
     #: Shown instead of the characters typed, for a password.
     masked: bool = False
     footer: str = ""
+    #: What the marks in the body mean, kept at the end of the footer line so
+    #: it does not read as one more key.
+    legend: str = ""
     #: Drawn inside the field while it is empty, so a field that takes an
     #: unusual value still says what that value looks like.
     placeholder: str = ""
@@ -422,8 +437,11 @@ class TextField:
         # drawn only when there is no `detail` naming the exact string.
         inside = f"{shown}_" if typed else f"_{truncate(self.placeholder, room - 1)}"
         screen.write(row, 2, f"[ {inside}{' ' * (room - width(inside))} ]", highlight=True)
-        if self.footer:
-            screen.write(lines - 1, 0, truncate(self.footer, columns))
+        if self.footer or self.legend:
+            # Held apart rather than run together: the keys and what the marks
+            # mean are two things to read, and one line of `[enter] open
+            # [q] cancel * required ~ never opened` reads as neither.
+            screen.write(lines - 1, 0, spread(self.footer, self.legend, columns))
         screen.show()
 
 
@@ -444,6 +462,9 @@ class Confirm:
     #: sixty characters and its last component names the same disk.
     also: tuple[str, ...] = ()
     footer: str = ""
+    #: What the marks in the body mean, kept at the end of the footer line so
+    #: it does not read as one more key.
+    legend: str = ""
     #: The two answers, already translated by the caller. Defaulted so a test
     #: needs no catalog, and passed in everywhere the operator will read them.
     no: str = "No"
@@ -457,6 +478,7 @@ class Confirm:
             typed = TextField(
                 title=self.title,
                 footer=self.footer,
+                legend=self.legend,
                 placeholder=self.placeholder,
                 detail=self.detail,
             ).run(screen)
@@ -467,6 +489,7 @@ class Confirm:
             title=self.title,
             items=[Item(label=self.no, value=False), Item(label=self.yes, value=True)],
             footer=self.footer,
+            legend=self.legend,
             current=self.current,
         )
         answer = menu.run(screen)
@@ -535,6 +558,9 @@ class Form:
     title: str
     fields: list[Field]
     footer: str = ""
+    #: What the marks in the body mean, kept at the end of the footer line so
+    #: it does not read as one more key.
+    legend: str = ""
     done: str = "Done"
     #: Drawn under the title after one of the answers was rejected. Retrying
     #: with the values kept is the point: an
@@ -643,6 +669,9 @@ class Form:
             )
         end = min(len(self.fields) + offset + 1, lines - 2)
         screen.write(end, 2, self.done, highlight=cursor == len(self.fields))
-        if self.footer:
-            screen.write(lines - 1, 0, truncate(self.footer, columns))
+        if self.footer or self.legend:
+            # Held apart rather than run together: the keys and what the marks
+            # mean are two things to read, and one line of `[enter] open
+            # [q] cancel * required ~ never opened` reads as neither.
+            screen.write(lines - 1, 0, spread(self.footer, self.legend, columns))
         screen.show()

--- a/tests/unit/test_tui_app.py
+++ b/tests/unit/test_tui_app.py
@@ -27,7 +27,7 @@ from gentoo_install.model.device import (
 )
 from gentoo_install.model.validate import validate
 from gentoo_install.model import compat
-from gentoo_install.tui import app, screens, settings
+from gentoo_install.tui import app, widgets, screens, settings
 from gentoo_install.tui.app import run
 from gentoo_install.tui.overview import overview_screen
 from gentoo_install.tui.widgets import Outcome
@@ -888,7 +888,26 @@ def test_compiler_group_uses_tool_translation() -> None:
 
 
 def test_main_menu_enter_action_is_open() -> None:
-    assert "[enter] Open" in app._menu_footer(context(), config())
+    assert "[enter] Open" in app._menu_footer(context())
+
+
+def test_the_footer_keys_and_the_legend_are_not_one_run_of_text() -> None:
+    """`[enter] open  [q] cancel  * required  ~ never opened` on one line reads
+    as neither the keys nor the legend. The legend sits at the end of the line,
+    and is dropped rather than cut when the two cannot both fit."""
+    keys = app._menu_footer(context())
+    legend = app._legend(config(), context())
+
+    assert legend, "a fresh configuration has rows that were never opened"
+    assert legend not in keys
+
+    wide = widgets.spread(keys, legend, 80)
+    assert wide.startswith(keys)
+    assert wide.endswith(legend)
+    assert wide[len(keys) : -len(legend)].strip() == "", "one gap, not a divider"
+
+    narrow = widgets.spread(keys, legend, len(keys) + 2)
+    assert legend not in narrow
 
 
 def test_language_section_reaches_every_language_setting_from_the_menu() -> None:


### PR DESCRIPTION
The main menu ran its keys and its legend together into `[enter] open  [q] cancel  * required  ~ never opened`, which reads as neither. The legend now sits at the end of the footer line, and `spread` — the placement `band` already used — drops it rather than cutting it when the two cannot both fit, because half a legend explains a mark the reader can no longer see named.