### PR TITLE
vm: ask the files backend by name, and start on a fresh line

### DIFF
--- a/tests/unit/test_harness.py
+++ b/tests/unit/test_harness.py
@@ -2440,11 +2440,11 @@ def test_the_carried_hosts_say_whether_they_answer() -> None:
     said = carry_hosts("210.28.130.3 mirrors.nju.edu.cn\\n20.27.177.113 github.com\\n")
 
     assert ">> /etc/hosts" in said
-    assert "getent hosts mirrors.nju.edu.cn" in said
-    assert "PINNED_ANSWERS" in said and "PINNED_UNANSWERED" in said
+    assert "getent -s files hosts mirrors.nju.edu.cn" in said
+    assert "PINNED_IN_FILES" in said and "PINNED_NOT_IN_FILES" in said
 
 
 def test_nothing_pinned_asks_nothing() -> None:
     from tests.vm.cluster import carry_hosts
 
-    assert "getent hosts " in carry_hosts("")
+    assert "getent -s files hosts " in carry_hosts("")

--- a/tests/vm/cluster.py
+++ b/tests/vm/cluster.py
@@ -799,11 +799,15 @@ def carry_hosts(pinned: str) -> str:
     apart from the file never being written.
     """
     first = pinned.split("\\n", 1)[0].split(" ", 1)[-1] if pinned else ""
+    # `-s files`, not a plain lookup: a name DNS can also answer proves nothing
+    # about the file, and the first diagnostic could not tell them apart.
+    # Newline first, because the medium's own `/etc/hosts` may not end in one
+    # and the first pinned entry would be glued to its last line.
     return (
-        f"printf '{pinned}' >> /etc/hosts; "
+        f"printf '\\n{pinned}' >> /etc/hosts; "
         f"printf 'PINNED_%s_LINES\\n' \"$(grep -c . /etc/hosts)\"; "
-        f"getent hosts {first} > /dev/null && printf 'PINNED_ANSWERS\\n' "
-        f"|| printf 'PINNED_UNANSWERED\\n'"
+        f"getent -s files hosts {first} > /dev/null && printf 'PINNED_IN_FILES\\n' "
+        f"|| printf 'PINNED_NOT_IN_FILES\\n'"
     )
 
 


### PR DESCRIPTION
The diagnostic added a round ago said `PINNED_ANSWERS` for a guest whose installer then failed to resolve a pinned name. That answer was ambiguous: a plain `getent hosts` is served by whichever backend replies, so DNS answering it proves nothing about the file. `-s files` asks the file and nothing else.

The append now starts with a newline as well, because the medium is not required to leave `/etc/hosts` ending in one, and the first pinned entry would otherwise be glued to its last line.