### PR TITLE
vm: write the address keeper as a script, a line at a time

### DIFF
--- a/tests/unit/test_cluster.py
+++ b/tests/unit/test_cluster.py
@@ -458,11 +458,13 @@ def test_the_keeper_puts_the_address_back_and_counts_it() -> None:
     no network command in the installer's own run list."""
     import subprocess
 
-    command = cluster.keep_the_address("10.31.0.152")
-    assert subprocess.run(["bash", "-n", "-c", command], capture_output=True).returncode == 0
-    assert "10.31.0.152/24" in command
-    assert command.endswith("&"), "the keeper outlives the command that starts it"
-    assert cluster.KEEPER_LOG in command
+    written = cluster.keep_the_address("10.31.0.152")
+    for command in written:
+        assert subprocess.run(["bash", "-n", "-c", command], capture_output=True).returncode == 0
+        assert len(command) < cluster.CONSOLE_LINE_BYTES, command
+    assert any("10.31.0.152/24" in one for one in written)
+    assert written[-1].endswith("&"), "the keeper outlives the command that starts it"
+    assert any(cluster.KEEPER_LOG in one for one in written)
     assert cluster.KEEPER_LOG in cluster.REACHABILITY_PROBE
 
 
@@ -470,5 +472,5 @@ def test_the_keeper_starts_once_the_guest_has_its_address() -> None:
     link = _AnsweringLink(cluster.NETWORK_UP.encode())
     cluster.wait_for_network(cast(cluster.Reconnecting, link), vmid=9301)
     configured = link.ran.index(cluster.configure_statically(cluster.static_address(9301)))
-    kept = link.ran.index(cluster.keep_the_address(cluster.static_address(9301)))
+    kept = link.ran.index(cluster.keep_the_address(cluster.static_address(9301))[-1])
     assert configured < kept

--- a/tests/vm/cluster.py
+++ b/tests/vm/cluster.py
@@ -962,8 +962,12 @@ def use_our_resolvers() -> str:
 #: the network, and one that fires every five seconds names the interval.
 KEEPER_LOG: Final[str] = "/tmp/gentoo-install-address-keeper.log"
 
+#: The keeper itself, written a line at a time because a console line over
+#: `CONSOLE_LINE_BYTES` comes back mangled.
+KEEPER_SCRIPT: Final[str] = "/tmp/gentoo-install-address-keeper.sh"
 
-def keep_the_address(address: str) -> str:
+
+def keep_the_address(address: str) -> list[str]:
     """Put the address back whenever something takes it away.
 
     Round 32 measured `ens18` up with `10.31.0.152/24` immediately before the
@@ -971,17 +975,26 @@ def keep_the_address(address: str) -> str:
     in the kernel log and no network command in the installer's own run list.
     Rather than name the service that flushes it, this reasserts the
     configuration and counts how often it had to.
+
+    A script rather than one command: the whole loop is four hundred bytes and
+    a console line over `CONSOLE_LINE_BYTES` is mangled, which cost round 33.
     """
-    network, last = address.rsplit(".", 1)
-    body = (
-        "while :; do for one in /sys/class/net/e*; do dev=$(basename \"$one\"); "
-        f'ip -4 addr show dev \"$dev\" | grep -q {network}.{last}/{GUEST_PREFIX} || {{ '
-        'ip link set \"$dev\" up; '
-        f'ip -4 addr add {network}.{last}/{GUEST_PREFIX} dev \"$dev\" 2>/dev/null; '
-        f'ip -4 route replace default via {GUEST_GATEWAY} dev \"$dev\" 2>/dev/null; '
-        f"echo readded >> {KEEPER_LOG}; }}; done; sleep 5; done"
+    lines = (
+        "while :; do",
+        'for one in /sys/class/net/e*; do dev=$(basename "$one")',
+        f'ip -4 addr show dev "$dev" | grep -q {address}/{GUEST_PREFIX} && continue',
+        'ip link set "$dev" up',
+        f'ip -4 addr add {address}/{GUEST_PREFIX} dev "$dev" 2>/dev/null',
+        f'ip -4 route replace default via {GUEST_GATEWAY} dev "$dev" 2>/dev/null',
+        f"echo readded >> {KEEPER_LOG}",
+        "done",
+        "sleep 5",
+        "done",
     )
-    return f"nohup sh -c '{body}' >/dev/null 2>&1 &"
+    written = [f"rm -f {KEEPER_SCRIPT} {KEEPER_LOG}"]
+    written += [f"printf '%s\\n' '{line}' >> {KEEPER_SCRIPT}" for line in lines]
+    written.append(f"nohup sh {KEEPER_SCRIPT} >/dev/null 2>&1 &")
+    return written
 
 
 def _address_is_taken(address: str) -> bool:
@@ -1061,7 +1074,8 @@ def wait_for_network(
             # mid-fetch — sixty-one lookups answered `ENETUNREACH`.
             link.run(configure, timeout=120.0)
             if vmid:
-                link.run(keep_the_address(address or static_address(vmid)), timeout=120.0)
+                for command in keep_the_address(address or static_address(vmid)):
+                    link.run(command, timeout=120.0)
             link.run(REACHABILITY_PROBE, timeout=120.0)
             return
         # Every pass, not once: the fallback asks a DHCP server that answers


### PR DESCRIPTION
Every guest of round 33 died before its install began, on `never matched 'MARK_6_DONE'`, with the keeper's own line in the echo. The loop is four hundred bytes and `CONSOLE_LINE_BYTES` is two hundred. It is now written a line at a time into a file and started from there, and the test asserts each line stays under the limit.