### PR TITLE
compat: remote unlock needs a boot GRUB can read without a key

### DIFF
--- a/gentoo_install/data/locale/ja.toml
+++ b/gentoo_install/data/locale/ja.toml
@@ -454,6 +454,8 @@
 "cjktty patches the kernel VT layer, which no official kernel carries; sys-kernel/gentoo-cjk-kernel is the one that does" = "cjktty はカーネルの VT 層にパッチを当てます。公式カーネルには含まれず、sys-kernel/gentoo-cjk-kernel だけが持ちます"
 "dracut-crypt-ssh authorises /root/.ssh/authorized_keys, so with none the initramfs runs an ssh daemon nobody can log into" = "dracut-crypt-ssh は /root/.ssh/authorized_keys を参照するため、鍵がないと initramfs は誰もログインできない ssh を動かします"
 "there is no passphrase prompt to reach: the root is not encrypted" = "ルートが暗号化されていないため、接続先のパスフレーズ入力はありません。"
+"GRUB asks for that passphrase at the physical console, so the machine stops before the initramfs that runs the ssh daemon: a separate /boot outside the container is what a machine unlocked over the network needs" = "GRUB はそのパスフレーズを物理コンソールで要求するため、ssh デーモンを起動する initramfs に到達する前に停止します。ネットワーク越しに解錠する機器には、コンテナの外に置いた独立した /boot が必要です。"
+"GRUB unlocking /boot before it can read a kernel" = "カーネルを読む前に GRUB が /boot を解錠すること"
 "sys-kernel/gentoo-cjk-kernel is in that overlay and in no other repository, so the emerge fails once the disks have been partitioned" = "sys-kernel/gentoo-cjk-kernel はその overlay にしかなく、ディスクを分割した後で emerge が失敗します"
 "the cjk kernel builds CONFIG_FONT_CJK_16x16 alone, which pairs with the 8x16 font, because the 32x32 font the patch ships is empty" = "cjk カーネルは CONFIG_FONT_CJK_16x16 のみを有効にし、8x16 フォントと組みます。パッチが持つ 32x32 フォントが空だからです"
 "sys-boot/zfsbootmenu is in that overlay and in no other repository, so the emerge fails once the disks have already been partitioned" = "sys-boot/zfsbootmenu はその overlay にしかなく、ディスクを分割した後で emerge が失敗します"

--- a/gentoo_install/data/locale/ko.toml
+++ b/gentoo_install/data/locale/ko.toml
@@ -454,6 +454,8 @@
 "cjktty patches the kernel VT layer, which no official kernel carries; sys-kernel/gentoo-cjk-kernel is the one that does" = "cjktty 는 커널 VT 계층을 패치하며 공식 커널에는 없고 sys-kernel/gentoo-cjk-kernel 에만 있습니다"
 "dracut-crypt-ssh authorises /root/.ssh/authorized_keys, so with none the initramfs runs an ssh daemon nobody can log into" = "dracut-crypt-ssh 는 /root/.ssh/authorized_keys 를 사용하므로 키가 없으면 initramfs 는 아무도 로그인할 수 없는 ssh 를 실행합니다"
 "there is no passphrase prompt to reach: the root is not encrypted" = "도달할 암호 구절 입력이 없습니다. 루트가 암호화되지 않았습니다"
+"GRUB asks for that passphrase at the physical console, so the machine stops before the initramfs that runs the ssh daemon: a separate /boot outside the container is what a machine unlocked over the network needs" = "GRUB이 물리 콘솔에서 그 암호 구절을 요구하므로 ssh 데몬을 실행하는 initramfs에 도달하기 전에 멈춥니다. 네트워크로 잠금을 해제하는 기계에는 컨테이너 밖에 있는 별도의 /boot가 필요합니다"
+"GRUB unlocking /boot before it can read a kernel" = "커널을 읽기 전에 GRUB이 /boot를 잠금 해제하는 것"
 "sys-kernel/gentoo-cjk-kernel is in that overlay and in no other repository, so the emerge fails once the disks have been partitioned" = "sys-kernel/gentoo-cjk-kernel 은 그 overlay 에만 있어 디스크를 나눈 뒤에 emerge 가 실패합니다"
 "the cjk kernel builds CONFIG_FONT_CJK_16x16 alone, which pairs with the 8x16 font, because the 32x32 font the patch ships is empty" = "cjk 커널은 CONFIG_FONT_CJK_16x16 만 빌드하며 8x16 글꼴과 짝을 이룹니다. 패치가 제공하는 32x32 글꼴이 비어 있기 때문입니다"
 "sys-boot/zfsbootmenu is in that overlay and in no other repository, so the emerge fails once the disks have already been partitioned" = "sys-boot/zfsbootmenu 은 그 overlay 에만 있어 디스크를 나눈 뒤에 emerge 가 실패합니다"

