### PR TITLE
vm: drop the screenshot this cluster's api does not serve

### DIFF
--- a/tests/unit/test_proxmox.py
+++ b/tests/unit/test_proxmox.py
@@ -3433,3 +3433,19 @@ def test_the_editor_is_given_ten_presses_before_it_is_called_a_failure() -> None
 
     signature = inspect.signature(proxmox.append_to_cmdline)
     assert signature.parameters["timeout"].default == proxmox.EDITOR_PATIENCE
+
+
+def test_the_cluster_serves_no_screenshot_so_none_is_offered() -> None:
+    """`Guest.screenshot` read `GET /nodes/{node}/qemu/{vmid}/screenshot` and
+    answered `None` on any `ProxmoxError`. Proxmox VE 9.2.10 answers that path
+    `501 Method 'GET …/screenshot' not implemented`, so it could only ever have
+    answered `None` — a diagnostic that reports "no screen" for ever, on the
+    one path that has no other diagnostic.
+
+    Nothing called it. It is named here so that a reader who wants the VGA
+    console for the BIOS fixtures learns the endpoint does not exist rather
+    than adding a caller and reading `None`.
+    """
+    from tests.vm.proxmox import Guest
+
+    assert not hasattr(Guest, "screenshot")

--- a/tests/vm/proxmox.py
+++ b/tests/vm/proxmox.py
@@ -578,19 +578,6 @@ class Guest:
     def console(self) -> ConsoleChannel:
         return ConsoleChannel.open(self.api, self.node, self.vmid)
 
-    def screenshot(self, into: Path) -> Path | None:
-        """What is on the VGA console. A BIOS guest asking GRUB's own
-        passphrase prompt writes nothing to the serial port, so a run that
-        looks hung is diagnosed here or not at all."""
-        try:
-            raw = self.api.call("GET", f"/nodes/{self.node}/qemu/{self.vmid}/screenshot")
-        except ProxmoxError:
-            return None
-        if not isinstance(raw, str):
-            return None
-        into.write_text(raw)
-        return into
-
     #: Between keystrokes, and how many times one is repeated. Every key is a
     #: separate request over a new TLS connection, and twenty of them in a row
     #: were answered `Remote end closed connection without response`; a dropped


### PR DESCRIPTION
`Guest.screenshot` read `GET /nodes/{node}/qemu/{vmid}/screenshot` and returned `None` on any `ProxmoxError`. Asking that path on a running guest here answers `501 Method 'GET /nodes/infra-node5/qemu/9310/screenshot' not implemented` — Proxmox VE 9.2.10 does not have the endpoint. So the method could only ever have answered `None`.

Its docstring promised the one thing the BIOS fixtures lack: "A BIOS guest asking GRUB's own passphrase prompt writes nothing to the serial port, so a run that looks hung is diagnosed here or not at all." Nothing called it, and a caller added on the strength of that sentence would have read `None` for ever and concluded the screen was blank.

The test records the measurement rather than only removing the code, so the next reader who wants the VGA console learns the endpoint does not exist instead of writing the caller.