### PR TITLE
vm: let login turn the echo off before the password

### DIFF
--- a/tests/unit/test_cluster.py
+++ b/tests/unit/test_cluster.py
@@ -552,3 +552,55 @@ def test_the_converted_machine_is_read_back_the_same_way(monkeypatch: pytest.Mon
     assert "boot_and_check(" in code
     assert "install.sh --config fixtures/" in code
     assert "wait_for_network(" in code, "the installed system has to reach a mirror too"
+
+
+class _LoginConsole:
+    """A serial line that behaves like `login` on the guests.
+
+    It echoes whatever arrives before the prompt has turned the echo off, which
+    is what made `vm-lvm` answer `Login incorrect` after a complete install.
+    """
+
+    def __init__(self, refusals: int) -> None:
+        self.refusals = refusals
+        self.sent: list[str] = []
+        self.answers: list[bytes] = []
+
+    def respond(self, line: str) -> None:
+        self.sent.append(line)
+        if line == "root":
+            self.answers.append(b"Password: ")
+        elif self.refusals > 0:
+            self.refusals -= 1
+            self.answers.append(b"Login incorrect\r\nlogin: ")
+        else:
+            self.answers.append(b"lvmbox ~ # ")
+
+    def observe(self, pattern: str, timeout: float = 0.0) -> bytes:
+        return self.answers.pop(0) if self.answers else b""
+
+
+def test_a_refused_password_is_offered_again(monkeypatch: pytest.MonkeyPatch) -> None:
+    """`login` writes `Password:` and then turns the echo off; a password sent
+    inside that window is echoed and read as an empty one."""
+    monkeypatch.setattr("time.sleep", lambda seconds: None)
+    console = _LoginConsole(refusals=1)
+    assert cluster._log_in(cast(cluster.Reconnecting, console), "install") == ""
+    assert console.sent.count("install") == 2, console.sent
+
+
+def test_a_login_that_is_refused_every_time_is_reported(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr("time.sleep", lambda seconds: None)
+    console = _LoginConsole(refusals=99)
+    said = cluster._log_in(cast(cluster.Reconnecting, console), "install")
+    assert "refused every login" in said
+
+
+def test_the_password_waits_for_the_echo_to_be_turned_off() -> None:
+    import inspect
+
+    code = inspect.getsource(cluster._log_in)
+    assert "PASSWORD_ECHO_OFF_AFTER" in code
+    assert code.index("PASSWORD_ECHO_OFF_AFTER") < code.index("link.respond(password)")

--- a/tests/vm/cluster.py
+++ b/tests/vm/cluster.py
@@ -2194,6 +2194,33 @@ def _name_the_user(link: Reconnecting) -> bool:
     return False
 
 
+#: What `login` takes between writing `Password:` and turning the echo off. A
+#: password sent inside that window is echoed and read as an empty one:
+#: `vm-lvm` printed `install` under the prompt and answered `Login incorrect`
+#: after an install that was otherwise complete.
+PASSWORD_ECHO_OFF_AFTER: Final[float] = 1.0
+
+
+def _log_in(link: Reconnecting, password: str) -> str:
+    """Log root in, and say what is wrong when it does not happen.
+
+    Empty on success. A refused password is retried, because the reason it was
+    refused is a race with the terminal rather than the password being wrong.
+    """
+    for _ in range(LOGIN_TRIES):
+        if not _name_the_user(link):
+            return "the installed system asked for a name and kept asking"
+        time.sleep(PASSWORD_ECHO_OFF_AFTER)
+        link.respond(password)
+        try:
+            said = link.observe(r"#|\$|Login incorrect", timeout=120.0)
+        except ConsoleTimeout as error:
+            return f"root could not log into the installed system: {error}"[:200]
+        if b"Login incorrect" not in said:
+            return ""
+    return "the installed system refused every login"
+
+
 #: How long SeaBIOS and GRUB take to reach the cryptomount prompt. Nothing on
 #: the serial port marks it, so the passphrase is typed after this, and a
 #: wrong guess costs one retry at the next prompt, which is waited for.
@@ -2362,15 +2389,11 @@ def boot_and_check(
         except (ConsoleTimeout, ConsoleClosed) as error:
             return f"the installed system did not reach a login prompt: {error}"[:200]
     try:
-        if not _name_the_user(link):
-            return "the installed system asked for a name and kept asking"
-        link.respond(INSTALLED_PASSWORD)
+        refused = _log_in(link, INSTALLED_PASSWORD)
     except ConsoleClosed as error:
         return f"installed login response delivery is unknown: {error}"[:200]
-    try:
-        link.observe(r"#|\$", timeout=120.0)
-    except (ConsoleTimeout, ConsoleClosed) as error:
-        return f"root could not log into the installed system: {error}"[:200]
+    if refused:
+        return refused
 
     for name, command, wanted in _asked_for(installation):
         said = link.expect_output(command, timeout=120.0)


### PR DESCRIPTION
`vm-lvm` failed round 36 on `root could not log into the installed system` after an install that had finished and booted. The log carries `Password:` followed by `install` in clear and then `Login incorrect`: the password reached the line before `login` had turned the echo off, so it was echoed and the reader got an empty one. Same class as the agetty flush this harness already waits out for the user name. The password now waits, and a refused login is offered again rather than ending the run.