### PR TITLE
exec: say when this is not a live medium

### DIFF
--- a/gentoo_install/exec/preflight.py
+++ b/gentoo_install/exec/preflight.py
@@ -478,6 +478,18 @@ def inspect(
             )
     fatal += [problem.reason for problem in commands.unusable]
 
+    # Said rather than refused: installing from a running system onto a second
+    # disk is a real thing to do, and the guard that matters is below — a disk
+    # with anything mounted on it is not repartitioned. What was missing is
+    # that nothing named the difference before the disk screen.
+    if _disks_at_risk(config.disk.graph) and not probe.live_medium():
+        where = probe.root_source()
+        warnings.append(
+            "this does not look like a live medium"
+            + (f" ({where} is mounted at /)" if where else "")
+            + "; the disks below belong to the machine you are running on"
+        )
+
     for disk in _disks_at_risk(config.disk.graph):
         try:
             path = probe.resolve(disk.id, disk.selector)

--- a/gentoo_install/exec/probe.py
+++ b/gentoo_install/exec/probe.py
@@ -172,6 +172,9 @@ def _efi_bits() -> int:
 #: Where both install media keep the release engineering public key.
 RELEASE_KEY: Final[Path] = Path("/usr/share/openpgp-keys/gentoo-release.asc")
 MEMINFO: Final[Path] = Path("/proc/meminfo")
+
+#: Read rather than asked for: `findmnt` cannot say what booted this.
+CMDLINE: Final[Path] = Path("/proc/cmdline")
 PROFILES_DESC: Final[Path] = Path("/var/db/repos/gentoo/profiles/profiles.desc")
 
 
@@ -673,6 +676,50 @@ class Probe:
         if loaded.returncode != 0 or not any(path.exists() for path in self.ZFS_LOADED):
             return "this live system cannot load the zfs kernel module"
         return ""
+
+    #: What a dracut live medium puts on the kernel command line. The official
+    #: minimal ISO boots `root=live:CDLABEL=Gentoo-amd64-20260811 rd.live.dir=/
+    #: rd.live.squashimg=image.squashfs` and runs on an overlay over squashfs.
+    LIVE_CMDLINE: Final[tuple[str, ...]] = ("root=live:", "rd.live.")
+
+    #: Root filesystems that no installed machine has. `overlay` is what the
+    #: live medium mounts over its squashfs; `rootfs` is an initramfs that
+    #: never pivoted.
+    LIVE_ROOT_TYPES: Final[frozenset[str]] = frozenset({"overlay", "squashfs", "rootfs", "tmpfs"})
+
+    def live_medium(self) -> str:
+        """What proves this is a live medium, or empty when it is not.
+
+        The installer assumed it, and the assumption is what makes running it
+        on a machine somebody uses dangerous: nothing said so before the disk
+        screen. Read rather than guessed, because a medium can be anything —
+        Alpine, Debian, a Fedora live image.
+        """
+        try:
+            cmdline = CMDLINE.read_text(encoding="utf-8")
+        except OSError:
+            cmdline = ""
+        for marker in self.LIVE_CMDLINE:
+            if marker in cmdline:
+                return f"the kernel command line carries {marker}"
+        said = self.runner.run(
+            ["findmnt", "--noheadings", "--output", "FSTYPE", "--mountpoint", "/"],
+            check=False,
+        )
+        if said.returncode != 0:
+            return ""
+        kind = said.stdout.strip()
+        if kind in self.LIVE_ROOT_TYPES:
+            return f"the root filesystem is {kind}"
+        return ""
+
+    def root_source(self) -> str:
+        """What `/` is mounted from, for the warning that names it."""
+        said = self.runner.run(
+            ["findmnt", "--noheadings", "--output", "FSTYPE,SOURCE", "--mountpoint", "/"],
+            check=False,
+        )
+        return said.stdout.strip() if said.returncode == 0 else ""
 
     def zfs_kernel_max(self, target: Path | None = None) -> KernelCeiling:
         """Read the visible ZFS ebuild's ceiling from Portage metadata."""

--- a/tests/unit/test_preflight.py
+++ b/tests/unit/test_preflight.py
@@ -94,3 +94,41 @@ def test_a_new_operation_command_is_probed_without_editing_preflight(tmp_path: P
         operations=(operation,),
     )
     assert asked and "medium-tool" in asked[0]
