### PR TITLE
vm: wait for the initramfs ssh daemon instead of racing it

### DIFF
--- a/tests/unit/test_harness.py
+++ b/tests/unit/test_harness.py
@@ -2431,3 +2431,55 @@ def test_the_guest_is_told_not_to_ask_for_aaaa() -> None:
     assert "options no-aaaa" in written
     assert f"nameserver {GUEST_RESOLVER}" in written
     assert written.index("options no-aaaa") < written.index("nameserver")
+
+
+def test_the_unlock_waits_for_the_daemon_before_it_connects(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The daemon comes up inside an initramfs that has to be unpacked first,
+    and connecting the moment the reset returns answered `Connection timed out
+    during banner exchange` for one that was seconds from starting."""
+    from types import SimpleNamespace
+
+    from tests.vm import run as runner
+
+    answers = ["ssh: connect to host: Connection refused", "Permission denied (publickey)."]
+    asked: list[int] = []
+
+    def probing(argv: list[str], **rest: object) -> object:
+        asked.append(1)
+        said = answers[min(len(asked) - 1, len(answers) - 1)]
+        return SimpleNamespace(returncode=255, stdout="", stderr=said)
+
+    monkeypatch.setattr("subprocess.run", probing)
+    monkeypatch.setattr("time.sleep", lambda seconds: None)
+
+    runner.wait_for_unlock_daemon(tmp_path / "key", 2222)
+
+    assert len(asked) == 2, "the first refusal is not the answer"
+
+
+def test_a_daemon_that_never_answers_is_reported(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    from types import SimpleNamespace
+
+    from tests.vm import run as runner
+
+    def refusing(argv: list[str], **rest: object) -> object:
+        return SimpleNamespace(returncode=255, stdout="", stderr="Connection refused")
+
+    monkeypatch.setattr("subprocess.run", refusing)
+    monkeypatch.setattr("time.sleep", lambda seconds: None)
+
+    with pytest.raises(RuntimeError, match="no ssh daemon on port 2222"):
+        runner.wait_for_unlock_daemon(tmp_path / "key", 2222, patience=0.01)
+
+
+def test_the_unlock_itself_waits_first() -> None:
+    import inspect
+
+    from tests.vm import run as runner
+
+    code = inspect.getsource(runner.remote_unlock)
+    assert code.index("wait_for_unlock_daemon(") < code.index("subprocess.Popen(")

--- a/tests/vm/run.py
+++ b/tests/vm/run.py
@@ -227,6 +227,45 @@ def push_config(key: Path, port: int, path: str, contents: str) -> None:
         raise RuntimeError(f"the live SSH configuration push failed: {result.stderr.strip()}")
 
 
+#: How long the initramfs is given to reach its ssh daemon. The guest has to
+#: POST, load a bootloader and unpack an initramfs first, and connecting the
+#: moment the reset returns answered `Connection timed out during banner
+#: exchange` for a daemon that was seconds from starting.
+DAEMON_PATIENCE: Final[float] = 180.0
+DAEMON_PAUSE: Final[float] = 3.0
+
+
+def wait_for_unlock_daemon(
+    key: Path, port: int, *, host: str = "127.0.0.1", patience: float = DAEMON_PATIENCE
+) -> None:
+    """Block until the initramfs answers on `port`, or say it never did.
+
+    The banner is the whole question: exit 255 with `Permission denied` is a
+    daemon that is up and does not trust this key yet, and a refused or silent
+    port is one that is not.
+    """
+    deadline = time.monotonic() + patience
+    last = ""
+    while time.monotonic() < deadline:
+        probe = subprocess.run(
+            [
+                "ssh", "-p", str(port), "-i", str(key),
+                "-o", "StrictHostKeyChecking=no", "-o", "UserKnownHostsFile=/dev/null",
+                "-o", "BatchMode=yes", "-o", "ConnectTimeout=5",
+                f"root@{host}", "true",
+            ],
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+        said = f"{probe.stdout}{probe.stderr}"
+        if probe.returncode == 0 or "Permission denied" in said:
+            return
+        last = said.strip()[-200:]
+        time.sleep(DAEMON_PAUSE)
+    raise RuntimeError(f"no ssh daemon on port {port} after {patience:.0f}s: {last}")
+
+
 def remote_unlock(
     key: Path,
     port: int,
@@ -240,6 +279,9 @@ def remote_unlock(
     if commands is None:
         raise RuntimeError("remote unlock is disabled")
     command, proof = commands
+    # Before the unlock, not racing it: the daemon comes up inside an initramfs
+    # that has to be unpacked first.
+    wait_for_unlock_daemon(key, port, host=host)
     process = subprocess.Popen(
         [
             "ssh", "-p", str(port), "-i", str(key),


### PR DESCRIPTION
Carried forward from #292, which has been open since 2026-08-14, is ninety commits behind and conflicts with master. The idea is the same and the code is written against today's tree: the unlock probes for a banner until the daemon answers rather than connecting the moment the reset returns. `Permission denied` counts as up — a daemon that does not trust the key yet is still a daemon. #291's other half landed separately as #391, which gives the initramfs the address the harness will actually reach. #292 can be closed.