### PR TITLE
convert: carry the mounts the conversion does not manage

### DIFF
--- a/gentoo_install/exec/probe.py
+++ b/gentoo_install/exec/probe.py
@@ -117,6 +117,35 @@ class ProbedPartition:
     device_type: str
 
 
+#: The mount points a conversion writes itself. Every other line of the
+#: running `/etc/fstab` is carried across.
+_MANAGED_MOUNTS: Final[frozenset[str]] = frozenset({"/", "/boot", "/efi", "/boot/efi"})
+
+
+def _fstab_we_do_not_manage(esp: str | None, boot: str | None) -> tuple[str, ...]:
+    """The running fstab's other mounts, verbatim.
+
+    `distro2gentoo` copies the whole file across and keeps every mount the
+    machine had. This installer writes `/`, `/boot` and the esp from what it
+    probed, because their identifiers are the ones it just read; the rest —
+    a data partition, swap, a bind mount — is the operator's and is carried.
+    """
+    managed = set(_MANAGED_MOUNTS) | {one for one in (esp, boot) if one}
+    try:
+        lines = Path("/etc/fstab").read_text(encoding="utf-8").splitlines()
+    except OSError:
+        return ()
+    carried = []
+    for line in lines:
+        fields = line.split()
+        if not fields or fields[0].startswith("#") or len(fields) < 2:
+            continue
+        if fields[1] in managed:
+            continue
+        carried.append(line.rstrip())
+    return tuple(carried)
+
+
 def _mount_entries(document: object) -> tuple[Mapping[str, object], ...]:
     if not isinstance(document, Mapping):
         return ()
@@ -852,6 +881,10 @@ class Probe:
             esp_mountpoint=esp_mountpoint if uefi else None,
             uefi=uefi,
             root_free_bytes=_entry_int(root, "avail") if root is not None else None,
+            carried_fstab=_fstab_we_do_not_manage(
+                esp_mountpoint if uefi else None,
+                _entry_text(boot, "target") if boot is not None else None,
+            ),
         )
 
     def supports_v3(self) -> bool:

--- a/gentoo_install/model/device.py
+++ b/gentoo_install/model/device.py
@@ -154,6 +154,11 @@ class StorageLayout:
     esp_mountpoint: str | None
     uefi: bool
     root_free_bytes: int | None
+    #: Lines of the running `/etc/fstab` naming a path this installer does not
+    #: manage, verbatim. A conversion replaces `/etc`, and a machine that lost
+    #: its data partition or its swap boots and is wrong in a way no assertion
+    #: here can see.
+    carried_fstab: tuple[str, ...] = ()
 
 
 @dataclass(frozen=True, init=False)

--- a/gentoo_install/plan/build.py
+++ b/gentoo_install/plan/build.py
@@ -187,6 +187,9 @@ def _in_place(
             packages._required_licenses(derived, chosen),
         ),
         *system.build(derived),
+        # After `WriteFstab`, which is in the same stage and earlier in this
+        # list: the file has to exist before its other mounts are appended.
+        convert.CarryFstabEntries(lines=layout.carried_fstab),
         *kernel.build(derived),
         *(one for one in boot if not isinstance(one, AFTER_THE_SWAP)),
         *packages._build(derived, catalog, chosen),

--- a/gentoo_install/plan/convert.py
+++ b/gentoo_install/plan/convert.py
@@ -125,6 +125,32 @@ class SwapDirectories(Operation):
 
 
 @dataclass(frozen=True, kw_only=True)
