### PR TITLE
vm: give the GRUB editor time on a loaded node

### DIFF
--- a/tests/unit/test_proxmox.py
+++ b/tests/unit/test_proxmox.py
@@ -3331,3 +3331,19 @@ def test_a_heavy_guest_still_fits_a_four_core_node() -> None:
     assert heavy.cores == 4, "a heavy guest does ask for four"
     assert room_for(node, heavy)
     assert not room_for(node, heavy, None, {"infra-node4": 3}), "three guests already there"
+
+
+def test_the_editor_is_given_ten_presses_before_it_is_called_a_failure() -> None:
+    """Each attempt costs an escape, a settle and a snapshot. Thirty seconds
+    bought six presses, and `vm-mdraid` lost a run in forty-eight seconds while
+    its node sat at 99.8% CPU. The menu is already held, so waiting longer
+    races nothing."""
+    import inspect
+
+    from tests.vm import proxmox
+
+    one_press = proxmox.ESCAPE_SETTLES + 3.0
+    assert proxmox.EDITOR_PATIENCE >= 10 * one_press, proxmox.EDITOR_PATIENCE
+
+    signature = inspect.signature(proxmox.append_to_cmdline)
+    assert signature.parameters["timeout"].default == proxmox.EDITOR_PATIENCE

--- a/tests/vm/proxmox.py
+++ b/tests/vm/proxmox.py
@@ -843,6 +843,14 @@ GRUB_COUNTDOWN: Final[str] = (
 )
 
 
+#: How long GRUB is given to draw its editor. Each attempt costs an escape,
+#: a settle and a snapshot, so thirty seconds bought six presses; `vm-mdraid`
+#: lost a run in forty-eight seconds while its node sat at 99.8% CPU and every
+#: redraw crawled. The menu itself is already held, so waiting longer races
+#: nothing: the countdown is stopped and the guest is not about to boot.
+EDITOR_PATIENCE: Final[float] = 120.0
+
+
 def hold_the_menu(console: Line, timeout: float = 300.0) -> bytes:
     """Wait for GRUB's menu and stop its countdown.
 
@@ -858,7 +866,7 @@ def hold_the_menu(console: Line, timeout: float = 300.0) -> bytes:
     return seen
 
 
-def append_to_cmdline(console: Line, extra: str, timeout: float = 30.0) -> None:
+def append_to_cmdline(console: Line, extra: str, timeout: float = EDITOR_PATIENCE) -> None:
     """Add kernel parameters to the highlighted GRUB entry and boot it.
 
     The medium's own entry writes to the firmware console and says nothing more


### PR DESCRIPTION
`hold_the_menu` waits five minutes and then `append_to_cmdline` gave the editor thirty seconds. Each attempt is an escape, a two-second settle and a three-second snapshot, so that bought six presses; `vm-mdraid` — a UEFI fixture on the ordinary path, not the BIOS one — lost a run in forty-eight seconds while its node was measured at 99.8% CPU. The menu is already held when this runs, so a longer wait races nothing: the countdown is stopped and the guest is not about to boot. The test ties the patience to the cost of one press rather than to a number.