### PR TITLE
vm: ask python the same name getent was asked

### DIFF
--- a/tests/unit/test_harness.py
+++ b/tests/unit/test_harness.py
@@ -2473,3 +2473,16 @@ def test_nothing_pinned_carries_nothing() -> None:
 
 
 
+
+
+def test_the_diagnostic_asks_python_as_well_as_getent() -> None:
+    """The installer resolves with Python, so `getent` answering says nothing
+    about it: twenty-three mirrors failed with `EAI_AGAIN` in a guest whose
+    `/etc/hosts` held every one of their names and answered `PINNED_IN_FILES`
+    in the same breath."""
+    from tests.vm.cluster import carried_hosts
+
+    asked = " ".join(carried_hosts("1.1.1.1 first.example\\n2.2.2.2 last.example\\n"))
+
+    assert "socket.getaddrinfo" in asked
+    assert "PINNED_PYTHON_RESOLVES" in asked and "PINNED_PYTHON_FAILS" in asked

--- a/tests/vm/cluster.py
+++ b/tests/vm/cluster.py
@@ -829,6 +829,14 @@ def carried_hosts(pinned: str) -> list[str]:
         f"&& getent -s files hosts {last} > /dev/null "
         f"&& printf 'PINNED_IN_FILES\\n' || printf 'PINNED_NOT_IN_FILES\\n'"
     )
+    # The installer resolves with Python, and `getent` answering says nothing
+    # about that: twenty-three mirrors failed with `EAI_AGAIN` in a guest whose
+    # `/etc/hosts` held every one of their names.
+    commands.append(
+        f"python3 -c 'import socket,sys; socket.getaddrinfo(sys.argv[1], 443)' {first} "
+        f"2>/dev/null && printf 'PINNED_PYTHON_RESOLVES\\n' "
+        f"|| printf 'PINNED_PYTHON_FAILS\\n'"
+    )
     return commands
 
 


### PR DESCRIPTION
A guest wrote thirty-three addresses into `/etc/hosts`, answered `PINNED_IN_FILES` for both ends of the block, and then failed to reach twenty-three mirrors in a row with `Temporary failure in name resolution`. Both cannot be true of one resolver, and the diagnostic only ever asked `getent`, which is not what the installer uses.

It now asks Python for the same name, so the next round says whether the two disagree.