### PR TITLE
model: refuse a profile whose stage3 this installer does not fetch

### DIFF
--- a/gentoo_install/model/compat.py
+++ b/gentoo_install/model/compat.py
@@ -55,6 +55,19 @@ from .device import (
 #: to provide.
 CJK_FONT_SIZES = frozenset({ConsoleFontSize.SIZE_8X16})
 
+#: Profile path segments this installer has no stage3 for, and the reason each
+#: one needs a different tarball rather than a different `eselect profile set`.
+#: `variant_of` maps a profile to a published stage3, and a segment missing
+#: from its table silently gets the plain one: a musl profile on a glibc
+#: stage3 is two C libraries in one system, which no profile switch repairs.
+UNSERVED_PROFILES: Final[dict[str, str]] = {
+    "musl": "musl is a different C library, and the package groups here are built against glibc",
+    "hardened": "hardened needs its own stage3 and toolchain, not a profile switch",
+    "llvm": "the llvm profile needs a stage3 built with that toolchain",
+    "systemd-hardened": "hardened needs its own stage3 and toolchain, not a profile switch",
+}
+
+
 #: The package that provides each kernel choice. Here rather than in `plan/`
 #: because `traits_of` reads it and `model` is not allowed to call upward;
 #: `plan.kernel` imports this one.

--- a/gentoo_install/model/validate.py
+++ b/gentoo_install/model/validate.py
@@ -203,6 +203,7 @@ def validate(
         *_proxy_problems(config),
         *graph_problems,
         *_profile_problems(config),
+        *_unserved_profile_problems(config),
         *_repository_profile_problems(config.portage.profile, available_profiles),
         *_kernel_package_problems(config),
         *_network_problems(config, address_facts.system),
@@ -582,6 +583,19 @@ def _profile_problems(config: InstallConfig) -> list[str]:
         return []
     wanted = "one ending in /systemd" if wants_systemd else "one without /systemd"
     return [f"init is {config.system.init.value} and the profile is {profile}; use {wanted}"]
+
+
+def _unserved_profile_problems(config: InstallConfig) -> list[str]:
+    """A profile whose stage3 Gentoo publishes separately and this installer
+    does not fetch. The profile list comes from the machine's own repository,
+    so these are reachable choices, and taking one silently fetched the plain
+    tarball instead."""
+    segments = set(config.portage.profile.split("/"))
+    return [
+        f"profile {config.portage.profile} needs its own stage3: {reason}"
+        for segment, reason in sorted(compat.UNSERVED_PROFILES.items())
+        if segment in segments
+    ]
 
 
 def _repository_profile_problems(

--- a/tests/unit/test_validate.py
+++ b/tests/unit/test_validate.py
@@ -897,3 +897,41 @@ def test_an_unpinned_kernel_is_left_to_portage() -> None:
     assert zfs_kernel_version_problem("", KernelCeiling(maximum="7.0")) is None
     assert zfs_kernel_version_problem("6.18.41", KernelCeiling(maximum="7.0")) is None
     assert zfs_kernel_version_problem("7.1.0", KernelCeiling(maximum="7.0")) is not None
+
+
+def test_a_profile_whose_stage3_is_not_fetched_is_refused() -> None:
+    """`variant_of` maps a profile to a published stage3 and its table holds
+    `/no-multilib` and `/desktop`. A musl profile misses it and gets the plain
+    tarball, which is glibc: two C libraries in one system, and `eselect
+    profile set` repairs none of it. The profile list comes from the machine's
+    own repository, so these are choices an operator can make.
+    """
+    from dataclasses import replace
+
+    from gentoo_install.model import compat
+    from gentoo_install.plan.portage import variant_of
+
+    base = config()
+    for segment in compat.UNSERVED_PROFILES:
+        broken = replace(
+            base,
+            portage=replace(base.portage, profile=f"default/linux/amd64/23.0/{segment}"),
+            system=replace(base.system, init=InitSystem.OPENRC),
+        )
+        with pytest.raises(ValidationFailed, match="needs its own stage3"):
+            validate(broken)
+
+        # The reason it has to be refused rather than mapped: the variant this
+        # installer would fetch does not name the profile at all.
+        assert segment not in variant_of(broken), (segment, variant_of(broken))
+
+    # Negative control: the profiles the table does serve are not refused, and
+    # each one changes the tarball that is fetched.
+    for segment, expected in (("no-multilib", "nomultilib"), ("desktop", "desktop")):
+        served = replace(
+            base,
+            portage=replace(base.portage, profile=f"default/linux/amd64/23.0/{segment}"),
+            system=replace(base.system, init=InitSystem.OPENRC),
+        )
+        validate(served)
+        assert variant_of(served) == f"{expected}-openrc", variant_of(served)


### PR DESCRIPTION
`plan/portage.variant_of` picks the stage3 that matches the profile, and `STAGE3_BY_PROFILE` holds two entries: `/no-multilib` and `/desktop`. Anything else falls through to the plain tarball.

The profile list an operator chooses from comes from the machine's own repository — `probe.amd64_profiles()` reads `profiles.desc` — so `default/linux/amd64/23.0/musl` is a reachable choice. Taking it fetched a **glibc** stage3 and then ran `eselect profile set` to a musl profile: two C libraries in one system, and a profile switch removes nothing, which is the same reasoning `variant_of`'s own docstring gives for no-multilib.

Gentoo publishes musl, hardened and llvm stage3s separately. Fetching them is a feature — the package groups, the binhost subarchitecture and the CJK font sets here are all built against glibc — so this refuses the choice with the reason instead of pretending to serve it. Found by comparing against `oddlama-gentoo-install` (MIT), which represents these variants; nothing was copied.

The negative control is the two profiles the table does serve: they validate, and each changes the tarball.