### PR TITLE
vm: let a failed remote unlock still reach a login

### DIFF
--- a/tests/unit/test_harness.py
+++ b/tests/unit/test_harness.py
@@ -2543,3 +2543,36 @@ def test_create_target_refuses_a_path_outside_the_run_directories(tmp_path: Path
     finally:
         inside.unlink(missing_ok=True)
         inside.parent.rmdir()
+
+
+def test_a_failed_remote_unlock_answers_rather_than_raising(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """`--boot-installed` powered the machine off and returned the moment the
+    remote unlock failed, so `zbm-unlock` never reached a login: every verdict
+    it produced said only that nothing answered on a forwarded port. The
+    machine is sitting at its own passphrase prompt, and the console gets in,
+    so the failure is answered rather than raised.
+    """
+    from tests.vm import run as harness
+
+    def refuses(*rest: object, **named: object) -> str:
+        raise RuntimeError("no ssh daemon on port 56353 after 180s")
+
+    monkeypatch.setattr(harness, "remote_unlock", refuses)
+    said = harness.try_remote_unlock(Path("/dev/null"), 1, cast(Any, object()))
+    assert "no ssh daemon on port 56353" in said
+
+    # Negative control one: an unlock that worked answers nothing, or the
+    # caller would report a failure on every successful run.
+    monkeypatch.setattr(harness, "remote_unlock", lambda *rest, **named: "proof")
+    assert harness.try_remote_unlock(Path("/dev/null"), 1, cast(Any, object())) == ""
+
+    # Negative control two: only the unlock's own failure is answered. A
+    # KeyboardInterrupt or a programming error still leaves the run.
+    def breaks(*rest: object, **named: object) -> str:
+        raise ValueError("this is not the unlock failing")
+
+    monkeypatch.setattr(harness, "remote_unlock", breaks)
+    with pytest.raises(ValueError):
+        harness.try_remote_unlock(Path("/dev/null"), 1, cast(Any, object()))

--- a/tests/vm/run.py
+++ b/tests/vm/run.py
@@ -273,6 +273,15 @@ def wait_for_unlock_daemon(
     raise RuntimeError(f"no ssh daemon on port {port} after {patience:.0f}s: {last}")
 
 
+def try_remote_unlock(key: Path, port: int, installation: InstallConfig) -> str:
+    """Answer the empty string when the unlock worked, or why it did not."""
+    try:
+        remote_unlock(key, port, installation)
+    except RuntimeError as error:
+        return str(error)
+    return ""
+
+
 def remote_unlock(
     key: Path,
     port: int,
@@ -699,17 +708,20 @@ def _perform(args: argparse.Namespace, medium: Medium, workdir: Path) -> int:
             if args.boot_installed:
                 expected = load(REPOSITORY / "tests" / args.install)
                 unlocked_remotely = False
+                unlock_failed = ""
                 if expected.kernel.remote_unlock.enabled:
                     if remote_port is None:
                         raise RuntimeError("remote unlock is enabled without a forwarded port")
-                    try:
-                        remote_unlock(key, remote_port, expected)
-                    except RuntimeError as error:
-                        print(f"FAIL remote unlock: {error}", file=sys.stderr)
-                        power_off(console, vm)
-                        return 1
-                    unlocked_remotely = True
-                    print("installed root unlocked by remote SSH session")
+                    unlock_failed = try_remote_unlock(key, remote_port, expected)
+                    if unlock_failed:
+                        # Not a power-off: the machine is sitting at its own
+                        # passphrase prompt, the console gets in, and a verdict
+                        # that carries what the machine held beats one that
+                        # carries only the port nobody answered on.
+                        print(f"FAIL remote unlock: {unlock_failed}", file=sys.stderr)
+                    else:
+                        unlocked_remotely = True
+                        print("installed root unlocked by remote SSH session")
                 method = unlock_and_login(
                     console, expected, vm.monitor_socket, remote_unlocked=unlocked_remotely
                 )
@@ -719,6 +731,10 @@ def _perform(args: argparse.Namespace, medium: Medium, workdir: Path) -> int:
                 code = report(
                     result_disk, keep=args.keep, assertions=REPOSITORY / "tests" / args.install
                 )
+                if unlock_failed:
+                    # The subject of the fixture is the unlock, so a machine
+                    # that only came up by console has still failed it.
+                    code = code or 1
                 if code == 0:
                     # The boot check is the last reader of the target disk, and
                     # one campaign left 80 GiB of them behind. A failed run


### PR DESCRIPTION
`--boot-installed` printed `FAIL remote unlock`, powered the machine off and returned at the first failure, so `zbm-unlock` — the one fixture never green anywhere — produced a verdict naming only a forwarded port nobody answered on. The machine is sitting at ZFSBootMenu's own passphrase prompt, and the console gets in.

Run against the same disk after the change:

```
FAIL remote unlock: no ssh daemon on port 51087 after 180s: kex_exchange_identification: read: Connection reset by peer
[201.0s] logged into the installed system (console)
the installed system booted, mounted its layout and has no failed unit
```

That second half is new, and it says the installed ZFS system is sound and only the ZBM unlock is not. The verdict stays non-zero: the fixture's subject is the unlock.