### PR TITLE
vm: hold the guest's own address for the whole install

### DIFF
--- a/tests/unit/test_cluster.py
+++ b/tests/unit/test_cluster.py
@@ -410,3 +410,25 @@ def test_the_resolvers_are_written_before_the_first_network_probe() -> None:
 def test_the_interface_configuration_no_longer_carries_the_resolvers() -> None:
     """Two writers of one file is how the fallback undid the early write."""
     assert "/etc/resolv.conf" not in cluster.configure_statically("10.31.0.150")
+
+
+def test_the_guest_holds_its_own_address_once_the_probe_answers() -> None:
+    """A lease from the segment's DHCP server lapses mid-install: sixty-one
+    lookups in round 26 answered `ENETUNREACH` from an installer that had
+    reached a mirror over the same interface a minute earlier."""
+    link = _AnsweringLink(cluster.NETWORK_UP.encode())
+    cluster.wait_for_network(cast(cluster.Reconnecting, link), vmid=9301)
+    configured = link.ran.index(cluster.configure_statically(cluster.static_address(9301)))
+    probed = next(i for i, one in enumerate(link.ran) if "NETWORK_%s" in one)
+    assert probed < configured
+
+
+def test_the_address_does_not_depend_on_the_default_route_being_absent() -> None:
+    """The guard meant a guest that came up on DHCP never got one of its own,
+    so it had nothing left when the lease lapsed: sixty-one lookups answered
+    `ENETUNREACH` from an installer that had reached a mirror a minute
+    earlier."""
+    command = cluster.configure_statically("10.31.0.150")
+    assert "route show default | grep -q . || {" not in command
+    assert "pkill -x dhcpcd" in command
+    assert "addr add 10.31.0.150/24" in command

--- a/tests/unit/test_proxmox.py
+++ b/tests/unit/test_proxmox.py
@@ -1171,7 +1171,7 @@ def test_the_network_wait_returns_as_soon_as_the_guest_answers() -> None:
 
     link = cluster.Reconnecting(Late, tries=1)
     cluster.wait_for_network(link)
-    assert len(tries) == 5
+    assert len(tries) == 6
     assert sum(1 for line in tries if "NETWORK_%s" in line) == 2
     assert "REACH" in tries[-1]
 
@@ -1396,6 +1396,7 @@ def test_the_probe_runs_before_the_guest_is_touched() -> None:
     probe = next(at for at, line in enumerate(code) if "NETWORK_PROBE" in line)
     ask = next(at for at, line in enumerate(code) if "link.run(configure" in line)
     assert probe < ask, "the medium gets its chance before anything is raised"
+    assert ask < len(code), "and the address is pinned once the probe answers"
     assert "ip -4 route show default" in cluster.ASK_FOR_IPV4
 
 
@@ -2928,9 +2929,11 @@ def test_a_guest_leaves_its_own_address_alone_on_the_next_pass() -> None:
 
     command = configure_statically("10.31.0.113")
     assert subprocess.run(["bash", "-n", "-c", command], capture_output=True).returncode == 0
-    # The guard comes first, and nothing else runs when a route is already there.
-    assert command.startswith("ip -4 route show default | grep -q . || {"), command[:80]
-    assert command.index("addr add") > command.index("|| {")
+    # No branch that can tear a working configuration down, and every step
+    # idempotent, because this now runs on a guest that already has a route.
+    assert "dhclient" not in command and "dhcpcd -" not in command
+    assert command.count("addr add") == 1
+    assert "|| true" in command
     # `exit` would end the login shell this runs in, not just the command.
     assert "exit 0" not in command
 

--- a/tests/vm/cluster.py
+++ b/tests/vm/cluster.py
@@ -906,17 +906,18 @@ def configure_statically(address: str, pinned: str = "") -> str:
     # first probe, and writing them again from this line is what made the file
     # 101 lines when 68 were written.
     return (
-        # Nothing at all once there is a default route. Without this guard the
-        # second pass probed the address the first pass had taken, `arping -D`
-        # answered that something holds it — this guest — and the fallback
-        # then tore the working configuration down again.
-        "ip -4 route show default | grep -q . || { "
+        # The DHCP client first: the segment's server runs on a Raspberry Pi
+        # and a lapsed lease takes the address with it. Sixty-one lookups in
+        # round 26 answered `ENETUNREACH` from an installer that had reached a
+        # mirror over the same interface a minute earlier.
+        "pkill -x dhcpcd 2>/dev/null || true; "
+        # Unconditional, not only when the default route is missing: the guard
+        # meant a guest that came up on DHCP never received an address of its
+        # own, so it had nothing left once the lease went.
         'for one in /sys/class/net/e*; do dev=$(basename "$one"); ip link set "$dev" up; '
-        f'ip -4 addr add {network}.{last}/{prefix} dev "$dev"; '
-        f'ip -4 route replace default via {gateway} dev "$dev" 2>/dev/null; '
-        "done; }; "
-        # Appended, never written: the medium's own entry for localhost is in
-        # there and replacing the file takes it away.
+        f'ip -4 addr add {network}.{last}/{prefix} dev "$dev" 2>/dev/null || true; '
+        f'ip -4 route replace default via {gateway} dev "$dev" 2>/dev/null || true; '
+        "done; "
         "ip -4 route show default | grep -q . || true"
     )
 
@@ -1010,6 +1011,12 @@ def wait_for_network(
     while time.monotonic() < deadline:
         said = link.expect_output(NETWORK_PROBE, timeout=180.0)
         if NETWORK_UP.encode() in said:
+            # After the probe, not before it: an interface raised from outside
+            # the medium's own manager is one it then leaves alone. After it
+            # succeeds, though, the guest still has to hold the address for the
+            # rest of the install, and a lapsed DHCP lease took it away
+            # mid-fetch — sixty-one lookups answered `ENETUNREACH`.
+            link.run(configure, timeout=120.0)
             link.run(REACHABILITY_PROBE, timeout=120.0)
             return
         # Every pass, not once: the fallback asks a DHCP server that answers


### PR DESCRIPTION
The diagnostic from #348 answered `route to 10.31.0.199: OSError:101` on all sixty-one attempts in round 26: the guest had no route at all by the time the installer fetched, seconds after `ping` and `curl` had both reached the same addresses. The static address was only configured when the first probe failed, so a guest that came up on a DHCP lease had nothing of its own when the lease went. It is now configured once the probe answers — after the medium's own manager has had its chance, which is the constraint the old guard existed for — and the DHCP client is stopped so nothing withdraws it.