+class CarryFstabEntries(Operation):
+    """Append the running machine's other mounts to the fstab just written.
+
+    A conversion replaces `/etc`, so a data partition, a swap or a bind mount
+    the operator had would be gone from the new file: the machine boots and is
+    wrong in a way nothing here can see. `distro2gentoo` keeps the whole file;
+    this keeps every line naming a path the installer did not write itself.
+    """
+
+    stage: Stage = Stage.SYSTEM
+    lines: tuple[str, ...]
+
+    def describe(self) -> str:
+        return f"carry {len(self.lines)} fstab entries the conversion does not manage"
+
+    def apply(self, context: Context) -> None:
+        if not self.lines:
+            return
+        said = context.read(context.target / "etc/fstab")
+        carried = "\n".join(
+            ["# carried from the system this replaced", *self.lines]
+        )
+        context.write(context.target / "etc/fstab", f"{said.rstrip()}\n{carried}\n")
+
+
+@dataclass(frozen=True, kw_only=True)
 class PrepareStaging(Operation):
     """Create the directory the staged system is built in.
 

--- a/tests/unit/test_plan_convert.py
+++ b/tests/unit/test_plan_convert.py
@@ -75,6 +75,7 @@ def _layout(
     esp_mountpoint: str | None = "/boot/efi",
     uefi: bool = True,
     root_free_bytes: int | None = 20 * 2**30,
+    carried_fstab: tuple[str, ...] = (),
     boot_filesystem_type: str | None = "xfs",
     boot_same_filesystem: bool = True,
 ) -> StorageLayout:
@@ -94,6 +95,7 @@ def _layout(
         esp_mountpoint=esp_mountpoint,
         uefi=uefi,
         root_free_bytes=root_free_bytes,
+        carried_fstab=carried_fstab,
     )
 
 
@@ -481,3 +483,60 @@ def test_a_conversion_without_a_layout_is_refused_there_too() -> None:
 
     with pytest.raises(ConversionUnsupported, match="was not read"):
         running_config(_in_place(), None)
+
+
+def test_the_mounts_the_conversion_does_not_manage_are_carried() -> None:
+    """A conversion replaces `/etc`, so a data partition or a swap the operator
+    had would be gone from the new fstab: the machine boots and is wrong in a
+    way nothing here can see."""
+    carried = ("UUID=abc\t/srv\text4\tdefaults\t0\t2", "UUID=def\tnone\tswap\tsw\t0\t0")
+    operations = build(_in_place(), CATALOG, layout=_layout(carried_fstab=carried))
+    appended = [
+        one.inner
+        for one in operations
+        if isinstance(one, convert.Staged)
+        and isinstance(one.inner, convert.CarryFstabEntries)
+    ]
+    assert appended and appended[0].lines == carried
+
+    written = [
+        index
+        for index, one in enumerate(operations)
+        if isinstance(one, convert.Staged) and "fstab" in one.inner.describe()
+    ]
+    assert len(written) == 2, "the file is written, then the rest is appended"
+    assert written[0] < written[1]
+
+
+def test_a_machine_with_nothing_else_mounted_carries_nothing() -> None:
+    operations = build(_in_place(), CATALOG, layout=_layout())
+    appended = [
+        one.inner
+        for one in operations
+        if isinstance(one, convert.Staged)
+        and isinstance(one.inner, convert.CarryFstabEntries)
+    ]
+    assert appended and appended[0].lines == ()
+
+
+def test_carrying_appends_rather_than_replaces() -> None:
+    context = _RunningContext()
+    context.answers = {}
+    written: dict[str, str] = {}
+
+    class Writing(_RunningContext):
+        target = PurePosixPath("/gentoo-install.new")
+
+        def read(self, path: object) -> str:
+            return "# device\tmountpoint\ttype\toptions\tdump\tpass\nUUID=1\t/\text4\tdefaults\t0\t1\n"
+
+        def write(self, path: object, content: str, *, mode: int = 0o644) -> None:
+            written[str(path)] = content
+
+    convert.CarryFstabEntries(lines=("UUID=abc\t/srv\text4\tdefaults\t0\t2",)).apply(
+        cast(Any, Writing())
+    )
+    said = written["/gentoo-install.new/etc/fstab"]
+    assert "UUID=1\t/\text4" in said, "the generated entries survive"
+    assert "/srv" in said
+    assert said.index("UUID=1") < said.index("/srv")


### PR DESCRIPTION
`distro2gentoo` copies the running `/etc/fstab` across whole; this installer wrote a new one from what it probed, holding `/`, `/boot` and the esp and nothing else. A machine with a data partition, a swap or a bind mount therefore boots after conversion with none of them mounted — success with the wrong result, which is the class no assertion in this repository can see. The three lines the installer probed stay authoritative and every other line is carried verbatim. Measured on this workstation: `/var/tmp/portage` and two swap devices fall in that set.