### PR TITLE
portage: degrade to source when a binhost index cannot be read

### DIFF
--- a/gentoo_install/plan/portage.py
+++ b/gentoo_install/plan/portage.py
@@ -968,11 +968,10 @@ class VerifyPackages(Operation):
 
     def apply(self, context: Context) -> None:
         atoms = tuple(request.atom for request in self.requests)
-        output = context.run_in_target(
-            ["emerge", "--pretend", "--quiet", "--", *atoms], check=False
-        )
-        if not isinstance(output, CommandOutput):
-            raise ConfigError("emerge --pretend returned no exit status")
+        output = self._resolve(context, atoms, source_only=context.degraded(BINARY_PACKAGES))
+        if output.returncode == 0:
+            return
+        output = self._without_the_binary_host(context, atoms, output)
         if output.returncode == 0:
             return
 
@@ -1023,6 +1022,55 @@ class VerifyPackages(Operation):
         raise ConfigError(
             f"emerge --pretend rejected packages requested by {', '.join(requesters)}: {detail}"
         )
+
+    def _resolve(
+        self, context: Context, atoms: tuple[str, ...], *, source_only: bool
+    ) -> CommandOutput:
+        without = ("--usepkg=n", "--getbinpkg=n") if source_only else ()
+        output = context.run_in_target(
+            ["emerge", "--pretend", "--quiet", *without, "--", *atoms], check=False
+        )
+        if not isinstance(output, CommandOutput):
+            raise ConfigError("emerge --pretend returned no exit status")
+        return output
+
+    def _without_the_binary_host(
+        self, context: Context, atoms: tuple[str, ...], failed: CommandOutput
+    ) -> CommandOutput:
+        """Resolve again with binaries off when the host's index was the only
+        thing that could not be read.
+
+        `--pretend` fails on an unreadable index, so `vm-gnome` stopped six
+        minutes in with every requested package present and visible. Source is
+        the guaranteed path, so an index that cannot be read degrades to it
+        rather than ending the install.
+        """
+        unreadable = _binhost_unreadable(str(failed))
+        if unreadable is None or context.degraded(BINARY_PACKAGES):
+            return failed
+        # The same retry `Emerge` makes before giving up on binaries: one
+        # dropped connection would otherwise compile the whole install.
+        again = self._resolve(context, atoms, source_only=False)
+        if again.returncode == 0 or _binhost_unreadable(str(again)) is None:
+            return again
+        context.degrade(BINARY_PACKAGES, f"binary host index unreadable: {unreadable}")
+        return self._resolve(context, atoms, source_only=True)
+
+
+#: What Portage prints when it cannot read a binary host's index, taken from
+#: what stopped `vm-gnome`: `!!! [gentoo] Error fetching binhost package info
+#: from 'https://mirrors.nju.edu.cn/gentoo/releases/amd64/binpackages/23.0/
+#: x86-64'`, followed by `!!! [gentoo] <urlopen error timed out>`.
+BINHOST_INDEX_FAILURE: Final[str] = "Error fetching binhost package info"
+
+
+def _binhost_unreadable(output: str) -> str | None:
+    """The line proving the failure was the binary host and not a package."""
+    for raw in output.splitlines():
+        line = raw.strip()
+        if BINHOST_INDEX_FAILURE in line:
+            return line.removeprefix("!!! ")
+    return None
 
 
 def _requesters_ask(request: PackageRequest) -> str:

--- a/tests/unit/test_plan_portage.py
+++ b/tests/unit/test_plan_portage.py
@@ -889,6 +889,90 @@ def test_a_package_the_licence_refuses_is_named_as_that_and_not_as_a_typo() -> N
     assert "repositories do not carry" not in str(caught.value)
 
 
