### PR TITLE
fetch: try another mirror when the archive is corrupt

### DIFF
--- a/gentoo_install/errors.py
+++ b/gentoo_install/errors.py
@@ -78,6 +78,15 @@ class CommandFailed(GentooInstallError):
     is a different thing from data that cannot be trusted."""
 
 
+class ArchiveDigestMismatch(IntegrityError):
+    """A downloaded archive does not match the digest its signed DIGESTS names.
+
+    Separate from the rest of `IntegrityError` because it says something about
+    one mirror rather than about the release: the signature on the DIGESTS was
+    good, so the metadata is authentic and the copy of the file is not.
+    """
+
+
 class ConversionUnsupported(GentooInstallError):
     """The running layout is one the conversion cannot rebuild.
 

--- a/gentoo_install/exec/fetch.py
+++ b/gentoo_install/exec/fetch.py
@@ -28,6 +28,7 @@ from collections.abc import Iterator, Sequence
 from typing import Any, Callable, Final, cast
 
 from ..errors import (
+    ArchiveDigestMismatch,
     CommandFailed,
     ConfigError,
     DownloadFailed,
@@ -97,18 +98,22 @@ def stage3(
     or corrupted archive was an integrity check that verified nothing.
 
     `fallbacks` are tried in order when the first mirror cannot be reached at
-    all: a name that does not resolve or a host that refuses ends one mirror,
-    not the install, and the machine already has a list of them. A mirror that
-    answers with a file failing its signature is a different thing and stops
-    everything.
+    all, and when it answers with an archive that does not match its own signed
+    DIGESTS: both say something about that mirror rather than the release, and
+    `vm-convert` ended four minutes into a run because one copy of a stage3 was
+    corrupt. A DIGESTS file whose signature does not verify is a different
+    thing and stops everything.
     """
-    last: DownloadFailed | None = None
+    last: DownloadFailed | ArchiveDigestMismatch | None = None
     for one in (mirror, *fallbacks):
         try:
             return _stage3_from(one, variant, fingerprint, work, runner, proxy)
         except DownloadFailed as failed:
             last = failed
             runner.log(f"{one} did not serve the stage3: {failed}")
+        except ArchiveDigestMismatch as corrupt:
+            last = corrupt
+            runner.log(f"{one} served a corrupt stage3: {corrupt}")
     assert last is not None
     raise last
 
@@ -138,7 +143,14 @@ def _stage3_from(
     _download(f"{builds}/{where}.DIGESTS", digests, runner.log, proxy=selected)
     _import_release_key(runner, work, selected)
     _verify_signature(digests, fingerprint, runner)
-    _verify_digest(archive, digests)
+    try:
+        _verify_digest(archive, digests)
+    except ArchiveDigestMismatch:
+        # Removed before the next mirror is asked: the download below skips a
+        # file that is already there, so leaving the bad one would make every
+        # fallback verify the same corrupt copy.
+        archive.unlink(missing_ok=True)
+        raise
     marker.write_text(
         f"{MARKER_SCHEMA}\n{name}\n{_sha512(archive)}\n{fingerprint.lower()}\n"
     )
@@ -1080,7 +1092,9 @@ def _verify_digest(archive: Path, digests: Path) -> None:
     wanted = _expected_sha512(digests, archive.name)
     got = _sha512(archive)
     if got != wanted:
-        raise IntegrityError(f"{archive.name} has SHA512 {got}, the DIGESTS file says {wanted}")
+        raise ArchiveDigestMismatch(
+            f"{archive.name} has SHA512 {got}, the DIGESTS file says {wanted}"
+        )
 
 
 def _expected_sha512(digests: Path, name: str) -> str:

--- a/tests/unit/test_fetch.py
+++ b/tests/unit/test_fetch.py
@@ -7,7 +7,7 @@ from pathlib import Path
 
 import pytest
 
-from gentoo_install.errors import DownloadFailed
+from gentoo_install.errors import ArchiveDigestMismatch, DownloadFailed
 from gentoo_install.exec import fetch
 from gentoo_install.exec.runner import Runner
 
@@ -202,3 +202,82 @@ def test_the_diagnostic_names_the_interfaces_it_can_see() -> None:
 def test_the_diagnostic_says_whether_the_namespace_is_shared() -> None:
     said = fetch._network_namespace()
     assert said.startswith("namespace ")
+
+
+def test_a_corrupt_archive_moves_to_the_next_mirror(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The signature on the DIGESTS was good, so the metadata is authentic and
+    that mirror's copy of the file is not: `vm-convert` ended four minutes into
+    a run because one copy of a stage3 was corrupt."""
+    asked: list[str] = []
+
+    def serving(
+        mirror: str,
+        variant: str,
+        fingerprint: str,
+        work: Path,
+        runner: Runner,
+        proxy: object = None,
+    ) -> Path:
+        asked.append(mirror)
+        if mirror == "https://first.example":
+            raise ArchiveDigestMismatch("stage3.tar.xz has SHA512 aaa, the DIGESTS file says bbb")
+        return work / "stage3.tar.xz"
+
+    monkeypatch.setattr(fetch, "_stage3_from", serving)
+
+    where = fetch.stage3(
+        "https://first.example",
+        "systemd",
+        "0" * 40,
+        tmp_path,
+        Runner(log=lambda line: None),
+        None,
+        ("https://second.example",),
+    )
+
+    assert where.name == "stage3.tar.xz"
+    assert asked == ["https://first.example", "https://second.example"]
+
+
+def test_every_mirror_serving_a_corrupt_archive_still_stops(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    def serving(
+        mirror: str,
+        variant: str,
+        fingerprint: str,
+        work: Path,
+        runner: Runner,
+        proxy: object = None,
+    ) -> Path:
+        raise ArchiveDigestMismatch(f"{mirror} served a corrupt archive")
+
+    monkeypatch.setattr(fetch, "_stage3_from", serving)
+
+    with pytest.raises(ArchiveDigestMismatch, match="second.example"):
+        fetch.stage3(
+            "https://first.example",
+            "systemd",
+            "0" * 40,
+            tmp_path,
+            Runner(log=lambda line: None),
+            None,
+            ("https://second.example",),
+        )
+
+
+def test_a_corrupt_archive_is_removed_so_the_next_mirror_downloads_again(
+    tmp_path: Path
+) -> None:
+    """The download skips a file that is already there, so leaving the bad one
+    would make every fallback verify the same corrupt copy."""
+    archive = tmp_path / "stage3.tar.xz"
+    archive.write_bytes(b"corrupt")
+    digests = tmp_path / "stage3.tar.xz.DIGESTS"
+    digests.write_text("# SHA512 HASH\n" + "0" * 128 + " stage3.tar.xz\n")
+
+    with pytest.raises(ArchiveDigestMismatch):
+        fetch._verify_digest(archive, digests)
+    assert archive.exists(), "the check itself does not remove anything"


### PR DESCRIPTION
Round 38 ended `vm-convert` four and a half minutes in with `stage3-amd64-systemd-20260811T083102Z.tar.xz has SHA512 …, the DIGESTS file says …`. The signature on the DIGESTS verified, so the release metadata is authentic and that mirror's copy of the archive is not — which is a fact about the mirror, exactly like a host that refuses. It joins the fallback loop under its own exception, the bad copy is removed so the next mirror downloads rather than re-verifying it, and a DIGESTS file whose signature does not verify still stops everything.