### PR TITLE
vm: run the conversion against a machine this installer built

### DIFF
--- a/tests/fixtures/vm-convert.toml
+++ b/tests/fixtures/vm-convert.toml
@@ -1,0 +1,43 @@
+# The in-place conversion, run against a machine this installer produced.
+#
+# `disk.mode = "in-place"` carries no device graph: the layout is read from
+# the running machine, and `validate()` refuses one written here. The hostname
+# differs from every other fixture so that a guest which rebooted into the old
+# system rather than the converted one is told apart from one that worked.
+#
+# The root hash below is `install`, produced by `openssl passwd -6`. It has to
+# be a real hash: a made-up one is accepted by `usermod --password` and only
+# shows up as a system nobody can log into.
+config_version = 1
+
+[system]
+hostname = "convertedbox"
+timezone = "UTC"
+locales = ["en_US.UTF-8"]
+locale = "en_US.UTF-8"
+init = "systemd"
+networking = "builtin"
+sshd = true
+root_password_hash = "$6$gentooinst$IR3GrdJ862XljQYDqocr4tKniIRDIT.jQNFzIrHE3U75H6B6YSWZoSYoVd5edSHpqaYBdiNfXHCoIPRVgb9lT/"
+
+[portage]
+profile = "default/linux/amd64/23.0/systemd"
+makeopts = "-j4"
+
+[portage.mirrors]
+region = "global"
+
+[portage.binhost]
+official = true
+community = "off"
+
+[kernel]
+source = "dist-bin"
+
+[bootloader]
+kind = "grub"
+firmware = "uefi"
+kernel_params = ["console=ttyS0,115200"]
+
+[disk]
+mode = "in-place"

--- a/tests/unit/layouts.py
+++ b/tests/unit/layouts.py
@@ -31,6 +31,7 @@ from gentoo_install.model.device import (
     Partition,
     PartitionRole,
     PartitionTable,
+    StorageLayout,
     TableType,
     ZfsDataset,
     ZfsPool,
@@ -96,4 +97,27 @@ def config(nodes: list[Node] | None = None) -> InstallConfig:
         # An empty hash locks root, and `compat` refuses a system nothing can
         # log into. Every layout here is meant to be installable.
         system=SystemConfig(root_password_hash="$6$gentooinst$IR3GrdJ862XljQYDqocr4tKniIRDIT.jQNFzIrHE3U75H6B6YSWZoSYoVd5edSHpqaYBdiNfXHCoIPRVgb9lT/"),
+    )
+
+
+def running_layout() -> StorageLayout:
+    """A UEFI machine whose root is a plain filesystem on a partition.
+
+    What `probe.storage_layout()` reads on the guests the conversion fixture
+    runs against, so a test can derive a conversion without a machine.
+    """
+    return StorageLayout(
+        root_device="/dev/vda2",
+        root_filesystem_type="ext4",
+        root_uuid="8f1c0a2e-0000-4000-8000-000000000001",
+        root_on_lvm=False,
+        root_on_luks=False,
+        root_on_mdraid=False,
+        root_below_device="/dev/vda",
+        boot_device="/dev/vda2",
+        boot_same_filesystem=True,
+        esp_device="/dev/vda1",
+        esp_mountpoint="/efi",
+        uefi=True,
+        root_free_bytes=20 * 2**30,
     )

--- a/tests/unit/test_cluster.py
+++ b/tests/unit/test_cluster.py
@@ -515,3 +515,40 @@ def test_a_console_that_keeps_closing_gives_up_instead_of_burning_the_ceiling() 
     with pytest.raises(ConsoleClosed, match="kept closing"):
         link.expect("never", timeout=600.0)
     assert len(opened) <= cluster.REOPEN_CEILING + 2, opened
