### PR TITLE
compat: hold every way of unlocking remotely in one test

### DIFF
--- a/gentoo_install/model/compat.py
+++ b/gentoo_install/model/compat.py
@@ -361,8 +361,11 @@ def traits_of(
 
     if esp_mount(graph) is None:
         found.add(Trait.NO_MOUNTED_ESP)
-    # GRUB alone: systemd-boot and ZFSBootMenu read the kernel off the esp,
-    # which is not in the container, so their initramfs starts without a key.
+    # GRUB alone, and for two different reasons. systemd-boot reads the kernel
+    # off the esp, which is never in the container. ZFSBootMenu does keep the
+    # kernel in the pool, so it does ask for a key — but it asks from its own
+    # image, which carries `crypt-ssh` and dropbear, so the question reaches
+    # the network rather than the physical console.
     if config.bootloader.kind is Bootloader.GRUB and boot_is_encrypted(graph):
         found.add(Trait.GRUB_UNLOCKS_BOOT)
     if _encrypted_esp(graph):

--- a/tests/unit/test_compat.py
+++ b/tests/unit/test_compat.py
@@ -348,10 +348,10 @@ def test_every_rule_in_the_table_has_a_case_that_breaks_it() -> None:
 
 
 def test_a_bootloader_that_reads_the_kernel_off_the_esp_unlocks_remotely() -> None:
-    """The rule above is GRUB's alone. systemd-boot and ZFSBootMenu read the
-    kernel from the esp, which is not in the container, so their initramfs
-    starts without anyone at the console and refusing them would take the
-    feature away from the layout it works best on."""
+    """The rule above is GRUB's alone, and for two different reasons.
+    systemd-boot reads the kernel off the esp, which is never in the container.
+    ZFSBootMenu keeps the kernel in the pool and does ask for a key, but asks it
+    from its own image, which carries `crypt-ssh` and dropbear."""
     encrypted = [node for node in ext4_on_gpt() if node.id != i("rootfs")]
     encrypted += [
         Luks(id=i("crypt"), backing=i("rootpart"), name="root"),
@@ -879,3 +879,64 @@ def test_the_kernel_package_table_is_the_only_one() -> None:
             if named == members:
                 copies.append(f"{path.relative_to(root)}:{node.lineno}")
     assert copies == [], copies
+
+
+def test_every_way_of_unlocking_remotely_is_decided_and_none_is_decided_twice() -> None:
+    """The nine combinations of root and bootloader, each with remote unlock
+    asked for. Written out because the rules were added one at a time and the
+    reason an operator is shown has to be the reason that applies: an
+    unencrypted pool must not be refused for native encryption, and a native
+    pool under ZFSBootMenu must not be refused at all.
+    """
+    from gentoo_install.model.device import ZfsPool
+
+    def luks() -> list[Node]:
+        nodes = [node for node in ext4_on_gpt() if node.id != i("rootfs")]
+        return nodes + [
+            Luks(id=i("crypt"), backing=i("rootpart"), name="root"),
+            Filesystem(id=i("rootfs"), device=i("crypt"), kind=FilesystemType.EXT4),
+        ]
+
+    def pool(encrypted: bool) -> list[Node]:
+        return [
+            replace(
+                node,
+                encrypted=encrypted,
+                passphrase_file="/run/keys/pool" if encrypted else "",
+            )
+            if isinstance(node, ZfsPool)
+            else node
+            for node in zfs_root()
+        ]
+
+    overlay = PortageConfig(
+        overlays=(Overlay(name="gentoo-zh", sync_uri="https://example.invalid/o.git"),)
+    )
+
+    def refusals(nodes: list[Node], kind: Bootloader) -> set[Trait]:
+        installation = boots(config(nodes), kind, Firmware.UEFI)
+        installation = replace(
+            installation,
+            system=replace(installation.system, authorized_keys=(VALID_KEY,)),
+            kernel=KernelConfig(remote_unlock=RemoteUnlock(enabled=True)),
+            portage=overlay,
+        )
+        return {
+            rule.excludes
+            for rule in violations(installation)
+            if rule.when is Trait.REMOTE_UNLOCK
+        }
+
+    expected: dict[tuple[str, Bootloader], set[Trait]] = {
+        ("luks", Bootloader.GRUB): {Trait.GRUB_UNLOCKS_BOOT},
+        ("luks", Bootloader.SYSTEMD_BOOT): set(),
+        ("native", Bootloader.GRUB): {Trait.NATIVE_ZFS_SYSTEM_INITRAMFS},
+        ("native", Bootloader.SYSTEMD_BOOT): {Trait.NATIVE_ZFS_SYSTEM_INITRAMFS},
+        ("native", Bootloader.ZFSBOOTMENU): set(),
+        ("plain", Bootloader.GRUB): {Trait.NO_ENCRYPTED_CONTAINER},
+        ("plain", Bootloader.SYSTEMD_BOOT): {Trait.NO_ENCRYPTED_CONTAINER},
+        ("plain", Bootloader.ZFSBOOTMENU): {Trait.NO_ENCRYPTED_CONTAINER},
+    }
+    layouts = {"luks": luks(), "native": pool(True), "plain": pool(False)}
+    for (name, kind), wanted in expected.items():
+        assert refusals(layouts[name], kind) == wanted, (name, kind)


### PR DESCRIPTION
Prompted by a question about the ZFS, ZFSBootMenu and GRUB combinations. Working the nine cases out by hand says the table is right, but two things in it were not.

The comment added with #418 gave ZFSBootMenu systemd-boot's reason: that it reads the kernel off the esp. It does not — the kernel stays in the pool, which is why `generate-zbm` builds an image at all. ZFSBootMenu is exempt because it asks for the key from its own image, which carries `crypt-ssh` and dropbear, so the question reaches the network instead of the physical console. Same exemption, different reason, and the reason is the part worth keeping.

The rules were added one at a time and nothing held them together, so the test now states all nine outcomes: LUKS under GRUB needs a readable /boot, LUKS under systemd-boot is fine, a native pool is refused under GRUB and systemd-boot and allowed under ZFSBootMenu, and an unencrypted pool is refused everywhere for having nothing to unlock — not for native encryption. Removing the ZFSBootMenu exemption and treating an unencrypted pool as encrypted each turn it red.

`zfs-zbm` is the only fixture on that path and it has no green verdict yet: it needs the gentoo-zh overlay, which the cluster cannot reach.