### PR TITLE
vm: let the cluster know a fixture that passes by failing

### DIFF
--- a/tests/unit/test_cluster.py
+++ b/tests/unit/test_cluster.py
@@ -1120,3 +1120,29 @@ def test_the_prompt_after_a_refusal_is_read_before_the_name_is_offered_again(
     # waiting on a prompt that is not coming.
     stubborn = Agetty(refusals=99)
     assert "refused" in cluster._log_in(cast(cluster.Reconnecting, stubborn), "install")
+
+
+def test_a_fixture_that_passes_by_failing_is_not_recorded_as_a_failure() -> None:
+    """`vm-proxy-dead` points every fetch at a port nothing listens on, so
+    `the installer exited 4` is the result it exists to produce. The cluster
+    had no notion of that — `campaign.py` did — so it was the one fixture that
+    could never be green, and a readiness tally counted it as unverified."""
+    import inspect
+
+    assert cluster.EXPECTED_TO_FAIL, "an empty set is the defect this replaced"
+
+    code = inspect.getsource(cluster.install_one)
+    expected = code.index("EXPECTED_TO_FAIL")
+    ordinary = code.index('f"the installer exited {code!r}"')
+    assert expected < ordinary, "the exception has to be read before the general rule"
+
+    # And the two agree on which fixture it is: one fact, two runners.
+    from tests.vm import campaign
+
+    failing = {
+        Path(one.config).stem
+        for stage in campaign.STAGES.values()
+        for one in stage
+        if one.expect_failure
+    }
+    assert failing == set(cluster.EXPECTED_TO_FAIL), (failing, cluster.EXPECTED_TO_FAIL)

--- a/tests/unit/test_proxmox.py
+++ b/tests/unit/test_proxmox.py
@@ -1242,9 +1242,21 @@ def test_a_run_is_not_green_until_the_installed_system_answers() -> None:
 
     source = inspect.getsource(cluster.install_one)
     assert "boot_and_check" in source
-    ok = source.index("Verdict.OK")
     checked = source.index("boot_and_check")
-    assert checked < ok, "the verdict cannot be OK before the system was read"
+
+    # One exception, and it has to be the only one: a fixture in
+    # `EXPECTED_TO_FAIL` stops the install on purpose, so there is no installed
+    # system to read and its verdict is decided before that point. Every other
+    # `Verdict.OK` comes after the machine answered.
+    exception = source.index("EXPECTED_TO_FAIL")
+    early = [
+        at
+        for at in range(len(source))
+        if source.startswith("Verdict.OK", at) and at < checked
+    ]
+    assert len(early) == 1, early
+    assert exception < early[0] < checked, (exception, early, checked)
+    assert "Verdict.OK" in source[checked:], "and the ordinary verdict is after it"
 
 
 def test_installed_boot_attaches_before_reset_without_sending_a_line(

--- a/tests/vm/campaign.py
+++ b/tests/vm/campaign.py
@@ -189,7 +189,7 @@ STAGES: Final[dict[str, tuple[Run, ...]]] = {
         # The proxy pointed at a port nothing listens on: a run that reaches
         # the mirror proves something bypassed it, so this one is expected to
         # fail at the stage3 download and its failure is the result.
-        Run("fixtures/vm-proxy-dead.toml", expect_failure=True),
+        Run("fixtures/vm-proxy-dead.toml", expect_failure=True),  # see cluster.EXPECTED_TO_FAIL
         # The direction that matters to an operator on an intranet, and the one
         # nothing covered: the proxy answers and the install completes through
         # it. It needs a SOCKS5 listener on the workstation, so `run.py` refuses

--- a/tests/vm/cluster.py
+++ b/tests/vm/cluster.py
@@ -1563,6 +1563,19 @@ def install_one(
         files = collect(guest, link, log)
         keep_results(log, files)
         code = files.get("install.rc", b"").strip()
+        if job.name in EXPECTED_TO_FAIL:
+            # The install stopping is the whole answer here, so there is no
+            # installed system to boot afterwards and the run ends on this line.
+            stopped = code != b"0"
+            return Outcome(
+                job.name,
+                Verdict.OK if stopped else Verdict.FAIL,
+                time.monotonic() - started,
+                "" if stopped else "the install was supposed to stop and did not",
+                log,
+                phase=phase,
+                revision=revision,
+            )
         if code != b"0":
             outcome = Outcome(
                 job.name,
@@ -1984,6 +1997,13 @@ _Result = TypeVar("_Result")
 def _remaining(deadline: float) -> float:
     return max(0.0, deadline - time.monotonic())
 
+
+#: Fixtures whose install is supposed to stop. `vm-proxy-dead` points every
+#: fetch at a port nothing listens on, so `the installer exited 4` is the
+#: result it exists to produce; recording that as a failure made it the only
+#: fixture that could never be green, and it was counted as unverified for
+#: weeks. `campaign.py` knew this and the cluster did not.
+EXPECTED_TO_FAIL: Final[frozenset[str]] = frozenset({"vm-proxy-dead"})
 
 #: Nodes that take no guests until `--allow-node` names them. 66 of the 70
 #: console-proxy drops recorded across every run under `lab/` name


### PR DESCRIPTION
Tallying which fixtures have ever gone green found `vm-proxy-dead` at zero from two runs. It points every fetch at `127.0.0.1:1`, so `the installer exited 4` is the result it exists to produce — `campaign.py` has carried `expect_failure=True` for it all along and `cluster.py` had no notion of it. On the cluster it could not be green whatever it did.

The set lives in `cluster.py` beside the `Job` that carries it, and a test asserts the two runners name the same fixtures, so the fact stays in one place.

It also had to be reconciled with an existing invariant worth keeping: `test_a_run_is_not_green_until_the_installed_system_answers` requires no `Verdict.OK` before `boot_and_check`. That is right for every fixture with an installed system to read, and this one has none. The test now allows exactly one early OK and requires it to sit inside the `EXPECTED_TO_FAIL` branch; widening that branch to every fixture turns it red.

Verified locally on the way: `python3 -m tests.vm.run --install fixtures/vm-proxy-dead.toml` stops with `DownloadFailed: … <urlopen error [Errno 111] Connection refused>` and exit 4, which is the intended result.