### PR TITLE
convert: refuse a bios conversion of a partitionless root

### DIFF
--- a/gentoo_install/plan/convert.py
+++ b/gentoo_install/plan/convert.py
@@ -295,6 +295,14 @@ def layout_graph(layout: StorageLayout) -> DiskConfig:
         )
     if not layout.root_device or not layout.root_filesystem_type:
         raise ConversionUnsupported("the running root device could not be read")
+    if not layout.uefi and layout.root_below_device is None:
+        # Measured on an Alpine cloud image, whose ext4 sits on `/dev/vda`
+        # itself: `grub-install --target=i386-pc` answers `will not proceed
+        # with blocklists`, and it would answer that after the swap.
+        raise ConversionUnsupported(
+            f"the running root {layout.root_device} is a whole disk with no partition, "
+            "so a bios bootloader has nowhere to embed its core image"
+        )
     nodes: list[object] = [
         Existing(id=ROOT_DEVICE, selector=layout.root_device),
         Filesystem(

--- a/tests/unit/test_plan_convert.py
+++ b/tests/unit/test_plan_convert.py
@@ -633,3 +633,34 @@ def test_a_findmnt_that_failed_does_not_authorise_the_staging_root_to_be_removed
     clean = NothingUnderIt()
     convert.LeaveStaging().apply(clean)
     assert [one for one in clean.commands if one[0] == "rm"], clean.commands
+
+
+def test_a_bios_conversion_refuses_a_root_that_is_a_whole_disk() -> None:
+    """Measured on an Alpine 3.21 cloud image: its ext4 sits on `/dev/vda`
+    itself, with a dos label carrying no partitions and SYSLINUX in the boot
+    sector. `grub-install --target=i386-pc /dev/vda` there answers
+
+        warning: Embedding is not possible.
+        error: will not proceed with blocklists.
+
+    The plan rendered all 49 operations against that machine, so without this
+    the conversion emerges a whole system, swaps `/usr`, `/etc` and `/bin`, and
+    only then finds it cannot write a bootloader — with the old system gone.
+    """
+    whole_disk = replace(
+        _layout(uefi=False, esp_device=None, esp_mountpoint=None),
+        root_device="/dev/vda",
+        root_below_device=None,
+    )
+    with pytest.raises(ConversionUnsupported, match="nowhere to embed"):
+        convert.layout_graph(whole_disk)
+
+    # Negative control one: the same machine with root on a partition is what
+    # every ordinary bios install looks like, and it has a post-MBR gap.
+    partitioned = replace(whole_disk, root_device="/dev/vda2", root_below_device="/dev/vda")
+    assert convert.layout_graph(partitioned).mode is DiskMode.IN_PLACE
+
+    # Negative control two: on UEFI nothing is embedded in a boot sector, so a
+    # whole-disk root is not this failure and must still be accepted.
+    uefi = replace(whole_disk, uefi=True, esp_device="/dev/vda1", esp_mountpoint="/boot/efi")
+    assert convert.layout_graph(uefi).mode is DiskMode.IN_PLACE


### PR DESCRIPTION
An Alpine 3.21 cloud image carries ext4 on `/dev/vda` itself: a dos label with no partitions and SYSLINUX in the boot sector. Run there, `grub-install --target=i386-pc /dev/vda` answers `warning: Embedding is not possible` and `error: will not proceed with blocklists`.

The plan rendered all 49 operations against that machine, so the failure arrived after the atomic swap of `/usr`, `/etc` and `/bin` — the old system replaced and the new one with no bootloader. The layout carries the signal already: `root_below_device` is `None` when root is a whole disk.