### PR TITLE
vm: the prompt fallback accepts any hostname

### DIFF
--- a/tests/unit/test_cluster.py
+++ b/tests/unit/test_cluster.py
@@ -827,3 +827,27 @@ def test_the_flag_reaches_the_run() -> None:
     code = inspect.getsource(cluster.main)
     assert '"--skip-node"' in code
     assert "args.skip_node" in code
+
+
+def test_the_prompt_fallback_accepts_any_hostname() -> None:
+    """After a reconnect the shell being back at a prompt proves the command
+    returned. The pattern named the live medium, so a guest that had rebooted
+    into the system it installed never matched it: `vm-convert` waited
+    seventy-three minutes on `xfsbox`."""
+    import re
+
+    pattern = re.compile(cluster._ANY_ROOT_PROMPT)
+    for host in ("livecd", "xfsbox", "convertedbox", "gentoo-test.local"):
+        assert pattern.search(f"root@{host} ~ # "), host
+    assert not pattern.search("root@xfsbox /mnt # "), "only the home prompt"
+
+
+def test_the_fallback_is_used_only_after_a_reconnect() -> None:
+    """Before one, the marker is the only proof: a prompt in ordinary output
+    would end the wait while the command was still running."""
+    import inspect
+
+    code = inspect.getsource(cluster.Reconnecting.wait_for)
+    guarded = code.index("if after_reconnect:")
+    used = code.index("_ANY_ROOT_PROMPT")
+    assert guarded < used

--- a/tests/vm/cluster.py
+++ b/tests/vm/cluster.py
@@ -1957,7 +1957,11 @@ RECONNECT_TRIES: Final[int] = 4
 #: whole in the line the console is given: the shell echoes that line back,
 #: and a reader waiting for the end marker matched the echo and returned
 #: before the command had run. `printf` assembles them in the guest instead.
-_LIVE_PROMPT: Final[str] = "root@livecd ~ # "
+#: A root shell's prompt, whatever the machine calls itself. The live medium
+#: says `livecd`, a machine this installer produced says its own hostname, and
+#: a converted one says a third: `vm-convert` waited seventy-three minutes for
+#: `root@livecd ~ # ` on a guest that had rebooted into `xfsbox`.
+_ANY_ROOT_PROMPT: Final[str] = r"root@[A-Za-z0-9._-]+ ~ # "
 
 
 _Result = TypeVar("_Result")
@@ -2084,7 +2088,7 @@ class Reconnecting:
                 self.console.send(marked_command(command, token))
             completion = command_done(token)
             if after_reconnect:
-                completion = rf"{completion}|{re.escape(_LIVE_PROMPT)}"
+                completion = rf"{completion}|{_ANY_ROOT_PROMPT}"
             while True:
                 try:
                     self.console.expect(completion, _remaining(deadline), idle=idle)


### PR DESCRIPTION
`wait_for` adds a second completion pattern after a reconnect, because a shell back at its prompt has finished the command whether or not the marker survived the drop. That pattern was the literal `root@livecd ~ # `, which only the live medium prints. The conversion runs its second install on the machine the first one produced, so every reconnect there waited for a prompt that could never appear — `vm-convert` spent seventy-three minutes on it before the ceiling. The pattern now accepts any hostname and is still used only after a reconnect, where a prompt in ordinary output cannot end the wait early.