### PR TITLE
vm: separate a namespace from a deconfigured interface

### DIFF
--- a/gentoo_install/exec/fetch.py
+++ b/gentoo_install/exec/fetch.py
@@ -787,8 +787,32 @@ def _resolver_state(url: str) -> str:
         f" [{order}; {host} in /etc/hosts: {in_file};"
         f' {_resolvers(Path("/etc/resolv.conf"))}; {_families(host)};'
         f" {_route_to_resolver(Path('/etc/resolv.conf'))};"
-        f" {_kernel_routes(Path('/proc/net/route'))}]"
+        f" {_kernel_routes(Path('/proc/net/route'))}; {_interfaces()};"
+        f" {_network_namespace()}]"
     )
+
+
+def _interfaces() -> str:
+    """The interfaces this process can see.
+
+    An empty routing table beside a console that printed a full one is either a
+    namespace with nothing in it or an interface that was deconfigured, and the
+    interface list is what separates them.
+    """
+    try:
+        return f"interfaces {[name for _, name in socket.if_nameindex()]}"
+    except OSError as error:
+        return f"interfaces unreadable: {type(error).__name__}"
+
+
+def _network_namespace() -> str:
+    """Whether this process shares the machine's network namespace."""
+    try:
+        mine = Path("/proc/self/ns/net").readlink()
+        theirs = Path("/proc/1/ns/net").readlink()
+    except OSError as error:
+        return f"namespace unreadable: {type(error).__name__}"
+    return f"namespace {'shared' if mine == theirs else f'{mine} not {theirs}'}"
 
 
 def _kernel_routes(path: Path) -> str:

--- a/tests/unit/test_cluster.py
+++ b/tests/unit/test_cluster.py
@@ -437,3 +437,14 @@ def test_the_address_does_not_depend_on_the_default_route_being_absent() -> None
     assert "pkill -KILL -x dhcpcd" in command
     assert "pkill -x dhcpcd" not in command
     assert "addr add 10.31.0.150/24" in command
+
+
+def test_the_network_is_measured_once_more_after_the_install() -> None:
+    """A console that still has its routes when the installer saw none puts the
+    loss in the installer's view of the machine rather than in the machine."""
+    import inspect
+
+    code = inspect.getsource(cluster.install_one)
+    started = code.index("install.sh --config")
+    collected = code.index("files = collect(")
+    assert "REACHABILITY_PROBE" in code[started:collected]

--- a/tests/unit/test_fetch.py
+++ b/tests/unit/test_fetch.py
@@ -191,3 +191,14 @@ def test_an_empty_routing_table_is_named_as_such(tmp_path: Path) -> None:
     table = tmp_path / "route"
     table.write_text("Iface\tDestination\tGateway\tFlags\n")
     assert fetch._kernel_routes(table) == "no routes"
+
+
+def test_the_diagnostic_names_the_interfaces_it_can_see() -> None:
+    said = fetch._interfaces()
+    assert said.startswith("interfaces [")
+    assert "lo" in said
+
+
+def test_the_diagnostic_says_whether_the_namespace_is_shared() -> None:
+    said = fetch._network_namespace()
+    assert said.startswith("namespace ")

--- a/tests/vm/cluster.py
+++ b/tests/vm/cluster.py
@@ -1542,6 +1542,10 @@ def install_one(
             idle=INSTALL_IDLE,
             watch=watch,
         )
+        # A third time, after the install: a console that still has its routes
+        # when the installer saw none puts the loss in the installer's own
+        # view of the machine rather than in the machine.
+        link.run(REACHABILITY_PROBE, timeout=120.0)
         files = collect(guest, link, log)
         keep_results(log, files)
         code = files.get("install.rc", b"").strip()


### PR DESCRIPTION
Round 30 answered `no routes` on all 124 attempts, from guests whose console printed `ens18 UP 10.31.0.156/24` and `default via 10.31.0.254` four seconds earlier, so killing the DHCP client outright was not the answer either. The installer now names the interfaces it can see and whether it shares PID 1's network namespace, and the harness measures the console once more after the install.