### PR TITLE
disk: an unsized partition stops at the gap it was placed in

### DIFF
--- a/gentoo_install/plan/disk.py
+++ b/gentoo_install/plan/disk.py
@@ -218,6 +218,10 @@ class CreatePartition(Operation):
     #: Where this partition starts. Only the MBR path needs it: `sgdisk` places a
     #: partition at the first aligned free sector by itself, `parted` does not.
     start: Size
+    #: Where the free extent it was placed in ends, when the table is edited
+    #: rather than written. `100%` reaches past a partition the operator asked
+    #: to keep, and `parted` then refuses the whole edit.
+    limit: Size | None = None
 
     def required_host_commands(self) -> frozenset[str]:
         return frozenset(("sgdisk" if self.table_kind is TableType.GPT else "parted",))
@@ -247,7 +251,10 @@ class CreatePartition(Operation):
                 argv.append(f"--change-name={self.index}:{self.label}")
             context.run([*argv, path])
             return
-        end = str(self.start + self.size) if self.size is not None else "100%"
+        if self.size is not None:
+            end = str(self.start + self.size)
+        else:
+            end = str(self.limit) if self.limit is not None else "100%"
         context.run(
             ["parted", "--script", "--align", "optimal", path, "mkpart", "primary", str(self.start), end]
         )
@@ -1011,6 +1018,7 @@ def _operations_for(
                 size=node.size,
                 label=node.label,
                 start=_start_of(graph, node, storage_facts),
+                limit=_extent_end_of(graph, node, storage_facts),
             ),
         ]
     if isinstance(node, MdRaid):
@@ -1127,6 +1135,30 @@ def _start_of(
             return start
         start = (start + sibling.size).align_up()
     return start
+
+
+def _extent_end_of(
+    graph: DeviceGraph,
+    partition: Partition,
+    storage_facts: StorageFacts | None,
+) -> Size | None:
+    """Where the gap this partition was placed in ends, or None for a fresh
+    table where the rest of the disk is the answer.
+
+    An unsized partition in an edited table would otherwise be written as
+    `100%`, which reaches past every partition the operator asked to keep.
+    """
+    if partition.size is not None or storage_facts is None:
+        return None
+    table = _expect(graph, partition.table, PartitionTable)
+    if table.create:
+        return None
+    extents = storage_facts.free_extents.get(table.id, ())
+    start = _start_of(graph, partition, storage_facts)
+    for extent in extents:
+        if extent.start <= start.bytes <= extent.end:
+            return Size(extent.end + 1).align_down()
+    return None
 
 
 def _into_free_space(

--- a/tests/unit/test_plan_disk.py
+++ b/tests/unit/test_plan_disk.py
@@ -826,3 +826,67 @@ def test_a_pool_busy_with_nothing_mounted_is_named_rather_than_forced(
     with pytest.raises(CommandFailed, match="holder is unknown"):
         operation.apply(unknown)
     assert not any("-f" in one for one in unknown.commands)
+
+
+def _edited_mbr_taking_the_rest() -> DeviceGraph:
+    """The same edited table, with the added partition asking for the rest.
+
+    `_edited_mbr` substitutes a size for `None`, so the case this is about
+    cannot be expressed through it.
+    """
+    from pathlib import PurePosixPath
+
+    return DeviceGraph.build(
+        [
+            Existing(id=DeviceId("d"), selector="/dev/null", wipe=False),
+            PartitionTable(
+                id=DeviceId("t"),
+                disk=DeviceId("d"),
+                table=TableType.MBR,
+                create=False,
+            ),
+            Partition(
+                id=DeviceId("new"),
+                table=DeviceId("t"),
+                index=2,
+                role=PartitionRole.DATA,
+                size=None,
+            ),
+            Filesystem(id=DeviceId("fs"), device=DeviceId("new"), kind=FilesystemType.EXT4),
+            Mountpoint(id=DeviceId("m"), source=DeviceId("fs"), path=PurePosixPath("/")),
+        ]
+    )
+
+
+def test_an_unsized_partition_in_an_edited_table_stops_at_its_gap() -> None:
+    """`100%` reaches to the end of the disk, past every partition the operator
+    asked to keep, and `parted` refuses the whole edit. The planner already
+    knows which gap the partition was placed in, so it carries where that gap
+    ends."""
+    from gentoo_install.plan.disk import _extent_end_of
+
+    graph = _edited_mbr_taking_the_rest()
+    gap = Extent(start=1074790400, end=4294967295)
+    facts = StorageFacts(free_extents={DeviceId("t"): (gap,)})
+    added = next(one for one in graph.of_type(Partition) if one.id == DeviceId("new"))
+
+    limit = _extent_end_of(graph, added, facts)
+
+    assert limit is not None, "an edited table bounds an unsized partition"
+    assert limit.bytes <= gap.end + 1
+    assert limit.bytes > gap.start
+
+
+def test_an_unsized_partition_on_a_fresh_table_still_takes_the_rest() -> None:
+    """A table this run writes has nothing beyond it to protect."""
+    from gentoo_install.plan.disk import _extent_end_of
+
+    graph = DeviceGraph.build(
+        [
+            replace(node, create=True) if isinstance(node, PartitionTable) else node
+            for node in _edited_mbr_taking_the_rest().nodes.values()
+        ]
+    )
+    added = next(one for one in graph.of_type(Partition) if one.id == DeviceId("new"))
+
+    assert _extent_end_of(graph, added, StorageFacts()) is None


### PR DESCRIPTION
An added partition that asks for the rest of the disk is written as `parted mkpart primary <start> 100%`. In a table this run creates that is right; in a table it edits it reaches past every partition the operator asked to keep, and `parted` refuses the whole edit — after the removals of the same plan have already been committed, which is the state a failed edit is worst in.

The planner already chooses which free extent the partition goes in, so it carries where that extent ends and the operation uses it. A fresh table still gets `100%`, because there is nothing beyond it to protect.