### PR TITLE
plan: the staged half of a conversion

### DIFF
--- a/gentoo_install/plan/convert.py
+++ b/gentoo_install/plan/convert.py
@@ -1,0 +1,90 @@
+# SPDX-License-Identifier: GPL-2.0-or-later
+"""The irreversible userland swap in an in-place conversion."""
+
+from __future__ import annotations
+
+import importlib
+from dataclasses import dataclass
+from pathlib import Path, PurePosixPath
+from typing import Protocol, Sequence, cast
+
+from .operations import Context, Operation, Stage
+from .portage import InstallStage3
+
+
+REPLACED_DIRECTORIES: tuple[str, ...] = (
+    "bin",
+    "sbin",
+    "etc",
+    "lib",
+    "lib64",
+    "usr",
+    "var",
+)
+
+
+class _Converter(Protocol):
+    def convert(self, staging: Path, names: Sequence[str], *, root: Path = Path("/")) -> None: ...
+
+
+@dataclass(frozen=True, kw_only=True)
+class InstallStage3InStaging(Operation):
+    """Reuse stage3 fetching while unpacking into the conversion staging root."""
+
+    stage: Stage = Stage.STAGE3
+    source: InstallStage3
+    staging: PurePosixPath = PurePosixPath("/gentoo-install.new")
+
+    def describe(self) -> str:
+        return self.source.describe().replace("into the target", f"into {self.staging}")
+
+    def apply(self, context: Context) -> None:
+        self.source.apply(cast(Context, _StagingContext(parent=context, staging=self.staging)))
+
+
+@dataclass(frozen=True)
+class _StagingContext:
+    parent: Context
+    staging: PurePosixPath
+
+    @property
+    def target(self) -> PurePosixPath:
+        return self.staging
+
+    def run(
+        self,
+        argv: Sequence[str],
+        *,
+        check: bool = True,
+        input_text: str | None = None,
+    ) -> str:
+        return self.parent.run(argv, check=check, input_text=input_text)
+
+    def write(self, path: PurePosixPath, content: str, *, mode: int = 0o644) -> None:
+        self.parent.write(path, content, mode=mode)
+
+    def fetch_stage3(
+        self,
+        mirror: str,
+        variant: str,
+        fingerprint: str,
+        fallbacks: Sequence[str] = (),
+    ) -> PurePosixPath:
+        return self.parent.fetch_stage3(mirror, variant, fingerprint, fallbacks)
+
+
+@dataclass(frozen=True, kw_only=True)
+class SwapDirectories(Operation):
+    """Atomically replace the selected live-system directories."""
+
+    stage: Stage = Stage.BOOTLOADER
+    names: tuple[str, ...] = REPLACED_DIRECTORIES
+    staging: PurePosixPath = PurePosixPath("/gentoo-install.new")
+
+    def describe(self) -> str:
+        return f"atomically swap {', '.join('/' + name for name in self.names)} from {self.staging}"
+
+    def apply(self, context: Context) -> None:
+        module = importlib.import_module("gentoo_install.exec.convert")
+        converter = cast(_Converter, module)
+        converter.convert(Path(str(self.staging)), self.names)

--- a/tests/unit/test_plan_convert.py
+++ b/tests/unit/test_plan_convert.py
@@ -1,0 +1,55 @@
+# SPDX-License-Identifier: GPL-2.0-or-later
+from __future__ import annotations
+
+from dataclasses import replace
+from pathlib import Path, PurePosixPath
+from types import SimpleNamespace
+from typing import Any
+
+import pytest
+
+from gentoo_install.model.config import InstallConfig
+from gentoo_install.plan import disk as plan_disk
+from gentoo_install.plan import portage as plan_portage
+from gentoo_install.plan.bootloader import InstallGrub
+from gentoo_install.plan.build import build
+from gentoo_install.plan.convert import SwapDirectories
+from gentoo_install.plan.operations import Stage
+from gentoo_install.model.config import DiskConfig, DiskMode
+from gentoo_install.model.device import DeviceGraph, DeviceId
+from gentoo_install.plan.packages import Catalog, Group
+
+from .layouts import config
+
+
+CATALOG: Catalog = {"console": Group(name="console", packages=("app-editors/vim",))}
+
+
+def _in_place() -> InstallConfig:
+    """A conversion carries no device graph: the layout comes from the machine,
+    and `validate()` refuses one beside the mode."""
+    return replace(
+        config(),
+        disk=DiskConfig(graph=DeviceGraph.build([]), root=DeviceId(""), mode=DiskMode.IN_PLACE),
+    )
+
+
+def test_partition_mode_keeps_the_ordinary_list() -> None:
+    ordinary = build(config(), CATALOG)
+    explicit = build(replace(config(), disk=replace(config().disk)), CATALOG)
+    assert tuple(type(operation) for operation in explicit) == tuple(type(operation) for operation in ordinary)
+
+
+def test_conversion_operation_describes_and_applies(monkeypatch: pytest.MonkeyPatch) -> None:
+    called: list[tuple[Path, tuple[str, ...]]] = []
+
+    def convert(staging: Any, names: tuple[str, ...]) -> None:
+        called.append((staging, names))
+
+    from gentoo_install.exec import convert as executor
+
+    monkeypatch.setattr(executor, "convert", convert)
+    operation = SwapDirectories()
+    assert operation.describe()
+    operation.apply(SimpleNamespace(target=PurePosixPath("/target")))
+    assert called == [(Path("/gentoo-install.new"), operation.names)]


### PR DESCRIPTION
The reversible part of an in-place conversion: the stage3 unpacks into a directory on the running root instead of a mounted target, everything after it is the ordinary install`s own operations, and the swap is one operation over that directory.

`build` does not select this path yet. `bootloader.build` reads `graph[config.disk.root]`, and a conversion has no device graph — its root comes from what `probe.storage_layout()` found on the machine. Wiring the mode in before that is done would make a path that cannot describe its own last step.