### PR TITLE
vm: give up when the console keeps closing

### DIFF
--- a/tests/unit/test_cluster.py
+++ b/tests/unit/test_cluster.py
@@ -477,3 +477,41 @@ def test_the_keeper_starts_once_the_guest_has_its_address() -> None:
     configured = link.ran.index(cluster.configure_statically(cluster.static_address(9301)))
     kept = link.ran.index(cluster.keep_the_address(cluster.static_address(9301))[-1])
     assert configured < kept
+
+
+def test_a_console_that_keeps_closing_gives_up_instead_of_burning_the_ceiling() -> None:
+    """A node whose proxy is refusing grants a session and closes it at once,
+    so every reopen succeeds and nothing ever raises: two guests sat at step 11
+    for forty minutes with their installs running and no way to read them."""
+    from tests.vm.console import ConsoleClosed
+
+    opened: list[int] = []
+
+    class Closing:
+        def send(self, line: str) -> None:
+            pass
+
+        def send_raw(self, keys: str) -> None:
+            pass
+
+        def snapshot(self, seconds: float) -> bytes:
+            return b""
+
+        @property
+        def closed(self) -> bool:
+            return False
+
+        def expect(self, pattern: str, timeout: float, idle: float = 0.0) -> bytes:
+            raise ConsoleClosed("termproxy disconnected")
+
+        def close(self) -> None:
+            pass
+
+    def open_console() -> Closing:
+        opened.append(1)
+        return Closing()
+
+    link = cluster.Reconnecting(open_console, tries=1000)
+    with pytest.raises(ConsoleClosed, match="kept closing"):
+        link.expect("never", timeout=600.0)
+    assert len(opened) <= cluster.REOPEN_CEILING + 2, opened

--- a/tests/vm/cluster.py
+++ b/tests/vm/cluster.py
@@ -1885,6 +1885,13 @@ def _remaining(deadline: float) -> float:
     return max(0.0, deadline - time.monotonic())
 
 
+#: How many times one guest's console may be reopened before the node itself
+#: is called the problem. A healthy run reconnects a handful of times over an
+#: hour; a node whose proxy is refusing grants and closes a session every time,
+#: which raises nothing and burns the whole run ceiling.
+REOPEN_CEILING: Final[int] = 24
+
+
 class Reconnecting:
     """A console that opens another one when the cluster drops it.
 
@@ -1903,6 +1910,7 @@ class Reconnecting:
         self._open = open_console
         self._tries = tries
         self._marks = itertools.count(1)
+        self._reopens = 0
         self.console: Line = open_console()
 
     @classmethod
@@ -1910,6 +1918,16 @@ class Reconnecting:
         return cls(lambda: SerialConsole(guest.console(), log.open("ab")), tries)
 
     def reopen(self, *, solicit_prompt: bool = True) -> None:
+        self._reopens += 1
+        if self._reopens > REOPEN_CEILING:
+            # A node whose proxy is refusing grants a session and closes it at
+            # once, so every reopen succeeds and nothing ever raises: two guests
+            # on `infra-node3` sat at step 11 for forty minutes with their
+            # installs running and no way to read them.
+            raise ConsoleClosed(
+                f"the console was reopened {self._reopens} times and kept closing",
+                write_may_have_reached_guest=False,
+            )
         # Before the new one, not after: `termproxy` holds the guest's serial
         # chardev until its client leaves, and the second session reads nothing.
         try:


### PR DESCRIPTION
`console_proxy_dropped` names the node once a console operation raises, and on a node whose proxy is refusing nothing ever does: each reopen is granted and closed at once, so the worker waits out the whole run ceiling. Two guests of round 36 sat at step 11 for forty minutes while their installs ran. One guest's console may now be reopened 24 times before the node itself is called the problem, which is the rule that every dispatched job answers exactly once.