### PR TITLE
vm: a console line has a limit, so the addresses go in batches

### DIFF
--- a/tests/unit/test_harness.py
+++ b/tests/unit/test_harness.py
@@ -2213,8 +2213,11 @@ def test_nothing_reaches_etc_hosts_unless_it_was_asked_for() -> None:
     unnoticed, so the run would prove less than it says."""
     from tests.vm.cluster import configure_statically
 
+    # Not from this line any more: the addresses are carried in before the
+    # first probe, and writing them twice made the file 101 lines when 68 were
+    # written.
     assert "/etc/hosts" not in configure_statically("10.31.0.150")
-    assert "/etc/hosts" in configure_statically("10.31.0.150", "1.2.3.4 example\\n")
+    assert "/etc/hosts" not in configure_statically("10.31.0.150", "1.2.3.4 example\\n")
 
 
 def test_the_carried_names_are_written_before_the_first_probe() -> None:
@@ -2236,8 +2239,10 @@ def test_the_carried_names_are_written_before_the_first_probe() -> None:
     cluster.wait_for_network(cast(Any, Link()), 9300, "10.31.0.150", "1.2.3.4 example\\n")
 
     assert sent, "nothing was sent to the guest"
-    assert "/etc/hosts" in sent[0]
-    assert cluster.NETWORK_PROBE in sent[1]
+    carried = [one for one in sent if "/etc/hosts" in one]
+    assert carried, "the names were not carried in"
+    probe_at = next(at for at, one in enumerate(sent) if cluster.NETWORK_PROBE in one)
+    assert sent.index(carried[-1]) < probe_at, "carried after the probe"
 
 
 def test_nothing_is_carried_when_it_was_not_asked_for() -> None:
@@ -2431,20 +2436,37 @@ def test_a_file_that_cannot_be_written_does_not_end_the_run(tmp_path: Path) -> N
     keep_results(log, {"install.rc": b"0\n"})
 
 
-def test_the_carried_hosts_say_whether_they_answer() -> None:
-    """Three rounds wrote `/etc/hosts` and then failed to resolve a name that
-    was in it. The log could not tell that apart from the file never being
-    written, so the command answers for itself."""
-    from tests.vm.cluster import carry_hosts
+def test_the_carried_hosts_fit_one_console_line_each() -> None:
+    """A tty edits in canonical mode and drops what does not fit. One line
+    carrying every pinned address is 1349 characters, and two guests in six
+    wrote an `/etc/hosts` whose late entries were never there — while the
+    first entry, which the diagnostic asked about, always was."""
+    from tests.vm.cluster import CONSOLE_LINE_BYTES, carried_hosts, pinned_hosts
 
-    said = carry_hosts("210.28.130.3 mirrors.nju.edu.cn\\n20.27.177.113 github.com\\n")
+    commands = carried_hosts(pinned_hosts())
 
-    assert ">> /etc/hosts" in said
-    assert "getent -s files hosts mirrors.nju.edu.cn" in said
-    assert "PINNED_IN_FILES" in said and "PINNED_NOT_IN_FILES" in said
+    assert len(commands) > 3, "the whole block does not go in one line"
+    for command in commands:
+        assert len(command) <= CONSOLE_LINE_BYTES + 32, command[:80]
+    assert any("PINNED_IN_FILES" in one for one in commands)
 
 
-def test_nothing_pinned_asks_nothing() -> None:
-    from tests.vm.cluster import carry_hosts
+def test_the_diagnostic_asks_about_both_ends() -> None:
+    """A line that was cut kept its beginning, so the first name answers while
+    the mirror the install needs is missing."""
+    from tests.vm.cluster import carried_hosts
 
-    assert "getent -s files hosts " in carry_hosts("")
+    commands = carried_hosts("1.1.1.1 first.example\\n2.2.2.2 last.example\\n")
+    asked = " ".join(commands)
+
+    assert "getent -s files hosts first.example" in asked
+    assert "getent -s files hosts last.example" in asked
+
+
+def test_nothing_pinned_carries_nothing() -> None:
+    from tests.vm.cluster import carried_hosts
+
+    assert carried_hosts("") == []
+
+
+

--- a/tests/vm/cluster.py
+++ b/tests/vm/cluster.py
@@ -788,27 +788,48 @@ def pinned_hosts() -> str:
     return "".join(f"{line}\\n" for line in lines)
 
 
-def carry_hosts(pinned: str) -> str:
-    """Append the answers this machine has to the guest's `/etc/hosts`.
+#: How much of one command line a serial console carries. The tty edits in
+#: canonical mode and drops what does not fit, and one line carrying every
+#: pinned address is 1349 characters: two guests in six wrote a `/etc/hosts`
+#: whose late entries — `mirrors.nju.edu.cn` among them — were never there,
+#: while the first entry the diagnostic asked about always was.
+CONSOLE_LINE_BYTES: Final[int] = 200
 
