### PR TITLE
vm: name a silent console instead of blaming GRUB

### DIFF
--- a/tests/unit/test_proxmox.py
+++ b/tests/unit/test_proxmox.py
@@ -3549,3 +3549,40 @@ def test_a_boot_that_never_prompts_says_what_the_console_held(
     )
     assert "Kernel panic" in other, other
     assert other != said
+
+
+def test_a_silent_console_is_not_reported_as_a_stubborn_grub(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """`openrc-sdboot` came back with `GRUB never opened its editor: b'\\r\\n'`
+    after two minutes of pressing `e`: two bytes for the whole wait. That is a
+    console that delivered nothing, not a menu that refused to open an editor,
+    and the two need different answers — one is a node, the other is a
+    keystroke count."""
+    from tests.vm import proxmox
+    from tests.vm.proxmox import ProxmoxError
+
+    monkeypatch.setattr("time.sleep", lambda seconds: None)
+
+    class Console:
+        def __init__(self, screen: bytes) -> None:
+            self.screen = screen
+
+        def send_raw(self, keys: str) -> None:
+            return None
+
+        def snapshot(self, seconds: float) -> bytes:
+            return self.screen
+
+    with pytest.raises(ProxmoxError, match="the console delivered"):
+        proxmox._editor_screen(cast(Any, Console(b"\r\n")), 0.2)
+
+    # Negative control: a console that drew a menu and still opened no editor
+    # keeps the sentence about GRUB, because that is a different failure.
+    menu = b"\x1b[2J\x1b[01;01HGNU GRUB  version 2.14\r\nGentoo Linux\r\n" * 4
+    with pytest.raises(ProxmoxError, match="GRUB never opened its editor"):
+        proxmox._editor_screen(cast(Any, Console(menu)), 0.2)
+
+    # And a screen holding `setparams` is the editor, so neither fires.
+    editor = b"setparams 'Gentoo'\r\n  linux /boot/vmlinuz root=UUID=...\r\n"
+    assert b"setparams" in proxmox._editor_screen(cast(Any, Console(editor)), 0.2)

--- a/tests/vm/proxmox.py
+++ b/tests/vm/proxmox.py
@@ -1010,6 +1010,11 @@ class Reopenable(Protocol):
 #: read as one sequence.
 ESCAPE_SETTLES: Final[float] = 2.0
 
+#: Below this, the console said nothing rather than saying the wrong thing. A
+#: menu redraw is hundreds of bytes of escape sequences, so anything under a
+#: line is silence.
+SILENT_CONSOLE_BYTES: Final[int] = 16
+
 
 def _editor_screen(console: Line, timeout: float) -> bytes:
     """Press `e` until GRUB draws the entry, and answer with that screen.
@@ -1041,6 +1046,13 @@ def _editor_screen(console: Line, timeout: float) -> bytes:
         console.send_raw("e")
     # The whole read, not the last snapshot: the last one is empty on a guest
     # that booted while the loop was still pressing, which says nothing.
+    # A silent console and a stubborn GRUB need different answers, so they get
+    # different sentences: `openrc-sdboot` reported two bytes as GRUB's fault.
+    if len(everything.strip()) < SILENT_CONSOLE_BYTES:
+        raise ProxmoxError(
+            f"the console delivered {len(everything)} bytes while the editor was "
+            f"asked for over {timeout:.0f}s: {everything[-400:]!r}"
+        )
     raise ProxmoxError(f"GRUB never opened its editor: {everything[-400:]!r}")
 
 


### PR DESCRIPTION
`openrc-sdboot` failed with `GRUB never opened its editor: b'\r\n'`: two bytes for the whole 120s wait. The verdict named GRUB, but nothing was drawn at all, and the two failures have different causes — one is the node, the other is a keystroke count.