### PR TITLE
convert: swap a directory the machine does not have

### DIFF
--- a/gentoo_install/exec/convert.py
+++ b/gentoo_install/exec/convert.py
@@ -23,7 +23,7 @@ def convert(staging: Path, names: Sequence[str], *, root: Path = Path("/")) -> N
         # step exists to avoid: the window would be the whole copy.
         raise ConversionFailed("the staging directory is not on the root filesystem")
 
-    destinations: list[tuple[str, Path, Path, Path]] = []
+    destinations: list[tuple[str, Path, Path, Path, bool]] = []
     for name in names:
         destination = root / name
         staged = staging / name
@@ -32,15 +32,19 @@ def convert(staging: Path, names: Sequence[str], *, root: Path = Path("/")) -> N
             raise ConversionFailed(f"the staging directory has no {name}")
         if os.path.lexists(old):
             raise ConversionFailed(f"{old} is left from an earlier attempt")
-        destinations.append((name, destination, staged, old))
+        # A distribution without one of these is converted, not refused: a
+        # merged-usr Debian has no `/lib64` at all, and renaming what is not
+        # there fails half way through with the rest already swapped.
+        destinations.append((name, destination, staged, old, os.path.lexists(destination)))
 
-    swapped: list[tuple[str, Path, Path, Path]] = []
+    swapped: list[tuple[str, Path, Path, Path, bool]] = []
     for entry in destinations:
-        name, destination, staged, old = entry
+        name, destination, staged, old, present = entry
         moved_old = False
         try:
-            os.rename(destination, old)
-            moved_old = True
+            if present:
+                os.rename(destination, old)
+                moved_old = True
             os.rename(staged, destination)
         except OSError as error:
             if moved_old:
@@ -48,13 +52,18 @@ def convert(staging: Path, names: Sequence[str], *, root: Path = Path("/")) -> N
                     os.rename(old, destination)
                 except OSError as rollback_error:
                     error.add_note(f"could not restore {name}: {rollback_error}")
-            for swapped_name, swapped_destination, swapped_staged, swapped_old in reversed(swapped):
+            for entry_back in reversed(swapped):
+                swapped_name, swapped_destination, swapped_staged, swapped_old, was_there = (
+                    entry_back
+                )
                 try:
                     os.rename(swapped_destination, swapped_staged)
                 except OSError as rollback_error:
                     error.add_note(
                         f"could not restore {swapped_name}: {rollback_error}"
                     )
+                if not was_there:
+                    continue
                 try:
                     os.rename(swapped_old, swapped_destination)
                 except OSError as rollback_error:
@@ -66,7 +75,9 @@ def convert(staging: Path, names: Sequence[str], *, root: Path = Path("/")) -> N
 
     # Said rather than raised: every name is already swapped by now, so the
     # machine is converted and a directory left behind is not a failure of it.
-    for name, _, _, old in swapped:
+    for name, _, _, old, present in swapped:
+        if not present:
+            continue
         try:
             shutil.rmtree(old)
         except OSError as error:

--- a/tests/unit/test_convert.py
+++ b/tests/unit/test_convert.py
@@ -111,3 +111,50 @@ def test_existing_backup_is_refused_before_any_rename(tmp_path: Path) -> None:
     assert (root / "etc" / "content").read_text() == "old"
     assert (root / "etc.gentoo-install.old" / "content").read_text() == "previous"
     assert (staging / "etc" / "content").read_text() == "new"
+
+
+def test_a_directory_the_machine_lacks_is_moved_into_place(tmp_path: Path) -> None:
+    """A merged-usr Debian has no `/lib64` at all, and renaming what is not
+    there failed half way through with the rest already swapped."""
+    root = tmp_path / "root"
+    staging = tmp_path / "root" / "new"
+    (root / "usr").mkdir(parents=True)
+    (root / "usr" / "old.txt").write_text("old")
+    (staging / "usr").mkdir(parents=True)
+    (staging / "usr" / "new.txt").write_text("new")
+    (staging / "lib64").mkdir()
+    (staging / "lib64" / "new.txt").write_text("new")
+
+    convert.convert(staging, ("usr", "lib64"), root=root)
+
+    assert (root / "usr" / "new.txt").read_text() == "new"
+    assert (root / "lib64" / "new.txt").read_text() == "new"
+    assert not (root / "lib64.gentoo-install.old").exists()
+    assert not (root / "usr.gentoo-install.old").exists()
+
+
+def test_a_rollback_takes_back_a_directory_the_machine_lacked(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Rolling back a name that had no backup means putting it back in the
+    staging root, not restoring a `.old` that was never made."""
+    root = tmp_path / "root"
+    staging = tmp_path / "root" / "new"
+    (root / "usr").mkdir(parents=True)
+    (staging / "lib64").mkdir(parents=True)
+    (staging / "usr").mkdir()
+
+    real = os.rename
+
+    def failing(source: str, target: str) -> None:
+        if str(target).endswith("usr.gentoo-install.old"):
+            raise OSError(5, "input/output error")
+        real(source, target)
+
+    monkeypatch.setattr("os.rename", failing)
+    with pytest.raises(ConversionFailed, match="usr could not be swapped"):
+        convert.convert(staging, ("lib64", "usr"), root=root)
+
+    assert (staging / "lib64").is_dir(), "the staged one has to go back"
+    assert not (root / "lib64").exists()
+    assert (root / "usr").is_dir()


### PR DESCRIPTION
`convert()` pre-checked the staging side of every name and assumed the destination was there. A merged-usr Debian has no `/lib64` at all, so the rename would fail with `/bin`, `/sbin` and `/etc` already swapped — the rollback puts the machine back, but the conversion could never succeed on such a system. An absent destination now needs no backup, and rolling one back means returning it to the staging root rather than restoring a `.old` that was never made.