### PR TITLE
bootloader: a refused nvram entry is not a failed install

### DIFF
--- a/gentoo_install/plan/bootloader.py
+++ b/gentoo_install/plan/bootloader.py
@@ -16,7 +16,7 @@ from dataclasses import dataclass
 from pathlib import PurePosixPath
 from typing import Final
 
-from ..errors import ConfigError, InvalidLayout, NothingToBoot
+from ..errors import CommandFailed, ConfigError, InvalidLayout, NothingToBoot
 from ..model import compat
 from ..model.config import Bootloader, Firmware, InitSystem, InstallConfig, RemoteUnlock
 from ..model.device import (
@@ -123,6 +123,25 @@ ZBM_AUTHORIZED_KEYS: Final[PurePosixPath] = ZBM_KEY_DIRECTORY / "root_key"
 ZBM_HOST_KEY_TYPES: Final[tuple[str, ...]] = ("rsa", "ecdsa")
 
 
+#: The firmware boot entry, which is an accelerator and not the boot path.
+#: `EFI/BOOT/BOOTX64.EFI` is what the firmware falls back to with no entry at
+#: all, and both bootloaders write it before asking for one.
+NVRAM_ENTRY: Final[str] = "efi boot entry"
+
+
+def _try_the_nvram_entry(context: Context, argv: list[str]) -> None:
+    """Ask the firmware for a boot entry, and carry on when it refuses.
+
+    An NVRAM that is full or read-only is the machine's, not the install's,
+    and a machine whose fallback image is already in place boots without one.
+    Stopping there loses a complete install to a variable nobody needs.
+    """
+    try:
+        context.run_in_target(argv)
+    except CommandFailed as error:
+        context.degrade(NVRAM_ENTRY, f"the firmware refused a boot entry: {error}")
+
+
 @dataclass(frozen=True, kw_only=True)
 class InstallGrub(Operation):
     stage: Stage = Stage.BOOTLOADER
@@ -145,10 +164,11 @@ class InstallGrub(Operation):
     def apply(self, context: Context) -> None:
         if self.firmware is Firmware.UEFI and self.esp is not None:
             efi = ["grub-install", "--target=x86_64-efi", f"--efi-directory={self.esp}"]
-            context.run_in_target([*efi, "--bootloader-id=Gentoo"])
-            # Also as the removable-media path: firmware that loses its NVRAM
-            # entry, and every firmware that never had one, boots only that.
+            # The removable-media path first, because it is the one that boots
+            # without an NVRAM entry: firmware that loses its entry, and every
+            # firmware that never had one, boots only that.
             context.run_in_target([*efi, "--removable"])
+            _try_the_nvram_entry(context, [*efi, "--bootloader-id=Gentoo"])
         else:
             installed: set[str] = set()
             for device in self.boot_devices:
@@ -439,7 +459,8 @@ class InstallZfsBootMenu(Operation):
         context.run_in_target(["generate-zbm"])
         image = self._image(context)
         context.run_in_target(["install", "-D", "-m0644", image, f"{self.esp}/{FALLBACK_IMAGE}"])
-        context.run_in_target(
+        _try_the_nvram_entry(
+            context,
             [
                 "efibootmgr",
                 "--create",
@@ -447,7 +468,7 @@ class InstallZfsBootMenu(Operation):
                 "--part", str(context.partition_index(self.esp_device)),
                 "--label", "ZFSBootMenu",
                 "--loader", _windows_path(image, self.esp),
-            ]
+            ],
         )
 
     def _image(self, context: Context) -> str:

--- a/tests/unit/test_plan_bootloader.py
+++ b/tests/unit/test_plan_bootloader.py
@@ -5,6 +5,7 @@ import pytest
 
 from dataclasses import replace
 from pathlib import Path, PurePosixPath
+from typing import Sequence
 
 from gentoo_install.exec.config import load
 from gentoo_install.model.config import Bootloader, BootloaderConfig, Firmware, InstallConfig, RemoteUnlock
@@ -230,3 +231,60 @@ def test_the_bios_grub_describe_names_every_disk_that_gets_a_boot_sector() -> No
     )
     assert "/efi" in on_esp.describe()
     assert "first" not in on_esp.describe(), on_esp.describe()
