### PR TITLE
vm: drop driver CDs no run can still be using

### DIFF
--- a/tests/unit/test_proxmox.py
+++ b/tests/unit/test_proxmox.py
@@ -10,6 +10,7 @@ from email.message import Message
 import io
 import struct
 from threading import Event
+import time
 import urllib.error
 import urllib.response
 import urllib.request
@@ -2265,6 +2266,9 @@ def test_install_media_download_carries_the_signed_sha512() -> None:
         def __init__(self) -> None:
             self.form: dict[str, Any] = {}
 
+        def stale_drivers(self, node: str, keep: str, older_than: float) -> list[str]:
+            return []
+
         def isos(self, node: str) -> list[str]:
             return []
 
@@ -2304,6 +2308,9 @@ def test_an_existing_install_iso_needs_its_matching_verification_record(
             self.removed: list[str] = []
             self.fetched: list[str] = []
 
+        def stale_drivers(self, node: str, keep: str, older_than: float) -> list[str]:
+            return []
+
         def isos(self, node: str) -> list[str]:
             return ["minimal-a.iso", "driver.iso"]
 
@@ -2342,6 +2349,9 @@ def test_an_existing_install_iso_replaces_a_mismatched_record(tmp_path: Path) ->
         def __init__(self) -> None:
             self.removed: list[str] = []
             self.fetched: list[str] = []
+
+        def stale_drivers(self, node: str, keep: str, older_than: float) -> list[str]:
+            return []
 
         def isos(self, node: str) -> list[str]:
             return ["minimal-a.iso", "driver.iso"]
@@ -3191,3 +3201,31 @@ def test_cores_this_schedule_has_placed_are_subtracted_too() -> None:
     assert len(free_slots(Idle())) == 3
     assert len(free_slots(Idle(), None, {"one": GUEST_CORES * 2})) == 1
     assert free_slots(Idle(), None, {"one": GUEST_CORES * 3}) == []
+
+
+def test_a_driver_cd_old_enough_to_belong_to_nobody_is_named() -> None:
+    """A schedule removes its own driver CD, but one killed outright leaves it:
+    149 were counted across six nodes against a 33 GiB store. Age is what makes
+    the answer safe, because a campaign runs for hours and a file uploaded this
+    minute may be another campaign's."""
+    from tests.vm.proxmox import Api
+
+    day = 24 * 60 * 60.0
+    now = time.time()
+
+    class Stored(Api):
+        def __init__(self) -> None:
+            pass
+
+        def call(self, method: str, path: str, **fields: object) -> Any:
+            return [
+                {"volid": "local:iso/gi-driver-thisrun.iso", "ctime": now - 5 * day},
+                {"volid": "local:iso/gi-driver-abandoned.iso", "ctime": now - 2 * day},
+                {"volid": "local:iso/gi-driver-someone-elses.iso", "ctime": now - 60},
+                {"volid": "local:iso/install-amd64-minimal.iso", "ctime": now - 30 * day},
+                {"volid": "local:iso/harvester-v1.5.0-amd64.iso", "ctime": now - 30 * day},
+            ]
+
+    stale = Stored().stale_drivers("infra-node6", "gi-driver-thisrun.iso", day)
+
+    assert stale == ["gi-driver-abandoned.iso"]

--- a/tests/vm/cluster.py
+++ b/tests/vm/cluster.py
@@ -169,6 +169,10 @@ NODE_HEADROOM_BYTES: Final[int] = 2 * 1024**3
 #: two-core guests on four cores has nothing left to answer with.
 NODE_HEADROOM_CORES: Final[float] = 1.0
 
+#: How long a driver CD on a node is left alone. Longer than any run,
+#: so a campaign never removes one another campaign is booting from.
+DRIVER_KEPT_SECONDS: Final[float] = 24 * 60 * 60.0
+
 #: How often the watchdog looks, and how many quiet looks end a guest. Ten
 #: minutes because a stage3 extract and a kernel build both write progress more
 #: often than that, and half an hour of silence is not a slow mirror.
@@ -617,6 +621,10 @@ def prepare(
             raise ProxmoxError(f"no mirror served {medium} to {node}: {last}")
         stamp.parent.mkdir(parents=True, exist_ok=True)
         stamp.write_text(sha512)
+    for stale in api.stale_drivers(node, driver, DRIVER_KEPT_SECONDS):
+        reason = api.remove_iso(node, stale)
+        if reason:
+            print(f"{stale} stayed on {node}: {reason}", file=sys.stderr)
     driver_sha256 = driver_digest(driver_path)
     driver_stamp = trust / "remote" / node / f"{driver}.sha256"
     if driver in api.isos(node):

--- a/tests/vm/proxmox.py
+++ b/tests/vm/proxmox.py
@@ -74,6 +74,9 @@ TASK_POLL: Final[float] = 2.0
 #: What Proxmox writes as a task's exit status when it finished its work
 #: and logged a warning while doing it.
 TASK_WARNED: Final[str] = "WARNINGS:"
+
+#: What every driver CD this harness uploads is named after.
+DRIVER_PREFIX: Final[str] = "gi-driver-"
 CLEANUP_PAUSE: Final[float] = 2.0
 CLEANUP_PATIENCE: Final[float] = 300.0
 
@@ -314,6 +317,26 @@ class Api:
     def isos(self, node: str) -> list[str]:
         content = self.call("GET", f"/nodes/{node}/storage/{ISO_STORAGE}/content?content=iso")
         return sorted(str(one["volid"]).split("/")[-1] for one in content)
+
+    def stale_drivers(self, node: str, keep: str, older_than: float) -> list[str]:
+        """Driver CDs on this node that no run can still be using.
+
+        A schedule removes its own, but one killed outright leaves it, and 149
+        of them were counted across six nodes against a 33 GiB store. Age is
+        what makes the answer safe: a campaign runs for hours, so a file older
+        than a day belongs to nobody, while a name a second campaign uploaded
+        this minute is left alone.
+        """
+        content = self.call("GET", f"/nodes/{node}/storage/{ISO_STORAGE}/content?content=iso")
+        now = time.time()
+        found = []
+        for one in content:
+            name = str(one["volid"]).split("/")[-1]
+            if name == keep or not name.startswith(DRIVER_PREFIX):
+                continue
+            if now - float(one.get("ctime", now)) >= older_than:
+                found.append(name)
+        return sorted(found)
 
     def upload_iso(self, node: str, path: Path, name: str) -> str:
         """Put a file on a node's `local` storage and answer its name there.


### PR DESCRIPTION
A schedule removes the driver CD it uploaded, but one killed outright does not, and 149 had collected across six nodes against a 33 GiB per-node store. `prepare` now drops the ones older than a day: a campaign runs for hours, so age is what separates an abandoned file from the one a second campaign uploaded this minute and is about to boot from.