### PR TITLE
convert: refuse a root with no room for both systems

### DIFF
--- a/gentoo_install/plan/convert.py
+++ b/gentoo_install/plan/convert.py
@@ -186,6 +186,7 @@ def layout_graph(layout: StorageLayout) -> DiskConfig:
     it carries `create=False`, so no operation derived from it formats
     anything.
     """
+    _room_for_both(layout)
     below = _unsupported_layer(layout)
     if below:
         raise ConversionUnsupported(
@@ -226,6 +227,29 @@ def layout_graph(layout: StorageLayout) -> DiskConfig:
         root=ROOT_MOUNT,
         mode=DiskMode.IN_PLACE,
     )
+
+
+#: What the root filesystem needs free before a conversion starts. The staged
+#: system and the running one are on it at the same time: a base Gentoo with a
+#: binary kernel is about 4 GiB, the ebuild repository 1.5 GiB, and the
+#: binary packages and distfiles fetched on the way another 2 GiB.
+CONVERSION_FREE_BYTES: Final[int] = 10 * 2**30
+
+
+def _room_for_both(layout: StorageLayout) -> None:
+    """Stop before anything is written when the root cannot hold both systems.
+
+    An unknown figure is not a small one: `findmnt` not reporting `avail` is a
+    reason to carry on, because refusing there would stop machines that are
+    fine.
+    """
+    free = layout.root_free_bytes
+    if free is not None and free < CONVERSION_FREE_BYTES:
+        raise ConversionUnsupported(
+            f"the root filesystem has {free // 2**30} GiB free and a conversion needs "
+            f"{CONVERSION_FREE_BYTES // 2**30}: the staged system and the running one "
+            "are on it at the same time"
+        )
 
 
 def _unsupported_layer(layout: StorageLayout) -> str:

--- a/tests/unit/test_plan_convert.py
+++ b/tests/unit/test_plan_convert.py
@@ -74,6 +74,7 @@ def _layout(
     esp_device: str | None = "/dev/vda1",
     esp_mountpoint: str | None = "/boot/efi",
     uefi: bool = True,
+    root_free_bytes: int | None = 20 * 2**30,
 ) -> StorageLayout:
     """A UEFI machine whose root is a plain filesystem on a partition."""
     return StorageLayout(
@@ -89,7 +90,7 @@ def _layout(
         esp_device=esp_device,
         esp_mountpoint=esp_mountpoint,
         uefi=uefi,
-        root_free_bytes=20 * 2**30,
+        root_free_bytes=root_free_bytes,
     )
 
 
@@ -288,3 +289,20 @@ def test_only_the_esp_and_boot_sector_writes_wait_for_the_swap() -> None:
     )
     assert any(isinstance(one, InstallGrub) for one in after)
     assert not any(isinstance(one, InstallGrub) for one in before)
+
+
+def test_a_root_with_no_room_for_both_systems_is_refused() -> None:
+    """The staged system and the running one are on it at the same time, and
+    running out half way leaves a staging root and nothing converted."""
+    with pytest.raises(ConversionUnsupported, match="4 GiB free"):
+        convert.layout_graph(_layout(root_free_bytes=4 * 2**30))
+
+
+def test_a_root_with_room_is_accepted() -> None:
+    convert.layout_graph(_layout(root_free_bytes=convert.CONVERSION_FREE_BYTES))
+
+
+def test_an_unknown_amount_of_room_is_not_a_small_one() -> None:
+    """`findmnt` not reporting `avail` is a reason to carry on: refusing there
+    would stop machines that are fine."""
+    convert.layout_graph(_layout(root_free_bytes=None))


### PR DESCRIPTION
`docs/design.md` puts a space check in step one, before anything is written, and `probe.storage_layout()` has read `root_free_bytes` since it was added with nothing looking at it. The threshold is 10 GiB and the message says what was found and why: a base Gentoo with a binary kernel is about 4 GiB, the ebuild repository 1.5, and the packages fetched on the way another 2, all of it beside the system still running. An unknown figure is not a small one, so a `findmnt` that did not report `avail` carries on.