### PR TITLE
vm: measure the unspecified family as well as IPv4

### DIFF
--- a/tests/unit/test_cluster.py
+++ b/tests/unit/test_cluster.py
@@ -374,6 +374,8 @@ def test_the_reachability_probe_asks_every_resolver_and_changes_nothing() -> Non
         assert one in probe
     assert "> /etc/resolv.conf" not in probe
     assert "getent ahostsv4" in probe
+    assert "getent ahosts mirrors" in probe
+    assert "GNU_LIBC_VERSION" in probe
 
 
 def test_the_network_wait_measures_reachability_once_the_probe_answers() -> None:

--- a/tests/vm/cluster.py
+++ b/tests/vm/cluster.py
@@ -731,9 +731,16 @@ REACHABILITY_PROBE: Final[str] = (
     "printf 'REACH '; for one in " + " ".join(GUEST_RESOLVERS) + "; do "
     'ping -c1 -W2 "$one" >/dev/null 2>&1 '
     "&& printf '%s=up ' \"$one\" || printf '%s=down ' \"$one\"; done; "
-    "printf '\\nLOOKUPS '; for i in 1 2 3 4 5; do "
+    "printf '\\nLOOKUPS_V4 '; for i in 1 2 3 4 5; do "
     "getent ahostsv4 mirrors.ustc.edu.cn >/dev/null 2>&1 "
-    "&& printf 'ok ' || printf 'fail '; done; printf '\\n'"
+    "&& printf 'ok ' || printf 'fail '; done; "
+    # `ahosts` and not only `ahostsv4`: the installer asks `AF_UNSPEC`, which
+    # queries the AAAA as well, and `options no-aaaa` needs glibc 2.36. A
+    # resolver that answers the A and drops the AAAA fails the whole call.
+    "printf '\\nLOOKUPS_ANY '; for i in 1 2 3 4 5; do "
+    "getent ahosts mirrors.ustc.edu.cn >/dev/null 2>&1 "
+    "&& printf 'ok ' || printf 'fail '; done; "
+    "printf '\\nLIBC '; getconf GNU_LIBC_VERSION; printf '\\n'"
 )
 
 


### PR DESCRIPTION
Round 23 answered `10.31.0.199=up` and five IPv4 lookups out of five on every guest, and all eight still failed every mirror. The probe asked `getent ahostsv4`; the installer asks `AF_UNSPEC`, which queries the AAAA too, and `options no-aaaa` needs glibc 2.36. The probe now runs both families and prints the medium's glibc version.