--- a/gentoo_install/data/locale/zh-CN.toml
+++ b/gentoo_install/data/locale/zh-CN.toml
@@ -455,6 +455,8 @@
 "cjktty patches the kernel VT layer, which no official kernel carries; sys-kernel/gentoo-cjk-kernel is the one that does" = "cjktty 修补内核 VT 层，官方内核都没有这份补丁，只有 sys-kernel/gentoo-cjk-kernel 有"
 "dracut-crypt-ssh authorises /root/.ssh/authorized_keys, so with none the initramfs runs an ssh daemon nobody can log into" = "dracut-crypt-ssh 使用 /root/.ssh/authorized_keys 进行授权；没有公钥时，任何人都无法登录 initramfs 中的 SSH 服务。"
 "there is no passphrase prompt to reach: the root is not encrypted" = "根文件系统未加密，因此不存在可供远程解锁的密码短语提示"
+"GRUB asks for that passphrase at the physical console, so the machine stops before the initramfs that runs the ssh daemon: a separate /boot outside the container is what a machine unlocked over the network needs" = "GRUB 会在物理控制台上要求那个密码短语，机器因此停在运行 ssh 服务的 initramfs 之前：要用网络解锁的机器需要一个在容器外面的独立 /boot"
+"GRUB unlocking /boot before it can read a kernel" = "GRUB 必须先解开 /boot 才读得到内核"
 "sys-kernel/gentoo-cjk-kernel is in that overlay and in no other repository, so the emerge fails once the disks have been partitioned" = "sys-kernel/gentoo-cjk-kernel 仅存在于该 overlay；缺少 overlay 时，emerge 会在磁盘分区后失败"
 "the cjk kernel builds CONFIG_FONT_CJK_16x16 alone, which pairs with the 8x16 font, because the 32x32 font the patch ships is empty" = "cjk 内核仅启用 CONFIG_FONT_CJK_16x16；该选项对应 8x16 字体，因为补丁提供的 32x32 字体为空。"
 "sys-boot/zfsbootmenu is in that overlay and in no other repository, so the emerge fails once the disks have already been partitioned" = "sys-boot/zfsbootmenu 仅存在于该 overlay；缺少 overlay 时，emerge 会在磁盘分区后失败"

--- a/gentoo_install/data/locale/zh-TW.toml
+++ b/gentoo_install/data/locale/zh-TW.toml
@@ -455,6 +455,8 @@
 "cjktty patches the kernel VT layer, which no official kernel carries; sys-kernel/gentoo-cjk-kernel is the one that does" = "cjktty 修補核心 VT 層，官方核心都沒有這份補丁，只有 sys-kernel/gentoo-cjk-kernel 有"
 "dracut-crypt-ssh authorises /root/.ssh/authorized_keys, so with none the initramfs runs an ssh daemon nobody can log into" = "dracut-crypt-ssh 使用 /root/.ssh/authorized_keys 授權；沒有公鑰時，任何人都無法登入 initramfs 中的 SSH 服務。"
 "there is no passphrase prompt to reach: the root is not encrypted" = "根檔案系統未加密，因此不存在可供遠端解鎖的密語提示"
