### PR TITLE
clean: delete restated comments and the last filler words

### DIFF
--- a/gentoo_install/model/compat.py
+++ b/gentoo_install/model/compat.py
@@ -137,7 +137,6 @@ def filesystem_label_problems(config: InstallConfig) -> tuple[str, ...]:
 _BOOT = PurePosixPath("/boot")
 _ROOT = PurePosixPath("/")
 _USR = PurePosixPath("/usr")
-#: Where an esp is mounted in the target, in the order the installer prefers.
 #: Where an esp is mounted, in the order the handbook and the installers use.
 #: `/boot/efi` is what `calamares-settings-gig` mounts, so a layout the GUI
 #: installer produces has to be one this validator accepts.

--- a/gentoo_install/model/manual.py
+++ b/gentoo_install/model/manual.py
@@ -91,7 +91,6 @@ _OTHER: Final[Purpose] = PURPOSES[-1]
 
 
 def purpose_for(key: str) -> Purpose:
-    """The row of the table with that key."""
     return next(one for one in PURPOSES if one.key == key)
 
 

--- a/gentoo_install/model/paste.py
+++ b/gentoo_install/model/paste.py
@@ -59,7 +59,6 @@ EXPORTS: Final[tuple[Export, ...]] = (
 
 
 def export_for(key: str) -> Export:
-    """The row with that key."""
     return next(one for one in EXPORTS if one.key == key)
 
 

--- a/gentoo_install/model/qr.py
+++ b/gentoo_install/model/qr.py
@@ -137,14 +137,14 @@ def _smallest(length: int) -> int:
 
 def _codewords(payload: bytes, version: int) -> list[int]:
     """The data and its error correction, interleaved as the standard orders."""
-    data, ec_count, blocks = BLOCKS[version]
+    data, error_correction_count, blocks = BLOCKS[version]
     bits = _bitstream(payload, data * blocks)
     grouped = [bits[index * data : (index + 1) * data] for index in range(blocks)]
-    corrections = [_remainder(one, ec_count) for one in grouped]
+    corrections = [_remainder(one, error_correction_count) for one in grouped]
     out: list[int] = []
     for column in range(data):
         out += [one[column] for one in grouped]
-    for column in range(ec_count):
+    for column in range(error_correction_count):
         out += [one[column] for one in corrections]
     return out
 

--- a/gentoo_install/model/serialise.py
+++ b/gentoo_install/model/serialise.py
@@ -70,7 +70,7 @@ def to_toml(config: InstallConfig, *, publishing: bool = False) -> str:
     """The configuration as a file that parses back into the same object.
 
     `publishing` replaces every password hash, for the copy that goes to a
-    pastebin. The result still parses; it just installs no password.
+    pastebin. The result still parses and installs no password.
     """
     lines = [f"{model_config.CONFIG_VERSION_KEY} = {config.config_version}"]
     for name in model_config.PERSISTED_SECTIONS[:-1]:

--- a/gentoo_install/tui/widgets.py
+++ b/gentoo_install/tui/widgets.py
@@ -504,7 +504,7 @@ class Accepts(Enum):
 
     Rejecting a submitted form tells the operator they were wrong; refusing the
     key tells them before they are. A host name can never hold a space, so the
-    space is simply not typed.
+    space is not typed.
     """
 
     ANYTHING = "anything"

--- a/tests/unit/test_layers.py
+++ b/tests/unit/test_layers.py
@@ -147,3 +147,24 @@ def test_no_definition_in_the_package_is_unreachable() -> None:
                 if len(re.findall(rf"\b{re.escape(name)}\b", everything)) <= 1:
                     orphans.append(f"{path.relative_to(root)}:{node.lineno} {name}")
     assert orphans == [], orphans
+
+
+BANNED_WORDS = (
+    "simply", "note that", "basically", "obviously",
+    "powerful", "robust", "seamlessly", "leverage", "utilize",
+)
+
+
+def test_no_source_file_uses_a_banned_filler_word() -> None:
+    """The list is in CLAUDE.md and had five hits when it was first run: a
+    comment that says a thing is simple says nothing about the thing."""
+    import re
+
+    root = Path(__file__).resolve().parents[2]
+    pattern = re.compile("|".join(rf"\b{word}\b" for word in BANNED_WORDS), re.IGNORECASE)
+    found: list[str] = []
+    for path in sorted((root / "gentoo_install").rglob("*.py")):
+        for number, line in enumerate(path.read_text().splitlines(), 1):
+            if pattern.search(line):
+                found.append(f"{path.relative_to(root)}:{number} {line.strip()[:60]}")
+    assert found == [], found


### PR DESCRIPTION
From a read-only audit of `model/`, `plan/`, `exec/`, `tui/`, `cli.py` and `errors.py`, verified line by line rather than applied as reported: four of the ten findings were wrong — one enum's comments carry a fact its neighbouring table does not, and `stage3`, `GNU` and `zfs` are not abbreviations this project bans. What survived is two docstrings that restated their own signature, a `#:` line left beside the one that replaced it, two filler words, and `ec_count`. The filler list from CLAUDE.md is now a test, so the next one fails a gate.