### PR TITLE
golden: give the conversion a plan file and stop truncating the rest

### DIFF
--- a/tests/golden/btrfs-luks.txt
+++ b/tests/golden/btrfs-luks.txt
@@ -40,7 +40,7 @@
   point repository gentoo at https://mirrors.ustc.edu.cn/gentoo.git, commit signatures verified
   sync repository gentoo
   point repository gentoo-zh at https://mirrors.cernet.edu.cn/gentoo-zh.git
-  sync repository gentoo-zh
+  sync repository gentoo-zh, 4 other sites to fall back on
   accept ~amd64 for packages from gentoo-zh only
   install the key the community binary packages are signed with: emerge sec-keys/openpgp-keys-gentoozh, from source
   import 38A0234EC16AD42E from /usr/share/openpgp-keys/gentoozh.asc and locally sign it for gentoo-zh

--- a/tests/golden/regenerate.py
+++ b/tests/golden/regenerate.py
@@ -3,13 +3,29 @@
 
 from __future__ import annotations
 
+from gentoo_install.errors import GentooInstallError
+
 from .test_golden import HERE, fixtures, plan_text
 
 
 def main() -> None:
+    """Every fixture, and the failures at the end rather than at the first one.
+
+    `vm-convert` raised here and took the run down with it, so the twelve
+    fixtures after it alphabetically kept a golden file nobody had rewritten
+    and the suite stayed red on files this command claimed to have written.
+    """
+    refused: list[str] = []
     for name in fixtures():
-        (HERE / f"{name}.txt").write_text(plan_text(name))
+        try:
+            text = plan_text(name)
+        except GentooInstallError as error:
+            refused.append(f"{name}: {error}")
+            continue
+        (HERE / f"{name}.txt").write_text(text)
         print(f"wrote {name}.txt")
+    if refused:
+        raise SystemExit("no plan for:\n  " + "\n  ".join(refused))
 
 
 if __name__ == "__main__":

--- a/tests/golden/test_golden.py
+++ b/tests/golden/test_golden.py
@@ -15,15 +15,27 @@ import pytest
 
 from gentoo_install.data import load_catalog
 from gentoo_install.exec.config import load
+from gentoo_install.model.config import DiskMode, InstallConfig
 from gentoo_install.plan.build import build
 from gentoo_install.plan.render import render
+
+from ..unit.layouts import running_layout
 
 HERE = Path(__file__).resolve().parent
 FIXTURES = HERE.parent / "fixtures"
 
 
+def plan_of(installation: InstallConfig) -> str:
+    """An in-place configuration carries no device graph, so its plan is
+    derived from a machine. The fixed layout stands in for one, which is what
+    gives the conversion a golden file at all: without it `build` raises and
+    the fixture had none while every other fixture had one."""
+    layout = running_layout() if installation.disk.mode is DiskMode.IN_PLACE else None
+    return render(build(installation, load_catalog(), layout=layout))
+
+
 def plan_text(name: str) -> str:
-    return render(build(load(FIXTURES / f"{name}.toml"), load_catalog()))
+    return plan_of(load(FIXTURES / f"{name}.toml"))
 
 
 def fixtures() -> list[str]:
@@ -63,5 +75,4 @@ def test_the_order_devices_are_written_in_does_not_change_the_plan(name: str) ->
             graph=DeviceGraph.build(list(reversed(list(installation.disk.graph.nodes.values())))),
         ),
     )
-    catalog = load_catalog()
-    assert render(build(backwards, catalog)) == render(build(installation, catalog))
+    assert plan_of(backwards) == plan_of(installation)

--- a/tests/golden/vm-cjk-kernel.txt
+++ b/tests/golden/vm-cjk-kernel.txt
@@ -33,7 +33,7 @@
   point repository gentoo at https://github.com/gentoo-mirror/gentoo.git, commit signatures verified
   sync repository gentoo
   point repository gentoo-zh at https://github.com/gentoo-zh/overlay.git
-  sync repository gentoo-zh
+  sync repository gentoo-zh, 4 other sites to fall back on
   accept ~amd64 for packages from gentoo-zh only
   set sys-kernel/installkernel to dracut
   accept the linux-firmware licence