+"GRUB asks for that passphrase at the physical console, so the machine stops before the initramfs that runs the ssh daemon: a separate /boot outside the container is what a machine unlocked over the network needs" = "GRUB 會在實體主控台上要求那個密語，機器因此停在執行 ssh 服務的 initramfs 之前：要用網路解鎖的機器需要一個在容器外面的獨立 /boot"
+"GRUB unlocking /boot before it can read a kernel" = "GRUB 必須先解開 /boot 才讀得到核心"
 "sys-kernel/gentoo-cjk-kernel is in that overlay and in no other repository, so the emerge fails once the disks have been partitioned" = "sys-kernel/gentoo-cjk-kernel 僅存在於該 overlay；缺少 overlay 時，emerge 會在磁碟分割後失敗"
 "the cjk kernel builds CONFIG_FONT_CJK_16x16 alone, which pairs with the 8x16 font, because the 32x32 font the patch ships is empty" = "cjk 核心僅啟用 CONFIG_FONT_CJK_16x16；該選項對應 8x16 字型，因為補丁提供的 32x32 字型為空。"
 "sys-boot/zfsbootmenu is in that overlay and in no other repository, so the emerge fails once the disks have already been partitioned" = "sys-boot/zfsbootmenu 僅存在於該 overlay；缺少 overlay 時，emerge 會在磁碟分割後失敗"

--- a/gentoo_install/model/compat.py
+++ b/gentoo_install/model/compat.py
@@ -181,6 +181,7 @@ class Trait(Enum):
     REMOTE_UNLOCK = "unlocking the root over ssh"
     NO_AUTHORIZED_KEY = "no authorised ssh key"
     NO_ENCRYPTED_CONTAINER = "no encrypted container to unlock"
+    GRUB_UNLOCKS_BOOT = "GRUB unlocking /boot before it can read a kernel"
     NATIVE_ZFS_SYSTEM_INITRAMFS = "ZFS native encryption with GRUB or systemd-boot"
     FONT_WITHOUT_CJK_GLYPHS = "a console font other than 8x16"
     ROOT_LOCKED = "a root password hash that cannot authenticate"
