### PR TITLE
vm: offer the login name again when agetty flushed it

### DIFF
--- a/tests/unit/test_harness.py
+++ b/tests/unit/test_harness.py
@@ -2308,3 +2308,47 @@ def test_a_worker_cannot_hold_the_interpreter_open_after_the_schedule_ends() -> 
     assert daemons, "a worker thread is started without saying whether it is a daemon"
     for value in daemons:
         assert isinstance(value, ast.Constant) and value.value is True
+
+
+def test_a_name_typed_the_moment_the_prompt_appears_is_offered_again(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """agetty sleeps a second after writing `login:` and then flushes the
+    serial line, so a name sent at once is thrown away and the empty line
+    behind it brings the prompt back. `openrc-sdboot` and `vm-bios` printed
+    their issue three times and were failed for a password prompt that was
+    never coming."""
+    from tests.vm import cluster
+
+    monkeypatch.setattr(cluster, "AGETTY_FLUSHES_AFTER", 0.0)
+    said = [b"\r\nopenrcsdbox login: ", b"\r\nopenrcsdbox login: ", b"Password: "]
+    offered: list[str] = []
+
+    class Prompting:
+        def respond(self, line: str) -> None:
+            offered.append(line)
+
+        def observe(self, pattern: str, timeout: float) -> bytes:
+            return said.pop(0)
+
+    assert cluster._name_the_user(cast(Any, Prompting()))
+    assert offered == ["root", "root", "root"], "the flushed name is offered again"
+
+
+def test_a_prompt_that_never_takes_a_name_ends_rather_than_answers_for_ever(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from tests.vm import cluster
+
+    monkeypatch.setattr(cluster, "AGETTY_FLUSHES_AFTER", 0.0)
+    offered: list[str] = []
+
+    class Deaf:
+        def respond(self, line: str) -> None:
+            offered.append(line)
+
+        def observe(self, pattern: str, timeout: float) -> bytes:
+            return b"\r\nopenrcsdbox login: "
+
+    assert not cluster._name_the_user(cast(Any, Deaf()))
+    assert len(offered) == cluster.LOGIN_TRIES

--- a/tests/vm/cluster.py
+++ b/tests/vm/cluster.py
@@ -1977,6 +1977,37 @@ def _asked_for(installation: InstallConfig) -> list[tuple[str, str, str]]:
     return [(check.name, check.command, check.pattern) for check in checks(installation)]
 
 
+#: What agetty sleeps before it flushes the serial line and starts reading, so
+#: a name sent the moment `login:` appears is discarded. Its own value plus a
+#: margin, because the sleep starts when the prompt is written.
+AGETTY_FLUSHES_AFTER: Final[float] = 2.0
+
+#: How many times the user name is offered. An empty line brings the prompt
+#: back, so this must end rather than answer for ever.
+LOGIN_TRIES: Final[int] = 4
+
+
+def _name_the_user(link: Reconnecting) -> bool:
+    """Give the login prompt a name, and say whether it took one.
+
+    agetty sleeps a second after writing the prompt and then flushes whatever
+    arrived, so a name typed at once is thrown away and the empty line that
+    follows it brings the prompt back. `openrc-sdboot` and `vm-bios` printed
+    their issue three times and were failed for a password prompt that was
+    never coming.
+    """
+    for _ in range(LOGIN_TRIES):
+        time.sleep(AGETTY_FLUSHES_AFTER)
+        link.respond("root")
+        try:
+            said = link.observe(rf"{PASSWORD_PROMPT}|login:", timeout=60.0)
+        except ConsoleTimeout:
+            continue
+        if b"login:" not in said:
+            return True
+    return False
+
+
 #: How long SeaBIOS and GRUB take to reach the cryptomount prompt. Nothing on
 #: the serial port marks it, so the passphrase is typed after this, and a
 #: wrong guess costs one retry at the next prompt, which is waited for.
@@ -2104,8 +2135,8 @@ def boot_and_check(
         except (ConsoleTimeout, ConsoleClosed) as error:
             return f"the installed system did not reach a login prompt: {error}"[:200]
     try:
-        link.respond("root")
-        link.observe(PASSWORD_PROMPT, timeout=120.0)
+        if not _name_the_user(link):
+            return "the installed system asked for a name and kept asking"
         link.respond(INSTALLED_PASSWORD)
     except ConsoleClosed as error:
         return f"installed login response delivery is unknown: {error}"[:200]


### PR DESCRIPTION
agetty writes `login:`, sleeps a second, flushes whatever arrived on the serial line and only then reads. The harness answered within milliseconds, so the name was thrown away and the empty line behind it brought the prompt straight back: `openrc-sdboot` and `vm-bios` printed their issue three times and were failed for a password prompt that was never coming, on installed systems that had booted correctly.

The name is offered after the flush window and again whenever the prompt returns, four times before the guest is called deaf.