### PR TITLE
portage: degrade when a background binpkg fetch fails

### DIFF
--- a/gentoo_install/plan/portage.py
+++ b/gentoo_install/plan/portage.py
@@ -819,9 +819,15 @@ class Emerge(Operation):
         return [*argv, "--", *self.packages]
 
 
+#: Portage's own binary package extension, which is what proves a fetch was a
+#: binary one when the path is the only line naming it.
+GPKG_SUFFIX: Final[str] = ".gpkg.tar"
+
+
 def _binpkg_failure(output: str) -> str | None:
     """Return a Portage marker that proves the failure was a binary fetch."""
     binaries: set[str] = set()
+    pending = ""
     for raw in output.splitlines():
         line = raw.strip()
         if any(
@@ -839,7 +845,15 @@ def _binpkg_failure(output: str) -> str | None:
         # two are read together. `btrfs-luks` lost an hour of install there.
         if started := re.match(r">>> Emerging binary \(\d+ of \d+\) (\S+)", line):
             binaries.add(started.group(1).split("::")[0])
-        if failed := re.match(r">>> Failed to emerge (\S+?),", line):
+        # A package whose binary is fetched in the background never reaches
+        # `Emerging binary`, and its failure line carries no comma: `vm-desktop`
+        # stopped at `>>> Failed to emerge net-wireless/wireless-regdb-20251007`
+        # with `.gpkg.tar.partial` as the only proof it was a binary.
+        if checking := re.match(r">>> Running pre-merge checks for (\S+)", line):
+            pending = checking.group(1).split("::")[0]
+        elif GPKG_SUFFIX in line and pending:
+            binaries.add(pending)
+        if failed := re.match(r">>> Failed to emerge (\S+?)(?:,|$)", line):
             if failed.group(1) in binaries:
                 return line
     return None

--- a/tests/unit/test_plan_portage.py
+++ b/tests/unit/test_plan_portage.py
@@ -1856,3 +1856,77 @@ def test_a_binary_that_downloads_on_the_second_try_compiles_nothing() -> None:
     assert len(emerges) == 2
     assert all("--getbinpkg=n" not in argv for argv in emerges)
     assert not recorder.degraded(portage.BINARY_PACKAGES)
+
+
+#: Verbatim from `run54/vm-desktop.install.txt`, which ended at exit 4.
+BACKGROUND_FETCH = """>>> Verifying ebuild manifests
+
+>>> Running pre-merge checks for net-wireless/wireless-regdb-20251007
+ * Fetching in the background:
+ * /var/cache/binhost/gentoo/net-wireless/wireless-regdb/\
+wireless-regdb-20251007-1.gpkg.tar.partial
+ * To view fetch progress, run in another terminal:
+ * tail -f /var/log/emerge-fetch.log
+
+>>> Failed to emerge net-wireless/wireless-regdb-20251007
+"""
+
+
+def test_a_binary_fetched_in_the_background_retries_from_source() -> None:
+    """`vm-desktop` in run54 stopped at exit 4 after twelve minutes. A package
+    whose binary Portage fetches in the background never prints `Emerging
+    binary`, and its failure line carries no comma, so neither half of the
+    existing rule matched. The only line naming it a binary is the
+    `.gpkg.tar.partial` path.
+    """
+    recorder = Recorder()
+    recorder.answering = lambda argv: (
+        CommandOutput(BACKGROUND_FETCH, 1)
+        if argv[0] == "emerge" and "--usepkg=n" not in argv
+        else CommandOutput("[ebuild] net-wireless/wireless-regdb-20251007", 0)
+    )
+
+    portage.Emerge(
+        packages=("kde-plasma/plasma-meta",), summary="install the plasma group"
+    ).apply(recorder)
+
+    emerges = [argv for argv in recorder.in_target if argv[0] == "emerge"]
+    assert "--getbinpkg=n" in emerges[-1] and "--usepkg=n" in emerges[-1]
+    assert recorder.degraded(portage.BINARY_PACKAGES)
+
+
+def test_a_background_fetch_of_a_source_build_is_not_a_binary_failure() -> None:
+    """Negative control. The same shape without the `.gpkg.tar` line is a
+    package Portage was compiling, and retrying it from source repeats the
+    build that already failed."""
+    recorder = Recorder()
+    compiled = "\n".join(
+        line for line in BACKGROUND_FETCH.splitlines() if ".gpkg.tar" not in line
+    )
+    recorder.answering = lambda argv: CommandOutput(compiled, 1)
+
+    with pytest.raises(CommandFailed):
+        portage.Emerge(
+            packages=("kde-plasma/plasma-meta",), summary="install the plasma group"
+        ).apply(recorder)
+
+    assert not recorder.degraded(portage.BINARY_PACKAGES)
+
+
+def test_a_gpkg_for_one_package_does_not_excuse_another_failing() -> None:
+    """Negative control. The binary that was fetched and the package that
+    failed have to be the same one, or every source failure after any binary
+    download would be retried from source for nothing."""
+    recorder = Recorder()
+    other = BACKGROUND_FETCH.replace(
+        ">>> Failed to emerge net-wireless/wireless-regdb-20251007",
+        ">>> Failed to emerge sys-apps/portage-3.0.69",
+    )
+    recorder.answering = lambda argv: CommandOutput(other, 1)
+
+    with pytest.raises(CommandFailed):
+        portage.Emerge(
+            packages=("kde-plasma/plasma-meta",), summary="install the plasma group"
+        ).apply(recorder)
+
+    assert not recorder.degraded(portage.BINARY_PACKAGES)


### PR DESCRIPTION
`vm-desktop` ended run54 at exit 4 after twelve minutes. The log's own words:

```
>>> Running pre-merge checks for net-wireless/wireless-regdb-20251007
 * Fetching in the background:
 * /var/cache/binhost/gentoo/.../wireless-regdb-20251007-1.gpkg.tar.partial
>>> Failed to emerge net-wireless/wireless-regdb-20251007
```

A package fetched in the background never prints `Emerging binary`, and its failure line carries no comma, so neither half of `_binpkg_failure` matched and the install stopped where the binhost rule says it degrades to source. The `.gpkg.tar.partial` path is the only line naming it a binary.