### PR TITLE
convert: shorten the irreversible window

### DIFF
--- a/gentoo_install/plan/build.py
+++ b/gentoo_install/plan/build.py
@@ -112,6 +112,18 @@ def build(
     return tuple(ordered)
 
 
+#: The only bootloader operations that cannot be done before the swap: they
+#: write to the esp or the boot sector of the machine as it will boot, and
+#: `/boot` and the esp are not part of the swap. Emerging the package and
+#: writing `/etc/default/grub` are ordinary staged work, and leaving them in
+#: the irreversible window made it minutes long for no reason.
+AFTER_THE_SWAP: Final[tuple[type[Operation], ...]] = (
+    bootloader.InstallGrub,
+    bootloader.InstallSystemdBoot,
+    bootloader.ShowTheBootMenu,
+)
+
+
 def _in_place(
     config: InstallConfig,
     catalog: packages.Catalog,
@@ -138,6 +150,8 @@ def _in_place(
         storage_facts=StorageFacts(),
     )
     chosen = packages.groups(derived, catalog)
+    boot = bootloader.build(derived)
+    after_the_swap = tuple(one for one in boot if isinstance(one, AFTER_THE_SWAP))
     staged: list[Operation] = [
         *portage.build(
             derived,
@@ -148,6 +162,7 @@ def _in_place(
         ),
         *system.build(derived),
         *kernel.build(derived),
+        *(one for one in boot if not isinstance(one, AFTER_THE_SWAP)),
         *packages._build(derived, catalog, chosen),
         *fonts.build(derived, catalog),
         *portage.finish(derived),
@@ -168,7 +183,7 @@ def _in_place(
         # Between the swap and the bootloader: `grub-mkconfig` reads `/boot`,
         # and until this runs what is there belongs to the old distribution.
         convert.PopulateBoot(),
-        *bootloader.build(derived),
+        *after_the_swap,
         convert.LeaveStaging(),
     )
 

--- a/tests/unit/test_plan_convert.py
+++ b/tests/unit/test_plan_convert.py
@@ -263,3 +263,28 @@ def test_a_staging_root_with_something_still_mounted_is_left_alone() -> None:
 def test_the_conversion_ends_by_leaving_no_staging_root() -> None:
     operations = build(_in_place(), CATALOG, layout=_layout())
     assert isinstance(operations[-1], convert.LeaveStaging)
+
+
+def test_only_the_esp_and_boot_sector_writes_wait_for_the_swap() -> None:
+    """Emerging the bootloader and writing `/etc/default/grub` are ordinary
+    staged work, and leaving them in the irreversible window made it minutes
+    long for no reason."""
+    from gentoo_install.plan.bootloader import InstallGrub
+
+    operations = build(_in_place(), CATALOG, layout=_layout())
+    swapped = next(
+        index for index, one in enumerate(operations) if isinstance(one, SwapDirectories)
+    )
+    before = operations[:swapped]
+    after = operations[swapped:]
+    assert any(
+        isinstance(one, convert.Staged) and type(one.inner).__name__ == "Emerge"
+        and "bootloader" in one.inner.describe()
+        for one in before
+    ), "the bootloader package is emerged before the swap"
+    assert any(
+        isinstance(one, convert.Staged) and type(one.inner).__name__ == "WriteGrubDefaults"
+        for one in before
+    )
+    assert any(isinstance(one, InstallGrub) for one in after)
+    assert not any(isinstance(one, InstallGrub) for one in before)


### PR DESCRIPTION
The whole of `bootloader.build` ran after the swap, which put `emerge sys-boot/grub` and `/etc/default/grub` inside the one step that cannot be undone — minutes during which a power cut leaves a machine with a Gentoo userland and no bootloader. Only `InstallGrub`, `InstallSystemdBoot` and `ShowTheBootMenu` write to the esp or the boot sector; the rest is staged like everything else.