### PR TITLE
convert: name the command the machine could not be read with

### DIFF
--- a/gentoo_install/cli.py
+++ b/gentoo_install/cli.py
@@ -622,6 +622,12 @@ def _conversion_offer(probe: Probe) -> tuple[str, str]:
     medium = probe.live_medium()
     if medium:
         return "", f"this is a live medium ({medium}), so there is no system to replace"
+    # Measured on an Alpine cloud image: without these the layout reads back
+    # empty and the refusal blamed the root device rather than the package.
+    lacking = report.absent(preflight.LAYOUT_COMMANDS, probe)
+    if lacking:
+        missing = ", ".join(sorted(lacking))
+        return "", f"the running system cannot be read without {missing}"
     try:
         layout = probe.storage_layout()
     except GentooInstallError as error:

--- a/gentoo_install/exec/preflight.py
+++ b/gentoo_install/exec/preflight.py
@@ -60,6 +60,12 @@ BY_OPERATION: Final[dict[type[Operation], tuple[str, ...]]] = {
 #: `password_hash` already, and the menu computes one with `openssl passwd -6`.
 MENU_ONLY: Final[tuple[str, ...]] = ("openssl",)
 
+#: What `Probe.storage_layout` runs to read the machine it is offered to
+#: replace. Alpine's busybox has none of them, and without them every field
+#: comes back empty, so the conversion is refused for a reason that names the
+#: layout rather than the missing package.
+LAYOUT_COMMANDS: Final[tuple[str, ...]] = ("findmnt", "lsblk", "blkid")
+
 #: What each part of a layout adds. Derived from the graph, never a second list.
 BY_FEATURE: Final[dict[str, tuple[str, ...]]] = {
     # `partprobe` is absent here on purpose: it comes from parted, and

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -15,6 +15,7 @@ import pytest
 from gentoo_install import cli
 from gentoo_install.exec import fetch
 from gentoo_install.exec import report
+from gentoo_install.exec.probe import Probe as RealProbe
 from gentoo_install.exec.runner import Runner
 from gentoo_install.cli import EXIT_CONFIG, EXIT_INTEGRITY, EXIT_OK, EXIT_PREFLIGHT, main
 from gentoo_install.errors import ConfigError, IntegrityError
@@ -1203,3 +1204,34 @@ def test_the_machine_gets_the_derived_configuration_for_a_conversion(
     cli.install(converted, (), arguments, cli.RunState(), running)
 
     assert seen == [running], "the machine takes the derived one"
+
+
+def test_the_conversion_offer_names_the_command_the_reading_needs(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Measured on an Alpine 3.21 cloud image over ssh: busybox ships no
+    `findmnt` and no `lsblk`, so `storage_layout()` came back with every field
+    `None` and the conversion was refused with `the running root device could
+    not be read`. The machine was readable; the package was missing, and the
+    refusal has to say which one so the operator can install it."""
+
+    class Probe:
+        def live_medium(self) -> str:
+            return ""
+
+        def storage_layout(self) -> StorageLayout:
+            raise AssertionError("the layout must not be read without its commands")
+
+    absent: set[str] = {"findmnt", "lsblk"}
+    monkeypatch.setattr(report, "absent", lambda wanted, probe=None: set(absent))
+
+    running, refused = cli._conversion_offer(cast(RealProbe, Probe()))
+    assert running == ""
+    assert "findmnt" in refused and "lsblk" in refused, refused
+
+    # Negative control: with every command present the offer reads the layout,
+    # which this double refuses to answer. A guard that fires unconditionally
+    # would swallow that and return a refusal instead.
+    absent.clear()
+    with pytest.raises(AssertionError, match="must not be read"):
+        cli._conversion_offer(cast(RealProbe, Probe()))


### PR DESCRIPTION
Measured over ssh on an Alpine 3.21 cloud image: busybox ships neither `findmnt` nor `lsblk`, so `storage_layout()` returned every field `None` and the conversion offer answered `the running root device could not be read`. The machine was readable; the package was missing.

After `apk add util-linux` the same machine reads as `/dev/vda on ext4` and is refused for its real reason — 7 GiB free against the 10 a conversion needs.