### PR TITLE
plan: describe what apply writes, not what it was asked for

### DIFF
--- a/gentoo_install/plan/bootloader.py
+++ b/gentoo_install/plan/bootloader.py
@@ -132,8 +132,15 @@ class InstallGrub(Operation):
     boot_devices: tuple[DeviceId, ...]
 
     def describe(self) -> str:
-        where = f"the esp at {self.esp}" if self.esp is not None else "the boot disk"
-        return f"install GRUB for {self.firmware.value} on {where}"
+        if self.esp is not None:
+            return f"install GRUB for {self.firmware.value} on the esp at {self.esp}"
+        # Every disk, not "the boot disk": the BIOS branch writes a boot sector
+        # to the containing disk of each boot device, and a mirrored root has
+        # two. The devices rather than the disks, because a disk is resolved
+        # from the machine and `describe` has none.
+        under = ", ".join(str(one) for one in self.boot_devices)
+        disks = "disk" if len(self.boot_devices) == 1 else "disks"
+        return f"install GRUB for {self.firmware.value} on the {disks} under {under}"
 
     def apply(self, context: Context) -> None:
         if self.firmware is Firmware.UEFI and self.esp is not None:

--- a/gentoo_install/plan/disk.py
+++ b/gentoo_install/plan/disk.py
@@ -227,7 +227,15 @@ class CreatePartition(Operation):
         return frozenset(("sgdisk" if self.table_kind is TableType.GPT else "parted",))
 
     def describe(self) -> str:
