### PR TITLE
vm: aim the blind edit at the menu diskread dates

### DIFF
--- a/tests/unit/test_proxmox.py
+++ b/tests/unit/test_proxmox.py
@@ -3113,15 +3113,27 @@ def test_the_blind_edit_leaves_no_gap_in_when_the_menu_could_appear() -> None:
     from tests.vm.proxmox import BIOS_ATTEMPTS, BIOS_MENU_TIMEOUT
 
     delays = sorted({delay for delay, _ in BIOS_ATTEMPTS})
-    # The earliest sample covers a menu that is up at once.
-    assert delays[0] <= BIOS_MENU_TIMEOUT, delays
+    # The cover starts before the menu can: GRUB itself has to load first, and
+    # that finished at 12.7s and 13.6s on the two guests measured. Sampling
+    # earlier than that spends a boot on a menu that is not drawn yet, which is
+    # what the first two sets of samples did with all of theirs.
+    grub_is_loaded = 12.7
+    assert delays[0] - BIOS_MENU_TIMEOUT <= grub_is_loaded, delays
     # No gap: consecutive samples closer together than the countdown.
     for earlier, later in zip(delays, delays[1:]):
         assert later - earlier < BIOS_MENU_TIMEOUT, (earlier, later)
-    # And the cover reaches past a loaded node's menu. `vm-mdraid` needed more
-    # than thirty seconds to open a readable UEFI editor on such a node, so
-    # stopping at nine is what made every BIOS fixture unreachable.
-    assert delays[-1] >= 15.0, delays
+    # And the cover brackets the menu, which was measured rather than guessed:
+    # two guests booted the ordinary medium with nothing typed at them, and
+    # `diskread` stepped by tens of megabytes — GRUB loading the kernel, which
+    # it does when the countdown ends — at 33.4s on an idle node and 59.4s on
+    # one at 98% cpu. The menu is up for `BIOS_MENU_TIMEOUT` before each.
+    idle_kernel_load, busy_kernel_load = 33.4, 59.4
+    for load in (idle_kernel_load, busy_kernel_load):
+        menu = load - BIOS_MENU_TIMEOUT
+        assert any(menu < delay <= menu + BIOS_MENU_TIMEOUT for delay in delays), (
+            load,
+            delays,
+        )
     assert len({down for _, down in BIOS_ATTEMPTS}) > 1, "one line is one guess"
 
     # Bounded: each attempt costs its delay, the keystrokes and a wait for the

--- a/tests/vm/proxmox.py
+++ b/tests/vm/proxmox.py
@@ -891,31 +891,35 @@ _PLACED: Final[re.Pattern[bytes]] = re.compile(rb"\x1b\[(\d+);\d+H([^\x1b]*)")
 BIOS_MENU_TIMEOUT: Final[float] = 10.0
 
 #: When to press `e`, counted from the guest being started, paired with the
-#: line to move to. Nothing on the serial port says when the menu appeared —
-#: not SeaBIOS, not `Welcome to GRUB!`, nothing until the kernel speaks, and
-#: every BIOS log in `lab/` holds the guest's boot and no marker before it — so
-#: the moment is sampled rather than waited for.
+#: line to move to. Nothing on the serial port says when the menu appeared, and
+#: two other ways of finding out were measured and closed on 2026-08-17: the
+#: `screenshot` endpoint answers `501 not implemented`, and `args`, which would
+#: carry SeaBIOS's serial console, is refused to every token but root's.
 #:
-#: A sample at `d` lands when the menu appeared at some `t` with `d - 10 < t <=
-#: d`, because GRUB counts `BIOS_MENU_TIMEOUT` down from `t` and a key before
-#: `t` goes nowhere. Each attempt is its own boot, so the samples cover the
-#: union of those windows: spacing them under `BIOS_MENU_TIMEOUT` leaves no gap
-#: between the earliest and the latest.
+#: What is readable is `diskread`, and it dates the one event that matters.
+#: GRUB loads the kernel and the initramfs when its countdown ends, and that is
+#: tens of megabytes in one step. Two guests booted the ordinary medium with
+#: nothing typed at them:
 #:
-#: The samples used to stop at nine seconds, which covered a menu up at nine
-#: and nothing later, and no run has ever printed the line this function prints
-#: when an edit lands. Nodes measured between 80% and 100% busy all night, and
-#: `vm-mdraid`'s readable UEFI menu needed more than thirty seconds there, so
-#: a menu appearing after ten is the case to cover rather than the one to rule
-#: out.
+#:   idle node        +86 MB at 12.7s, quiet, +7/20/13 MB from 33.4s
+#:   node at 98% cpu  +86 MB at 13.6s, quiet, +40 MB at 59.4s
+#:
+#: So the kernel starts loading at 33s on an idle node and at about 50s on a
+#: busy one, and with `timeout=10` the menu is up for the ten seconds before
+#: that: roughly 23s to 33s, or 39s to 49s. Every sample ever tried was under
+#: 17s, which is why not one run has printed the line below.
+#:
+#: A sample at `d` lands when the menu appeared at some `t` with
+#: `d - BIOS_MENU_TIMEOUT < t <= d`, and each attempt is its own boot, so the
+#: samples cover the union of those windows.
 BIOS_ATTEMPTS: Final[tuple[tuple[float, int], ...]] = (
-    (6.0, 2),
-    (9.0, 2),
-    (13.0, 2),
-    (17.0, 2),
-    (3.0, 2),
-    (6.0, 1),
-    (13.0, 3),
+    (22.0, 2),
+    (30.0, 2),
+    (38.0, 2),
+    (46.0, 2),
+    (54.0, 2),
+    (30.0, 1),
+    (30.0, 3),
 )
 
 #: What the kernel prints once `console=ttyS0` is on its command line, and the


### PR DESCRIPTION
The BIOS fixtures have never once landed the edit — grepping every log under `lab/` for the line `append_to_cmdline_blind` prints on success returns nothing but the source line. Two sets of samples had been guessed, 3–9s and then 3–17s, and both were guesses because nothing on the serial port says when the menu appeared.

Two other ways to find out were measured and closed first. `GET .../screenshot` answers `501 not implemented` on PVE 9.2.10 (#424). `PUT .../config args=…`, which would carry SeaBIOS's serial console, answers `500 only root can set 'args' config` — a token with all 42 privileges on `/` is still not root.

What is readable is `diskread`. GRUB loads the kernel and initramfs when its countdown ends, and that is tens of megabytes in one step. Two guests booted the ordinary medium with nothing typed at them: the step is at 33.4s on an idle node and 59.4s on one at 98% cpu, so with `timeout=10` the menu is up 23–33s and 39–49s. Every sample ever tried sat below 17s — under the window in both cases, which is the whole explanation.

Samples now run 22 to 54s. The test checks the two measured loads against the cover rather than a bound: either earlier sample set, and dropping the 54s sample, each turn it red. Still unverified — the next round is what says whether the window holds on a third node.