### PR TITLE
fetch: report the kernel routing table in the diagnostic

### DIFF
--- a/gentoo_install/exec/fetch.py
+++ b/gentoo_install/exec/fetch.py
@@ -786,8 +786,35 @@ def _resolver_state(url: str) -> str:
     return (
         f" [{order}; {host} in /etc/hosts: {in_file};"
         f' {_resolvers(Path("/etc/resolv.conf"))}; {_families(host)};'
-        f" {_route_to_resolver(Path('/etc/resolv.conf'))}]"
+        f" {_route_to_resolver(Path('/etc/resolv.conf'))};"
+        f" {_kernel_routes(Path('/proc/net/route'))}]"
     )
+
+
+def _kernel_routes(path: Path) -> str:
+    """What the kernel's IPv4 table holds, read without running a command.
+
+    A guest whose shell printed `default via 10.31.0.254 dev ens18` a few
+    seconds earlier answered `ENETUNREACH` from this process, which separates a
+    table that emptied from a socket that cannot use one that is still there.
+    """
+    try:
+        lines = path.read_text(encoding="utf-8").splitlines()[1:]
+    except OSError:
+        return "routes unreadable"
+    routes = []
+    for line in lines:
+        fields = line.split()
+        if len(fields) < 3:
+            continue
+        routes.append(f"{fields[0]}:{_dotted(fields[1])}/{_dotted(fields[2])}")
+    return f"routes {routes}" if routes else "no routes"
+
+
+def _dotted(word: str) -> str:
+    """A little-endian hexadecimal address from `/proc/net/route`."""
+    value = int(word, 16)
+    return ".".join(str((value >> shift) & 0xFF) for shift in (0, 8, 16, 24))
 
 
 def _route_to_resolver(path: Path) -> str:

--- a/tests/unit/test_fetch.py
+++ b/tests/unit/test_fetch.py
@@ -173,3 +173,21 @@ def test_the_diagnostic_says_so_when_there_is_no_resolver_to_route_to(
     resolv = tmp_path / "resolv.conf"
     resolv.write_text("options no-aaaa\n")
     assert fetch._route_to_resolver(resolv) == "no route measured"
+
+
+def test_the_diagnostic_reads_the_kernel_routing_table(tmp_path: Path) -> None:
+    table = tmp_path / "route"
+    table.write_text(
+        "Iface\tDestination\tGateway\tFlags\n"
+        "ens18\t00000000\tFE001F0A\t0003\n"
+        "ens18\t00001F0A\t00000000\t0001\n"
+    )
+    assert fetch._kernel_routes(table) == (
+        "routes ['ens18:0.0.0.0/10.31.0.254', 'ens18:10.31.0.0/0.0.0.0']"
+    )
+
+
+def test_an_empty_routing_table_is_named_as_such(tmp_path: Path) -> None:
+    table = tmp_path / "route"
+    table.write_text("Iface\tDestination\tGateway\tFlags\n")
+    assert fetch._kernel_routes(table) == "no routes"


### PR DESCRIPTION
The second measurement added in #350 printed `ens18 UP 10.31.0.167/24` and `default via 10.31.0.254 dev ens18` immediately before the installer started, and the installer answered `route to 10.31.0.199: OSError:101` four seconds later on all sixty-four attempts. Reading `/proc/net/route` from the failing process separates a table that emptied from a socket that cannot use one that is still there.