### PR TITLE
convert: leave no staging root behind

### DIFF
--- a/gentoo_install/plan/build.py
+++ b/gentoo_install/plan/build.py
@@ -169,6 +169,7 @@ def _in_place(
         # and until this runs what is there belongs to the old distribution.
         convert.PopulateBoot(),
         *bootloader.build(derived),
+        convert.LeaveStaging(),
     )
 
 

--- a/gentoo_install/plan/convert.py
+++ b/gentoo_install/plan/convert.py
@@ -8,7 +8,7 @@ from dataclasses import dataclass
 from pathlib import Path, PurePosixPath
 from typing import Any, Final, Protocol, Sequence, cast
 
-from ..errors import ConversionUnsupported
+from ..errors import ConversionFailed, ConversionUnsupported
 from ..model.config import DiskConfig, DiskMode
 from ..model.device import (
     DeviceGraph,
@@ -103,6 +103,42 @@ class SwapDirectories(Operation):
         module = importlib.import_module("gentoo_install.exec.convert")
         converter = cast(_Converter, module)
         converter.convert(Path(str(self.staging)), self.names)
+
+
+@dataclass(frozen=True, kw_only=True)
+class LeaveStaging(Operation):
+    """Unmount what the chroot bound under the staging root and remove it.
+
+    `disk.finish` cannot be reused: it unmounts everything under the target,
+    and in this mode the target is `/`. What is left otherwise is `/proc` and
+    `/sys` bound into a directory nothing will ever enter again, which holds
+    the machine at shutdown, and a staging root on the disk for ever.
+    """
+
+    stage: Stage = Stage.FINISH
+    staging: PurePosixPath = PurePosixPath("/gentoo-install.new")
+
+    def required_host_commands(self) -> frozenset[str]:
+        return frozenset({"umount", "findmnt", "rm"})
+
+    def describe(self) -> str:
+        return f"unmount and remove {self.staging}"
+
+    def apply(self, context: Context) -> None:
+        context.run(["umount", "--recursive", "--lazy", str(self.staging)], check=False)
+        listed = context.run(
+            ["findmnt", "--noheadings", "--list", "--output", "TARGET"], check=False
+        )
+        under = f"{self.staging}/"
+        if any(
+            line.strip() == str(self.staging) or line.strip().startswith(under)
+            for line in listed.splitlines()
+        ):
+            # Said rather than raised: the machine is converted, and `rm` walking
+            # into a `/proc` still bound here is not a risk worth taking to
+            # tidy up.
+            raise ConversionFailed(f"{self.staging} still has something mounted under it")
+        context.run(["rm", "--recursive", "--force", str(self.staging)])
 
 
 class _BootPopulator(Protocol):

--- a/tests/unit/test_plan_convert.py
+++ b/tests/unit/test_plan_convert.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 from dataclasses import replace
 from pathlib import Path, PurePosixPath
 from types import SimpleNamespace
-from typing import Any
+from typing import Any, cast
 
 import pytest
 
@@ -16,7 +16,7 @@ from gentoo_install.plan.build import build
 from gentoo_install.plan.convert import SwapDirectories
 from gentoo_install.plan.operations import Stage
 from gentoo_install.model.config import DiskConfig, DiskMode
-from gentoo_install.errors import ConversionUnsupported
+from gentoo_install.errors import ConversionFailed, ConversionUnsupported
 from gentoo_install.model.device import (
     DeviceGraph,
     DeviceId,
@@ -226,3 +226,40 @@ def test_boot_is_not_one_of_the_directories_that_are_renamed() -> None:
     """A rename refuses a mount point and a directory holding one, and `/boot`
     is one on many machines and holds the esp on many more."""
     assert "boot" not in convert.REPLACED_DIRECTORIES
+
+
+class _RunningContext:
+    """A context that records commands and answers `findmnt` from a list."""
+
+    def __init__(self, mounted: tuple[str, ...] = ()) -> None:
+        self.mounted = mounted
+        self.ran: list[list[str]] = []
+
+    target = PurePosixPath("/")
+
+    def run(self, argv: list[str], *, check: bool = True, input_text: str | None = None) -> str:
+        self.ran.append(argv)
+        if argv[0] == "findmnt":
+            return "\n".join(self.mounted)
+        return ""
+
+
+def test_the_staging_root_is_unmounted_and_removed() -> None:
+    context = _RunningContext(mounted=("/", "/boot"))
+    convert.LeaveStaging().apply(cast(Any, context))
+    assert ["umount", "--recursive", "--lazy", "/gentoo-install.new"] in context.ran
+    assert ["rm", "--recursive", "--force", "/gentoo-install.new"] in context.ran
+
+
+def test_a_staging_root_with_something_still_mounted_is_left_alone() -> None:
+    """`rm` walking into a `/proc` still bound there is not a risk worth taking
+    to tidy up a machine that is already converted."""
+    context = _RunningContext(mounted=("/", "/gentoo-install.new/proc"))
+    with pytest.raises(ConversionFailed, match="still has something mounted"):
+        convert.LeaveStaging().apply(cast(Any, context))
+    assert not any(argv[0] == "rm" for argv in context.ran)
+
+
+def test_the_conversion_ends_by_leaving_no_staging_root() -> None:
+    operations = build(_in_place(), CATALOG, layout=_layout())
+    assert isinstance(operations[-1], convert.LeaveStaging)


### PR DESCRIPTION
A conversion skips `disk.finish`, because `UnmountTarget` unmounts everything under the target and in this mode the target is `/`. What that left is `/proc`, `/sys`, `/dev` and `/run` bound into a directory nothing will enter again — which holds the machine at shutdown — and the staging root on the disk for ever. `LeaveStaging` unmounts what is under the staging root and removes it, and stops without removing anything if something is still mounted there.