+
+
+def test_an_install_from_a_machine_that_is_not_a_medium_says_so(tmp_path: Path) -> None:
+    """Nothing named the difference before the disk screen: the installer
+    assumed it was running from a medium. Said rather than refused, because
+    installing from a running system onto a second disk is a real thing to do
+    and the guard that matters is the one on a mounted disk."""
+
+    class Installed(Probe):
+        def live_medium(self) -> str:
+            return ""
+
+        def root_source(self) -> str:
+            return "zfs rpool/ROOT/gentoo"
+
+    report = preflight.check(
+        config(),
+        Installed(runner=Runner(log=lambda line: None), work=tmp_path),
+        operations=(),
+    )
+
+    assert any("does not look like a live medium" in one for one in report.warnings)
+    assert any("rpool/ROOT/gentoo" in one for one in report.warnings)
+    assert not any("live medium" in one for one in report.fatal), "said, not refused"
+
+
+def test_an_install_from_a_medium_says_nothing_about_it(tmp_path: Path) -> None:
+    class OnAMedium(Probe):
+        def live_medium(self) -> str:
+            return "the kernel command line carries root=live:"
+
+    report = preflight.check(
+        config(),
+        OnAMedium(runner=Runner(log=lambda line: None), work=tmp_path),
+        operations=(),
+    )
+
+    assert not any("live medium" in one for one in report.warnings)

--- a/tests/unit/test_probe.py
+++ b/tests/unit/test_probe.py
@@ -4,6 +4,7 @@ from typing import Sequence
 
 import pytest
 
+from gentoo_install.exec import probe
 from gentoo_install.exec.probe import Probe
 from gentoo_install.exec.runner import Result, Runner
 
@@ -88,3 +89,51 @@ def test_a_partition_probe_keeps_the_exact_size_that_the_display_tuple_lost(
     with pytest.raises(FrozenInstanceError):
         setattr(partition, "size_bytes", 0)
     assert probe.partitions("/dev/vda") == (("/dev/vda1", "16G", "ext4"),)
+
+
+def test_the_live_medium_is_read_from_the_kernel_command_line(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The official minimal ISO boots `root=live:CDLABEL=Gentoo-amd64-20260811
+    rd.live.dir=/ rd.live.squashimg=image.squashfs`, which is what says the
+    machine is a medium and not somebody's computer."""
+    cmdline = tmp_path / "cmdline"
+    cmdline.write_text(
+        "BOOT_IMAGE=/boot/gentoo dokeymap nodhcp root=live:CDLABEL=Gentoo-amd64-20260811 "
+        "rd.live.dir=/ rd.live.squashimg=image.squashfs cdroot\n"
+    )
+    monkeypatch.setattr(probe, "CMDLINE", cmdline)
+
+    said = probe.Probe(runner=Runner(log=lambda line: None), work=tmp_path).live_medium()
+
+    assert "root=live:" in said
+
+
+def test_an_overlay_root_is_a_live_medium_without_the_command_line(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setattr(probe, "CMDLINE", tmp_path / "absent")
+
+    class Overlaid(Runner):
+        def run(self, argv: Sequence[str], **rest: object) -> Result:
+            return Result(argv=tuple(argv), returncode=0, stdout="overlay\n", stderr="", seconds=0.0)
+
+    said = probe.Probe(runner=Overlaid(log=lambda line: None), work=tmp_path).live_medium()
+
+    assert "overlay" in said
+
+
+def test_an_installed_machine_is_not_called_a_live_medium(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A workstation whose root is `zfs rpool/ROOT/gentoo` must not read as a
+    medium, or the warning that names the difference never appears."""
+    cmdline = tmp_path / "cmdline"
+    cmdline.write_text("BOOT_IMAGE=/vmlinuz root=ZFS=rpool/ROOT/gentoo ro quiet\n")
+    monkeypatch.setattr(probe, "CMDLINE", cmdline)
+
+    class Installed(Runner):
+        def run(self, argv: Sequence[str], **rest: object) -> Result:
+            return Result(argv=tuple(argv), returncode=0, stdout="zfs\n", stderr="", seconds=0.0)
+
+    assert probe.Probe(runner=Installed(log=lambda line: None), work=tmp_path).live_medium() == ""


### PR DESCRIPTION
Nothing checked. The installer assumed it was running from a medium, and on a machine somebody uses that assumption is the whole difference: the disk screen looks the same either way.

The medium says so itself — the official minimal ISO boots `root=live:CDLABEL=Gentoo-amd64-20260811 rd.live.dir=/ rd.live.squashimg=image.squashfs` and runs on an overlay over squashfs — so `live_medium()` reads the kernel command line first and the root filesystem type second.

Said rather than refused: installing from a running system onto a second disk is a real thing to do, and the guard that matters is unchanged, a disk with anything mounted on it is still not repartitioned. What was missing is that nothing named the difference.