### PR TITLE
fetch: report the route to the resolver in the diagnostic

### DIFF
--- a/gentoo_install/exec/fetch.py
+++ b/gentoo_install/exec/fetch.py
@@ -785,8 +785,31 @@ def _resolver_state(url: str) -> str:
         in_file = False
     return (
         f" [{order}; {host} in /etc/hosts: {in_file};"
-        f' {_resolvers(Path("/etc/resolv.conf"))}; {_families(host)}]'
+        f' {_resolvers(Path("/etc/resolv.conf"))}; {_families(host)};'
+        f" {_route_to_resolver(Path('/etc/resolv.conf'))}]"
     )
+
+
+def _route_to_resolver(path: Path) -> str:
+    """Whether this process can reach the first resolver, and from which address.
+
+    `getent` answered five times out of five and the same lookup timed out from
+    this process twenty seconds later, which separates a resolver that stopped
+    answering from a guest that lost the address it was answering from.
+    """
+    servers = _resolvers(path)
+    if not servers.startswith("nameservers "):
+        return "no route measured"
+    first = servers.removeprefix("nameservers ").strip("[]'").split("', '")[0]
+    probe = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
+    try:
+        probe.connect((first, 53))
+    except OSError as error:
+        return f"route to {first}: {type(error).__name__}:{getattr(error, 'errno', '')}"
+    else:
+        return f"route to {first} from {probe.getsockname()[0]}"
+    finally:
+        probe.close()
 
 
 def _families(host: str) -> str:

--- a/tests/unit/test_fetch.py
+++ b/tests/unit/test_fetch.py
@@ -159,3 +159,17 @@ def test_the_diagnostic_separates_the_two_address_families() -> None:
 def test_a_family_that_cannot_be_answered_names_its_error() -> None:
     said = fetch._families("no-such-name.gentoo-install.invalid")
     assert "v4=gaierror" in said
+
+
+def test_the_diagnostic_says_which_address_reaches_the_resolver(tmp_path: Path) -> None:
+    resolv = tmp_path / "resolv.conf"
+    resolv.write_text("nameserver 127.0.0.1\n")
+    assert fetch._route_to_resolver(resolv) == "route to 127.0.0.1 from 127.0.0.1"
+
+
+def test_the_diagnostic_says_so_when_there_is_no_resolver_to_route_to(
+    tmp_path: Path,
+) -> None:
+    resolv = tmp_path / "resolv.conf"
+    resolv.write_text("options no-aaaa\n")
+    assert fetch._route_to_resolver(resolv) == "no route measured"


### PR DESCRIPTION
Round 25 measured `v4=gaierror:-3 v6=gaierror:-5` on all 52 attempts: the A query times out while `no-aaaa` returns NODATA for the AAAA without asking. Nothing between the successful `getent` and the failure touches the network, so the remaining question is whether the process can still send to the resolver and from which source address.