### PR TITLE
vm: read the kernel log where the interface was lost

### DIFF
--- a/tests/unit/test_cluster.py
+++ b/tests/unit/test_cluster.py
@@ -378,6 +378,8 @@ def test_the_reachability_probe_asks_every_resolver_and_changes_nothing() -> Non
     assert "GNU_LIBC_VERSION" in probe
     assert "ip -4 -brief address show" in probe
     assert "ip -4 route show" in probe
+    assert "ip -brief link show" in probe
+    assert "dmesg | tail" in probe
 
 
 def test_the_network_wait_measures_reachability_once_the_probe_answers() -> None:

--- a/tests/vm/cluster.py
+++ b/tests/vm/cluster.py
@@ -745,7 +745,12 @@ REACHABILITY_PROBE: Final[str] = (
     # `ENETUNREACH` from a guest that had passed this probe a minute earlier,
     # and only the addresses and routes at each moment say what went.
     "printf 'ADDRS '; ip -4 -brief address show | tr '\\n' ';'; "
-    "printf '\\nROUTES '; ip -4 route show | tr '\\n' ';'; printf '\\n'"
+    "printf '\\nROUTES '; ip -4 route show | tr '\\n' ';'; "
+    # The links regardless of address, and the kernel's own account: round 31
+    # measured `ens18` with an address, then the installer four seconds later
+    # with no routes, then no `ens18` at all. Only `dmesg` says what removed it.
+    "printf '\\nLINKS '; ip -brief link show | tr '\\n' ';'; "
+    "printf '\\nDMESG '; dmesg | tail -6 | tr '\\n' ';'; printf '\\n'"
 )
 
 


### PR DESCRIPTION
Round 31 answered `interfaces ['lo', 'ens18']; namespace shared` from the installer beside `no routes`, so it is neither a namespace nor a missing driver. The console measured a full table before the run and, after it, no `ens18` at all. The probe now prints every link regardless of address and the last six kernel messages, which is the only place a device removal is recorded.