### PR TITLE
vm: a refused login carries the screen the guest was showing

### DIFF
--- a/tests/unit/test_cluster.py
+++ b/tests/unit/test_cluster.py
@@ -560,6 +560,18 @@ def test_the_converted_machine_is_read_back_the_same_way(monkeypatch: pytest.Mon
     assert "wait_for_network(" in code, "the installed system has to reach a mirror too"
 
 
+class _Screen:
+    """What `Reconnecting.console` offers a verdict that has to say what the
+    guest was showing. The real one is a live console; a test supplies the
+    tail it wants to see in the message."""
+
+    def __init__(self, trailing: bytes = b"") -> None:
+        self.trailing = trailing
+
+    def snapshot(self, seconds: float) -> bytes:
+        return self.trailing
+
+
 class _LoginConsole:
     """A serial line that behaves like `login` on the guests.
 
@@ -571,6 +583,7 @@ class _LoginConsole:
         self.refusals = refusals
         self.sent: list[str] = []
         self.answers: list[bytes] = []
+        self.console = _Screen(b"lvmbox login: ")
 
     def respond(self, line: str) -> None:
         self.sent.append(line)
@@ -618,6 +631,7 @@ class _EchoingConsole:
         self.sent: list[str] = []
         self.settles: list[float] = []
         self.answers: list[bytes] = []
+        self.console = _Screen(b"openrcsdbox login: ")
 
     def respond(self, line: str) -> None:
         self.sent.append(line)
@@ -1079,6 +1093,7 @@ def test_the_prompt_after_a_refusal_is_read_before_the_name_is_offered_again(
             self.refusals = refusals
             self.sent: list[str] = []
             self.pending: list[bytes] = []
+            self.console = _Screen(b"lvmbox login: ")
             #: What the guest is waiting for. A name sent here is echoed; a
             #: password is not, which is how the two are told apart below.
             self.wants = "name"
@@ -1146,3 +1161,32 @@ def test_a_fixture_that_passes_by_failing_is_not_recorded_as_a_failure() -> None
         if one.expect_failure
     }
     assert failing == set(cluster.EXPECTED_TO_FAIL), (failing, cluster.EXPECTED_TO_FAIL)
+
+
+def test_a_refused_login_says_what_the_guest_was_showing(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """`never matched '#|\\$|Login incorrect'` names the pattern that missed and
+    not what the guest was showing instead, which is how three rounds went on
+    `vm-lvm` guessing at a phase slip. The unlock's verdict carried nothing
+    either until #407, and every round after that answered a different layer
+    because the screen was in the message."""
+    monkeypatch.setattr("time.sleep", lambda seconds: None)
+
+    console = _LoginConsole(refusals=99)
+    # The symptom `vm-lvm` showed: the password typed into the name field.
+    console.console = _Screen(b"lvmbox login: install\r\nPassword: ")
+    said = cluster._log_in(cast(cluster.Reconnecting, console), "install")
+
+    assert "refused every login" in said
+    assert "login: install" in said, said
+
+    # Negative control: what the screen holds is what reaches the verdict, so
+    # a different screen gives a different message. Without the snapshot both
+    # of these read identically — which is what the old verdict did for every
+    # failure, whatever the guest was showing.
+    other = _LoginConsole(refusals=99)
+    other.console = _Screen(b"Maximum number of tries exceeded (5)")
+    theirs = cluster._log_in(cast(cluster.Reconnecting, other), "install")
+    assert "Maximum number of tries exceeded" in theirs, theirs
+    assert theirs != said, "two different screens gave the same verdict"

--- a/tests/vm/cluster.py
+++ b/tests/vm/cluster.py
@@ -2323,6 +2323,19 @@ VERDICT_BYTES: Final[int] = 3600
 REPROMPT_PATIENCE: Final[float] = 30.0
 
 
+def _seen_since(link: Reconnecting, said: bytes) -> str:
+    """What the console holds, for a verdict that would otherwise be a guess.
+
+    The unlock's verdict carried nothing until `#407` and three rounds were
+    spent guessing at it; each round after that answered a different layer
+    because the screen was in the failure. A refused login is the same shape:
+    the pattern that missed is named and what the guest was showing is not.
+    """
+    trailing = link.console.snapshot(UNLOCK_SCREEN_PATIENCE)
+    held = (said + trailing)[-UNLOCK_SCREEN_BYTES:]
+    return repr(held) if held else "nothing"
+
+
 def _log_in(link: Reconnecting, password: str) -> str:
     """Log root in, and say what is wrong when it does not happen.
 
@@ -2343,7 +2356,10 @@ def _log_in(link: Reconnecting, password: str) -> str:
         try:
             said = link.observe(r"#|\$|Login incorrect", timeout=120.0)
         except ConsoleTimeout as error:
-            return f"root could not log into the installed system: {error}"[:200]
+            return (
+                f"root could not log into the installed system: {error}; "
+                f"the console held {_seen_since(link, b'')}"
+            )[:VERDICT_BYTES]
         if b"Login incorrect" not in said:
             return ""
         if password.encode() in said and echoed < PASSWORD_ECHO_CATCHES:
@@ -2360,7 +2376,10 @@ def _log_in(link: Reconnecting, password: str) -> str:
             link.observe(r"login:", timeout=REPROMPT_PATIENCE)
         except ConsoleTimeout:
             pass
-    return "the installed system refused every login"
+    return (
+        "the installed system refused every login; "
+        f"the console held {_seen_since(link, said)}"
+    )[:VERDICT_BYTES]
 
 
 #: How long SeaBIOS and GRUB take to reach the cryptomount prompt. Nothing on


### PR DESCRIPTION
`root could not log into the installed system: never matched '#|\$|Login incorrect'` names the pattern that missed and not what the guest was showing instead. Three rounds went on `vm-lvm` guessing at a phase slip from that message alone, and the fix stopped at the limit this repository sets for repeated attempts.

The unlock verdict was in the same state until #407, and every round since has answered a different layer — the GRUB passphrase prompt, then the initramfs, then the NIC rename at 156.6s — because the screen was in the failure. This does the same for a refused login: both exits carry the last observation plus a snapshot of what followed it.

The test asserts the screen reaches the verdict by giving two doubles different screens and requiring different messages. Removing the snapshot makes them identical, which is what the old verdict did for every failure whatever the guest was showing.

No further change to `_log_in`'s logic: that has had its three attempts (#410, #427). This is the diagnostic that has to come before a fourth.