### PR TITLE
kernel: write the crypt-ssh dracut config under a name no package owns

### DIFF
--- a/gentoo_install/plan/kernel.py
+++ b/gentoo_install/plan/kernel.py
@@ -52,6 +52,16 @@ FILESYSTEM_MODULES: Final[dict[FilesystemType, str]] = {FilesystemType.BTRFS: "b
 #: and one of the network managers dracut's network module can drive.
 REMOTE_UNLOCK_PACKAGE: Final[str] = "sys-kernel/dracut-crypt-ssh"
 
+#: Not `crypt-ssh.conf`: `dracut-crypt-ssh` installs a file of exactly that
+#: name, so writing ours there is a CONFIG_PROTECT collision and the merge
+#: leaves the package's copy unapplied as `._cfg0000_crypt-ssh.conf`.
+#: `zz-` and not a digit prefix: dracut sources the directory in lexical order
+#: and the last assignment to a scalar wins, and a digit sorts before every
+#: letter, so `99-` would be read before `crypt-ssh.conf` and lose the port.
+REMOTE_UNLOCK_CONFIG: Final[PurePosixPath] = PurePosixPath(
+    "/etc/dracut.conf.d/zz-gentoo-install-crypt-ssh.conf"
+)
+
 #: Executables required by dracut's network-legacy module. ZFSBootMenu omits
 #: systemd, so its remote-unlock image cannot use systemd-networkd instead.
 ZBM_LEGACY_NETWORK_PACKAGES: Final[tuple[str, ...]] = (
@@ -341,7 +351,7 @@ class ConfigureRemoteUnlock(Operation):
 
     def describe(self) -> str:
         if not self.system_initramfs:
-            return "write /etc/dracut.conf.d/crypt-ssh.conf to omit ssh from the system initramfs"
+            return f"write {REMOTE_UNLOCK_CONFIG} to omit ssh from the system initramfs"
         return f"configure remote unlock over ssh on port {self.port}"
 
     def apply(self, context: Context) -> None:
@@ -352,7 +362,7 @@ class ConfigureRemoteUnlock(Operation):
         ).apply(context)
         if not self.system_initramfs:
             context.write(
-                PurePosixPath("/etc/dracut.conf.d/crypt-ssh.conf"),
+                REMOTE_UNLOCK_CONFIG,
                 'omit_dracutmodules+=" crypt-ssh "\n',
             )
             return
@@ -368,7 +378,7 @@ class ConfigureRemoteUnlock(Operation):
             'install_items+=" /sbin/cryptsetup "',
         ]
         context.write(
-            PurePosixPath("/etc/dracut.conf.d/crypt-ssh.conf"),
+            REMOTE_UNLOCK_CONFIG,
             "".join(f"{line}\n" for line in lines),
         )
 

--- a/tests/golden/zfs-zbm.txt
+++ b/tests/golden/zfs-zbm.txt
@@ -45,7 +45,7 @@
   verify the selected kernel against the target sys-fs/zfs ceiling
   accept the linux-firmware licence
   ask for dhclient and arping, which ZFSBootMenu networking requires
-  write /etc/dracut.conf.d/crypt-ssh.conf to omit ssh from the system initramfs
+  write /etc/dracut.conf.d/zz-gentoo-install-crypt-ssh.conf to omit ssh from the system initramfs
   accept sys-kernel/gentoo-cjk-kernel-bin as testing, with cjk on
   unmask virtual/dist-kernel, which the cjk kernel depends on by revision
   tell sys-fs/zfs to build against the dist-kernel

--- a/tests/unit/test_plan_boot.py
+++ b/tests/unit/test_plan_boot.py
@@ -620,7 +620,7 @@ def test_the_unlock_daemon_is_keyworded_and_told_where_to_read_its_keys() -> Non
         PurePosixPath("/etc/portage/package.accept_keywords/dracut-crypt-ssh")
     ]
     assert keywords == "sys-kernel/dracut-crypt-ssh ~amd64\n"
-    written = recorder.files[PurePosixPath("/etc/dracut.conf.d/crypt-ssh.conf")]
+    written = recorder.files[kernel.REMOTE_UNLOCK_CONFIG]
     assert 'dropbear_port="222"' in written
     # The `unlock` helper runs cryptsetup and the module does not pull it in.
     assert "/sbin/cryptsetup" in written
