### PR TITLE
fetch: a body that stops early is a download failure

### DIFF
--- a/gentoo_install/exec/fetch.py
+++ b/gentoo_install/exec/fetch.py
@@ -222,7 +222,7 @@ def _probe(mirror: str, proxy: ProxyConfig | None = None) -> float:
     try:
         with _urlopen(_asked(url), proxy, PROBE_TIMEOUT) as response:
             response.read(1 << 16)
-    except (urllib.error.URLError, TimeoutError, OSError):
+    except (urllib.error.URLError, TimeoutError, OSError, http.client.HTTPException):
         return float("inf")
     return time.monotonic() - started
 
@@ -329,7 +329,7 @@ def upload(
     try:
         with _urlopen(request, proxy, TIMEOUT) as response:
             answered = json.loads(response.read().decode())
-    except (urllib.error.URLError, TimeoutError, OSError) as error:
+    except (urllib.error.URLError, TimeoutError, OSError, http.client.HTTPException) as error:
         raise UploadFailed(f"{paste.HOST} did not take the paste: {error}") from error
     except ValueError as error:
         raise UploadFailed(f"{paste.HOST} answered something that is not JSON") from error
@@ -363,7 +363,7 @@ def network_time(proxy: ProxyConfig | None = None) -> float:
         request = _asked(CLOCK_URL, method="HEAD")
         with _urlopen(request, proxy, PROBE_TIMEOUT) as response:
             stamp = response.headers.get("Date", "")
-    except (urllib.error.URLError, TimeoutError, OSError):
+    except (urllib.error.URLError, TimeoutError, OSError, http.client.HTTPException):
         return 0.0
     try:
         return parsedate_to_datetime(stamp).timestamp()
@@ -892,7 +892,7 @@ def _read_once(url: str, proxy: ProxyConfig | None = None) -> str:
     try:
         with _urlopen(_asked(url), proxy, TIMEOUT) as response:
             return str(response.read().decode("utf-8", "replace"))
-    except (urllib.error.URLError, TimeoutError, OSError) as error:
+    except (urllib.error.URLError, TimeoutError, OSError, http.client.HTTPException) as error:
         raise DownloadFailed(f"{url} could not be read: {error}{_resolver_state(url)}") from error
 
 
@@ -1026,7 +1026,11 @@ def _download_once(
                 if log is not None and time.monotonic() - said >= PROGRESS_INTERVAL:
                     said = time.monotonic()
                     log(_progress(target.name, got, total))
-    except (urllib.error.URLError, TimeoutError, OSError) as error:
+    # `http.client.HTTPException` beside the rest: `IncompleteRead` is one and
+    # is not an `OSError`, so a server closing the connection with bytes still
+    # promised escaped this handler, left the `.part` file behind and stopped
+    # the install instead of reaching the next mirror.
+    except (urllib.error.URLError, TimeoutError, OSError, http.client.HTTPException) as error:
         partial.unlink(missing_ok=True)
         raise DownloadFailed(f"{url} could not be fetched: {error}") from error
     partial.replace(target)

--- a/tests/unit/test_fetch.py
+++ b/tests/unit/test_fetch.py
@@ -281,3 +281,38 @@ def test_a_corrupt_archive_is_removed_so_the_next_mirror_downloads_again(
     with pytest.raises(ArchiveDigestMismatch):
         fetch._verify_digest(archive, digests)
     assert archive.exists(), "the check itself does not remove anything"
+
+
+def test_a_body_that_stops_early_is_a_download_failure(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """`http.client.IncompleteRead` is an `HTTPException` and not an `OSError`,
+    so a server that closed the connection with bytes still promised escaped
+    the handler: the `.part` file stayed behind and the install stopped instead
+    of reaching the next mirror."""
+    import http.client
+
+    assert not issubclass(http.client.IncompleteRead, OSError), "the whole reason"
+
+    class Truncated:
+        def __enter__(self) -> "Truncated":
+            return self
+
+        def __exit__(self, *unused: object) -> None:
+            return None
+
+        @property
+        def headers(self) -> dict[str, str]:
+            return {"Content-Length": "1024"}
+
+        def read(self, size: int = 0) -> bytes:
+            raise http.client.IncompleteRead(b"half", 1020)
+
+    monkeypatch.setattr(fetch, "_urlopen", lambda *unused, **ignored: Truncated())
+    target = tmp_path / "stage3.tar.xz"
+    with pytest.raises(DownloadFailed, match="could not be fetched"):
+        fetch._download("https://example.invalid/stage3.tar.xz", target)
+
+    # The partial file goes with it, or the next mirror verifies this one.
+    assert not target.with_suffix(target.suffix + ".part").exists()
+    assert not target.exists()


### PR DESCRIPTION
Every response read in this module caught `(urllib.error.URLError, TimeoutError, OSError)`. `http.client.IncompleteRead` is none of those — `issubclass(http.client.IncompleteRead, OSError)` is `False`, it descends from `HTTPException` — and it is what `response.read()` raises when a server closes the connection with bytes still promised by `Content-Length`.

So a truncated stage3 did not become a `DownloadFailed`. It escaped `_download` past the `partial.unlink`, left the `.part` file behind, and skipped the mirror-fallback loop that exists for exactly this: the install stopped on the first flaky mirror rather than trying the next. Round 38 lost four guests to a link that delivered four different SHA512s of one archive, which is the same failure family one step further along.

`RemoteDisconnected` was already covered — it is a `ConnectionResetError` and so an `OSError`. The four other response reads in the module take the same widening, since a truncated body is a transport failure wherever it happens.