### PR TITLE
vm: cpu time is shared, so a guest costs one core not its vCPUs

### DIFF
--- a/tests/unit/test_proxmox.py
+++ b/tests/unit/test_proxmox.py
@@ -3174,13 +3174,13 @@ def test_a_node_out_of_cores_offers_no_slot_however_much_memory_it_has() -> None
     offered = [node.name for node in free_slots(Saturated())]
 
     assert "busy" not in offered
-    assert offered == ["idle"], "one two-core guest on a node with 3.2 cores free"
+    assert offered == ["idle", "idle"], "two guests on a node with 3.2 cores free"
 
 
 def test_cores_this_schedule_has_placed_are_subtracted_too() -> None:
     """A guest's load takes minutes to show in what the node reports, the same
     lag the memory reservation exists for."""
-    from tests.vm.cluster import GUEST_CORES, GUEST_MEMORY_MIB, NODE_HEADROOM_BYTES, free_slots
+    from tests.vm.cluster import GUEST_MEMORY_MIB, NODE_HEADROOM_BYTES, free_slots
     from tests.vm.proxmox import Api, Node
 
     guest = GUEST_MEMORY_MIB * 1024**2
@@ -3199,9 +3199,11 @@ def test_cores_this_schedule_has_placed_are_subtracted_too() -> None:
                 )
             ]
 
-    assert len(free_slots(Idle())) == 3
-    assert len(free_slots(Idle(), None, {"one": GUEST_CORES * 2})) == 1
-    assert free_slots(Idle(), None, {"one": GUEST_CORES * 3}) == []
+    # One per guest, not one per vCPU: a node with 7 cores free carries six
+    # after the headroom, and each guest already placed there takes one.
+    assert len(free_slots(Idle())) == 6
+    assert len(free_slots(Idle(), None, {"one": 4})) == 2
+    assert free_slots(Idle(), None, {"one": 6}) == []
 
 
 def test_a_driver_cd_old_enough_to_belong_to_nobody_is_named() -> None:
@@ -3296,3 +3298,24 @@ def test_a_delete_refused_for_another_reason_is_not_retried() -> None:
 
     assert isinstance(answered, ProxmoxError)
     assert not isinstance(answered, ProxmoxTransientError)
+
+
+def test_a_heavy_guest_still_fits_a_four_core_node() -> None:
+    """Every node in this cluster has four cores and a heavy guest asks for
+    four vCPUs. Requiring those to be free meant `btrfs-luks`, `vm-desktop`,
+    `vm-gnome`, `vm-openrc-desktop` and `zfs-zbm` could never be placed at all:
+    a round dispatched three light fixtures and stalled."""
+    from tests.vm.cluster import HEAVY_MEMORY_MIB, Job, NODE_HEADROOM_BYTES, room_for
+    from tests.vm.proxmox import Node
+
+    node = Node(
+        name="infra-node4",
+        free_bytes=NODE_HEADROOM_BYTES + HEAVY_MEMORY_MIB * 1024**2,
+        cores=4,
+        free_cores=3.5,
+    )
+    heavy = Job(name="vm-desktop", fixture=Path("vm-desktop.toml"), heavy=True)
+
+    assert heavy.cores == 4, "a heavy guest does ask for four"
+    assert room_for(node, heavy)
+    assert not room_for(node, heavy, None, {"infra-node4": 3}), "three guests already there"

--- a/tests/vm/cluster.py
+++ b/tests/vm/cluster.py
@@ -1105,9 +1105,12 @@ def free_slots(
         by_memory = max(0, int(room // need))
         # A node that is out of cores is out of slots whatever its memory says:
         # `infra-node1` sat at 100% of four cores with 7 GiB free, and the
-        # cluster proxy answered 595 for the node next to it.
+        # cluster proxy answered 595 for the node next to it. One guest per
+        # free core, not one per its vCPU count: cpu time is shared rather than
+        # handed out, and requiring a heavy guest's four to be free left five
+        # fixtures unschedulable on a four-core node.
         spare = node.free_cores - NODE_HEADROOM_CORES - cores_held.get(node.name, 0)
-        by_cores = max(0, int(spare // GUEST_CORES))
+        by_cores = max(0, int(spare))
         per_node.append([node] * min(by_memory, by_cores))
     # One from each node in turn, rather than a node's whole share before the
     # next one is touched: five guests went onto `infra-node5` and left the
@@ -1138,7 +1141,7 @@ def room_for(
     spare = (
         node.free_cores - NODE_HEADROOM_CORES - (cores_placed or {}).get(node.name, 0)
     )
-    return room >= job.reservation_bytes and spare >= job.cores
+    return room >= job.reservation_bytes and spare >= 1.0
 
 
 class Stoppable(Protocol):
@@ -1253,7 +1256,10 @@ def _reserved_cores(scheduled: Mapping[str, Job]) -> Counter[str]:
             continue
         if job.node is None:
             raise ProxmoxError(f"{job.name} holds resources without a node")
-        held[job.node] += job.cores
+        # One per guest, matching what `free_slots` subtracts: a guest's
+        # sustained load is not its vCPU count, and counting that made a heavy
+        # job need more cores than any node in this cluster has.
+        held[job.node] += 1
     return held
 
 


### PR DESCRIPTION
Counting a guest against free cores by its vCPU count was wrong in a way that stalled the next round: every node here has four cores, a heavy guest asks for four, and one core is left to the node itself — so `btrfs-luks`, `vm-desktop`, `vm-gnome`, `vm-openrc-desktop` and `zfs-zbm` could never be placed anywhere. The round dispatched three light fixtures and stopped.

Cpu time is shared rather than handed out, so a guest costs one core of the budget whatever its vCPU count, and the headroom that keeps `pveproxy` answering is unchanged.