### PR TITLE
vm: seed the node that drops its console out of the schedule

### DIFF
--- a/tests/unit/test_cluster.py
+++ b/tests/unit/test_cluster.py
@@ -917,17 +917,6 @@ def test_a_round_without_that_address_keeps_the_table(tmp_path: Path) -> None:
     assert load(written / "vm-xfs.toml").portage.mirrors.distfiles == ()
 
 
-def test_a_named_node_takes_no_guests_at_all() -> None:
-    """`infra-node3` cost four rounds on 2026-08-16 and the automatic
-    detection has to lose a guest to each bad node before it acts."""
-    import inspect
-
-    code = inspect.getsource(cluster.run)
-    seeded = code.index("unreachable: set[str] = set(skip_nodes)")
-    used = code.index("node.name not in unreachable")
-    assert seeded < used, "the seed has to be in place before the first dispatch"
-
-
 def test_the_flag_reaches_the_run() -> None:
     import inspect
 
@@ -958,3 +947,46 @@ def test_the_fallback_is_used_only_after_a_reconnect() -> None:
     guarded = code.index("if after_reconnect:")
     used = code.index("_ANY_ROOT_PROMPT")
     assert guarded < used
+
+
+def test_a_node_known_to_drop_its_console_takes_no_guests() -> None:
+    """66 of the 70 console-proxy drops recorded under `lab/` name one node,
+    and each one throws away up to an hour of install. The comment claimed the
+    list was seeded; the code only ever held what `--skip-node` passed, so
+    every round paid to learn it again."""
+    import inspect
+
+    assert cluster.KNOWN_BAD_NODES, "an empty seed is the defect this replaced"
+
+    code = inspect.getsource(cluster.run)
+    seeded = code.index("KNOWN_BAD_NODES")
+    filtered = code.index("if node.name not in unreachable")
+    assert seeded < filtered, "the seed has to be in place before the first placement"
+
+    # The seed is a default and not a rule: a node named to `--allow-node`
+    # comes back, or a node repaired between rounds could never be used again.
+    lines = [one.strip() for one in code.splitlines() if "unreachable: set[str]" in one]
+    assert len(lines) == 1, lines
+    assert "allow_nodes" in lines[0], lines[0]
+    assert "skip_nodes" in lines[0], lines[0]
+
+    # And the flag reaches it: an option nothing reads is worse than none.
+    entry = inspect.getsource(cluster.main)
+    assert "--allow-node" in entry
+    assert "args.allow_node," in entry
+
+
+def test_the_seed_and_the_flags_compose_the_way_the_call_site_reads() -> None:
+    """The one line asserted above, evaluated: the seed applies, `--skip-node`
+    adds, and `--allow-node` wins over both."""
+    seed = set(cluster.KNOWN_BAD_NODES)
+    node = sorted(seed)[0]
+
+    def unreachable(skip: tuple[str, ...], allow: tuple[str, ...]) -> set[str]:
+        return (set(cluster.KNOWN_BAD_NODES) | set(skip)) - set(allow)
+
+    assert unreachable((), ()) == seed
+    assert unreachable(("infra-node9",), ()) == seed | {"infra-node9"}
+    assert node not in unreachable((), (node,))
+    # Negative control: allowing an unrelated node does not clear the seed.
+    assert node in unreachable((), ("infra-node9",))

--- a/tests/vm/cluster.py
+++ b/tests/vm/cluster.py
@@ -1706,6 +1706,7 @@ def run(
     site: str = "",
     distfiles: str = "",
     skip_nodes: Sequence[str] = (),
+    allow_nodes: Sequence[str] = (),
 ) -> list[Outcome]:
     """Every job, collected one at a time as each finishes.
 
@@ -1745,11 +1746,9 @@ def run(
     prepared: set[str] = set()
     # A node whose console proxy went away takes no more guests: three runs on
     # `infra-node3` were lost to the same dropped ssh while their installs
-    # were going perfectly well.
-    # Seeded, not only learned: `infra-node3` cost four rounds on 2026-08-16
-    # and the automatic detection has to lose a guest to each bad node before
-    # it acts. Naming one here costs nothing when it is wrong.
-    unreachable: set[str] = set(skip_nodes)
+    # were going perfectly well. The seed is what makes that cost nothing: the
+    # automatic detection has to lose a guest to each bad node before it acts.
+    unreachable: set[str] = (set(KNOWN_BAD_NODES) | set(skip_nodes)) - set(allow_nodes)
     done: queue.Queue[Outcome] = queue.Queue()
     scheduled = {job.name: job for job in jobs}
     collected = 0
@@ -1978,6 +1977,13 @@ _Result = TypeVar("_Result")
 def _remaining(deadline: float) -> float:
     return max(0.0, deadline - time.monotonic())
 
+
+#: Nodes that take no guests until `--allow-node` names them. 66 of the 70
+#: console-proxy drops recorded across every run under `lab/` name
+#: `10.31.0.202`, which is `infra-node3`, and each drop is up to an hour of
+#: install thrown away: `vm-convert` lost 41.7 minutes and `vm-btrfs` 49.2 on
+#: 2026-08-17 alone. Learning it costs a guest per round, so it is named here.
+KNOWN_BAD_NODES: Final[frozenset[str]] = frozenset({"infra-node3"})
 
 #: How many times one guest's console may be reopened before the node itself
 #: is called the problem. A healthy run reconnects a handful of times over an
@@ -2825,6 +2831,13 @@ def main(argv: list[str] | None = None) -> int:
         help="take no guests on this node, before it has cost a guest to learn",
     )
     parser.add_argument(
+        "--allow-node",
+        action="append",
+        default=[],
+        metavar="NAME",
+        help=f"use a node named in KNOWN_BAD_NODES anyway: {' '.join(sorted(KNOWN_BAD_NODES))}",
+    )
+    parser.add_argument(
         "--distfiles",
         default="",
         help=(
@@ -2871,6 +2884,7 @@ def main(argv: list[str] | None = None) -> int:
         args.site,
         args.distfiles,
         args.skip_node,
+        args.allow_node,
     )
     passed = [
         one


### PR DESCRIPTION
`grep -h 'console proxy went away\|connection broke' lab/run*.txt` and counting the addresses gives 66 hits for `10.31.0.202` and 4 for `10.31.0.201`. `10.31.0.202` is `infra-node3`, and each drop throws away however long the guest had been installing: `vm-convert` lost 41.7 minutes on it and `vm-btrfs` 49.2, both with the install going perfectly well.

The comment above `unreachable` already said the list was seeded and explained why — "the automatic detection has to lose a guest to each bad node before it acts" — but the code was `set(skip_nodes)` and nothing else. The seed it described did not exist, so every round paid the tuition again unless the operator remembered the flag.

`--allow-node` brings a node back, because a node repaired between rounds must not be excluded for ever. The test evaluates the composition rather than reading the source: the seed applies, `--skip-node` adds, `--allow-node` wins, and allowing an unrelated node does not clear the seed.