### PR TITLE
vm: give the initramfs the address the guest will have

### DIFF
--- a/tests/unit/test_cluster.py
+++ b/tests/unit/test_cluster.py
@@ -107,6 +107,7 @@ def _rewrite(
     sync: Sync,
     public_key: str = "",
     site: str = "",
+    unlock_addresses: object = None,
 ) -> Path:
     return into
 
@@ -702,3 +703,41 @@ def test_a_busy_guest_with_a_healthy_console_is_left_running(tmp_path: Path) -> 
     held = _held(log, moved=False, stuck=False, busy=True)
     cluster._sweep({"vm-xfs": cast(Any, held)})
     assert not cast(Any, held).guest.stopped
+
+
+def test_the_initramfs_is_given_the_address_the_guest_will_have(tmp_path: Path) -> None:
+    """`vm-unlock` pinned `192.0.2.10`, a documentation address. On the cluster
+    the guest was on 10.31.0.155 and the unlock answered `No route to host`
+    after ninety minutes of installing."""
+    from gentoo_install.exec.config import load
+    from gentoo_install.model.config import MirrorRegion, Sync
+
+    jobs = cluster.fixtures(["vm-unlock"])
+    written = cluster.rewrite_fixtures(
+        jobs,
+        tmp_path / "fixtures",
+        MirrorRegion.CN,
+        Sync.GIT,
+        "",
+        "nju",
+        {"vm-unlock": "10.31.0.155"},
+    )
+    rewritten = load(written / "vm-unlock.toml")
+    assert rewritten.kernel.remote_unlock.address == f"10.31.0.155/{cluster.GUEST_PREFIX}"
+
+
+def test_a_fixture_that_does_not_unlock_remotely_keeps_its_addresses() -> None:
+    from gentoo_install.exec.config import load
+    from gentoo_install.model.config import MirrorRegion, Sync
+
+    jobs = cluster.fixtures(["vm-xfs"])
+    written = cluster.rewrite_fixtures(
+        jobs,
+        Path(cluster.REPOSITORY) / "lab" / ".rewrite-check",
+        MirrorRegion.CN,
+        Sync.GIT,
+        "",
+        "nju",
+        {"vm-xfs": "10.31.0.155"},
+    )
+    assert load(written / "vm-xfs.toml").kernel.remote_unlock.address == ""

