### PR TITLE
vm: kill the DHCP client without letting it tear the link down

### DIFF
--- a/tests/unit/test_cluster.py
+++ b/tests/unit/test_cluster.py
@@ -432,5 +432,8 @@ def test_the_address_does_not_depend_on_the_default_route_being_absent() -> None
     earlier."""
     command = cluster.configure_statically("10.31.0.150")
     assert "route show default | grep -q . || {" not in command
-    assert "pkill -x dhcpcd" in command
+    # SIGKILL: a term makes dhcpcd release the lease and deconfigure the
+    # interface, which is what emptied the routing table under the installer.
+    assert "pkill -KILL -x dhcpcd" in command
+    assert "pkill -x dhcpcd" not in command
     assert "addr add 10.31.0.150/24" in command

--- a/tests/unit/test_proxmox.py
+++ b/tests/unit/test_proxmox.py
@@ -2931,7 +2931,10 @@ def test_a_guest_leaves_its_own_address_alone_on_the_next_pass() -> None:
     assert subprocess.run(["bash", "-n", "-c", command], capture_output=True).returncode == 0
     # No branch that can tear a working configuration down, and every step
     # idempotent, because this now runs on a guest that already has a route.
-    assert "dhclient" not in command and "dhcpcd -" not in command
+    # A DHCP client is killed outright, never asked to release: a release
+    # deconfigures the interface, which is what emptied the routing table.
+    assert "pkill -KILL" in command
+    assert "dhcpcd -" not in command and "--release" not in command
     assert command.count("addr add") == 1
     assert "|| true" in command
     # `exit` would end the login shell this runs in, not just the command.

--- a/tests/vm/cluster.py
+++ b/tests/vm/cluster.py
@@ -911,11 +911,12 @@ def configure_statically(address: str, pinned: str = "") -> str:
     # first probe, and writing them again from this line is what made the file
     # 101 lines when 68 were written.
     return (
-        # The DHCP client first: the segment's server runs on a Raspberry Pi
-        # and a lapsed lease takes the address with it. Sixty-one lookups in
-        # round 26 answered `ENETUNREACH` from an installer that had reached a
-        # mirror over the same interface a minute earlier.
-        "pkill -x dhcpcd 2>/dev/null || true; "
+        # SIGKILL, not SIGTERM: dhcpcd answers a term by releasing the lease
+        # and deconfiguring the interface, and it does that after the command
+        # returns. Round 29 measured a full routing table on the console and
+        # `no routes` from the installer four seconds later.
+        "pkill -KILL -x dhcpcd 2>/dev/null; pkill -KILL -x dhclient 2>/dev/null; "
+        "pkill -KILL -x udhcpc 2>/dev/null; "
         # Unconditional, not only when the default route is missing: the guard
         # meant a guest that came up on DHCP never received an address of its
         # own, so it had nothing left once the lease went.
@@ -923,6 +924,8 @@ def configure_statically(address: str, pinned: str = "") -> str:
         f'ip -4 addr add {network}.{last}/{prefix} dev "$dev" 2>/dev/null || true; '
         f'ip -4 route replace default via {gateway} dev "$dev" 2>/dev/null || true; '
         "done; "
+        # The client is dead, so nothing will put these back if they go: report
+        # what is there rather than a bare success, and the log carries it.
         "ip -4 route show default | grep -q . || true"
     )
 


### PR DESCRIPTION
The table added in #351 answered `no routes` on all sixty-six attempts in round 29, from a guest whose console had printed `default via 10.31.0.254 dev ens18` and `10.31.0.156/24` four seconds earlier. Nothing in the installer touches the network, and an empty IPv4 table is what an interface being deconfigured leaves behind. `pkill` sent a term, which dhcpcd answers by releasing the lease and deconfiguring, asynchronously enough that the measurement taken immediately before still saw the address.