### PR TITLE
tui: ask for the word before the irreversible swap

### DIFF
--- a/gentoo_install/cli.py
+++ b/gentoo_install/cli.py
@@ -46,6 +46,7 @@ from .model.config import (
 )
 from .exec.config import load
 from .plan import convert
+from .plan.convert import SWAP_CONFIRMATION
 from .plan.build import DEFAULT_MIRROR, build, running_config, stage3_mirror
 from .plan.operations import Context, Operation, Stage
 from .plan.portage import variant_of
@@ -387,10 +388,6 @@ def _release(
             # Release is best-effort because a prior failure owns the exit
             # category, but later release operations still have work to do.
             record(f"warning: {operation.describe()}: {error}")
-
-
-#: What an operator types to authorise the one step with no second attempt.
-SWAP_CONFIRMATION: Final[str] = "convert"
 
 
 def _confirmed_swap(

--- a/gentoo_install/data/locale/ja.toml
+++ b/gentoo_install/data/locale/ja.toml
@@ -565,3 +565,7 @@
 "Running system: " = "実行中のシステム: "
 "Conversion is not offered: " = "変換は提供しません: "
 "the conversion takes the layout from the running system" = "変換はレイアウトを実行中のシステムから取得します"
+"This replaces the running system and cannot be undone." = "実行中のシステムを置き換えます。元には戻せません。"
+"Replaced: " = "置き換える対象: "
+"Kept: /home, /root and every other mount." = "残す対象: /home、/root、およびその他のマウント。"
+"Type the word to confirm." = "この語を入力して確認してください。"

--- a/gentoo_install/data/locale/ko.toml
+++ b/gentoo_install/data/locale/ko.toml
@@ -565,3 +565,7 @@
 "Running system: " = "실행 중인 시스템: "
 "Conversion is not offered: " = "변환을 제공하지 않습니다: "
 "the conversion takes the layout from the running system" = "변환은 레이아웃을 실행 중인 시스템에서 가져옵니다"
+"This replaces the running system and cannot be undone." = "실행 중인 시스템을 교체하며 되돌릴 수 없습니다."
+"Replaced: " = "교체 대상: "
+"Kept: /home, /root and every other mount." = "유지 대상: /home, /root 및 그 밖의 모든 마운트."
+"Type the word to confirm." = "이 단어를 입력하여 확인하십시오."

--- a/gentoo_install/data/locale/zh-CN.toml
+++ b/gentoo_install/data/locale/zh-CN.toml
@@ -566,3 +566,7 @@
 "Running system: " = "正在运行的系统："
 "Conversion is not offered: " = "不提供就地转换："
 "the conversion takes the layout from the running system" = "就地转换的布局来自正在运行的系统"
+"This replaces the running system and cannot be undone." = "这会替换正在运行的系统，而且无法恢复。"
+"Replaced: " = "被替换："
+"Kept: /home, /root and every other mount." = "保留：/home、/root，以及其他每一个挂载点。"
+"Type the word to confirm." = "输入这个词确认。"

--- a/gentoo_install/data/locale/zh-TW.toml
+++ b/gentoo_install/data/locale/zh-TW.toml
@@ -566,3 +566,7 @@
 "Running system: " = "執行中的系統："
 "Conversion is not offered: " = "不提供就地轉換："
 "the conversion takes the layout from the running system" = "就地轉換的版面來自執行中的系統"
+"This replaces the running system and cannot be undone." = "這會取代執行中的系統，而且無法復原。"
+"Replaced: " = "被取代："
+"Kept: /home, /root and every other mount." = "保留：/home、/root，以及其他每一個掛載點。"
+"Type the word to confirm." = "輸入這個字確認。"

--- a/gentoo_install/plan/convert.py
+++ b/gentoo_install/plan/convert.py
@@ -22,6 +22,11 @@ from ..model.device import (
 from .operations import CommandOutput, Context, Operation, Stage
 
 
+#: What an operator types to agree to the swap, on the terminal and in the
+#: menu alike. One word in one place: the two asked with different ones, and an
+#: operator who had done it once on the command line could not answer the menu.
+SWAP_CONFIRMATION: Final[str] = "convert"
+
 REPLACED_DIRECTORIES: tuple[str, ...] = (
     "bin",
     "sbin",

--- a/gentoo_install/tui/screens.py
+++ b/gentoo_install/tui/screens.py
@@ -68,6 +68,7 @@ from ..model.device import (
     ZfsTopology,
 )
 from ..plan import automatic as automatic_values
+from ..plan.convert import REPLACED_DIRECTORIES, SWAP_CONFIRMATION
 from ..plan import kernel as plan_kernel
 from ..plan.fonts import CJK_SANS_PREFERENCE, CjkFontconfigLocale, FontCategory
 from ..model.compat import KERNEL_PACKAGES
@@ -430,11 +431,45 @@ def install_mode_screen(
     mode = answer.unwrap()
     if mode is config.disk.mode:
         return Answer(Outcome.CHOSE, config)
+    if mode is DiskMode.IN_PLACE:
+        agreed = _confirm_the_swap(screen, context)
+        if agreed is not None:
+            return agreed
     graph = DeviceGraph.build([]) if mode is DiskMode.IN_PLACE else config.disk.graph
     return Answer(
         Outcome.CHOSE,
         replace(config, disk=replace(config.disk, mode=mode, graph=graph, root=DeviceId(""))),
     )
+
+
+def _confirm_the_swap(screen: Screen, context: Context) -> Answer[InstallConfig] | None:
+    """None once the operator has typed the word, an outcome to return if not.
+
+    The swap is irreversible: `/home` and `/root` are outside
+    `REPLACED_DIRECTORIES` and survive, but that is not a way back — the old
+    `/usr`, `/etc` and `/var` are gone and the staging root is removed. So the
+    screen names what goes, names what stays, and asks for a word rather than a
+    keypress.
+    """
+    translate = context.translate
+    replaced = ", ".join("/" + name for name in REPLACED_DIRECTORIES)
+    question = Confirm(
+        **answers(translate),
+        title=translate("This replaces the running system and cannot be undone."),
+        phrase=SWAP_CONFIRMATION,
+        detail=(
+            f"{translate('Replaced: ')}{replaced}. "
+            f"{translate('Kept: /home, /root and every other mount.')} "
+            f"{translate('Type the word to confirm.')}"
+        ),
+        footer=footer(translate),
+    )
+    answer = question.run(screen)
+    if not answer.chosen:
+        return Answer(answer.outcome)
+    if answer.unwrap():
+        return None
+    return Answer(Outcome.BACK)
 
 
 def disk_screen(screen: Screen, config: InstallConfig, context: Context) -> Answer[InstallConfig]:

--- a/tests/unit/test_tui_app.py
+++ b/tests/unit/test_tui_app.py
@@ -1432,13 +1432,16 @@ def test_what_still_asks_before_it_changes() -> None:
         "Encrypt this array?",
         "Use DHCP?",
         "Unlock the root over SSH from the initramfs?",
+        "This replaces the running system and cannot be undone.",
         "Install",
     }
     for title in asked:
         assert title in source, title
-    # Five call sites, eight titles: one encryption editor serves three titles,
-    # and the slice screen words its title for a pool or for a partition.
-    assert source.count("Confirm(") == 5
+    # Six call sites, nine titles: one encryption editor serves three titles,
+    # and the slice screen words its title for a pool or for a partition. The
+    # sixth is the in-place swap, which takes a typed word for the same reason
+    # the erase screen does — it cannot be undone.
+    assert source.count("Confirm(") == 6
     # `settle` asks the same kind of question with three answers rather than
     # two, because the third opens the row the values land on.
     assert "This choice also sets" in source
@@ -3145,6 +3148,7 @@ def test_choosing_the_conversion_drops_the_device_graph() -> None:
     cannot run."""
     from gentoo_install.model.config import DiskMode
     from gentoo_install.model.validate import validate
+    from gentoo_install.plan import convert
 
     offering = app.MainMenuContext(screens.Context(
         translate=Catalog("en"),
@@ -3157,12 +3161,24 @@ def test_choosing_the_conversion_drops_the_device_graph() -> None:
     built = config()
     assert built.disk.graph.nodes, "the fixture starts with a layout"
 
-    screen = FakeScreen(keys=["KEY_DOWN", "\n"], lines=24, columns=110)
+    # Down to the conversion, enter, then the word it asks to be typed: a
+    # highlight and enter is not enough for something with no way back.
+    screen = FakeScreen(
+        keys=["KEY_DOWN", "\n", *convert.SWAP_CONFIRMATION, "\n"], lines=24, columns=110
+    )
     answer = screens.install_mode_screen(screen, built, offering)
     converted = answer.unwrap()
     assert converted.disk.mode is DiskMode.IN_PLACE
     assert not converted.disk.graph.nodes, converted.disk.graph.nodes
     validate(converted)
+
+    # The word is required, not decorative: a wrong one leaves the mode alone
+    # and the layout with it. Without this the screen could stop asking and
+    # every assertion above would still pass.
+    refused = FakeScreen(keys=["KEY_DOWN", "\n", *"nope", "\n"], lines=24, columns=110)
+    answer = screens.install_mode_screen(refused, built, offering)
+    assert not answer.chosen, answer.outcome
+    assert built.disk.mode is DiskMode.PARTITION
 
     # Negative control: staying on the disks keeps the layout untouched.
     staying = FakeScreen(keys=["\n"], lines=24, columns=110)


### PR DESCRIPTION
`#428` put the conversion in the menu and switched to it on a highlight and enter. `convert.py`'s own first line calls it "The irreversible userland swap": `/bin`, `/sbin`, `/etc`, `/lib`, `/lib64`, `/usr` and `/var` are replaced, the staging root is removed and the old `/boot` images are dropped. `/home` and `/root` surviving is not a way back.

The terminal path already asked for a typed word. The menu now asks with the same `Confirm` the erase screen uses for a disk, naming what goes and what stays, and `SWAP_CONFIRMATION` moves to `plan/convert.py` so both ask for the same word — they would otherwise have drifted, and an operator who had done it once on the command line could not answer the menu.

The test types a wrong word and asserts the mode is unchanged. Without that assertion the screen could stop asking and everything else would still pass — removing the confirmation is green until it is added, which is how I found it.