### PR TITLE
exec: a written file is whole or absent

### DIFF
--- a/gentoo_install/exec/apply.py
+++ b/gentoo_install/exec/apply.py
@@ -36,7 +36,7 @@ from ..plan.operations import CommandOutput, Operation
 from . import fetch, packages
 from .preflight import SecretStore
 from .probe import Probe
-from .runner import Runner, open_in_target, under, write_file
+from .runner import Runner, TargetEscape, open_in_target, under, write_file
 
 
 @dataclass
@@ -82,14 +82,30 @@ class Machine:
         return packages.target_is_directory(self.mountpoint, path)
 
     def write(self, path: PurePosixPath, content: str, *, mode: int = 0o644) -> None:
+        # Beside it and renamed over, never in place: a run cut short between
+        # the truncate and the write leaves a half-written `fstab` or
+        # `make.conf`, and `--resume` reads it as the operator's own.
+        beside = path.with_name(f".{path.name}.gentoo-install")
         # The mode is set at open time: writing first and narrowing afterwards
         # leaves a secret readable for the interval in between.
         handle = open_in_target(
-            self.mountpoint, path, os.O_WRONLY | os.O_CREAT | os.O_TRUNC, mode, parents=True
+            self.mountpoint, beside, os.O_WRONLY | os.O_CREAT | os.O_TRUNC, mode, parents=True
         )
         with os.fdopen(handle, "w") as opened:
             opened.write(content)
-        os.chmod(under(self.mountpoint, path), mode, follow_symlinks=False)
+            opened.flush()
+            os.fsync(opened.fileno())
+        written = under(self.mountpoint, beside)
+        os.chmod(written, mode, follow_symlinks=False)
+        destination = under(self.mountpoint, path)
+        # `os.replace` takes the symlink's place rather than following it, so
+        # the refusal `open_in_target` gives the other paths has to be made
+        # here as well: a stage3 that ships `/etc/mtab` as a link out of the
+        # target must not have it quietly replaced either.
+        if os.path.islink(destination):
+            os.unlink(written)
+            raise TargetEscape(f"{path} in the target is a symlink")
+        os.replace(written, destination)
 
     def read(self, path: PurePosixPath) -> str:
         """Empty for a file that is not there, which is the normal case before

--- a/tests/unit/test_exec.py
+++ b/tests/unit/test_exec.py
@@ -1,6 +1,8 @@
 # SPDX-License-Identifier: GPL-2.0-or-later
 from __future__ import annotations
 
+import os
+
 from dataclasses import replace
 from pathlib import Path, PurePosixPath
 from typing import AbstractSet, Iterable, Mapping, Sequence
@@ -2244,3 +2246,62 @@ def test_a_refused_connection_is_not_waited_out_as_long(
     fetch._download("https://distfiles.invalid/stage3.tar.xz", tmp_path / "stage3.tar.xz")
 
     assert waited == [fetch.ONLINE_PAUSE]
+
+
+def test_a_written_file_is_whole_or_absent(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A run cut short between the truncate and the write leaves a half
+    written `fstab` or `make.conf`, and `--resume` reads it as the operator's
+    own. The content lands beside the name and is renamed over it."""
+    target = tmp_path / "target"
+    (target / "etc").mkdir(parents=True)
+    runner = Runner(log=lambda line: None)
+    machine = apply.Machine(
+        config=config(),
+        runner=runner,
+        probe=Probe(runner=runner, work=tmp_path),
+        work=tmp_path,
+    )
+    machine.mountpoint = target
+
+    renames: list[tuple[str, str]] = []
+    real_replace = os.replace
+
+    def watched(src: str | Path, dst: str | Path) -> None:
+        renames.append((os.fspath(src), os.fspath(dst)))
+        real_replace(src, dst)
+
+    monkeypatch.setattr(os, "replace", watched)
+    machine.write(PurePosixPath("/etc/fstab"), "UUID=1 / ext4 defaults 0 1\n")
+
+    assert (target / "etc" / "fstab").read_text().endswith("0 1\n")
+    assert renames, "the content was written straight into the name"
+    source, destination = renames[-1]
+    assert Path(source).name.startswith(".") and source != destination
+    leftovers = [one.name for one in (target / "etc").iterdir() if one.name.startswith(".")]
+    assert not leftovers, f"the file it was written through stayed: {leftovers}"
+
+
+def test_a_symlink_at_the_destination_is_refused_rather_than_replaced(tmp_path: Path) -> None:
+    """`os.replace` takes a symlink's place instead of following it, so the
+    refusal the other paths get has to be made here too."""
+    from gentoo_install.exec.runner import TargetEscape
+
+    target = tmp_path / "target"
+    (target / "etc").mkdir(parents=True)
+    (target / "etc" / "mtab").symlink_to("/proc/self/mounts")
+    runner = Runner(log=lambda line: None)
+    machine = apply.Machine(
+        config=config(),
+        runner=runner,
+        probe=Probe(runner=runner, work=tmp_path),
+        work=tmp_path,
+    )
+    machine.mountpoint = target
+
+    with pytest.raises(TargetEscape):
+        machine.write(PurePosixPath("/etc/mtab"), "nothing\n")
+
+    assert (target / "etc" / "mtab").is_symlink()
+    assert not list((target / "etc").glob(".mtab*")), "the temporary file was removed"


### PR DESCRIPTION
Every file the installer put in the target was opened with `O_TRUNC` and written in place, so a run cut short in between — a killed process, a lost machine — left a half-written `fstab` or `make.conf` behind. `--resume` then reads one as the operator own work.

The content is written beside the name, flushed, fsynced, and renamed over it. `os.replace` takes a symlink place rather than following it, so the refusal `open_in_target` gives every other path is made here too: a stage3 that ships `/etc/mtab` as a link out of the target is not quietly replaced either.