### PR TITLE
vm: read the prompt a refusal leaves behind before naming the user again

### DIFF
--- a/tests/unit/test_cluster.py
+++ b/tests/unit/test_cluster.py
@@ -1058,3 +1058,65 @@ def test_a_fixture_that_needs_user_mode_networking_is_refused_here() -> None:
     assert cluster.fixtures(["vm-proxy-dead"])[0].name == "vm-proxy-dead"
     # And so is every fixture that names no proxy at all.
     assert cluster.fixtures(["vm-xfs", "zfs-zbm"])
+
+
+def test_the_prompt_after_a_refusal_is_read_before_the_name_is_offered_again(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """`Login incorrect` matches before the prompt that follows it, so that
+    prompt stayed in the buffer. `_name_the_user` read it, called it a login
+    prompt, and offered the name again — and the second name landed in the
+    password field. `vm-lvm` failed at 55.6 minutes with `root` echoed under
+    `Password:`, which is what a name in that field looks like.
+    """
+    monkeypatch.setattr("time.sleep", lambda seconds: None)
+
+    class Agetty:
+        """A login that writes its prompt and its refusal as separate reads,
+        which is what leaves one of them behind."""
+
+        def __init__(self, refusals: int) -> None:
+            self.refusals = refusals
+            self.sent: list[str] = []
+            self.pending: list[bytes] = []
+            #: What the guest is waiting for. A name sent here is echoed; a
+            #: password is not, which is how the two are told apart below.
+            self.wants = "name"
+            self.into_the_password_field: list[str] = []
+
+        def respond(self, line: str) -> None:
+            self.sent.append(line)
+            if self.wants == "name":
+                self.wants = "password"
+                self.pending.append(b"Password: ")
+                return
+            if line != "install":
+                self.into_the_password_field.append(line)
+            self.wants = "name"
+            if self.refusals > 0 and line != "install":
+                self.refusals -= 1
+                self.pending.append(b"\r\nLogin incorrect\r\n")
+                self.pending.append(b"lvmbox login: ")
+                return
+            if self.refusals > 0:
+                self.refusals -= 1
+                self.pending.append(b"\r\nLogin incorrect\r\n")
+                self.pending.append(b"lvmbox login: ")
+                return
+            self.pending.append(b"lvmbox ~ # ")
+
+        def observe(self, pattern: str, timeout: float = 0.0) -> bytes:
+            if not self.pending:
+                raise ConsoleTimeout("nothing more")
+            return self.pending.pop(0)
+
+    console = Agetty(refusals=2)
+    assert cluster._log_in(cast(cluster.Reconnecting, console), "install") == ""
+    # Nothing but the password ever reached the password field.
+    assert console.into_the_password_field == [], console.sent
+    assert console.sent.count("root") == 3, console.sent
+
+    # Negative control: a login that never comes back still ends rather than
+    # waiting on a prompt that is not coming.
+    stubborn = Agetty(refusals=99)
+    assert "refused" in cluster._log_in(cast(cluster.Reconnecting, stubborn), "install")

--- a/tests/vm/cluster.py
+++ b/tests/vm/cluster.py
@@ -2292,6 +2292,11 @@ PASSWORD_ECHO_OFF_AFTER: Final[float] = 1.0
 PASSWORD_ECHO_BACKOFF: Final[float] = 2.0
 PASSWORD_ECHO_CATCHES: Final[int] = 3
 
+#: How long the prompt that follows a refusal is waited for before the next
+#: attempt. `login` writes it at once, so this only has to outlast a loaded
+#: node rather than anything the guest is doing.
+REPROMPT_PATIENCE: Final[float] = 30.0
+
 
 def _log_in(link: Reconnecting, password: str) -> str:
     """Log root in, and say what is wrong when it does not happen.
@@ -2321,6 +2326,15 @@ def _log_in(link: Reconnecting, password: str) -> str:
             settle += PASSWORD_ECHO_BACKOFF
             continue
         refusals += 1
+        # `Login incorrect` matches before the prompt that follows it, so the
+        # re-prompt stays in the buffer. `_name_the_user` then reads that one,
+        # calls it a login prompt, and offers the name a second time — and the
+        # second one lands in the password field. `vm-lvm` failed at 55.6
+        # minutes with `root` echoed under `Password:` for exactly that.
+        try:
+            link.observe(r"login:", timeout=REPROMPT_PATIENCE)
+        except ConsoleTimeout:
+            pass
     return "the installed system refused every login"
 
 


### PR DESCRIPTION
`vm-lvm` failed at 55.6 minutes with #410 already in place, and the verdict carries the mechanism: `b' \r\nroot\r\nMaximum number of tries exceeded (5)'`. `root` echoed where a password goes is a name in the password field.

`_log_in` observes `#|\$|Login incorrect`, and `Login incorrect` matches before the `lvmbox login: ` that `login` writes immediately after it — so that prompt stays in the buffer. The next `_name_the_user` reads it, sees `login:`, concludes its name was not taken and sends `root` again. By then the guest is at the password prompt, so the second name is the password, and the phase stays slipped for the rest of the attempts: the console shows `login: install` two lines later.

Reading that prompt before looping is the whole fix. The test's double writes the refusal and the prompt as separate reads, which is what leaves one behind, and counts what reaches the password field: without the drain it is `['root', 'root']`, which is the guest's own symptom.