### PR TITLE
vm: ask again for the login prompt after a reconnect

### DIFF
--- a/tests/unit/test_cluster.py
+++ b/tests/unit/test_cluster.py
@@ -1190,3 +1190,52 @@ def test_a_refused_login_says_what_the_guest_was_showing(
     theirs = cluster._log_in(cast(cluster.Reconnecting, other), "install")
     assert "Maximum number of tries exceeded" in theirs, theirs
     assert theirs != said, "two different screens gave the same verdict"
+
+
+def test_the_login_wait_asks_again_after_the_console_is_reopened() -> None:
+    """run54 compared against run51 byte for byte at the same point: run51 has
+    the kernel's own first line straight after `Loading initial ramdisk ...`,
+    and run54 has the reconnect banner there instead and nothing after it. The
+    guest had booted; the console was reopened past the prompt.
+
+    `agetty` writes `login:` once, so a wait that never writes to the guest
+    spends the whole of `BOOT_PATIENCE` on a healthy machine.
+    """
+    from tests.vm.console import ConsoleClosed
+
+    class Console:
+        def __init__(self, opened: int) -> None:
+            self.opened = opened
+            self.asked = False
+
+        def expect(self, pattern: str, timeout: float) -> bytes:
+            if self.opened == 1:
+                raise ConsoleClosed("the guest closed the serial connection")
+            # The second console is the reopened one, and the prompt has
+            # already gone by: only a keystroke brings it back.
+            if not self.asked:
+                raise ConsoleClosed("still nothing")
+            return b"gentoo login:"
+
+        def send(self, line: str) -> None:
+            self.asked = True
+
+        def close(self) -> None:
+            return None
+
+    opened: list[Console] = []
+
+    def open_console() -> Any:
+        opened.append(Console(len(opened) + 1))
+        return opened[-1]
+
+    link = cluster.Reconnecting(open_console, tries=4)
+    assert b"login:" in link.observe(r"login:", timeout=30.0, solicit=True)
+
+    # Negative control: the default is still the silent wait, because an empty
+    # line at a passphrase prompt is an attempt rather than a request. Without
+    # soliciting, the same guest never shows the prompt again.
+    opened.clear()
+    silent = cluster.Reconnecting(open_console, tries=4)
+    with pytest.raises(ConsoleClosed):
+        silent.observe(r"login:", timeout=30.0)

--- a/tests/unit/test_proxmox.py
+++ b/tests/unit/test_proxmox.py
@@ -1690,7 +1690,7 @@ def test_installed_login_uses_the_login_observed_by_unlock(
         def reopen(self, *, solicit_prompt: bool = True) -> None:
             events.append(f"reopen:{solicit_prompt}")
 
-        def observe(self, pattern: str, timeout: float) -> bytes:
+        def observe(self, pattern: str, timeout: float, *, solicit: bool = False) -> bytes:
             events.append(f"observe:{pattern}")
             if pattern == PASSWORD_PROMPT:
                 return "\u5bc6\u78bc\uff1a".encode()
@@ -3524,7 +3524,7 @@ def test_a_boot_that_never_prompts_says_what_the_console_held(
         def reopen(self, *, solicit_prompt: bool = True) -> None:
             return None
 
-        def observe(self, pattern: str, timeout: float) -> bytes:
+        def observe(self, pattern: str, timeout: float, *, solicit: bool = False) -> bytes:
             raise ConsoleTimeout("never matched 'login:'")
 
     from gentoo_install.exec.config import load

--- a/tests/vm/cluster.py
+++ b/tests/vm/cluster.py
@@ -2079,16 +2079,18 @@ class Reconnecting:
             lambda deadline: self.console.expect(pattern, _remaining(deadline)),
         )
 
-    def observe(self, pattern: str, timeout: float) -> bytes:
+    def observe(self, pattern: str, timeout: float, *, solicit: bool = False) -> bytes:
         """Wait through a reconnect without writing to the guest.
 
         Boot prompts own the console input field. An empty line there is a
         password attempt, not a harmless request for another shell prompt.
+        `solicit` is for the wait where that does not hold: `login:` is printed
+        once, so a console reopened past it never sees the prompt again.
         """
         return self._with_reconnect(
             timeout,
             lambda deadline: self.console.expect(pattern, _remaining(deadline)),
-            solicit_on_reconnect=False,
+            solicit_on_reconnect=solicit,
         )
 
     def run(self, command: str, timeout: float = 120.0) -> None:
@@ -2569,7 +2571,10 @@ def boot_and_check(
         return unlocked.refused
     if unlocked.state is InstalledBootState.WAIT_LOGIN:
         try:
-            link.observe(r"login:", timeout=BOOT_PATIENCE)
+            # Solicited: run54 reopened the console between `Loading initial
+            # ramdisk` and the kernel's first line, and agetty prints `login:`
+            # once, so the whole patience was spent on a guest that had booted.
+            link.observe(r"login:", timeout=BOOT_PATIENCE, solicit=True)
         except (ConsoleTimeout, ConsoleClosed) as error:
             # The same reason the refused login carries one: `never matched
             # 'login:'` with the console banner as the last output says the


### PR DESCRIPTION
`vm-convert` failed in run53 and run54, and `openrc-sdboot` in run54, all with `the installed system did not reach a login prompt` and a console holding only the reconnect banner.

Comparing the same point of run51's log, which passed that stage: run51 carries the kernel's own first line straight after `Loading initial ramdisk ...`, and run54 carries the reconnect banner there and nothing after it. Both runs installed the identical 54 operations from an identical fixture, and `grep 'Linux version'` finds two in run51 and one in run54.

The guest had booted. `agetty` writes `login:` once, so a wait that never writes to the guest cannot see it again. `observe` keeps its silent default, since an empty line at a passphrase prompt is an attempt rather than a request.