### PR TITLE
model: a configuration can convert the running system

### DIFF
--- a/gentoo_install/model/config.py
+++ b/gentoo_install/model/config.py
@@ -32,6 +32,11 @@ PERSISTED_SECTIONS: Final[tuple[str, ...]] = (
 )
 
 
+class DiskMode(Enum):
+    PARTITION = "partition"
+    IN_PLACE = "in-place"
+
+
 class InitSystem(Enum):
     OPENRC = "openrc"
     SYSTEMD = "systemd"
@@ -421,8 +426,9 @@ class BootloaderConfig:
 @dataclass(frozen=True)
 class DiskConfig:
     graph: DeviceGraph
-    #: Named explicitly: a malformed graph can hold two mountpoints for `/`.
+    #: Empty means the running layout supplies the root.
     root: DeviceId
+    mode: DiskMode = DiskMode.PARTITION
 
 
 @dataclass(frozen=True)

--- a/gentoo_install/model/parse.py
+++ b/gentoo_install/model/parse.py
@@ -24,6 +24,7 @@ from .config import (
     BootloaderConfig,
     ConsoleFontSize,
     DiskConfig,
+    DiskMode,
     Firewall,
     Firmware,
     InitSystem,
@@ -317,15 +318,18 @@ def _packages(raw: Mapping[str, Any], at: str) -> PackagesConfig:
         display_manager=_str(raw, "display_manager", at, default.display_manager),
     )
 
-
 def _disk(raw: Mapping[str, Any], at: str) -> DiskConfig:
-    _reject_unknown(raw, at, {"root", "devices"})
+    _reject_unknown(raw, at, {"root", "devices", "mode"})
+    mode = _enum(raw, "mode", at, DiskMode, DiskMode.PARTITION)
     devices = _tables(raw, "devices", at)
-    if not devices:
-        raise ConfigError(f"{at}.devices is empty; nothing to install onto")
     nodes = [_node(entry, f"{at}.devices[{n}]") for n, entry in enumerate(devices)]
-    return DiskConfig(graph=DeviceGraph.build(nodes), root=DeviceId(_str(raw, "root", at, required=True)))
-
+    if mode is DiskMode.PARTITION and not nodes:
+        raise ConfigError(f"{at}.devices is empty; nothing to install onto")
+    return DiskConfig(
+        graph=DeviceGraph.build(nodes),
+        root=DeviceId(_str(raw, "root", at)),
+        mode=mode,
+    )
 
 def _node(raw: Mapping[str, Any], at: str) -> Node:
     kind = _str(raw, "kind", at, required=True)

--- a/gentoo_install/model/serialise.py
+++ b/gentoo_install/model/serialise.py
@@ -16,7 +16,7 @@ from pathlib import PurePosixPath
 from typing import Any, Final
 
 from . import config as model_config
