### PR TITLE
mirrors: the stage3 follows a replaced mirror list

### DIFF
--- a/gentoo_install/plan/build.py
+++ b/gentoo_install/plan/build.py
@@ -55,6 +55,13 @@ def stage3_mirror(config: InstallConfig, fallback: str = DEFAULT_MIRROR) -> str:
     Only sites that carry `releases/` are considered, whichever was chosen: an
     install told to use one that does not stopped with no stage3 at all.
     """
+    # A replaced list is the whole answer, stage3 included: an operator who
+    # points Portage at a caching mirror on the segment and still downloads
+    # several hundred megabytes of stage3 from the public one has the slow half
+    # of both. `emerge-webrsync` already reads snapshots from this list.
+    replaced = config.portage.mirrors.distfiles
+    if replaced:
+        return replaced[0]
     chosen = config.portage.mirrors.site
     offered = [
         site for site in mirrors.gentoo_sites(config.portage.mirrors.region) if site.releases

--- a/tests/unit/test_mirrors.py
+++ b/tests/unit/test_mirrors.py
@@ -108,3 +108,50 @@ def test_the_chinese_default_is_ustc_and_not_tuna() -> None:
     ):
         assert "ustc" in address, address
         assert "tuna" not in address, address
+
+
+def test_the_stage3_follows_a_replaced_mirror_list() -> None:
+    """An operator who points Portage at a caching mirror on the segment and
+    still downloads the stage3 from the public one has the slow half of both.
+    `emerge-webrsync` already reads its snapshots from this list."""
+    from dataclasses import replace
+
+    from gentoo_install.plan.build import stage3_mirror
+
+    from .layouts import config
+
+    ordinary = config()
+    cached = replace(
+        ordinary,
+        portage=replace(
+            ordinary.portage,
+            mirrors=replace(
+                ordinary.portage.mirrors, distfiles=("http://10.31.0.2/gentoo",)
+            ),
+        ),
+    )
+    assert stage3_mirror(cached) == "http://10.31.0.2/gentoo"
+    assert stage3_mirror(ordinary) != "http://10.31.0.2/gentoo"
+
+
+def test_a_replaced_list_beats_the_chosen_site() -> None:
+    """The list is the operator's own answer and the site table is a default."""
+    from dataclasses import replace
+
+    from gentoo_install.plan.build import stage3_mirror
+
+    from .layouts import config
+
+    ordinary = config()
+    both = replace(
+        ordinary,
+        portage=replace(
+            ordinary.portage,
+            mirrors=replace(
+                ordinary.portage.mirrors,
+                site="ustc",
+                distfiles=("http://10.31.0.2/gentoo",),
+            ),
+        ),
+    )
+    assert stage3_mirror(both) == "http://10.31.0.2/gentoo"


### PR DESCRIPTION
`mirrors.distfiles` replaces the built-in list and becomes `GENTOO_MIRRORS`, which is where `emerge-webrsync` reads its snapshots and where every later fetch goes. The stage3 did not follow it: `stage3_mirror()` read only the site table, so a machine behind a caching mirror on its own segment still pulled several hundred megabytes from a public one. Measured against a cache at `http://10.31.0.2/gentoo`: the pointer file, the archive, its `DIGESTS` and its signature are all served from there.