### PR TITLE
cli: a conversion acts on the running root

### DIFF
--- a/gentoo_install/cli.py
+++ b/gentoo_install/cli.py
@@ -268,21 +268,27 @@ def install(
 ) -> int:
     """Check the machine, then perform every operation in order."""
     work: Path = arguments.work
-    with report.recording(work, arguments.target) as active_report:
+    # A conversion replaces the running userland, so every operation after the
+    # swap acts on `/`. Left at `--target` they would chroot into a directory
+    # the machine does not have.
+    target: Path = (
+        Path("/") if config.disk.mode is DiskMode.IN_PLACE else arguments.target
+    )
+    with report.recording(work, target) as active_report:
         record = active_report.record
         journal = active_report.journal
         runner = Runner(log=record, journal=journal)
         probe = Probe(runner=runner, work=work)
         probe.load()
         if not arguments.skip_preflight:
-            preflight_report = preflight.check(config, probe, str(arguments.target))
+            preflight_report = preflight.check(config, probe, str(target))
             for warning in preflight_report.warnings:
                 record(f"warning: {warning}")
             preflight_report.raise_if_fatal()
         if config.disk.mode is DiskMode.IN_PLACE and not _confirmed_swap(arguments, record):
             return EXIT_CONFIG
         machine = Machine(
-            config=config, runner=runner, probe=probe, work=work, mountpoint=arguments.target
+            config=config, runner=runner, probe=probe, work=work, mountpoint=target
         )
         finished = completed(journal) if arguments.resume else frozenset()
         if arguments.resume:
@@ -320,7 +326,7 @@ def install(
         # Before the closing stage: that stage unmounts the target, so a later
         # copy lands on the install medium's tmpfs and vanishes at reboot.
         try:
-            report.keep_log(work, arguments.target, record)
+            report.keep_log(work, target, record)
         except BaseException as error:
             failure = _first_failure(failure, error, record)
         if failure is None:
@@ -335,7 +341,7 @@ def install(
             raise failure
         counted = journal.counts()
         record(
-            f"installed {len(operations)} operations into {arguments.target}; "
+            f"installed {len(operations)} operations into {target}; "
             f"{counted.get('binary', 0)} packages from a binary host, "
             f"{counted.get('compiled', 0)} compiled"
         )

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -1123,3 +1123,40 @@ def test_a_layout_that_cannot_be_converted_exits_as_a_preflight_failure(
 
     assert code == EXIT_PREFLIGHT
     assert "zfs" in capsys.readouterr().err
+
+
+def test_a_conversion_acts_on_the_running_root_not_the_mount_point(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Every operation after the swap acts on `/`. Left at `--target` they
+    would chroot into a directory the machine does not have."""
+    from dataclasses import replace
+
+    from .layouts import config
+
+    seen: list[Path] = []
+
+    class Recording:
+        def __init__(self, **fields: object) -> None:
+            seen.append(cast(Path, fields["mountpoint"]))
+            self.given_up: set[str] = set()
+            self.runner = fields["runner"]
+
+    converted = replace(
+        config(),
+        disk=DiskConfig(graph=DeviceGraph.build([]), root=DeviceId(""), mode=DiskMode.IN_PLACE),
+    )
+    monkeypatch.setattr(cli, "Machine", Recording)
+    monkeypatch.setattr(cli, "apply", lambda *args, **kwargs: None)
+    monkeypatch.setattr(cli, "_confirmed_swap", lambda arguments, record: True)
+    monkeypatch.setattr(report, "keep_log", lambda work, target, record: None)
+    arguments = argparse.Namespace(
+        work=tmp_path / "work",
+        target=Path("/mnt/gentoo"),
+        skip_preflight=True,
+        resume=False,
+        no_shell=True,
+        dry_run=False,
+    )
+    cli.install(converted, (), arguments, cli.RunState())
+    assert seen == [Path("/")], seen


### PR DESCRIPTION
`Machine` took its mount point from `--target`, which defaults to `/mnt/gentoo`. Everything before the swap is wrapped in `Staged` and writes to `/gentoo-install.new`, but the bootloader runs after the swap and would have chrooted into a directory a machine being converted does not have. The mount point, the preflight target and the log's destination are all `/` in that mode.