### PR TITLE
docs: correct three comments that had drifted from the code

### DIFF
--- a/gentoo_install/errors.py
+++ b/gentoo_install/errors.py
@@ -55,8 +55,12 @@ class PreflightFailed(GentooInstallError):
 
 
 class IntegrityError(GentooInstallError):
-    """A signature, checksum or key fingerprint did not match. Never retried
-    against another mirror: untrusted data stays untrusted."""
+    """A signature, checksum or key fingerprint did not match.
+
+    Never retried against another mirror: untrusted data stays untrusted. The
+    one exception is `ArchiveDigestMismatch`, which says something about that
+    mirror's copy rather than about the release.
+    """
 
 
 class NothingToBoot(GentooInstallError):

--- a/gentoo_install/model/manual.py
+++ b/gentoo_install/model/manual.py
@@ -60,14 +60,14 @@ class Purpose:
     key: str
     label: str
     role: PartitionRole
-    #: Where it mounts. Empty for a purpose that mounts nothing, and for the
-    #: one purpose that asks.
+    #: Where it mounts. Empty for a purpose that mounts nothing, and for one
+    #: that asks the operator instead.
     mountpoint: str = ""
     filesystem: FilesystemType | None = None
     #: A purpose whose filesystem is fixed by the firmware or the pool takes no
     #: filesystem menu.
     chooses_filesystem: bool = True
-    #: Only `other` asks, because every other purpose already knows.
+    #: `other` and `zfs` ask; the rest already know where they go.
     asks_mountpoint: bool = False
 
 

--- a/gentoo_install/plan/build.py
+++ b/gentoo_install/plan/build.py
@@ -39,7 +39,9 @@ PORTAGE_PREREQUISITES: Final[tuple[type[Operation], ...]] = (
 def stage3_mirror(config: InstallConfig, fallback: str = DEFAULT_MIRROR) -> str:
     """Where the stage3 comes from.
 
-    The site the operator chose, which is the same one `GENTOO_MIRRORS` gets.
+    The site the operator chose, which is the same one `GENTOO_MIRRORS` gets,
+    unless that site carries no `releases/`: the region's first is used then,
+    for the reason given at the line that does it.
     Only `--mirror` was read, so choosing USTC set the mirror for every later
     fetch and downloaded the several hundred megabytes of the stage3 itself
     from `distfiles.gentoo.org`, which is the slow one from China.

--- a/tests/unit/test_tui_partitions.py
+++ b/tests/unit/test_tui_partitions.py
@@ -1227,3 +1227,20 @@ def test_the_partitions_row_lists_a_hand_written_table() -> None:
     shown = settings._partitions(config(), at)
     assert shown == "/efi 1GiB, / the rest", shown
     assert shown.strip(", ")
+
+
+def test_the_comment_names_every_purpose_that_asks_for_a_mount_point() -> None:
+    """The comment said only `other` asks and `zfs` asks too, so a reader
+    believed a ZFS pool member takes no mount point from the operator."""
+    from gentoo_install.model.manual import PURPOSES
+
+    asking = {one.key for one in PURPOSES if one.asks_mountpoint}
+    assert asking == {"other", "zfs"}, asking
+
+    from pathlib import Path as Where
+
+    source = Where(__file__).resolve().parents[2] / "gentoo_install" / "model" / "manual.py"
+    said = source.read_text()
+    for key in sorted(asking):
+        assert f"`{key}`" in said, f"the comment does not name {key}"
+    assert "Only `other` asks" not in said


### PR DESCRIPTION
From a read-only audit for comments that describe behaviour the code no longer has, verified line by line: five findings, two rejected. Both rejections read a past-tense rationale as a present-tense claim — `\`_newest\` did not [retry]` is the reason `READ_TRIES` exists, not a statement that it still does not. The three that stood: `IntegrityError` says integrity failures are never retried against another mirror and `ArchiveDigestMismatch` is, `stage3_mirror`'s docstring says the chosen site supplies the stage3 and a site without `releases/` is replaced, and `zfs` asks the operator for a mount point while the comment named `other` as the only one that does. The last has a test, because it is a claim about a table.