### PR TITLE
vm: create_target refuses a path outside the run directories

### DIFF
--- a/tests/unit/test_harness.py
+++ b/tests/unit/test_harness.py
@@ -2514,3 +2514,32 @@ def test_the_local_runner_pins_no_interface_name_either() -> None:
             one for one in unlock_parameters(prepared) if one.startswith("ip=")
         )
         assert "eth0" not in address, address
+
+
+def test_create_target_refuses_a_path_outside_the_run_directories(tmp_path: Path) -> None:
+    """Its first act is to delete the file it is given. The images an in-place
+    conversion will be handed are downloaded once and kept — `lab/vm/cloud/`
+    holds three — so a path outside `WORKROOT` is a mistake, and one caught
+    after the unlink is caught too late."""
+    import pytest
+
+    from tests.vm.run import WORKROOT, create_target
+
+    keep = tmp_path / "debian-12-genericcloud-amd64.qcow2"
+    keep.write_bytes(b"not really an image, but it stands for one")
+
+    with pytest.raises(ValueError, match="deletes what it is given"):
+        create_target(keep)
+    assert keep.exists(), "the refusal has to come before the unlink"
+    assert keep.read_bytes().startswith(b"not really"), "and leave it untouched"
+
+    # Negative control: a path inside a run directory is the ordinary case and
+    # still works, or the guard would have stopped every run.
+    inside = WORKROOT / "unit-test-create-target" / "target.qcow2"
+    inside.parent.mkdir(parents=True, exist_ok=True)
+    try:
+        made = create_target(inside)
+        assert made.exists() and made.stat().st_size > 0
+    finally:
+        inside.unlink(missing_ok=True)
+        inside.parent.rmdir()

--- a/tests/vm/run.py
+++ b/tests/vm/run.py
@@ -154,6 +154,13 @@ def create_target(path: Path, seed: tuple[str, ...] = ()) -> Path:
     Seeded through a raw image and converted: `parted` writes to a file, and
     it cannot read a qcow2.
     """
+    # The first thing this does is delete the file, and the images an in-place
+    # conversion will be given are downloaded once and kept: `lab/vm/cloud/`
+    # holds three of them. A run writes only inside its own directory, so a
+    # path outside `WORKROOT` is a mistake rather than a target, and it is
+    # refused before the unlink rather than diagnosed after it.
+    if WORKROOT not in path.resolve().parents:
+        raise ValueError(f"{path} is not inside {WORKROOT}, and this deletes what it is given")
     path.unlink(missing_ok=True)
     if not seed:
         subprocess.run(


### PR DESCRIPTION
`create_target` opens with `path.unlink(missing_ok=True)`. Every caller today passes a path inside the run's own directory, so nothing is at risk yet — but the next piece of work hands this harness disk images it must not destroy. `lab/vm/cloud/` holds three cloud images downloaded from NJU for converting a foreign distribution in place, and a conversion boots an existing writable root rather than a blank disk.

So the check goes in before the work that needs it, not after the first loss. A path outside `WORKROOT` raises instead of deleting, and the message says why. The negative control is the ordinary case: a path inside a run directory still creates a disk, or the guard would have stopped every run.

This is the "look at the target before deleting it" rule applied to a function whose whole job is to delete and recreate.