### PR TITLE
vm: measure the network again immediately before the installer

### DIFF
--- a/tests/unit/test_cluster.py
+++ b/tests/unit/test_cluster.py
@@ -376,6 +376,8 @@ def test_the_reachability_probe_asks_every_resolver_and_changes_nothing() -> Non
     assert "getent ahostsv4" in probe
     assert "getent ahosts mirrors" in probe
     assert "GNU_LIBC_VERSION" in probe
+    assert "ip -4 -brief address show" in probe
+    assert "ip -4 route show" in probe
 
 
 def test_the_network_wait_measures_reachability_once_the_probe_answers() -> None:

--- a/tests/vm/cluster.py
+++ b/tests/vm/cluster.py
@@ -740,7 +740,12 @@ REACHABILITY_PROBE: Final[str] = (
     "printf '\\nLOOKUPS_ANY '; for i in 1 2 3 4 5; do "
     "getent ahosts mirrors.ustc.edu.cn >/dev/null 2>&1 "
     "&& printf 'ok ' || printf 'fail '; done; "
-    "printf '\\nLIBC '; getconf GNU_LIBC_VERSION; printf '\\n'"
+    "printf '\\nLIBC '; getconf GNU_LIBC_VERSION; "
+    # The state itself, not only whether it worked: sixty-one lookups answered
+    # `ENETUNREACH` from a guest that had passed this probe a minute earlier,
+    # and only the addresses and routes at each moment say what went.
+    "printf 'ADDRS '; ip -4 -brief address show | tr '\\n' ';'; "
+    "printf '\\nROUTES '; ip -4 route show | tr '\\n' ';'; printf '\\n'"
 )
 
 
@@ -1522,6 +1527,10 @@ def install_one(
         # tell a slow mirror from a dead guest.
         # `wait_for`, not `run`: a console dropped mid-install is reopened and
         # listened to again, never handed the command a second time.
+        # Again, immediately before the installer: the first measurement is
+        # taken a minute earlier and passed on every guest of round 27, whose
+        # installers then found no route at all. This one splits that window.
+        link.run(REACHABILITY_PROBE, timeout=120.0)
         phase = Phase.INSTALL
         link.wait_for(
             f"{{ sh /mnt/driver/install.sh --config fixtures/{job.fixture.name}; "


### PR DESCRIPTION
Pinning the address in #349 did not change the outcome: round 27 answered `route to 10.31.0.199: OSError:101` on all seventy-eight attempts while the probe a minute earlier reported every resolver up and five lookups out of five. The probe now prints the addresses and routes themselves and runs a second time immediately before the installer starts, which puts the loss inside one of two named windows instead of somewhere in between.