### PR TITLE
model: keep one kernel package table, in the layer that owns it

### DIFF
--- a/gentoo_install/model/compat.py
+++ b/gentoo_install/model/compat.py
@@ -55,14 +55,22 @@ from .device import (
 #: to provide.
 CJK_FONT_SIZES = frozenset({ConsoleFontSize.SIZE_8X16})
 
-_KERNEL_PACKAGES: Final[dict[KernelSource, str]] = {
+#: The package that provides each kernel choice. Here rather than in `plan/`
+#: because `traits_of` reads it and `model` is not allowed to call upward;
+#: `plan.kernel` imports this one.
+KERNEL_PACKAGES: Final[dict[KernelSource, str]] = {
     KernelSource.DIST_BIN: "sys-kernel/gentoo-kernel-bin",
     KernelSource.DIST_SOURCE: "sys-kernel/gentoo-kernel",
     KernelSource.CJK_BIN: "sys-kernel/gentoo-cjk-kernel-bin",
     KernelSource.CJK: "sys-kernel/gentoo-cjk-kernel",
 }
+
+#: The kernel choices patched with cjktty, and the packages that carry them.
+#: Derived, not listed again: a second copy of these two names disagrees with
+#: the table above the first time a package is renamed.
+CJK_KERNELS: Final[tuple[KernelSource, ...]] = (KernelSource.CJK_BIN, KernelSource.CJK)
 _CJK_KERNEL_PACKAGES: Final[frozenset[str]] = frozenset(
-    {"sys-kernel/gentoo-cjk-kernel", "sys-kernel/gentoo-cjk-kernel-bin"}
+    KERNEL_PACKAGES[source] for source in CJK_KERNELS
 )
 
 
@@ -406,7 +414,7 @@ def traits_of(
             and _encrypted_pool(graph, config.disk.root)
         ):
             found.add(Trait.NATIVE_ZFS_SYSTEM_INITRAMFS)
-    package = config.kernel.package or _KERNEL_PACKAGES[config.kernel.source]
+    package = config.kernel.package or KERNEL_PACKAGES[config.kernel.source]
     package_name = package.lstrip("=<>~!").split(":", 1)[0]
     package_name = re.sub(r"-r\d+$", "", package_name)
     package_name = re.sub(r"-\d[\w.]*$", "", package_name)

--- a/gentoo_install/plan/kernel.py
+++ b/gentoo_install/plan/kernel.py
@@ -15,6 +15,7 @@ from typing import Final
 from ..model.config import Bootloader, InitSystem, InstallConfig, KernelSource
 from ..errors import ConfigError, InvalidLayout, NothingToBoot, ValidationFailed
 from ..model import compat
+from ..model.compat import CJK_KERNELS, KERNEL_PACKAGES
 from ..model.validate import zfs_kernel_version_problem
 from ..model.device import (
     DeviceId,
@@ -36,14 +37,6 @@ from .portage import (
     WritePortageConfig,
 )
 from .bootloader import VerifyPackageUse
-
-#: The package that provides each kernel choice.
-KERNEL_PACKAGES: Final[dict[KernelSource, str]] = {
-    KernelSource.DIST_BIN: "sys-kernel/gentoo-kernel-bin",
-    KernelSource.DIST_SOURCE: "sys-kernel/gentoo-kernel",
-    KernelSource.CJK_BIN: "sys-kernel/gentoo-cjk-kernel-bin",
-    KernelSource.CJK: "sys-kernel/gentoo-cjk-kernel",
-}
 
 #: Filesystems whose driver dracut only includes when asked.
 FILESYSTEM_MODULES: Final[dict[FilesystemType, str]] = {FilesystemType.BTRFS: "btrfs"}
@@ -76,7 +69,6 @@ REMOTE_UNLOCK_MODULES: Final[tuple[str, ...]] = ("crypt-ssh", "network")
 
 #: The two packages that carry the cjktty patch, prebuilt and from source.
 #: Both take the `cjk` flag and both are keyworded `~amd64` in gentoo-zh.
-CJK_KERNELS: Final[tuple[KernelSource, ...]] = (KernelSource.CJK_BIN, KernelSource.CJK)
 
 INSTALLKERNEL_STATE: Final[str] = "/var/lib/misc/installkernel"
 #: The cjk USE flag of the patched kernels, which merges the

--- a/gentoo_install/plan/system.py
+++ b/gentoo_install/plan/system.py
@@ -494,7 +494,7 @@ class RequestNetworkUse(Operation):
 class LinkResolvConf(Operation):
     """Point the target's resolver at the one that will run on it.
 
-    `PrepareChroot` copies the installing system's `/etc/resolv.conf` in so the
+    `SeedResolver` copies the installing system's `/etc/resolv.conf` in so the
     emerges can resolve, and nothing takes it out again: the installed machine
     booted with the live medium's nameservers. `systemd-networkd` publishes
     what it learns only through `systemd-resolved`, so the DNS the operator

--- a/gentoo_install/tui/screens.py
+++ b/gentoo_install/tui/screens.py
@@ -68,7 +68,7 @@ from ..model.device import (
 from ..plan import automatic as automatic_values
 from ..plan import kernel as plan_kernel
 from ..plan.fonts import CJK_SANS_PREFERENCE, CjkFontconfigLocale, FontCategory
-from ..plan.kernel import KERNEL_PACKAGES
+from ..model.compat import KERNEL_PACKAGES
 from ..plan.portage import community_binhost
 from ..plan.operations import Operation
 from ..plan.render import counts
@@ -1570,7 +1570,7 @@ def kernel_screen(screen: Screen, config: InstallConfig, context: Context) -> An
         return Answer(answer.outcome)
     chosen = answer.unwrap()
     changed = replace(config, kernel=replace(config.kernel, source=chosen))
-    if chosen in plan_kernel.CJK_KERNELS:
+    if chosen in compat.CJK_KERNELS:
         # cjk on with it, the mirror of the branch below: `RequestCjkKernel`
         # reads this flag, so choosing the patched kernel and leaving the flag
         # off wrote `-cjk` and compiled the patch out of the package that

--- a/gentoo_install/tui/settings.py
+++ b/gentoo_install/tui/settings.py
@@ -24,7 +24,7 @@ from ..model.config import (
     Keywords,
     Networking,
 )
-from ..plan.kernel import CJK_KERNELS, KERNEL_PACKAGES
+from ..model.compat import CJK_KERNELS, KERNEL_PACKAGES
 from ..model import compat, mirrors
 from ..model.device import (
     DeviceGraph,

--- a/tests/unit/test_compat.py
+++ b/tests/unit/test_compat.py
@@ -802,3 +802,39 @@ def test_writing_over_a_partition_this_plan_creates_does_not_condemn_the_disk() 
         ),
     )
     assert compat.destroyed(kept.disk.graph) == ()
+
+
+def test_the_kernel_package_table_is_the_only_one() -> None:
+    """`model/compat.py` and `plan/kernel.py` each held a complete copy, and a
+    package renamed in one of them would have left `traits_of` deciding
+    `CJK_KERNEL` from a name the installer no longer merges."""
+    import ast
+    from pathlib import Path
+
+    from gentoo_install.model import compat
+    from gentoo_install.model.config import KernelSource
+
+    assert set(compat.KERNEL_PACKAGES) == set(KernelSource), "every choice has a package"
+
+    # Derived rather than listed: the cjk set has to move when the table does.
+    assert compat._CJK_KERNEL_PACKAGES == {
+        compat.KERNEL_PACKAGES[source] for source in compat.CJK_KERNELS
+    }
+
+    # No second table anywhere: a dict whose keys are every KernelSource member
+    # is a copy of this one. Matched on the member names rather than on the
+    # enum's identifier, because `import KernelSource as _K` would otherwise
+    # walk straight past — the first version of this check did.
+    members = {source.name for source in KernelSource}
+    root = Path(compat.__file__).resolve().parent.parent
+    copies: list[str] = []
+    for path in sorted(root.rglob("*.py")):
+        if path.resolve() == Path(compat.__file__).resolve():
+            continue
+        for node in ast.walk(ast.parse(path.read_text())):
+            if not isinstance(node, ast.Dict):
+                continue
+            named = {key.attr for key in node.keys if isinstance(key, ast.Attribute)}
+            if named == members:
+                copies.append(f"{path.relative_to(root)}:{node.lineno}")
+    assert copies == [], copies

--- a/tests/unit/test_plan_boot.py
+++ b/tests/unit/test_plan_boot.py
@@ -663,7 +663,7 @@ def test_the_prebuilt_patched_kernel_is_the_one_a_chinese_interface_takes() -> N
     one: same cjktty patch, same `+cjk` flag, same `virtual/dist-kernel`, and
     nothing to compile on the target."""
     from gentoo_install.model.config import KernelSource
-    from gentoo_install.plan.kernel import CJK_KERNELS, KERNEL_PACKAGES
+    from gentoo_install.model.compat import CJK_KERNELS, KERNEL_PACKAGES
 
     assert KERNEL_PACKAGES[KernelSource.CJK_BIN] == "sys-kernel/gentoo-cjk-kernel-bin"
     assert set(CJK_KERNELS) == {KernelSource.CJK_BIN, KernelSource.CJK}
@@ -680,7 +680,7 @@ def test_the_prebuilt_patched_kernel_is_the_one_a_chinese_interface_takes() -> N
 def test_the_prebuilt_patched_kernel_sits_beside_the_source_one() -> None:
     """`sys-kernel/gentoo-cjk-kernel-bin` is in gentoo-zh: same cjktty patch,
     same `+cjk` flag, same `virtual/dist-kernel`, nothing to compile."""
-    from gentoo_install.plan.kernel import CJK_KERNELS, KERNEL_PACKAGES
+    from gentoo_install.model.compat import CJK_KERNELS, KERNEL_PACKAGES
 
     assert KERNEL_PACKAGES[KernelSource.CJK_BIN] == "sys-kernel/gentoo-cjk-kernel-bin"
     assert set(CJK_KERNELS) == {KernelSource.CJK_BIN, KernelSource.CJK}


### PR DESCRIPTION
`model/compat.py` and `plan/kernel.py` each carried a complete `KernelSource` → package mapping, byte for byte the same. `traits_of` decided `CJK_KERNEL` from its copy while the install merged from the other, so renaming a package in one of them would have merged under one name and classified under the other — and the standard is one table per rule set.

It stays in `model`, because `traits_of` reads it and `model` may not call upward; `plan.kernel` and the two TUI modules import it. `_CJK_KERNEL_PACKAGES` is now derived from it rather than listed a third time.

The test walks every module's AST for a dict keyed by the full member set. It matches on the member names rather than on the enum's identifier, because the first version of the check walked straight past `import KernelSource as _K` — the negative control found that, not review.