### PR TITLE
convert: let preflight see through the staging wrapper

### DIFF
--- a/gentoo_install/exec/preflight.py
+++ b/gentoo_install/exec/preflight.py
@@ -244,6 +244,9 @@ def _operation_commands(operation: Operation) -> frozenset[str]:
     for operation_type, commands in BY_OPERATION.items():
         if isinstance(operation, operation_type):
             wanted.update(commands)
+    inner = operation.wrapped
+    if inner is not None:
+        wanted.update(_operation_commands(inner))
     return frozenset(wanted)
 
 

--- a/gentoo_install/plan/convert.py
+++ b/gentoo_install/plan/convert.py
@@ -50,6 +50,17 @@ class Staged(Operation):
     inner: Operation
     staging: PurePosixPath = PurePosixPath("/gentoo-install.new")
 
+    @property
+    def wrapped(self) -> Operation | None:
+        # Preflight reads this: `--missing-commands` and the check before an
+        # install key part of their table on the operation's type, and a
+        # wrapper is not an instance of what it wraps.
+        return self.inner
+
+    @property
+    def releases_the_machine(self) -> bool:
+        return self.inner.releases_the_machine
+
     def describe(self) -> str:
         return f"{self.inner.describe()}, in {self.staging}"
 

--- a/gentoo_install/plan/operations.py
+++ b/gentoo_install/plan/operations.py
@@ -189,6 +189,16 @@ class Operation(ABC):
         return frozenset(self.host_commands)
 
     @property
+    def wrapped(self) -> "Operation | None":
+        """The operation this one stands in for, when it stands in for one.
+
+        Preflight keys part of its command table on the operation's type, and
+        a wrapper is not an instance of what it wraps: without this a staged
+        conversion reported that it needed no `tar`.
+        """
+        return None
+
+    @property
     def releases_the_machine(self) -> bool:
         """Whether this still runs once the install has already failed.
 

--- a/tests/unit/test_plan_convert.py
+++ b/tests/unit/test_plan_convert.py
@@ -330,3 +330,25 @@ def test_an_empty_staging_root_is_accepted() -> None:
     context = _RunningContext()
     convert.PrepareStaging().apply(cast(Any, context))
     assert ["mkdir", "--parents", "/gentoo-install.new"] in context.ran
+
+
+def test_a_staged_operation_keeps_the_requirements_of_the_one_it_wraps() -> None:
+    """`--missing-commands` and the preflight check read this, and a wrapper
+    that answered for itself would have said a conversion needs nothing."""
+    from gentoo_install.exec import preflight
+
+    operations = build(_in_place(), CATALOG, layout=_layout())
+    wanted = preflight.required_commands(_in_place(), operations)
+    assert "tar" in wanted
+    assert "mkdir" in wanted
+
+
+def test_a_staged_operation_reports_whether_it_releases_the_machine() -> None:
+    staged = [
+        one for one in build(_in_place(), CATALOG, layout=_layout())
+        if isinstance(one, convert.Staged)
+    ]
+    assert staged
+    assert all(
+        one.releases_the_machine == one.inner.releases_the_machine for one in staged
+    )


### PR DESCRIPTION
`required_commands` for a whole conversion answered `find findmnt lsblk mkdir rm swapon umount` — no `tar`, no `gpg`, no `xz`. Part of preflight's table is keyed on the operation's type and `Staged` is not an instance of what it wraps, so every staged operation contributed nothing. `Operation.wrapped` is the general answer: `None` for an ordinary operation, the inner one for a wrapper, and preflight recurses into it. The same list now answers thirteen commands including the three above.