### PR TITLE
vm: tell the resolver to read the file it was given

### DIFF
--- a/tests/unit/test_harness.py
+++ b/tests/unit/test_harness.py
@@ -2486,3 +2486,17 @@ def test_the_diagnostic_asks_python_as_well_as_getent() -> None:
 
     assert "socket.getaddrinfo" in asked
     assert "PINNED_PYTHON_RESOLVES" in asked and "PINNED_PYTHON_FAILS" in asked
+
+
+def test_the_resolver_is_told_to_read_the_file() -> None:
+    """`/etc/hosts` is consulted only if `nsswitch.conf` says so, and
+    `getent -s files` bypasses nsswitch, so it cannot tell one from the other:
+    a guest answered `PINNED_IN_FILES` and then failed to resolve the same
+    name for twenty-three mirrors in a row."""
+    from tests.vm.cluster import carried_hosts
+
+    commands = carried_hosts("1.1.1.1 first.example\\n2.2.2.2 last.example\\n")
+
+    assert "nsswitch.conf" in commands[0]
+    assert "hosts: files dns" in commands[0]
+    assert commands.index(next(one for one in commands if "/etc/hosts" in one)) > 0

--- a/tests/vm/cluster.py
+++ b/tests/vm/cluster.py
@@ -807,7 +807,14 @@ def carried_hosts(pinned: str) -> list[str]:
     """
     if not pinned:
         return []
-    commands: list[str] = ["printf '\\n' >> /etc/hosts"]
+    # The file is only consulted if `nsswitch.conf` says so, and `getent -s
+    # files` proves nothing about that because it bypasses nsswitch entirely:
+    # a guest answered `PINNED_IN_FILES` and then failed to resolve the same
+    # name twenty-three times.
+    commands: list[str] = [
+        "printf 'hosts: files dns\\n' > /etc/nsswitch.conf",
+        "printf '\\n' >> /etc/hosts",
+    ]
     batch = ""
     for line in pinned.split("\\n"):
         if not line:


### PR DESCRIPTION
Every fixture of the last round failed at the stage3 fetch, each after trying twenty-three mirrors, in guests that had just answered `PINNED_IN_FILES` for both ends of the pinned block. Those two facts are only compatible if the resolver never reads the file: `getent -s files` asks the files backend directly and bypasses `nsswitch.conf`, so it can say the name is in `/etc/hosts` while `getaddrinfo` — which is what the installer uses — consults DNS alone.

The guest is now given `hosts: files dns` before the addresses are written.