### PR TITLE
vm: a frame the reader cannot parse closes the console

### DIFF
--- a/tests/unit/test_proxmox.py
+++ b/tests/unit/test_proxmox.py
@@ -3229,3 +3229,32 @@ def test_a_driver_cd_old_enough_to_belong_to_nobody_is_named() -> None:
     stale = Stored().stale_drivers("infra-node6", "gi-driver-thisrun.iso", day)
 
     assert stale == ["gi-driver-abandoned.iso"]
+
+
+def test_a_frame_the_reader_cannot_parse_closes_the_console() -> None:
+    """`_protocol_error` raises `WebSocketError`, which is not a `ConsoleClosed`
+    and not an `OSError`: it went past every reconnect handler. A corrupt frame
+    is one more way for a connection to end, and the reader above reopens a
+    closed one."""
+    from tests.vm.proxmox import ConsoleChannel
+    from tests.vm.websocket import WebSocketError
+
+    class Corrupt:
+        def __init__(self) -> None:
+            self.closed = False
+
+        def read(self) -> bytes:
+            self.closed = True
+            raise WebSocketError("the server sent an invalid websocket control frame")
+
+        def send(self, data: bytes, opcode: int = 2) -> None:
+            pass
+
+        def close(self) -> None:
+            self.closed = True
+
+    socket = Corrupt()
+    channel = ConsoleChannel(cast(Any, socket))
+
+    assert channel.recv(4096) == b""
+    assert channel.closed, "the reader reopens a closed console"

--- a/tests/vm/proxmox.py
+++ b/tests/vm/proxmox.py
@@ -782,7 +782,14 @@ class ConsoleChannel:
         raise ProxmoxError(f"no console for vm {vmid} on {node}: {last}")
 
     def recv(self, size: int) -> bytes:
-        got = self._socket.read()
+        try:
+            got = self._socket.read()
+        except WebSocketError:
+            # A frame this reader cannot parse ends the connection the same way
+            # a reset does. `read` already closed the socket, so the caller
+            # sees a closed console and reopens it; raised, it went past every
+            # `except ConsoleClosed` and ended the run.
+            return b""
         now = time.monotonic()
         if not got and now - self._last_said > self.KEEPALIVE:
             self._socket.send(b"2")


### PR DESCRIPTION
A reset already ends a console the way the reader expects — `read` marks the socket closed and returns, and the caller reopens. A frame the parser rejects did not: `_protocol_error` raises `WebSocketError`, which is neither `ConsoleClosed` nor `OSError`, so it went past every reconnect handler and ended the run on a guest whose install was still going.