### PR TITLE
vm: a delete that found the guest running is tried again

### DIFF
--- a/tests/unit/test_proxmox.py
+++ b/tests/unit/test_proxmox.py
@@ -3258,3 +3258,40 @@ def test_a_frame_the_reader_cannot_parse_closes_the_console() -> None:
 
     assert channel.recv(4096) == b""
     assert channel.closed, "the reader reopens a closed console"
+
+
+def test_a_delete_that_found_the_guest_running_is_tried_again() -> None:
+    """`destroy` stops the guest and then deletes it, and the stop can fail on
+    its own: 9302 sat on a node refusing connections, the delete answered
+    `VM 9302 is running - destroy failed`, and that ended the only loop that
+    would have stopped it again. It held its memory until the schedule closed."""
+    from tests.vm.proxmox import ProxmoxTransientError, _http_exception
+
+    error = urllib.error.HTTPError(
+        "https://pve/api2/json/nodes/infra-node3/qemu/9302",
+        500,
+        "VM 9302 is running - destroy failed",
+        Message(),
+        io.BytesIO(b'{"message":"VM 9302 is running - destroy failed\\n","data":null}'),
+    )
+
+    answered = _http_exception("DELETE", "/nodes/infra-node3/qemu/9302?purge=1", error)
+
+    assert isinstance(answered, ProxmoxTransientError)
+
+
+def test_a_delete_refused_for_another_reason_is_not_retried() -> None:
+    from tests.vm.proxmox import ProxmoxError, ProxmoxTransientError, _http_exception
+
+    error = urllib.error.HTTPError(
+        "https://pve/api2/json/nodes/infra-node3/qemu/9302",
+        500,
+        "storage 'ceph-pve' is not online",
+        Message(),
+        io.BytesIO(b'{"message":"storage is not online","data":null}'),
+    )
+
+    answered = _http_exception("DELETE", "/nodes/infra-node3/qemu/9302?purge=1", error)
+
+    assert isinstance(answered, ProxmoxError)
+    assert not isinstance(answered, ProxmoxTransientError)

--- a/tests/vm/proxmox.py
+++ b/tests/vm/proxmox.py
@@ -77,6 +77,9 @@ TASK_WARNED: Final[str] = "WARNINGS:"
 
 #: What every driver CD this harness uploads is named after.
 DRIVER_PREFIX: Final[str] = "gi-driver-"
+
+#: What Proxmox answers when a delete reaches a guest that never stopped.
+STILL_RUNNING: Final[str] = "is running - destroy failed"
 CLEANUP_PAUSE: Final[float] = 2.0
 CLEANUP_PATIENCE: Final[float] = 300.0
 
@@ -134,6 +137,10 @@ def _http_exception(method: str, path: str, error: urllib.error.HTTPError) -> Pr
     retryable_500 = error.code == 500 and (
         re.fullmatch(r"/nodes/[^/]+/qemu/\d+/termproxy(?:\?.*)?", path) is not None
         or re.fullmatch(r"/nodes/[^/]+/tasks/[^/]+/status(?:\?.*)?", path) is not None
+        # `destroy` stops the guest and deletes it, and the stop can fail on
+        # its own: 9302 was left running on a node refusing connections, and
+        # this answer ended the only loop that would have stopped it again.
+        or (STILL_RUNNING in said and method == "DELETE")
     )
     # 595 is the cluster proxy saying it could not reach the node, not the node
     # saying no: `infra-node3` answered it four times while restarting, and the


### PR DESCRIPTION
`destroy` stops the guest and then deletes it, and the stop can fail on its own. Against `infra-node3` while it was refusing connections, the stop failed, the delete answered `VM 9302 is running - destroy failed`, and that answer was not transient — so it ended the only loop that would have stopped the guest again. 9302 held four gibibytes and its node slot until the schedule closed hours later.