### PR TITLE
Revert "vm: aim the blind edit at the menu diskread dates"

### DIFF
--- a/tests/unit/test_proxmox.py
+++ b/tests/unit/test_proxmox.py
@@ -3113,27 +3113,15 @@ def test_the_blind_edit_leaves_no_gap_in_when_the_menu_could_appear() -> None:
     from tests.vm.proxmox import BIOS_ATTEMPTS, BIOS_MENU_TIMEOUT
 
     delays = sorted({delay for delay, _ in BIOS_ATTEMPTS})
-    # The cover starts before the menu can: GRUB itself has to load first, and
-    # that finished at 12.7s and 13.6s on the two guests measured. Sampling
-    # earlier than that spends a boot on a menu that is not drawn yet, which is
-    # what the first two sets of samples did with all of theirs.
-    grub_is_loaded = 12.7
-    assert delays[0] - BIOS_MENU_TIMEOUT <= grub_is_loaded, delays
+    # The earliest sample covers a menu that is up at once.
+    assert delays[0] <= BIOS_MENU_TIMEOUT, delays
     # No gap: consecutive samples closer together than the countdown.
     for earlier, later in zip(delays, delays[1:]):
         assert later - earlier < BIOS_MENU_TIMEOUT, (earlier, later)
-    # And the cover brackets the menu, which was measured rather than guessed:
-    # two guests booted the ordinary medium with nothing typed at them, and
-    # `diskread` stepped by tens of megabytes — GRUB loading the kernel, which
-    # it does when the countdown ends — at 33.4s on an idle node and 59.4s on
-    # one at 98% cpu. The menu is up for `BIOS_MENU_TIMEOUT` before each.
-    idle_kernel_load, busy_kernel_load = 33.4, 59.4
-    for load in (idle_kernel_load, busy_kernel_load):
-        menu = load - BIOS_MENU_TIMEOUT
-        assert any(menu < delay <= menu + BIOS_MENU_TIMEOUT for delay in delays), (
-            load,
-            delays,
-        )
+    # And the cover reaches past a loaded node's menu. `vm-mdraid` needed more
+    # than thirty seconds to open a readable UEFI editor on such a node, so
+    # stopping at nine is what made every BIOS fixture unreachable.
+    assert delays[-1] >= 15.0, delays
     assert len({down for _, down in BIOS_ATTEMPTS}) > 1, "one line is one guess"
 
     # Bounded: each attempt costs its delay, the keystrokes and a wait for the

--- a/tests/vm/proxmox.py
+++ b/tests/vm/proxmox.py
@@ -891,35 +891,38 @@ _PLACED: Final[re.Pattern[bytes]] = re.compile(rb"\x1b\[(\d+);\d+H([^\x1b]*)")
 BIOS_MENU_TIMEOUT: Final[float] = 10.0
 
 #: When to press `e`, counted from the guest being started, paired with the
-#: line to move to. Nothing on the serial port says when the menu appeared, and
-#: two other ways of finding out were measured and closed on 2026-08-17: the
-#: `screenshot` endpoint answers `501 not implemented`, and `args`, which would
-#: carry SeaBIOS's serial console, is refused to every token but root's.
+#: line to move to. Nothing on the serial port says when the menu appeared —
+#: not SeaBIOS, not `Welcome to GRUB!`, nothing until the kernel speaks, and
+#: every BIOS log in `lab/` holds the guest's boot and no marker before it — so
+#: the moment is sampled rather than waited for.
 #:
-#: What is readable is `diskread`, and it dates the one event that matters.
-#: GRUB loads the kernel and the initramfs when its countdown ends, and that is
-#: tens of megabytes in one step. Two guests booted the ordinary medium with
-#: nothing typed at them:
+#: A sample at `d` lands when the menu appeared at some `t` with `d - 10 < t <=
+#: d`, because GRUB counts `BIOS_MENU_TIMEOUT` down from `t` and a key before
+#: `t` goes nowhere. Each attempt is its own boot, so the samples cover the
+#: union of those windows: spacing them under `BIOS_MENU_TIMEOUT` leaves no gap
+#: between the earliest and the latest.
 #:
-#:   idle node        +86 MB at 12.7s, quiet, +7/20/13 MB from 33.4s
-#:   node at 98% cpu  +86 MB at 13.6s, quiet, +40 MB at 59.4s
+#: The samples used to stop at nine seconds, which covered a menu up at nine
+#: and nothing later, and no run has ever printed the line this function prints
+#: when an edit lands. Nodes measured between 80% and 100% busy all night, and
+#: `vm-mdraid`'s readable UEFI menu needed more than thirty seconds there, so
+#: a menu appearing after ten is the case to cover rather than the one to rule
+#: out.
 #:
-#: So the kernel starts loading at 33s on an idle node and at about 50s on a
-#: busy one, and with `timeout=10` the menu is up for the ten seconds before
-#: that: roughly 23s to 33s, or 39s to 49s. Every sample ever tried was under
-#: 17s, which is why not one run has printed the line below.
-#:
-#: A sample at `d` lands when the menu appeared at some `t` with
-#: `d - BIOS_MENU_TIMEOUT < t <= d`, and each attempt is its own boot, so the
-#: samples cover the union of those windows.
+#: Not later than that, though. `diskread` dates GRUB's countdown on a *cold*
+#: start — the kernel load steps by tens of megabytes at 33.4s on an idle node
+#: and 59.4s at 98% cpu — and moving the samples out to meet it made things
+#: worse, because every attempt here follows a `reset` of a guest that has
+#: already booted once, where the medium is in the host's cache and
+#: `Welcome to GRUB!` arrives 1.9s later. The two clocks are not the same one.
 BIOS_ATTEMPTS: Final[tuple[tuple[float, int], ...]] = (
-    (22.0, 2),
-    (30.0, 2),
-    (38.0, 2),
-    (46.0, 2),
-    (54.0, 2),
-    (30.0, 1),
-    (30.0, 3),
+    (6.0, 2),
+    (9.0, 2),
+    (13.0, 2),
+    (17.0, 2),
+    (3.0, 2),
+    (6.0, 1),
+    (13.0, 3),
 )
 
 #: What the kernel prints once `console=ttyS0` is on its command line, and the


### PR DESCRIPTION
The measurement in #425 is real and the conclusion drawn from it was wrong. `diskread` dates GRUB's countdown on a **cold** start: 33.4s on an idle node, 59.4s at 98% cpu. Every attempt in `append_to_cmdline_blind` follows a `reset` of a guest that has already booted once, where the medium is in the host's cache — `memory/what-the-bios-blind-edit-experiments-measured.md` has `Welcome to GRUB!` arriving 1.9 to 2.0 seconds after a reset, measured twice. Moving the samples out to 22–54s aimed them at a clock the loop does not run on.

That entry also records something #425's premise contradicts: the edit does land. Round twelve read the kernel command line off three BIOS guests and `console=ttyS0,115200` was on it, with the kernel printing to 1.94s. My grep proved only that the success line never appears in a log, which is a weaker statement than the one I built on.

So the samples go back to #416's, and the comment now says why later is wrong as well as why earlier was. The real question is the one that entry already names: the BIOS guests stop after the kernel hands off to the initramfs, not at the GRUB edit.