### PR TITLE
cli: confirm the swap before it runs

### DIFF
--- a/gentoo_install/cli.py
+++ b/gentoo_install/cli.py
@@ -45,6 +45,7 @@ from .model.config import (
     PortageConfig,
 )
 from .exec.config import load
+from .plan import convert
 from .plan.build import DEFAULT_MIRROR, build, stage3_mirror
 from .plan.operations import Context, Operation, Stage
 from .plan.portage import variant_of
@@ -272,6 +273,8 @@ def install(
             for warning in preflight_report.warnings:
                 record(f"warning: {warning}")
             preflight_report.raise_if_fatal()
+        if config.disk.mode is DiskMode.IN_PLACE and not _confirmed_swap(arguments, record):
+            return EXIT_CONFIG
         machine = Machine(
             config=config, runner=runner, probe=probe, work=work, mountpoint=arguments.target
         )
@@ -363,6 +366,34 @@ def _release(
             # Release is best-effort because a prior failure owns the exit
             # category, but later release operations still have work to do.
             record(f"warning: {operation.describe()}: {error}")
+
+
+#: What an operator types to authorise the one step with no second attempt.
+SWAP_CONFIRMATION: Final[str] = "convert"
+
+
+def _confirmed_swap(
+    arguments: argparse.Namespace, record: Callable[[str], None]
+) -> bool:
+    """Name what the conversion replaces and what it leaves, then ask once.
+
+    Unattended runs are not asked: `mode = "in-place"` in a configuration file
+    is the authorisation, and a question here would hold a serial console open
+    for ever. The list is recorded either way, so a log says what was replaced.
+    """
+    replaced = ", ".join("/" + name for name in convert.REPLACED_DIRECTORIES)
+    record(f"in-place conversion replaces {replaced} and leaves everything else")
+    if _unattended(arguments):
+        return True
+    print(f"This replaces {replaced} on the running system.")
+    print("Everything else, including /home and /root, is left alone.")
+    print(f"Type {SWAP_CONFIRMATION} to continue, anything else to stop.")
+    answer = input("> ").strip()
+    if answer == SWAP_CONFIRMATION:
+        return True
+    record("in-place conversion was not confirmed")
+    print("nothing was changed", file=sys.stderr)
+    return False
 
 
 def _unattended(arguments: argparse.Namespace) -> bool:

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -1,6 +1,7 @@
 # SPDX-License-Identifier: GPL-2.0-or-later
 from __future__ import annotations
 
+import argparse
 import os
 import shutil
 import time
@@ -1035,3 +1036,39 @@ def test_a_conversion_reads_the_running_layout_even_for_a_dry_run(
     assert code == EXIT_OK
     assert read == ["layout"], "the layout is what a conversion plan is derived from"
     assert "swap" in capsys.readouterr().out
+
+
+def _conversion_arguments(no_shell: bool) -> argparse.Namespace:
+    return argparse.Namespace(no_shell=no_shell)
+
+
+def test_the_swap_is_confirmed_before_it_runs(
+    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """The one step with no second attempt. A wrong answer stops the run."""
+    said: list[str] = []
+    monkeypatch.setattr(cli, "_unattended", lambda arguments: False)
+    monkeypatch.setattr("builtins.input", lambda *_: "convert")
+    assert cli._confirmed_swap(_conversion_arguments(False), said.append)
+    printed = capsys.readouterr().out
+    assert "/usr" in printed and "/home" in printed
+
+    monkeypatch.setattr("builtins.input", lambda *_: "yes")
+    assert not cli._confirmed_swap(_conversion_arguments(False), said.append)
+    assert any("not confirmed" in one for one in said)
+
+
+def test_an_unattended_conversion_is_not_asked_but_is_recorded(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A question here would hold a serial console open for ever, and the mode
+    in the configuration file is the authorisation."""
+
+    def refuse(*_: object) -> str:
+        raise AssertionError("an unattended run must not be asked")
+
+    monkeypatch.setattr("builtins.input", refuse)
+    monkeypatch.setattr(cli, "_unattended", lambda arguments: True)
+    said: list[str] = []
+    assert cli._confirmed_swap(_conversion_arguments(True), said.append)
+    assert any("/usr" in one for one in said)


### PR DESCRIPTION
`docs/design.md` puts one confirmation between the reversible work and the irreversible window, and nothing implemented it. The list of replaced directories is recorded either way, so a log says what a run was going to do; an operator at a keyboard also reads it and types `convert`. An unattended run is not asked, because a question on a serial console waits for ever and `mode = "in-place"` in the file is already the authorisation.