--- a/tests/golden/vm-convert.txt
+++ b/tests/golden/vm-convert.txt
@@ -1,0 +1,62 @@
+[stage3]
+  create /gentoo-install.new for the staged system, in /gentoo-install.new
+  download the newest systemd stage3 from https://distfiles.gentoo.org directly, verify it against BB572E0E2D182910 and unpack it into the target, in /gentoo-install.new
+
+[chroot]
+  mount transient proc, sys, dev and run filesystems into the target, in /gentoo-install.new
+  seed the target's resolv.conf from the install medium, in /gentoo-install.new
+
+[portage]
+  write /etc/portage/make.conf with MAKEOPTS, INPUT_DEVICES, ACCEPT_LICENSE, L10N, FEATURES; 2 mirrors in the configured order, 5 appended, in /gentoo-install.new
+  configure Portage, wget, curl, git and gpg for direct connection, in /gentoo-install.new
+  create the three autounmask files emerge writes its decisions into, in /gentoo-install.new
+  run getuto so Portage has a keyring to verify binary packages against, in /gentoo-install.new
+  add verified binary package host gentoo at https://distfiles.gentoo.org/releases/amd64/binpackages/23.0/x86-64, in /gentoo-install.new
+  fetch the first ebuild repository snapshot with emerge-webrsync, in /gentoo-install.new
+  select profile default/linux/amd64/23.0/systemd, in /gentoo-install.new
+  install git, which every later repository sync needs: emerge dev-vcs/git, in /gentoo-install.new
+  point repository gentoo at https://github.com/gentoo-mirror/gentoo.git, commit signatures verified, in /gentoo-install.new
+  sync repository gentoo, in /gentoo-install.new
+  set sys-kernel/installkernel to dracut, in /gentoo-install.new
+  accept the linux-firmware licence, in /gentoo-install.new
+  resolve net-misc/openssh sys-process/cronie sys-kernel/installkernel sys-kernel/dracut sys-kernel/linux-firmware sys-fs/dosfstools sys-fs/e2fsprogs sys-kernel/gentoo-kernel-bin sys-boot/grub sys-boot/efibootmgr together before installing the requested packages, in /gentoo-install.new
+
+[system]
+  generate and verify locales en_US.UTF-8, in /gentoo-install.new
+  set the system locale to en_US.UTF-8, in /gentoo-install.new
+  set the timezone to UTC, in /gentoo-install.new
+  set the console keymap to us and its font to default8x16, in /gentoo-install.new
+  set the hostname to convertedbox, in /gentoo-install.new
+  give the target its own machine id, in /gentoo-install.new
+  write /etc/fstab with entries for /, /efi, in /gentoo-install.new
+  treat the hardware clock as UTC, in /gentoo-install.new
+  set the root password, in /gentoo-install.new
+  install sshd: emerge net-misc/openssh, in /gentoo-install.new
+  ssh password login: off, root: off, in /gentoo-install.new
+  enable sshd at boot, in /gentoo-install.new
+  generate the ssh host keys, in /gentoo-install.new
+  configure the wired interface for DHCP, in /gentoo-install.new
+  enable systemd-networkd at boot, in /gentoo-install.new
+  enable systemd-resolved at boot, in /gentoo-install.new
+  install cron: emerge sys-process/cronie, in /gentoo-install.new
+  enable cronie at boot, in /gentoo-install.new
+  carry 0 fstab entries the conversion does not manage, in /gentoo-install.new
+
+[kernel]
+  install the hook that puts a kernel in /boot: emerge sys-kernel/installkernel, in /gentoo-install.new
+  install the initramfs builder and firmware: emerge sys-kernel/dracut sys-kernel/linux-firmware, in /gentoo-install.new
+  install the storage tools: emerge sys-fs/dosfstools sys-fs/e2fsprogs, in /gentoo-install.new
+  install the kernel: emerge sys-kernel/gentoo-kernel-bin, in /gentoo-install.new
+  rebuild the initramfs from sys-kernel/gentoo-kernel-bin with the modules written above, in /gentoo-install.new
+  check the installkernel payload names existing kernel files, in /gentoo-install.new
+
+[bootloader]
+  install the bootloader: emerge sys-boot/grub sys-boot/efibootmgr, in /gentoo-install.new
+  write /etc/default/grub with cmdline console=ttyS0,115200, its menu on ttyS0, in /gentoo-install.new
+  atomically swap /bin, /sbin, /etc, /lib, /lib64, /usr, /var from /gentoo-install.new
+  put the kernel from /gentoo-install.new/boot into /boot and drop the old images
+  install GRUB for uefi on the esp at /efi
+
+[finish]
+  point /etc/resolv.conf at systemd-resolved rather than the install medium's, in /gentoo-install.new
+  unmount and remove /gentoo-install.new

