### PR TITLE
convert: read the btrfs subvolume a root sits on

### DIFF
--- a/gentoo_install/exec/probe.py
+++ b/gentoo_install/exec/probe.py
@@ -201,6 +201,17 @@ def _entry_text(entry: Mapping[str, object], key: str) -> str | None:
     return value if isinstance(value, str) and value else None
 
 
+def _source_and_subvolume(source: str | None) -> tuple[str | None, str | None]:
+    """Split `findmnt`'s source into the device and the subvolume it named."""
+    if source is None:
+        return None, None
+    if not (opened := source.find("[")) >= 0 or not source.endswith("]"):
+        return source, None
+    # No `[/]` case: `mount -o subvol=/` still answers a plain source, checked
+    # against btrfs on 2026-08-17, so brackets always name a real subvolume.
+    return source[:opened] or None, source[opened + 1 : -1]
+
+
 def _device_path(value: object) -> str | None:
     if not isinstance(value, str) or not value:
         return None
@@ -814,7 +825,7 @@ class Probe:
     def storage_layout(self) -> StorageLayout:
         """Read the running root, boot filesystems, and block-device stack."""
         mounts_result = self.runner.run(
-            ["findmnt", "--json", "--bytes", "--output", "TARGET,SOURCE,FSTYPE,AVAIL"],
+            ["findmnt", "--json", "--bytes", "--output", "TARGET,SOURCE,FSTYPE,AVAIL,OPTIONS"],
             check=False,
         )
         mounts: tuple[Mapping[str, object], ...] = ()
@@ -828,7 +839,11 @@ class Probe:
             (entry for entry in mounts if _entry_text(entry, "target") == "/boot"),
             None,
         )
