### PR TITLE
convert: refuse a separately mounted directory before the work

### DIFF
--- a/gentoo_install/exec/probe.py
+++ b/gentoo_install/exec/probe.py
@@ -901,6 +901,18 @@ class Probe:
             uefi=uefi,
             root_free_bytes=_entry_int(root, "avail") if root is not None else None,
             root_subvolume=root_subvolume,
+            separate_mounts=tuple(
+                sorted(
+                    {
+                        target
+                        for entry in mounts
+                        if (target := _entry_text(entry, "target"))
+                        and target.startswith("/")
+                        and target.count("/") == 1
+                        and target != "/"
+                    }
+                )
+            ),
             carried_fstab=_fstab_we_do_not_manage(
                 esp_mountpoint if uefi else None,
                 _entry_text(boot, "target") if boot is not None else None,

--- a/gentoo_install/model/device.py
+++ b/gentoo_install/model/device.py
@@ -163,6 +163,10 @@ class StorageLayout:
     #: level. `findmnt` writes it into the source as `/dev/sda2[/@]` and into
     #: the options as `subvol=/@`, and a root read without it names no device.
     root_subvolume: str | None = None
+    #: Top-level directories that are their own mount, `/var` and `/home` on a
+    #: Fedora cloud image. A conversion renames the directories it replaces,
+    #: and rename cannot replace a mount point.
+    separate_mounts: tuple[str, ...] = ()
 
 
 @dataclass(frozen=True, init=False)

--- a/gentoo_install/plan/convert.py
+++ b/gentoo_install/plan/convert.py
@@ -315,6 +315,18 @@ def layout_graph(layout: StorageLayout) -> DiskConfig:
         )
     if not layout.root_device or not layout.root_filesystem_type:
         raise ConversionUnsupported("the running root device could not be read")
+    # `exec/convert.py` refuses the same thing at the rename, which on a Fedora
+    # cloud image arrived at operation 44 of 46 with the whole system already
+    # emerged. The mount table says it before anything is written.
+    mounted = [
+        name for name in REPLACED_DIRECTORIES if f"/{name}" in layout.separate_mounts
+    ]
+    if mounted:
+        raise ConversionUnsupported(
+            f"{', '.join('/' + one for one in mounted)} "
+            f"{'is' if len(mounted) == 1 else 'are'} a separate mount, "
+            "which rename cannot replace"
+        )
     if not layout.uefi and layout.root_below_device is None:
         # Measured on an Alpine cloud image, whose ext4 sits on `/dev/vda`
         # itself: `grub-install --target=i386-pc` answers `will not proceed

--- a/tests/unit/test_plan_convert.py
+++ b/tests/unit/test_plan_convert.py
@@ -763,3 +763,25 @@ def test_a_failed_conversion_still_unmounts_the_staging_root() -> None:
     others = [one for one in closing if not isinstance(one, convert.LeaveStaging)]
     assert others, "the closing stage has more than the unmount"
     assert not any(one.releases_the_machine for one in others), others
+
+
+def test_a_conversion_refuses_a_replaced_directory_that_is_its_own_mount() -> None:
+    """A Fedora 41 cloud image mounts `/var` and `/home` as their own btrfs
+    subvolumes. `exec/convert.py` refuses that at the rename, which arrived at
+    operation 44 of 46 with the whole system already emerged and the staging
+    root left behind; the mount table says it before anything is written.
+    """
+    fedora = replace(_layout(), separate_mounts=("/boot", "/home", "/proc", "/var"))
+    with pytest.raises(ConversionUnsupported, match=r"/var is a separate mount"):
+        convert.layout_graph(fedora)
+
+    # Negative control one: a mount that is not replaced is not a reason to
+    # refuse, or every machine with a separate /home would be turned away.
+    ordinary = replace(fedora, separate_mounts=("/boot", "/home", "/proc"))
+    assert convert.layout_graph(ordinary).mode is DiskMode.IN_PLACE
+
+    # Negative control two: the message names every one of them, because an
+    # operator who moves /var only to be refused for /usr has learned nothing.
+    both = replace(fedora, separate_mounts=("/usr", "/var"))
+    with pytest.raises(ConversionUnsupported, match=r"/usr, /var are a separate mount"):
+        convert.layout_graph(both)


### PR DESCRIPTION
Converting a Fedora 41 cloud image stopped here:

```
[43/46] [bootloader] write /etc/default/grub ...
[44/46] [bootloader] atomically swap /bin, /sbin, /etc, /lib, /lib64, /usr, /var
the install stopped: ConversionFailed: /var is a separate mount, which rename cannot replace
```

`exec/convert.py` was right to refuse, and its own comment says such a machine "can never be converted this way" — but it learned that after eight minutes of emerging here and hours on a real machine, and left the staging root behind.

`findmnt` already reports it. `StorageLayout` now carries the top-level directories that are their own mount, and `layout_graph` refuses when one of them is a directory the swap replaces. On that same machine the offer now answers `/var is a separate mount, which rename cannot replace` before anything runs.