### PR TITLE
convert: the staging context forwards everything

### DIFF
--- a/gentoo_install/plan/convert.py
+++ b/gentoo_install/plan/convert.py
@@ -70,6 +70,14 @@ class Staged(Operation):
 
 @dataclass(frozen=True)
 class _StagingContext:
+    """The install context with `target` moved to the staging root.
+
+    Everything else is forwarded rather than listed: naming the members by
+    hand is exactly what drifted, and a conversion stopped at `make.conf`
+    with `'_StagingContext' object has no attribute 'read'` after it had
+    already downloaded and unpacked a stage3.
+    """
+
     parent: Context
     staging: PurePosixPath
 
@@ -77,26 +85,8 @@ class _StagingContext:
     def target(self) -> PurePosixPath:
         return self.staging
 
-    def run(
-        self,
-        argv: Sequence[str],
-        *,
-        check: bool = True,
-        input_text: str | None = None,
-    ) -> str:
-        return self.parent.run(argv, check=check, input_text=input_text)
-
-    def write(self, path: PurePosixPath, content: str, *, mode: int = 0o644) -> None:
-        self.parent.write(path, content, mode=mode)
-
-    def fetch_stage3(
-        self,
-        mirror: str,
-        variant: str,
-        fingerprint: str,
-        fallbacks: Sequence[str] = (),
-    ) -> PurePosixPath:
-        return self.parent.fetch_stage3(mirror, variant, fingerprint, fallbacks)
+    def __getattr__(self, name: str) -> object:
+        return getattr(self.parent, name)
 
 
 @dataclass(frozen=True, kw_only=True)

--- a/tests/unit/test_plan_convert.py
+++ b/tests/unit/test_plan_convert.py
@@ -386,3 +386,25 @@ def test_a_separate_boot_that_could_not_be_read_is_refused() -> None:
         convert.layout_graph(
             _layout(boot_same_filesystem=False, boot_filesystem_type=None)
         )
+
+
+def test_the_staging_context_answers_every_member_of_the_context() -> None:
+    """Naming the members by hand is what drifted: a conversion stopped at
+    `make.conf` with `'_StagingContext' object has no attribute 'read'` after
+    it had already downloaded and unpacked a stage3."""
+    from gentoo_install.plan.operations import Context
+
+    wanted = [name for name in dir(Context) if not name.startswith("_")]
+    parent = SimpleNamespace(**{name: name for name in wanted})
+    staged = convert._StagingContext(
+        parent=cast(Any, parent), staging=PurePosixPath("/gentoo-install.new")
+    )
+
+    assert staged.target == PurePosixPath("/gentoo-install.new")
+    missing = [name for name in wanted if not hasattr(staged, name)]
+    assert missing == [], missing
+    # Everything but `target` comes from the parent unchanged.
+    for name in wanted:
+        if name == "target":
+            continue
+        assert getattr(staged, name) == name, name


### PR DESCRIPTION
The first conversion on the cluster created its staging root, downloaded and unpacked a stage3, bound `/proc`, `/sys`, `/dev` and `/run` into it, seeded `resolv.conf`, and stopped at step 5 of 46 with `AttributeError: '_StagingContext' object has no attribute 'read'`. The wrapper listed four members of the `Context` protocol by hand and the protocol has twenty-one. It now overrides `target` and forwards the rest, and the test asserts it answers every name the protocol declares.