### PR TITLE
vm: skip a node that is known bad

### DIFF
--- a/tests/unit/test_cluster.py
+++ b/tests/unit/test_cluster.py
@@ -808,3 +808,22 @@ def test_a_round_without_that_address_keeps_the_table(tmp_path: Path) -> None:
         jobs, tmp_path / "plain", MirrorRegion.CN, Sync.GIT, "", "nju"
     )
     assert load(written / "vm-xfs.toml").portage.mirrors.distfiles == ()
+
+
+def test_a_named_node_takes_no_guests_at_all() -> None:
+    """`infra-node3` cost four rounds on 2026-08-16 and the automatic
+    detection has to lose a guest to each bad node before it acts."""
+    import inspect
+
+    code = inspect.getsource(cluster.run)
+    seeded = code.index("unreachable: set[str] = set(skip_nodes)")
+    used = code.index("node.name not in unreachable")
+    assert seeded < used, "the seed has to be in place before the first dispatch"
+
+
+def test_the_flag_reaches_the_run() -> None:
+    import inspect
+
+    code = inspect.getsource(cluster.main)
+    assert '"--skip-node"' in code
+    assert "args.skip_node" in code

--- a/tests/vm/cluster.py
+++ b/tests/vm/cluster.py
@@ -36,7 +36,7 @@ from enum import Enum
 from pathlib import Path
 from collections import Counter
 from collections.abc import Callable, Mapping
-from typing import Final, Protocol, TypeVar, cast
+from typing import Final, Protocol, TypeVar, cast, Sequence
 
 from gentoo_install.model.config import Firmware as BootFirmware
 from gentoo_install.model.config import (
@@ -1697,6 +1697,7 @@ def run(
     sync: Sync = Sync.RSYNC,
     site: str = "",
     distfiles: str = "",
+    skip_nodes: Sequence[str] = (),
 ) -> list[Outcome]:
     """Every job, collected one at a time as each finishes.
 
@@ -1737,7 +1738,10 @@ def run(
     # A node whose console proxy went away takes no more guests: three runs on
     # `infra-node3` were lost to the same dropped ssh while their installs
     # were going perfectly well.
-    unreachable: set[str] = set()
+    # Seeded, not only learned: `infra-node3` cost four rounds on 2026-08-16
+    # and the automatic detection has to lose a guest to each bad node before
+    # it acts. Naming one here costs nothing when it is wrong.
+    unreachable: set[str] = set(skip_nodes)
     done: queue.Queue[Outcome] = queue.Queue()
     scheduled = {job.name: job for job in jobs}
     collected = 0
@@ -2769,6 +2773,13 @@ def main(argv: list[str] | None = None) -> int:
         help="pin every mirror to one site by its key in model/mirrors.py",
     )
     parser.add_argument(
+        "--skip-node",
+        action="append",
+        default=[],
+        metavar="NAME",
+        help="take no guests on this node, before it has cost a guest to learn",
+    )
+    parser.add_argument(
         "--distfiles",
         default="",
         help=(
@@ -2814,6 +2825,7 @@ def main(argv: list[str] | None = None) -> int:
         Sync(args.sync),
         args.site,
         args.distfiles,
+        args.skip_node,
     )
     passed = [
         one


### PR DESCRIPTION
A node whose console proxy goes away joins the unreachable set, but only after a guest has been lost to it: `infra-node3` took `zfs-zbm` and then `vm-xfs` in the same round, on top of three earlier ones tonight. `--skip-node NAME` seeds that set before the first dispatch. It is deliberately blunt — a node named here takes no guests even if it is healthy — because the cost of being wrong is one node's worth of capacity and the cost of being right is a whole round.