### PR TITLE
vm: make the remote unlock reachable and its failure readable

### DIFF
--- a/tests/unit/test_cluster.py
+++ b/tests/unit/test_cluster.py
@@ -727,6 +727,44 @@ def test_the_initramfs_is_given_the_address_the_guest_will_have(tmp_path: Path) 
     assert rewritten.kernel.remote_unlock.address == f"10.31.0.155/{cluster.GUEST_PREFIX}"
 
 
+def test_the_initramfs_is_not_pinned_to_an_interface_the_guest_does_not_have(
+    tmp_path: Path,
+) -> None:
+    """`vm-unlock` pinned `eth0` and every cluster guest's only NIC is `ens18`
+    under predictable naming. dracut's `ip=` names the device in its sixth
+    field, so the address was configured on nothing and `rd.neednet=1` waited
+    for a link that never arrived: two hours of installing answered `no ssh
+    daemon on port 2222`."""
+    from gentoo_install.exec.config import load
+    from gentoo_install.model.config import MirrorRegion, Sync
+    from gentoo_install.plan.bootloader import unlock_parameters
+
+    jobs = cluster.fixtures(["vm-unlock"])
+    # The fixture is what an operator on real hardware may well write, and the
+    # rewrite is what makes it true here, so the negative control is the input.
+    assert load(jobs[0].fixture).kernel.remote_unlock.interface == "eth0"
+
+    written = cluster.rewrite_fixtures(
+        jobs,
+        tmp_path / "fixtures",
+        MirrorRegion.CN,
+        Sync.GIT,
+        "",
+        "nju",
+        {"vm-unlock": "10.31.0.155"},
+    )
+    rewritten = load(written / "vm-unlock.toml")
+    assert rewritten.kernel.remote_unlock.interface == ""
+
+    # Not only the field: the parameter the initramfs is handed carries no
+    # device name, which is what lets dracut use whichever NIC came up.
+    parameters = unlock_parameters(rewritten)
+    address = next(one for one in parameters if one.startswith("ip="))
+    fields = address.removeprefix("ip=").split(":")
+    assert fields[0] == "10.31.0.155", fields
+    assert fields[5] == "", fields
+
+
 def test_a_fixture_that_does_not_unlock_remotely_keeps_its_addresses() -> None:
     from gentoo_install.exec.config import load
     from gentoo_install.model.config import MirrorRegion, Sync

--- a/tests/unit/test_proxmox.py
+++ b/tests/unit/test_proxmox.py
@@ -1300,6 +1300,76 @@ def test_installed_boot_attaches_before_reset_without_sending_a_line(
     ]
 
 
