### PR TITLE
readme: name everything publishing removes, not only the hashes

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -50,7 +50,7 @@ gentoo-install は Linux ライブ環境で動作し、amd64 アーキテクチ�
 
 <!-- fact: plan-records -->
 
-**計画と記録** dry run はストレージハードウェアを調査せずに操作計画を表示します。実際のインストールでは、再利用するデバイスから調査した mdraid メタデータを追加したうえで同じ planner を使用するため、ハードウェアに依存する検証結果が変わる場合があります。`install.log` はコマンド出力を記録し、`install.jsonl` は操作、パッケージの取得元、バイナリパッケージのフォールバック理由を記録します。メニューは設定を `paste.gentoozh.org` にアップロードする前に、`password_hash` と `root_password_hash` の値だけを `removed-before-publishing` に置き換えます。その他の設定値はアップロードに残ります。メニューはアップロード先ページのアドレスをテキストと QR コードで表示します。
+**計画と記録** dry run はストレージハードウェアを調査せずに操作計画を表示します。実際のインストールでは、再利用するデバイスから調査した mdraid メタデータを追加したうえで同じ planner を使用するため、ハードウェアに依存する検証結果が変わる場合があります。`install.log` はコマンド出力を記録し、`install.jsonl` は操作、パッケージの取得元、バイナリパッケージのフォールバック理由を記録します。メニューは設定を `paste.gentoozh.org` にアップロードする前に、`password_hash` と `root_password_hash` の値を `removed-before-publishing` に置き換え、プロキシの `username` と `password` は鍵ごと出力しません。その他の設定値はアップロードに残ります。メニューはアップロード先ページのアドレスをテキストと QR コードで表示します。
 
 ## 検証状況
 

--- a/README.ko.md
+++ b/README.ko.md
@@ -50,7 +50,7 @@ gentoo-install은 Linux 라이브 환경에서 실행되어 amd64 아키텍처�
 
 <!-- fact: plan-records -->
 
-**계획 및 기록** dry run은 저장 장치 하드웨어를 조사하지 않고 작업 계획을 표시한다. 실제 설치는 재사용 장치에서 조사한 mdraid 메타데이터를 추가한 뒤 같은 planner를 사용하므로 하드웨어에 의존하는 검증 결과가 달라질 수 있다. `install.log`는 명령 출력을 기록하고, `install.jsonl`은 작업, 패키지 소스, 바이너리 패키지에서 소스 빌드로 전환한 사유를 기록한다. 메뉴는 설정을 `paste.gentoozh.org`에 업로드하기 전에 `password_hash`와 `root_password_hash` 값만 `removed-before-publishing`으로 바꾼다. 다른 설정값은 업로드에 남는다. 메뉴는 업로드된 페이지의 주소를 텍스트와 QR 코드로 표시한다.
+**계획 및 기록** dry run은 저장 장치 하드웨어를 조사하지 않고 작업 계획을 표시한다. 실제 설치는 재사용 장치에서 조사한 mdraid 메타데이터를 추가한 뒤 같은 planner를 사용하므로 하드웨어에 의존하는 검증 결과가 달라질 수 있다. `install.log`는 명령 출력을 기록하고, `install.jsonl`은 작업, 패키지 소스, 바이너리 패키지에서 소스 빌드로 전환한 사유를 기록한다. 메뉴는 설정을 `paste.gentoozh.org`에 업로드하기 전에 `password_hash`와 `root_password_hash` 값을 `removed-before-publishing`으로 바꾸고, 프록시의 `username`과 `password`는 키 자체를 출력하지 않는다. 다른 설정값은 업로드에 남는다. 메뉴는 업로드된 페이지의 주소를 텍스트와 QR 코드로 표시한다.
 
 ## 검증 상태
 

--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ After the proxy is selected, the configured proxy is used for stage3 and its sig
 
 <!-- fact: plan-records -->
 
-**Plan and records.** A dry run prints an operation plan without probing storage hardware. A real installation uses the same planner after adding probed mdraid metadata for reused devices, so hardware-dependent validation can change the result. `install.log` records command output, and `install.jsonl` records operations, package sources and binary-package degradation reasons. Before uploading a configuration to `paste.gentoozh.org`, the menu replaces only `password_hash` and `root_password_hash` values with `removed-before-publishing`; the other configuration values remain in the upload. The menu displays the resulting page address as text and as a QR code.
+**Plan and records.** A dry run prints an operation plan without probing storage hardware. A real installation uses the same planner after adding probed mdraid metadata for reused devices, so hardware-dependent validation can change the result. `install.log` records command output, and `install.jsonl` records operations, package sources and binary-package degradation reasons. Before uploading a configuration to `paste.gentoozh.org`, the menu replaces `password_hash` and `root_password_hash` with `removed-before-publishing` and omits the proxy `username` and `password` keys entirely; the other configuration values remain in the upload. The menu displays the resulting page address as text and as a QR code.
 
 ## Verification status
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -50,7 +50,7 @@ gentoo-install 在 Linux live 环境中运行，用于安装 amd64 架构的 Gen
 
 <!-- fact: plan-records -->
 
