### PR TITLE
vm: keep what the guest handed back

### DIFF
--- a/tests/unit/test_harness.py
+++ b/tests/unit/test_harness.py
@@ -2397,3 +2397,34 @@ def test_an_ordinary_console_timeout_blames_no_node(tmp_path: Path) -> None:
     )
 
     assert console_proxy_dropped(log) == ""
+
+
+def test_what_the_guest_handed_back_is_written_beside_its_log(tmp_path: Path) -> None:
+    """`install.jsonl` says which packages came from a binary host, which were
+    compiled and why each degradation happened. It crossed the console and was
+    dropped: only `install.rc` was ever read."""
+    from tests.vm.cluster import keep_results
+
+    log = tmp_path / "vm-btrfs.log"
+    log.write_text("")
+
+    keep_results(
+        log,
+        {
+            "install.rc": b"0\n",
+            "install.jsonl": b'{"package":"sys-apps/portage","source":"binhost"}\n',
+        },
+    )
+
+    assert (tmp_path / "vm-btrfs.install.rc").read_bytes() == b"0\n"
+    assert b"binhost" in (tmp_path / "vm-btrfs.install.jsonl").read_bytes()
+
+
+def test_a_file_that_cannot_be_written_does_not_end_the_run(tmp_path: Path) -> None:
+    """The install already happened; a directory that refuses a write is not a
+    reason to throw its result away."""
+    from tests.vm.cluster import keep_results
+
+    log = tmp_path / "sub" / "vm-btrfs.log"
+
+    keep_results(log, {"install.rc": b"0\n"})

--- a/tests/vm/cluster.py
+++ b/tests/vm/cluster.py
@@ -1374,6 +1374,7 @@ def install_one(
             watch=watch,
         )
         files = collect(guest, link, log)
+        keep_results(log, files)
         code = files.get("install.rc", b"").strip()
         if code != b"0":
             outcome = Outcome(
@@ -2166,6 +2167,22 @@ def boot_and_check(
         if said != wanted.encode() and re.search(wanted.encode(), said) is None:
             return f"{name}: the installed system does not say {wanted!r}"
     return ""
+
+
+def keep_results(log: Path, files: Mapping[str, bytes]) -> None:
+    """Write beside the log what the guest handed back.
+
+    Only `install.rc` was read and the rest was dropped, `install.jsonl` with
+    it: the record of which packages came from a binary host, which were
+    compiled and why each degradation happened existed in the guest, crossed
+    the console, and was never written anywhere.
+    """
+    for name, content in files.items():
+        beside = log.with_name(f"{log.stem}.{Path(name).name}")
+        try:
+            beside.write_bytes(content)
+        except OSError as error:
+            print(f"{beside} was not written: {error}", file=sys.stderr)
 
 
 def collect(guest: Guest, link: "Reconnecting", log: Path) -> dict[str, bytes]:


### PR DESCRIPTION
The result archive is unpacked, `install.rc` is read and everything else is dropped — `install.jsonl` with it. That file is where the installer records which packages came from a binary host, which were compiled, and the reason for every degradation to source, so the one artefact that can answer whether the binhost was used at all never reached the disk.

Each collected file is written beside the guest log. A write that fails is reported and does not end a run whose install already finished.