### PR TITLE
vm: measure the resolver from the guest once the network is up

### DIFF
--- a/tests/unit/test_cluster.py
+++ b/tests/unit/test_cluster.py
@@ -1,6 +1,8 @@
 # SPDX-License-Identifier: GPL-2.0-or-later
 from __future__ import annotations
 
+from typing import cast
+
 import time
 from collections.abc import Callable
 from io import BytesIO
@@ -364,3 +366,32 @@ def test_no_site_leaves_the_region_to_choose(tmp_path: Path) -> None:
 
     assert moved.mirrors.site == ""
     assert moved.mirrors.gentoo_zh.value == "cernet"
+
+
+def test_the_reachability_probe_asks_every_resolver_and_changes_nothing() -> None:
+    probe = cluster.REACHABILITY_PROBE
+    for one in cluster.GUEST_RESOLVERS:
+        assert one in probe
+    assert "> /etc/resolv.conf" not in probe
+    assert "getent ahostsv4" in probe
+
+
+def test_the_network_wait_measures_reachability_once_the_probe_answers() -> None:
+    link = _AnsweringLink(cluster.NETWORK_UP.encode())
+    cluster.wait_for_network(cast(cluster.Reconnecting, link), vmid=9301)
+    assert cluster.REACHABILITY_PROBE in link.ran
+
+
+class _AnsweringLink:
+    """A link whose network probe succeeds on the first pass."""
+
+    def __init__(self, answer: bytes) -> None:
+        self.answer = answer
+        self.ran: list[str] = []
+
+    def expect_output(self, command: str, timeout: float = 0.0) -> bytes:
+        self.ran.append(command)
+        return self.answer
+
+    def run(self, command: str, timeout: float = 0.0) -> None:
+        self.ran.append(command)

--- a/tests/unit/test_proxmox.py
+++ b/tests/unit/test_proxmox.py
@@ -1147,11 +1147,11 @@ def test_the_network_wait_gives_up_rather_than_hanging(
 def test_the_network_wait_returns_as_soon_as_the_guest_answers() -> None:
     from tests.vm import cluster
 
-    tries: list[int] = []
+    tries: list[str] = []
 
     class Late:
         def send(self, line: str) -> None:
-            tries.append(1)
+            tries.append(line)
 
         def send_raw(self, keys: str) -> None:
             pass
@@ -1171,7 +1171,9 @@ def test_the_network_wait_returns_as_soon_as_the_guest_answers() -> None:
 
     link = cluster.Reconnecting(Late, tries=1)
     cluster.wait_for_network(link)
-    assert len(tries) == 3
+    assert len(tries) == 4
+    assert sum(1 for line in tries if "NETWORK_%s" in line) == 2
+    assert "REACH" in tries[-1]
 
 
 def test_the_network_probe_is_sent_again_after_a_reconnect() -> None:

--- a/tests/vm/cluster.py
+++ b/tests/vm/cluster.py
@@ -723,6 +723,21 @@ GUEST_RESOLVER: Final[str] = "10.31.0.199"
 GUEST_RESOLVERS: Final[tuple[str, ...]] = (GUEST_RESOLVER, GUEST_GATEWAY, "223.5.5.5")
 
 
+#: Asked once the network is up, because every round so far has failed at the
+#: stage3 while `/etc/resolv.conf` named a resolver nobody had proved the guest
+#: could reach. Read-only: it rewrites nothing, so a run cannot be changed by
+#: being measured.
+REACHABILITY_PROBE: Final[str] = (
+    "printf 'REACH '; for one in " + " ".join(GUEST_RESOLVERS) + "; do "
+    'ping -c1 -W2 "$one" >/dev/null 2>&1 '
+    "&& printf '%s=up ' \"$one\" || printf '%s=down ' \"$one\"; done; "
+    "printf '\\nLOOKUPS '; for i in 1 2 3 4 5; do "
+    "getent ahostsv4 mirrors.ustc.edu.cn >/dev/null 2>&1 "
+    "&& printf 'ok ' || printf 'fail '; done; printf '\\n'"
+)
+
+
+
 #: What a guest outside the cluster does, where no address is reserved for it.
 #: Any daemon from an earlier attempt is stopped first: dhcpcd that finds one
 #: running prints `sending commands to dhcpcd process` and returns at once.
@@ -969,6 +984,7 @@ def wait_for_network(
     while time.monotonic() < deadline:
         said = link.expect_output(NETWORK_PROBE, timeout=180.0)
         if NETWORK_UP.encode() in said:
+            link.run(REACHABILITY_PROBE, timeout=120.0)
             return
         # Every pass, not once: the fallback asks a DHCP server that answers
         # intermittently, and the static path is cheap to repeat.


### PR DESCRIPTION
Twenty-one rounds ended at the stage3 fetch. The diagnostic added in #343 proved `/etc/resolv.conf` named `10.31.0.199` at the moment of failure, and `dig` inside the resolver container answers correctly, but no measurement has ever been taken from a guest. The guest now pings each configured resolver and runs five lookups once the network probe answers, so the log says which of the two is wrong.