### PR TITLE
repo: state the licence as GPL-2 or later

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -65,10 +65,11 @@ A body is added only when the subject cannot carry the reason. It states the cau
 
 ## Derived code
 
-Code may be taken from a project whose licence is compatible with GPL-2:
-`distro2gentoo` and `catalyst` are GPL-2, `oddlama/gentoo-install` and
-`gentoo-install-zh` are MIT. `archinstall` is GPL-3 and nothing may be taken
-from it while this repository is GPL-2 without an `or later` clause.
+Code may be taken from a project whose licence is compatible with GPL-2 or
+later: `distro2gentoo` and `catalyst` are GPL-2, `oddlama/gentoo-install` and
+`gentoo-install-zh` are MIT, and `archinstall` is GPL-3. Taking from a GPL-3
+project is lawful under the `or later` clause and changes what the release goes
+out under: a release carrying any GPL-3 code is distributed under GPL-3.
 
 A derivation is recorded in three places in the commit that introduces it: a
 comment at the top of the file naming the source project, file and licence and

--- a/CREDITS.md
+++ b/CREDITS.md
@@ -1,7 +1,8 @@
 # Credits
 
-gentoo-install is licensed under GPL-2. This file records every place its code
-came from something else, so that a reader can find the original and its terms.
+gentoo-install is licensed under GPL-2 or, at the recipient's option, any later
+version. This file records every place its code came from something else, so
+that a reader can find the original and its terms.
 
 ## Derived code
 
