### PR TITLE
vm: keep enough of the screen a failed unlock left to read it

### DIFF
--- a/tests/unit/test_proxmox.py
+++ b/tests/unit/test_proxmox.py
@@ -1358,6 +1358,33 @@ def test_a_failed_remote_unlock_answers_with_what_the_console_held(
     assert "GNU GRUB" in refused, refused
     assert stuck_at_grub.console.asked == [cluster.UNLOCK_SCREEN_PATIENCE]
 
+    # Enough of it to reach the lines before the last prompt. `vm-unlock` came
+    # back holding only `Please enter passphrase for disk root`, which says the
+    # initramfs is running and nothing about why its network was not; the lines
+    # above it are the ones naming the services that started.
+    # The marker sits about 2.5 kB before the prompt, which is where the line
+    # that names a service that did or did not start would be. At 400 bytes it
+    # is cut and the verdict says only that a passphrase was asked for.
+    boot = (
+        b"[  OK  ] Started Network Configuration.\r\n"
+        + (
+            b"[  OK  ] Reached target Preparation for Network.\r\n"
+            b"         Starting dracut cmdline hook...\r\n"
+        ) * 25
+        + b"Please enter passphrase for disk root: "
+    )
+    assert len(boot) - boot.index(b"Started Network Configuration") > 2000, len(boot)
+    verbose = Link(boot)
+    said = cluster.boot_and_check(
+        cast(Any, Guest()),
+        cast(Any, verbose),
+        Path("unused"),
+        installation,
+        remote_key=Path("unused.key"),
+    )
+    assert "Started Network Configuration" in said, said
+    assert "passphrase for disk root" in said, said
+
     # Negative control: a console that produced nothing says so, rather than
     # an empty pair of quotes that reads as a screen that was read and blank.
     silent = Link(b"")

--- a/tests/vm/cluster.py
+++ b/tests/vm/cluster.py
@@ -2292,6 +2292,11 @@ PASSWORD_ECHO_OFF_AFTER: Final[float] = 1.0
 PASSWORD_ECHO_BACKOFF: Final[float] = 2.0
 PASSWORD_ECHO_CATCHES: Final[int] = 3
 
+#: What a verdict may carry. The console excerpt above is the reason it is not
+#: the 200 the other verdicts use: an excerpt cut to fit says less than none,
+#: because it reads as the whole screen.
+VERDICT_BYTES: Final[int] = 3600
+
 #: How long the prompt that follows a refusal is waited for before the next
 #: attempt. `login` writes it at once, so this only has to outlast a loaded
 #: node rather than anything the guest is doing.
@@ -2353,7 +2358,13 @@ UNLOCK_TRIES: Final[int] = 5
 #: reached, so this is a read of a screen that has stopped changing rather than
 #: a wait for anything.
 UNLOCK_SCREEN_PATIENCE: Final[float] = 5.0
-UNLOCK_SCREEN_BYTES: Final[int] = 400
+
+#: How much of that screen the verdict carries. Four hundred bytes held the
+#: passphrase prompt and stopped mid-escape-sequence, which answered "the
+#: initramfs is running" and nothing about why its network was not: the lines
+#: before it are the ones that say whether `systemd-networkd` started. Console
+#: output is escape-heavy, so this buys fewer lines than its size suggests.
+UNLOCK_SCREEN_BYTES: Final[int] = 3000
 
 
 class Typeable(Protocol):
@@ -2511,7 +2522,7 @@ def boot_and_check(
             # identically. The screen tells them apart.
             screen = link.console.snapshot(UNLOCK_SCREEN_PATIENCE)
             held = repr(screen[-UNLOCK_SCREEN_BYTES:]) if screen else "nothing"
-            return f"remote unlock failed: {error}; the console held {held}"[:600]
+            return f"remote unlock failed: {error}; the console held {held}"[:VERDICT_BYTES]
         remotely_unlocked = True
         print("installed root unlocked by remote SSH session", flush=True)
     unlocked = _unlock(guest, link, installation, remotely_unlocked)


### PR DESCRIPTION
The capture added in #407 has now answered `vm-unlock` twice. In run50, with #418 and #420 in place, it showed the guest past GRUB and inside the initramfs at `Please enter passphrase for disk root: (press TAB for no echo)` — so the separate /boot works, the kernel command line is right (`rd.neednet=1 ip=10.31.0.157::10.31.0.254:255.255.255.0:::none`, read off the guest's own `Command line:`), and what is left is the network inside the image.

Four hundred bytes is not enough to see that. The excerpt stopped mid-escape-sequence holding only the prompt; the lines that name which services started are above it, and console output is escape-heavy so the byte count buys fewer lines than it looks. The verdict's own truncation moves with it, since an excerpt cut to fit says less than none — it reads as the whole screen.

The test puts a marker 2 kB before the prompt and asserts it survives; at 400 it does not.