### PR TITLE
portage: try the binary once more before compiling the group

### DIFF
--- a/gentoo_install/plan/portage.py
+++ b/gentoo_install/plan/portage.py
@@ -687,6 +687,10 @@ class Emerge(Operation):
             marker = _binpkg_failure(str(error))
             if marker is None or context.degraded(BINARY_PACKAGES):
                 raise
+            if (again := self._one_more_binary_try(context, command)) is not None:
+                marker = again
+            else:
+                return
             context.degrade(BINARY_PACKAGES, f"selected binary package failed: {marker}")
             retry_result = context.run_in_target(self._argv(context, source_only=True), check=False)
             if isinstance(retry_result, CommandOutput) and retry_result.returncode != 0:
@@ -699,7 +703,12 @@ class Emerge(Operation):
             return
         if not _binpkg_failure(str(result)) or context.degraded(BINARY_PACKAGES):
             raise CommandFailed(f"emerge failed with exit {result.returncode}: {str(result).strip()}")
-        reason = f"selected binary package failed: {_binpkg_failure(str(result))}"
+        marker = _binpkg_failure(str(result))
+        if (again := self._one_more_binary_try(context, command)) is not None:
+            marker = again
+        else:
+            return
+        reason = f"selected binary package failed: {marker}"
         context.degrade(BINARY_PACKAGES, reason)
         retry = self._argv(context, source_only=True)
         retry_result = context.run_in_target(retry, check=False)
@@ -707,6 +716,23 @@ class Emerge(Operation):
             raise CommandFailed(
                 f"source retry failed with exit {retry_result.returncode}: {str(retry_result).strip()}"
             )
+
+    def _one_more_binary_try(self, context: Context, command: list[str]) -> str | None:
+        """Run the same emerge again, and answer what still names a binary
+        failure, or `None` when the second run succeeded.
+
+        One dropped TLS handshake would otherwise compile a whole group from
+        source: `libtommath` failed that way inside the plasma group, and
+        rebuilding all of it costs hours against a package that downloads in
+        seconds.
+        """
+        try:
+            again = context.run_in_target(command, check=False)
+        except CommandFailed as error:
+            return _binpkg_failure(str(error)) or str(error).strip()
+        if not isinstance(again, CommandOutput) or again.returncode == 0:
+            return None
+        return _binpkg_failure(str(again)) or str(again).strip()
 
     def _argv(self, context: Context, *, source_only: bool) -> list[str]:
         argv = ["emerge", *EMERGE_OPTIONS]

--- a/tests/unit/test_plan_portage.py
+++ b/tests/unit/test_plan_portage.py
@@ -695,8 +695,11 @@ def test_a_selected_binary_fetch_failure_retries_from_source() -> None:
     ).apply(recorder)
 
     emerges = [argv for argv in recorder.in_target if argv[0] == "emerge"]
-    assert len(emerges) == 2
+    # Binaries, binaries again because one dropped handshake is not the host
+    # being gone, then source.
+    assert len(emerges) == 3
     assert "--getbinpkg=n" in emerges[-1] and "--usepkg=n" in emerges[-1]
+    assert "--getbinpkg=n" not in emerges[1]
     assert recorder.degraded(portage.BINARY_PACKAGES)
 
 
@@ -1595,8 +1598,11 @@ def test_a_binary_whose_download_broke_retries_from_source() -> None:
     ).apply(recorder)
 
     emerges = [argv for argv in recorder.in_target if argv[0] == "emerge"]
-    assert len(emerges) == 2
+    # Binaries, binaries again because one dropped handshake is not the host
+    # being gone, then source.
+    assert len(emerges) == 3
     assert "--getbinpkg=n" in emerges[-1] and "--usepkg=n" in emerges[-1]
+    assert "--getbinpkg=n" not in emerges[1]
     assert recorder.degraded(portage.BINARY_PACKAGES)
 
 
@@ -1615,4 +1621,30 @@ def test_a_source_build_that_failed_is_not_called_a_binary_failure() -> None:
             packages=("kde-plasma/plasma-meta",), summary="install the plasma group"
         ).apply(recorder)
 
+    assert not recorder.degraded(portage.BINARY_PACKAGES)
+
+
+def test_a_binary_that_downloads_on_the_second_try_compiles_nothing() -> None:
+    """A dropped TLS handshake is not the binary host being gone. Degrading on
+    the first one rebuilds a whole group from source: `libtommath` failed that
+    way inside the plasma group, which downloads in seconds and compiles in
+    hours."""
+    recorder = Recorder()
+    tries: list[int] = []
+
+    def answering(argv: Sequence[str]) -> CommandOutput:
+        if argv[0] != "emerge":
+            return CommandOutput("", 0)
+        tries.append(1)
+        return CommandOutput(SSL_DROPPED, 1) if len(tries) == 1 else CommandOutput("", 0)
+
+    recorder.answering = answering
+
+    portage.Emerge(
+        packages=("kde-plasma/plasma-meta",), summary="install the plasma group"
+    ).apply(recorder)
+
+    emerges = [argv for argv in recorder.in_target if argv[0] == "emerge"]
+    assert len(emerges) == 2
+    assert all("--getbinpkg=n" not in argv for argv in emerges)
     assert not recorder.degraded(portage.BINARY_PACKAGES)


### PR DESCRIPTION
Degrading on the first binary failure is right when the host is gone and wrong when one handshake dropped: `libtommath` failed that way inside the plasma group, and the fallback rebuilds all of it from source — hours against a package that downloads in seconds.

The same emerge runs a second time with binaries still enabled. Only a failure that survives that degrades the group to source, with the reason recorded as before.