### PR TITLE
convert: derive the device graph from the running layout

### DIFF
--- a/gentoo_install/errors.py
+++ b/gentoo_install/errors.py
@@ -78,6 +78,15 @@ class CommandFailed(GentooInstallError):
     is a different thing from data that cannot be trusted."""
 
 
+class ConversionUnsupported(GentooInstallError):
+    """The running layout is one the conversion cannot rebuild.
+
+    Names the layer that stops it. A root below LUKS, LVM or mdraid needs the
+    whole stack described, not one `Existing` node, and stopping here leaves
+    the machine untouched.
+    """
+
+
 class ConversionFailed(GentooInstallError):
     """The in-place swap could not be completed.
 

--- a/gentoo_install/exec/probe.py
+++ b/gentoo_install/exec/probe.py
@@ -31,6 +31,7 @@ from ..model.device import (
     PartitionTable,
     RaidMetadata,
     StorageFacts,
+    StorageLayout,
 )
 from ..model.validate import KernelCeiling, ProbedProfile, parse_profile_list, zfs_kernel_ceiling
 from .runner import Runner
@@ -114,25 +115,6 @@ class ProbedPartition:
     size_bytes: int
     filesystem: str
     device_type: str
-
-
-@dataclass(frozen=True)
-class StorageLayout:
-    """Facts about the filesystems and block-device stack running the system."""
-
-    root_device: str | None
-    root_filesystem_type: str | None
-    root_uuid: str | None
-    root_on_lvm: bool | None
-    root_on_luks: bool | None
-    root_on_mdraid: bool | None
-    root_below_device: str | None
-    boot_device: str | None
-    boot_same_filesystem: bool | None
-    esp_device: str | None
-    esp_mountpoint: str | None
-    uefi: bool
-    root_free_bytes: int | None
 
 
 def _mount_entries(document: object) -> tuple[Mapping[str, object], ...]:

--- a/gentoo_install/model/device.py
+++ b/gentoo_install/model/device.py
@@ -136,6 +136,25 @@ class Extent:
         return self.end - self.start + 1
 
 
+@dataclass(frozen=True)
+class StorageLayout:
+    """Facts about the filesystems and block-device stack running the system."""
+
+    root_device: str | None
+    root_filesystem_type: str | None
+    root_uuid: str | None
+    root_on_lvm: bool | None
+    root_on_luks: bool | None
+    root_on_mdraid: bool | None
+    root_below_device: str | None
+    boot_device: str | None
+    boot_same_filesystem: bool | None
+    esp_device: str | None
+    esp_mountpoint: str | None
+    uefi: bool
+    root_free_bytes: int | None
+
+
 @dataclass(frozen=True, init=False)
 class StorageFacts:
     """Runtime storage evidence, separate from persistent user intent."""

--- a/gentoo_install/plan/convert.py
+++ b/gentoo_install/plan/convert.py
@@ -6,8 +6,19 @@ from __future__ import annotations
 import importlib
 from dataclasses import dataclass
 from pathlib import Path, PurePosixPath
-from typing import Protocol, Sequence, cast
+from typing import Any, Final, Protocol, Sequence, cast
 
+from ..errors import ConversionUnsupported
+from ..model.config import DiskConfig, DiskMode
+from ..model.device import (
+    DeviceGraph,
+    DeviceId,
+    Existing,
+    Filesystem,
+    FilesystemType,
+    Mountpoint,
+    StorageLayout,
+)
 from .operations import Context, Operation, Stage
 from .portage import InstallStage3
 
@@ -88,3 +99,86 @@ class SwapDirectories(Operation):
         module = importlib.import_module("gentoo_install.exec.convert")
         converter = cast(_Converter, module)
         converter.convert(Path(str(self.staging)), self.names)
