### PR TITLE
vm: the campaign docstring names a limit the code does not have

### DIFF
--- a/tests/vm/campaign.py
+++ b/tests/vm/campaign.py
@@ -6,8 +6,10 @@
 
 Every stage runs its own configurations at once; the stages themselves are
 ordered, and a failure in the first one stops the rest unless `--keep-going`
-says otherwise. Six at a time is what 60 GiB holds at the 8 GiB a guest is
-given, measured rather than assumed.
+says otherwise. How many run at once is decided by `_room_for_a_guest` against
+the memory the machine has at that moment, under a ceiling of `GUESTS`;
+starting `tests/vm/run.py` by hand instead goes around that admission control,
+and four guests started that way left this machine with 788 MiB free.
 """
 
 from __future__ import annotations


### PR DESCRIPTION
The module docstring said "Six at a time is what 60 GiB holds". `GUESTS` is four, and it is a ceiling rather than the limit — `_room_for_a_guest` decides against the memory the machine has at that moment, with `GUEST_BYTES` at 9 GiB and `HEADROOM_BYTES` at 8.

Measured tonight, and the reason I noticed: starting `tests/vm/run.py` four times by hand goes around that admission control entirely. Each guest reached 6.5 GiB resident and the machine dropped to 788 MiB free, under earlyoom's threshold, which prefers `qemu-system`. The campaign would have admitted two.