--- a/tests/unit/test_harness.py
+++ b/tests/unit/test_harness.py
@@ -1033,7 +1033,11 @@ def test_zero_cluster_capacity_returns_an_error_after_a_deadline(
 
     now = [0.0]
     monkeypatch.setattr(cluster, "Api", lambda: Empty())
-    monkeypatch.setattr(cluster, "rewrite_fixtures", lambda jobs, into, region, sync, public_key="", site="": into)
+    monkeypatch.setattr(
+        cluster,
+        "rewrite_fixtures",
+        lambda jobs, into, region, sync, public_key="", site="", unlock_addresses=None: into,
+    )
 
     def build(path: Path, **kwargs: object) -> Path:
         path.parent.mkdir(parents=True, exist_ok=True)

--- a/tests/vm/cluster.py
+++ b/tests/vm/cluster.py
@@ -1024,6 +1024,7 @@ def rewrite_fixtures(
     sync: Sync,
     public_key: str = "",
     site: str = "",
+    unlock_addresses: Mapping[str, str] | None = None,
 ) -> Path:
     """Write each fixture out again with its mirror region, site and sync.
 
@@ -1044,12 +1045,12 @@ def rewrite_fixtures(
     # in-place fixture it runs against the result. Writing only `fixture` left
     # the CD without the second one, and the guest answered `no such file`.
     wanted = [
-        path
+        (job, path)
         for job in jobs
         for path in (job.fixture, job.convert_to)
         if path is not None
     ]
-    for source in wanted:
+    for job, source in wanted:
         config = load(source)
         # The overlay moves with the region. A `cn` run that still cloned
         # gentoo-zh from github stopped the install after two hundred seconds
@@ -1077,6 +1078,20 @@ def rewrite_fixtures(
                 ),
             ),
         )
+        # The address the initramfs will answer on, which is the one the
+        # scheduler reserved for this guest: a fixture that pins a
+        # documentation address is one the harness can never reach.
+        given = (unlock_addresses or {}).get(job.name, "")
+        if given and moved.kernel.remote_unlock.enabled:
+            moved = replace(
+                moved,
+                kernel=replace(
+                    moved.kernel,
+                    remote_unlock=replace(
+                        moved.kernel.remote_unlock, address=f"{given}/{GUEST_PREFIX}"
+                    ),
+                ),
+            )
         (into / source.name).write_text(to_toml(moved))
     return into
 
@@ -1684,10 +1699,18 @@ def run(
     # Packed: the ingress refuses the 1.4 MiB loose-file CD with `413`.
     staging = workdir / f".driver-{uuid.uuid4().hex}.iso"
     fixture_dir = workdir / "fixtures"
-    if public_key:
-        rewritten = rewrite_fixtures(jobs, fixture_dir, region, sync, public_key, site)
-    else:
-        rewritten = rewrite_fixtures(jobs, fixture_dir, region, sync, "", site)
+    # Reserved before the CD is written, not at dispatch: a fixture that
+    # unlocks over SSH pins the initramfs address, and the harness has to ssh
+    # to that address. `vm-unlock` carried `192.0.2.10`, which is a
+    # documentation address; on the cluster the guest was on 10.31.0.155 and
+    # the unlock answered `No route to host` after ninety minutes.
+    unlock_addresses = {
+        job.name: addresses.reserve(f"{GUEST_NETWORK}.{GUEST_ADDRESS_BASE}")
+        for job in jobs
+    }
+    rewritten = rewrite_fixtures(
+        jobs, fixture_dir, region, sync, public_key, site, unlock_addresses
+    )
     built_path = build_driver(staging, packed=True, fixtures=rewritten)
     driver_path = retain_driver(workdir, built_path)
     driver = driver_path.name
@@ -1768,7 +1791,7 @@ def run(
                     for one in scheduled.values()
                     if one.holds_resources and one.vmid
                 )
-                address = addresses.reserve(f"{GUEST_NETWORK}.{GUEST_ADDRESS_BASE}")
+                address = unlock_addresses[job.name]
                 try:
                     job = _reserve_job(
                         api,
@@ -1780,7 +1803,6 @@ def run(
                         address,
                     )
                 except Exception:
-                    addresses.release(address)
                     raise
                 execution = job.execution
                 if execution is None:
@@ -1844,8 +1866,6 @@ def run(
             job = scheduled[outcome.name].answered(outcome)
             if outcome.removed and job.lease is not None:
                 job.lease.unlink(missing_ok=True)
-                if job.execution is not None and job.execution.address:
-                    addresses.release(job.execution.address)
             job = job.collect(collected)
             collected += 1
             scheduled[job.name] = job
@@ -1863,6 +1883,11 @@ def run(
                 flush=True,
             )
     finally:
+        # Every one, here: they are taken before the first guest exists, so a
+        # run that ends early would otherwise hold ten of them until the lease
+        # expires.
+        for one in unlock_addresses.values():
+            addresses.release(one)
         _abandon_jobs(scheduled)
         for node_name in prepared:
             said = api.remove_iso(node_name, driver)


### PR DESCRIPTION
`vm-unlock` sets `kernel.remote_unlock.address = "192.0.2.10/24"`, which is TEST-NET-1. A local qemu run reaches it; a cluster guest comes up on 10.31.0.x and the harness sshs to the address the scheduler gave it, so the unlock answered `ssh: connect to host 10.31.0.155 port 2222: No route to host` after ninety minutes of installing. Addresses are now reserved before the driver CD is written rather than at dispatch, so each fixture that unlocks remotely carries the address its own guest will answer on; they are all released together when the run ends.