-from .config import InstallConfig, ProxyConfig
+from .config import DiskMode, InstallConfig, ProxyConfig
 from .device import (
     Existing,
     Filesystem,
@@ -144,7 +144,11 @@ _NOTHING: Final[_Nothing] = _Nothing()
 
 
 def _disk(config: InstallConfig) -> list[str]:
-    lines = ["", "[disk]", f'root = "{config.disk.root}"']
+    lines = ["", "[disk]"]
+    if config.disk.mode is not DiskMode.PARTITION:
+        lines.append(f'mode = "{config.disk.mode.value}"')
+        return lines
+    lines.append(f'root = "{config.disk.root}"')
     for node in config.disk.graph.nodes.values():
         kind = KINDS.get(type(node))
         if kind is None:
@@ -161,7 +165,6 @@ def _disk(config: InstallConfig) -> list[str]:
             named = RENAMED.get((type(node), field.name), field.name)
             lines.append(f"{named} = {_value(held)}")
     return lines
-
 
 def _value(held: Any) -> str:
     if isinstance(held, bool):

--- a/gentoo_install/model/validate.py
+++ b/gentoo_install/model/validate.py
@@ -17,7 +17,8 @@ from typing import Collection, Final, Mapping
 
 from ..errors import CommandFailed, ValidationFailed
 from . import compat
-from .config import InitSystem, InstallConfig, Networking, ProxyKind
+from .compat import Trait
+from .config import Bootloader, DiskMode, InitSystem, InstallConfig, Networking, ProxyKind
 from .device import (
     DeviceGraph,
     DeviceId,
@@ -185,30 +186,49 @@ def validate(
     ),
 ) -> None:
     address_facts = _derive_address_facts(config)
+    graph_problems: list[str] = []
+    if config.disk.mode is DiskMode.PARTITION:
+        graph_problems = [
+            *_layout_problems(config),
+            *compat.filesystem_label_problems(config),
+            *root_size_problems(config),
+            *_zfs_kernel_problems(config, zfs_kernel_max),
+            *_reuse_problems(config),
+            *_pool_problems(config),
+            *_array_problems(config),
+            *(rule.describe() for rule in compat.violations(config, storage_facts)),
+        ]
     problems = [
+        *_disk_mode_problems(config),
         *_proxy_problems(config),
-        *_layout_problems(config),
-        *compat.filesystem_label_problems(config),
-        *root_size_problems(config),
+        *graph_problems,
         *_profile_problems(config),
         *_repository_profile_problems(config.portage.profile, available_profiles),
-        *_zfs_kernel_problems(config, zfs_kernel_max),
         *_kernel_package_problems(config),
-        *_reuse_problems(config),
-        *_pool_problems(config),
-        *_array_problems(config),
         *_network_problems(config, address_facts.system),
         *_unlock_problems(config, address_facts.remote_unlock),
         *_locale_problems(config),
         *_l10n_problems(config),
         *compat.binhost_subarch_problems(config),
-        *(rule.describe() for rule in compat.violations(config, storage_facts)),
     ]
     if problems:
         raise ValidationFailed(
             "the configuration does not describe an installable system:\n  " + "\n  ".join(problems)
         )
 
+
+def _disk_mode_problems(config: InstallConfig) -> list[str]:
+    disk = config.disk
+    if disk.mode is DiskMode.PARTITION:
+        return []
+    problems: list[str] = []
+    if disk.graph.nodes:
+        problems.append("disk.devices is not allowed in in-place mode")
+    if disk.root:
+        problems.append("disk.root is not allowed in in-place mode")
+    if config.bootloader.kind is Bootloader.ZFSBOOTMENU:
+        problems.append("disk.mode in-place cannot select ZFSBootMenu without a device graph")
+    return problems
 
 def _proxy_problems(config: InstallConfig) -> list[str]:
     """Check proxy syntax for configurations built without the TOML parser."""

--- a/tests/unit/test_parse.py
+++ b/tests/unit/test_parse.py
@@ -12,6 +12,7 @@ from gentoo_install.model.config import (
     BinhostChannel,
     Bootloader,
     ConsoleFontSize,
+    DiskMode,
     InitSystem,
     KernelSource,
     Keywords,
@@ -88,6 +89,13 @@ def test_parsing_needs_no_hardware() -> None:
     assert parse(raw).disk.graph.nodes[DeviceId("disk")]
 
 
+def test_in_place_mode_has_no_device_graph_or_root() -> None:
+    raw = fixture()
+    raw["disk"] = {"mode": "in-place"}
+    disk = parse(raw).disk
+    assert disk.mode is DiskMode.IN_PLACE
+    assert not disk.graph.nodes
+    assert not disk.root
 def test_defaults_apply_when_a_section_is_absent() -> None:
     raw = fixture()
     for section in ("system", "portage", "kernel", "bootloader", "packages"):

--- a/tests/unit/test_validate.py
+++ b/tests/unit/test_validate.py
@@ -10,7 +10,8 @@ import pytest
 
 from gentoo_install.errors import ConfigError, ValidationFailed
 from gentoo_install.model import compat
-from gentoo_install.model.config import InitSystem, InstallConfig
+from gentoo_install.model.config import DiskMode, InitSystem, InstallConfig
+from gentoo_install.model.device import DeviceGraph
 from gentoo_install.model.device import (
     Existing,
     Filesystem,
@@ -48,6 +49,25 @@ def test_the_profile_probe_reads_current_amd64_paths(tmp_path: Path) -> None:
     )
 
 
+def test_an_in_place_configuration_validates_without_a_device_graph() -> None:
+    installation = replace(config(), disk=replace(config().disk, graph=DeviceGraph.build(()), root=i(""), mode=DiskMode.IN_PLACE))
+    validate(installation)
+
+
+def test_in_place_mode_rejects_a_device_graph() -> None:
+    installation = replace(config(), disk=replace(config().disk, mode=DiskMode.IN_PLACE))
+    with pytest.raises(ValidationFailed, match="disk.devices is not allowed"):
+        validate(installation)
+
+
+def test_in_place_mode_rejects_a_graph_root() -> None:
+    installation = replace(config(), disk=replace(config().disk, graph=DeviceGraph.build(()), mode=DiskMode.IN_PLACE))
+    with pytest.raises(ValidationFailed, match="disk.root is not allowed"):
+        validate(installation)
+
+
+def test_partition_mode_is_unaffected() -> None:
+    validate(config())
 def test_a_plain_uefi_install_validates() -> None:
     validate(config())
 


### PR DESCRIPTION
The mode a conversion needs, in the layer that owns configuration. `DiskMode` is an enum rather than a boolean because the two modes differ in where the layout comes from — read from the running machine, or written by the installer — and a third is foreseeable.

`validate()` refuses a device graph or a root id beside the mode, since those describe a layout this mode does not create, and refuses ZFSBootMenu, which needs a pool the installer would have had to make. Everything after the disk stage is unchanged, and the round trip through `serialise` holds.