### PR TITLE
vm: the local runner must not pin eth0 either

### DIFF
--- a/tests/unit/test_harness.py
+++ b/tests/unit/test_harness.py
@@ -2483,3 +2483,34 @@ def test_the_unlock_itself_waits_first() -> None:
 
     code = inspect.getsource(runner.remote_unlock)
     assert code.index("wait_for_unlock_daemon(") < code.index("subprocess.Popen(")
+
+
+def test_the_local_runner_pins_no_interface_name_either() -> None:
+    """`vm-unlock`'s own serial log has `virtio_net virtio0 enp0s2: renamed
+    from eth0` at 156.6 seconds — after `systemd-networkd` started and after
+    `Reached target Network`. The unit generated from `ip=eth0:dhcp` matched a
+    name that no longer existed, so nothing answered on the forwarded port.
+
+    `cluster.rewrite_fixtures` has cleared the interface since #407; this is
+    the other runner, which did not, so the two disagreed about the one
+    parameter that decides whether the initramfs is reachable.
+    """
+    from pathlib import Path
+
+    from gentoo_install.exec.config import load
+    from gentoo_install.plan.bootloader import unlock_parameters
+    from tests.vm.run import remote_config
+
+    for name in ("vm-unlock", "zbm-unlock"):
+        fixture = load(Path(f"tests/fixtures/{name}.toml"))
+        # The negative control is the input: the fixture names a device, which
+        # is a reasonable thing for an operator to write and wrong here.
+        assert fixture.kernel.remote_unlock.interface, name
+
+        prepared = remote_config(fixture, "ssh-ed25519 AAAA test")
+        assert prepared.kernel.remote_unlock.interface == "", name
+
+        address = next(
+            one for one in unlock_parameters(prepared) if one.startswith("ip=")
+        )
+        assert "eth0" not in address, address

--- a/tests/vm/run.py
+++ b/tests/vm/run.py
@@ -330,7 +330,15 @@ def remote_unlock_commands(installation: InstallConfig) -> tuple[str, str | None
 
 
 def remote_config(installation: InstallConfig, public_key: str) -> InstallConfig:
-    """Replace fixture-only remote credentials with values owned by this run."""
+    """Replace fixture-only remote credentials with values owned by this run.
+
+    The interface goes with the address, for the reason `cluster.rewrite_fixtures`
+    clears it: `vm-unlock` names `eth0`, and udev renames that device. This
+    guest's own serial log has `virtio_net virtio0 enp0s2: renamed from eth0`
+    at 156.6 seconds, after `systemd-networkd` had started and after `Reached
+    target Network` — so the unit generated from `ip=eth0:dhcp` was matching a
+    name that no longer existed, and nothing answered on the forwarded port.
+    """
     unlock = installation.kernel.remote_unlock
     if not unlock.enabled:
         return installation
@@ -339,7 +347,7 @@ def remote_config(installation: InstallConfig, public_key: str) -> InstallConfig
         system=replace(installation.system, authorized_keys=(public_key,)),
         kernel=replace(
             installation.kernel,
-            remote_unlock=replace(unlock, address=""),
+            remote_unlock=replace(unlock, address="", interface=""),
         ),
     )
 


### PR DESCRIPTION
`vm-unlock` fails locally as well as on the cluster, which rules out anything cluster-specific. The guest is still at its passphrase prompt as I write this, and its `serial.log` — a console neither runner had ever read, because both wait for the daemon before attaching — says why:

    [  OK  ] Started Network Management.
    [  OK  ] Reached target Network.
             Starting Wait for Network to be Online...
    [  156.573502] virtio_net virtio0 enp0s2: renamed from eth0
             Starting Cryptography Setup for root...

`systemd-networkd` started and the Network target was reached, and only then did udev rename the device. The unit `systemd-network-generator` wrote from `ip=eth0:dhcp` matches `Name=eth0`, which by that point does not exist.

`eth0` reaches the command line because `remote_config` clears the fixture's address and leaves its interface. `cluster.rewrite_fixtures` has cleared both since #407; this is the other runner, so the two disagreed about the one parameter that decides whether the initramfs is reachable. With it cleared the parameter is `ip=dhcp`, which dracut applies to whichever device exists.

Whether that is the whole fault is what the next local run answers; the cluster's static-address form failed too and its rename is at 3.9–11.4s.