### PR TITLE
vm: cover a bios menu that appears after the countdown's length

### DIFF
--- a/tests/unit/test_proxmox.py
+++ b/tests/unit/test_proxmox.py
@@ -3100,23 +3100,39 @@ def test_an_error_carried_in_a_two_hundred_is_not_thrown_away() -> None:
     assert api.call("PUT", "/nodes/n/qemu/9300/config", description="x") is None
 
 
-def test_the_blind_edit_presses_before_the_menu_boots_itself() -> None:
-    """The medium's `grub.cfg` sets `timeout=10` and the delay before the first
-    key was twelve seconds, so the entry had already booted: every key went to
-    a kernel that was never told to use the serial port, and `vm-bios`,
-    `vm-bios-luks` and `ext4-bios` ended every round at `the kernel never spoke
-    after editing GRUB blind`."""
+def test_the_blind_edit_leaves_no_gap_in_when_the_menu_could_appear() -> None:
+    """A sample at `d` lands only when the menu appeared at some `t` with
+    `d - BIOS_MENU_TIMEOUT < t <= d`, so the samples cover a union of windows
+    and a gap between two of them is a menu time no attempt can catch.
+
+    The samples used to be capped below `BIOS_MENU_TIMEOUT`, which covered a
+    menu up within ten seconds and nothing after: no run has ever printed the
+    line `append_to_cmdline_blind` prints when an edit lands, and every BIOS
+    fixture ended every round at `the kernel never spoke`.
+    """
     from tests.vm.proxmox import BIOS_ATTEMPTS, BIOS_MENU_TIMEOUT
 
-    for delay, _ in BIOS_ATTEMPTS:
-        assert delay < BIOS_MENU_TIMEOUT, (delay, BIOS_MENU_TIMEOUT)
-    # Not every sample early: SeaBIOS and the medium's own search take a few
-    # seconds before the menu is drawn, and a node at full load takes longer.
-    # One sample under four seconds is deliberate; all of them would be blind
-    # in the other direction.
-    assert max(delay for delay, _ in BIOS_ATTEMPTS) >= 6.0
-    assert len({delay for delay, _ in BIOS_ATTEMPTS}) > 1, "one delay is one guess"
+    delays = sorted({delay for delay, _ in BIOS_ATTEMPTS})
+    # The earliest sample covers a menu that is up at once.
+    assert delays[0] <= BIOS_MENU_TIMEOUT, delays
+    # No gap: consecutive samples closer together than the countdown.
+    for earlier, later in zip(delays, delays[1:]):
+        assert later - earlier < BIOS_MENU_TIMEOUT, (earlier, later)
+    # And the cover reaches past a loaded node's menu. `vm-mdraid` needed more
+    # than thirty seconds to open a readable UEFI editor on such a node, so
+    # stopping at nine is what made every BIOS fixture unreachable.
+    assert delays[-1] >= 15.0, delays
     assert len({down for _, down in BIOS_ATTEMPTS}) > 1, "one line is one guess"
+
+    # Bounded: each attempt costs its delay, the keystrokes and a wait for the
+    # kernel, and a schedule cannot give one guest the whole round.
+    import inspect
+
+    from tests.vm import proxmox
+
+    patience = inspect.signature(proxmox.append_to_cmdline_blind).parameters["patience"]
+    worst = sum(delay + 4.0 + float(patience.default) for delay, _ in BIOS_ATTEMPTS)
+    assert worst < 900.0, worst
 
 
 def test_a_refusal_from_the_node_itself_is_not_transient() -> None:

--- a/tests/vm/proxmox.py
+++ b/tests/vm/proxmox.py
@@ -905,19 +905,30 @@ BIOS_MENU_TIMEOUT: Final[float] = 10.0
 
 #: When to press `e`, counted from the guest being started, paired with the
 #: line to move to. Nothing on the serial port says when the menu appeared —
-#: not SeaBIOS, not `Welcome to GRUB!`, nothing until the kernel speaks — so
-#: the moment is sampled rather than waited for. Six seconds was the only one
-#: tried, and on a node at full load the menu was not up yet: the keypress went
-#: nowhere, the menu timed out into the default entry, and the kernel was never
-#: told to speak. The delays stay under `BIOS_MENU_TIMEOUT` from whenever GRUB
-#: started, which is what makes several of them necessary rather than one long
-#: one.
+#: not SeaBIOS, not `Welcome to GRUB!`, nothing until the kernel speaks, and
+#: every BIOS log in `lab/` holds the guest's boot and no marker before it — so
+#: the moment is sampled rather than waited for.
+#:
+#: A sample at `d` lands when the menu appeared at some `t` with `d - 10 < t <=
+#: d`, because GRUB counts `BIOS_MENU_TIMEOUT` down from `t` and a key before
+#: `t` goes nowhere. Each attempt is its own boot, so the samples cover the
+#: union of those windows: spacing them under `BIOS_MENU_TIMEOUT` leaves no gap
+#: between the earliest and the latest.
+#:
+#: The samples used to stop at nine seconds, which covered a menu up at nine
+#: and nothing later, and no run has ever printed the line this function prints
+#: when an edit lands. Nodes measured between 80% and 100% busy all night, and
+#: `vm-mdraid`'s readable UEFI menu needed more than thirty seconds there, so
+#: a menu appearing after ten is the case to cover rather than the one to rule
+#: out.
 BIOS_ATTEMPTS: Final[tuple[tuple[float, int], ...]] = (
     (6.0, 2),
     (9.0, 2),
+    (13.0, 2),
+    (17.0, 2),
     (3.0, 2),
     (6.0, 1),
-    (6.0, 3),
+    (13.0, 3),
 )
 
 #: What the kernel prints once `console=ttyS0` is on its command line, and the


### PR DESCRIPTION
Every BIOS fixture — `vm-bios`, `vm-bios-luks`, `ext4-bios`, `mbr-edit` — ends its round at `the kernel never spoke after N blind GRUB edits`. Grepping every log under `lab/` for the line `append_to_cmdline_blind` prints when an edit lands returns nothing but the source line itself: it has never landed.

The samples were 3, 6 and 9 seconds and the old test asserted every one of them stayed under `BIOS_MENU_TIMEOUT`. That premise assumed the menu is drawn at once. A sample at `d` lands only when the menu appeared at some `t` with `d - 10 < t <= d`, so capping `d` below ten covers a menu up within ten seconds and nothing after — and nodes measured 80% to 100% busy all night, where `vm-mdraid` needed more than thirty seconds to open a readable UEFI editor.

The samples now reach seventeen seconds and the test asserts the real property: consecutive samples closer together than the countdown, so their windows leave no gap, plus a bound on what the whole sequence costs one guest. Unverified — this is a widening, and the next round is what says whether the menu is inside it.