### PR TITLE
convert: stage by moving the machine's target, not by wrapping it

### DIFF
--- a/gentoo_install/plan/convert.py
+++ b/gentoo_install/plan/convert.py
@@ -4,7 +4,7 @@
 from __future__ import annotations
 
 import importlib
-from dataclasses import dataclass
+from dataclasses import dataclass, replace
 from pathlib import Path, PurePosixPath
 from typing import Any, Final, Protocol, Sequence, cast
 
@@ -65,7 +65,25 @@ class Staged(Operation):
         return f"{self.inner.describe()}, in {self.staging}"
 
     def apply(self, context: Context) -> None:
-        self.inner.apply(cast(Context, _StagingContext(parent=context, staging=self.staging)))
+        self.inner.apply(_aimed_at(context, self.staging))
+
+
+def _aimed_at(parent: Context, staging: PurePosixPath) -> Context:
+    """The same machine with everything aimed at the staging root.
+
+    `run_in_target` chroots into the machine's own mount point rather than
+    `context.target`, so a context that answered only `target` would have run
+    every `emerge` in the system being replaced. The live implementation keeps
+    that path in one field, so moving it moves all of them; a recorder that
+    keeps no such field gets the wrapper, which is enough for one that runs
+    nothing.
+    """
+    if hasattr(parent, "mountpoint"):
+        try:
+            return cast(Context, replace(cast(Any, parent), mountpoint=Path(str(staging))))
+        except TypeError:
+            pass
+    return cast(Context, _StagingContext(parent=parent, staging=staging))
 
 
 @dataclass(frozen=True)

--- a/tests/unit/test_plan_convert.py
+++ b/tests/unit/test_plan_convert.py
@@ -408,3 +408,49 @@ def test_the_staging_context_answers_every_member_of_the_context() -> None:
         if name == "target":
             continue
         assert getattr(staged, name) == name, name
+
+
+def test_staging_moves_the_chroot_not_only_the_target() -> None:
+    """`run_in_target` chroots into the machine's own mount point rather than
+    `context.target`, so a context that answered only `target` would have run
+    every `emerge` in the system being replaced."""
+    from dataclasses import dataclass as plain
+    from pathlib import Path as RealPath
+
+    @plain
+    class Machinelike:
+        mountpoint: RealPath = RealPath("/mnt/gentoo")
+
+        @property
+        def target(self) -> PurePosixPath:
+            return PurePosixPath(self.mountpoint)
+
+        def run_in_target(self, argv: list[str], *, check: bool = True) -> str:
+            return f"chroot {self.mountpoint}"
+
+    staged = convert._aimed_at(cast(Any, Machinelike()), PurePosixPath("/gentoo-install.new"))
+
+    assert staged.target == PurePosixPath("/gentoo-install.new")
+    assert staged.run_in_target(["emerge"]) == "chroot /gentoo-install.new"
+
+
+def test_the_live_machine_still_keeps_its_target_in_one_field() -> None:
+    """The move works by replacing that one field. A machine that grew a
+    second copy of the path would keep half of itself aimed at the old root."""
+    from dataclasses import fields
+
+    from gentoo_install.exec.apply import Machine
+
+    assert "mountpoint" in {one.name for one in fields(Machine)}
+
+
+def test_a_context_without_that_field_still_reaches_the_staging_root() -> None:
+    class Recorder:
+        target = PurePosixPath("/mnt/gentoo")
+
+        def read(self, path: PurePosixPath) -> str:
+            return "from the parent"
+
+    staged = convert._aimed_at(cast(Any, Recorder()), PurePosixPath("/gentoo-install.new"))
+    assert staged.target == PurePosixPath("/gentoo-install.new")
+    assert staged.read(PurePosixPath("/etc/portage/make.conf")) == "from the parent"


### PR DESCRIPTION
`_StagingContext` answered `target` and forwarded the rest, and `run_in_target`, `installed_package_paths`, `target_is_directory` and `installed_command_help` all read the machine's own `mountpoint` instead. Every staged `emerge`, `locale-gen` and `eselect` would therefore have run in the system being replaced rather than in `/gentoo-install.new`, which is the one mistake this whole design exists to avoid. Staging now replaces that one field, so everything derived from it follows; a recorder that keeps no such field still gets the wrapper, which is enough for one that runs nothing.