### PR TITLE
kernel: the legacy initramfs needs its network tools on both paths

### DIFF
--- a/gentoo_install/plan/kernel.py
+++ b/gentoo_install/plan/kernel.py
@@ -57,7 +57,7 @@ REMOTE_UNLOCK_CONFIG: Final[PurePosixPath] = PurePosixPath(
 
 #: Executables required by dracut's network-legacy module. ZFSBootMenu omits
 #: systemd, so its remote-unlock image cannot use systemd-networkd instead.
-ZBM_LEGACY_NETWORK_PACKAGES: Final[tuple[str, ...]] = (
+LEGACY_NETWORK_PACKAGES: Final[tuple[str, ...]] = (
     "sys-apps/iproute2",
     "net-misc/dhcp",
     "net-misc/iputils",
@@ -245,20 +245,24 @@ class RequestStorageUse(Operation):
 
 
 @dataclass(frozen=True, kw_only=True)
-class RequestZfsBootMenuNetworkTools(Operation):
-    """Enable the two optional executables network-legacy checks for."""
+class RequestLegacyNetworkTools(Operation):
+    """Enable the two optional executables network-legacy checks for.
+
+    Both remote-unlock images need them: the ZFSBootMenu one has always
+    omitted systemd, and the system one now does as well.
+    """
 
     stage: Stage = Stage.PORTAGE
 
     def describe(self) -> str:
-        return "ask for dhclient and arping, which ZFSBootMenu networking requires"
+        return "ask for dhclient and arping, which the legacy network module requires"
 
     def apply(self, context: Context) -> None:
         VerifyPackageUse(atom="net-misc/dhcp", flags=("client", "-server")).apply(context)
         VerifyPackageUse(atom="net-misc/iputils", flags=("arping",)).apply(context)
         WritePortageConfig(
             kind=PortageConfigKind.USE,
-            name="zfsbootmenu-network",
+            name="legacy-network",
             lines=("net-misc/dhcp client -server", "net-misc/iputils arping"),
         ).apply(context)
 
@@ -628,10 +632,13 @@ def build(config: InstallConfig) -> list[Operation]:
     if config.kernel.remote_unlock.enabled:
         unlock = config.kernel.remote_unlock
         system_initramfs = config.bootloader.kind is not Bootloader.ZFSBOOTMENU
-        remote_packages: tuple[str, ...] = (REMOTE_UNLOCK_PACKAGE,)
-        if not system_initramfs:
-            operations.append(RequestZfsBootMenuNetworkTools())
-            remote_packages += ZBM_LEGACY_NETWORK_PACKAGES
+        # Both images are the legacy kind now: `crypt-ssh` starts dropbear from
+        # a dracut initqueue hook, so the system initramfs omits systemd too.
+        # `network-legacy` refuses to install without these, and dracut then
+        # refuses `crypt-ssh` with it: `Module 'crypt-ssh' cannot be installed`
+        # stopped an install at the kernel's own postinst.
+        remote_packages: tuple[str, ...] = (REMOTE_UNLOCK_PACKAGE, *LEGACY_NETWORK_PACKAGES)
+        operations.append(RequestLegacyNetworkTools())
         operations += [
             ConfigureRemoteUnlock(port=unlock.port, system_initramfs=system_initramfs),
             Emerge(

--- a/tests/golden/vm-unlock.txt
+++ b/tests/golden/vm-unlock.txt
@@ -45,8 +45,9 @@
   set sys-kernel/installkernel to dracut
   ask for sys-apps/systemd[cryptsetup], which provides the unlock generator
   accept the linux-firmware licence
+  ask for dhclient and arping, which the legacy network module requires
   configure remote unlock over ssh on port 2222
-  resolve net-misc/openssh sys-process/cronie sys-kernel/installkernel sys-apps/systemd sys-kernel/dracut sys-kernel/linux-firmware sys-kernel/dracut-crypt-ssh sys-fs/cryptsetup sys-fs/btrfs-progs sys-fs/dosfstools sys-fs/e2fsprogs sys-kernel/gentoo-kernel-bin sys-boot/grub sys-boot/efibootmgr together before installing the requested packages
+  resolve net-misc/openssh sys-process/cronie sys-kernel/installkernel sys-apps/systemd sys-kernel/dracut sys-kernel/linux-firmware sys-kernel/dracut-crypt-ssh sys-apps/iproute2 net-misc/dhcp net-misc/iputils sys-fs/cryptsetup sys-fs/btrfs-progs sys-fs/dosfstools sys-fs/e2fsprogs sys-kernel/gentoo-kernel-bin sys-boot/grub sys-boot/efibootmgr together before installing the requested packages
 
 [system]
   generate and verify locales en_US.UTF-8, zh_TW.UTF-8
@@ -74,7 +75,7 @@
   install the hook that puts a kernel in /boot: emerge sys-kernel/installkernel
   rebuild systemd with the unlock generator: emerge sys-apps/systemd, from source
   install the initramfs builder and firmware: emerge sys-kernel/dracut sys-kernel/linux-firmware
-  install the initramfs ssh daemon: emerge sys-kernel/dracut-crypt-ssh
+  install the initramfs ssh daemon: emerge sys-kernel/dracut-crypt-ssh sys-apps/iproute2 net-misc/dhcp net-misc/iputils
   install the storage tools: emerge sys-fs/cryptsetup sys-fs/btrfs-progs sys-fs/dosfstools sys-fs/e2fsprogs
   install the kernel: emerge sys-kernel/gentoo-kernel-bin
   tell dracut to carry crypt, btrfs, crypt-ssh, network-legacy

--- a/tests/golden/zbm-unlock.txt
+++ b/tests/golden/zbm-unlock.txt
@@ -44,7 +44,7 @@
   set sys-kernel/installkernel to dracut, installing into /boot
   verify the selected kernel against the target sys-fs/zfs ceiling
   accept the linux-firmware licence
-  ask for dhclient and arping, which ZFSBootMenu networking requires
+  ask for dhclient and arping, which the legacy network module requires
   write /etc/dracut.conf.d/zz-gentoo-install-crypt-ssh.conf to omit ssh from the system initramfs
   accept sys-kernel/gentoo-cjk-kernel-bin as testing, with cjk on
   unmask virtual/dist-kernel, which the cjk kernel depends on by revision

--- a/tests/unit/test_plan_kernel.py
+++ b/tests/unit/test_plan_kernel.py
@@ -64,7 +64,10 @@ def test_grub_remote_unlock_keeps_the_system_dracut_path() -> None:
         for one in kernel.build(installation)
         if isinstance(one, Emerge) and kernel.REMOTE_UNLOCK_PACKAGE in one.packages
     )
-    assert unlock_packages == (kernel.REMOTE_UNLOCK_PACKAGE,)
+    # The legacy network tools come with it: the system image omits systemd
+    # too, so `network-legacy` needs them and dracut refuses `crypt-ssh`
+    # without it.
+    assert unlock_packages == (kernel.REMOTE_UNLOCK_PACKAGE, *kernel.LEGACY_NETWORK_PACKAGES)
 
 
 def test_zfsbootmenu_installs_network_legacy_executables() -> None:
@@ -79,18 +82,18 @@ def test_zfsbootmenu_installs_network_legacy_executables() -> None:
     )
     assert unlock_packages == (
         kernel.REMOTE_UNLOCK_PACKAGE,
-        *kernel.ZBM_LEGACY_NETWORK_PACKAGES,
+        *kernel.LEGACY_NETWORK_PACKAGES,
     )
 
     request = next(
         one
         for one in operations
-        if isinstance(one, kernel.RequestZfsBootMenuNetworkTools)
+        if isinstance(one, kernel.RequestLegacyNetworkTools)
     )
     recorder = Recorder()
     request.apply(recorder)
     assert recorder.files[
-        PurePosixPath("/etc/portage/package.use/zfsbootmenu-network")
+        PurePosixPath("/etc/portage/package.use/legacy-network")
     ] == "net-misc/dhcp client -server\nnet-misc/iputils arping\n"
 
 
@@ -192,6 +195,22 @@ def test_the_unlock_initramfs_omits_systemd_so_its_queue_runs_first() -> None:
     assert "network-legacy" in modules, modules
     assert "network" not in modules, modules
 
+    # The legacy network module refuses to install without dhclient and
+    # arping, and dracut then refuses `crypt-ssh` with it: `Module 'crypt-ssh'
+    # cannot be installed` stopped an install at the kernel's own postinst
+    # when the modules were changed and the packages were not.
+    unlock_packages = next(
+        one.packages
+        for one in kernel.build(installation)
+        if isinstance(one, Emerge) and kernel.REMOTE_UNLOCK_PACKAGE in one.packages
+    )
+    for package in kernel.LEGACY_NETWORK_PACKAGES:
+        assert package in unlock_packages, (package, unlock_packages)
+    assert any(
+        isinstance(one, kernel.RequestLegacyNetworkTools)
+        for one in kernel.build(installation)
+    )
+
     # Negative control: the fixture that does not unlock remotely keeps the
     # ordinary systemd initramfs, so this is not a change to every install.
     plain = load(Path("tests/fixtures/vm-luks.toml"))
@@ -199,4 +218,7 @@ def test_the_unlock_initramfs_omits_systemd_so_its_queue_runs_first() -> None:
     assert "network-legacy" not in kernel.dracut_modules(plain)
     assert not [
         one for one in kernel.build(plain) if isinstance(one, kernel.ConfigureRemoteUnlock)
+    ]
+    assert not [
+        one for one in kernel.build(plain) if isinstance(one, kernel.RequestLegacyNetworkTools)
     ]


### PR DESCRIPTION
#439 made the system unlock image omit systemd, and the next local run stopped earlier than before with `dracut[E]: Module 'crypt-ssh' cannot be installed` during `emerge --config sys-kernel/gentoo-kernel-bin`.

`network-legacy` checks for `dhclient` and `arping` and refuses to install without them, and dracut then refuses `crypt-ssh`, which requires a network module. The ZFSBootMenu path has installed `sys-apps/iproute2`, `net-misc/dhcp` and `net-misc/iputils` for exactly this reason since it was written; the system path did not, because until #439 it used the systemd initramfs.

So both paths now request them, and `RequestZfsBootMenuNetworkTools` becomes `RequestLegacyNetworkTools` since it is no longer ZFSBootMenu's alone — the `package.use` file it writes is renamed with it. Restricting the packages to the ZFSBootMenu path again turns the test red.

Found by running it: the change in #439 is right about the queue and was incomplete.