### PR TITLE
vm: guests ask a resolver of ours

### DIFF
--- a/tests/vm/cluster.py
+++ b/tests/vm/cluster.py
@@ -713,7 +713,14 @@ GUEST_ADDRESS_BASE: Final[int] = 150
 #: Every resolver, in the order glibc tries them. The router's own is first
 #: because it resolves names on this network too; the public ones follow so a
 #: guest is not stranded when that Pi is busy.
-GUEST_RESOLVERS: Final[tuple[str, ...]] = (GUEST_GATEWAY, "1.1.1.1", "8.8.8.8")
+#: A resolver of ours on the guest segment, asked before anything else. The
+#: segment's own answers arrive intermittently — a guest resolved a mirror at
+#: one step and failed on the next five seconds later — and `1.1.1.1` and
+#: `8.8.8.8` are outside China, where this cluster is. `gi-resolver` is an
+#: Alpine container at this address running dnsmasq over Chinese forwarders.
+GUEST_RESOLVER: Final[str] = "10.31.0.199"
+
+GUEST_RESOLVERS: Final[tuple[str, ...]] = (GUEST_RESOLVER, GUEST_GATEWAY, "223.5.5.5")
 
 
 #: What a guest outside the cluster does, where no address is reserved for it.


### PR DESCRIPTION
Nine rounds died at the stage3 fetch with `Temporary failure in name resolution`, and the segment is why: a guest resolved a mirror at one step and failed on the next five seconds later. The two fallbacks behind it, `1.1.1.1` and `8.8.8.8`, are outside China — this cluster runs there, on cheap power — so neither was ever the fallback it looked like.

`gi-resolver` is a 256 MiB Alpine container at `10.31.0.199` on the guest bridge, running dnsmasq over Chinese forwarders, and guests ask it first. Its template came from the USTC mirror of Proxmox images: the node fetched the same 3 MiB file from `download.proxmox.com` for fifteen minutes and received nothing.