### PR TITLE
convert: unmount the staging root after a failure too

### DIFF
--- a/gentoo_install/plan/convert.py
+++ b/gentoo_install/plan/convert.py
@@ -218,6 +218,18 @@ class LeaveStaging(Operation):
     def required_host_commands(self) -> frozenset[str]:
         return frozenset({"umount", "findmnt", "rm"})
 
+    @property
+    def releases_the_machine(self) -> bool:
+        """Run after a failure too, because the failure is what needs it.
+
+        A conversion that stopped leaves `/proc`, `/sys` and `/dev` bound under
+        the staging root, which this class's own docstring calls holding the
+        machine at shutdown, and `PrepareStaging` then refuses the next attempt
+        because the directory is not empty. `rm -rf` on it from outside walks
+        those binds into the running system's `/dev`.
+        """
+        return True
+
     def describe(self) -> str:
         return f"unmount and remove {self.staging}"
 

--- a/tests/unit/test_plan_convert.py
+++ b/tests/unit/test_plan_convert.py
@@ -734,3 +734,24 @@ def test_the_carried_fstab_opens_inside_the_staging_root(tmp_path: Path) -> None
     assert opened == [PurePosixPath("/etc/fstab")]
     kept = (staging / "etc" / "fstab").read_text()
     assert "UUID=1" in kept and "/swap/swapfile" in kept
+
+
+def test_a_failed_conversion_still_unmounts_the_staging_root() -> None:
+    """`_release` runs only the closing operations that say they release the
+    machine, and `LeaveStaging` did not. A conversion that stopped therefore
+    left `/proc`, `/sys` and `/dev` bound under `/gentoo-install.new`, and
+    `PrepareStaging` refuses the next attempt because that directory is not
+    empty. Removing it by hand walks those binds into the running `/dev`, which
+    is what happened after the Arch run stopped at operation 34 of 46.
+    """
+    operations = build(_in_place(), CATALOG, layout=_layout())
+    closing = [one for one in operations if one.stage is Stage.FINISH]
+    leaving = [one for one in closing if isinstance(one, convert.LeaveStaging)]
+    assert leaving, closing
+    assert leaving[0].releases_the_machine
+
+    # Negative control: the rest of the closing stage still does not run after
+    # a failure, or an empty chroot's error replaces the one that matters.
+    others = [one for one in closing if not isinstance(one, convert.LeaveStaging)]
+    assert others, "the closing stage has more than the unmount"
+    assert not any(one.releases_the_machine for one in others), others


### PR DESCRIPTION
`_release` runs only the closing operations that answer `releases_the_machine`, and `LeaveStaging` did not, so a conversion that stopped left `/proc`, `/sys` and `/dev` bound under `/gentoo-install.new`. Its own docstring calls that state holding the machine at shutdown.

Two further consequences, both met on the Arch run that stopped at operation 34 of 46: `PrepareStaging` refuses the next attempt because the directory is not empty, and `rm -rf /gentoo-install.new` from outside walks those binds into the running system's `/dev` — which is how that guest lost its `/dev`.

The negative control holds: every other closing operation still stays out of the release path, so an empty chroot's error cannot replace the one that matters.