+
+
+#: The synthetic ids. Fixed rather than derived from the device name so that a
+#: plan reads the same whichever disk the machine happens to boot from.
+ROOT_DEVICE: Final[DeviceId] = DeviceId("running-root-device")
+ROOT_FILESYSTEM: Final[DeviceId] = DeviceId("running-root")
+ROOT_MOUNT: Final[DeviceId] = DeviceId("running-root-mount")
+ESP_DEVICE: Final[DeviceId] = DeviceId("running-esp-device")
+ESP_FILESYSTEM: Final[DeviceId] = DeviceId("running-esp")
+ESP_MOUNT: Final[DeviceId] = DeviceId("running-esp-mount")
+
+
+def layout_graph(layout: StorageLayout) -> DiskConfig:
+    """Describe the running layout as the device graph the planners read.
+
+    The bootloader, `fstab` and kernel planners all take the root device, the
+    esp and the mount options from `config.disk.graph`. A second description
+    for the conversion would be the same rule set in two tables, so the facts
+    `probe.storage_layout()` read become a graph instead. Every filesystem in
+    it carries `create=False`, so no operation derived from it formats
+    anything.
+    """
+    below = _unsupported_layer(layout)
+    if below:
+        raise ConversionUnsupported(
+            f"the running root is below {below}, which the conversion cannot rebuild"
+        )
+    if not layout.root_device or not layout.root_filesystem_type:
+        raise ConversionUnsupported("the running root device could not be read")
+    nodes: list[object] = [
+        Existing(id=ROOT_DEVICE, selector=layout.root_device),
+        Filesystem(
+            id=ROOT_FILESYSTEM,
+            device=ROOT_DEVICE,
+            kind=_filesystem(layout.root_filesystem_type, "root"),
+            create=False,
+        ),
+        Mountpoint(id=ROOT_MOUNT, source=ROOT_FILESYSTEM, path=PurePosixPath("/")),
+    ]
+    if layout.uefi:
+        if not layout.esp_device:
+            raise ConversionUnsupported("the machine booted through UEFI and has no esp")
+        nodes += [
+            Existing(id=ESP_DEVICE, selector=layout.esp_device),
+            Filesystem(
+                id=ESP_FILESYSTEM,
+                device=ESP_DEVICE,
+                kind=FilesystemType.VFAT,
+                create=False,
+            ),
+            Mountpoint(
+                id=ESP_MOUNT,
+                source=ESP_FILESYSTEM,
+                path=PurePosixPath(layout.esp_mountpoint or "/efi"),
+                options=("umask=0077",),
+            ),
+        ]
+    return DiskConfig(
+        graph=DeviceGraph(cast(Sequence[Any], nodes)),
+        root=ROOT_MOUNT,
+        mode=DiskMode.IN_PLACE,
+    )
+
+
+def _unsupported_layer(layout: StorageLayout) -> str:
+    """The first stacked layer below the root, empty when there is none."""
+    for name, present in (
+        ("LUKS", layout.root_on_luks),
+        ("LVM", layout.root_on_lvm),
+        ("mdraid", layout.root_on_mdraid),
+    ):
+        if present:
+            return name
+    return ""
+
+
+def _filesystem(name: str, where: str) -> FilesystemType:
+    try:
+        return FilesystemType(name)
+    except ValueError as error:
+        raise ConversionUnsupported(
+            f"the running {where} is on {name}, which this installer cannot describe"
+        ) from error

--- a/tests/unit/test_plan_convert.py
+++ b/tests/unit/test_plan_convert.py
@@ -16,7 +16,16 @@ from gentoo_install.plan.build import build
 from gentoo_install.plan.convert import SwapDirectories
 from gentoo_install.plan.operations import Stage
 from gentoo_install.model.config import DiskConfig, DiskMode
-from gentoo_install.model.device import DeviceGraph, DeviceId
+from gentoo_install.errors import ConversionUnsupported
+from gentoo_install.model.device import (
+    DeviceGraph,
+    DeviceId,
+    Existing,
+    Filesystem,
+    Mountpoint,
+    StorageLayout,
+)
+from gentoo_install.plan import convert
 from gentoo_install.plan.packages import Catalog, Group
 
 from .layouts import config
