### PR TITLE
convert: refuse a separately mounted directory

### DIFF
--- a/gentoo_install/exec/convert.py
+++ b/gentoo_install/exec/convert.py
@@ -32,6 +32,14 @@ def convert(staging: Path, names: Sequence[str], *, root: Path = Path("/")) -> N
             raise ConversionFailed(f"the staging directory has no {name}")
         if os.path.lexists(old):
             raise ConversionFailed(f"{old} is left from an earlier attempt")
+        if os.path.ismount(destination):
+            # Refused here rather than discovered at the rename: a machine with
+            # a separate /var or /usr can never be converted this way, and the
+            # rollback that follows a half-done swap is not the place to learn
+            # it.
+            raise ConversionFailed(
+                f"{destination} is a separate mount, which rename cannot replace"
+            )
         # A distribution without one of these is converted, not refused: a
         # merged-usr Debian has no `/lib64` at all, and renaming what is not
         # there fails half way through with the rest already swapped.

--- a/tests/unit/test_convert.py
+++ b/tests/unit/test_convert.py
@@ -215,3 +215,26 @@ def test_a_file_that_is_not_a_kernel_image_is_left_alone(tmp_path: Path) -> None
     convert.populate_boot(staging, root=root)
 
     assert (root / "boot" / "memtest86+.bin").read_text() == "keep"
+
+
+def test_a_separately_mounted_directory_is_refused_before_any_rename(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A machine with a separate /var can never be converted by renaming, and
+    the rollback after a half-done swap is not the place to learn it."""
+    root = tmp_path / "root"
+    staging = root / "new"
+    for name in ("usr", "var"):
+        (root / name).mkdir(parents=True)
+        (staging / name).mkdir(parents=True)
+    (root / "usr" / "kept.txt").write_text("old")
+
+    real = os.path.ismount
+    monkeypatch.setattr(
+        "os.path.ismount", lambda path: str(path).endswith("/var") or real(path)
+    )
+
+    with pytest.raises(ConversionFailed, match="separate mount"):
+        convert.convert(staging, ("usr", "var"), root=root)
+
+    assert (root / "usr" / "kept.txt").read_text() == "old", "nothing was renamed"


### PR DESCRIPTION
`rename(2)` refuses a mount point, so a machine with `/var` or `/usr` on its own partition would fail part way through the swap. The rollback puts it back, but the conversion can never succeed there, and finding that out with three directories already exchanged is worse than being told before the first one.