### PR TITLE
vm: the console line limit was never measured cutting anything

### DIFF
--- a/tests/unit/test_harness.py
+++ b/tests/unit/test_harness.py
@@ -2437,10 +2437,10 @@ def test_a_file_that_cannot_be_written_does_not_end_the_run(tmp_path: Path) -> N
 
 
 def test_the_carried_hosts_fit_one_console_line_each() -> None:
-    """A tty edits in canonical mode and drops what does not fit. One line
-    carrying every pinned address is 1349 characters, and two guests in six
-    wrote an `/etc/hosts` whose late entries were never there — while the
-    first entry, which the diagnostic asked about, always was."""
+    """A tty edits in canonical mode and drops what does not fit, and one line
+    carrying every pinned address is 1349 characters. Nothing here was ever
+    measured being cut: the guests that were suspected of it all answered
+    `PINNED_IN_FILES`. The split is what keeps the question from returning."""
     from tests.vm.cluster import carried_hosts, pinned_hosts
 
     commands = carried_hosts(pinned_hosts())

--- a/tests/vm/cluster.py
+++ b/tests/vm/cluster.py
@@ -788,11 +788,12 @@ def pinned_hosts() -> str:
     return "".join(f"{line}\\n" for line in lines)
 
 
-#: How much of one command line a serial console carries. The tty edits in
-#: canonical mode and drops what does not fit, and one line carrying every
-#: pinned address is 1349 characters: two guests in six wrote a `/etc/hosts`
-#: whose late entries — `mirrors.nju.edu.cn` among them — were never there,
-#: while the first entry the diagnostic asked about always was.
+#: How much of one command line to send at a time. One line carrying every
+#: pinned address is 1349 characters, which is more than a tty edits in
+#: canonical mode without dropping the rest, so the block is split whether or
+#: not it has ever been cut here: forty-two guests answered `PINNED_IN_FILES`
+#: with the whole thing on one line, so the truncation this guards against is
+#: a property of the console rather than something measured on this cluster.
 CONSOLE_LINE_BYTES: Final[int] = 200
 
 


### PR DESCRIPTION
The comment introduced with the batched writes said two guests in six wrote an `/etc/hosts` whose late entries were never there. That reading counted the command echo: the line that asks the question contains both `PINNED_IN_FILES` and `PINNED_NOT_IN_FILES` as literals, so every guest appeared to answer both. Counting only the output lines, forty-two guests answered `PINNED_IN_FILES` and none answered otherwise.

The split stays — 1349 characters on one console line is fragile whether or not it has been cut here — but it is not the cause of the stage3 failures, and the comment no longer says it was.