### PR TITLE
tests: the rewrite doubles take the new parameter

### DIFF
--- a/tests/unit/test_cluster.py
+++ b/tests/unit/test_cluster.py
@@ -108,6 +108,7 @@ def _rewrite(
     public_key: str = "",
     site: str = "",
     unlock_addresses: object = None,
+    distfiles: str = "",
 ) -> Path:
     return into
 

--- a/tests/unit/test_harness.py
+++ b/tests/unit/test_harness.py
@@ -1036,7 +1036,7 @@ def test_zero_cluster_capacity_returns_an_error_after_a_deadline(
     monkeypatch.setattr(
         cluster,
         "rewrite_fixtures",
-        lambda jobs, into, region, sync, public_key="", site="", unlock_addresses=None: into,
+        lambda jobs, into, region, sync, public_key="", site="", unlock_addresses=None, distfiles="": into,
     )
 
     def build(path: Path, **kwargs: object) -> Path:


### PR DESCRIPTION
`#399` added a parameter to `rewrite_fixtures` and two test doubles kept the old signature. The suite was red at that commit; the chain that runs the gates and then commits, pushes and merges in one command let it through because the result was not read before the chain continued. Fixed here, and master is green on both gates.