@@ -30,5 +31,7 @@ somewhere and the reader deserves to know where.
 | [catalyst](https://github.com/gentoo/catalyst) | GPL-2 | How a Gentoo installation medium is built |
 | [releng](https://gitweb.gentoo.org/proj/releng.git/) | — | What the official install CD contains |
 
-`archinstall` is GPL-3. Nothing may be copied from it while this repository is
-GPL-2 without an `or later` clause.
+`archinstall` is GPL-3. The `or later` clause makes taking code from it lawful,
+and a release that carries any of it is distributed under GPL-3 rather than
+GPL-2. A derivation from it says so in this file, because the terms the whole
+release goes out under change with it.

--- a/README.ja.md
+++ b/README.ja.md
@@ -243,4 +243,4 @@ path = "/"
 
 <!-- fact: license -->
 
-本プロジェクトは GNU General Public License バージョン 2 のもとで配布される。全文は [LICENSE](LICENSE) にある。
+本プロジェクトは GNU General Public License のバージョン 2、または受領者が選ぶそれ以降のバージョンのもとで配布される。バージョン 2 の全文は [LICENSE](LICENSE) にあり、各ソースファイルは `SPDX-License-Identifier: GPL-2.0-or-later` を持つ。

--- a/README.ko.md
+++ b/README.ko.md
@@ -243,4 +243,4 @@ path = "/"
 
 <!-- fact: license -->
 
-이 프로젝트는 GNU General Public License 버전 2에 따라 배포된다. 전문은 [LICENSE](LICENSE)에 있다.
+이 프로젝트는 GNU General Public License 버전 2 또는 수령자가 선택하는 이후 버전에 따라 배포된다. 버전 2 전문은 [LICENSE](LICENSE)에 있으며, 각 소스 파일은 `SPDX-License-Identifier: GPL-2.0-or-later`를 가진다.

--- a/README.md
+++ b/README.md
@@ -243,4 +243,4 @@ For `gentoo-install`, `0` means successful completion and `1` means configuratio
 
 <!-- fact: license -->
 
-gentoo-install is distributed under the GNU General Public License version 2. The full text is in [LICENSE](LICENSE).
+gentoo-install is distributed under the GNU General Public License, either version 2 or, at the recipient's option, any later version. The version 2 text is in [LICENSE](LICENSE), and every source file carries `SPDX-License-Identifier: GPL-2.0-or-later`.

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -243,4 +243,4 @@ path = "/"
 
 <!-- fact: license -->
 
-本项目以 GNU General Public License 第 2 版发布，全文见 [LICENSE](LICENSE)。
+本项目以 GNU General Public License 发布，版本为第 2 版，或由接收者选择任何更新的版本。第 2 版全文见 [LICENSE](LICENSE)，每份源代码文件带有 `SPDX-License-Identifier: GPL-2.0-or-later`。

--- a/README.zh-TW.md
+++ b/README.zh-TW.md
@@ -243,4 +243,4 @@ path = "/"
 
 <!-- fact: license -->
 
-本專案以 GNU General Public License 第 2 版散布，全文見 [LICENSE](LICENSE)。
+本專案以 GNU General Public License 散布，版本為第 2 版，或由接收者選擇任何較新的版本。第 2 版全文見 [LICENSE](LICENSE)，每份原始碼檔案帶有 `SPDX-License-Identifier: GPL-2.0-or-later`。

--- a/gentoo_install/__init__.py
+++ b/gentoo_install/__init__.py
@@ -1,0 +1,1 @@
+# SPDX-License-Identifier: GPL-2.0-or-later

--- a/gentoo_install/__main__.py
+++ b/gentoo_install/__main__.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: GPL-2.0-or-later
 from __future__ import annotations
 
 import sys

--- a/gentoo_install/cli.py
+++ b/gentoo_install/cli.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: GPL-2.0-or-later
 """Argument parsing and the one place an exception becomes an exit code.
 
 The table is in docs/design.md. Codes 3 and 4 stay apart on purpose: 3 says the

--- a/gentoo_install/data.py
+++ b/gentoo_install/data.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: GPL-2.0-or-later
 """Reads the tables shipped beside the code: desktop profiles and app groups.
 
 The plan layer is a pure function of its arguments, so the catalog is read here

--- a/gentoo_install/errors.py
+++ b/gentoo_install/errors.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: GPL-2.0-or-later
 """Every exception the installer raises. `cli.py` is the only module that maps
 these to exit codes; the table lives in docs/design.md."""
 

--- a/gentoo_install/exec/__init__.py
+++ b/gentoo_install/exec/__init__.py
@@ -1,0 +1,1 @@
+# SPDX-License-Identifier: GPL-2.0-or-later

--- a/gentoo_install/exec/apply.py
+++ b/gentoo_install/exec/apply.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: GPL-2.0-or-later
 """Runs an operation list against a machine.
 
 This is the `Context` the plan layer declares. Everything it does goes through

--- a/gentoo_install/exec/config.py
+++ b/gentoo_install/exec/config.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: GPL-2.0-or-later
 """Reading a configuration off this machine.
 
 The model parses a mapping and nothing else. Opening a path is I/O, so it

--- a/gentoo_install/exec/fetch.py
+++ b/gentoo_install/exec/fetch.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: GPL-2.0-or-later
 """The only module that opens a network connection.
 
 stage3 is verified before it is unpacked and never after: a signature that does

--- a/gentoo_install/exec/packages.py
+++ b/gentoo_install/exec/packages.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: GPL-2.0-or-later
 """Read package payload contracts from an installed Gentoo target."""
 
 from __future__ import annotations

--- a/gentoo_install/exec/preflight.py
+++ b/gentoo_install/exec/preflight.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: GPL-2.0-or-later
 """Checks that run before anything is written.
 
 Facts come from `probe.py`; nothing here reads the system itself, so the checks

--- a/gentoo_install/exec/probe.py
+++ b/gentoo_install/exec/probe.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: GPL-2.0-or-later
 """The only module that reads the machine's state.
 
 Everything else asks this. `preflight.py` in particular holds no `os.path` call

--- a/gentoo_install/exec/report.py
+++ b/gentoo_install/exec/report.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: GPL-2.0-or-later
 """Persist and publish the artifacts produced by an install run."""
 
 from __future__ import annotations

--- a/gentoo_install/exec/runner.py
+++ b/gentoo_install/exec/runner.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: GPL-2.0-or-later
 """The only module in the package that imports `subprocess`.
 
 Every external command goes through here, so there is one place that owns exit

--- a/gentoo_install/i18n.py
+++ b/gentoo_install/i18n.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: GPL-2.0-or-later
 """Interface language: which one, and the strings for it.
 
 Source strings are English and are the keys. A tag with no catalog, or a key a

--- a/gentoo_install/log.py
+++ b/gentoo_install/log.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: GPL-2.0-or-later
 """Two logs: one to read, one to query.
 
 `install.log` is the running commentary. `install.jsonl` is one JSON object per

--- a/gentoo_install/model/__init__.py
+++ b/gentoo_install/model/__init__.py
@@ -1,0 +1,1 @@
+# SPDX-License-Identifier: GPL-2.0-or-later

--- a/gentoo_install/model/atoms.py
+++ b/gentoo_install/model/atoms.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: GPL-2.0-or-later
 """Whether a word the operator typed has the shape its destination needs.
 
 Syntax only. Whether an atom resolves to an ebuild is a question for the

--- a/gentoo_install/model/compat.py
+++ b/gentoo_install/model/compat.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: GPL-2.0-or-later
 """The one table of combinations that do not work.
 
 A rule is a pair of traits: when the condition holds and the excluded trait holds

--- a/gentoo_install/model/config.py
+++ b/gentoo_install/model/config.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: GPL-2.0-or-later
 """The whole installation, as data.
 
 `parse.py` builds this from a TOML file and the TUI builds it from answers; both

--- a/gentoo_install/model/device.py
+++ b/gentoo_install/model/device.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: GPL-2.0-or-later
 """The device graph: what the target machine's storage should look like.
 
 Every node carries an id chosen by the configuration, and references its inputs

--- a/gentoo_install/model/manual.py
+++ b/gentoo_install/model/manual.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: GPL-2.0-or-later
 """A hand-written partition list, turned into the same device graph.
 
 The interface edits a list of `Partition` rows; this builds a `DeviceGraph`

--- a/gentoo_install/model/mirrors.py
+++ b/gentoo_install/model/mirrors.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: GPL-2.0-or-later
 """Where each repository is fetched from, as one table per repository.
 
 The main tree and gentoo-zh are separate choices and separate tables: they hold

--- a/gentoo_install/model/parse.py
+++ b/gentoo_install/model/parse.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: GPL-2.0-or-later
 """TOML to `InstallConfig`.
 
 Nothing here touches the machine. A device selector is carried through as the

--- a/gentoo_install/model/paste.py
+++ b/gentoo_install/model/paste.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: GPL-2.0-or-later
 """The project's pastebin: where a key is copied from, and where a failed
 install's log is sent so an issue can point at it.
 

--- a/gentoo_install/model/qr.py
+++ b/gentoo_install/model/qr.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: GPL-2.0-or-later
 """A QR code for a short URL, drawn on the console.
 
 Byte mode, error correction level M, versions 1 to 6. That is every code this

--- a/gentoo_install/model/serialise.py
+++ b/gentoo_install/model/serialise.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: GPL-2.0-or-later
 """An `InstallConfig` written back out as the TOML `parse.py` reads.
 
 Driven by the dataclass fields, not by a second list of key names: the parser

--- a/gentoo_install/model/size.py
+++ b/gentoo_install/model/size.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: GPL-2.0-or-later
 """Byte counts and sector arithmetic.
 
 Every length in the disk model is a `Size`. Passing raw integers around is how

--- a/gentoo_install/model/sshkey.py
+++ b/gentoo_install/model/sshkey.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: GPL-2.0-or-later
 """One public key, checked before it is the only way into the machine."""
 
 from __future__ import annotations

--- a/gentoo_install/model/templates.py
+++ b/gentoo_install/model/templates.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: GPL-2.0-or-later
 """Whole-disk layouts, as functions that return a device graph.
 
 A template is not a mode the rest of the installer knows about: it produces the

--- a/gentoo_install/model/validate.py
+++ b/gentoo_install/model/validate.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: GPL-2.0-or-later
 """Checks that need more than one field, run before anything touches a disk.
 
 Every problem is collected and reported together: fixing one rule per run means

--- a/gentoo_install/plan/__init__.py
+++ b/gentoo_install/plan/__init__.py
@@ -1,0 +1,1 @@
+# SPDX-License-Identifier: GPL-2.0-or-later

--- a/gentoo_install/plan/automatic.py
+++ b/gentoo_install/plan/automatic.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: GPL-2.0-or-later
 """What the installer puts on the kernel command line and in USE by itself.
 
 The panel shows these beside what the operator typed. A value the installed

--- a/gentoo_install/plan/bootloader.py
+++ b/gentoo_install/plan/bootloader.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: GPL-2.0-or-later
 """GRUB, systemd-boot and ZFSBootMenu.
 
 A ZFS root gets no GRUB artefacts at all. The Live ISO's Calamares run installs

--- a/gentoo_install/plan/build.py
+++ b/gentoo_install/plan/build.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: GPL-2.0-or-later
 """One configuration in, one ordered operation list out.
 
 Each module contributes the operations for what it owns; the order across them

--- a/gentoo_install/plan/disk.py
+++ b/gentoo_install/plan/disk.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: GPL-2.0-or-later
 """Disks: partition tables, arrays, filesystems and mounts.
 
 The device graph decides the order. Nodes are emitted in topological order so a

--- a/gentoo_install/plan/fonts.py
+++ b/gentoo_install/plan/fonts.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: GPL-2.0-or-later
 """Font selection configured for the package groups that provide the faces."""
 
 from __future__ import annotations

--- a/gentoo_install/plan/kernel.py
+++ b/gentoo_install/plan/kernel.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: GPL-2.0-or-later
 """Kernel, initramfs and the storage modules dracut has to carry.
 
 The dracut modules are derived from the device graph, never listed by hand: a

--- a/gentoo_install/plan/mounts.py
+++ b/gentoo_install/plan/mounts.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: GPL-2.0-or-later
 """Resolve device graph mountpoints for runtime and persistent consumers."""
 
 from __future__ import annotations

--- a/gentoo_install/plan/operations.py
+++ b/gentoo_install/plan/operations.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: GPL-2.0-or-later
 """What an installation is made of: one named operation per thing that happens.
 
 `describe()` is what a dry run prints and `apply()` is what an install performs.

--- a/gentoo_install/plan/packages.py
+++ b/gentoo_install/plan/packages.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: GPL-2.0-or-later
 """Desktop profiles and the applications chosen separately from them.
 
 A profile is data, not code: `data/profiles/*.toml` names packages, services and

--- a/gentoo_install/plan/portage.py
+++ b/gentoo_install/plan/portage.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: GPL-2.0-or-later
 """stage3, the chroot, and everything Portage needs before the first emerge.
 
 The order here is not a preference. `getuto` has to build `/etc/portage/gnupg`

--- a/gentoo_install/plan/render.py
+++ b/gentoo_install/plan/render.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: GPL-2.0-or-later
 """The operation list as text.
 
 A dry run prints this and a golden test compares it, so what a reviewer reads is

--- a/gentoo_install/plan/system.py
+++ b/gentoo_install/plan/system.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: GPL-2.0-or-later
 """The target's own settings: locale, time, console, identity, mounts, users."""
 
 from __future__ import annotations

--- a/gentoo_install/tui/__init__.py
+++ b/gentoo_install/tui/__init__.py
@@ -1,0 +1,1 @@
+# SPDX-License-Identifier: GPL-2.0-or-later

--- a/gentoo_install/tui/app.py
+++ b/gentoo_install/tui/app.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: GPL-2.0-or-later
 """The main menu: every setting, its current value, and what edits it.
 
 Not a wizard. The operator opens rows in any order and as often as they like,

--- a/gentoo_install/tui/curses_screen.py
+++ b/gentoo_install/tui/curses_screen.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: GPL-2.0-or-later
 """The real terminal, behind the narrow `Screen` the widgets need."""
 
 from __future__ import annotations

--- a/gentoo_install/tui/overview.py
+++ b/gentoo_install/tui/overview.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: GPL-2.0-or-later
 """Render the final configuration and operation overview."""
 
 from __future__ import annotations

--- a/gentoo_install/tui/screens.py
+++ b/gentoo_install/tui/screens.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: GPL-2.0-or-later
 """One screen per decision, each a function of the configuration so far.
 
 A screen never mutates what it was given: it returns a new `InstallConfig`, and

--- a/gentoo_install/tui/settings.py
+++ b/gentoo_install/tui/settings.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: GPL-2.0-or-later
 """The main menu's rows: what each one is called, shows, and edits.
 
 One table, read by the menu to draw itself and by the menu to dispatch. A row

--- a/gentoo_install/tui/widgets.py
+++ b/gentoo_install/tui/widgets.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: GPL-2.0-or-later
 """The pieces every screen is built from.
 
 Each one is a loop over key presses that returns an `Answer`: what the operator

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,0 +1,1 @@
+# SPDX-License-Identifier: GPL-2.0-or-later

--- a/tests/golden/__init__.py
+++ b/tests/golden/__init__.py
@@ -1,0 +1,1 @@
+# SPDX-License-Identifier: GPL-2.0-or-later

--- a/tests/golden/regenerate.py
+++ b/tests/golden/regenerate.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: GPL-2.0-or-later
 """Rewrite every golden plan file. Run it, then read the diff before committing."""
 
 from __future__ import annotations

--- a/tests/golden/test_golden.py
+++ b/tests/golden/test_golden.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: GPL-2.0-or-later
 """Every fixture's plan, compared against a file in version control.
 
 A diff here is the point: any change to what an install does shows up as a

--- a/tests/mirrors_probe.py
+++ b/tests/mirrors_probe.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: GPL-2.0-or-later
 """Ask every mirror in the tables whether it serves what the table claims.
 
 Run by hand, not in the suite: it is a network measurement, and a mirror that

--- a/tests/test_console.py
+++ b/tests/test_console.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: GPL-2.0-or-later
 from __future__ import annotations
 
 import socket

--- a/tests/unit/__init__.py
+++ b/tests/unit/__init__.py
@@ -1,0 +1,1 @@
+# SPDX-License-Identifier: GPL-2.0-or-later

--- a/tests/unit/fake_screen.py
+++ b/tests/unit/fake_screen.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: GPL-2.0-or-later
 """A `Screen` that records what was drawn and replays key presses.
 
 Every widget is driven through this, so the interface is tested without a

--- a/tests/unit/layouts.py
+++ b/tests/unit/layouts.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: GPL-2.0-or-later
 """Configurations the compatibility and validation tests start from.
 
 Each builder returns a configuration that breaks no rule, so a test states what

--- a/tests/unit/recorder.py
+++ b/tests/unit/recorder.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: GPL-2.0-or-later
 """A `Context` that records instead of doing.
 
 `apply()` is the half of an operation a golden file cannot see. Recording the

--- a/tests/unit/test_automatic.py
+++ b/tests/unit/test_automatic.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: GPL-2.0-or-later
 """What the panel says the installer adds, against what it actually writes.
 
 `plan/automatic.py` exists so an operator can see the parameters and USE flags

--- a/tests/unit/test_bootstrap.py
+++ b/tests/unit/test_bootstrap.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: GPL-2.0-or-later
 """The launcher runs before the installer does, on a system we did not build.
 
 Every case here drives `bootstrap.sh` itself rather than a copy of its tables,

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: GPL-2.0-or-later
 from __future__ import annotations
 
 import os

--- a/tests/unit/test_cluster.py
+++ b/tests/unit/test_cluster.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: GPL-2.0-or-later
 from __future__ import annotations
 
 import time

--- a/tests/unit/test_compat.py
+++ b/tests/unit/test_compat.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: GPL-2.0-or-later
 from __future__ import annotations
 
 import re

--- a/tests/unit/test_device.py
+++ b/tests/unit/test_device.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: GPL-2.0-or-later
 from __future__ import annotations
 
 from pathlib import PurePosixPath

--- a/tests/unit/test_every_row.py
+++ b/tests/unit/test_every_row.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: GPL-2.0-or-later
 """Every row of the menu, opened once and read back.
 
 Two interface defects reached an operator in one session, and neither was a

--- a/tests/unit/test_exec.py
+++ b/tests/unit/test_exec.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: GPL-2.0-or-later
 from __future__ import annotations
 
 from dataclasses import replace

--- a/tests/unit/test_harness.py
+++ b/tests/unit/test_harness.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: GPL-2.0-or-later
 """The harness has to report a failed install as a failed run.
 
 It reads the installer's exit code off the result disk rather than from the

--- a/tests/unit/test_i18n.py
+++ b/tests/unit/test_i18n.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: GPL-2.0-or-later
 from __future__ import annotations
 
 import tomllib

--- a/tests/unit/test_layers.py
+++ b/tests/unit/test_layers.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: GPL-2.0-or-later
 """The three layers, checked by reading the source rather than by convention.
 
 `model/` holds data and validation with no I/O, `plan/` derives operations as
@@ -9,6 +10,7 @@ from __future__ import annotations
 
 import ast
 from pathlib import Path
+from typing import Final
 
 PACKAGE = Path(__file__).resolve().parents[2] / "gentoo_install"
 
@@ -92,3 +94,25 @@ def test_no_suppression_hides_a_finding() -> None:
             if marker.search(line):
                 offenders.append(f"{module.relative_to(root)}:{number}")
     assert not offenders, offenders
+
+
+#: The grant Zakk chose on 2026-08-15. Machine-readable and per file, because
+#: `or later` decides what a release carrying borrowed code goes out under.
+SPDX: Final[str] = "# SPDX-License-Identifier: GPL-2.0-or-later"
+
+
+def test_every_source_file_states_the_licence() -> None:
+    """The repository is GPL-2 or later. A file that says nothing leaves the
+    question to whoever finds it, and the `or later` clause is what lets code
+    be taken from a GPL-3 project at all."""
+    root = PACKAGE.parent
+    silent = [
+        one.relative_to(root)
+        for one in sorted(root.rglob("*.py"))
+        if one.is_file()
+        and ".git" not in one.parts
+        and "lab" not in one.parts
+        and one.read_text(encoding="utf-8").splitlines()[:1] != [SPDX]
+    ]
+
+    assert not silent, f"no licence on the first line of: {silent}"

--- a/tests/unit/test_log.py
+++ b/tests/unit/test_log.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: GPL-2.0-or-later
 from __future__ import annotations
 
 import json

--- a/tests/unit/test_mirrors.py
+++ b/tests/unit/test_mirrors.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: GPL-2.0-or-later
 """The mirror tables. Every address here was taken from the project's own list
 rather than derived from a pattern, because the paths do not follow one."""
 

--- a/tests/unit/test_packages.py
+++ b/tests/unit/test_packages.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: GPL-2.0-or-later
 from dataclasses import replace
 from pathlib import PurePosixPath
 

--- a/tests/unit/test_parse.py
+++ b/tests/unit/test_parse.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: GPL-2.0-or-later
 from __future__ import annotations
 
 import tomllib

--- a/tests/unit/test_plan.py
+++ b/tests/unit/test_plan.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: GPL-2.0-or-later
 from __future__ import annotations
 
 from dataclasses import replace

--- a/tests/unit/test_plan_boot.py
+++ b/tests/unit/test_plan_boot.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: GPL-2.0-or-later
 from __future__ import annotations
 
 from dataclasses import replace

--- a/tests/unit/test_plan_bootloader.py
+++ b/tests/unit/test_plan_bootloader.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: GPL-2.0-or-later
 from __future__ import annotations
 
 import pytest

--- a/tests/unit/test_plan_disk.py
+++ b/tests/unit/test_plan_disk.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: GPL-2.0-or-later
 from __future__ import annotations
 
 from dataclasses import replace

--- a/tests/unit/test_plan_fonts.py
+++ b/tests/unit/test_plan_fonts.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: GPL-2.0-or-later
 from __future__ import annotations
 
 from dataclasses import replace

--- a/tests/unit/test_plan_kernel.py
+++ b/tests/unit/test_plan_kernel.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: GPL-2.0-or-later
 from __future__ import annotations
 
 from dataclasses import replace

--- a/tests/unit/test_plan_portage.py
+++ b/tests/unit/test_plan_portage.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: GPL-2.0-or-later
 from __future__ import annotations
 
 import subprocess

--- a/tests/unit/test_plan_system.py
+++ b/tests/unit/test_plan_system.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: GPL-2.0-or-later
 from __future__ import annotations
 
 from dataclasses import replace

--- a/tests/unit/test_preflight.py
+++ b/tests/unit/test_preflight.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: GPL-2.0-or-later
 from __future__ import annotations
 
 from dataclasses import dataclass

--- a/tests/unit/test_probe.py
+++ b/tests/unit/test_probe.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: GPL-2.0-or-later
 from dataclasses import FrozenInstanceError
 from pathlib import Path
 from typing import Sequence

--- a/tests/unit/test_proxmox.py
+++ b/tests/unit/test_proxmox.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: GPL-2.0-or-later
 """The cluster backend's parsing and its safety guard, with no cluster."""
 
 from __future__ import annotations

--- a/tests/unit/test_proxy.py
+++ b/tests/unit/test_proxy.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: GPL-2.0-or-later
 from __future__ import annotations
 
 import json

--- a/tests/unit/test_qr.py
+++ b/tests/unit/test_qr.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: GPL-2.0-or-later
 """The QR encoder against `qrencode`, module for module.
 
 The fixtures were produced by `qrencode -l M -m 0 -t ASCII`, one at the byte

--- a/tests/unit/test_random_configurations.py
+++ b/tests/unit/test_random_configurations.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: GPL-2.0-or-later
 """Random configurations through `validate` and `build`.
 
 `GentooInstallError` is an answer: a refusal the operator can read. Anything

--- a/tests/unit/test_readme.py
+++ b/tests/unit/test_readme.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: GPL-2.0-or-later
 """The README set is five files that have to move together.
 
 Five translations drift the moment one of them is edited alone, and the drift

--- a/tests/unit/test_resume.py
+++ b/tests/unit/test_resume.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: GPL-2.0-or-later
 """Carrying on from where a run stopped.
 
 The question this answers: an install that reached the desktop stage and died

--- a/tests/unit/test_serialise.py
+++ b/tests/unit/test_serialise.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: GPL-2.0-or-later
 from __future__ import annotations
 
 import tomllib

--- a/tests/unit/test_size.py
+++ b/tests/unit/test_size.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: GPL-2.0-or-later
 from __future__ import annotations
 
 from typing import cast

--- a/tests/unit/test_sshkey.py
+++ b/tests/unit/test_sshkey.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: GPL-2.0-or-later
 """A public key is checked before it becomes the only way into the machine."""
 
 from __future__ import annotations

--- a/tests/unit/test_stage3_pointer.py
+++ b/tests/unit/test_stage3_pointer.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: GPL-2.0-or-later
 """`_newest` reads the pointer file, which every mirror serves identically."""
 
 from __future__ import annotations

--- a/tests/unit/test_templates.py
+++ b/tests/unit/test_templates.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: GPL-2.0-or-later
 from __future__ import annotations
 
 from dataclasses import replace

--- a/tests/unit/test_tui_app.py
+++ b/tests/unit/test_tui_app.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: GPL-2.0-or-later
 from __future__ import annotations
 
 from dataclasses import replace

--- a/tests/unit/test_tui_curses.py
+++ b/tests/unit/test_tui_curses.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: GPL-2.0-or-later
 """The menu under a real terminal, not the fake screen.
 
 `FakeScreen` proves what the widgets decide; it proves nothing about curses.

--- a/tests/unit/test_tui_partitions.py
+++ b/tests/unit/test_tui_partitions.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: GPL-2.0-or-later
 """The hand-written partition table.
 
 Driven through the fake screen like every other widget, so the table can be

--- a/tests/unit/test_tui_widgets.py
+++ b/tests/unit/test_tui_widgets.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: GPL-2.0-or-later
 from __future__ import annotations
 
 import pytest

--- a/tests/unit/test_validate.py
+++ b/tests/unit/test_validate.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: GPL-2.0-or-later
 from __future__ import annotations
 
 import ipaddress

--- a/tests/vm/__init__.py
+++ b/tests/vm/__init__.py
@@ -1,0 +1,1 @@
+# SPDX-License-Identifier: GPL-2.0-or-later

--- a/tests/vm/campaign.py
+++ b/tests/vm/campaign.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: GPL-2.0-or-later
 """Run the whole VM matrix unattended, in the order `docs/vm-campaign.md` sets.
 
     python3 -m tests.vm.campaign --stage blocking

--- a/tests/vm/cluster.py
+++ b/tests/vm/cluster.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: GPL-2.0-or-later
 """Run the install fixtures on the Proxmox cluster, unattended.
 
 One process, many guests. Each guest is a thread that builds a machine, drives

--- a/tests/vm/console.py
+++ b/tests/vm/console.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: GPL-2.0-or-later
 """Serial console client: the primary control channel for a test VM."""
 
 from __future__ import annotations

--- a/tests/vm/driver.py
+++ b/tests/vm/driver.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: GPL-2.0-or-later
 """Package the working tree into a second CD the guest can run.
 
 The installer is not on the install medium, so every run builds this from the

--- a/tests/vm/installed.py
+++ b/tests/vm/installed.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: GPL-2.0-or-later
 """The installed-state contract shared by local and cluster runners."""
 
 from __future__ import annotations

--- a/tests/vm/media.py
+++ b/tests/vm/media.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: GPL-2.0-or-later
 """Install media the harness can boot, and how to get a shell on each."""
 
 from __future__ import annotations

--- a/tests/vm/monitor.py
+++ b/tests/vm/monitor.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: GPL-2.0-or-later
 """QEMU's monitor socket, for the console the serial port cannot reach.
 
 GRUB unlocks an encrypted BIOS disk before it reads `grub.cfg`, so its

--- a/tests/vm/netcheck.py
+++ b/tests/vm/netcheck.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: GPL-2.0-or-later
 """Boot the installer on a guest with one address family and see what it does.
 
 Three networks, one guest each: dual stack, IPv4 only, IPv6 only. The cluster

--- a/tests/vm/proxmox.py
+++ b/tests/vm/proxmox.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: GPL-2.0-or-later
 """Test machines on a Proxmox VE cluster, driven entirely through its API.
 
 The workstation cannot host the campaign: five guests share its memory with an

--- a/tests/vm/qemu.py
+++ b/tests/vm/qemu.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: GPL-2.0-or-later
 """QEMU process management for the test harness."""
 
 from __future__ import annotations

--- a/tests/vm/results.py
+++ b/tests/vm/results.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: GPL-2.0-or-later
 """Result transfer from guest to host.
 
 The guest writes a tar stream straight onto a raw virtio disk and the host reads it

--- a/tests/vm/run.py
+++ b/tests/vm/run.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: GPL-2.0-or-later
 """Boot an install medium in QEMU and probe it, drive the installer, or hand it
 to a human.
 

--- a/tests/vm/tui.py
+++ b/tests/vm/tui.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: GPL-2.0-or-later
 """Walk the menu in a real terminal, on the medium it ships on.
 
 `tests/unit/` drives the screens through `FakeScreen`, which answers a key and

--- a/tests/vm/websocket.py
+++ b/tests/vm/websocket.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: GPL-2.0-or-later
 """A websocket client, enough of RFC 6455 to carry a serial console.
 
 Proxmox hands out a console over `vncwebsocket` and nothing else: the node's

--- a/tests/vm/workdir.py
+++ b/tests/vm/workdir.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: GPL-2.0-or-later
 """Confinement for VM harness artifacts."""
 
 from __future__ import annotations


### PR DESCRIPTION
Zakk chose `or later` on 2026-08-15, and it is what makes taking code from a GPL-3 project lawful — `archinstall` was the one clone the previous wording ruled out. It is not free: a release carrying GPL-3 code goes out under GPL-3 rather than GPL-2, which `CREDITS.md` and `CONTRIBUTING.md` now say.

Every source file carries `SPDX-License-Identifier: GPL-2.0-or-later` on its first line, because the grant decides what a release can contain and a file that says nothing leaves the question to whoever finds it. A test fails on any file without it.