### PR TITLE
kernel: crypt-ssh needs the legacy initramfs to reach its queue

### DIFF
--- a/gentoo_install/plan/kernel.py
+++ b/gentoo_install/plan/kernel.py
@@ -65,7 +65,10 @@ ZBM_LEGACY_NETWORK_PACKAGES: Final[tuple[str, ...]] = (
 
 #: Modules an initramfs needs to answer on the network before the root is
 #: unlocked. `crypt-ssh` is the module dracut-crypt-ssh installs as 60crypt-ssh.
-REMOTE_UNLOCK_MODULES: Final[tuple[str, ...]] = ("crypt-ssh", "network")
+#: `network-legacy` by name rather than the `network` meta-module: with
+#: systemd omitted there is no `systemd-networkd` for `40network` to pick, and
+#: `crypt-ssh`'s own hooks are the legacy kind.
+REMOTE_UNLOCK_MODULES: Final[tuple[str, ...]] = ("crypt-ssh", "network-legacy")
 
 #: The two packages that carry the cjktty patch, prebuilt and from source.
 #: Both take the `cjk` flag and both are keyworded `~amd64` in gentoo-zh.
@@ -359,6 +362,14 @@ class ConfigureRemoteUnlock(Operation):
             )
             return
         lines = [
+            # `crypt-ssh` starts dropbear from a dracut initqueue hook, and a
+            # systemd initramfs asks for the passphrase before it reaches that
+            # queue: a guest's own serial log has `dracut cmdline hook` and
+            # `dracut pre-udev hook` finishing, then `Please enter passphrase
+            # for disk root`, and `dracut-initqueue` never starting at all. So
+            # nothing was ever listening on the port. ZFSBootMenu's image omits
+            # systemd for the same reason.
+            'omit_dracutmodules+=" systemd systemd-networkd "',
             f'dropbear_port="{self.port}"',
             # SYSTEM converts the target's own host key, so a client that has
             # already trusted this machine does not see a new one at unlock.

--- a/tests/golden/vm-unlock.txt
+++ b/tests/golden/vm-unlock.txt
@@ -77,7 +77,7 @@
   install the initramfs ssh daemon: emerge sys-kernel/dracut-crypt-ssh
   install the storage tools: emerge sys-fs/cryptsetup sys-fs/btrfs-progs sys-fs/dosfstools sys-fs/e2fsprogs
   install the kernel: emerge sys-kernel/gentoo-kernel-bin
-  tell dracut to carry crypt, btrfs, crypt-ssh, network
+  tell dracut to carry crypt, btrfs, crypt-ssh, network-legacy
   rebuild the initramfs from sys-kernel/gentoo-kernel-bin with the modules written above
   check the installkernel payload names existing kernel files
 

--- a/tests/unit/test_plan_boot.py
+++ b/tests/unit/test_plan_boot.py
@@ -605,7 +605,7 @@ def test_remote_unlock_adds_the_modules_that_answer_on_the_network() -> None:
 
     wanted = replace(config(), kernel=KernelConfig(remote_unlock=RemoteUnlock(enabled=True)))
     modules = kernel.dracut_modules(wanted)
-    assert "crypt-ssh" in modules and "network" in modules
+    assert "crypt-ssh" in modules and "network-legacy" in modules
     assert "crypt-ssh" not in kernel.dracut_modules(config())
 
 

--- a/tests/unit/test_plan_kernel.py
+++ b/tests/unit/test_plan_kernel.py
@@ -54,7 +54,7 @@ def test_grub_remote_unlock_keeps_the_system_dracut_path() -> None:
     assert 'dropbear_port="2222"' in written
     assert 'dropbear_rsa_key="SYSTEM"' in written
     assert 'install_items+=" /sbin/cryptsetup "' in written
-    assert kernel.dracut_modules(installation)[-2:] == ("crypt-ssh", "network")
+    assert kernel.dracut_modules(installation)[-2:] == ("crypt-ssh", "network-legacy")
     assert not any(
         isinstance(one, bootloader.ConfigureZfsBootMenuRemoteAccess)
         for one in bootloader.build(installation)
@@ -160,3 +160,43 @@ def test_zfs_kernel_check_reads_target_metadata_and_refuses_unknown() -> None:
     unknown = Recorder()
     with pytest.raises(ValidationFailed, match="kernel ceiling could not be read"):
         kernel.VerifyZfsKernelCompatibility(version="6.12.1").apply(unknown)
+
+
+def test_the_unlock_initramfs_omits_systemd_so_its_queue_runs_first() -> None:
+    """`crypt-ssh` starts dropbear from a dracut initqueue hook. A systemd
+    initramfs asks for the passphrase before it reaches that queue: a guest's
+    own serial log finishes `dracut cmdline hook` and `dracut pre-udev hook`,
+    then prints `Please enter passphrase for disk root`, and never starts
+    `dracut-initqueue` at all — so nothing was ever listening on the port.
+
+    ZFSBootMenu's image omits systemd for the same reason, and that is the only
+    remote-unlock image this installer has ever built successfully.
+    """
+    installation = load(Path("tests/fixtures/vm-unlock.toml"))
+    operation = next(
+        one
+        for one in kernel.build(installation)
+        if isinstance(one, kernel.ConfigureRemoteUnlock)
+    )
+    recorder = Recorder()
+    operation.apply(recorder)
+    written = recorder.files[kernel.REMOTE_UNLOCK_CONFIG]
+
+    assert "omit_dracutmodules" in written, written
+    for module in ("systemd", "systemd-networkd"):
+        assert module in written, (module, written)
+
+    # And the network module has to be the legacy one: with systemd omitted
+    # there is no `systemd-networkd` for dracut's `40network` to pick.
+    modules = kernel.dracut_modules(installation)
+    assert "network-legacy" in modules, modules
+    assert "network" not in modules, modules
+
+    # Negative control: the fixture that does not unlock remotely keeps the
+    # ordinary systemd initramfs, so this is not a change to every install.
+    plain = load(Path("tests/fixtures/vm-luks.toml"))
+    assert not plain.kernel.remote_unlock.enabled, "the control has to be a plain one"
+    assert "network-legacy" not in kernel.dracut_modules(plain)
+    assert not [
+        one for one in kernel.build(plain) if isinstance(one, kernel.ConfigureRemoteUnlock)
+    ]


### PR DESCRIPTION
Remote unlock has never worked, on the cluster or locally, and the guest's own `serial.log` — a console neither runner attaches to, because both wait for the daemon first — says why. Its dracut hooks are:

    Starting dracut cmdline hook...
    [  OK  ] Finished dracut cmdline hook.
    Starting dracut pre-udev hook...
    [  OK  ] Finished dracut pre-udev hook.
    ...
    Please enter passphrase for disk root: (press TAB for no echo)

`dracut-initqueue` never starts. `dracut-crypt-ssh` installs `dropbear-start.sh` as an initqueue hook, so dropbear is never run: in a systemd initramfs `systemd-cryptsetup` asks for the passphrase as soon as the device appears, which is before that queue is reached. Nothing was ever listening on the port, which is why the symptom was `No route to host` on the cluster and a banner timeout locally — two readings of the same absence.

So the unlock initramfs omits `systemd`, exactly as `ConfigureZfsBootMenuRemoteAccess` already does for the ZFSBootMenu image — the only remote-unlock image this installer has ever built successfully. The network module becomes `network-legacy` by name for the same reason it does there: with systemd omitted, `40network` has no `systemd-networkd` to pick.

The negative control is `vm-luks`: it does not unlock remotely and keeps the ordinary systemd initramfs, so this is not a change to every install. Not yet verified end to end — the local `vm-unlock` run measuring it starts next.