--- a/tests/golden/vm-raidz.txt
+++ b/tests/golden/vm-raidz.txt
@@ -45,7 +45,7 @@
   point repository gentoo at https://github.com/gentoo-mirror/gentoo.git, commit signatures verified
   sync repository gentoo
   point repository gentoo-zh at https://github.com/gentoo-zh/overlay.git
-  sync repository gentoo-zh
+  sync repository gentoo-zh, 4 other sites to fall back on
   accept ~amd64 for packages from gentoo-zh only
   set sys-kernel/installkernel to dracut, installing into /boot
   verify the selected kernel against the target sys-fs/zfs ceiling

--- a/tests/golden/vm-zfs-encrypted.txt
+++ b/tests/golden/vm-zfs-encrypted.txt
@@ -37,7 +37,7 @@
   point repository gentoo at https://github.com/gentoo-mirror/gentoo.git, commit signatures verified
   sync repository gentoo
   point repository gentoo-zh at https://github.com/gentoo-zh/overlay.git
-  sync repository gentoo-zh
+  sync repository gentoo-zh, 4 other sites to fall back on
   accept ~amd64 for packages from gentoo-zh only
   set sys-kernel/installkernel to dracut, installing into /boot
   verify the selected kernel against the target sys-fs/zfs ceiling

--- a/tests/golden/vm-zfs-mirror.txt
+++ b/tests/golden/vm-zfs-mirror.txt
@@ -41,7 +41,7 @@
   point repository gentoo at https://github.com/gentoo-mirror/gentoo.git, commit signatures verified
   sync repository gentoo
   point repository gentoo-zh at https://github.com/gentoo-zh/overlay.git
-  sync repository gentoo-zh
+  sync repository gentoo-zh, 4 other sites to fall back on
   accept ~amd64 for packages from gentoo-zh only
   set sys-kernel/installkernel to dracut, installing into /boot
   verify the selected kernel against the target sys-fs/zfs ceiling

--- a/tests/golden/vm-zfs.txt
+++ b/tests/golden/vm-zfs.txt
@@ -37,7 +37,7 @@
   point repository gentoo at https://github.com/gentoo-mirror/gentoo.git, commit signatures verified
   sync repository gentoo
   point repository gentoo-zh at https://github.com/gentoo-zh/overlay.git
-  sync repository gentoo-zh
+  sync repository gentoo-zh, 4 other sites to fall back on
   accept ~amd64 for packages from gentoo-zh only
   set sys-kernel/installkernel to dracut, installing into /boot
   verify the selected kernel against the target sys-fs/zfs ceiling

--- a/tests/golden/zfs-zbm.txt
+++ b/tests/golden/zfs-zbm.txt
@@ -39,7 +39,7 @@
   point repository gentoo at https://github.com/gentoo-mirror/gentoo.git, commit signatures verified
   sync repository gentoo
   point repository gentoo-zh at https://mirrors.cernet.edu.cn/gentoo-zh.git
-  sync repository gentoo-zh
+  sync repository gentoo-zh, 4 other sites to fall back on
   accept ~amd64 for packages from gentoo-zh only
   set sys-kernel/installkernel to dracut, installing into /boot
   verify the selected kernel against the target sys-fs/zfs ceiling


### PR DESCRIPTION
`origin/master` was red on `tests/golden`. `#406` changed `SyncRepository.describe()` and seven golden files still held the old line, because the gate that ran was `pytest tests/unit`, which does not reach `tests/golden`.

Regenerating did not fix it either: `vm-convert` carries no device graph, `build` raised `ConversionUnsupported`, and the regenerator stopped there — so the twelve fixtures after it alphabetically kept a file the command had claimed to write. `tests/unit/layouts.running_layout()` already exists for exactly this and now stands in for the machine, which gives the conversion a golden file for the first time: 46 steps, and the staging path is visible in it.

The regenerator now reports its refusals at the end instead of at the first one. Negative control: with the layout withheld the suite is red and the regenerator still writes 28 of 29 rather than 8.