### PR TITLE
vm: let the keeper launch compose with the console wrapper

### DIFF
--- a/tests/unit/test_cluster.py
+++ b/tests/unit/test_cluster.py
@@ -463,7 +463,10 @@ def test_the_keeper_puts_the_address_back_and_counts_it() -> None:
         assert subprocess.run(["bash", "-n", "-c", command], capture_output=True).returncode == 0
         assert len(command) < cluster.CONSOLE_LINE_BYTES, command
     assert any("10.31.0.152/24" in one for one in written)
-    assert written[-1].endswith("&"), "the keeper outlives the command that starts it"
+    assert " &" in written[-1], "the keeper outlives the command that starts it"
+    # The console wrapper appends `; printf MARK...` to whatever it is given.
+    composed = subprocess.run(["bash", "-n", "-c", f"{written[-1]}; true"], capture_output=True)
+    assert composed.returncode == 0, written[-1]
     assert any(cluster.KEEPER_LOG in one for one in written)
     assert cluster.KEEPER_LOG in cluster.REACHABILITY_PROBE
 

--- a/tests/vm/cluster.py
+++ b/tests/vm/cluster.py
@@ -993,7 +993,9 @@ def keep_the_address(address: str) -> list[str]:
     )
     written = [f"rm -f {KEEPER_SCRIPT} {KEEPER_LOG}"]
     written += [f"printf '%s\\n' '{line}' >> {KEEPER_SCRIPT}" for line in lines]
-    written.append(f"nohup sh {KEEPER_SCRIPT} >/dev/null 2>&1 &")
+    # Braced: the console wrapper appends `; printf MARK...`, and a bare `&`
+    # followed by `;` is a syntax error, which ended every guest of round 34.
+    written.append(f"{{ nohup sh {KEEPER_SCRIPT} >/dev/null 2>&1 & }}")
     return written
 
 


### PR DESCRIPTION
Round 34 ended every guest on `never matched 'MARK_17_DONE'` with `-bash: syntax error near unexpected token ';'`. The console wrapper appends `; printf MARK...` to whatever it is given, and a bare `&` cannot be followed by `;`. The launch is braced, and the test now checks the command composed with a following `;` rather than only on its own.