### PR TITLE
vm: the carried hosts say whether they answer

### DIFF
--- a/tests/unit/test_harness.py
+++ b/tests/unit/test_harness.py
@@ -2429,3 +2429,22 @@ def test_a_file_that_cannot_be_written_does_not_end_the_run(tmp_path: Path) -> N
     log = tmp_path / "sub" / "vm-btrfs.log"
 
     keep_results(log, {"install.rc": b"0\n"})
+
+
+def test_the_carried_hosts_say_whether_they_answer() -> None:
+    """Three rounds wrote `/etc/hosts` and then failed to resolve a name that
+    was in it. The log could not tell that apart from the file never being
+    written, so the command answers for itself."""
+    from tests.vm.cluster import carry_hosts
+
+    said = carry_hosts("210.28.130.3 mirrors.nju.edu.cn\\n20.27.177.113 github.com\\n")
+
+    assert ">> /etc/hosts" in said
+    assert "getent hosts mirrors.nju.edu.cn" in said
+    assert "PINNED_ANSWERS" in said and "PINNED_UNANSWERED" in said
+
+
+def test_nothing_pinned_asks_nothing() -> None:
+    from tests.vm.cluster import carry_hosts
+
+    assert "getent hosts " in carry_hosts("")

--- a/tests/vm/cluster.py
+++ b/tests/vm/cluster.py
@@ -786,8 +786,18 @@ def carry_hosts(pinned: str) -> str:
 
     Appended rather than written: the medium's own entry for localhost is in
     there, and replacing the file takes it away.
+
+    Answered afterwards rather than assumed: three rounds wrote this file and
+    then failed to resolve a name that was in it, which the log could not tell
+    apart from the file never being written.
     """
-    return f"printf '{pinned}' >> /etc/hosts"
+    first = pinned.split("\\n", 1)[0].split(" ", 1)[-1] if pinned else ""
+    return (
+        f"printf '{pinned}' >> /etc/hosts; "
+        f"printf 'PINNED_%s_LINES\\n' \"$(grep -c . /etc/hosts)\"; "
+        f"getent hosts {first} > /dev/null && printf 'PINNED_ANSWERS\\n' "
+        f"|| printf 'PINNED_UNANSWERED\\n'"
+    )
 
 
 def configure_statically(address: str, pinned: str = "") -> str:


### PR DESCRIPTION
Three rounds wrote thirty-three addresses into a guest`s `/etc/hosts` and then died at the stage3 fetch with `Temporary failure in name resolution` for a name that was in the file. The medium resolves `files dns`, and `curl` in the same guest resolved the same names, so the log left two very different explanations indistinguishable: the file was never written, or it was written and the resolver did not read it.

The command now counts the lines it wrote and answers `PINNED_ANSWERS` or `PINNED_UNANSWERED` for the first name, so the next round says which.