@@ -53,3 +62,103 @@ def test_conversion_operation_describes_and_applies(monkeypatch: pytest.MonkeyPa
     assert operation.describe()
     operation.apply(SimpleNamespace(target=PurePosixPath("/target")))
     assert called == [(Path("/gentoo-install.new"), operation.names)]
+
+
+def _layout(
+    *,
+    root_device: str | None = "/dev/vda2",
+    root_filesystem_type: str | None = "xfs",
+    root_on_lvm: bool = False,
+    root_on_luks: bool = False,
+    root_on_mdraid: bool = False,
+    esp_device: str | None = "/dev/vda1",
+    esp_mountpoint: str | None = "/boot/efi",
+    uefi: bool = True,
+) -> StorageLayout:
+    """A UEFI machine whose root is a plain filesystem on a partition."""
+    return StorageLayout(
+        root_device=root_device,
+        root_filesystem_type=root_filesystem_type,
+        root_uuid="8f1c0a2e-0000-4000-8000-000000000001",
+        root_on_lvm=root_on_lvm,
+        root_on_luks=root_on_luks,
+        root_on_mdraid=root_on_mdraid,
+        root_below_device="/dev/vda",
+        boot_device="/dev/vda2",
+        boot_same_filesystem=True,
+        esp_device=esp_device,
+        esp_mountpoint=esp_mountpoint,
+        uefi=uefi,
+        root_free_bytes=20 * 2**30,
+    )
+
+
+def test_the_running_layout_becomes_a_graph_that_formats_nothing() -> None:
+    disk = convert.layout_graph(_layout())
+    filesystems = [
+        node for node in disk.graph.nodes.values() if isinstance(node, Filesystem)
+    ]
+    assert filesystems, "the graph has to describe the filesystems already there"
+    assert all(not one.create for one in filesystems), filesystems
+    assert disk.mode is DiskMode.IN_PLACE
+
+
+def test_the_graph_names_the_devices_the_probe_read() -> None:
+    disk = convert.layout_graph(_layout())
+    selectors = {
+        node.selector for node in disk.graph.nodes.values() if isinstance(node, Existing)
+    }
+    assert selectors == {"/dev/vda2", "/dev/vda1"}
+    root = disk.graph[disk.root]
+    assert isinstance(root, Mountpoint)
+    assert root.path == PurePosixPath("/")
+
+
+def test_the_esp_keeps_the_mountpoint_the_machine_already_uses() -> None:
+    disk = convert.layout_graph(_layout(esp_mountpoint="/efi"))
+    mounts = {
+        node.path: node.options
+        for node in disk.graph.nodes.values()
+        if isinstance(node, Mountpoint)
+    }
+    assert mounts[PurePosixPath("/efi")] == ("umask=0077",)
+
+
+def test_a_machine_without_uefi_gets_no_esp() -> None:
+    disk = convert.layout_graph(_layout(uefi=False, esp_device=None, esp_mountpoint=None))
+    assert not [
+        node for node in disk.graph.nodes.values() if isinstance(node, Mountpoint)
+        if node.path != PurePosixPath("/")
+    ]
+
+
+def test_uefi_without_an_esp_is_refused() -> None:
+    with pytest.raises(ConversionUnsupported, match="no esp"):
+        convert.layout_graph(_layout(esp_device=None))
+
+
+def test_a_root_below_luks_is_refused_by_name() -> None:
+    """One `Existing` node cannot describe a stack, and a conversion that
+    guessed would rewrite a bootloader for a root it cannot unlock."""
+    with pytest.raises(ConversionUnsupported, match="LUKS"):
+        convert.layout_graph(_layout(root_on_luks=True))
+
+
+def test_a_root_below_lvm_is_refused_by_name() -> None:
+    with pytest.raises(ConversionUnsupported, match="LVM"):
+        convert.layout_graph(_layout(root_on_lvm=True))
+
+
+def test_a_root_below_mdraid_is_refused_by_name() -> None:
+    with pytest.raises(ConversionUnsupported, match="mdraid"):
+        convert.layout_graph(_layout(root_on_mdraid=True))
+
+
+def test_a_filesystem_the_model_has_no_member_for_is_refused() -> None:
+    with pytest.raises(ConversionUnsupported, match="reiserfs"):
+        convert.layout_graph(_layout(root_filesystem_type="reiserfs"))
+
+
+def test_a_root_device_that_could_not_be_read_is_refused() -> None:
+    with pytest.raises(ConversionUnsupported, match="could not be read"):
+        convert.layout_graph(_layout(root_device=None))


### PR DESCRIPTION
The design said the conversion has no device graph and `validate()` checks the probed facts instead. The bootloader, `fstab` and kernel planners all take the root device, the esp and the mount options from `config.disk.graph`, so a second description would be the same rule set in two tables. `plan/convert.layout_graph()` turns the facts into a graph whose filesystems all carry `create=False`, so nothing derived from it formats anything, and a root below LUKS, LVM or mdraid is refused by name rather than guessed at. `docs/design.md` carries the change.