### PR TITLE
tests: keep the worker test off the host's network

### DIFF
--- a/tests/unit/test_cluster.py
+++ b/tests/unit/test_cluster.py
@@ -156,6 +156,10 @@ def test_worker_failure_reports_outcome_and_releases_vmid(
     monkeypatch.setattr(cluster, "threading", Threading)
     monkeypatch.setattr(cluster, "WATCH_EVERY", 0.001)
     monkeypatch.setattr(cluster, "POLL_WHILE_QUEUED", 0.001)
+    # The occupancy probe shells out to `arping` against a segment this machine
+    # is not on, so without this the test answers whatever the host's network
+    # happens to say and the whole suite was run with it deselected.
+    monkeypatch.setattr(cluster, "_address_is_taken", lambda address: False)
 
     jobs = [
         cluster.Job("first", tmp_path / "first.toml"),


### PR DESCRIPTION
`cluster.run` reaches `_address_is_taken`, which shells out to `arping` against 10.31.0.0/24 — a segment the machine running the tests is not on — so the result came from whatever the host's network answered. The probe is now stubbed, which is the difference between a test and a measurement of the room it runs in.