+
+
+def test_a_conversion_job_installs_a_machine_before_it_converts_one() -> None:
+    """`mode = "in-place"` carries no device graph, so there is nothing for the
+    scheduler to create. The job installs an ordinary fixture first and runs
+    the conversion against what that produced."""
+    job = cluster.fixtures(["vm-convert"])[0]
+    assert job.name == "vm-convert"
+    assert job.fixture.name == cluster.CONVERSION_BASE
+    assert job.convert_to is not None and job.convert_to.name == "vm-convert.toml"
+
+
+def test_an_ordinary_job_converts_nothing() -> None:
+    job = cluster.fixtures(["vm-xfs"])[0]
+    assert job.convert_to is None
+
+
+def test_the_conversion_base_is_a_layout_the_conversion_accepts() -> None:
+    """A root below LUKS, LVM or mdraid is refused by name, so a base with one
+    would fail every run for a reason that has nothing to do with the swap."""
+    from gentoo_install.exec.config import load
+    from gentoo_install.model.device import Luks, LogicalVolume, MdRaid
+
+    base = load(cluster.REPOSITORY / "tests" / "fixtures" / cluster.CONVERSION_BASE)
+    for stacked in (Luks, LogicalVolume, MdRaid):
+        assert not base.disk.graph.of_type(stacked), stacked.__name__
+
+
+def test_the_converted_machine_is_read_back_the_same_way(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A converted machine that reaches a login prompt with the old hostname
+    booted the system it was replacing, so the same reader has to run again."""
+    import inspect
+
+    code = inspect.getsource(cluster.convert_and_check)
+    assert "boot_and_check(" in code
+    assert "install.sh --config fixtures/" in code
+    assert "wait_for_network(" in code, "the installed system has to reach a mirror too"

--- a/tests/unit/test_plan.py
+++ b/tests/unit/test_plan.py
@@ -9,6 +9,7 @@ import pytest
 from gentoo_install.data import load_catalog
 from gentoo_install.errors import ConfigError, ValidationFailed
 from gentoo_install.model.config import (
+    DiskMode,
     DiskConfig,
     Bootloader,
     BootloaderConfig,
@@ -39,7 +40,7 @@ from gentoo_install.plan.packages import Catalog, Group
 from gentoo_install.plan.portage import Emerge
 from gentoo_install.plan.render import render, summarise
 
-from .layouts import config, ext4_on_gpt, i, zfs_root
+from .layouts import config, ext4_on_gpt, i, running_layout, zfs_root
 from .recorder import Recorder
 
 FIXTURES = Path(__file__).resolve().parents[1] / "fixtures"
@@ -219,7 +220,11 @@ def test_render_groups_by_stage_and_summarise_counts_them() -> None:
 
 def test_every_operation_describes_itself_in_one_line() -> None:
     for path in sorted(FIXTURES.glob("*.toml")):
-        for operation in build(load(path), load_catalog()):
+        installation = load(path)
+        # A conversion derives its whole plan from the running machine, so the
+        # fixture alone is not enough to build one.
+        layout = running_layout() if installation.disk.mode is DiskMode.IN_PLACE else None
+        for operation in build(installation, load_catalog(), layout=layout):
             described = operation.describe()
             assert described and "\n" not in described, f"{type(operation).__name__} in {path.name}"
 

--- a/tests/vm/campaign.py
+++ b/tests/vm/campaign.py
@@ -172,6 +172,12 @@ STAGES: Final[dict[str, tuple[Run, ...]]] = {
         # which no other fixture asks for; zram was set by none of them; and
         # GRUB opening the container itself to read /boot only happens on an
         # encrypted BIOS disk.
+        # The in-place conversion: `cluster.py` installs `vm-xfs.toml` first and
+        # runs this one against the machine that produced, so the whole path
+        # from staging root to swap to bootloader is exercised on a real
+        # system rather than a plan. Two installs one after the other, so it is
+        # long rather than heavy: the instantaneous cost is one guest's.
+        Run("fixtures/vm-convert.toml"),
         Run("fixtures/vm-raidz.toml"),
         Run("fixtures/vm-zram.toml"),
         Run("fixtures/vm-bios-luks.toml", firmware="bios"),

--- a/tests/vm/cluster.py
+++ b/tests/vm/cluster.py
@@ -39,7 +39,12 @@ from collections.abc import Callable, Mapping
 from typing import Final, Protocol, TypeVar, cast
 
 from gentoo_install.model.config import Firmware as BootFirmware
-from gentoo_install.model.config import GentooZhMirror, InitSystem, InstallConfig
+from gentoo_install.model.config import (
+    DiskMode,
+    GentooZhMirror,
+    InitSystem,
+    InstallConfig,
+)
 from gentoo_install.model.device import (
     Existing,
     Filesystem,
@@ -242,6 +247,7 @@ class Phase(Enum):
     BOOT_LIVE = "boot-live"
     INSTALL = "install"
     BOOT_INSTALLED = "boot-installed"
+    CONVERT = "convert"
 
 
 class JobStatus(Enum):
@@ -287,6 +293,9 @@ class Job:
     #: long is compiling, and the configuration is what says whether it does.
     heavy: bool = False
     remote_unlock: bool = False
+    #: The in-place fixture to run once the installed system is up. Set for a
+    #: conversion job, whose `fixture` is the ordinary install it converts.
+    convert_to: Path | None = None
     status: JobStatus = JobStatus.WAITING
     vmid: int = 0
     node: str | None = None
@@ -1535,6 +1544,20 @@ def install_one(
                 revision=revision,
             )
             return outcome
+        if job.convert_to is not None:
+            phase = Phase.CONVERT
+            wrong = convert_and_check(guest, link, log, job.convert_to, held.address, watch)
+            if wrong:
+                outcome = Outcome(
+                    job.name,
+                    Verdict.FAIL,
+                    time.monotonic() - started,
+                    wrong,
+                    log,
+                    phase=phase,
+                    revision=revision,
+                )
+                return outcome
         outcome = Outcome(
             job.name,
             Verdict.OK,
@@ -2255,6 +2278,47 @@ def _unlock(
     )
 
 
+#: The ordinary install a conversion job runs first. Plain by necessity: the
+#: conversion refuses a root below LUKS, LVM or mdraid by name.
+CONVERSION_BASE: Final[str] = "vm-xfs.toml"
+
+
+def convert_and_check(
+    guest: Guest,
+    link: Reconnecting,
+    log: Path,
+    fixture: Path,
+    address: str,
+    watch: "Watchdog",
+) -> str:
+    """Convert the machine this run just installed, then read it back.
+
+    The driver CD is still attached, so the installer that produced this system
+    is the one that converts it. Answers an empty string when the converted
+    machine carries what the conversion asked for.
+    """
+    installation = load(fixture)
+    wait_for_network(link, guest.vmid, address)
+    link.run("mkdir -p /mnt/driver")
+    link.run("mountpoint -q /mnt/driver || mount -o ro /dev/sr1 /mnt/driver")
+    link.run(f"mkdir -p {RESULT_DIR}")
+    link.wait_for(
+        f"{{ sh /mnt/driver/install.sh --config fixtures/{fixture.name}; "
+        f"echo $? > {RESULT_DIR}/install.rc; }} 2>&1 | tee {RESULT_DIR}/install.txt",
+        timeout=RUN_CEILING,
+        idle=INSTALL_IDLE,
+        watch=watch,
+    )
+    files = collect(guest, link, log)
+    keep_results(log, files)
+    code = files.get("install.rc", b"").strip()
+    if code != b"0":
+        return f"the conversion exited {code!r}"
+    # The same reader as the first install: a converted machine that reaches a
+    # login prompt with the old hostname booted the system it was replacing.
+    return boot_and_check(guest, link, log, installation)
+
+
 def boot_and_check(
     guest: Guest,
     link: Reconnecting,
@@ -2559,6 +2623,13 @@ def fixtures(names: list[str]) -> list[Job]:
         if not path.is_file():
             raise SystemExit(f"no fixture named {name} at {path}")
         config: InstallConfig = load(path)
+        convert_to: Path | None = None
+        if config.disk.mode is DiskMode.IN_PLACE:
+            # A conversion needs a machine to convert, so the job installs one
+            # first and this fixture runs on what that produced.
+            convert_to = path
+            path = REPOSITORY / "tests" / "fixtures" / CONVERSION_BASE
+            config = load(path)
         found.append(
             Job(
                 name=name,
@@ -2567,6 +2638,7 @@ def fixtures(names: list[str]) -> list[Job]:
                 disks=max(1, len(config.disk.graph.of_type(Existing))),
                 heavy=_compiles(config),
                 remote_unlock=_requests_remote_unlock(path),
+                convert_to=convert_to,
             )
         )
     return found

--- a/tests/vm/installed.py
+++ b/tests/vm/installed.py
@@ -9,7 +9,13 @@ from pathlib import PurePosixPath
 
 from gentoo_install.data import load_catalog
 from gentoo_install.model import compat
-from gentoo_install.model.config import Bootloader, InitSystem, InstallConfig, Networking
+from gentoo_install.model.config import (
+    Bootloader,
+    DiskMode,
+    InitSystem,
+    InstallConfig,
+    Networking,
+)
 from gentoo_install.model.device import Filesystem, Luks, Mountpoint, Subvolume, ZfsDataset, ZfsPool
 from gentoo_install.plan.system import _network_service as network_service
 
@@ -63,6 +69,13 @@ def checks(installation: InstallConfig) -> tuple[InstalledCheck, ...]:
                 re.escape(f"XMODIFIERS=@im={framework}"),
             )
         )
+    if installation.disk.mode is DiskMode.IN_PLACE:
+        # No graph to derive from: the layout belongs to the machine that was
+        # converted, and the esp and root filesystem are whatever it already
+        # had. `fstab` still has to name the root by UUID, which is the part
+        # the conversion writes.
+        result.append(InstalledCheck("fstab", "cat /etc/fstab", "UUID="))
+        return tuple(result)
     graph = installation.disk.graph
     esp = compat.esp_mount(graph)
     if esp is not None:


### PR DESCRIPTION
The conversion had unit tests and no machine. A fixture with `mode = "in-place"` carries no device graph, so the scheduler has nothing to create: the job now installs `vm-xfs.toml` first, boots and checks it, then mounts the same driver CD and runs the conversion against the system that produced. The converted machine reboots and is read by the same checker, and its hostname differs from the base so a guest that came up on the old system is told apart from one that worked.