### PR TITLE
vm: count every pinned line, not the two ends of the block

### DIFF
--- a/tests/unit/test_harness.py
+++ b/tests/unit/test_harness.py
@@ -2500,3 +2500,24 @@ def test_the_resolver_is_told_to_read_the_file() -> None:
     assert "nsswitch.conf" in commands[0]
     assert "hosts: files dns" in commands[0]
     assert commands.index(next(one for one in commands if "/etc/hosts" in one)) > 0
+
+
+def test_every_pinned_line_is_counted_not_just_the_ends() -> None:
+    """The block is written in batches, so the first and last name are in the
+    first and last of them: a batch lost in between leaves both ends in place.
+    `mirrors.ustc.edu.cn` sits in the middle and was the name the install could
+    not resolve while the guest answered `PINNED_IN_FILES`."""
+    from tests.vm.cluster import PINNED_MARK, carried_hosts, pinned_hosts
+
+    commands = carried_hosts(pinned_hosts())
+    counted = [one for one in commands if "_OF_" in one]
+    written = [one for one in commands if ">> /etc/hosts" in one]
+    marks = sum(one.count(PINNED_MARK) for one in written)
+
+    assert len(counted) == 1, "one count, after every batch"
+    wanted = len([one for one in pinned_hosts().split("\\n") if one])
+    assert f"_OF_{wanted}" in counted[0]
+    assert marks == wanted, f"{marks} of {wanted} lines carry the mark to count"
+    assert commands.index(counted[0]) > commands.index(written[-1]), (
+        "counted after the last batch was written"
+    )

--- a/tests/vm/cluster.py
+++ b/tests/vm/cluster.py
@@ -796,6 +796,10 @@ def pinned_hosts() -> str:
 #: a property of the console rather than something measured on this cluster.
 CONSOLE_LINE_BYTES: Final[int] = 200
 
+#: Written after every pinned address so the guest can count them. A
+#: comment to `/etc/hosts`, which ignores everything after a hash.
+PINNED_MARK: Final[str] = "# gentoo-install"
+
 
 def carried_hosts(pinned: str) -> list[str]:
     """The commands that put those addresses in the guest's `/etc/hosts`.
@@ -815,16 +819,25 @@ def carried_hosts(pinned: str) -> list[str]:
         "printf 'hosts: files dns\\n' > /etc/nsswitch.conf",
         "printf '\\n' >> /etc/hosts",
     ]
+    # Every line carries the marker, so the count below says exactly how many
+    # arrived. Checking the two ends could not: they are in the first and last
+    # batch, and a batch lost in between leaves both of them in place.
+    wanted = 0
     batch = ""
     for line in pinned.split("\\n"):
         if not line:
             continue
-        if len(batch) + len(line) + 2 > CONSOLE_LINE_BYTES:
+        wanted += 1
+        marked = f"{line} {PINNED_MARK}"
+        if len(batch) + len(marked) + 2 > CONSOLE_LINE_BYTES:
             commands.append(f"printf '{batch}' >> /etc/hosts")
             batch = ""
-        batch += f"{line}\\n"
+        batch += f"{marked}\\n"
     if batch:
         commands.append(f"printf '{batch}' >> /etc/hosts")
+    commands.append(
+        f"printf 'PINNED_%s_OF_{wanted}\\n' \"$(grep -c '{PINNED_MARK}' /etc/hosts)\""
+    )
     first = pinned.split("\\n", 1)[0].split(" ", 1)[-1]
     last = [one for one in pinned.split("\\n") if one][-1].split(" ", 1)[-1]
     # Both ends, because a line that was cut kept its beginning: asking only


### PR DESCRIPTION
The diagnostic asked whether the first and last pinned name were in `/etc/hosts`, which was the right question when the block went in as one line and the wrong one once it went in batches: the two ends are in the first and last batch, so a batch lost in between leaves both of them in place. `mirrors.ustc.edu.cn` sits in the middle, and it is the name the install could not resolve in a guest that had just answered `PINNED_IN_FILES`.

Every pinned line now carries a comment marker, and the guest counts them: `PINNED_31_OF_33` says which batch went missing instead of hiding it.