### PR TITLE
stage3: try every mirror of the region, not only the first

### DIFF
--- a/gentoo_install/exec/apply.py
+++ b/gentoo_install/exec/apply.py
@@ -265,12 +265,26 @@ class Machine:
         self.runner.log(f"fetching {url}")
         return fetch.text(url)
 
-    def fetch_stage3(self, mirror: str, variant: str, fingerprint: str) -> PurePosixPath:
+    def fetch_stage3(
+        self,
+        mirror: str,
+        variant: str,
+        fingerprint: str,
+        fallbacks: Sequence[str] = (),
+    ) -> PurePosixPath:
         """Downloaded onto the target, not into the work directory: that is a
         tmpfs on an install medium, and a stage3 there costs the memory the
         emerge is about to need."""
         return PurePosixPath(
-            fetch.stage3(mirror, variant, fingerprint, self.mountpoint / STAGE3_CACHE, self.runner)
+            fetch.stage3(
+                mirror,
+                variant,
+                fingerprint,
+                self.mountpoint / STAGE3_CACHE,
+                self.runner,
+                self.config.proxy,
+                fallbacks,
+            )
         )
 
     def zfs_kernel_max(self) -> KernelCeiling:

--- a/gentoo_install/exec/fetch.py
+++ b/gentoo_install/exec/fetch.py
@@ -24,7 +24,7 @@ import urllib.error
 import urllib.parse
 import urllib.request
 from pathlib import Path
-from collections.abc import Iterator
+from collections.abc import Iterator, Sequence
 from typing import Any, Callable, Final, cast
 
 from ..errors import (
@@ -87,6 +87,7 @@ def stage3(
     work: Path,
     runner: Runner,
     proxy: ProxyConfig | None = None,
+    fallbacks: Sequence[str] = (),
 ) -> Path:
     """Download the newest stage3 of `variant`, verify it, return where it is.
 
@@ -94,7 +95,32 @@ def stage3(
     download of several gigabytes. It names the digest it was written for and
     that digest is recomputed here, because an empty marker beside a replaced
     or corrupted archive was an integrity check that verified nothing.
+
+    `fallbacks` are tried in order when the first mirror cannot be reached at
+    all: a name that does not resolve or a host that refuses ends one mirror,
+    not the install, and the machine already has a list of them. A mirror that
+    answers with a file failing its signature is a different thing and stops
+    everything.
     """
+    last: DownloadFailed | None = None
+    for one in (mirror, *fallbacks):
+        try:
+            return _stage3_from(one, variant, fingerprint, work, runner, proxy)
+        except DownloadFailed as failed:
+            last = failed
+            runner.log(f"{one} did not serve the stage3: {failed}")
+    assert last is not None
+    raise last
+
+
+def _stage3_from(
+    mirror: str,
+    variant: str,
+    fingerprint: str,
+    work: Path,
+    runner: Runner,
+    proxy: ProxyConfig | None = None,
+) -> Path:
     selected = proxy if proxy is not None else _bootstrap_proxy(work)
     if selected is not None:
         configure_proxy(selected)

--- a/gentoo_install/plan/operations.py
+++ b/gentoo_install/plan/operations.py
@@ -151,9 +151,17 @@ class Context(Protocol):
         half-configured with nobody watching.
         """
 
-    def fetch_stage3(self, mirror: str, variant: str, fingerprint: str) -> PurePosixPath:
+    def fetch_stage3(
+        self,
+        mirror: str,
+        variant: str,
+        fingerprint: str,
+        fallbacks: Sequence[str] = (),
+    ) -> PurePosixPath:
         """Download the newest stage3 of `variant`, check its signature against
-        `fingerprint` and its digest, and return where it was written."""
+        `fingerprint` and its digest, and return where it was written.
+
+        `fallbacks` are tried in order when a mirror cannot be reached at all."""
 
     def zfs_kernel_max(self) -> KernelCeiling:
         """Read the selected target tree's authoritative ZFS kernel ceiling."""

--- a/gentoo_install/plan/portage.py
+++ b/gentoo_install/plan/portage.py
@@ -126,6 +126,10 @@ class InstallStage3(Operation):
     mirror: str
     variant: str
     proxy: ProxyConfig = ProxyConfig()
+    #: The rest of the region's sites, in order. A mirror that cannot be
+    #: reached at all ends that mirror, not the install: the stage3 fetch was
+    #: the one step in the whole plan with no second address to try.
+    fallbacks: tuple[str, ...] = ()
 
     def describe(self) -> str:
         route = f" via {self.proxy.redacted_url}" if self.proxy.enabled else " directly"
@@ -140,7 +144,9 @@ class InstallStage3(Operation):
             _proxy_toml(self.proxy),
             mode=0o600,
         )