+
+
+def test_a_firmware_that_refuses_a_boot_entry_still_leaves_a_bootable_machine() -> None:
+    """`EFI/BOOT/BOOTX64.EFI` is what firmware boots with no entry at all, and
+    both bootloaders write it. An NVRAM that is full or read-only belongs to
+    the machine, so failing the install there loses a system that boots."""
+    from gentoo_install.errors import CommandFailed
+    from gentoo_install.model.device import DeviceId
+
+    class NoRoomInNvram(Recorder):
+        #: Every attempt including the refused one, which `in_target` does not
+        #: hold: without it the order assertion below passes either way.
+        attempts: list[tuple[str, ...]] = []
+
+        def run_in_target(self, argv: Sequence[str], *, check: bool = True) -> str:
+            self.attempts.append(tuple(argv))
+            if "--bootloader-id=Gentoo" in argv or argv[0] == "efibootmgr":
+                raise CommandFailed(
+                    "efibootmgr: Could not prepare Boot variable: No space left on device"
+                )
+            return super().run_in_target(argv, check=check)
+
+        def containing_disk(self, device: DeviceId) -> str:
+            return "/dev/vda"
+
+    on_esp = bootloader.InstallGrub(
+        firmware=Firmware.UEFI, esp=PurePosixPath("/efi"), boot_devices=()
+    )
+    recorder = NoRoomInNvram(replies={"grep": "1"})
+    recorder.attempts = []
+    on_esp.apply(recorder)
+
+    assert recorder.degraded(bootloader.NVRAM_ENTRY)
+    # The removable image is written before the entry is asked for, or the
+    # refusal would leave nothing behind at all.
+    tried = [one for one in recorder.attempts if one[0] == "grub-install"]
+    assert "--removable" in tried[0], tried
+    assert "--bootloader-id=Gentoo" in tried[1], tried
+    assert "grub-mkconfig" in {one[0] for one in recorder.in_target}, recorder.in_target
+
+    # Negative control: a firmware that takes the entry is not degraded, and
+    # both installs still run.
+    working = Recorder(replies={"grep": "1"})
+    on_esp.apply(working)
+    assert not working.degraded(bootloader.NVRAM_ENTRY)
+    assert len([one for one in working.in_target if one[0] == "grub-install"]) == 2
+
+    # Negative control: a `grub-install` that fails for any other reason is not
+    # a refused boot entry and still stops the install.
+    class Broken(Recorder):
+        def run_in_target(self, argv: Sequence[str], *, check: bool = True) -> str:
+            if argv[0] == "grub-install":
+                raise CommandFailed("grub-install: error: cannot find EFI directory")
+            return super().run_in_target(argv, check=check)
+
+    with pytest.raises(CommandFailed):
+        on_esp.apply(Broken(replies={"grep": "1"}))


### PR DESCRIPTION
Source build is the guaranteed path for packages, and `EFI/BOOT/BOOTX64.EFI` is the guaranteed path for booting: it is what firmware loads with no NVRAM entry at all, and both bootloaders already write it. Neither degraded when the firmware refused an entry.

`InstallGrub` ran `grub-install --bootloader-id=Gentoo` before `--removable`, so an NVRAM that is full or read-only — `Could not prepare Boot variable: No space left on device` — ended the install with nothing on the esp. `InstallZfsBootMenu` installed the fallback image and then made `efibootmgr --create` fatal, throwing away a machine that was already bootable.

The removable install now goes first and the entry is asked for after, with a recorded degradation. Negative controls: reversing the two is red, removing the degradation is red, and a `grub-install` that fails for any other reason still stops the install.