-        extent = str(self.size) if self.size is not None else "the rest of the disk"
+        if self.size is not None:
+            extent = str(self.size)
+        elif self.limit is not None:
+            # An edited table places the partition in one free gap, so "the
+            # rest of the disk" would promise the operator the retained
+            # partitions' space as well.
+            extent = f"the free space from {self.start} to {self.limit}"
+        else:
+            extent = "the rest of the disk"
         name = f" labelled {self.label}" if self.label else ""
         return (
             f"create partition {self.index} on {self.disk} as {self.partition}: "

--- a/gentoo_install/plan/system.py
+++ b/gentoo_install/plan/system.py
@@ -388,9 +388,18 @@ class WriteCrypttab(Operation):
     init: InitSystem
 
     def describe(self) -> str:
-        names = ", ".join(entry.name for entry in self.entries)
         where = "/etc/crypttab" if self.init is InitSystem.SYSTEMD else "/etc/conf.d/dmcrypt"
-        return f"write {where} for {names}"
+        written = self._written()
+        if not written:
+            return f"write {where} empty: the initramfs opens every encrypted device"
+        return f"write {where} for {', '.join(entry.name for entry in written)}"
+
+    def _written(self) -> tuple[CrypttabEntry, ...]:
+        """openrc's dmcrypt does not open what the initramfs already did, so a
+        describe naming every entry promises a file the run does not write."""
+        if self.init is InitSystem.SYSTEMD:
+            return self.entries
+        return tuple(entry for entry in self.entries if not entry.initrd_attach)
 
     def apply(self, context: Context) -> None:
         if self.init is InitSystem.SYSTEMD:
@@ -406,8 +415,7 @@ class WriteCrypttab(Operation):
         # parser assumes; the root is already open, so it is left out.
         sections = [
             f"target={entry.name}\nsource='UUID={context.device_uuid(entry.backing)}'"
-            for entry in self.entries
-            if not entry.initrd_attach
+            for entry in self._written()
         ]
         context.write(
             PurePosixPath("/etc/conf.d/dmcrypt"), "\n\n".join(sections) + "\n" if sections else ""

--- a/tests/golden/ext4-bios.txt
+++ b/tests/golden/ext4-bios.txt
@@ -63,7 +63,7 @@
 [bootloader]
   install the bootloader: emerge sys-boot/grub
   write /etc/default/grub with cmdline console=ttyS0,115200, its menu on ttyS0
-  install GRUB for bios on the boot disk
+  install GRUB for bios on the disk under disk
 
 [finish]
   delete the downloaded stage3 from /var/cache/gentoo-install

--- a/tests/golden/mbr-edit.txt
+++ b/tests/golden/mbr-edit.txt
@@ -62,7 +62,7 @@
 [bootloader]
   install the bootloader: emerge sys-boot/grub
   write /etc/default/grub with cmdline console=ttyS0,115200, its menu on ttyS0
-  install GRUB for bios on the boot disk
+  install GRUB for bios on the disk under disk
 
 [finish]
   delete the downloaded stage3 from /var/cache/gentoo-install

--- a/tests/golden/vm-bios-luks.txt
+++ b/tests/golden/vm-bios-luks.txt
@@ -48,7 +48,7 @@
   give the target its own machine id
   write /etc/fstab with entries for /, swap
   treat the hardware clock as UTC
-  write /etc/conf.d/dmcrypt for root
+  write /etc/conf.d/dmcrypt empty: the initramfs opens every encrypted device
   start a login on ttyS0 at 115200 baud
   set the root password
   install the network tools: emerge net-misc/netifrc net-misc/dhcpcd
@@ -71,7 +71,7 @@
 [bootloader]
   install the bootloader: emerge sys-boot/grub
   write /etc/default/grub with cmdline console=ttyS0,115200, cryptodisk enabled and its menu on ttyS0
-  install GRUB for bios on the boot disk
+  install GRUB for bios on the disk under disk
 
 [finish]
   delete the downloaded stage3 from /var/cache/gentoo-install

--- a/tests/golden/vm-bios.txt
+++ b/tests/golden/vm-bios.txt
@@ -65,7 +65,7 @@
 [bootloader]
   install the bootloader: emerge sys-boot/grub
   write /etc/default/grub with cmdline console=ttyS0,115200, its menu on ttyS0
-  install GRUB for bios on the boot disk
+  install GRUB for bios on the disk under disk
 
 [finish]
   delete the downloaded stage3 from /var/cache/gentoo-install

--- a/tests/unit/test_plan_bootloader.py
+++ b/tests/unit/test_plan_bootloader.py
@@ -191,3 +191,42 @@ def test_every_zfsbootmenu_host_key_can_be_written_in_the_format_asked_for() -> 
             )
             assert target.is_file(), (keytype, done.stdout, done.stderr)
             assert target.read_bytes().startswith(b"-----BEGIN "), keytype
+
+
+def test_the_bios_grub_describe_names_every_disk_that_gets_a_boot_sector() -> None:
+    """The BIOS branch writes a boot sector to the containing disk of each boot
+    device, and a mirrored root has two. `--dry-run` said "the boot disk",
+    naming neither, so an operator could not see which disks the run rewrites.
+    """
+    from gentoo_install.model.device import DeviceId
+
+    mirrored = bootloader.InstallGrub(
+        firmware=Firmware.BIOS,
+        esp=None,
+        boot_devices=(DeviceId("first"), DeviceId("second")),
+    )
+    said = mirrored.describe()
+    assert "first" in said and "second" in said, said
+    assert "disks" in said, said
+
+    # Not a claim about the text alone: apply writes to exactly those disks.
+    class Disks(Recorder):
+        def containing_disk(self, device: DeviceId) -> str:
+            return f"/dev/{device}"
+
+    recorder = Disks(replies={"grep": "1"})
+    mirrored.apply(recorder)
+    installed = [one[-1] for one in recorder.in_target if one[0] == "grub-install"]
+    assert installed == ["/dev/first", "/dev/second"], installed
+    for disk in installed:
+        assert disk.removeprefix("/dev/") in said, (disk, said)
+
+    # Negative control: the UEFI branch installs on the esp and names it, and
+    # must not start listing devices it does not write a boot sector to.
+    on_esp = bootloader.InstallGrub(
+        firmware=Firmware.UEFI,
+        esp=PurePosixPath("/efi"),
+        boot_devices=(DeviceId("first"),),
+    )
+    assert "/efi" in on_esp.describe()
+    assert "first" not in on_esp.describe(), on_esp.describe()

--- a/tests/unit/test_plan_disk.py
+++ b/tests/unit/test_plan_disk.py
@@ -890,3 +890,39 @@ def test_an_unsized_partition_on_a_fresh_table_still_takes_the_rest() -> None:
     added = next(one for one in graph.of_type(Partition) if one.id == DeviceId("new"))
 
     assert _extent_end_of(graph, added, StorageFacts()) is None
+
+
+def test_a_partition_placed_in_a_gap_does_not_promise_the_rest_of_the_disk() -> None:
+    """An edited table places an unsized partition inside one free extent, and
+    `parted` is given that extent's end rather than `100%`. `--dry-run` said
+    "the rest of the disk", which is the retained partitions' space as well —
+    the exact claim the operator opened an edited table to avoid."""
+    from gentoo_install.model.device import PartitionRole, TableType
+
+    def placed(limit: Size | None) -> disk.CreatePartition:
+        return disk.CreatePartition(
+            partition=DeviceId("part"),
+            disk=DeviceId("disk"),
+            table_kind=TableType.MBR,
+            index=2,
+            role=PartitionRole.DATA,
+            size=None,
+            label="",
+            start=Size(2 * 2**30),
+            limit=limit,
+        )
+
+    bounded = placed(Size(10 * 2**30))
+    assert "the rest of the disk" not in bounded.describe(), bounded.describe()
+    assert str(Size(10 * 2**30)) in bounded.describe(), bounded.describe()
+
+    # Negative control: a fresh table really does take the rest, and saying so
+    # is right there.
+    fresh = placed(None)
+    assert "the rest of the disk" in fresh.describe(), fresh.describe()
+
+    # Not a claim about the text alone: what parted is told has to match.
+    recorder = Recorder()
+    bounded.apply(recorder)
+    ends = [one[-1] for one in recorder.commands if one[0] == "parted" and "mkpart" in one]
+    assert ends == [str(Size(10 * 2**30))], recorder.commands

--- a/tests/unit/test_plan_system.py
+++ b/tests/unit/test_plan_system.py
@@ -826,6 +826,46 @@ def test_openrc_reads_its_containers_from_conf_d_and_not_from_crypttab() -> None
     assert "x-initrd.attach" in systemd.files[PurePosixPath("/etc/crypttab")]
 
 
+def test_the_crypttab_describe_names_only_what_the_file_will_hold() -> None:
+    """An encrypted openrc root is the ordinary case and it is the one where
+    the two disagreed: every entry is opened by the initramfs, so the file is
+    written empty while `--dry-run` said it would name `root`."""
+    only_root = (system.CrypttabEntry(name="root", backing=i("crypt"), initrd_attach=True),)
+    operation = system.WriteCrypttab(entries=only_root, init=InitSystem.OPENRC)
+    recorder = Recorder()
+    operation.apply(recorder)
+
+    assert "root" not in recorder.files[PurePosixPath("/etc/conf.d/dmcrypt")]
+    assert "root" not in operation.describe()
+    assert "empty" in operation.describe(), operation.describe()
+
+    # Not vacuous: on systemd the same entry is written and named.
+    on_systemd = system.WriteCrypttab(entries=only_root, init=InitSystem.SYSTEMD)
+    written = Recorder()
+    on_systemd.apply(written)
+    assert "root" in written.files[PurePosixPath("/etc/crypttab")]
+    assert "root" in on_systemd.describe()
+
+    # The rule rather than the case: every name the describe gives is a name
+    # the file holds, whichever init and whichever mix of entries.
+    for init in (InitSystem.OPENRC, InitSystem.SYSTEMD):
+        mixed = system.WriteCrypttab(entries=entries_for_both(), init=init)
+        seen = Recorder()
+        mixed.apply(seen)
+        holds = "".join(seen.files.values())
+        for entry in entries_for_both():
+            assert (entry.name in mixed.describe()) == (
+                f"={entry.name}" in holds or f"{entry.name}\t" in holds
+            ), (init, entry.name, mixed.describe())
+
+
+def entries_for_both() -> tuple[system.CrypttabEntry, ...]:
+    return (
+        system.CrypttabEntry(name="root", backing=i("crypt"), initrd_attach=True),
+        system.CrypttabEntry(name="data", backing=i("crypt2"), initrd_attach=False),
+    )
+
+
 def test_an_openrc_storage_service_is_enabled_after_its_package_is_merged() -> None:
     """`rc-update add lvm boot` exits 1 with `service does not exist` until
     sys-fs/lvm2 is installed, and that happens with the kernel stack."""


### PR DESCRIPTION
Three operations whose `describe()` did not name what `apply()` writes, so an operator reading `--dry-run` could not see it. Found by auditing every operation against its apply; twenty of the twenty-three candidates were terse but complete and are left alone.

`InstallGrub` said "the boot disk" on BIOS while the branch writes a boot sector to the containing disk of every entry in `boot_devices`, which is two for a mirrored root. `CreatePartition` said "the rest of the disk" for an unsized partition whenever `size` was absent, but an edited table passes `parted` the free gap's end — "the rest" is the retained partitions' space, the exact claim an edited table exists to avoid. `WriteCrypttab` on openrc named every entry while the file holds only the ones the initramfs does not open, so an encrypted openrc root was described as naming `root` and written empty.

Each test checks the text against what the operation actually runs or writes, not against a string.