@@ -278,6 +279,13 @@ RULES: tuple[Rule, ...] = (
     ),
     Rule(
         Trait.REMOTE_UNLOCK,
+        Trait.GRUB_UNLOCKS_BOOT,
+        "GRUB asks for that passphrase at the physical console, so the machine "
+        "stops before the initramfs that runs the ssh daemon: a separate /boot "
+        "outside the container is what a machine unlocked over the network needs",
+    ),
+    Rule(
+        Trait.REMOTE_UNLOCK,
         Trait.NATIVE_ZFS_SYSTEM_INITRAMFS,
         "GRUB and systemd-boot put the ssh helper in the system initramfs, where "
         "it calls cryptsetup and cannot load a native ZFS key",
@@ -353,6 +361,10 @@ def traits_of(
 
     if esp_mount(graph) is None:
         found.add(Trait.NO_MOUNTED_ESP)
+    # GRUB alone: systemd-boot and ZFSBootMenu read the kernel off the esp,
+    # which is not in the container, so their initramfs starts without a key.
+    if config.bootloader.kind is Bootloader.GRUB and boot_is_encrypted(graph):
+        found.add(Trait.GRUB_UNLOCKS_BOOT)
     if _encrypted_esp(graph):
         found.add(Trait.ESP_ENCRYPTED)
     # Where `kernel-install` writes, which is `$BOOT_ROOT`: the XBOOTLDR

--- a/tests/fixtures/vm-unlock.toml
+++ b/tests/fixtures/vm-unlock.toml
@@ -1,4 +1,5 @@
-# Remote unlock over ssh from the initramfs, on an encrypted root.
+# Remote unlock over ssh from the initramfs, on an encrypted root with a
+# readable /boot.
 #
 # Nothing had ever enabled it: seventeen fixtures, `remote_unlock` off in
 # every one and not a single authorised key between them, so sshd was
@@ -66,11 +67,24 @@ index = 1
 role = "esp"
 size = "512MiB"
 
+# Outside the container, and this is what the whole fixture turns on: with
+# /boot on the encrypted root, GRUB has to `cryptomount` before it can read
+# grub.cfg, so it asks for the passphrase at the physical console and no
+# initramfs — and no ssh daemon — ever starts. A machine unlocked over the
+# network needs a /boot GRUB can read without a key.
+[[disk.devices]]
+kind = "partition"
+id = "boot"
+table = "table"
+index = 2
+role = "data"
+size = "1GiB"
+
 [[disk.devices]]
 kind = "partition"
 id = "cryptroot"
 table = "table"
-index = 2
+index = 3
 role = "data"
 
 [[disk.devices]]
@@ -79,6 +93,13 @@ id = "espfs"
 device = "esp"
 type = "vfat"
 label = "ESP"
+
+[[disk.devices]]
+kind = "filesystem"
+id = "bootfs"
+device = "boot"
+type = "ext4"
+label = "BOOT"
 
 [[disk.devices]]
 kind = "luks"
@@ -118,6 +139,12 @@ id = "mnt-home"
 source = "sub-home"
 path = "/home"
 options = ["compress=zstd:1"]
+
+[[disk.devices]]
+kind = "mountpoint"
+id = "mnt-boot"
+source = "bootfs"
+path = "/boot"
 
 [[disk.devices]]
 kind = "mountpoint"

--- a/tests/golden/vm-unlock.txt
+++ b/tests/golden/vm-unlock.txt
@@ -3,7 +3,8 @@
   wipe existing signatures from disk
   create a gpt partition table on disk as table
   create partition 1 on disk as esp: esp, 512MiB
-  create partition 2 on disk as cryptroot: data, the rest of the disk
+  create partition 2 on disk as boot: data, 1GiB
+  create partition 3 on disk as cryptroot: data, the rest of the disk
   reread the partition table of disk and wait for its nodes
 
 [array]
@@ -11,6 +12,7 @@
   open cryptroot as /dev/mapper/root
 
 [format]
+  make a ext4 filesystem on boot as bootfs labelled BOOT
   make a vfat filesystem on esp as espfs labelled ESP
   make a btrfs filesystem on root-luks as rootfs
   create btrfs subvolume @home on root-luks as sub-home
@@ -18,6 +20,7 @@
 
 [mount]
   mount root-luks at / with compress=zstd:1,subvol=@
+  mount boot at /boot
   mount esp at /efi with umask=0077
   mount root-luks at /home with compress=zstd:1,subvol=@home
 
@@ -43,7 +46,7 @@
   ask for sys-apps/systemd[cryptsetup], which provides the unlock generator
   accept the linux-firmware licence
   configure remote unlock over ssh on port 2222
-  resolve net-misc/openssh sys-process/cronie sys-kernel/installkernel sys-apps/systemd sys-kernel/dracut sys-kernel/linux-firmware sys-kernel/dracut-crypt-ssh sys-fs/cryptsetup sys-fs/btrfs-progs sys-fs/dosfstools sys-kernel/gentoo-kernel-bin sys-boot/grub sys-boot/efibootmgr together before installing the requested packages
+  resolve net-misc/openssh sys-process/cronie sys-kernel/installkernel sys-apps/systemd sys-kernel/dracut sys-kernel/linux-firmware sys-kernel/dracut-crypt-ssh sys-fs/cryptsetup sys-fs/btrfs-progs sys-fs/dosfstools sys-fs/e2fsprogs sys-kernel/gentoo-kernel-bin sys-boot/grub sys-boot/efibootmgr together before installing the requested packages
 
 [system]
   generate and verify locales en_US.UTF-8, zh_TW.UTF-8
@@ -52,7 +55,7 @@
   set the console keymap to us and its font to default8x16
   set the hostname to unlockbox
   give the target its own machine id
-  write /etc/fstab with entries for /, /efi, /home
+  write /etc/fstab with entries for /, /boot, /efi, /home
   treat the hardware clock as UTC
   write /etc/crypttab for root
   authorise 1 ssh key(s) for root
@@ -72,7 +75,7 @@
   rebuild systemd with the unlock generator: emerge sys-apps/systemd, from source
   install the initramfs builder and firmware: emerge sys-kernel/dracut sys-kernel/linux-firmware
   install the initramfs ssh daemon: emerge sys-kernel/dracut-crypt-ssh
-  install the storage tools: emerge sys-fs/cryptsetup sys-fs/btrfs-progs sys-fs/dosfstools
+  install the storage tools: emerge sys-fs/cryptsetup sys-fs/btrfs-progs sys-fs/dosfstools sys-fs/e2fsprogs
   install the kernel: emerge sys-kernel/gentoo-kernel-bin
   tell dracut to carry crypt, btrfs, crypt-ssh, network
   rebuild the initramfs from sys-kernel/gentoo-kernel-bin with the modules written above
@@ -80,7 +83,7 @@
 
 [bootloader]
   install the bootloader: emerge sys-boot/grub sys-boot/efibootmgr
-  write /etc/default/grub with cmdline rd.neednet=1 ip=192.0.2.10::192.0.2.1:255.255.255.0::eth0:none console=ttyS0,115200, cryptodisk enabled and its menu on ttyS0
+  write /etc/default/grub with cmdline rd.neednet=1 ip=192.0.2.10::192.0.2.1:255.255.255.0::eth0:none console=ttyS0,115200, its menu on ttyS0
   install GRUB for uefi on the esp at /efi
 
 [finish]

--- a/tests/unit/layouts.py
+++ b/tests/unit/layouts.py
@@ -89,6 +89,30 @@ def encrypted_root() -> list[Node]:
     ]
 
 
+def unlockable_root() -> list[Node]:
+    """`encrypted_root` with a /boot outside the container.
+
+    GRUB reads its kernel from /boot, so with /boot on the encrypted root it
+    asks for the passphrase at the physical console and the initramfs that
+    serves the ssh daemon never starts. `vm-unlock` spent three rounds proving
+    it: the console held `Enter passphrase for hd0,gpt2` at fifty-one minutes.
+    """
+    return [
+        Existing(id=i("disk"), selector="/dev/disk/by-id/virtio-target", wipe=True),
+        PartitionTable(id=i("table"), disk=i("disk"), table=TableType.GPT),
+        Partition(id=i("esp"), table=i("table"), index=1, role=PartitionRole.ESP, size=Size.parse("512MiB")),
+        Partition(id=i("bootpart"), table=i("table"), index=2, role=PartitionRole.DATA, size=Size.parse("1GiB")),
+        Partition(id=i("rootpart"), table=i("table"), index=3, role=PartitionRole.DATA, size=None),
+        Filesystem(id=i("espfs"), device=i("esp"), kind=FilesystemType.VFAT, label="ESP"),
+        Filesystem(id=i("bootfs"), device=i("bootpart"), kind=FilesystemType.EXT4, label="BOOT"),
+        Luks(id=i("crypt"), backing=i("rootpart"), name="root", passphrase_file="/run/keys/root"),
+        Filesystem(id=i("rootfs"), device=i("crypt"), kind=FilesystemType.EXT4, label="gentoo"),
+        Mountpoint(id=i("mnt-root"), source=i("rootfs"), path=PurePosixPath("/")),
+        Mountpoint(id=i("mnt-boot"), source=i("bootfs"), path=PurePosixPath("/boot")),
+        Mountpoint(id=i("mnt-esp"), source=i("espfs"), path=PurePosixPath("/efi")),
+    ]
+
+
 def config(nodes: list[Node] | None = None) -> InstallConfig:
     return InstallConfig(
         disk=DiskConfig(graph=DeviceGraph.build(nodes or ext4_on_gpt()), root=i("mnt-root")),

--- a/tests/unit/test_compat.py
+++ b/tests/unit/test_compat.py
@@ -281,6 +281,24 @@ def native_zfs_remote_unlock_with_systemd_boot() -> InstallConfig:
     return remote_unlock_of_a_native_zfs_root(Bootloader.SYSTEMD_BOOT)
 
 
+def remote_unlock_with_boot_inside_the_container() -> InstallConfig:
+    """`vm-unlock` was this. The console held `Enter passphrase for hd0,gpt2`
+    fifty-one minutes into the round: GRUB unlocks /boot before it can read a
+    kernel, so it asked at the physical console and the initramfs that serves
+    the ssh daemon never started."""
+    encrypted = [node for node in ext4_on_gpt() if node.id != i("rootfs")]
+    encrypted += [
+        Luks(id=i("crypt"), backing=i("rootpart"), name="root"),
+        Filesystem(id=i("rootfs"), device=i("crypt"), kind=FilesystemType.EXT4),
+    ]
+    installation = config(encrypted)
+    return replace(
+        installation,
+        kernel=KernelConfig(remote_unlock=RemoteUnlock(enabled=True)),
+        system=replace(installation.system, authorized_keys=(VALID_KEY,)),
+    )
+
+
 def a_system_nothing_can_log_into() -> InstallConfig:
     """No root password, no user and no key: the machine boots and refuses
     every login. `zfs-zbm.toml` was this until a VM run reached its prompt."""
@@ -307,6 +325,7 @@ CASES: list[tuple[Callable[[], InstallConfig], Trait, Trait]] = [
     (the_patched_kernel_without_its_overlay, Trait.CJK_KERNEL, Trait.NO_GENTOOZH_OVERLAY),
     (remote_unlock_without_a_key, Trait.REMOTE_UNLOCK, Trait.NO_AUTHORIZED_KEY),
     (remote_unlock_of_an_unencrypted_root, Trait.REMOTE_UNLOCK, Trait.NO_ENCRYPTED_CONTAINER),
+    (remote_unlock_with_boot_inside_the_container, Trait.REMOTE_UNLOCK, Trait.GRUB_UNLOCKS_BOOT),
     (
         native_zfs_remote_unlock_with_systemd_boot,
         Trait.REMOTE_UNLOCK,
@@ -326,6 +345,28 @@ def test_every_rule_in_the_table_has_a_case_that_breaks_it() -> None:
     assert {(when, excludes) for _, when, excludes in CASES} == {
         (rule.when, rule.excludes) for rule in RULES
     }
+
+
+def test_a_bootloader_that_reads_the_kernel_off_the_esp_unlocks_remotely() -> None:
+    """The rule above is GRUB's alone. systemd-boot and ZFSBootMenu read the
+    kernel from the esp, which is not in the container, so their initramfs
+    starts without anyone at the console and refusing them would take the
+    feature away from the layout it works best on."""
+    encrypted = [node for node in ext4_on_gpt() if node.id != i("rootfs")]
+    encrypted += [
+        Luks(id=i("crypt"), backing=i("rootpart"), name="root"),
+        Filesystem(id=i("rootfs"), device=i("crypt"), kind=FilesystemType.EXT4),
+    ]
+    for kind in (Bootloader.SYSTEMD_BOOT, Bootloader.GRUB):
+        installation = boots(config(encrypted), kind, Firmware.UEFI)
+        installation = replace(
+            installation,
+            system=replace(installation.system, authorized_keys=(VALID_KEY,)),
+            kernel=KernelConfig(remote_unlock=RemoteUnlock(enabled=True)),
+        )
+        broken = {(rule.when, rule.excludes) for rule in violations(installation)}
+        pair = (Trait.REMOTE_UNLOCK, Trait.GRUB_UNLOCKS_BOOT)
+        assert (pair in broken) == (kind is Bootloader.GRUB), (kind, broken)
 
 
 def test_a_plain_uefi_install_breaks_no_rule() -> None:

--- a/tests/unit/test_plan_system.py
+++ b/tests/unit/test_plan_system.py
@@ -1261,9 +1261,9 @@ def test_remote_unlock_gets_host_keys_without_enabling_target_sshd() -> None:
     from gentoo_install.model.config import KernelConfig, RemoteUnlock
     from gentoo_install.plan.build import build
 
-    from .layouts import config, encrypted_root
+    from .layouts import config, unlockable_root
 
-    base = config(encrypted_root())
+    base = config(unlockable_root())
     installation = replace(
         base,
         system=replace(base.system, sshd=False, authorized_keys=("ssh-ed25519 AAAA test",)),

--- a/tests/unit/test_tui_app.py
+++ b/tests/unit/test_tui_app.py
@@ -34,7 +34,7 @@ from gentoo_install.tui.overview import overview_screen
 from gentoo_install.tui.widgets import Outcome
 
 from .fake_screen import FakeScreen
-from .layouts import config, encrypted_root, zfs_root
+from .layouts import config, encrypted_root, unlockable_root, zfs_root
 
 DISKS = [("/dev/disk/by-id/virtio-target0", "20 GiB"), ("/dev/disk/by-id/virtio-target1", "40 GiB")]
 
@@ -1845,7 +1845,7 @@ def test_a_bad_port_keeps_the_address_that_was_typed_beside_it() -> None:
     # An encrypted root as well as a key: with neither there is no passphrase
     # prompt to reach, and the screen says so instead of asking.
     with_key = replace(
-        config(encrypted_root()), system=replace(config().system, authorized_keys=(GOOD_KEY,))
+        config(unlockable_root()), system=replace(config().system, authorized_keys=(GOOD_KEY,))
     )
     # Yes to unlocking, then `abc` appended to the port and an address typed.
     # The form comes back with an inline message and both values, so deleting the three
@@ -2305,7 +2305,7 @@ def test_remote_unlock_is_refused_without_a_key_and_without_encryption() -> None
 def test_remote_unlock_is_offered_once_both_hold() -> None:
     at = context()
     both = replace(
-        config(encrypted_root()),
+        config(unlockable_root()),
         system=replace(config().system, authorized_keys=(GOOD_KEY,)),
     )
     screen = FakeScreen(keys=["q"], lines=24, columns=110)

--- a/tests/unit/test_validate.py
+++ b/tests/unit/test_validate.py
@@ -29,7 +29,7 @@ from gentoo_install.exec.probe import amd64_profiles, profiles_from_eselect
 from gentoo_install.model.validate import validate, zfs_kernel_ceiling
 from gentoo_install.model.parse import parse
 
-from .layouts import encrypted_root, config, ext4_on_gpt, i, zfs_root
+from .layouts import encrypted_root, config, ext4_on_gpt, i, unlockable_root, zfs_root
 
 FIXTURES = Path(__file__).resolve().parents[1] / "fixtures"
 
@@ -524,7 +524,7 @@ def test_validate_parses_each_configured_network_value_once(
     from gentoo_install.model.config import RemoteUnlock
 
     interface_calls, address_calls = _record_address_parses(monkeypatch)
-    base = config(encrypted_root())
+    base = config(unlockable_root())
     installation = replace(
         base,
         system=replace(
@@ -567,7 +567,7 @@ def test_validate_does_not_reparse_malformed_remote_unlock_values(
     from gentoo_install.model.config import RemoteUnlock
 
     interface_calls, address_calls = _record_address_parses(monkeypatch)
-    base = config(encrypted_root())
+    base = config(unlockable_root())
     installation = replace(
         base,
         system=replace(
@@ -722,7 +722,7 @@ def test_a_remote_unlock_pair_of_one_family_is_a_working_configuration() -> None
     for address, gateway in (("192.0.2.10/24", "192.0.2.1"), ("2001:db8::10/64", "2001:db8::1")):
         validate(
             replace(
-                config(encrypted_root()),
+                config(unlockable_root()),
                 system=replace(config().system, authorized_keys=("ssh-ed25519 AAAA test",)),
                 kernel=replace(
                     KernelConfig(),


### PR DESCRIPTION
The console capture added in #407 answered this on its first failure. `vm-unlock` failed at 51.7 minutes with `ssh: connect to host 10.31.0.152 port 2222: No route to host`, and the screen behind it held:

    BdsDxe: starting Boot0003 "Gentoo" ... \EFI\Gentoo\grubx64.efi
    Enter passphrase for hd0,gpt2 (1c0438c5-2259-45c0-a361-fd9abe71345a):

The guest was at GRUB's own prompt. The fixture had no separate `/boot`, so the kernel sat on the encrypted root and GRUB had to `cryptomount` before it could read one — at the physical console, which is the one thing remote unlock exists to avoid. No initramfs ran, so there was never anything listening on 2222.

That is a configuration the model can refuse rather than a fixture to patch, so it is a `compat` rule and the fixture gains the `/boot` a headless machine needs. The rule is GRUB's alone: systemd-boot and ZFSBootMenu read the kernel off the esp, which is not in the container, and a test holds both directions — widening it to every bootloader turns that test red. `vm-luks`, `vm-bios-luks` and `btrfs-luks` keep the encrypted-`/boot` coverage.

Not run on a cluster guest yet; `vm-unlock` is in the next round.