### PR TITLE
vm: refuse a fixture that needs qemu's user-mode network here

### DIFF
--- a/tests/unit/test_cluster.py
+++ b/tests/unit/test_cluster.py
@@ -1040,3 +1040,21 @@ def test_the_seed_and_the_flags_compose_the_way_the_call_site_reads() -> None:
     assert node not in unreachable((), (node,))
     # Negative control: allowing an unrelated node does not clear the seed.
     assert node in unreachable((), ("infra-node9",))
+
+
+def test_a_fixture_that_needs_user_mode_networking_is_refused_here() -> None:
+    """`vm-proxy` and `vm-proxy-http` reach `10.0.2.2`, which is the machine
+    running qemu as its user-mode network presents it. A cluster guest is
+    bridged and has no such host, so every fetch times out: the two of them
+    spent 116.0 and 112.8 minutes proving it in one round."""
+    import pytest
+
+    for name in ("vm-proxy", "vm-proxy-http"):
+        with pytest.raises(SystemExit, match="user-mode network"):
+            cluster.fixtures([name])
+
+    # Negative control: a dead proxy at 127.0.0.1 is dead on any machine, so it
+    # is a real cluster fixture and must not be swept up by the guard.
+    assert cluster.fixtures(["vm-proxy-dead"])[0].name == "vm-proxy-dead"
+    # And so is every fixture that names no proxy at all.
+    assert cluster.fixtures(["vm-xfs", "zfs-zbm"])

--- a/tests/vm/cluster.py
+++ b/tests/vm/cluster.py
@@ -18,6 +18,7 @@ from __future__ import annotations
 
 import argparse
 import fcntl
+import ipaddress
 import itertools
 import json
 import os
@@ -2765,6 +2766,26 @@ def _compiles(config: InstallConfig) -> bool:
     return True
 
 
+#: qemu's user-mode network, where `10.0.2.2` is the machine running qemu and
+#: `10.0.2.3` is its resolver. A cluster guest is bridged and has neither, so a
+#: fixture naming one of them can only run under `tests/vm/run.py`. Dispatching
+#: `vm-proxy` and `vm-proxy-http` here anyway cost 116.0 and 112.8 minutes,
+#: both spent timing out on a proxy that was never going to answer.
+USER_MODE_NETWORK: Final[str] = "10.0.2.0/24"
+
+
+def _needs_user_mode_networking(config: InstallConfig) -> str:
+    """The address that only the local hypervisor provides, or empty."""
+    if not config.proxy.host:
+        return ""
+    network = ipaddress.ip_network(USER_MODE_NETWORK)
+    try:
+        host = ipaddress.ip_address(config.proxy.host)
+    except ValueError:
+        return ""
+    return config.proxy.host if host in network else ""
+
+
 def fixtures(names: list[str]) -> list[Job]:
     found: list[Job] = []
     for name in names:
@@ -2772,6 +2793,12 @@ def fixtures(names: list[str]) -> list[Job]:
         if not path.is_file():
             raise SystemExit(f"no fixture named {name} at {path}")
         config: InstallConfig = load(path)
+        local_only = _needs_user_mode_networking(config)
+        if local_only:
+            raise SystemExit(
+                f"{name} reaches {local_only}, which only qemu's user-mode network "
+                "provides: run it with tests/vm/run.py, not on the cluster"
+            )
         convert_to: Path | None = None
         if config.disk.mode is DiskMode.IN_PLACE:
             # A conversion needs a machine to convert, so the job installs one


### PR DESCRIPTION
`vm-proxy` failed at 116.0 minutes and `vm-proxy-http` at 112.8, both with `DownloadFailed: … latest-stage3-amd64-systemd.txt could not be read: <urlopen error timed out>`. `vm-proxy.toml`'s own header already says why: `10.0.2.2 is the workstation as qemu's user-mode network presents it, so this fixture runs under tests/vm/run.py and not on the cluster`. A cluster guest is bridged and has no such host.

Nothing enforced that, so the scheduler took them and spent 3.8 hours of cluster time proving a proxy that could never answer does not answer. `fixtures()` now refuses them by name and says which command to use instead.

The guard is the address, not the presence of a proxy: `vm-proxy-dead` points at `127.0.0.1:1`, which is dead on any machine and is a real cluster fixture. Widening the check to any proxy sweeps it up, and that is the negative control.