### PR TITLE
convert: swap the userland by rename, not by deleting and copying

### DIFF
--- a/gentoo_install/errors.py
+++ b/gentoo_install/errors.py
@@ -76,3 +76,12 @@ class UploadFailed(GentooInstallError):
 class CommandFailed(GentooInstallError):
     """An external command exited non-zero. The operation did not finish, which
     is a different thing from data that cannot be trusted."""
+
+
+class ConversionFailed(GentooInstallError):
+    """The in-place swap could not be completed.
+
+    Carries what was put back and what was not: this is the one step with no
+    second attempt, and an operator reading it is deciding between a reboot
+    and a rescue medium.
+    """

--- a/gentoo_install/exec/convert.py
+++ b/gentoo_install/exec/convert.py
@@ -1,0 +1,73 @@
+# SPDX-License-Identifier: GPL-2.0-or-later
+"""Atomically replace selected live-system directories with staged ones."""
+
+from __future__ import annotations
+
+import os
+import shutil
+import sys
+from pathlib import Path
+from typing import Sequence
+
+from ..errors import ConversionFailed
+
+
+def convert(staging: Path, names: Sequence[str], *, root: Path = Path("/")) -> None:
+    """Replace each named directory and remove backups after all swaps finish."""
+    try:
+        same = os.stat(staging).st_dev == os.stat(root).st_dev
+    except OSError as error:
+        raise ConversionFailed(f"the staging directory could not be read: {error}") from error
+    if not same:
+        # Rename cannot cross a filesystem, and copying is exactly what this
+        # step exists to avoid: the window would be the whole copy.
+        raise ConversionFailed("the staging directory is not on the root filesystem")
+
+    destinations: list[tuple[str, Path, Path, Path]] = []
+    for name in names:
+        destination = root / name
+        staged = staging / name
+        old = root / f"{name}.gentoo-install.old"
+        if not staged.is_dir():
+            raise ConversionFailed(f"the staging directory has no {name}")
+        if os.path.lexists(old):
+            raise ConversionFailed(f"{old} is left from an earlier attempt")
+        destinations.append((name, destination, staged, old))
+
+    swapped: list[tuple[str, Path, Path, Path]] = []
+    for entry in destinations:
+        name, destination, staged, old = entry
+        moved_old = False
+        try:
+            os.rename(destination, old)
+            moved_old = True
+            os.rename(staged, destination)
+        except OSError as error:
+            if moved_old:
+                try:
+                    os.rename(old, destination)
+                except OSError as rollback_error:
+                    error.add_note(f"could not restore {name}: {rollback_error}")
+            for swapped_name, swapped_destination, swapped_staged, swapped_old in reversed(swapped):
+                try:
+                    os.rename(swapped_destination, swapped_staged)
+                except OSError as rollback_error:
+                    error.add_note(
+                        f"could not restore {swapped_name}: {rollback_error}"
+                    )
+                try:
+                    os.rename(swapped_old, swapped_destination)
+                except OSError as rollback_error:
+                    error.add_note(
+                        f"could not restore {swapped_name}: {rollback_error}"
+                    )
+            raise ConversionFailed(f"{name} could not be swapped: {error}") from error
+        swapped.append(entry)
+
+    # Said rather than raised: every name is already swapped by now, so the
+    # machine is converted and a directory left behind is not a failure of it.
+    for name, _, _, old in swapped:
+        try:
+            shutil.rmtree(old)
+        except OSError as error:
+            print(f"{old} stayed behind: {error}", file=sys.stderr)

