### PR TITLE
vm: keep the guest's address applied for the whole install

### DIFF
--- a/tests/unit/test_cluster.py
+++ b/tests/unit/test_cluster.py
@@ -450,3 +450,25 @@ def test_the_network_is_measured_once_more_after_the_install() -> None:
     started = code.index("install.sh --config")
     collected = code.index("files = collect(")
     assert "REACHABILITY_PROBE" in code[started:collected]
+
+
+def test_the_keeper_puts_the_address_back_and_counts_it() -> None:
+    """Round 32 measured the interface up with its address immediately before
+    the installer and up with none after it, with nothing in the kernel log and
+    no network command in the installer's own run list."""
+    import subprocess
+
+    command = cluster.keep_the_address("10.31.0.152")
+    assert subprocess.run(["bash", "-n", "-c", command], capture_output=True).returncode == 0
+    assert "10.31.0.152/24" in command
+    assert command.endswith("&"), "the keeper outlives the command that starts it"
+    assert cluster.KEEPER_LOG in command
+    assert cluster.KEEPER_LOG in cluster.REACHABILITY_PROBE
+
+
+def test_the_keeper_starts_once_the_guest_has_its_address() -> None:
+    link = _AnsweringLink(cluster.NETWORK_UP.encode())
+    cluster.wait_for_network(cast(cluster.Reconnecting, link), vmid=9301)
+    configured = link.ran.index(cluster.configure_statically(cluster.static_address(9301)))
+    kept = link.ran.index(cluster.keep_the_address(cluster.static_address(9301)))
+    assert configured < kept

--- a/tests/vm/cluster.py
+++ b/tests/vm/cluster.py
@@ -750,7 +750,10 @@ REACHABILITY_PROBE: Final[str] = (
     # measured `ens18` with an address, then the installer four seconds later
     # with no routes, then no `ens18` at all. Only `dmesg` says what removed it.
     "printf '\\nLINKS '; ip -brief link show | tr '\\n' ';'; "
-    "printf '\\nDMESG '; dmesg | tail -6 | tr '\\n' ';'; printf '\\n'"
+    "printf '\\nDMESG '; dmesg | tail -6 | tr '\\n' ';'; "
+    "printf '\\nKEEPER '; wc -l < /tmp/gentoo-install-address-keeper.log "
+    "2>/dev/null || printf 'none'; "
+    "printf '\\n'"
 )
 
 
@@ -954,6 +957,33 @@ def use_our_resolvers() -> str:
     return f"printf '{resolvers}' > /etc/resolv.conf"
 
 
+#: Where the keeper records each time it had to put the address back. The
+#: count is the evidence: a keeper that never fires means something else took
+#: the network, and one that fires every five seconds names the interval.
+KEEPER_LOG: Final[str] = "/tmp/gentoo-install-address-keeper.log"
+
+
+def keep_the_address(address: str) -> str:
+    """Put the address back whenever something takes it away.
+
+    Round 32 measured `ens18` up with `10.31.0.152/24` immediately before the
+    installer and the same interface up with no address after it, with nothing
+    in the kernel log and no network command in the installer's own run list.
+    Rather than name the service that flushes it, this reasserts the
+    configuration and counts how often it had to.
+    """
+    network, last = address.rsplit(".", 1)
+    body = (
+        "while :; do for one in /sys/class/net/e*; do dev=$(basename \"$one\"); "
+        f'ip -4 addr show dev \"$dev\" | grep -q {network}.{last}/{GUEST_PREFIX} || {{ '
+        'ip link set \"$dev\" up; '
+        f'ip -4 addr add {network}.{last}/{GUEST_PREFIX} dev \"$dev\" 2>/dev/null; '
+        f'ip -4 route replace default via {GUEST_GATEWAY} dev \"$dev\" 2>/dev/null; '
+        f"echo readded >> {KEEPER_LOG}; }}; done; sleep 5; done"
+    )
+    return f"nohup sh -c '{body}' >/dev/null 2>&1 &"
+
+
 def _address_is_taken(address: str) -> bool:
     """Check occupancy before the scheduler reserves an address."""
     result = subprocess.run(
@@ -1030,6 +1060,8 @@ def wait_for_network(
             # rest of the install, and a lapsed DHCP lease took it away
             # mid-fetch — sixty-one lookups answered `ENETUNREACH`.
             link.run(configure, timeout=120.0)
+            if vmid:
+                link.run(keep_the_address(address or static_address(vmid)), timeout=120.0)
             link.run(REACHABILITY_PROBE, timeout=120.0)
             return
         # Every pass, not once: the fallback asks a DHCP server that answers


### PR DESCRIPTION
Round 32 measured `ens18 UP 10.31.0.152/24` immediately before the installer, `no routes` from the installer four seconds later, and `ens18` up with no address at all after the run. The kernel log holds no device event and the installer's own run list holds no network command, so something on the medium reasserts the interface after the harness has configured it. A keeper puts the address back and records each time it had to: a keeper that never fires refutes this reading, and one that fires names the interval.