### PR TITLE
vm: put the conversion fixture on the driver cd

### DIFF
--- a/tests/unit/test_cluster.py
+++ b/tests/unit/test_cluster.py
@@ -651,3 +651,15 @@ def test_a_quiet_guest_with_a_healthy_console_is_left_running(tmp_path: Path) ->
     held = _held(log, moved=False, stuck=False)
     cluster._sweep({"vm-xfs": cast(Any, held)})
     assert not cast(Any, held).guest.stopped
+
+
+def test_both_fixtures_of_a_conversion_job_reach_the_driver_cd(tmp_path: Path) -> None:
+    """A conversion job carries two: the ordinary install it runs first and the
+    in-place fixture it runs against the result. Writing only the first left
+    the CD without the second and the guest answered `no such file`."""
+    jobs = cluster.fixtures(["vm-convert"])
+    written = cluster.rewrite_fixtures(
+        jobs, tmp_path / "fixtures", cluster.MirrorRegion.CN, cluster.Sync.GIT, site="nju"
+    )
+    names = {path.name for path in written.iterdir()}
+    assert names == {cluster.CONVERSION_BASE, "vm-convert.toml"}, names

--- a/tests/vm/cluster.py
+++ b/tests/vm/cluster.py
@@ -1049,8 +1049,17 @@ def rewrite_fixtures(
     installer.
     """
     into.mkdir(parents=True, exist_ok=True)
-    for job in jobs:
-        config = load(job.fixture)
+    # A conversion job carries two: the ordinary install it runs first and the
+    # in-place fixture it runs against the result. Writing only `fixture` left
+    # the CD without the second one, and the guest answered `no such file`.
+    wanted = [
+        path
+        for job in jobs
+        for path in (job.fixture, job.convert_to)
+        if path is not None
+    ]
+    for source in wanted:
+        config = load(source)
         # The overlay moves with the region. A `cn` run that still cloned
         # gentoo-zh from github stopped the install after two hundred seconds
         # of `Could not connect to server`, while every other fetch in the same
@@ -1077,7 +1086,7 @@ def rewrite_fixtures(
                 ),
             ),
         )
-        (into / job.fixture.name).write_text(to_toml(moved))
+        (into / source.name).write_text(to_toml(moved))
     return into
 
 


### PR DESCRIPTION
`rewrite_fixtures` wrote one file per job, taken from `job.fixture`. For a conversion job that is the ordinary install it runs first; the in-place fixture is `job.convert_to` and never reached the CD, so the run would have failed on `--config fixtures/vm-convert.toml` after an hour of installing the base. Found by calling the function rather than by reading it.