### PR TITLE
portage: fall back to another site when an overlay is unreachable

### DIFF
--- a/gentoo_install/model/mirrors.py
+++ b/gentoo_install/model/mirrors.py
@@ -273,6 +273,18 @@ def gentoozh_binhost(
     return f"{gentoozh(chosen).distfiles}/{where}/{subarch}"
 
 
+def overlay_sync_uris(name: str, chosen: GentooZhMirror) -> tuple[str, ...]:
+    """Every site carrying that overlay, the chosen one first.
+
+    Only gentoo-zh has a mirror set. `gig` is published from one host, so an
+    install that cannot reach it has nowhere else to look and stops there.
+    """
+    if name != "gentoo-zh":
+        return ()
+    ordered = sorted(GENTOOZH_SITES, key=lambda site: site.key != chosen.value)
+    return tuple(site.git for site in ordered if site.git)
+
+
 def gentoozh_distfiles(chosen: GentooZhMirror) -> tuple[str, ...]:
     """Every site, the chosen one first, the same as `gentoo_distfiles`: a
     mirror behind on one file still has the rest. Portage appends `distfiles/`,

--- a/gentoo_install/plan/portage.py
+++ b/gentoo_install/plan/portage.py
@@ -577,6 +577,31 @@ class SourcePolicy:
         return self.subset
 
 
+#: What a sync failure says when the site was never reached, so retrying the
+#: same one is pointless and another site is worth trying. Taken from what git
+#: printed on a cluster guest that could not reach the overlay mirror: `fatal:
+#: unable to access 'https://mirror.nju.edu.cn/git/gentoo-zh.git/': Failed to
+#: connect to mirror.nju.edu.cn:443 after 2052 ms: Could not connect to
+#: server`. Every marker names the transport; none of them names content, so a
+#: mirror mid-update never matches.
+UNREACHABLE_MARKERS: Final[tuple[str, ...]] = (
+    "unable to access",
+    "could not connect to server",
+    "failed to connect",
+    "could not resolve host",
+    "name or service not known",
+    "connection refused",
+    "connection timed out",
+    "network is unreachable",
+)
+
+
+def site_unreachable(message: str) -> bool:
+    """Whether a sync failure was the site rather than what it served."""
+    lowered = message.lower()
+    return any(marker in lowered for marker in UNREACHABLE_MARKERS)
+
+
 @dataclass(frozen=True, kw_only=True)
 class SyncRepository(Operation):
     """A directory holding a copy that git did not create makes `emerge --sync`
@@ -585,9 +610,16 @@ class SyncRepository(Operation):
     stage: Stage = Stage.PORTAGE
     name: str
     location: PurePosixPath
+    #: Other sites carrying the same repository, tried in order when the
+    #: configured one cannot be reached. Each one is a whole stanza rather than
+    #: a bare address, so `ConfigureRepository` stays the only writer of that
+    #: file.
+    alternates: tuple[ConfigureRepository, ...] = ()
 
     def describe(self) -> str:
-        return f"sync repository {self.name}"
+        if not self.alternates:
+            return f"sync repository {self.name}"
+        return f"sync repository {self.name}, {len(self.alternates)} other sites to fall back on"
 
     def apply(self, context: Context) -> None:
         context.run_in_target(["rm", "--recursive", "--force", str(self.location)])
@@ -595,7 +627,35 @@ class SyncRepository(Operation):
         context.run_in_target(["chown", "--recursive", "portage:portage", str(self.location)])
 
     def _sync(self, context: Context) -> None:
-        """`emerge --sync`, retried on a mirror that is mid-update.
+        """The configured site, then each alternate that a reachability failure
+        makes worth trying.
+
+        A site that was not reached will not be reached by waiting, and a
+        cluster guest spent fifteen minutes on three attempts at one host
+        before the install stopped. A mirror that answers and serves an
+        incomplete snapshot is the opposite case and is retried where it is.
+        """
+        try:
+            self._attempt(context)
+            return
+        except CommandFailed as failed:
+            last = failed
+        for alternate in self.alternates:
+            if not site_unreachable(str(last)):
+                raise last
+            alternate.apply(context)
+            # git refuses to clone into a directory it did not create, and the
+            # failed attempt may have left one.
+            context.run_in_target(["rm", "--recursive", "--force", str(self.location)])
+            try:
+                self._attempt(context)
+                return
+            except CommandFailed as failed:
+                last = failed
+        raise last
+
+    def _attempt(self, context: Context) -> None:
+        """One site's `emerge --sync`, retried while it is mid-update.
 
         Three of eight guests stopped in the same minute with `Manifest
         mismatch for gui-apps/Manifest.gz __size__: expected: 5745, have:
@@ -615,6 +675,8 @@ class SyncRepository(Operation):
                 return
             except CommandFailed as failed:
                 last = failed
+                if site_unreachable(str(failed)):
+                    raise
                 if attempt + 1 < SYNC_TRIES:
                     context.run(["sleep", f"{SYNC_PAUSE * (attempt + 1):g}"])
         assert last is not None
@@ -1132,7 +1194,22 @@ def build(
                 sync_uri=overlay.sync_uri,
                 verify_commits=False,
             ),
-            SyncRepository(name=overlay.name, location=location),
+            SyncRepository(
+                name=overlay.name,
+                location=location,
+                alternates=tuple(
+                    ConfigureRepository(
+                        name=overlay.name,
+                        location=location,
+                        sync_uri=uri,
+                        verify_commits=False,
+                    )
+                    for uri in mirrors.overlay_sync_uris(
+                        overlay.name, portage.mirrors.gentoo_zh
+                    )
+                    if uri != overlay.sync_uri
+                ),
+            ),
             AcceptOverlayKeywords(repository=overlay.name),
         ]
     if portage.testing_packages:

--- a/tests/unit/test_plan_portage.py
+++ b/tests/unit/test_plan_portage.py
@@ -7,7 +7,7 @@ import pytest
 
 from dataclasses import fields, replace
 from pathlib import PurePosixPath
-from typing import Any, Sequence
+from typing import Any, Final, Sequence
 
 from gentoo_install.model.config import (
     Binhost,
@@ -1200,6 +1200,129 @@ def test_a_mirror_rewriting_its_manifests_is_retried_rather_than_fatal(
     stubborn.refusals = plan_portage.SYNC_TRIES
     with pytest.raises(CommandFailed):
         operation.apply(stubborn)
+
+
+#: What a cluster guest's git printed on 2026-08-16 when the overlay mirror was
+#: not reachable, and what portage printed when a mirror was mid-update. The
+#: two are told apart by their text, so both are held here verbatim.
+_UNREACHABLE_SAYS: Final[str] = (
+    "chroot /mnt/gentoo env RSYNC_TIMEOUT=900 emerge --sync gentoo-zh exited 1: "
+    "fatal: unable to access 'https://mirror.nju.edu.cn/git/gentoo-zh.git/': "
+    "Failed to connect to mirror.nju.edu.cn:443 after 2052 ms: "
+    "Could not connect to server | !!! git clone error in /var/db/repos/gentoo-zh"
+)
+_MID_UPDATE_SAYS: Final[str] = (
+    "emerge --sync gentoo exited 1: Manifest mismatch for gui-apps/Manifest.gz "
+    "__size__: expected: 5745, have: 5746"
+)
+
+
+def test_a_site_that_cannot_be_reached_is_told_apart_from_one_mid_update() -> None:
+    from gentoo_install.plan import portage as plan_portage
+
+    assert plan_portage.site_unreachable(_UNREACHABLE_SAYS)
+    # The negative control the whole fallback rests on: a mirror that answered
+    # and served an incomplete snapshot must be retried where it is, because
+    # every other mirror is equally likely to be mid-update.
+    assert not plan_portage.site_unreachable(_MID_UPDATE_SAYS)
+
+
+def test_an_unreachable_overlay_site_moves_to_the_next_one(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """`btrfs-luks` and `vm-zfs-mirror` both stopped fifteen minutes into an
+    install because the one overlay mirror they were pointed at refused the
+    connection, while four other sites carry the same repository."""
+    from typing import Sequence
+
+    from gentoo_install.errors import CommandFailed
+    from gentoo_install.plan import portage as plan_portage
+
+    from .recorder import Recorder
+
+    class Unreachable(Recorder):
+        """Refuses every sync until the repository points at `reachable`."""
+
+        reachable: str = "https://mirrors.ha.edu.cn/gentoo-zh.git"
+        pointed: str = "https://mirror.nju.edu.cn/git/gentoo-zh.git"
+        attempts: int = 0
+
+        def run_in_target(self, argv: Sequence[str], *, check: bool = True) -> str:
+            if "--sync" in argv:
+                self.attempts += 1
+                if self.pointed != self.reachable:
+                    raise CommandFailed(_UNREACHABLE_SAYS)
+            return super().run_in_target(argv, check=check)
+
+        def write(self, path: PurePosixPath, content: str, *, mode: int = 0o644) -> None:
+            for line in content.splitlines():
+                if line.startswith("sync-uri = "):
+                    self.pointed = line.removeprefix("sync-uri = ")
+            super().write(path, content, mode=mode)
+
+    location = PurePosixPath("/var/db/repos/gentoo-zh")
+    alternates = tuple(
+        plan_portage.ConfigureRepository(
+            name="gentoo-zh", location=location, sync_uri=uri, verify_commits=False
+        )
+        for uri in (
+            "https://mirrors.cernet.edu.cn/gentoo-zh.git",
+            "https://mirrors.ha.edu.cn/gentoo-zh.git",
+        )
+    )
+    operation = plan_portage.SyncRepository(
+        name="gentoo-zh", location=location, alternates=alternates
+    )
+    monkeypatch.setattr(plan_portage, "SYNC_PAUSE", 0.0)
+
+    recorder = Unreachable()
+    operation.apply(recorder)
+    assert recorder.pointed == recorder.reachable
+    # One attempt per site and no more: a host that refused the connection is
+    # not waited on, so the three sites cost three attempts rather than nine.
+    assert recorder.attempts == 3, recorder.attempts
+    assert recorder.argv_starting("sleep") == ()
+
+    # The directory is cleared before each retry, or git refuses to clone into
+    # what the failed attempt left behind.
+    cleared = [one for one in recorder.in_target if one[0] == "rm"]
+    assert len(cleared) == 3, cleared
+
+    # Negative control: with no alternates the same failure stops the install.
+    alone = plan_portage.SyncRepository(name="gentoo-zh", location=location)
+    with pytest.raises(CommandFailed):
+        alone.apply(Unreachable())
+
+    # Negative control: a mid-update mirror is retried where it is and never
+    # spends an alternate, however many alternates it has.
+    class MidUpdate(Recorder):
+        attempts: int = 0
+        pointed_at: list[str] = []
+
+        def run_in_target(self, argv: Sequence[str], *, check: bool = True) -> str:
+            if "--sync" in argv:
+                self.attempts += 1
+                raise CommandFailed(_MID_UPDATE_SAYS)
+            return super().run_in_target(argv, check=check)
+
+    stubborn = MidUpdate()
+    with pytest.raises(CommandFailed):
+        operation.apply(stubborn)
+    assert stubborn.attempts == plan_portage.SYNC_TRIES, stubborn.attempts
+
+
+def test_the_overlay_fallback_names_sites_the_mirror_table_carries() -> None:
+    """The alternates are the other sites in the one table, never the chosen
+    one again, and `gig` has none because it is published from one host."""
+    from gentoo_install.model import mirrors
+    from gentoo_install.model.config import GentooZhMirror
+
+    for chosen in GentooZhMirror:
+        uris = mirrors.overlay_sync_uris("gentoo-zh", chosen)
+        assert len(uris) == len(set(uris)), uris
+        assert uris[0] == mirrors.gentoozh(chosen).git
+        assert set(uris) == {site.git for site in mirrors.GENTOOZH_SITES if site.git}
+        assert mirrors.overlay_sync_uris("gig", chosen) == ()
 def test_the_stage3_matches_the_profile_and_not_only_the_init_system() -> None:
     """`eselect profile set` is all the installer runs, and a profile switch
     removes nothing: a no-multilib profile on a multilib stage3 keeps every


### PR DESCRIPTION
`btrfs-luks` and `vm-zfs-mirror` each stopped fifteen minutes into an install with `fatal: unable to access 'https://mirror.nju.edu.cn/git/gentoo-zh.git/': Failed to connect`, while four other sites in `GENTOOZH_SITES` carry the same repository. `SyncRepository` retried the one host three times and raised.

The two sync failures are opposites and the message tells them apart. A host that was never reached is repointed at the next site, one attempt each. A mirror that answered and served an incomplete snapshot stays where it is for `SYNC_TRIES`, because every other mirror is equally likely to be mid-update; that case is the test's negative control.