### PR TITLE
clean: remove twelve definitions nothing reaches

### DIFF
--- a/gentoo_install/exec/fetch.py
+++ b/gentoo_install/exec/fetch.py
@@ -227,26 +227,6 @@ def _probe(mirror: str, proxy: ProxyConfig | None = None) -> float:
     return time.monotonic() - started
 
 
-def passphrase_for(device: DeviceId, source: str) -> str:
-    """Read an encryption passphrase from the file the layout names.
-
-    A path, never the passphrase itself: the configuration is copied into the
-    target and the log is the file people paste into bug reports.
-    """
-    if not source:
-        raise ConfigError(
-            f"{device} is encrypted but names no passphrase_file, and nothing else asks for one"
-        )
-    path = Path(source)
-    try:
-        passphrase = path.read_text().strip("\n")
-    except OSError as error:
-        raise ConfigError(f"{device}: {source} cannot be read: {error}") from error
-    if not passphrase:
-        raise ConfigError(f"{device}: {source} is empty")
-    return passphrase
-
-
 #: A reset connection is not an answer. `why_unreachable` already retries the
 #: same way and `_newest` did not, so one `Connection reset by peer` from
 #: `distfiles.gentoo.org` ended an install a minute after it started.

--- a/gentoo_install/model/qr.py
+++ b/gentoo_install/model/qr.py
@@ -440,22 +440,6 @@ def _squares(matrix: Matrix) -> int:
     return total
 
 
