### PR TITLE
convert: carry the staged kernel into the machine's boot

### DIFF
--- a/gentoo_install/exec/convert.py
+++ b/gentoo_install/exec/convert.py
@@ -82,3 +82,59 @@ def convert(staging: Path, names: Sequence[str], *, root: Path = Path("/")) -> N
             shutil.rmtree(old)
         except OSError as error:
             print(f"{old} stayed behind: {error}", file=sys.stderr)
+
+
+#: What a distribution names a kernel, an initramfs and the two files that go
+#: with them. Files only: `/boot/grub` and the esp mounted under `/boot` are
+#: directories and are left exactly as they are.
+KERNEL_FILES: tuple[str, ...] = (
+    "vmlinuz",
+    "vmlinux",
+    "initrd",
+    "initramfs",
+    "config-",
+    "System.map-",
+)
+
+
+def populate_boot(staging: Path, *, root: Path = Path("/")) -> None:
+    """Put the staged kernel into the machine's own `/boot`.
+
+    Copied rather than renamed, and not part of the swap: `/boot` is a separate
+    mount on many machines and holds the esp as a mount below it on many more,
+    and `rename` refuses both. What it costs is a copy of a few tens of
+    megabytes, inside the irreversible window but at its end.
+
+    The old distribution's kernels are removed once the staged ones are in,
+    because their modules left with `/lib`, so a menu entry for one is an entry
+    that cannot boot.
+    """
+    source = staging / "boot"
+    destination = root / "boot"
+    if not source.is_dir():
+        raise ConversionFailed(f"the staging directory has no {source}")
+    destination.mkdir(parents=True, exist_ok=True)
+    carried: set[str] = set()
+    for entry in sorted(source.iterdir()):
+        target = destination / entry.name
+        try:
+            if entry.is_dir() and not entry.is_symlink():
+                shutil.copytree(entry, target, dirs_exist_ok=True, symlinks=True)
+            else:
+                if target.exists() or target.is_symlink():
+                    target.unlink()
+                shutil.copy2(entry, target, follow_symlinks=False)
+        except OSError as error:
+            raise ConversionFailed(f"{entry.name} could not be put in {destination}: {error}") from error
+        carried.add(entry.name)
+    for entry in sorted(destination.iterdir()):
+        if entry.name in carried or entry.is_dir():
+            continue
+        if not any(entry.name.startswith(one) for one in KERNEL_FILES):
+            continue
+        try:
+            entry.unlink()
+        except OSError as error:
+            # Said rather than raised: the machine is already converted, and a
+            # stale image left behind is a menu entry, not a broken system.
+            print(f"{entry} stayed behind: {error}", file=sys.stderr)

