### PR TITLE
vm: end a job whose node dropped its console

### DIFF
--- a/tests/unit/test_cluster.py
+++ b/tests/unit/test_cluster.py
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: GPL-2.0-or-later
 from __future__ import annotations
 
-from typing import cast
+from typing import Any, cast
 
 import time
 from collections.abc import Callable
@@ -608,3 +608,46 @@ def test_the_password_waits_for_the_echo_to_be_turned_off() -> None:
     code = inspect.getsource(cluster._log_in)
     assert "PASSWORD_ECHO_OFF_AFTER" in code
     assert code.index("PASSWORD_ECHO_OFF_AFTER") < code.index("link.respond(password)")
+
+
+class _Stoppable:
+    def __init__(self) -> None:
+        self.stopped = False
+
+    def stop(self) -> None:
+        self.stopped = True
+
+    def destroy(self) -> None:
+        self.stopped = True
+
+
+def _held(log: Path, moved: bool, stuck: bool) -> object:
+    watch = cluster.Watchdog(log=log, counters=lambda: 0)
+    # One pass so the watchdog has seen the log: the first call always reports
+    # growth, from nothing to whatever is there.
+    watch.moved()
+    watch.strikes = cluster.WATCH_STRIKES if stuck else 0
+    return cluster.Running(guest=cast(Any, _Stoppable()), watch=watch, reservation_bytes=0)
+
+
+def test_a_quiet_guest_whose_node_dropped_the_console_is_ended_at_once(
+    tmp_path: Path,
+) -> None:
+    """A node whose proxy is refusing leaves the socket open and silent, so
+    nothing raises and the guest's own counters still say it is working."""
+    log = tmp_path / "vm-zfs.log"
+    log.write_text(
+        "installing\nRead from remote host 10.31.0.202: Connection reset by peer\n"
+        "Connection to 10.31.0.202 closed.\n"
+    )
+    held = _held(log, moved=False, stuck=False)
+    cluster._sweep({"vm-zfs": cast(Any, held)})
+    assert cast(Any, held).guest.stopped
+
+
+def test_a_quiet_guest_with_a_healthy_console_is_left_running(tmp_path: Path) -> None:
+    log = tmp_path / "vm-xfs.log"
+    log.write_text("emerging sys-kernel/gentoo-kernel\n")
+    held = _held(log, moved=False, stuck=False)
+    cluster._sweep({"vm-xfs": cast(Any, held)})
+    assert not cast(Any, held).guest.stopped

--- a/tests/vm/cluster.py
+++ b/tests/vm/cluster.py
@@ -2608,13 +2608,20 @@ def _sweep(inflight: Mapping[str, Running]) -> None:
     for name, held in list(inflight.items()):
         if held.watch.moved():
             continue
-        if not held.watch.stuck:
+        # A node whose proxy is refusing leaves the socket open and silent, so
+        # nothing raises and the guest's own counters still say it is working:
+        # `vm-zfs` sat that way for thirty-five minutes with its install
+        # running. The tail of its log is the only thing that names it, and it
+        # is only read once the log has stopped growing, so a console that
+        # recovered is not ended for a message that scrolled past.
+        dropped = console_proxy_dropped(held.watch.log)
+        if not held.watch.stuck and not dropped:
             print(
                 f"… {name} quiet for {held.watch.strikes * WATCH_EVERY / 60:.0f}m",
                 flush=True,
             )
             continue
-        print(f"! {name} stopped writing; ending it", flush=True)
+        print(f"! {name} {dropped or 'stopped writing'}; ending it", flush=True)
         try:
             held.guest.stop()
         except ProxmoxError as error:


### PR DESCRIPTION
The reopen ceiling in #365 covers a console that is granted and closed at once. `vm-zfs` in round 37 met the other shape: `infra-node3` left the socket open and silent, so no read raised, and the guest's own byte counters still said it was working — the watchdog is right that the machine is alive and wrong that the run can continue. The sweep now reads the tail of a log that has stopped growing, and a job whose node said `Connection reset` is ended there, which also marks that node as taking no more guests.