### PR TITLE
vm: the send count follows the second resolver write

### DIFF
--- a/tests/unit/test_proxmox.py
+++ b/tests/unit/test_proxmox.py
@@ -1171,7 +1171,7 @@ def test_the_network_wait_returns_as_soon_as_the_guest_answers() -> None:
 
     link = cluster.Reconnecting(Late, tries=1)
     cluster.wait_for_network(link)
-    assert len(tries) == 6
+    assert len(tries) == 7
     assert sum(1 for line in tries if "NETWORK_%s" in line) == 2
     assert "REACH" in tries[-1]
 


### PR DESCRIPTION
`#399` staged `tests/vm/cluster.py` by name and the file carried a second, unrelated change: the resolvers are written again once the DHCP client is dead, which `vm-zfs-mirror` earned by reaching the installer with two addresses, two default routes and `route to 10.31.0.252`. Its own test came along; the send count in `test_proxmox.py` lives in a third file and did not, so master has been red since. Naming the path is not enough when the file holds two changes.