### PR TITLE
vm: refuse a BIOS fixture the cluster cannot drive

### DIFF
--- a/tests/unit/test_cluster.py
+++ b/tests/unit/test_cluster.py
@@ -323,3 +323,22 @@ def test_the_init_check_asks_the_running_init_not_a_file_listing() -> None:
         assert init[2] == expected, init
         if wanted:
             assert init[2] == wanted, init
+
+
+def test_a_bios_fixture_is_refused_before_the_cluster_is_asked_anything() -> None:
+    """Three BIOS fixtures failed every cluster round for ten minutes each. The
+    medium's `grub.cfg` runs `terminal_output gfxterm` and never enables serial
+    input, so under SeaBIOS GRUB clears the serial terminal after its banner
+    and no keypress reaches it; `vga` set to `serial0` and to `none` were both
+    measured and both ended at the same clear."""
+    with pytest.raises(SystemExit) as refused:
+        cluster.fixtures(["vm-bios"])
+
+    said = str(refused.value)
+    assert "vm-bios" in said
+    assert "gfxterm" in said
+    assert "tests/vm/run.py" in said
+
+
+def test_a_uefi_fixture_is_still_dispatched() -> None:
+    assert [job.name for job in cluster.fixtures(["vm-btrfs"])] == ["vm-btrfs"]

--- a/tests/unit/test_proxmox.py
+++ b/tests/unit/test_proxmox.py
@@ -1730,9 +1730,9 @@ def test_a_guest_that_compiles_is_given_a_whole_node() -> None:
     from tests.vm.cluster import fixtures as cluster_fixtures
 
     weights = {one.name: one for one in cluster_fixtures(
-        ["vm-binpkg", "vm-zfs", "vm-desktop", "vm-gnome", "ext4-bios"]
+        ["vm-binpkg", "vm-zfs", "vm-desktop", "vm-gnome", "btrfs-luks"]
     )}
-    for name in ("vm-desktop", "vm-gnome", "ext4-bios"):
+    for name in ("vm-desktop", "vm-gnome", "btrfs-luks"):
         job = weights[name]
         assert job.heavy, name
         assert (job.cores, job.memory_mib) == (HEAVY_CORES, HEAVY_MEMORY_MIB), name

--- a/tests/vm/cluster.py
+++ b/tests/vm/cluster.py
@@ -2306,6 +2306,8 @@ def fixtures(names: list[str]) -> list[Job]:
         if not path.is_file():
             raise SystemExit(f"no fixture named {name} at {path}")
         config: InstallConfig = load(path)
+        if config.bootloader.firmware.value == "bios":
+            raise SystemExit(BIOS_IS_LOCAL_ONLY.format(name=name))
         found.append(
             Job(
                 name=name,
@@ -2317,6 +2319,18 @@ def fixtures(names: list[str]) -> list[Job]:
             )
         )
     return found
+
+
+#: Why a BIOS fixture is not dispatched. The medium's own `grub.cfg` runs
+#: `terminal_output gfxterm` and never enables serial input, so under SeaBIOS
+#: GRUB prints `Welcome to GRUB!`, clears the serial terminal and says nothing
+#: more, and no keypress reaches it. Under OVMF the firmware console is the
+#: serial port and the same medium is driven normally.
+BIOS_IS_LOCAL_ONLY: Final[str] = (
+    "{name} boots BIOS, which this cluster cannot drive: the medium's GRUB "
+    "leaves the serial terminal for gfxterm and takes no serial input. "
+    "Run it with tests/vm/run.py, where qemu gives the guest no display."
+)
 
 
 def _leave_on_a_signal() -> None:


### PR DESCRIPTION
The medium's own `boot/grub/grub.cfg` runs `terminal_output gfxterm` and never enables serial input. Under SeaBIOS GRUB prints `Welcome to GRUB!`, clears the serial terminal and says nothing more, and a keypress sent afterwards reaches nothing — measured on a guest with `vga` set to `serial0` and again with it set to `none`, both ending at the same clear. Under OVMF the firmware console is the serial port and the same medium is driven normally.

`ext4-bios`, `mbr-edit`, `vm-bios` and `vm-bios-luks` therefore cannot pass on the cluster whatever the timing, and each spent ten minutes of a node proving it every round. They are refused with the reason and pointed at `tests/vm/run.py`, where qemu gives the guest no display.