--- a/tests/unit/test_convert.py
+++ b/tests/unit/test_convert.py
@@ -1,0 +1,113 @@
+# SPDX-License-Identifier: GPL-2.0-or-later
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+import pytest
+
+from gentoo_install.errors import ConversionFailed
+from gentoo_install.exec import convert
+
+
+def _directory(path: Path, content: str) -> None:
+    path.mkdir()
+    (path / "content").write_text(content)
+
+
+def test_swapping_several_directories_removes_backups(tmp_path: Path) -> None:
+    root = tmp_path / "root"
+    staging = tmp_path / "staging"
+    root.mkdir()
+    staging.mkdir()
+    names = ("bin", "etc", "usr")
+    for name in names:
+        _directory(root / name, f"old {name}")
+        _directory(staging / name, f"new {name}")
+
+    convert.convert(staging, names, root=root)
+
+    for name in names:
+        assert (root / name / "content").read_text() == f"new {name}"
+        assert not (root / f"{name}.gentoo-install.old").exists()
+
+
+def test_different_filesystem_is_refused_before_any_rename(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    root = tmp_path / "root"
+    staging = tmp_path / "staging"
+    root.mkdir()
+    staging.mkdir()
+    _directory(root / "etc", "old")
+    _directory(staging / "etc", "new")
+    real_stat = os.stat
+    root_device = real_stat(root).st_dev
+    staging_device = root_device + 1
+
+    def fake_stat(path: os.PathLike[str] | str) -> os.stat_result:
+        result = real_stat(path)
+        if Path(path) == root:
+            values = list(result)
+            values[2] = staging_device
+            return os.stat_result(values)
+        return result
+
+    monkeypatch.setattr(os, "stat", fake_stat)
+
+    with pytest.raises(ConversionFailed, match="not on the root filesystem"):
+        convert.convert(staging, ("etc",), root=root)
+    assert (root / "etc" / "content").read_text() == "old"
+    assert (staging / "etc" / "content").read_text() == "new"
+
+
+def test_rename_failure_restores_previous_swaps(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    root = tmp_path / "root"
+    staging = tmp_path / "staging"
+    root.mkdir()
+    staging.mkdir()
+    names = ("one", "two", "three")
+    for name in names:
+        _directory(root / name, f"old {name}")
+        _directory(staging / name, f"new {name}")
+    real_rename = os.rename
+    calls = 0
+
+    def failing_rename(source: os.PathLike[str] | str, destination: os.PathLike[str] | str) -> None:
+        nonlocal calls
+        calls += 1
+        if calls == 5:
+            raise OSError("injected rename failure")
+        real_rename(source, destination)
+
+    monkeypatch.setattr(os, "rename", failing_rename)
+
+    # Wrapped, not re-raised: `errors.py` owns what leaves this package, and
+    # the message still carries what the kernel said.
+    with pytest.raises(ConversionFailed, match="injected rename failure"):
+        convert.convert(staging, names, root=root)
+
+    for name in names:
+        assert (root / name / "content").read_text() == f"old {name}"
+        assert not (root / f"{name}.gentoo-install.old").exists()
+        if name != "three":
+            assert (staging / name / "content").read_text() == f"new {name}"
+
+
+def test_existing_backup_is_refused_before_any_rename(tmp_path: Path) -> None:
+    root = tmp_path / "root"
+    staging = tmp_path / "staging"
+    root.mkdir()
+    staging.mkdir()
+    _directory(root / "etc", "old")
+    _directory(staging / "etc", "new")
+    _directory(root / "etc.gentoo-install.old", "previous")
+
+    with pytest.raises(ConversionFailed, match="left from an earlier attempt"):
+        convert.convert(staging, ("etc",), root=root)
+
+    assert (root / "etc" / "content").read_text() == "old"
+    assert (root / "etc.gentoo-install.old" / "content").read_text() == "previous"
+    assert (staging / "etc" / "content").read_text() == "new"


### PR DESCRIPTION
The one irreversible step of an in-place conversion, made as short as it can be. `distro2gentoo` removes the old root with `find -delete` and then copies the staged tree in, so the window in which neither system exists lasts the whole copy; a machine losing power there has neither. Staging on the same filesystem makes each directory a rename, and the window one syscall.

It refuses before touching anything when the staging directory is on another filesystem, when a name is missing from it, or when a `.gentoo-install.old` from an earlier attempt is still there. A rename that fails partway puts back what was already swapped, in reverse, and the failure it raises carries what could not be restored rather than being replaced by it.