### PR TITLE
vm: check the console proxy even while the guest works

### DIFF
--- a/tests/unit/test_cluster.py
+++ b/tests/unit/test_cluster.py
@@ -621,8 +621,13 @@ class _Stoppable:
         self.stopped = True
 
 
-def _held(log: Path, moved: bool, stuck: bool) -> object:
-    watch = cluster.Watchdog(log=log, counters=lambda: 0)
+def _held(log: Path, moved: bool, stuck: bool, busy: bool = False) -> object:
+    """`busy` gives the guest moving byte counters, which is a guest whose disk
+    is working while its console has gone."""
+    counters = iter(range(0, 10**9, cluster.QUIET_BYTES * 2))
+    watch = cluster.Watchdog(
+        log=log, counters=(lambda: next(counters)) if busy else (lambda: 0)
+    )
     # One pass so the watchdog has seen the log: the first call always reports
     # growth, from nothing to whatever is there.
     watch.moved()
@@ -674,3 +679,26 @@ def test_the_conversion_keeps_its_own_copy_of_both_logs() -> None:
 
     code = inspect.getsource(cluster.convert_and_check)
     assert 'f"convert.{name}"' in code
+
+
+def test_a_busy_guest_whose_console_went_is_ended_too(tmp_path: Path) -> None:
+    """A node whose proxy is refusing leaves the socket open and silent while
+    the disk stays busy, so the watchdog is right that the guest is alive and
+    the run still cannot be read: `btrfs-luks` sat that way for sixteen
+    minutes."""
+    log = tmp_path / "btrfs-luks.log"
+    log.write_text(
+        "emerging\nRead from remote host 10.31.0.202: Connection reset by peer\n"
+    )
+    held = _held(log, moved=False, stuck=False, busy=True)
+    assert cast(Any, held).watch.moved() is True, "the counters say it is working"
+    cluster._sweep({"btrfs-luks": cast(Any, held)})
+    assert cast(Any, held).guest.stopped
+
+
+def test_a_busy_guest_with_a_healthy_console_is_left_running(tmp_path: Path) -> None:
+    log = tmp_path / "vm-xfs.log"
+    log.write_text("emerging sys-kernel/gentoo-kernel\n")
+    held = _held(log, moved=False, stuck=False, busy=True)
+    cluster._sweep({"vm-xfs": cast(Any, held)})
+    assert not cast(Any, held).guest.stopped

--- a/tests/vm/cluster.py
+++ b/tests/vm/cluster.py
@@ -430,14 +430,27 @@ class Watchdog:
     _counter_after: int = field(default=0, init=False)
     #: Consecutive samples the hypervisor would not answer.
     _blind: int = field(default=0, init=False)
+    #: Whether the last sample saw nothing new in the log.
+    _silent: bool = field(default=False, init=False)
     _lock: threading.Lock = field(default_factory=threading.Lock, init=False, repr=False)
 
     def moved(self) -> bool:
         with self._lock:
             size = self.log.stat().st_size if self.log.exists() else 0
             talking = size > self._seen
+            self._silent = not talking
             self._seen = max(self._seen, size)
             return self._observe(talking)
+
+    @property
+    def silent(self) -> bool:
+        """Whether the last sample saw nothing new in the log.
+
+        Separate from `moved`, which is also true for a guest whose console has
+        gone while its disk is still busy: that is the one shape where the log
+        has to be read for the node's own words.
+        """
+        return self._silent
 
     def _observe(self, talking: bool) -> bool:
         traffic = self.counters()
@@ -2596,15 +2609,15 @@ def _sweep(inflight: Mapping[str, Running]) -> None:
     log, so the next question is what was on the screen.
     """
     for name, held in list(inflight.items()):
-        if held.watch.moved():
+        working = held.watch.moved()
+        # Asked whenever the log stopped growing, not only when the guest also
+        # looks idle: a node whose proxy is refusing leaves the socket open and
+        # silent while the disk stays busy, so `moved` is true and this is the
+        # only shape that names it. Read from the log's tail, which a console
+        # that recovered scrolls past on its own.
+        dropped = console_proxy_dropped(held.watch.log) if held.watch.silent else ""
+        if working and not dropped:
             continue
-        # A node whose proxy is refusing leaves the socket open and silent, so
-        # nothing raises and the guest's own counters still say it is working:
-        # `vm-zfs` sat that way for thirty-five minutes with its install
-        # running. The tail of its log is the only thing that names it, and it
-        # is only read once the log has stopped growing, so a console that
-        # recovered is not ended for a message that scrolled past.
-        dropped = console_proxy_dropped(held.watch.log)
         if not held.watch.stuck and not dropped:
             print(
                 f"… {name} quiet for {held.watch.strikes * WATCH_EVERY / 60:.0f}m",


### PR DESCRIPTION
#376 read the log's tail after `watch.moved()` returned false. A node whose proxy is refusing leaves the socket open and silent while the guest's disk stays busy, so `moved()` is true and the check never ran for the one shape it was written for — `btrfs-luks` lost its console at 15:59 in round 39 and was still counted as running at 16:15. The watchdog now reports whether the log itself went quiet, separately from whether the guest is alive, and the tail is read on that.