### PR TITLE
convert: carry the btrfs subvolume a root sits on

### DIFF
--- a/gentoo_install/plan/convert.py
+++ b/gentoo_install/plan/convert.py
@@ -18,6 +18,7 @@ from ..model.device import (
     FilesystemType,
     Mountpoint,
     StorageLayout,
+    Subvolume,
 )
 from .operations import CommandOutput, Context, Operation, Stage
 
@@ -287,6 +288,7 @@ class PopulateBoot(Operation):
 ROOT_DEVICE: Final[DeviceId] = DeviceId("running-root-device")
 ROOT_FILESYSTEM: Final[DeviceId] = DeviceId("running-root")
 ROOT_MOUNT: Final[DeviceId] = DeviceId("running-root-mount")
+ROOT_SUBVOLUME: Final[DeviceId] = DeviceId("running-root-subvolume")
 BOOT_DEVICE: Final[DeviceId] = DeviceId("running-boot-device")
 BOOT_FILESYSTEM: Final[DeviceId] = DeviceId("running-boot")
 BOOT_MOUNT: Final[DeviceId] = DeviceId("running-boot-mount")
@@ -313,14 +315,6 @@ def layout_graph(layout: StorageLayout) -> DiskConfig:
         )
     if not layout.root_device or not layout.root_filesystem_type:
         raise ConversionUnsupported("the running root device could not be read")
-    if layout.root_subvolume:
-        # `layout_graph` emits no Subvolume, so `_rootflags` answers nothing and
-        # the cmdline carries no `rootflags=`: the initramfs would mount the
-        # default subvolume and never see the system that was written.
-        raise ConversionUnsupported(
-            f"the running root is on the btrfs subvolume {layout.root_subvolume}, "
-            "which the conversion cannot carry onto the new command line"
-        )
     if not layout.uefi and layout.root_below_device is None:
         # Measured on an Alpine cloud image, whose ext4 sits on `/dev/vda`
         # itself: `grub-install --target=i386-pc` answers `will not proceed
@@ -337,8 +331,23 @@ def layout_graph(layout: StorageLayout) -> DiskConfig:
             kind=_filesystem(layout.root_filesystem_type, "root"),
             create=False,
         ),
-        Mountpoint(id=ROOT_MOUNT, source=ROOT_FILESYSTEM, path=PurePosixPath("/")),
     ]
+    # Fedora mounts `/dev/vda4[/root]` and Ubuntu `[/@]`. The mount has to name
+    # it: the new fstab's root line and systemd-boot's `rootflags=subvol=` both
+    # come from here, and without it the machine mounts the default subvolume.
+    if layout.root_subvolume:
+        nodes.append(
+            Subvolume(
+                id=ROOT_SUBVOLUME, filesystem=ROOT_FILESYSTEM, name=layout.root_subvolume
+            )
+        )
+    nodes.append(
+        Mountpoint(
+            id=ROOT_MOUNT,
+            source=ROOT_SUBVOLUME if layout.root_subvolume else ROOT_FILESYSTEM,
+            path=PurePosixPath("/"),
+        )
+    )
     if layout.boot_same_filesystem is False:
         # A separate `/boot` has to be in the new `fstab`: the kernel this
         # conversion puts there is on that filesystem, and a machine that does

--- a/tests/unit/test_plan_convert.py
+++ b/tests/unit/test_plan_convert.py
@@ -670,20 +670,28 @@ def test_a_bios_conversion_refuses_a_root_that_is_a_whole_disk() -> None:
     assert convert.layout_graph(uefi).mode is DiskMode.IN_PLACE
 
 
-def test_a_conversion_refuses_a_root_on_a_btrfs_subvolume() -> None:
-    """Fedora, Ubuntu and openSUSE all put root on a btrfs subvolume.
-    `layout_graph` emits no `Subvolume`, so `_rootflags` answers nothing and the
-    new command line carries no `rootflags=subvol=`: the initramfs would mount
-    the default subvolume and never see the system that was written into `/@`.
+def test_a_conversion_carries_the_btrfs_subvolume_onto_the_command_line() -> None:
+    """Fedora 41 mounts `/dev/vda4[/root]` and Ubuntu `[/@]`. Without a
+    `Subvolume` in the graph, `_rootflags` answers nothing and the new command
+    line carries no `rootflags=subvol=`, so the initramfs mounts the default
+    subvolume instead of the system that was written.
     """
-    on_a_subvolume = replace(_layout(root_filesystem_type="btrfs"), root_subvolume="/@")
-    with pytest.raises(ConversionUnsupported, match="btrfs subvolume /@"):
-        convert.layout_graph(on_a_subvolume)
+    from gentoo_install.model.device import Subvolume
+    from gentoo_install.plan.automatic import _rootflags
+
+    on_a_subvolume = replace(_layout(root_filesystem_type="btrfs"), root_subvolume="/root")
+    disk = convert.layout_graph(on_a_subvolume)
+    carried = [one for one in disk.graph.nodes.values() if isinstance(one, Subvolume)]
+    assert [one.name for one in carried] == ["/root"]
+    assert _rootflags(replace(_in_place(), disk=disk)) == "/root"
 
     # Negative control: btrfs at the top level is what Arch's cloud image runs,
-    # and it needs no `rootflags=` at all.
+    # and inventing a subvolume for it would put a `rootflags=` on a machine
+    # that must not have one.
     top_level = replace(on_a_subvolume, root_subvolume=None)
-    assert convert.layout_graph(top_level).mode is DiskMode.IN_PLACE
+    plain = convert.layout_graph(top_level)
+    assert not [one for one in plain.graph.nodes.values() if isinstance(one, Subvolume)]
+    assert _rootflags(replace(_in_place(), disk=plain)) == ""
 
 
 def test_the_carried_fstab_opens_inside_the_staging_root(tmp_path: Path) -> None:


### PR DESCRIPTION
Read on a Fedora 41 cloud image: root is `/dev/vda4[/root]`, `subvol=/root`, `subvolid=256`. Ubuntu uses `[/@]`. `#451` split the device from the subvolume and refused such a root because the graph could not describe it; this describes it instead.

The graph now carries a `Subvolume` for the running root, so `resolve_mounts` answers `subvolume='/root'` and the new fstab's root line names it. `_in_place` derives no operations from disk nodes, so nothing tries to create a subvolume that already exists.

Verified against that machine: the offer answers `('/dev/vda4 on btrfs', '')`, and the resolved root mount carries `subvolume='/root'` where it carried `None` before.