@@ -1033,7 +1033,7 @@ def test_the_dropbear_port_written_is_the_port_the_configuration_asked_for() -> 
             operation.apply(recorder)
             ran += 1
     assert ran == 1, "the fixture enables remote unlock, so exactly one is planned"
-    written = recorder.files[PurePosixPath("/etc/dracut.conf.d/crypt-ssh.conf")]
+    written = recorder.files[kernel.REMOTE_UNLOCK_CONFIG]
     assert f'dropbear_port="{asked}"' in written, written
 
 

--- a/tests/unit/test_plan_bootloader.py
+++ b/tests/unit/test_plan_bootloader.py
@@ -87,7 +87,7 @@ def test_zfsbootmenu_carries_remote_access_in_its_own_image() -> None:
     for operation in kernel.build(installation):
         if isinstance(operation, kernel.ConfigureRemoteUnlock):
             operation.apply(kernel_recorder)
-    assert kernel_recorder.files[PurePosixPath("/etc/dracut.conf.d/crypt-ssh.conf")] == (
+    assert kernel_recorder.files[kernel.REMOTE_UNLOCK_CONFIG] == (
         'omit_dracutmodules+=" crypt-ssh "\n'
     )
     assert "crypt-ssh" not in kernel.dracut_modules(installation)

--- a/tests/unit/test_plan_kernel.py
+++ b/tests/unit/test_plan_kernel.py
@@ -23,6 +23,23 @@ from gentoo_install.model.validate import KernelCeiling
 from .recorder import Recorder
 
 
+def test_no_dracut_config_this_installer_writes_is_a_file_a_package_owns() -> None:
+    """`sys-kernel/dracut-crypt-ssh` installs `/etc/dracut.conf.d/crypt-ssh.conf`,
+    and this installer wrote its own file at that exact path. Portage refused to
+    replace it and left the package's copy as `._cfg0000_crypt-ssh.conf`, which
+    nothing in an install ever applies: `vm-unlock`'s log carries `IMPORTANT:
+    config file '/etc/dracut.conf.d/crypt-ssh.conf' needs updating`.
+
+    The prefix is the other half. dracut reads the directory in lexical order,
+    so a name sorting before what the package or dracut itself ships loses.
+    """
+    owned = {"crypt-ssh.conf", "01-gentoo.conf", "10-hostonly.conf", "11-generic.conf"}
+    ours = kernel.REMOTE_UNLOCK_CONFIG
+    assert ours.parent == PurePosixPath("/etc/dracut.conf.d")
+    assert ours.name not in owned, ours
+    assert all(ours.name > one for one in owned), ours
+
+
 def test_grub_remote_unlock_keeps_the_system_dracut_path() -> None:
     installation = load(Path("tests/fixtures/vm-unlock.toml"))
     operation = next(
@@ -33,7 +50,7 @@ def test_grub_remote_unlock_keeps_the_system_dracut_path() -> None:
     recorder = Recorder()
     operation.apply(recorder)
 
-    written = recorder.files[PurePosixPath("/etc/dracut.conf.d/crypt-ssh.conf")]
+    written = recorder.files[kernel.REMOTE_UNLOCK_CONFIG]
     assert 'dropbear_port="2222"' in written
     assert 'dropbear_rsa_key="SYSTEM"' in written
     assert 'install_items+=" /sbin/cryptsetup "' in written


### PR DESCRIPTION
`sys-kernel/dracut-crypt-ssh` installs `/etc/dracut.conf.d/crypt-ssh.conf`, and this installer wrote its own file at that exact path. `vm-unlock`'s log from run44 carries the result: `>>> /etc/dracut.conf.d/._cfg0000_crypt-ssh.conf` and `IMPORTANT: config file '/etc/dracut.conf.d/crypt-ssh.conf' needs updating`. Nothing in an install runs `etc-update`, so the two files are decided by merge order rather than by intent.

The rename is the surviving half of #292, whose harness half landed as #394. `zz-` rather than that PR's `99-`: dracut sources the directory in lexical order and the last assignment to a scalar wins, and `'9' < 'c'`, so a digit prefix would be read before `crypt-ssh.conf` and lose `dropbear_port` to whatever the package sets. The test asserts the name sorts after every conf the package and dracut ship.