### PR TITLE
preflight: refuse a conversion on a live medium

### DIFF
--- a/gentoo_install/exec/preflight.py
+++ b/gentoo_install/exec/preflight.py
@@ -14,7 +14,7 @@ from typing import AbstractSet, Final, Iterable, Mapping
 
 from ..errors import DeviceNotFound, PreflightFailed
 from ..model import compat
-from ..model.config import Firmware, InstallConfig
+from ..model.config import DiskMode, Firmware, InstallConfig
 from ..model.device import (
     DeviceGraph,
     DeviceId,
@@ -483,6 +483,14 @@ def inspect(
     # disk is a real thing to do, and the guard that matters is below — a disk
     # with anything mounted on it is not repartitioned. What was missing is
     # that nothing named the difference before the disk screen.
+    if config.disk.mode is DiskMode.IN_PLACE:
+        medium = probe.live_medium()
+        if medium:
+            fatal.append(
+                "in-place conversion replaces the running userland, and this is a live "
+                f"medium ({medium}): install onto a disk instead"
+            )
+
     if _disks_at_risk(config.disk.graph) and not probe.live_medium():
         where = probe.root_source()
         warnings.append(

--- a/tests/unit/test_preflight.py
+++ b/tests/unit/test_preflight.py
@@ -133,3 +133,56 @@ def test_an_install_from_a_medium_says_nothing_about_it(tmp_path: Path) -> None:
     )
 
     assert not any("live medium" in one for one in report.warnings)
+
+
+def test_a_conversion_from_a_live_medium_is_refused(tmp_path: Path) -> None:
+    """The conversion replaces the running userland. On a live medium that
+    userland is a squashfs in RAM, so the swap would rename directories the
+    machine loses at the next boot and touch nothing that survives."""
+    from dataclasses import replace
+
+    from gentoo_install.model.config import DiskConfig, DiskMode
+    from gentoo_install.model.device import DeviceGraph, DeviceId
+
+    class OnAMedium(Probe):
+        def live_medium(self) -> str:
+            return "the kernel command line carries root=live:"
+
+    converted = replace(
+        config(),
+        disk=DiskConfig(graph=DeviceGraph.build([]), root=DeviceId(""), mode=DiskMode.IN_PLACE),
+    )
+    report = preflight.check(
+        converted,
+        OnAMedium(runner=Runner(log=lambda line: None), work=tmp_path),
+        operations=(),
+    )
+
+    assert any("in-place conversion" in one for one in report.fatal)
+    assert any("root=live:" in one for one in report.fatal)
+
+
+def test_a_conversion_from_a_running_system_is_allowed(tmp_path: Path) -> None:
+    from dataclasses import replace
+
+    from gentoo_install.model.config import DiskConfig, DiskMode
+    from gentoo_install.model.device import DeviceGraph, DeviceId
+
+    class Installed(Probe):
+        def live_medium(self) -> str:
+            return ""
+
+        def root_source(self) -> str:
+            return "/dev/vda2"
+
+    converted = replace(
+        config(),
+        disk=DiskConfig(graph=DeviceGraph.build([]), root=DeviceId(""), mode=DiskMode.IN_PLACE),
+    )
+    report = preflight.check(
+        converted,
+        Installed(runner=Runner(log=lambda line: None), work=tmp_path),
+        operations=(),
+    )
+
+    assert not any("in-place conversion" in one for one in report.fatal)


### PR DESCRIPTION
`docs/design.md` says the mode is chosen by `live_medium()`: a live medium takes the existing install path and only a running system is offered the conversion. Nothing enforced it. On a live medium the userland being replaced is a squashfs in RAM, so the swap would rename directories the machine loses at the next boot and leave the disk untouched — a run that reports success and changes nothing.