### PR TITLE
vm: tell the guest not to ask for AAAA

### DIFF
--- a/tests/unit/test_harness.py
+++ b/tests/unit/test_harness.py
@@ -2555,3 +2555,18 @@ def test_a_lease_of_a_running_guest_is_left_alone(tmp_path: Path) -> None:
     (leases / "10.31.0.150").touch()
 
     assert pool.reserve("10.31.0.150") == "10.31.0.151"
+
+
+def test_the_guest_is_told_not_to_ask_for_aaaa() -> None:
+    """`/etc/hosts` carries IPv4 addresses only, and an `AF_UNSPEC` lookup asks
+    DNS for the AAAA regardless. A resolver that does not answer turns that
+    into `EAI_AGAIN` for the whole call, so a name that is in the file fails
+    anyway: sixteen rounds ended at the stage3 fetch with `hosts: files dns`
+    and `in /etc/hosts: True` printed beside the error."""
+    from tests.vm.cluster import GUEST_RESOLVER, configure_statically
+
+    written = configure_statically("10.31.0.150")
+
+    assert "options no-aaaa" in written
+    assert f"nameserver {GUEST_RESOLVER}" in written
+    assert written.index("options no-aaaa") < written.index("nameserver")

--- a/tests/vm/cluster.py
+++ b/tests/vm/cluster.py
@@ -875,7 +875,14 @@ def configure_statically(address: str, pinned: str = "") -> str:
     prefix = GUEST_PREFIX
     # `\\n` for printf, not a real newline: the whole thing is one line sent to
     # a serial console, and a literal break there is two commands.
-    resolvers = "".join(f"nameserver {one}\\n" for one in GUEST_RESOLVERS)
+    # `no-aaaa` as well as the servers: `/etc/hosts` carries IPv4 addresses
+    # only, and an `AF_UNSPEC` lookup still asks DNS for the AAAA. A resolver
+    # that does not answer turns that into `EAI_AGAIN` for the whole call, so
+    # a name sitting in the file fails anyway — which is what ended sixteen
+    # rounds at the stage3 fetch.
+    resolvers = "options no-aaaa\\n" + "".join(
+        f"nameserver {one}\\n" for one in GUEST_RESOLVERS
+    )
     # Not here: the addresses are carried in by `carried_hosts` before the
     # first probe, and writing them again from this line is what made the file
     # 101 lines when 68 were written.


### PR DESCRIPTION
Sixteen rounds ended at the stage3 fetch with `Temporary failure in name resolution`, and the installer now prints what it saw: `hosts: files dns; enceladus.sg.ext.planetunix.net in /etc/hosts: True`. The order is right and the name is there.

The guests have no IPv6 at all, and `socket.create_connection` calls `getaddrinfo` with no `AI_ADDRCONFIG`, so glibc asks for an AAAA that cannot exist on that machine. The A record comes from the file, the AAAA query goes to a resolver that does not answer, and glibc returns `EAI_AGAIN` for the whole call — a name sitting in `/etc/hosts` fails because of a lookup for an address family the guest does not have.

`options no-aaaa` stops the second query.