### PR TITLE
convert: the machine sees the derived layout

### DIFF
--- a/gentoo_install/cli.py
+++ b/gentoo_install/cli.py
@@ -46,7 +46,7 @@ from .model.config import (
 )
 from .exec.config import load
 from .plan import convert
-from .plan.build import DEFAULT_MIRROR, build, stage3_mirror
+from .plan.build import DEFAULT_MIRROR, build, running_config, stage3_mirror
 from .plan.operations import Context, Operation, Stage
 from .plan.portage import variant_of
 from .plan.render import render, summarise
@@ -196,7 +196,11 @@ def main(argv: Sequence[str] | None = None) -> int:
             print(render(operations), end="")
             print(summarise(operations))
             return EXIT_OK
-        return install(config, operations, arguments, state)
+        # The derived one for the machine, the operator's own for preflight:
+        # the check that refuses a mounted disk has to see the empty graph a
+        # conversion was given, and everything that resolves a `DeviceId` has
+        # to see the graph read from the machine.
+        return install(config, operations, arguments, state, running_config(config, layout))
     except errors.DeviceNotFound as error:
         _print_machine_state(state)
         print(f"device: {error}", file=sys.stderr)
@@ -265,6 +269,7 @@ def install(
     operations: tuple[Operation, ...],
     arguments: argparse.Namespace,
     state: RunState,
+    running: InstallConfig | None = None,
 ) -> int:
     """Check the machine, then perform every operation in order."""
     work: Path = arguments.work
@@ -288,7 +293,11 @@ def install(
         if config.disk.mode is DiskMode.IN_PLACE and not _confirmed_swap(arguments, record):
             return EXIT_CONFIG
         machine = Machine(
-            config=config, runner=runner, probe=probe, work=work, mountpoint=target
+            config=running if running is not None else config,
+            runner=runner,
+            probe=probe,
+            work=work,
+            mountpoint=target,
         )
         finished = completed(journal) if arguments.resume else frozenset()
         if arguments.resume:

--- a/gentoo_install/plan/build.py
+++ b/gentoo_install/plan/build.py
@@ -68,6 +68,22 @@ def stage3_mirror(config: InstallConfig, fallback: str = DEFAULT_MIRROR) -> str:
     return offered[0].distfiles if offered else fallback
 
 
+def running_config(config: InstallConfig, layout: StorageLayout | None) -> InstallConfig:
+    """The configuration the operations act on, which is not always the one given.
+
+    A conversion carries no device graph: the layout belongs to the machine and
+    the graph is derived from it. Whatever resolves a `DeviceId` at apply time
+    has to see that derived graph, and the `Machine` was handed the operator's
+    own configuration — `write /etc/fstab` stopped twenty-four operations in
+    with `no node with id 'running-root-device'`.
+    """
+    if config.disk.mode is not DiskMode.IN_PLACE:
+        return config
+    if layout is None:
+        raise ConversionUnsupported("the running layout was not read")
+    return replace(config, disk=convert.layout_graph(layout))
+
+
 def build(
     config: InstallConfig,
     catalog: packages.Catalog,
@@ -142,7 +158,7 @@ def _in_place(
     # The operator's own configuration first, because that is where the rule
     # against writing a device graph beside the mode applies.
     validate(config, storage_facts=StorageFacts())
-    derived = replace(config, disk=convert.layout_graph(layout))
+    derived = running_config(config, layout)
     # And the derived one as an ordinary layout: it describes concrete devices
     # now, so the compatibility table has something to check.
     validate(

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -1162,3 +1162,44 @@ def test_a_conversion_acts_on_the_running_root_not_the_mount_point(
     )
     cli.install(converted, (), arguments, cli.RunState())
     assert seen == [Path("/")], seen
+
+
+def test_the_machine_gets_the_derived_configuration_for_a_conversion(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The check that refuses a mounted disk has to see the empty graph a
+    conversion was given; everything that resolves a `DeviceId` has to see the
+    graph read from the machine."""
+    from dataclasses import replace
+
+    from .layouts import config
+
+    seen: list[object] = []
+
+    class Recording:
+        def __init__(self, **fields: object) -> None:
+            seen.append(fields["config"])
+            self.given_up: set[str] = set()
+            self.runner = fields["runner"]
+
+    converted = replace(
+        config(),
+        disk=DiskConfig(graph=DeviceGraph.build([]), root=DeviceId(""), mode=DiskMode.IN_PLACE),
+    )
+    running = replace(converted, disk=DiskConfig(graph=DeviceGraph.build([]), root=DeviceId("x")))
+    monkeypatch.setattr(cli, "Machine", Recording)
+    monkeypatch.setattr(cli, "apply", lambda *args, **kwargs: None)
+    monkeypatch.setattr(cli, "_confirmed_swap", lambda arguments, record: True)
+    monkeypatch.setattr(report, "keep_log", lambda work, target, record: None)
+    arguments = argparse.Namespace(
+        work=tmp_path / "work",
+        target=Path("/mnt/gentoo"),
+        skip_preflight=True,
+        resume=False,
+        no_shell=True,
+        dry_run=False,
+    )
+
+    cli.install(converted, (), arguments, cli.RunState(), running)
+
+    assert seen == [running], "the machine takes the derived one"

--- a/tests/unit/test_plan_convert.py
+++ b/tests/unit/test_plan_convert.py
@@ -454,3 +454,30 @@ def test_a_context_without_that_field_still_reaches_the_staging_root() -> None:
     staged = convert._aimed_at(cast(Any, Recorder()), PurePosixPath("/gentoo-install.new"))
     assert staged.target == PurePosixPath("/gentoo-install.new")
     assert staged.read(PurePosixPath("/etc/portage/make.conf")) == "from the parent"
+
+
+def test_the_machine_is_given_the_derived_graph() -> None:
+    """Whatever resolves a `DeviceId` at apply time has to see the graph read
+    from the machine: `write /etc/fstab` stopped twenty-four operations into a
+    real conversion with `no node with id 'running-root-device'`."""
+    from gentoo_install.plan.build import running_config
+
+    running = running_config(_in_place(), _layout())
+    assert running.disk.graph[convert.ROOT_MOUNT] is not None
+    assert running.disk.root == convert.ROOT_MOUNT
+
+
+def test_an_ordinary_configuration_is_handed_back_unchanged() -> None:
+    from gentoo_install.plan.build import running_config
+
+    from .layouts import config
+
+    ordinary = config()
+    assert running_config(ordinary, None) is ordinary
+
+
+def test_a_conversion_without_a_layout_is_refused_there_too() -> None:
+    from gentoo_install.plan.build import running_config
+
+    with pytest.raises(ConversionUnsupported, match="was not read"):
+        running_config(_in_place(), None)


### PR DESCRIPTION
The first conversion to get past the staging context reached step 24 of 46 — chroot, portage, a git sync, locales, the timezone, the hostname `convertedbox`, a fresh machine id — and stopped at `write /etc/fstab` with `UnknownDeviceId: no node with id 'running-root-device'`. `Machine` was handed the operator's own configuration, and a conversion's is the one with no device graph; the graph derived from `probe.storage_layout()` lived only inside `build()`. Preflight keeps the operator's, because the check that refuses a mounted disk has to see an empty graph on a machine whose root is mounted by definition.