### PR TITLE
fetch: name the resolvers when a read fails

### DIFF
--- a/gentoo_install/exec/fetch.py
+++ b/gentoo_install/exec/fetch.py
@@ -783,7 +783,22 @@ def _resolver_state(url: str) -> str:
         )
     except OSError:
         in_file = False
-    return f" [{order}; {host} in /etc/hosts: {in_file}]"
+    return f" [{order}; {host} in /etc/hosts: {in_file}; {_resolvers(Path("/etc/resolv.conf"))}]"
+
+
+def _resolvers(path: Path) -> str:
+    """The servers the C library would have asked, at the moment of the failure.
+
+    A guest reached its mirrors through `curl` and then failed the same names
+    from this process minutes later, which only `/etc/resolv.conf` as it stood
+    at each moment can separate.
+    """
+    try:
+        lines = path.read_text(encoding="utf-8").splitlines()
+    except OSError:
+        return "resolv.conf unreadable"
+    servers = [line.split()[1] for line in lines if line.startswith("nameserver ")]
+    return f"nameservers {servers}" if servers else "no nameserver line"
 
 
 def _read_once(url: str, proxy: ProxyConfig | None = None) -> str:

--- a/tests/unit/test_fetch.py
+++ b/tests/unit/test_fetch.py
@@ -126,3 +126,26 @@ def test_a_name_absent_from_the_file_is_said_so(
 
     assert "no hosts line" in said
     assert "mirrors.ustc.edu.cn in /etc/hosts: False" in said
+
+
+def test_a_failed_read_names_the_servers_the_library_would_have_asked(
+    tmp_path: Path,
+) -> None:
+    resolv = tmp_path / "resolv.conf"
+    resolv.write_text("options no-aaaa\nnameserver 10.31.0.199\nnameserver 223.5.5.5\n")
+    assert fetch._resolvers(resolv) == "nameservers ['10.31.0.199', '223.5.5.5']"
+
+
+def test_a_failed_read_says_so_when_no_resolver_is_configured(tmp_path: Path) -> None:
+    resolv = tmp_path / "resolv.conf"
+    resolv.write_text("options no-aaaa\n")
+    assert fetch._resolvers(resolv) == "no nameserver line"
+
+
+def test_a_failed_read_says_so_when_the_resolver_file_is_missing(tmp_path: Path) -> None:
+    assert fetch._resolvers(tmp_path / "absent") == "resolv.conf unreadable"
+
+
+def test_the_diagnostic_carries_the_resolver_state(tmp_path: Path) -> None:
+    said = fetch._resolver_state("https://mirrors.nju.edu.cn/gentoo/x")
+    assert "nameserver" in said


### PR DESCRIPTION
A guest reached its mirrors through `curl` and then failed the same names from the installer minutes later. The diagnostic beside `EAI_AGAIN` now carries `/etc/resolv.conf` as it stood at the failure, which is the only thing that separates a resolver that stopped answering from one that was never configured.