### PR TITLE
readme: record the runs of 2026-08-17 and where they had to run

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -64,6 +64,10 @@ gentoo-install は Linux ライブ環境で動作し、amd64 アーキテクチ�
 
 2026 年 8 月 16 日付のクラスタ記録は、インストーラリビジョン [`a8bf2f3837b6`](https://github.com/Zakkaus/gentoo-install/commit/a8bf2f3837b6) を対象とし、amd64 Gentoo minimal ISO 上で `vm-luks`、`vm-mdraid`、`vm-xfs`、`vm-btrfs`、`vm-f2fs` の 5 件がそれぞれインストールと起動を完了し、起動後の設定チェックをすべて通過しています。`vm-lvm` はリビジョン `073997aa74d2` で同じチェックを通過しています。
 
+2026-08-17 のクラスタ記録は次を追加で対象とします。`openrc-sdboot` はリビジョン `40ea3d90f1cc`、`vm-binpkg`、`vm-btrfs`、`vm-desktop`、`vm-gnome` は `6ba5530fd3c8`、`vm-xfs` は `304dffa41602`、`vm-f2fs`、`vm-mdraid`、`vm-proxy-dead`、`vm-xfs`、`vm-zram` は `7ac43a1d5050` です。
+
+同じ日付で、クラスタではなく単一マシン上の QEMU による記録もあり、クラスタでは駆動できない経路を対象とします。クラスタの BIOS ゲストはカーネル起動までシリアルポートへ何も出力せず、root 以外の API トークンではスクリーンショットのエンドポイントもファームウェア引数の受け渡しも利用できません。したがって `vm-bios`、`vm-bios-luks`、`ext4-bios`、`mbr-edit` は `304dffa41602` で QEMU から記録しています。`zfs-zbm`、`vm-proxy`、`vm-proxy-http` は `15d45598637a` で同様です。プロキシ用の fixture は QEMU のユーザーモードネットワーク経由でホスト上のプロキシに接続しますが、ブリッジ接続のクラスタゲストにはそのアドレスがありません。
+
 インプレース変換にはユニットテストとプラン層のテストがあり、エンドツーエンドの記録はありません。操作の順序、各種の拒否条件、交換そのものはテストで扱われていますが、実際にマシンを変換して起動を確認した実行はまだありません。この経路は未検証として扱う必要があります。
 
 その他の実装済みの組み合わせは、エンドツーエンド未検証です。現在の根拠は、initramfs の SSH ロック解除、greetd のデスクトップセッション、GNOME 以外での ibus を対象としていません。公式 Gentoo minimal ISO、Alpine または Gig-OS のライブメディア、binhost 障害時のフォールバックも対象としていません。

--- a/README.ko.md
+++ b/README.ko.md
@@ -64,6 +64,10 @@ gentoo-install은 Linux 라이브 환경에서 실행되어 amd64 아키텍처�
 
 2026년 8월 16일 자 클러스터 기록은 설치 도구 리비전 [`a8bf2f3837b6`](https://github.com/Zakkaus/gentoo-install/commit/a8bf2f3837b6)을 대상으로 하며, amd64 Gentoo minimal ISO에서 `vm-luks`, `vm-mdraid`, `vm-xfs`, `vm-btrfs`, `vm-f2fs` 다섯 건이 각각 설치와 부팅을 마치고 부팅 후 설정 검사를 모두 통과했다. `vm-lvm`은 리비전 `073997aa74d2`에서 같은 검사를 통과했다.
 
+2026-08-17 클러스터 기록은 다음을 추가로 다룬다. `openrc-sdboot`는 리비전 `40ea3d90f1cc`, `vm-binpkg`, `vm-btrfs`, `vm-desktop`, `vm-gnome`은 `6ba5530fd3c8`, `vm-xfs`는 `304dffa41602`, `vm-f2fs`, `vm-mdraid`, `vm-proxy-dead`, `vm-xfs`, `vm-zram`은 `7ac43a1d5050`이다.
+
+같은 날짜로 클러스터가 아니라 단일 machine에서 QEMU를 직접 실행한 기록도 있으며, 클러스터가 구동할 수 없는 경로를 다룬다. 클러스터의 BIOS 게스트는 커널이 시작하기 전까지 직렬 포트에 아무것도 출력하지 않고, root가 아닌 API 토큰으로는 스크린샷 엔드포인트도 펌웨어 인자 전달도 사용할 수 없다. 따라서 `vm-bios`, `vm-bios-luks`, `ext4-bios`, `mbr-edit`는 `304dffa41602`에서 QEMU로 기록했다. `zfs-zbm`, `vm-proxy`, `vm-proxy-http`는 `15d45598637a`에서 같은 방식이다. 프록시 fixture는 QEMU의 user-mode 네트워크를 통해 호스트의 프록시에 연결하는데, 브리지로 연결된 클러스터 게스트에는 그 주소가 없다.
+
 인플레이스 변환에는 단위 테스트와 플랜 계층 테스트가 있으며 엔드투엔드 기록은 없다. 동작 순서, 각 거부 조건, 교환 자체는 테스트가 다루지만 실제로 기계를 변환하고 부팅까지 확인한 실행은 아직 없다. 검증되지 않은 경로로 다루어야 한다.
 
 그 밖의 구현된 조합은 엔드투엔드 검증을 거치지 않았다. 현재 증거는 initramfs SSH 잠금 해제, greetd 데스크톱 세션, GNOME 외부의 ibus를 다루지 않는다. 공식 Gentoo minimal ISO, Alpine 또는 Gig-OS 라이브 미디어, binhost 장애 시 전환도 다루지 않는다.

--- a/README.md
+++ b/README.md
@@ -64,6 +64,10 @@ Revision-tagged end-to-end records dated 2026-08-11 cover one installation and b
 
 Revision-tagged cluster records dated 2026-08-16 cover installer revision [`a8bf2f3837b6`](https://github.com/Zakkaus/gentoo-install/commit/a8bf2f3837b6) on the amd64 Gentoo minimal ISO: `vm-luks`, `vm-mdraid`, `vm-xfs`, `vm-btrfs` and `vm-f2fs` each installed, booted and answered every post-boot configuration check. `vm-lvm` did so at revision `073997aa74d2`.
 
+Further cluster records dated 2026-08-17 cover `openrc-sdboot` at `40ea3d90f1cc`; `vm-binpkg`, `vm-btrfs`, `vm-desktop` and `vm-gnome` at `6ba5530fd3c8`; `vm-xfs` at `304dffa41602`; and `vm-f2fs`, `vm-mdraid`, `vm-proxy-dead`, `vm-xfs` and `vm-zram` at `7ac43a1d5050`.
+
+Records of the same date from a single machine running QEMU directly, rather than the cluster, cover the paths the cluster cannot drive. A BIOS guest on this cluster writes nothing to its serial port before the kernel starts, and neither a screenshot endpoint nor a way to pass firmware arguments is available to a non-root API token, so `vm-bios`, `vm-bios-luks`, `ext4-bios` and `mbr-edit` are recorded at `304dffa41602` from QEMU. `zfs-zbm`, `vm-proxy` and `vm-proxy-http` are recorded at `15d45598637a` the same way: the proxy fixtures reach a proxy on the host through QEMU's user-mode network, which a bridged cluster guest does not have.
+
 The in-place conversion has unit and plan coverage and no end-to-end record. Its operation order, its refusals and the exchange itself are covered by tests; no run has yet converted a machine and booted the result. Treat it as an unverified path.
 
 Other implemented combinations remain unverified end to end. Current evidence does not cover initramfs SSH unlock, greetd desktop sessions or ibus outside GNOME. It also does not cover the official Gentoo minimal ISO, Alpine or Gig-OS live media, or binary-host failure fallback.

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -64,6 +64,10 @@ gentoo-install 在 Linux live 环境中运行，用于安装 amd64 架构的 Gen
 
 2026 年 8 月 16 日的集群记录标有安装程序修订版 [`a8bf2f3837b6`](https://github.com/Zakkaus/gentoo-install/commit/a8bf2f3837b6)，在 amd64 Gentoo minimal ISO 上覆盖 `vm-luks`、`vm-mdraid`、`vm-xfs`、`vm-btrfs` 和 `vm-f2fs`，五者各自完成安装、引导并通过全部引导后配置检查。`vm-lvm` 在修订版 `073997aa74d2` 完成同一组检查。
 
+2026-08-17 的集群记录另外涵盖：`openrc-sdboot` 于 `40ea3d90f1cc`；`vm-binpkg`、`vm-btrfs`、`vm-desktop`、`vm-gnome` 于 `6ba5530fd3c8`；`vm-xfs` 于 `304dffa41602`；`vm-f2fs`、`vm-mdraid`、`vm-proxy-dead`、`vm-xfs`、`vm-zram` 于 `7ac43a1d5050`。
+
+同一天另有一批记录来自单机直接运行 QEMU 而非集群，涵盖集群无法驱动的路径。集群上的 BIOS 客机在内核启动前不会向串口写入任何内容，而非 root 的 API token 调用屏幕截图端点会得到 501，也无法传递固件参数，因此 `vm-bios`、`vm-bios-luks`、`ext4-bios`、`mbr-edit` 的记录是 `304dffa41602`，由 QEMU 产生。`zfs-zbm`、`vm-proxy`、`vm-proxy-http` 于 `15d45598637a` 同样如此：代理 fixture 通过 QEMU 的 user-mode 网络连到宿主机上的代理，桥接的集群客机没有这个地址。
+
 就地转换具备单元与计划层测试，尚无端到端记录。其操作顺序、各项拒绝条件与交换本身均有测试覆盖，但尚未有任何一次执行完成转换并引导验证结果。此路径应视为未验证。
 
 其他已实现组合仍未完成端到端验证。当前证据未覆盖 initramfs SSH 解锁、greetd 桌面会话或 GNOME 以外的 ibus。当前证据也未覆盖官方 Gentoo minimal ISO、Alpine 或 Gig-OS live 介质，以及 binhost 失败时的降级。

--- a/README.zh-TW.md
+++ b/README.zh-TW.md
@@ -64,6 +64,10 @@ gentoo-install 在 Linux live 環境中執行，用於安裝 amd64 架構的 Gen
 
 2026 年 8 月 16 日的叢集記錄標有安裝器修訂版 [`a8bf2f3837b6`](https://github.com/Zakkaus/gentoo-install/commit/a8bf2f3837b6)，在 amd64 Gentoo minimal ISO 上涵蓋 `vm-luks`、`vm-mdraid`、`vm-xfs`、`vm-btrfs` 與 `vm-f2fs`，五者各自完成安裝、開機並通過全部開機後設定檢查。`vm-lvm` 在修訂版 `073997aa74d2` 完成同一組檢查。
 
+2026-08-17 的叢集記錄另外涵蓋：`openrc-sdboot` 於 `40ea3d90f1cc`；`vm-binpkg`、`vm-btrfs`、`vm-desktop`、`vm-gnome` 於 `6ba5530fd3c8`；`vm-xfs` 於 `304dffa41602`；`vm-f2fs`、`vm-mdraid`、`vm-proxy-dead`、`vm-xfs`、`vm-zram` 於 `7ac43a1d5050`。
+
+同一天另有一批記錄來自單機直接執行 QEMU 而非叢集，涵蓋叢集無法驅動的路徑。叢集上的 BIOS 客機在核心啟動前不會向序列埠寫入任何內容，而非 root 的 API token 呼叫螢幕擷取端點會得到 501，也無法傳遞韌體參數，因此 `vm-bios`、`vm-bios-luks`、`ext4-bios`、`mbr-edit` 的記錄是 `304dffa41602`，由 QEMU 產生。`zfs-zbm`、`vm-proxy`、`vm-proxy-http` 於 `15d45598637a` 同樣如此：代理 fixture 透過 QEMU 的 user-mode 網路連到宿主機上的代理，橋接的叢集客機沒有這個位址。
+
 就地轉換具備單元與計畫層測試，尚無端到端記錄。其操作順序、各項拒絕條件與交換本身均有測試涵蓋，但尚未有任何一次執行完成轉換並開機驗證結果。此路徑應視為未驗證。
 
 其他已實作組合仍未完成端到端驗證。現行實據未涵蓋 initramfs SSH 解鎖、greetd 桌面工作階段或 GNOME 以外的 ibus。現行實據也未涵蓋官方 Gentoo minimal ISO、Alpine 或 Gig-OS live 媒介，以及 binhost 失敗時的降級。


### PR DESCRIPTION
The verification record stopped at revision `a8bf2f3837b6` on 2026-08-16. Since then eleven cluster records have accumulated, and — more importantly — a whole class of run that the record had no place for.

Four fixtures cannot be driven on this cluster at all. A BIOS guest writes nothing to its serial port before the kernel starts (measured: 49 bytes in 75 seconds), `GET .../screenshot` answers `501 not implemented` on PVE 9.2.10, and `args` is refused to every token but root's. `vm-bios`, `vm-bios-luks`, `ext4-bios` and `mbr-edit` are therefore recorded from QEMU on one machine, at `304dffa41602`. `zfs-zbm`, `vm-proxy` and `vm-proxy-http` are recorded the same way at `15d45598637a`; the proxy fixtures reach a proxy through QEMU's user-mode network, which a bridged guest does not have.

Every revision here was read from the run's own log rather than assumed. All five READMEs carry the same facts; the two Chinese ones pass `chinese_lint` at warning level.