-    Appended rather than written: the medium's own entry for localhost is in
-    there, and replacing the file takes it away.
 
-    Answered afterwards rather than assumed: three rounds wrote this file and
-    then failed to resolve a name that was in it, which the log could not tell
-    apart from the file never being written.
+def carried_hosts(pinned: str) -> list[str]:
+    """The commands that put those addresses in the guest's `/etc/hosts`.
+
+    Several, not one: the whole block does not survive a single console line.
+    Appended rather than written, and starting on a newline of its own,
+    because the medium's own entry for localhost is in there and it is not
+    required to end in a newline.
     """
-    first = pinned.split("\\n", 1)[0].split(" ", 1)[-1] if pinned else ""
-    # `-s files`, not a plain lookup: a name DNS can also answer proves nothing
-    # about the file, and the first diagnostic could not tell them apart.
-    # Newline first, because the medium's own `/etc/hosts` may not end in one
-    # and the first pinned entry would be glued to its last line.
-    return (
-        f"printf '\\n{pinned}' >> /etc/hosts; "
-        f"printf 'PINNED_%s_LINES\\n' \"$(grep -c . /etc/hosts)\"; "
-        f"getent -s files hosts {first} > /dev/null && printf 'PINNED_IN_FILES\\n' "
-        f"|| printf 'PINNED_NOT_IN_FILES\\n'"
+    if not pinned:
+        return []
+    commands: list[str] = ["printf '\\n' >> /etc/hosts"]
+    batch = ""
+    for line in pinned.split("\\n"):
+        if not line:
+            continue
+        if len(batch) + len(line) + 2 > CONSOLE_LINE_BYTES:
+            commands.append(f"printf '{batch}' >> /etc/hosts")
+            batch = ""
+        batch += f"{line}\\n"
+    if batch:
+        commands.append(f"printf '{batch}' >> /etc/hosts")
+    first = pinned.split("\\n", 1)[0].split(" ", 1)[-1]
+    last = [one for one in pinned.split("\\n") if one][-1].split(" ", 1)[-1]
+    # Both ends, because a line that was cut kept its beginning: asking only
+    # about the first name answered `in files` for three rounds while the
+    # mirror the install actually needed was missing.
+    commands.append(f"printf 'PINNED_%s_LINES\\n' \"$(grep -c . /etc/hosts)\"")
+    commands.append(
+        f"getent -s files hosts {first} > /dev/null "
+        f"&& getent -s files hosts {last} > /dev/null "
+        f"&& printf 'PINNED_IN_FILES\\n' || printf 'PINNED_NOT_IN_FILES\\n'"
     )
+    return commands
+
 
 
 def configure_statically(address: str, pinned: str = "") -> str:
@@ -826,7 +847,9 @@ def configure_statically(address: str, pinned: str = "") -> str:
     # `\\n` for printf, not a real newline: the whole thing is one line sent to
     # a serial console, and a literal break there is two commands.
     resolvers = "".join(f"nameserver {one}\\n" for one in GUEST_RESOLVERS)
-    carried = carry_hosts(pinned) + "; " if pinned else ""
+    # Not here: the addresses are carried in by `carried_hosts` before the
+    # first probe, and writing them again from this line is what made the file
+    # 101 lines when 68 were written.
     return (
         # Nothing at all once there is a default route. Without this guard the
         # second pass probed the address the first pass had taken, `arping -D`
@@ -840,7 +863,6 @@ def configure_statically(address: str, pinned: str = "") -> str:
         f"printf '{resolvers}' > /etc/resolv.conf; "
         # Appended, never written: the medium's own entry for localhost is in
         # there and replacing the file takes it away.
-        f"{carried}"
         "ip -4 route show default | grep -q . || true"
     )
 
@@ -905,7 +927,8 @@ def wait_for_network(
     # twenty steps later, so a guest that reached a mirror once was left
     # depending on it for the rest of the install.
     if pinned:
-        link.run(carry_hosts(pinned), timeout=120.0)
+        for command in carried_hosts(pinned):
+            link.run(command, timeout=120.0)
     asked = False
     while time.monotonic() < deadline:
         said = link.expect_output(NETWORK_PROBE, timeout=180.0)


### PR DESCRIPTION
Three rounds pinned thirty-three addresses into a guest `/etc/hosts` and then failed to resolve one of them. The diagnostic added for it answered `in files` every time, and the reason both were true is the console: the write was one line of 1349 characters, a tty edits in canonical mode and drops what does not fit, and the names are sorted — so `distfiles.gentoo.org`, which the diagnostic asked about, was always present while `mirrors.nju.edu.cn`, which the install needs, was cut off.

`PINNED_NOT_IN_FILES` appeared for two guests in six once the diagnostic asked the files backend rather than any resolver, which is what named the cause.

The addresses now go in batches that fit a line, the diagnostic asks about both ends of the block, and `configure_statically` no longer writes them a second time — that duplicate is why the file held 101 lines when 68 were written.