+def test_a_failed_remote_unlock_answers_with_what_the_console_held(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """`no ssh daemon on port 2222 after 180s` was the whole of what a
+    two-hour run produced. The unlock is attempted over the network and returns
+    before anything reads the console, so a guest that never left GRUB and one
+    whose initramfs came up without an address answered identically."""
+    from gentoo_install.exec.config import load
+    from tests.vm import cluster
+
+    class Guest:
+        def stop(self) -> None:
+            return None
+
+        def boot_from_disk(self) -> None:
+            return None
+
+        def start(self) -> None:
+            return None
+
+        def reset(self) -> None:
+            return None
+
+    class Console:
+        def __init__(self, screen: bytes) -> None:
+            self.screen = screen
+            self.asked: list[float] = []
+
+        def snapshot(self, seconds: float) -> bytes:
+            self.asked.append(seconds)
+            return self.screen
+
+    class Link:
+        def __init__(self, screen: bytes) -> None:
+            self.console = Console(screen)
+
+        def reopen(self, *, solicit_prompt: bool = True) -> None:
+            return None
+
+    def refuse(*unused: object, **ignored: object) -> None:
+        raise RuntimeError("no ssh daemon on port 2222 after 180s")
+
+    monkeypatch.setattr(cluster, "remote_unlock", refuse)
+    installation = load(Path("tests/fixtures/vm-unlock.toml"))
+    assert installation.kernel.remote_unlock.enabled, "the fixture under test"
+
+    stuck_at_grub = Link(b"\x1b[2JGNU GRUB  version 2.14\r\nGentoo Linux\r\n")
+    refused = cluster.boot_and_check(
+        cast(Any, Guest()),
+        cast(Any, stuck_at_grub),
+        Path("unused"),
+        installation,
+        remote_key=Path("unused.key"),
+    )
+    assert "no ssh daemon on port 2222" in refused
+    assert "GNU GRUB" in refused, refused
+    assert stuck_at_grub.console.asked == [cluster.UNLOCK_SCREEN_PATIENCE]
+
+    # Negative control: a console that produced nothing says so, rather than
+    # an empty pair of quotes that reads as a screen that was read and blank.
+    silent = Link(b"")
+    assert "the console held nothing" in cluster.boot_and_check(
+        cast(Any, Guest()),
+        cast(Any, silent),
+        Path("unused"),
+        installation,
+        remote_key=Path("unused.key"),
+    )
+
+
 def test_unlock_reconnect_never_solicits_a_shell_prompt() -> None:
     """There is no shell while GRUB owns the console, so a solicitation is an
     empty passphrase and changes the state the reader is trying to observe."""

--- a/tests/vm/cluster.py
+++ b/tests/vm/cluster.py
@@ -1104,7 +1104,15 @@ def rewrite_fixtures(
                 kernel=replace(
                     moved.kernel,
                     remote_unlock=replace(
-                        moved.kernel.remote_unlock, address=f"{given}/{GUEST_PREFIX}"
+                        moved.kernel.remote_unlock,
+                        address=f"{given}/{GUEST_PREFIX}",
+                        # Cleared for the same reason the address is rewritten:
+                        # a cluster guest's only NIC is `ens18` under
+                        # predictable naming, and `vm-unlock` pinned `eth0`.
+                        # dracut's `ip=` names the device in its sixth field,
+                        # so a name no device carries configures nothing and
+                        # `rd.neednet=1` waits for a link that never arrives.
+                        interface="",
                     ),
                 ),
             )

--- a/tests/vm/cluster.py
+++ b/tests/vm/cluster.py
@@ -2302,6 +2302,13 @@ GRUB_PROMPT_SECONDS: Final[float] = 30.0
 #: unbounded loop would never fail.
 UNLOCK_TRIES: Final[int] = 5
 
+#: What a failed remote unlock reads off the console before answering, and how
+#: much of it the verdict carries. The guest is already at whatever prompt it
+#: reached, so this is a read of a screen that has stopped changing rather than
+#: a wait for anything.
+UNLOCK_SCREEN_PATIENCE: Final[float] = 5.0
+UNLOCK_SCREEN_BYTES: Final[int] = 400
+
 
 class Typeable(Protocol):
     """All the unlock step needs of a guest: GRUB's prompt never reaches the
@@ -2451,7 +2458,14 @@ def boot_and_check(
         try:
             remote_unlock(remote_key, unlock.port, installation, host=remote_host)
         except RuntimeError as error:
-            return f"remote unlock failed: {error}"[:200]
+            # The unlock is attempted over the network and returns before
+            # anything reads the console, so `no ssh daemon on port 2222` was
+            # the whole of what a two-hour run produced: a guest that never
+            # left GRUB and one whose initramfs came up without an address read
+            # identically. The screen tells them apart.
+            screen = link.console.snapshot(UNLOCK_SCREEN_PATIENCE)
+            held = repr(screen[-UNLOCK_SCREEN_BYTES:]) if screen else "nothing"
+            return f"remote unlock failed: {error}; the console held {held}"[:600]
         remotely_unlocked = True
         print("installed root unlocked by remote SSH session", flush=True)
     unlocked = _unlock(guest, link, installation, remotely_unlocked)


### PR DESCRIPTION
`vm-unlock` failed at 116.7 minutes with `remote unlock failed: no ssh daemon on port 2222 after 180s`, and the install itself had exited 0.

Two independent causes, one commit each. The fixture pinned `interface = "eth0"` while a cluster guest's only NIC is `ens18`; dracut's `ip=` names the device in its sixth field, so the reserved address was configured on nothing and `rd.neednet=1` waited for a link that never arrived. `rewrite_fixtures` now clears it for the same reason it rewrites the address.

The second is why that took two hours to guess at: the unlock is attempted over the network and returns before anything reads the console, so a guest still sitting in GRUB and one whose initramfs came up without an address produced the same verdict. The failure now carries the screen.