### PR TITLE
convert: order the whole conversion around the swap

### DIFF
--- a/gentoo_install/plan/build.py
+++ b/gentoo_install/plan/build.py
@@ -12,10 +12,11 @@ from dataclasses import replace
 from typing import Final, Sequence
 
 from ..model import mirrors
-from ..model.config import InstallConfig
-from ..model.device import StorageFacts
+from ..errors import ConversionUnsupported
+from ..model.config import DiskMode, InstallConfig
+from ..model.device import StorageFacts, StorageLayout
 from ..model.validate import validate
-from . import bootloader, disk, fonts, kernel, packages, portage, system
+from . import bootloader, convert, disk, fonts, kernel, packages, portage, system
 from .operations import Operation, Stage
 
 #: The mirror a stage3 is fetched from when the configuration names none.
@@ -73,9 +74,12 @@ def build(
     *,
     mirror: str = DEFAULT_MIRROR,
     storage_facts: StorageFacts | None = None,
+    layout: StorageLayout | None = None,
 ) -> tuple[Operation, ...]:
     """Validate, then derive the whole install. Nothing here touches a machine."""
     facts = storage_facts if storage_facts is not None else StorageFacts()
+    if config.disk.mode is DiskMode.IN_PLACE:
+        return _in_place(config, catalog, mirror, layout)
     validate(config, storage_facts=facts)
     chosen = packages.groups(config, catalog)
     operations: list[Operation] = [
@@ -106,6 +110,63 @@ def build(
         ) + 1
         ordered.insert(after_configuration, portage.VerifyPackages(requests=requests))
     return tuple(ordered)
+
+
+def _in_place(
+    config: InstallConfig,
+    catalog: packages.Catalog,
+    mirror: str,
+    layout: StorageLayout | None,
+) -> tuple[Operation, ...]:
+    """Derive the conversion of a running system, in the order it must run.
+
+    Not the stage order the rest of the installer sorts by: everything that
+    writes has to land in the staging root first, the swap comes after all of
+    it, and the bootloader after the swap, because it writes to the root the
+    machine will boot from and that is the old one until the swap happens.
+    """
+    if layout is None:
+        raise ConversionUnsupported("the running layout was not read")
+    # The operator's own configuration first, because that is where the rule
+    # against writing a device graph beside the mode applies.
+    validate(config, storage_facts=StorageFacts())
+    derived = replace(config, disk=convert.layout_graph(layout))
+    # And the derived one as an ordinary layout: it describes concrete devices
+    # now, so the compatibility table has something to check.
+    validate(
+        replace(derived, disk=replace(derived.disk, mode=DiskMode.PARTITION)),
+        storage_facts=StorageFacts(),
+    )
+    chosen = packages.groups(derived, catalog)
+    staged: list[Operation] = [
+        *portage.build(
+            derived,
+            stage3_mirror(derived, mirror),
+            packages._required_use(chosen),
+            packages._required_video_cards(derived, chosen),
+            packages._required_licenses(derived, chosen),
+        ),
+        *system.build(derived),
+        *kernel.build(derived),
+        *packages._build(derived, catalog, chosen),
+        *fonts.build(derived, catalog),
+        *portage.finish(derived),
+    ]
+    ordered = sorted(
+        (_in_portage_phase(operation) for operation in staged),
+        key=lambda operation: operation.stage.order,
+    )
+    requests = _package_requests(ordered)
+    if requests:
+        after_configuration = max(
+            index for index, operation in enumerate(ordered) if operation.stage is Stage.PORTAGE
+        ) + 1
+        ordered.insert(after_configuration, portage.VerifyPackages(requests=requests))
+    return (
+        *(convert.Staged(stage=operation.stage, inner=operation) for operation in ordered),
+        convert.SwapDirectories(),
+        *bootloader.build(derived),
+    )
 
 
 def _in_portage_phase(operation: Operation) -> Operation:

--- a/gentoo_install/plan/convert.py
+++ b/gentoo_install/plan/convert.py
@@ -20,7 +20,6 @@ from ..model.device import (
     StorageLayout,
 )
 from .operations import Context, Operation, Stage
-from .portage import InstallStage3
 
 
 REPLACED_DIRECTORIES: tuple[str, ...] = (
@@ -39,18 +38,23 @@ class _Converter(Protocol):
 
 
 @dataclass(frozen=True, kw_only=True)
-class InstallStage3InStaging(Operation):
-    """Reuse stage3 fetching while unpacking into the conversion staging root."""
+class Staged(Operation):
+    """Run an operation against the staging root instead of the target.
 
-    stage: Stage = Stage.STAGE3
-    source: InstallStage3
+    Everything before the swap has to land in `/gentoo-install.new`, because
+    the running userland is still the one on disk. One wrapper rather than a
+    staging variant of each operation: the planners stay unaware of the mode.
+    """
+
+    stage: Stage
+    inner: Operation
     staging: PurePosixPath = PurePosixPath("/gentoo-install.new")
 
     def describe(self) -> str:
-        return self.source.describe().replace("into the target", f"into {self.staging}")
+        return f"{self.inner.describe()}, in {self.staging}"
 
     def apply(self, context: Context) -> None:
-        self.source.apply(cast(Context, _StagingContext(parent=context, staging=self.staging)))
+        self.inner.apply(cast(Context, _StagingContext(parent=context, staging=self.staging)))
 
 
 @dataclass(frozen=True)

--- a/tests/unit/test_plan_convert.py
+++ b/tests/unit/test_plan_convert.py
@@ -162,3 +162,43 @@ def test_a_filesystem_the_model_has_no_member_for_is_refused() -> None:
 def test_a_root_device_that_could_not_be_read_is_refused() -> None:
     with pytest.raises(ConversionUnsupported, match="could not be read"):
         convert.layout_graph(_layout(root_device=None))
+
+
+def test_the_conversion_stages_everything_then_swaps_then_writes_the_bootloader() -> None:
+    """The stage order the rest of the installer sorts by puts the bootloader
+    before packages. A conversion cannot: the bootloader writes to the root the
+    machine will boot from, and that is the old one until the swap happens."""
+    operations = build(_in_place(), CATALOG, layout=_layout())
+    swapped = next(
+        index
+        for index, operation in enumerate(operations)
+        if isinstance(operation, SwapDirectories)
+    )
+    assert all(isinstance(one, convert.Staged) for one in operations[:swapped])
+    assert not any(isinstance(one, convert.Staged) for one in operations[swapped + 1 :])
+    assert operations[swapped + 1 :], "the bootloader has to follow the swap"
+
+
+def test_nothing_before_the_swap_writes_outside_the_staging_root() -> None:
+    operations = build(_in_place(), CATALOG, layout=_layout())
+    staged = [one for one in operations if isinstance(one, convert.Staged)]
+    assert staged
+    assert all(str(one.staging) == "/gentoo-install.new" for one in staged)
+    assert all("/gentoo-install.new" in one.describe() for one in staged)
+
+
+def test_a_conversion_without_a_probed_layout_is_refused() -> None:
+    with pytest.raises(ConversionUnsupported, match="was not read"):
+        build(_in_place(), CATALOG)
+
+
+def test_the_conversion_formats_nothing_and_mounts_nothing() -> None:
+    """The machine is already running on these filesystems."""
+    operations = build(_in_place(), CATALOG, layout=_layout())
+    stages = {
+        (one.inner.stage if isinstance(one, convert.Staged) else one.stage)
+        for one in operations
+    }
+    assert Stage.FORMAT not in stages
+    assert Stage.PARTITION not in stages
+    assert Stage.MOUNT not in stages


### PR DESCRIPTION
`build()` now derives the whole in-place list. Everything that writes is wrapped in `Staged`, so it lands in `/gentoo-install.new` while the running userland is still the one on disk; `SwapDirectories` follows all of it; the bootloader follows the swap, because it writes to the root the machine will boot from and that is the old one until then. `InstallStage3InStaging` is gone: `Staged` covers every operation, and two ways to say the same thing is the shape this project refuses. No caller passes `layout` yet, so an in-place configuration stops with `ConversionUnsupported` rather than running.