### PR TITLE
fetch: separate the address families in the failure diagnostic

### DIFF
--- a/gentoo_install/exec/fetch.py
+++ b/gentoo_install/exec/fetch.py
@@ -783,7 +783,28 @@ def _resolver_state(url: str) -> str:
         )
     except OSError:
         in_file = False
-    return f" [{order}; {host} in /etc/hosts: {in_file}; {_resolvers(Path("/etc/resolv.conf"))}]"
+    return (
+        f" [{order}; {host} in /etc/hosts: {in_file};"
+        f' {_resolvers(Path("/etc/resolv.conf"))}; {_families(host)}]'
+    )
+
+
+def _families(host: str) -> str:
+    """Which address family the C library could still answer for this name.
+
+    A guest answered `getent ahosts` five times out of five and failed the same
+    name from this process twenty seconds later. Asking each family separately
+    separates a resolver that drops the AAAA from one that answers nothing.
+    """
+    answers = []
+    for name, family in (("v4", socket.AF_INET), ("v6", socket.AF_INET6)):
+        try:
+            socket.getaddrinfo(host, None, family)
+        except OSError as error:
+            answers.append(f"{name}={type(error).__name__}:{getattr(error, 'errno', '')}")
+        else:
+            answers.append(f"{name}=ok")
+    return " ".join(answers)
 
 
 def _resolvers(path: Path) -> str:

--- a/tests/unit/test_fetch.py
+++ b/tests/unit/test_fetch.py
@@ -149,3 +149,13 @@ def test_a_failed_read_says_so_when_the_resolver_file_is_missing(tmp_path: Path)
 def test_the_diagnostic_carries_the_resolver_state(tmp_path: Path) -> None:
     said = fetch._resolver_state("https://mirrors.nju.edu.cn/gentoo/x")
     assert "nameserver" in said
+
+
+def test_the_diagnostic_separates_the_two_address_families() -> None:
+    said = fetch._families("localhost")
+    assert "v4=" in said and "v6=" in said
+
+
+def test_a_family_that_cannot_be_answered_names_its_error() -> None:
+    said = fetch._families("no-such-name.gentoo-install.invalid")
+    assert "v4=gaierror" in said


### PR DESCRIPTION
Round 24 measured `LOOKUPS_V4 ok x5`, `LOOKUPS_ANY ok x5` and glibc 2.43 on every guest, and all four still failed every mirror four seconds later with `EAI_AGAIN`. The diagnostic beside the error now asks each family separately from inside the failing process, which separates a resolver that drops the AAAA from one that answers nothing.