### PR TITLE
repo: record where code comes from

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -62,3 +62,17 @@ Comments explain only a non-obvious invariant, constraint, trade-off or workarou
 Each commit contains one logical change and all code, tests, generated files and documentation needed to make that change true. The subject uses `module: summary`, is imperative and is at most 69 characters.
 
 A body is added only when the subject cannot carry the reason. It states the cause and effect without narrating the diff or listing routine checks.
+
+## Derived code
+
+Code may be taken from a project whose licence is compatible with GPL-2:
+`distro2gentoo` and `catalyst` are GPL-2, `oddlama/gentoo-install` and
+`gentoo-install-zh` are MIT. `archinstall` is GPL-3 and nothing may be taken
+from it while this repository is GPL-2 without an `or later` clause.
+
+A derivation is recorded in three places in the commit that introduces it: a
+comment at the top of the file naming the source project, file and licence and
+saying that it was modified, a line in [CREDITS.md](CREDITS.md), and the reason
+in the commit body. Derived code still has to satisfy everything else here: the
+three layers, the annotations, the named exceptions and a test that fails
+without it.

--- a/CREDITS.md
+++ b/CREDITS.md
@@ -1,0 +1,34 @@
+# Credits
+
+gentoo-install is licensed under GPL-2. This file records every place its code
+came from something else, so that a reader can find the original and its terms.
+
+## Derived code
+
+Nothing yet. Every line in this repository was written for it.
+
+A derivation is recorded here in the same commit that introduces it, one row
+per file, naming the source project, the file it came from and what was taken.
+The file itself carries the same statement in a comment at the top, because a
+reader of that file cannot be assumed to have read this one.
+
+| File here | Source project | Source file | Licence | Taken |
+|---|---|---|---|---|
+
+## Projects read for behaviour
+
+These were read to learn what a working installer does and where it fails. No
+code was taken from them; they are listed because the knowledge came from
+somewhere and the reader deserves to know where.
+
+| Project | Licence | What it taught |
+|---|---|---|
+| [distro2gentoo](https://gitlab.com/cwittlut/distro2gentoo) | GPL-2 | How an in-place conversion replaces a running userland |
+| [oddlama/gentoo-install](https://github.com/oddlama/gentoo-install) | MIT | The real install steps and the pitfalls in their order |
+| [gentoo-install-zh](https://github.com/zozx/gentoo-install-zh) | MIT | Chinese terminology |
+| [archinstall](https://github.com/archlinux/archinstall) | GPL-3 | Menu structure and configuration schema layering |
+| [catalyst](https://github.com/gentoo/catalyst) | GPL-2 | How a Gentoo installation medium is built |
+| [releng](https://gitweb.gentoo.org/proj/releng.git/) | — | What the official install CD contains |
+
+`archinstall` is GPL-3. Nothing may be copied from it while this repository is
+GPL-2 without an `or later` clause.


### PR DESCRIPTION
Zakk allowed taking code from a compatible project on 2026-08-15, once the repository was licensed GPL-2. A derivation nobody can trace back to its author is worse than one written from scratch, so the mechanism exists before the first one lands.

`CREDITS.md` is the ledger and currently records that nothing has been taken. `CONTRIBUTING.md` says what a derivation must carry: a comment at the top of the file naming the source and licence, a line in the ledger, and the reason in the commit body. It also names the one clone that cannot be used — `archinstall` is GPL-3, and this repository is GPL-2 without an `or later` clause.