+#: What Portage printed when the official binary host timed out during
+#: `emerge --pretend`, verbatim from `vm-gnome`'s log.
+BINHOST_TIMED_OUT: Final[str] = (
+    "!!! [gentoo] Error fetching binhost package info from "
+    "'https://mirrors.nju.edu.cn/gentoo/releases/amd64/binpackages/23.0/x86-64'\n"
+    "!!! [gentoo] <urlopen error timed out>\n"
+    "[ebuild  N    ] dev-perl/Error-0.170.300-r1\n"
+)
+
+
+def test_a_binary_host_that_cannot_be_read_degrades_the_resolve_to_source() -> None:
+    """`vm-gnome` stopped six minutes in, before anything was merged, with
+    every requested package present and visible: `--pretend` fails on an index
+    it cannot fetch. Source is the guaranteed path, so the host is dropped and
+    the install continues."""
+    recorder = Recorder()
+    attempts: list[tuple[str, ...]] = []
+
+    def answer(argv: Sequence[str]) -> str | None:
+        if argv[0] != "emerge":
+            return CommandOutput("", 0)
+        attempts.append(tuple(argv))
+        # Off only when the resolve stops asking the host for anything.
+        if "--getbinpkg=n" in argv:
+            return CommandOutput("[ebuild  N    ] gnome-base/gnome-3.56\n", 0)
+        return CommandOutput(BINHOST_TIMED_OUT, 1)
+
+    recorder.answering = answer
+    check = portage.VerifyPackages(
+        requests=(
+            portage.PackageRequest(atom="gnome-base/gnome", requesters=("the `gnome` group",)),
+        )
+    )
+    check.apply(recorder)
+
+    assert recorder.degraded(portage.BINARY_PACKAGES)
+    # One retry with binaries still on before the whole install is committed to
+    # compiling, the same as `Emerge` makes.
+    assert [("--getbinpkg=n" in one) for one in attempts] == [False, False, True], attempts
+
+    # Negative control: the same unreadable index when binaries are already
+    # gone is a real rejection, not another degradation.
+    already = Recorder()
+    already.given_up.add(portage.BINARY_PACKAGES)
+    tried: list[tuple[str, ...]] = []
+
+    def refuse(argv: Sequence[str]) -> str | None:
+        if argv[0] == "emerge":
+            tried.append(tuple(argv))
+            return CommandOutput(BINHOST_TIMED_OUT, 1)
+        if argv[1] == "pquery":
+            return CommandOutput("gnome-base/gnome\n", 0)
+        return CommandOutput("gnome-base/gnome-3.56\n", 0)
+
+    already.answering = refuse
+    with pytest.raises(ConfigError, match="Error fetching binhost package info"):
+        check.apply(already)
+    assert len(tried) == 1, tried
+
+
+def test_a_rejection_that_is_not_the_binary_host_is_never_degraded() -> None:
+    """The negative control the degradation rests on: a masked package answers
+    with a rejection whatever the binary host is doing, because dropping the
+    host would not make it installable and would compile the whole system."""
+    recorder = Recorder()
+
+    def answer(argv: Sequence[str]) -> str | None:
+        if argv[0] == "emerge":
+            return CommandOutput(PACKAGE_MASKED, 1)
+        if argv[1] == "pquery":
+            return CommandOutput("app-text/catdoc\n", 0)
+        return CommandOutput("", 1)
+
+    recorder.answering = answer
+    check = portage.VerifyPackages(
+        requests=(
+            portage.PackageRequest(atom="app-text/catdoc", requesters=("the `catdoc` group",)),
+        )
+    )
+    with pytest.raises(ConfigError, match="configuration masks"):
+        check.apply(recorder)
+    assert not recorder.degraded(portage.BINARY_PACKAGES)
+
+
 def test_an_unclassified_nonzero_package_probe_is_rejected() -> None:
     recorder = Recorder()
 


### PR DESCRIPTION
`vm-gnome` stopped at 6.7 minutes, before anything was merged, with `emerge --pretend rejected packages requested by` fourteen requesters. Every one of those packages was present and visible; what failed was `!!! [gentoo] Error fetching binhost package info from '…/binpackages/23.0/x86-64'` followed by `<urlopen error timed out>`.

Source is the guaranteed path and every binhost failure is supposed to degrade to it. The merge path already did; the resolve did not, so an unreachable host ended the install rather than costing it compile time. One retry with binaries still on comes first, the same as `Emerge` makes, so a single dropped connection does not commit the whole install to compiling.

The negative control is a masked package: it answers with a rejection whatever the host is doing.