### PR TITLE
vm: do not count an echoed password as a refused login

### DIFF
--- a/tests/unit/test_cluster.py
+++ b/tests/unit/test_cluster.py
@@ -604,6 +604,75 @@ def test_a_login_that_is_refused_every_time_is_reported(
     assert "refused every login" in said
 
 
+class _EchoingConsole:
+    """`login` before it has turned the echo off: the password comes back on
+    the console and is read as an empty one.
+
+    Taken from `openrc-sdboot`'s log, where `Password: ` was followed by
+    `install` on its own line and then `Login incorrect`, against `vm-lvm`'s
+    working exchange where nothing appeared between the two.
+    """
+
+    def __init__(self, echoes: int) -> None:
+        self.echoes = echoes
+        self.sent: list[str] = []
+        self.settles: list[float] = []
+        self.answers: list[bytes] = []
+
+    def respond(self, line: str) -> None:
+        self.sent.append(line)
+        if line == "root":
+            self.answers.append(b"Password: ")
+        elif self.echoes > 0:
+            self.echoes -= 1
+            self.answers.append(f"{line}\r\n\r\nLogin incorrect\r\nlogin: ".encode())
+        else:
+            self.answers.append(b"openrcsdbox ~ # ")
+
+    def observe(self, pattern: str, timeout: float = 0.0) -> bytes:
+        return self.answers.pop(0) if self.answers else b""
+
+
+def test_a_password_the_console_echoed_is_not_counted_as_a_refusal(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """`openrc-sdboot` lost this race twice. `login` gives up after three
+    attempts of its own, so a race counted against the harness's own budget
+    ends the login before a clean attempt is ever made."""
+    settles: list[float] = []
+    monkeypatch.setattr("time.sleep", lambda seconds: settles.append(seconds))
+    console = _EchoingConsole(echoes=3)
+    assert cluster._log_in(cast(cluster.Reconnecting, console), "install") == ""
+    assert console.sent.count("install") == 4, console.sent
+
+    # The settle grows on each catch rather than staying at a guess.
+    waited = [one for one in settles if one not in (cluster.AGETTY_FLUSHES_AFTER,)]
+    assert waited == [
+        cluster.PASSWORD_ECHO_OFF_AFTER + n * cluster.PASSWORD_ECHO_BACKOFF
+        for n in range(4)
+    ], waited
+
+    # Negative control: a refusal with no echo is the installed system saying
+    # no, and it must end after the ordinary budget rather than be absorbed.
+    monkeypatch.setattr("time.sleep", lambda seconds: None)
+    silent = _LoginConsole(refusals=99)
+    assert "refused every login" in cluster._log_in(
+        cast(cluster.Reconnecting, silent), "install"
+    )
+    assert silent.sent.count("install") == cluster.LOGIN_TRIES, silent.sent
+
+    # Negative control: an echo that never stops still ends, so a guest whose
+    # console echoes everything cannot hold the schedule open.
+    forever = _EchoingConsole(echoes=999)
+    assert "refused every login" in cluster._log_in(
+        cast(cluster.Reconnecting, forever), "install"
+    )
+    assert (
+        forever.sent.count("install")
+        == cluster.LOGIN_TRIES + cluster.PASSWORD_ECHO_CATCHES
+    ), forever.sent
+
+
 def test_the_password_waits_for_the_echo_to_be_turned_off() -> None:
     import inspect
 

--- a/tests/vm/cluster.py
+++ b/tests/vm/cluster.py
@@ -2271,17 +2271,31 @@ def _name_the_user(link: Reconnecting) -> bool:
 #: after an install that was otherwise complete.
 PASSWORD_ECHO_OFF_AFTER: Final[float] = 1.0
 
+#: Added to the settle each time the console proves it lost that race, and how
+#: many of those are absorbed. A fixed wait is a guess about a machine whose
+#: load is not ours to choose: `openrc-sdboot` lost the same second twice on a
+#: node that spent the run between 13% and 85% busy, and `login` gives up after
+#: three attempts of its own, so a race that repeats burns the whole login.
+PASSWORD_ECHO_BACKOFF: Final[float] = 2.0
+PASSWORD_ECHO_CATCHES: Final[int] = 3
+
 
 def _log_in(link: Reconnecting, password: str) -> str:
     """Log root in, and say what is wrong when it does not happen.
 
-    Empty on success. A refused password is retried, because the reason it was
-    refused is a race with the terminal rather than the password being wrong.
+    Empty on success. A password that comes back on the console was read as an
+    empty one, so that attempt is this harness losing a race rather than the
+    installed system refusing a password: it does not count, and the settle
+    grows. A refusal with no echo is counted, so a genuinely wrong password
+    still ends.
     """
-    for _ in range(LOGIN_TRIES):
+    settle = PASSWORD_ECHO_OFF_AFTER
+    refusals = 0
+    echoed = 0
+    while refusals < LOGIN_TRIES:
         if not _name_the_user(link):
             return "the installed system asked for a name and kept asking"
-        time.sleep(PASSWORD_ECHO_OFF_AFTER)
+        time.sleep(settle)
         link.respond(password)
         try:
             said = link.observe(r"#|\$|Login incorrect", timeout=120.0)
@@ -2289,6 +2303,11 @@ def _log_in(link: Reconnecting, password: str) -> str:
             return f"root could not log into the installed system: {error}"[:200]
         if b"Login incorrect" not in said:
             return ""
+        if password.encode() in said and echoed < PASSWORD_ECHO_CATCHES:
+            echoed += 1
+            settle += PASSWORD_ECHO_BACKOFF
+            continue
+        refusals += 1
     return "the installed system refused every login"
 
 


### PR DESCRIPTION
`openrc-sdboot` failed at 25.1m with `root could not log into the installed system`, and again at 40.6m in an earlier round. The install exited 0 and the guest reached its own login prompt with the right hostname.

The console says what happened. Working (`vm-lvm`): `Password: " then nothing, then the shell. Failing: `Password: `, then `install` on its own line, then `Login incorrect` — the password came back on the console, so `login` had not turned the echo off yet and read an empty one. That race is already named by `PASSWORD_ECHO_OFF_AFTER`; what was missing is that losing it consumed one of the harness's four attempts, and `login` itself gives up after three, so the retries landed in a restarted getty and typed the password into the username field.

An echoed attempt now grows the settle instead of counting, bounded at three. The negative controls are a refusal with no echo, which still ends after the ordinary budget, and an echo that never stops, which ends too.