### PR TITLE
convert: unmount each mount under the staging root

### DIFF
--- a/gentoo_install/plan/convert.py
+++ b/gentoo_install/plan/convert.py
@@ -234,8 +234,31 @@ class LeaveStaging(Operation):
     def describe(self) -> str:
         return f"unmount and remove {self.staging}"
 
+    def _mounted_under(self, context: Context) -> list[str]:
+        """Every mount below the staging root, deepest first.
+
+        Deepest first because `/gentoo-install.new/dev/pts` has to go before
+        `/gentoo-install.new/dev`, and `umount` refuses a busy parent.
+        """
+        listed = context.run(
+            ["findmnt", "--noheadings", "--list", "--output", "TARGET"], check=False
+        )
+        if isinstance(listed, CommandOutput) and listed.returncode != 0:
+            return []
+        under = f"{self.staging}/"
+        found = [
+            line.strip()
+            for line in str(listed).splitlines()
+            if line.strip().startswith(under) or line.strip() == str(self.staging)
+        ]
+        return sorted(found, key=lambda one: one.count("/"), reverse=True)
+
     def apply(self, context: Context) -> None:
-        context.run(["umount", "--recursive", "--lazy", str(self.staging)], check=False)
+        # Not `umount --recursive` on the staging root: that needs the root
+        # itself to be a mount, and it is a plain directory, so the command
+        # answered `not mounted` and exited 1 while seventeen binds stayed.
+        for mounted in self._mounted_under(context):
+            context.run(["umount", "--lazy", mounted], check=False)
         listed = context.run(
             ["findmnt", "--noheadings", "--list", "--output", "TARGET"], check=False
         )

--- a/tests/unit/test_plan_convert.py
+++ b/tests/unit/test_plan_convert.py
@@ -255,7 +255,11 @@ class _RunningContext:
 def test_the_staging_root_is_unmounted_and_removed() -> None:
     context = _RunningContext(mounted=("/", "/boot"))
     convert.LeaveStaging().apply(cast(Any, context))
-    assert ["umount", "--recursive", "--lazy", "/gentoo-install.new"] in context.ran
+    # Nothing is mounted under it here, so there is nothing to unmount. The
+    # assertion was `umount --recursive --lazy /gentoo-install.new`, which the
+    # machine answers `not mounted` to, so the test held a call that did
+    # nothing.
+    assert not [one for one in context.ran if one[0] == "umount"], context.ran
     assert ["rm", "--recursive", "--force", "/gentoo-install.new"] in context.ran
 
 
@@ -785,3 +789,57 @@ def test_a_conversion_refuses_a_replaced_directory_that_is_its_own_mount() -> No
     both = replace(fedora, separate_mounts=("/usr", "/var"))
     with pytest.raises(ConversionUnsupported, match=r"/usr, /var are a separate mount"):
         convert.layout_graph(both)
+
+
+def test_the_staging_root_is_unmounted_from_the_deepest_mount_up() -> None:
+    """Read on a Fedora 41 machine after a conversion stopped:
+
+        $ umount --recursive --lazy /gentoo-install.new
+        umount: /gentoo-install.new: not mounted
+        退出碼 1
+
+    `umount --recursive` needs its target to be a mount, and the staging root
+    is a plain directory, so the command failed and seventeen binds stayed
+    under it. `rm -rf` on those walks into the running system's `/dev`.
+    """
+    from gentoo_install.plan.operations import CommandOutput
+
+    from .recorder import Recorder
+
+    mounts = "\n".join(
+        (
+            "/",
+            "/gentoo-install.new/dev",
+            "/gentoo-install.new/dev/pts",
+            "/gentoo-install.new/proc",
+            "/home",
+        )
+    )
+    seen: list[list[str]] = []
+
+    class Mounted(Recorder):
+        def run(
+            self, argv: Sequence[str], *, check: bool = True, input_text: str | None = None
+        ) -> CommandOutput:
+            seen.append(list(argv))
+            if argv[0] == "findmnt":
+                # Emptied once the unmounts have been issued, as a real one is.
+                remaining = "/\n/home" if any(one[0] == "umount" for one in seen) else mounts
+                return CommandOutput(remaining, 0)
+            return CommandOutput("", 0)
+
+    convert.LeaveStaging().apply(cast(Any, Mounted()))
+
+    unmounted = [one[-1] for one in seen if one[0] == "umount"]
+    assert unmounted == [
+        "/gentoo-install.new/dev/pts",
+        "/gentoo-install.new/dev",
+        "/gentoo-install.new/proc",
+    ], unmounted
+
+    # Negative control one: never `umount --recursive` on the staging root,
+    # which is the call that answered `not mounted` and did nothing.
+    assert not any("--recursive" in one for one in seen if one[0] == "umount"), seen
+
+    # Negative control two: a mount outside the staging root is not touched.
+    assert not any(one.endswith("/home") for one in unmounted), unmounted


### PR DESCRIPTION
Run on a Fedora 41 machine whose conversion had stopped:

```
$ umount --recursive --lazy /gentoo-install.new
umount: /gentoo-install.new: not mounted
exit 1
$ findmnt -rno TARGET | grep -c gentoo-install.new
17
```

`umount --recursive` unmounts a mount point and everything below it, and the staging root is a plain directory, so the call failed and `check=False` swallowed it. The normal install path works because `/mnt/gentoo` really is a mount.

Each mount below the staging root is unmounted instead, deepest first, since `/gentoo-install.new/dev/pts` has to go before `/gentoo-install.new/dev`. The existing test asserted the call that did nothing, so it is rewritten too.