### PR TITLE
convert: create the staging root before anything is written

### DIFF
--- a/gentoo_install/plan/build.py
+++ b/gentoo_install/plan/build.py
@@ -153,6 +153,7 @@ def _in_place(
     boot = bootloader.build(derived)
     after_the_swap = tuple(one for one in boot if isinstance(one, AFTER_THE_SWAP))
     staged: list[Operation] = [
+        convert.PrepareStaging(),
         *portage.build(
             derived,
             stage3_mirror(derived, mirror),

--- a/gentoo_install/plan/convert.py
+++ b/gentoo_install/plan/convert.py
@@ -106,6 +106,39 @@ class SwapDirectories(Operation):
 
 
 @dataclass(frozen=True, kw_only=True)
+class PrepareStaging(Operation):
+    """Create the directory the staged system is built in.
+
+    Nothing else does: the ordinary path gets `/mnt/gentoo` from the mount
+    operations, and a conversion has none, so `tar --directory` was the first
+    thing to find out.
+    """
+
+    # `STAGE3`, not `MOUNT`: creating a directory is not a mount, and a
+    # conversion mounts nothing. Sorting is stable, so it stays ahead of the
+    # unpack it exists for.
+    stage: Stage = Stage.STAGE3
+    staging: PurePosixPath = PurePosixPath("/gentoo-install.new")
+
+    def required_host_commands(self) -> frozenset[str]:
+        return frozenset({"mkdir", "find"})
+
+    def describe(self) -> str:
+        return f"create {self.staging} for the staged system"
+
+    def apply(self, context: Context) -> None:
+        context.run(["mkdir", "--parents", str(self.staging)])
+        inside = context.run(
+            ["find", str(self.staging), "-maxdepth", "1", "-mindepth", "1"], check=False
+        ).strip()
+        if inside:
+            raise ConversionFailed(
+                f"{self.staging} is not empty and is left from an earlier attempt: "
+                "remove it before converting"
+            )
+
+
+@dataclass(frozen=True, kw_only=True)
 class LeaveStaging(Operation):
     """Unmount what the chroot bound under the staging root and remove it.
 

--- a/tests/unit/test_plan_convert.py
+++ b/tests/unit/test_plan_convert.py
@@ -238,11 +238,13 @@ class _RunningContext:
 
     target = PurePosixPath("/")
 
+    answers: dict[str, str] = {}
+
     def run(self, argv: list[str], *, check: bool = True, input_text: str | None = None) -> str:
         self.ran.append(argv)
         if argv[0] == "findmnt":
             return "\n".join(self.mounted)
-        return ""
+        return self.answers.get(argv[0], "")
 
 
 def test_the_staging_root_is_unmounted_and_removed() -> None:
@@ -306,3 +308,25 @@ def test_an_unknown_amount_of_room_is_not_a_small_one() -> None:
     """`findmnt` not reporting `avail` is a reason to carry on: refusing there
     would stop machines that are fine."""
     convert.layout_graph(_layout(root_free_bytes=None))
+
+
+def test_the_staging_root_is_created_before_anything_is_written() -> None:
+    """The ordinary path gets `/mnt/gentoo` from the mount operations, and a
+    conversion has none, so `tar --directory` was the first thing to find out."""
+    operations = build(_in_place(), CATALOG, layout=_layout())
+    first = operations[0]
+    assert isinstance(first, convert.Staged)
+    assert isinstance(first.inner, convert.PrepareStaging)
+
+
+def test_a_staging_root_left_from_an_earlier_attempt_is_refused() -> None:
+    context = _RunningContext()
+    context.answers = {"find": "/gentoo-install.new/usr"}
+    with pytest.raises(ConversionFailed, match="earlier attempt"):
+        convert.PrepareStaging().apply(cast(Any, context))
+
+
+def test_an_empty_staging_root_is_accepted() -> None:
+    context = _RunningContext()
+    convert.PrepareStaging().apply(cast(Any, context))
+    assert ["mkdir", "--parents", "/gentoo-install.new"] in context.ran


### PR DESCRIPTION
Nothing created `/gentoo-install.new`. In the ordinary path the directory a stage3 is unpacked into comes from the mount operations, and a conversion skips `disk.build` entirely, so the first thing to notice would have been `tar --directory`. The new operation also refuses a staging root left non-empty by an earlier attempt, because unpacking a second stage3 over the first is not something to discover after the swap.