### PR TITLE
convert: say the session is the lifeline before the swap

### DIFF
--- a/gentoo_install/cli.py
+++ b/gentoo_install/cli.py
@@ -56,6 +56,13 @@ from .plan.render import render, summarise
 #: and no answer at all, takes the global list.
 CN: Final[str] = "CN"
 
+#: What an operator has to know before a conversion starts, because after it
+#: there is no way to tell them.
+SESSION_IS_THE_LIFELINE: Final[str] = (
+    "Keep this session open: once the directories are replaced, a new ssh "
+    "login will not work until the machine reboots."
+)
+
 #: Everything a run needs to keep: the device map, the staged keys, the log.
 WORK = Path("/run/gentoo-install")
 
@@ -401,10 +408,16 @@ def _confirmed_swap(
     """
     replaced = ", ".join("/" + name for name in convert.REPLACED_DIRECTORIES)
     record(f"in-place conversion replaces {replaced} and leaves everything else")
+    # Recorded before the unattended return, because an unattended run is the
+    # one nobody is watching: measured on Debian 12 and Arch, a new ssh login
+    # stops working once `/usr` and `/etc` belong to the new system, while the
+    # session that started the run keeps its own mapped binaries.
+    record(SESSION_IS_THE_LIFELINE)
     if _unattended(arguments):
         return True
     print(f"This replaces {replaced} on the running system.")
     print("Everything else, including /home and /root, is left alone.")
+    print(SESSION_IS_THE_LIFELINE)
     print(f"Type {SWAP_CONFIRMATION} to continue, anything else to stop.")
     answer = input("> ").strip()
     if answer == SWAP_CONFIRMATION:

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -1235,3 +1235,23 @@ def test_the_conversion_offer_names_the_command_the_reading_needs(
     absent.clear()
     with pytest.raises(AssertionError, match="must not be read"):
         cli._conversion_offer(cast(RealProbe, Probe()))
+
+
+def test_an_unattended_conversion_still_records_that_ssh_stops() -> None:
+    """Measured on Debian 12 and Arch: once `/usr` and `/etc` belong to the new
+    system, a new ssh login stops working until the machine reboots, while the
+    session that started the run keeps its own mapped binaries. An unattended
+    run is not asked anything, so the warning has to be recorded before that
+    return or the one run nobody is watching never carries it.
+    """
+    said: list[str] = []
+    unattended = argparse.Namespace(no_shell=True)
+
+    assert cli._confirmed_swap(unattended, said.append)
+    assert any(cli.SESSION_IS_THE_LIFELINE in line for line in said), said
+    assert any("in-place conversion replaces" in line for line in said), said
+
+    # Negative control: the sentence has to name ssh and the reboot, or it
+    # tells the operator nothing they can act on.
+    assert "ssh" in cli.SESSION_IS_THE_LIFELINE
+    assert "reboot" in cli.SESSION_IS_THE_LIFELINE


### PR DESCRIPTION
Converting Debian 12 and Arch, every new ssh connection failed from the swap onwards: `/usr/sbin/sshd` and `/etc/ssh` belong to the new system by then, and the Gentoo sshd is only enabled for the next boot. The session that started the run keeps working, because its binaries stay mapped.

`distro2gentoo` tells its operator the same thing before it starts — "make sure at least one interactive shell with root privileges is active" — and this installer said nothing.

The line is recorded before the unattended return, since an unattended run is the one nobody is watching.