### PR TITLE
vm: a refusing node does not end the campaign

### DIFF
--- a/tests/unit/test_cluster.py
+++ b/tests/unit/test_cluster.py
@@ -741,3 +741,22 @@ def test_a_fixture_that_does_not_unlock_remotely_keeps_its_addresses() -> None:
         {"vm-xfs": "10.31.0.155"},
     )
     assert load(written / "vm-xfs.toml").kernel.remote_unlock.address == ""
+
+
+def test_a_node_that_refuses_a_guest_does_not_end_the_campaign() -> None:
+    """`POST /nodes/infra-node3/qemu` answered `595 Connection refused` and the
+    exception left the dispatch loop, so the closing path removed five guests
+    that were installing."""
+    import inspect
+
+    from tests.vm.proxmox import ProxmoxTransientError
+
+    code = inspect.getsource(cluster.run)
+    caught = code.index("except ProxmoxTransientError as refused:")
+    reserved = code.index("_reserve_job(")
+    assert reserved < caught, "the guard has to sit on the call that creates the guest"
+    after = code[caught : caught + 900]
+    assert "unreachable.add(node.name)" in after
+    assert "waiting.insert(index, job)" in after
+    assert "continue" in after
+    assert ProxmoxTransientError.__name__ in code

--- a/tests/vm/cluster.py
+++ b/tests/vm/cluster.py
@@ -80,6 +80,7 @@ from .proxmox import (
     GrubNotReadable,
     Node,
     ProxmoxError,
+    ProxmoxTransientError,
     VMID_FIRST,
     VMID_LAST,
     Line,
@@ -1802,8 +1803,21 @@ def run(
                         held_vmids,
                         address,
                     )
-                except Exception:
-                    raise
+                except ProxmoxTransientError as refused:
+                    # The node, not the job: `POST /nodes/infra-node3/qemu`
+                    # answered `595 Connection refused` and the exception left
+                    # the loop, so the closing path removed five guests that
+                    # were installing. That node takes no more of them and the
+                    # job goes back to the queue.
+                    unreachable.add(node.name)
+                    waiting.insert(index, job)
+                    print(
+                        f"! {node.name} refused a guest ({refused}); "
+                        f"{job.name} goes back to the queue",
+                        file=sys.stderr,
+                        flush=True,
+                    )
+                    continue
                 execution = job.execution
                 if execution is None:
                     raise ProxmoxError(f"{job.name} has no reserved guest")


### PR DESCRIPTION
Round 40 died eighteen minutes in with `ProxmoxTransientError: POST /nodes/infra-node3/qemu answered 595 Connection refused`. The exception left the dispatch loop, the closing path ran, and five guests that were installing were removed. A node that refuses to create a guest is a fact about the node — the same class as the console proxy that went away — so it joins the unreachable set and the job goes back to the queue instead of ending the run. Third time `infra-node3` has cost a round tonight.