### PR TITLE
fetch: a read that failed says what the resolver was told

### DIFF
--- a/gentoo_install/exec/fetch.py
+++ b/gentoo_install/exec/fetch.py
@@ -758,12 +758,40 @@ def _read(url: str, proxy: ProxyConfig | None = None) -> str:
     raise last
 
 
+def _resolver_state(url: str) -> str:
+    """What the machine says about this name, when a fetch could not read it.
+
+    Twenty-three mirrors failed with `EAI_AGAIN` in guests whose `/etc/hosts`
+    held every one of their names, and no diagnostic outside the failing
+    process could tell which of the two was wrong.
+    """
+    host = urllib.parse.urlsplit(url).hostname
+    if host is None:
+        return ""
+    try:
+        nsswitch = Path("/etc/nsswitch.conf").read_text(encoding="utf-8")
+    except OSError:
+        nsswitch = ""
+    order = next(
+        (line.strip() for line in nsswitch.splitlines() if line.startswith("hosts:")),
+        "no hosts line",
+    )
+    try:
+        in_file = any(
+            host in line.split("#", 1)[0].split()
+            for line in Path("/etc/hosts").read_text(encoding="utf-8").splitlines()
+        )
+    except OSError:
+        in_file = False
+    return f" [{order}; {host} in /etc/hosts: {in_file}]"
+
+
 def _read_once(url: str, proxy: ProxyConfig | None = None) -> str:
     try:
         with _urlopen(_asked(url), proxy, TIMEOUT) as response:
             return str(response.read().decode("utf-8", "replace"))
     except (urllib.error.URLError, TimeoutError, OSError) as error:
-        raise DownloadFailed(f"{url} could not be read: {error}") from error
+        raise DownloadFailed(f"{url} could not be read: {error}{_resolver_state(url)}") from error
 
 
 #: A stage3 is a quarter of a gigabyte over whatever link the operator has, so

--- a/tests/unit/test_fetch.py
+++ b/tests/unit/test_fetch.py
@@ -78,3 +78,51 @@ def test_every_mirror_refusing_raises_the_last_reason(
             None,
             ("https://second.example",),
         )
+
+
+def test_a_read_that_failed_says_what_the_resolver_was_told(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Twenty-three mirrors failed with `EAI_AGAIN` in guests whose
+    `/etc/hosts` held every one of their names, and no diagnostic outside the
+    failing process could say which of the two was wrong."""
+    hosts = tmp_path / "hosts"
+    hosts.write_text("210.28.130.3 mirrors.nju.edu.cn # gentoo-install\n")
+    nsswitch = tmp_path / "nsswitch.conf"
+    nsswitch.write_text("passwd: files\nhosts: files dns\n")
+
+    real_read = Path.read_text
+
+    def reading(self: Path, *args: object, **rest: object) -> str:
+        if str(self) == "/etc/hosts":
+            return real_read(hosts)
+        if str(self) == "/etc/nsswitch.conf":
+            return real_read(nsswitch)
+        return real_read(self)
+
+    monkeypatch.setattr(Path, "read_text", reading)
+
+    said = fetch._resolver_state("https://mirrors.nju.edu.cn/gentoo/x")
+
+    assert "hosts: files dns" in said
+    assert "mirrors.nju.edu.cn in /etc/hosts: True" in said
+
+
+def test_a_name_absent_from_the_file_is_said_so(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    hosts = tmp_path / "hosts"
+    hosts.write_text("127.0.0.1 localhost\n")
+    real_read = Path.read_text
+
+    def reading(self: Path, *args: object, **rest: object) -> str:
+        if str(self) == "/etc/hosts":
+            return real_read(hosts)
+        raise OSError("no nsswitch here")
+
+    monkeypatch.setattr(Path, "read_text", reading)
+
+    said = fetch._resolver_state("https://mirrors.ustc.edu.cn/gentoo/x")
+
+    assert "no hosts line" in said
+    assert "mirrors.ustc.edu.cn in /etc/hosts: False" in said


### PR DESCRIPTION
Six rounds of the cluster matrix died at the stage3 fetch with `Temporary failure in name resolution`, in guests that had written every mirror name into `/etc/hosts` and answered every diagnostic put to them from the shell. Nothing asked the question from inside the process that was failing, which is the only place both halves are visible.

A failed read now carries the `hosts:` line of `/etc/nsswitch.conf` and whether the name it could not resolve is in `/etc/hosts`. This is for the installer log of a real machine as much as for the campaign: an operator whose install stops here gets told which of the two is wrong instead of a bare errno.