### PR TITLE
vm: keep both installs' logs on a conversion run

### DIFF
--- a/tests/unit/test_cluster.py
+++ b/tests/unit/test_cluster.py
@@ -665,3 +665,12 @@ def test_both_fixtures_of_a_conversion_job_reach_the_driver_cd(tmp_path: Path) -
     )
     names = {path.name for path in written.iterdir()}
     assert names == {cluster.CONVERSION_BASE, "vm-convert.toml"}, names
+
+
+def test_the_conversion_keeps_its_own_copy_of_both_logs() -> None:
+    """A conversion run has two installs and their result files have the same
+    names, so writing the second over the first left only one."""
+    import inspect
+
+    code = inspect.getsource(cluster.convert_and_check)
+    assert 'f"convert.{name}"' in code

--- a/tests/vm/cluster.py
+++ b/tests/vm/cluster.py
@@ -2346,7 +2346,10 @@ def convert_and_check(
         watch=watch,
     )
     files = collect(guest, link, log)
-    keep_results(log, files)
+    # Prefixed: the names are the same as the install that produced this
+    # machine, and writing them again left only the conversion's log beside a
+    # run that has two.
+    keep_results(log, {f"convert.{name}": content for name, content in files.items()})
     code = files.get("install.rc", b"").strip()
     if code != b"0":
         return f"the conversion exited {code!r}"


### PR DESCRIPTION
`keep_results` names a file after the log it sits beside, so the conversion's `install.txt`, `install.rc` and `install.jsonl` overwrote the ones from the install that produced the machine. A run with two installs should keep two sets, and the base one is exactly what a reader needs when the conversion fails on a machine that was built wrong.