### PR TITLE
model: a mountpoint cannot climb out of the target

### DIFF
--- a/gentoo_install/model/parse.py
+++ b/gentoo_install/model/parse.py
@@ -460,6 +460,12 @@ def _mountpoint(raw: Mapping[str, Any], at: str) -> Node:
     path = _str(raw, "path", at, required=True)
     if not path.startswith("/"):
         raise ConfigError(f"{at}.path is {path!r}; a mountpoint must be absolute")
+    # Absolute is not inside: `/../outside` reaches `/mnt/outside` once it is
+    # joined to the target, and the plan would `mkdir` and `mount` there.
+    if ".." in PurePosixPath(path).parts:
+        raise ConfigError(
+            f"{at}.path is {path!r}; a mountpoint cannot climb out of the target with `..`"
+        )
     return Mountpoint(
         id=_id(raw, at),
         source=_ref(raw, "source", at),

--- a/tests/unit/test_parse.py
+++ b/tests/unit/test_parse.py
@@ -381,3 +381,31 @@ def test_the_parser_knows_every_field_the_writer_emits(monkeypatch: pytest.Monke
         if missing:
             unreachable.append(f"{holds.__name__}: {', '.join(sorted(missing))}")
     assert not unreachable, unreachable
+
+
+def test_a_mountpoint_cannot_climb_out_of_the_target() -> None:
+    """`/../outside` is absolute and reaches `/mnt/outside` once it is joined
+    to the install target: the plan would `mkdir --parents` and `mount` there,
+    on the live system rather than the machine being built."""
+    raw = fixture()
+    for node in raw["disk"]["devices"]:
+        if node["kind"] == "mountpoint" and node["path"] == "/efi":
+            node["path"] = "/../outside"
+            break
+    else:
+        raise AssertionError("the fixture no longer mounts an esp")
+
+    with pytest.raises(ConfigError, match="climb out of the target"):
+        parse(raw)
+
+
+def test_an_ordinary_mountpoint_is_still_taken() -> None:
+    raw = fixture()
+    for node in raw["disk"]["devices"]:
+        if node["kind"] == "mountpoint" and node["path"] == "/efi":
+            node["path"] = "/home/zakk"
+            break
+
+    config = parse(raw)
+
+    assert any(str(one.path) == "/home/zakk" for one in config.disk.graph.of_type(Mountpoint))


### PR DESCRIPTION
A mountpoint was checked for a leading slash and nothing else. `/../outside` passes that, and joining it to the install target gives `/mnt/outside`: the plan would `mkdir --parents` and `mount` on the live system rather than on the machine being built.

A `..` component is refused where the path is read. The other two findings in the same review — a zero-sized partition and a non-final partition taking the rest of the disk — are already refused by `validate`.