### PR TITLE
vm: write the resolvers before the first network probe

### DIFF
--- a/tests/unit/test_cluster.py
+++ b/tests/unit/test_cluster.py
@@ -395,3 +395,16 @@ class _AnsweringLink:
 
     def run(self, command: str, timeout: float = 0.0) -> None:
         self.ran.append(command)
+
+
+def test_the_resolvers_are_written_before_the_first_network_probe() -> None:
+    link = _AnsweringLink(cluster.NETWORK_UP.encode())
+    cluster.wait_for_network(cast(cluster.Reconnecting, link), vmid=9301)
+    written = link.ran.index(cluster.use_our_resolvers())
+    probed = next(i for i, one in enumerate(link.ran) if "NETWORK_%s" in one)
+    assert written < probed
+
+
+def test_the_interface_configuration_no_longer_carries_the_resolvers() -> None:
+    """Two writers of one file is how the fallback undid the early write."""
+    assert "/etc/resolv.conf" not in cluster.configure_statically("10.31.0.150")

--- a/tests/unit/test_harness.py
+++ b/tests/unit/test_harness.py
@@ -2563,9 +2563,9 @@ def test_the_guest_is_told_not_to_ask_for_aaaa() -> None:
     into `EAI_AGAIN` for the whole call, so a name that is in the file fails
     anyway: sixteen rounds ended at the stage3 fetch with `hosts: files dns`
     and `in /etc/hosts: True` printed beside the error."""
-    from tests.vm.cluster import GUEST_RESOLVER, configure_statically
+    from tests.vm.cluster import GUEST_RESOLVER, use_our_resolvers
 
-    written = configure_statically("10.31.0.150")
+    written = use_our_resolvers()
 
     assert "options no-aaaa" in written
     assert f"nameserver {GUEST_RESOLVER}" in written

--- a/tests/unit/test_proxmox.py
+++ b/tests/unit/test_proxmox.py
@@ -1171,7 +1171,7 @@ def test_the_network_wait_returns_as_soon_as_the_guest_answers() -> None:
 
     link = cluster.Reconnecting(Late, tries=1)
     cluster.wait_for_network(link)
-    assert len(tries) == 4
+    assert len(tries) == 5
     assert sum(1 for line in tries if "NETWORK_%s" in line) == 2
     assert "REACH" in tries[-1]
 
@@ -1202,10 +1202,11 @@ def test_the_network_probe_is_sent_again_after_a_reconnect() -> None:
             return False
 
         def expect(self, pattern: str, timeout: float, idle: float = 0.0) -> bytes:
-            if self.drop:
+            probed = any(cluster.NETWORK_PROBE in line for line in self.sent)
+            if self.drop and probed:
                 self.drop = False
                 raise ConsoleClosed("termproxy disconnected")
-            if not any(cluster.NETWORK_PROBE in line for line in self.sent):
+            if not self.sent:
                 raise ConsoleTimeout("the reopened console received no probe")
             if "BEGIN" in pattern:
                 return b"MARK_2_BEGIN"
@@ -2861,6 +2862,7 @@ def test_a_guest_is_given_an_address_rather_than_asking_for_one() -> None:
         GUEST_RESOLVERS,
         configure_statically,
         static_address,
+        use_our_resolvers,
     )
     from tests.vm.proxmox import VMID_FIRST, VMID_LAST
 
@@ -2875,8 +2877,10 @@ def test_a_guest_is_given_an_address_rather_than_asking_for_one() -> None:
     assert "arping -D" not in command
     assert "addr add 10.31.0.113/24" in command
     assert f"via {GUEST_GATEWAY}" in command
+    resolvers = use_our_resolvers()
+    assert "\n" not in resolvers, "one line: this goes to a serial console"
     for one in GUEST_RESOLVERS:
-        assert f"nameserver {one}" in command
+        assert f"nameserver {one}" in resolvers
 
 
 def test_two_workers_reserve_different_static_addresses(tmp_path: Path) -> None:

--- a/tests/vm/cluster.py
+++ b/tests/vm/cluster.py
@@ -895,9 +895,6 @@ def configure_statically(address: str, pinned: str = "") -> str:
     # that does not answer turns that into `EAI_AGAIN` for the whole call, so
     # a name sitting in the file fails anyway — which is what ended sixteen
     # rounds at the stage3 fetch.
-    resolvers = "options no-aaaa\\n" + "".join(
-        f"nameserver {one}\\n" for one in GUEST_RESOLVERS
-    )
     # Not here: the addresses are carried in by `carried_hosts` before the
     # first probe, and writing them again from this line is what made the file
     # 101 lines when 68 were written.
@@ -911,11 +908,29 @@ def configure_statically(address: str, pinned: str = "") -> str:
         f'ip -4 addr add {network}.{last}/{prefix} dev "$dev"; '
         f'ip -4 route replace default via {gateway} dev "$dev" 2>/dev/null; '
         "done; }; "
-        f"printf '{resolvers}' > /etc/resolv.conf; "
         # Appended, never written: the medium's own entry for localhost is in
         # there and replacing the file takes it away.
         "ip -4 route show default | grep -q . || true"
     )
+
+
+def use_our_resolvers() -> str:
+    """Point the guest at the resolver the cluster runs, whatever DHCP said.
+
+    The segment's DHCP server hands out a resolver on a Raspberry Pi that
+    answers intermittently. A guest whose first network probe succeeded kept
+    that resolver for the whole install, which is why one guest in a round
+    fetched its stage3 and the rest failed every mirror.
+    """
+    # `\\n` for printf, not a real newline: the whole thing is one line sent to
+    # a serial console, and a literal break there is two commands.
+    # `no-aaaa` as well as the servers: an `AF_UNSPEC` lookup asks for the AAAA
+    # too, and a resolver that does not answer turns that into `EAI_AGAIN` for
+    # the whole call even when the A record arrived.
+    resolvers = "options no-aaaa\\n" + "".join(
+        f"nameserver {one}\\n" for one in GUEST_RESOLVERS
+    )
+    return f"printf '{resolvers}' > /etc/resolv.conf"
 
 
 def _address_is_taken(address: str) -> bool:
@@ -980,6 +995,10 @@ def wait_for_network(
     if pinned:
         for command in carried_hosts(pinned):
             link.run(command, timeout=120.0)
+    # Before the probe, for the same reason the pinned names are: a probe that
+    # succeeds returns without ever running the fallback, so a resolver written
+    # only in the fallback reaches the guests that needed it least.
+    link.run(use_our_resolvers(), timeout=120.0)
     asked = False
     while time.monotonic() < deadline:
         said = link.expect_output(NETWORK_PROBE, timeout=180.0)


### PR DESCRIPTION
The reachability probe added in #344 answered `10.31.0.199=up` and five lookups out of five on every guest, and three of the four still failed every mirror at the stage3. The resolver write sat in the fallback that only runs after a failed probe, so a guest whose first probe answered kept the DHCP-provided resolver for the whole install. It is now written before the probe, like the pinned names, and `configure_statically` no longer writes the file at all.