-        archive = context.fetch_stage3(self.mirror, self.variant, RELENG_FINGERPRINT)
+        archive = context.fetch_stage3(
+            self.mirror, self.variant, RELENG_FINGERPRINT, self.fallbacks
+        )
         context.run(
             [
                 "tar", "--extract",
@@ -996,6 +1002,21 @@ class AcceptTestingGlobally(Operation):
         context.append(PurePosixPath("/etc/portage/make.conf"), 'ACCEPT_KEYWORDS="~amd64"\n')
 
 
+def _other_mirrors(config: InstallConfig, chosen: str) -> tuple[str, ...]:
+    """Every other site of the configured region, in its order.
+
+    The stage3 fetch was the one step with a single address: a mirror whose
+    name did not resolve ended the install three minutes in, with the disks
+    already partitioned and mounted.
+    """
+    sites = mirrors.gentoo_sites(config.portage.mirrors.region)
+    return tuple(
+        site.distfiles
+        for site in sites
+        if site.distfiles and site.distfiles.rstrip("/") != chosen.rstrip("/")
+    )
+
+
 def build(
     config: InstallConfig,
     mirror: str,
@@ -1006,7 +1027,12 @@ def build(
     portage = config.portage
     gentoo = PurePosixPath("/var/db/repos/gentoo")
     operations: list[Operation] = [
-        InstallStage3(mirror=mirror, variant=variant_of(config), proxy=config.proxy),
+        InstallStage3(
+            mirror=mirror,
+            variant=variant_of(config),
+            proxy=config.proxy,
+            fallbacks=_other_mirrors(config, mirror),
+        ),
         MountChrootFilesystems(),
         SeedResolver(),
     ]

--- a/tests/unit/recorder.py
+++ b/tests/unit/recorder.py
@@ -145,8 +145,14 @@ class Recorder:
             raise DownloadFailed(f"nothing staged for {url}")
         return self.pages[url]
 
-    def fetch_stage3(self, mirror: str, variant: str, fingerprint: str) -> PurePosixPath:
-        self.commands.append(("fetch-stage3", mirror, variant, fingerprint))
+    def fetch_stage3(
+        self,
+        mirror: str,
+        variant: str,
+        fingerprint: str,
+        fallbacks: Sequence[str] = (),
+    ) -> PurePosixPath:
+        self.commands.append(("fetch-stage3", mirror, variant, fingerprint, *fallbacks))
         return PurePosixPath("/var/cache/gentoo-install/stage3.tar.xz")
 
     def zfs_kernel_max(self) -> KernelCeiling:

--- a/tests/unit/test_fetch.py
+++ b/tests/unit/test_fetch.py
@@ -1,0 +1,80 @@
+# SPDX-License-Identifier: GPL-2.0-or-later
+"""The stage3 fetch, and what it does when a mirror will not answer."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from gentoo_install.errors import DownloadFailed
+from gentoo_install.exec import fetch
+from gentoo_install.exec.runner import Runner
+
+
+def test_a_mirror_that_cannot_be_reached_is_not_the_end_of_the_install(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The stage3 fetch was the one step in the plan with a single address. A
+    name that did not resolve ended the install three minutes in, with the
+    disks already partitioned and mounted."""
+    asked: list[str] = []
+
+    def refusing(
+        mirror: str,
+        variant: str,
+        fingerprint: str,
+        work: Path,
+        runner: Runner,
+        proxy: object = None,
+    ) -> Path:
+        asked.append(mirror)
+        if mirror != "https://third.example":
+            raise DownloadFailed(f"{mirror} could not be reached")
+        return work / "stage3.tar.xz"
+
+    monkeypatch.setattr(fetch, "_stage3_from", refusing)
+
+    where = fetch.stage3(
+        "https://first.example",
+        "systemd",
+        "0" * 40,
+        tmp_path,
+        Runner(log=lambda line: None),
+        None,
+        ("https://second.example", "https://third.example"),
+    )
+
+    assert where.name == "stage3.tar.xz"
+    assert asked == [
+        "https://first.example",
+        "https://second.example",
+        "https://third.example",
+    ]
+
+
+def test_every_mirror_refusing_raises_the_last_reason(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    def refusing(
+        mirror: str,
+        variant: str,
+        fingerprint: str,
+        work: Path,
+        runner: Runner,
+        proxy: object = None,
+    ) -> Path:
+        raise DownloadFailed(f"{mirror} could not be reached")
+
+    monkeypatch.setattr(fetch, "_stage3_from", refusing)
+
+    with pytest.raises(DownloadFailed, match="second.example"):
+        fetch.stage3(
+            "https://first.example",
+            "systemd",
+            "0" * 40,
+            tmp_path,
+            Runner(log=lambda line: None),
+            None,
+            ("https://second.example",),
+        )


### PR DESCRIPTION
The stage3 fetch had one address. A mirror that could not be reached at all — a name that did not resolve, a host that refused — ended the install three minutes in, with the disks already partitioned, formatted and mounted, and that is the shape most of this week`s cluster rounds failed in.

The plan already knows the region`s other sites, so it carries them and the fetch tries each in order. A mirror that answers with a file failing its signature or digest still stops everything: that is a different thing from a mirror that is not there.