-#: The two shapes rule three looks for, in both directions.
-_FINDER_LIKE: Final[tuple[tuple[bool, ...], ...]] = (
-    (True, False, True, True, True, False, True, False, False, False, False),
-    (False, False, False, False, True, False, True, True, True, False, True),
-)
-
-
-def _finders(matrix: Matrix) -> int:
-    total = 0
-    for line in (*matrix, *zip(*matrix)):
-        for at in range(len(line) - 10):
-            window = tuple(line[at : at + 11])
-            total += 40 if window in _FINDER_LIKE else 0
-    return total
-
-
 def _balance(matrix: Matrix) -> int:
     """How far the proportion of dark modules is from half, in steps of 5%.
 

--- a/gentoo_install/plan/kernel.py
+++ b/gentoo_install/plan/kernel.py
@@ -69,11 +69,6 @@ REMOTE_UNLOCK_MODULES: Final[tuple[str, ...]] = ("crypt-ssh", "network")
 CJK_KERNELS: Final[tuple[KernelSource, ...]] = (KernelSource.CJK_BIN, KernelSource.CJK)
 
 INSTALLKERNEL_STATE: Final[str] = "/var/lib/misc/installkernel"
-KERNEL_IMAGES: Final[str] = "/boot"
-
-#: One directory per kernel that can actually load a driver.
-MODULE_DIRECTORY: Final[str] = "/lib/modules"
-
 #: The cjk USE flag of the patched kernels, which merges the
 #: patch's own `cjk.config`. It is on by default, so only turning it off has
 #: to be written.
@@ -501,93 +496,6 @@ class VerifyZfsKernelCompatibility(Operation):
         problem = zfs_kernel_version_problem(self.version, ceiling)
         if problem is not None:
             raise ValidationFailed(problem)
-
-
-#: Names installkernel gives an image, for the cleanup that reads /boot.
-IMAGE_NAMES: Final[tuple[tuple[str, str], ...]] = (
-    ("kernel-", ""),
-    ("vmlinuz-", ""),
-    ("initramfs-", ".img"),
-    ("System.map-", ""),
-    ("config-", ""),
-)
-
-def _version_in(name: str) -> str | None:
-    """The kernel version a file in /boot is named for, or None for a name
-    this does not recognise. Unrecognised is left alone: /boot holds the
-    bootloader's own files and they are nobody's to delete.
-
-    `.old` is one of those names. installkernel keeps the previous image under
-    it, and its version is the one it had, so matching it against the modules
-    that are installed now would delete every backup there is.
-    """
-    if name.endswith(".old"):
-        return None
-    for prefix, suffix in IMAGE_NAMES:
-        if name.startswith(prefix) and name.endswith(suffix):
-            return name[len(prefix) : len(name) - len(suffix) or None]
-    return None
-
-
-def _version_inside(context: Context, name: str) -> str | None:
-    """What the image says it is, or None when nothing said.
-
-    `file` answers `Linux kernel x86 boot executable bzImage, version 6.18.41
-    -gentoo-dist-bin (...)`. None rather than a guess: an unreadable answer is
-    not evidence that the image is wrong, and deleting the only kernel on that
-    basis leaves nothing to boot.
-    """
-    said = context.run_in_target(["file", "--brief", f"{KERNEL_IMAGES}/{name}"], check=False)
-    words = said.split()
-    if "version" not in words:
-        return None
-    return words[words.index("version") + 1] if len(words) > words.index("version") + 1 else None
-
-
-@dataclass(frozen=True, kw_only=True)
-class RemoveUnbootableKernels(Operation):
-    """Delete a kernel image in /boot that has no modules to go with it.
-
-    `sys-fs/zfs` reinstalls the initramfs from its own postinst, and the
-    version it computes off `/usr/src/linux` is `-gentoo-dist` where the
-    prebuilt kernel is `-gentoo-dist-bin`, so kernel-install copies the image
-    a second time under the wrong name. `generate-zbm` then refuses every
-    kernel it can see -- "ignoring inconsistent versions" -- and GRUB would
-    have offered the operator an entry that cannot boot.
-
-    Two tests, because one image failed only the second. An image whose
-    version has no modules directory loads no driver and reaches no root. An
-    image whose file name disagrees with the version string inside it is the
-    one `generate-zbm` names in that message: `sys-fs/zfs` also leaves
-    `/lib/modules/<wrong version>` behind, so the modules test passes and the
-    kernel is still refused.
-
-    `file` reads the string. It is in `@system`, so a stage3 has it.
-    """
-
-    stage: Stage = Stage.KERNEL
-
-    def describe(self) -> str:
-        return "delete any kernel image in /boot that has no modules directory"
-
-    def apply(self, context: Context) -> None:
-        listed = context.run_in_target(["ls", "-1", KERNEL_IMAGES], check=False)
-        known = context.run_in_target(["ls", "-1", MODULE_DIRECTORY], check=False)
-        versions = {line.strip() for line in known.splitlines() if line.strip()}
-        if not versions:
-            # Nothing to compare against: deleting on no evidence is worse
-            # than leaving an image that may be the only one.
-            return
-        for name in (line.strip() for line in listed.splitlines()):
-            version = _version_in(name)
-            if version is None:
-                continue
-            inside = _version_inside(context, name)
-            # Only a disagreement, never an unknown: `file` answering nothing
-            # is not evidence, and this is the last chance to keep a kernel.
-            if version in versions and inside in (None, version):
-                continue
-            context.run_in_target(["rm", "--force", f"{KERNEL_IMAGES}/{name}"])
 
 
 @dataclass(frozen=True, kw_only=True)

--- a/gentoo_install/tui/screens.py
+++ b/gentoo_install/tui/screens.py
@@ -1068,12 +1068,6 @@ def _mirror_site_row(config: InstallConfig, translate: Catalog) -> Item[str]:
     return Item(label=translate("Gentoo mirror"), value=_SITE, detail=detail)
 
 
-def _mirror_toggle_row(
-    config: InstallConfig, translate: Catalog, label: str, key: str, value: bool
-) -> Item[str]:
-    return Item(label=translate(label), value=key, detail=translate("in use") if value else translate("not used"))
-
-
 def _mirror_measure_row(config: InstallConfig, translate: Catalog) -> Item[str]:
     return Item(
         label=translate("Measure them"), value=_MEASURE,
@@ -2486,63 +2480,6 @@ def _input_configuration_summary(
             "Write the Fcitx profile and input environment for: {engines}."
         ).format(engines=subject)
     return translate("Write the IBus input environment.")
-
-
-def _language_package_screen(
-    screen: Screen,
-    config: InstallConfig,
-    context: Context,
-    title: str,
-    names: Sequence[str],
-) -> Answer[InstallConfig]:
-    """Edit one catalog-defined subset without disturbing other applications."""
-    translate = context.translate
-    selected_names = frozenset(names)
-    have = {overlay.name for overlay in config.portage.overlays}
-    items = [
-        Item(
-            label=name,
-            value=name,
-            detail=" ".join(context.groups[name].packages)
-            + _adds(
-                config,
-                context,
-                lambda packages, one: replace(
-                    packages, applications=(*packages.applications, one)
-                ),
-                name,
-            ),
-            disabled_because=_needs_an_overlay(
-                context.groups[name].repositories, have, translate
-            ),
-        )
-        for name in names
-    ]
-    chosen_already = set(config.packages.applications) & selected_names
-    while True:
-        answer = MultipleChoiceMenu(
-            title=translate(title),
-            items=items,
-            selected={
-                index for index, item in enumerate(items) if item.value in chosen_already
-            },
-            footer=footer(translate),
-        ).run(screen)
-        if not answer.chosen:
-            return Answer(answer.outcome)
-        chosen = tuple(answer.unwrap())
-        kept = tuple(
-            name for name in config.packages.applications if name not in selected_names
-        )
-        edited = replace(
-            config,
-            packages=replace(config.packages, applications=(*kept, *chosen)),
-        )
-        clash = framework_conflict(edited, context.groups)
-        if not clash:
-            return settle(screen, context, config, edited)
-        chosen_already = set(chosen)
-        _say(screen, context, clash)
 
 
 def input_method_screen(

--- a/gentoo_install/tui/settings.py
+++ b/gentoo_install/tui/settings.py
@@ -269,14 +269,6 @@ def _keywords(config: InstallConfig, context: Context) -> str:
     return "~amd64" if config.portage.keywords is Keywords.TESTING else "amd64"
 
 
-def _compiler(config: InstallConfig, context: Context) -> str:
-    """The three the operator is most likely to have changed. The rest are on
-    the screen behind this row."""
-    portage = config.portage
-    jobs = portage.makeopts or f"-j{context.cores}"
-    return f"{jobs}, {portage.common_flags}, {' '.join(portage.accept_license)}"
-
-
 def _bootloader(config: InstallConfig, context: Context) -> str:
     return f"{config.bootloader.kind.value}, {config.bootloader.firmware.value}"
 
@@ -613,13 +605,6 @@ def _other_locales(config: InstallConfig, context: Context) -> str:
     return ", ".join(
         locale for locale in config.system.locales if locale != config.system.locale
     ) or context.translate("none")
-
-
-def _selected_groups(
-    config: InstallConfig, context: Context, offered: tuple[str, ...]
-) -> str:
-    selected = [name for name in config.packages.applications if name in offered]
-    return ", ".join(selected) or context.translate("none")
 
 
 def _input_method(config: InstallConfig, context: Context) -> str:

--- a/tests/unit/test_layers.py
+++ b/tests/unit/test_layers.py
@@ -116,3 +116,34 @@ def test_every_source_file_states_the_licence() -> None:
     ]
 
     assert not silent, f"no licence on the first line of: {silent}"
+
+
+def test_no_definition_in_the_package_is_unreachable() -> None:
+    """A rebase left `RemoveUnbootableKernels` and its five helpers in the tree
+    after the operation it replaced them with had landed: the class was there,
+    nothing built it, and nothing tested it."""
+    import ast
+    import re
+
+    root = Path(__file__).resolve().parents[2]
+    everything = "\n".join(
+        path.read_text()
+        for where in ("gentoo_install", "tests")
+        for path in sorted((root / where).rglob("*.py"))
+    )
+    orphans: list[str] = []
+    for path in sorted((root / "gentoo_install").rglob("*.py")):
+        for node in ast.parse(path.read_text()).body:
+            named: list[str] = []
+            if isinstance(node, (ast.FunctionDef, ast.ClassDef)):
+                named = [node.name]
+            elif isinstance(node, ast.AnnAssign) and isinstance(node.target, ast.Name):
+                named = [node.target.id]
+            elif isinstance(node, ast.Assign):
+                named = [one.id for one in node.targets if isinstance(one, ast.Name)]
+            for name in named:
+                if name.startswith("__"):
+                    continue
+                if len(re.findall(rf"\b{re.escape(name)}\b", everything)) <= 1:
+                    orphans.append(f"{path.relative_to(root)}:{node.lineno} {name}")
+    assert orphans == [], orphans


### PR DESCRIPTION
`#261` replaced `RemoveUnbootableKernels` with `RequireKernelImage` and removed both the class and its call; `#263` brought the class back without the call, and `git log -S` shows it. It carried five helpers with it — `_version_in`, `_version_inside`, `IMAGE_NAMES`, `KERNEL_IMAGES`, `MODULE_DIRECTORY` — and six more definitions elsewhere had lost their callers the same way. 206 lines, none of them reachable, none of them tested. The test that found them stays, so the next one fails a gate instead of sitting there.