--- a/gentoo_install/plan/build.py
+++ b/gentoo_install/plan/build.py
@@ -165,6 +165,9 @@ def _in_place(
     return (
         *(convert.Staged(stage=operation.stage, inner=operation) for operation in ordered),
         convert.SwapDirectories(),
+        # Between the swap and the bootloader: `grub-mkconfig` reads `/boot`,
+        # and until this runs what is there belongs to the old distribution.
+        convert.PopulateBoot(),
         *bootloader.build(derived),
     )
 

--- a/gentoo_install/plan/convert.py
+++ b/gentoo_install/plan/convert.py
@@ -105,6 +105,31 @@ class SwapDirectories(Operation):
         converter.convert(Path(str(self.staging)), self.names)
 
 
+class _BootPopulator(Protocol):
+    def populate_boot(self, staging: Path, *, root: Path = Path("/")) -> None: ...
+
+
+@dataclass(frozen=True, kw_only=True)
+class PopulateBoot(Operation):
+    """Put the staged kernel into the machine's own `/boot`, after the swap.
+
+    `/boot` is not in the swap: it is a separate mount on many machines and
+    holds the esp below it on many more, and `rename` refuses both. Without
+    this the converted machine keeps the old distribution's kernels and the
+    one that was just built stays in the staging root.
+    """
+
+    stage: Stage = Stage.BOOTLOADER
+    staging: PurePosixPath = PurePosixPath("/gentoo-install.new")
+
+    def describe(self) -> str:
+        return f"put the kernel from {self.staging}/boot into /boot and drop the old images"
+
+    def apply(self, context: Context) -> None:
+        module = importlib.import_module("gentoo_install.exec.convert")
+        cast(_BootPopulator, module).populate_boot(Path(str(self.staging)))
+
+
 #: The synthetic ids. Fixed rather than derived from the device name so that a
 #: plan reads the same whichever disk the machine happens to boot from.
 ROOT_DEVICE: Final[DeviceId] = DeviceId("running-root-device")

--- a/tests/unit/test_convert.py
+++ b/tests/unit/test_convert.py
@@ -158,3 +158,60 @@ def test_a_rollback_takes_back_a_directory_the_machine_lacked(
     assert (staging / "lib64").is_dir(), "the staged one has to go back"
     assert not (root / "lib64").exists()
     assert (root / "usr").is_dir()
+
+
+def test_the_staged_kernel_is_put_into_the_machines_boot(tmp_path: Path) -> None:
+    """`/boot` is not in the swap, so without this the machine keeps the old
+    distribution's kernels and the one just built stays in the staging root."""
+    root = tmp_path / "root"
+    staging = root / "new"
+    (root / "boot").mkdir(parents=True)
+    (root / "boot" / "vmlinuz-6.1.0-debian").write_text("old")
+    (root / "boot" / "initrd.img-6.1.0-debian").write_text("old")
+    (root / "boot" / "grub").mkdir()
+    (root / "boot" / "grub" / "grub.cfg").write_text("old menu")
+    (staging / "boot").mkdir(parents=True)
+    (staging / "boot" / "vmlinuz-6.18.43-gentoo").write_text("new")
+
+    convert.populate_boot(staging, root=root)
+
+    assert (root / "boot" / "vmlinuz-6.18.43-gentoo").read_text() == "new"
+    assert not (root / "boot" / "vmlinuz-6.1.0-debian").exists()
+    assert not (root / "boot" / "initrd.img-6.1.0-debian").exists()
+    # Not a kernel and a directory: `grub` and an esp mounted below `/boot`
+    # both have to survive.
+    assert (root / "boot" / "grub" / "grub.cfg").read_text() == "old menu"
+
+
+def test_a_boot_directory_the_machine_lacks_is_created(tmp_path: Path) -> None:
+    root = tmp_path / "root"
+    staging = root / "new"
+    (staging / "boot").mkdir(parents=True)
+    (staging / "boot" / "vmlinuz-6.18.43-gentoo").write_text("new")
+    root.mkdir(exist_ok=True)
+
+    convert.populate_boot(staging, root=root)
+
+    assert (root / "boot" / "vmlinuz-6.18.43-gentoo").read_text() == "new"
+
+
+def test_a_staging_root_without_a_kernel_is_refused(tmp_path: Path) -> None:
+    root = tmp_path / "root"
+    (root / "new").mkdir(parents=True)
+    with pytest.raises(ConversionFailed, match="no "):
+        convert.populate_boot(root / "new", root=root)
+
+
+def test_a_file_that_is_not_a_kernel_image_is_left_alone(tmp_path: Path) -> None:
+    """The rule names kernels, not everything: a machine's own `memtest86+` or
+    a signed shim under `/boot` is not this installer's to delete."""
+    root = tmp_path / "root"
+    staging = root / "new"
+    (root / "boot").mkdir(parents=True)
+    (root / "boot" / "memtest86+.bin").write_text("keep")
+    (staging / "boot").mkdir(parents=True)
+    (staging / "boot" / "vmlinuz-6.18.43-gentoo").write_text("new")
+
+    convert.populate_boot(staging, root=root)
+
+    assert (root / "boot" / "memtest86+.bin").read_text() == "keep"

--- a/tests/unit/test_plan_convert.py
+++ b/tests/unit/test_plan_convert.py
@@ -202,3 +202,27 @@ def test_the_conversion_formats_nothing_and_mounts_nothing() -> None:
     assert Stage.FORMAT not in stages
     assert Stage.PARTITION not in stages
     assert Stage.MOUNT not in stages
+
+
+def test_the_kernel_reaches_boot_between_the_swap_and_the_bootloader() -> None:
+    """`grub-mkconfig` reads `/boot`, and until this runs what is there belongs
+    to the old distribution."""
+    operations = build(_in_place(), CATALOG, layout=_layout())
+    swapped = next(
+        index for index, one in enumerate(operations) if isinstance(one, SwapDirectories)
+    )
+    populated = next(
+        index for index, one in enumerate(operations)
+        if isinstance(one, convert.PopulateBoot)
+    )
+    grub = next(
+        index for index, one in enumerate(operations)
+        if type(one).__name__ == "InstallGrub"
+    )
+    assert swapped < populated < grub
+
+
+def test_boot_is_not_one_of_the_directories_that_are_renamed() -> None:
+    """A rename refuses a mount point and a directory holding one, and `/boot`
+    is one on many machines and holds the esp on many more."""
+    assert "boot" not in convert.REPLACED_DIRECTORIES


### PR DESCRIPTION
`REPLACED_DIRECTORIES` is `bin sbin etc lib lib64 usr var`, and the kernel is installed into the staging root's `/boot`. After the swap the machine therefore held the old distribution's kernels, whose modules had just left with `/lib`, and the one that was built stayed in `/gentoo-install.new/boot` — `grub-mkconfig` then wrote a menu of entries that cannot boot. `/boot` cannot join the swap: it is a separate mount on many machines and holds the esp below it on many more, and `rename` refuses both. It is copied instead, between the swap and the bootloader, and the old images are dropped. Directories are never removed, so `/boot/grub` and a mounted esp survive.