-        root_device = _entry_text(root, "source") if root is not None else None
+        # Run against btrfs on 2026-08-17: a subvolume mount answers
+        # `/dev/vda3[/probe-test]`, which names no block device at all.
+        root_device, root_subvolume = _source_and_subvolume(
+            _entry_text(root, "source") if root is not None else None
+        )
         root_type = _entry_text(root, "fstype") if root is not None else None
         blocks_result = self.runner.run(
             ["lsblk", "--json", "--bytes", "--paths", "--output", "NAME,PATH,TYPE,FSTYPE,UUID,PKNAME,PARTTYPE"],
@@ -868,7 +883,11 @@ class Probe:
             root_on_luks=luks,
             root_on_mdraid=mdraid,
             root_below_device=below,
-            boot_device=_entry_text(boot, "source") if boot is not None else root_device,
+            boot_device=(
+                _source_and_subvolume(_entry_text(boot, "source"))[0]
+                if boot is not None
+                else root_device
+            ),
             boot_filesystem_type=(
                 _entry_text(boot, "fstype") if boot is not None else root_type
             ),
@@ -881,6 +900,7 @@ class Probe:
             esp_mountpoint=esp_mountpoint if uefi else None,
             uefi=uefi,
             root_free_bytes=_entry_int(root, "avail") if root is not None else None,
+            root_subvolume=root_subvolume,
             carried_fstab=_fstab_we_do_not_manage(
                 esp_mountpoint if uefi else None,
                 _entry_text(boot, "target") if boot is not None else None,

--- a/gentoo_install/model/device.py
+++ b/gentoo_install/model/device.py
@@ -159,6 +159,10 @@ class StorageLayout:
     #: its data partition or its swap boots and is wrong in a way no assertion
     #: here can see.
     carried_fstab: tuple[str, ...] = ()
+    #: The btrfs subvolume the root is mounted from, when it is not the top
+    #: level. `findmnt` writes it into the source as `/dev/sda2[/@]` and into
+    #: the options as `subvol=/@`, and a root read without it names no device.
+    root_subvolume: str | None = None
 
 
 @dataclass(frozen=True, init=False)

--- a/gentoo_install/plan/convert.py
+++ b/gentoo_install/plan/convert.py
@@ -295,6 +295,14 @@ def layout_graph(layout: StorageLayout) -> DiskConfig:
         )
     if not layout.root_device or not layout.root_filesystem_type:
         raise ConversionUnsupported("the running root device could not be read")
+    if layout.root_subvolume:
+        # `layout_graph` emits no Subvolume, so `_rootflags` answers nothing and
+        # the cmdline carries no `rootflags=`: the initramfs would mount the
+        # default subvolume and never see the system that was written.
+        raise ConversionUnsupported(
+            f"the running root is on the btrfs subvolume {layout.root_subvolume}, "
+            "which the conversion cannot carry onto the new command line"
+        )
     if not layout.uefi and layout.root_below_device is None:
         # Measured on an Alpine cloud image, whose ext4 sits on `/dev/vda`
         # itself: `grub-install --target=i386-pc` answers `will not proceed

--- a/tests/unit/test_plan_convert.py
+++ b/tests/unit/test_plan_convert.py
@@ -664,3 +664,19 @@ def test_a_bios_conversion_refuses_a_root_that_is_a_whole_disk() -> None:
     # whole-disk root is not this failure and must still be accepted.
     uefi = replace(whole_disk, uefi=True, esp_device="/dev/vda1", esp_mountpoint="/boot/efi")
     assert convert.layout_graph(uefi).mode is DiskMode.IN_PLACE
+
+
+def test_a_conversion_refuses_a_root_on_a_btrfs_subvolume() -> None:
+    """Fedora, Ubuntu and openSUSE all put root on a btrfs subvolume.
+    `layout_graph` emits no `Subvolume`, so `_rootflags` answers nothing and the
+    new command line carries no `rootflags=subvol=`: the initramfs would mount
+    the default subvolume and never see the system that was written into `/@`.
+    """
+    on_a_subvolume = replace(_layout(root_filesystem_type="btrfs"), root_subvolume="/@")
+    with pytest.raises(ConversionUnsupported, match="btrfs subvolume /@"):
+        convert.layout_graph(on_a_subvolume)
+
+    # Negative control: btrfs at the top level is what Arch's cloud image runs,
+    # and it needs no `rootflags=` at all.
+    top_level = replace(on_a_subvolume, root_subvolume=None)
+    assert convert.layout_graph(top_level).mode is DiskMode.IN_PLACE

--- a/tests/unit/test_probe.py
+++ b/tests/unit/test_probe.py
@@ -242,3 +242,69 @@ def test_an_esp_nothing_is_mounted_from_is_still_named(tmp_path: Path) -> None:
     blocks = ({"path": "/dev/sda1", "parttype": esp_type},)
 
     assert _esp_from_blocks(blocks, ()) == ("/dev/sda1", None)
+
+
+class SubvolumeListing(Runner):
+    """Verbatim shapes from `findmnt` on btrfs, read on 2026-08-17: a
+    subvolume mount answers `/dev/vda3[/probe-test]` in its source and
+    `subvol=/probe-test` in its options, while the top level answers a plain
+    device and `subvol=/`."""
+
+    def run(self, argv: Sequence[str], **rest: object) -> Result:
+        if argv[0] == "findmnt":
+            output = json.dumps({"filesystems": [
+                {
+                    "target": "/",
+                    "source": "/dev/vda3[/@]",
+                    "fstype": "btrfs",
+                    "avail": 38334017536,
+                    "options": "rw,relatime,compress=zstd:1,subvolid=256,subvol=/@",
+                },
+            ]})
+        elif argv[0] == "lsblk":
+            output = json.dumps({"blockdevices": [
+                {"path": "/dev/vda3", "type": "part", "fstype": "btrfs",
+                 "uuid": "root-uuid", "pkname": "/dev/vda"},
+            ]})
+        else:
+            output = "root-uuid\n"
+        return Result(argv=tuple(argv), returncode=0, stdout=output, stderr="", seconds=0.0)
+
+
+def test_a_subvolume_root_names_its_device_and_its_subvolume(tmp_path: Path) -> None:
+    """`/dev/vda3[/@]` is not a block device. Left whole it matches nothing in
+    `lsblk`, so the uuid and the disk below both come back empty and the
+    conversion builds a graph around a selector no device carries."""
+    found = probe.Probe(runner=SubvolumeListing(log=lambda line: None), work=tmp_path)
+    layout = found.storage_layout()
+
+    assert layout.root_device == "/dev/vda3"
+    # Kept as `findmnt` wrote it, leading slash and all.
+    assert layout.root_subvolume == "/@"
+    # The point of splitting it: everything keyed by the device now resolves.
+    assert layout.root_uuid == "root-uuid"
+    assert layout.root_below_device == "/dev/vda"
+
+
+def test_a_top_level_btrfs_root_is_not_called_a_subvolume(tmp_path: Path) -> None:
+    """Negative control. Arch's cloud image answers `subvol=/` with a plain
+    source, and refusing that would refuse every ordinary btrfs machine."""
+
+    class TopLevel(SubvolumeListing):
+        def run(self, argv: Sequence[str], **rest: object) -> Result:
+            answer = super().run(argv, **rest)
+            if argv[0] != "findmnt":
+                return answer
+            return Result(
+                argv=answer.argv,
+                returncode=0,
+                stdout=answer.stdout.replace("/dev/vda3[/@]", "/dev/vda3").replace(
+                    "subvol=/@", "subvol=/"
+                ),
+                stderr="",
+                seconds=0.0,
+            )
+
+    layout = probe.Probe(runner=TopLevel(log=lambda line: None), work=tmp_path).storage_layout()
+    assert layout.root_device == "/dev/vda3"
+    assert layout.root_subvolume is None


### PR DESCRIPTION
Fedora, Ubuntu and openSUSE all put root on a btrfs subvolume. Run against btrfs on 2026-08-17, `findmnt --json` answers

```
"source": "/dev/vda3[/probe-test]",
"options": "rw,relatime,...,subvolid=259,subvol=/probe-test"
```

That source names no block device, so `lsblk` matched nothing and both `root_uuid` and `root_below_device` came back empty — and `layout_graph` did not refuse, it built a graph around a selector no device carries.

The device and the subvolume are now split apart. `layout_graph` emits no `Subvolume`, so `_rootflags` answers nothing and the new command line would carry no `rootflags=subvol=`; such a root is refused rather than converted into a machine whose initramfs mounts the default subvolume. Carrying it is the follow-up.

Checked with the tool both ways: `mount -o subvol=/` still answers a plain source, so brackets always name a real subvolume.