-**计划与记录** dry run 会在不探测存储硬件的情况下显示操作计划。实际安装使用相同的规划器，但会先加入从复用设备探测到的 mdraid 元数据，因此依赖硬件的验证结果可能不同。`install.log` 记录命令输出，`install.jsonl` 记录操作、软件包来源和二进制软件包降级原因。菜单将配置上传至 `paste.gentoozh.org` 前，只会把 `password_hash` 和 `root_password_hash` 的值替换为 `removed-before-publishing`；其他配置值仍会上传。菜单会以文本和 QR 码显示上传页面的网址。
+**计划与记录** dry run 会在不探测存储硬件的情况下显示操作计划。实际安装使用相同的规划器，但会先加入从复用设备探测到的 mdraid 元数据，因此依赖硬件的验证结果可能不同。`install.log` 记录命令输出，`install.jsonl` 记录操作、软件包来源和二进制软件包降级原因。菜单将配置上传至 `paste.gentoozh.org` 前，会把 `password_hash` 和 `root_password_hash` 的值替换为 `removed-before-publishing`，并且完全不写出代理的 `username` 和 `password` 这两个键；其他配置值仍会上传。菜单会以文本和 QR 码显示上传页面的网址。
 
 ## 验证状态
 

--- a/README.zh-TW.md
+++ b/README.zh-TW.md
@@ -50,7 +50,7 @@ gentoo-install 在 Linux live 環境中執行，用於安裝 amd64 架構的 Gen
 
 <!-- fact: plan-records -->
 
-**計畫與記錄** dry run 會在不探測儲存硬體的情況下顯示操作計畫。實際安裝使用相同的規劃器，但會先加入從重用裝置探測到的 mdraid 中繼資料，因此依賴硬體的驗證結果可能不同。`install.log` 記錄指令輸出，`install.jsonl` 記錄操作、套件來源與二進位套件降級原因。選單將設定上傳至 `paste.gentoozh.org` 前，只會把 `password_hash` 與 `root_password_hash` 的值替換為 `removed-before-publishing`；其他設定值仍會上傳。選單會以文字與 QR 碼顯示上傳頁面的網址。
+**計畫與記錄** dry run 會在不探測儲存硬體的情況下顯示操作計畫。實際安裝使用相同的規劃器，但會先加入從重用裝置探測到的 mdraid 中繼資料，因此依賴硬體的驗證結果可能不同。`install.log` 記錄指令輸出，`install.jsonl` 記錄操作、套件來源與二進位套件降級原因。選單將設定上傳至 `paste.gentoozh.org` 前，會把 `password_hash` 與 `root_password_hash` 的值替換為 `removed-before-publishing`，並且完全不寫出代理的 `username` 與 `password` 這兩個鍵；其他設定值仍會上傳。選單會以文字與 QR 碼顯示上傳頁面的網址。
 
 ## 驗證狀態
 

--- a/tests/unit/test_readme.py
+++ b/tests/unit/test_readme.py
@@ -347,3 +347,31 @@ def test_the_readme_set_holds_no_contributor_instructions() -> None:
         said = (ROOT / name).read_text()
         assert "mypy" not in said, name
         assert "pytest" not in said, name
+
+
+def test_the_readme_names_everything_publishing_removes() -> None:
+    """The README said the menu replaces `only` those two values and that the
+    other values remain. `to_toml(publishing=True)` also drops the proxy
+    username and password, and drops them rather than replacing them — so the
+    sentence understated the protection and mis-stated its mechanism, on the
+    one paragraph a reader consults before putting a configuration on a public
+    address."""
+    from dataclasses import fields
+
+    from gentoo_install.model.config import ProxyConfig
+    from gentoo_install.model.serialise import REDACTED, SECRET
+
+    english = (ROOT / "README.md").read_text(encoding="utf-8")
+    said = next(line for line in english.splitlines() if REDACTED in line)
+
+    for name in SECRET:
+        assert f"`{name}`" in said, name
+    # And the keys that are omitted rather than replaced, by their real names.
+    dropped = {"username", "password"}
+    assert dropped <= {field.name for field in fields(ProxyConfig)}, "the model moved"
+    for name in dropped:
+        assert f"`{name}`" in said, name
+
+    # `only` was the word that made it wrong; it must not come back beside the
+    # two hashes it used to qualify.
+    assert "replaces only" not in said, said


### PR DESCRIPTION
All five READMEs said the menu "replaces only `password_hash` and `root_password_hash` values with `removed-before-publishing`; the other configuration values remain in the upload".

`model/serialise.py` does two different things. `SECRET` names the two hashes and they are replaced with `REDACTED`. Separately, `to_toml(..., publishing=True)` skips the proxy `username` and `password` fields entirely, so those keys are absent rather than replaced. `tests/unit/test_serialise.py::test_proxy_credentials_round_trip_and_are_removed_from_published_config` has asserted both all along.

So the sentence understated the protection and mis-stated its mechanism, in the one paragraph someone reads before putting a configuration on a public address. All five now name the four keys and distinguish replaced from omitted.

The test ties the sentence to the code: it reads `SECRET` and `ProxyConfig`'s field names rather than a copied list, so renaming a field there fails here. Restoring the old sentence turns it red.