### PR TITLE
vm: remove the mirror name list left by the hosts detour

### DIFF
--- a/tests/unit/test_harness.py
+++ b/tests/unit/test_harness.py
@@ -2189,25 +2189,6 @@ def test_a_console_that_refuses_to_close_does_not_stop_the_reconnect() -> None:
     link.reopen(solicit_prompt=False)
 
     assert opened == ["open", "open"]
-def test_the_pinned_names_come_from_the_mirror_table() -> None:
-    """Listing them beside the mirrors is how the two lists drift apart. Every
-    mirror this installer can be pointed at has to be reachable when the
-    segment's own resolver is not answering."""
-    from urllib.parse import urlsplit
-
-    from gentoo_install.model import mirrors
-    from tests.vm.cluster import UNMIRRORED, wanted_names
-
-    named = set(wanted_names())
-    for site in (*mirrors.GENTOO_SITES, *mirrors.GENTOOZH_SITES):
-        for url in (site.distfiles, site.git, site.rsync):
-            if not url:
-                continue
-            host = urlsplit(url).hostname or url.split("::", 1)[0].split("/", 1)[0]
-            assert host in named, host
-    assert set(UNMIRRORED) <= named
-
-
 def test_nothing_is_carried_when_it_was_not_asked_for() -> None:
     from tests.vm import cluster
 

--- a/tests/vm/cluster.py
+++ b/tests/vm/cluster.py
@@ -790,28 +790,6 @@ def static_address(vmid: int) -> str:
     return f"{GUEST_NETWORK}.{GUEST_ADDRESS_BASE + vmid - VMID_FIRST}"
 
 
-#: What an install reaches that is not a mirror. `model/mirrors.py` lists the
-#: rest, and listing them twice is how the two lists drift apart.
-UNMIRRORED: Final[tuple[str, ...]] = ("keys.gentoo.org",)
-
-
-def wanted_names() -> tuple[str, ...]:
-    """Every host an install resolves, from the mirror table and the few that
-    are not mirrors."""
-    from urllib.parse import urlsplit
-
-    found: set[str] = set(UNMIRRORED)
-    for site in (*mirrors.GENTOO_SITES, *mirrors.GENTOOZH_SITES):
-        for url in (site.distfiles, site.git, site.rsync):
-            if not url:
-                continue
-            # An rsync URI is `host::module`, which `urlsplit` reads as a path.
-            host = urlsplit(url).hostname or url.split("::", 1)[0].split("/", 1)[0]
-            if host:
-                found.add(host)
-    return tuple(sorted(found))
-
-
 #: How much of one command line to send at a time. One line carrying every
 #: address keeper is four hundred characters, which is more than a tty edits
 #: in canonical mode without dropping the rest: every guest of round 33 died


### PR DESCRIPTION
`wanted_names()` collected every mirror host so that `pinned_hosts()` could write them into a guest's `/etc/hosts`. That path was removed in #360 and the function stayed, reached only by a test asserting the list agrees with the table it is built from. The guard that matters — nothing writes to `/etc/hosts` — is a separate test and stays.