### PR TITLE
vm: a lease older than any run is taken over

### DIFF
--- a/tests/unit/test_harness.py
+++ b/tests/unit/test_harness.py
@@ -2521,3 +2521,37 @@ def test_every_pinned_line_is_counted_not_just_the_ends() -> None:
     assert commands.index(counted[0]) > commands.index(written[-1]), (
         "counted after the last batch was written"
     )
+
+
+def test_a_lease_older_than_any_run_is_taken_over(tmp_path: Path) -> None:
+    """A schedule that is killed never releases what it took. Sixteen rounds
+    left a hundred leases behind and the pool was empty from the first
+    dispatch of the next: the whole campaign died at `no static address is
+    available from 10.31.0.150`."""
+    import os
+    import time
+
+    from tests.vm.cluster import LEASE_SECONDS, AddressPool
+
+    pool = AddressPool(tmp_path, lambda address: False)
+    leases = tmp_path / "addresses"
+    leases.mkdir()
+    stale = leases / "10.31.0.150"
+    stale.touch()
+    old = time.time() - LEASE_SECONDS - 60
+    os.utime(stale, (old, old))
+
+    assert pool.reserve("10.31.0.150") == "10.31.0.150"
+
+
+def test_a_lease_of_a_running_guest_is_left_alone(tmp_path: Path) -> None:
+    """Six hours is longer than any run, so a guest still installing keeps the
+    address it was given."""
+    from tests.vm.cluster import AddressPool
+
+    pool = AddressPool(tmp_path, lambda address: False)
+    leases = tmp_path / "addresses"
+    leases.mkdir()
+    (leases / "10.31.0.150").touch()
+
+    assert pool.reserve("10.31.0.150") == "10.31.0.151"

--- a/tests/vm/cluster.py
+++ b/tests/vm/cluster.py
@@ -1245,6 +1245,12 @@ class Running:
     created: bool = False
 
 
+#: How long an address lease is honoured. Longer than the longest run, so a
+#: guest still installing never loses its address, and short enough that a
+#: killed schedule frees what it took before the next campaign.
+LEASE_SECONDS: Final[float] = 6 * 60 * 60.0
+
+
 class AddressPool:
     """Reserve static addresses under one host-wide scheduler lock."""
 
@@ -1259,7 +1265,16 @@ class AddressPool:
         self._leases.mkdir(exist_ok=True)
         with self._lock_path.open("a+") as lock:
             fcntl.flock(lock, fcntl.LOCK_EX)
-            held = {path.name for path in self._leases.iterdir()}
+            # A lease older than any run cannot belong to a live guest, and a
+            # schedule that was killed never released its own: sixteen rounds
+            # left a hundred of them and the pool was empty from the first
+            # dispatch of the next.
+            now = time.time()
+            held = {
+                path.name
+                for path in self._leases.iterdir()
+                if now - path.stat().st_mtime < LEASE_SECONDS
+            }
             network, last = preferred.rsplit(".", 1)
             ceiling = GUEST_ADDRESS_BASE + (VMID_LAST - VMID_FIRST)
             for number in range(int(last), ceiling + 1):
@@ -1270,7 +1285,10 @@ class AddressPool:
                 try:
                     lease.touch(exist_ok=False)
                 except FileExistsError:
-                    continue
+                    # Only reached for a lease older than any run, which the
+                    # loop above already decided is nobody's: taking it over
+                    # is the point, and the timestamp says it is ours now.
+                    lease.touch()
                 return address
         raise ProxmoxError(f"no static address is available from {preferred}")
 


### PR DESCRIPTION
The address pool is a directory shared by every run on this machine, and a schedule that is killed never releases what it took. Sixteen rounds of stopping campaigns left a hundred lease files — every address from `.150` to `.249` — and the next campaign died at its first dispatch with `no static address is available from 10.31.0.150`, before making a single guest.

A lease is honoured for six hours, which is longer than any run and short enough that a killed schedule frees what it held before the next campaign starts. An address whose lease is older than that is taken over, and the new timestamp says who holds it now.