### PR TITLE
vm: check the ZFSBootMenu image carries its ssh daemon

### DIFF
--- a/tests/unit/test_harness.py
+++ b/tests/unit/test_harness.py
@@ -2576,3 +2576,31 @@ def test_a_failed_remote_unlock_answers_rather_than_raising(
     monkeypatch.setattr(harness, "remote_unlock", breaks)
     with pytest.raises(ValueError):
         harness.try_remote_unlock(Path("/dev/null"), 1, cast(Any, object()))
+
+
+def test_a_zfsbootmenu_unlock_fixture_checks_the_image_that_carries_the_daemon() -> None:
+    """ZFSBootMenu unlocks the pool from its own EFI image, not the system
+    initramfs, so that file is the only place the ssh daemon can be.
+    `zbm-unlock` failed three times reporting nothing but a forwarded port
+    that went unanswered, while the machine itself was sound.
+    """
+    from gentoo_install.exec.config import load
+    from tests.vm.installed import checks
+
+    unlocking = load(Path("tests/fixtures/zbm-unlock.toml"))
+    named = {one.name: one for one in checks(unlocking)}
+    assert "zbm dropbear" in named, sorted(named)
+    assert "/efi/EFI/zbm" in named["zbm dropbear"].command
+
+    # Negative control one: ZFSBootMenu without the unlock has no daemon to
+    # look for, and asking for one would fail every ordinary ZBM install.
+    plain = load(Path("tests/fixtures/zfs-zbm.toml"))
+    assert plain.bootloader.kind is unlocking.bootloader.kind
+    assert not plain.kernel.remote_unlock.enabled
+    assert "zbm dropbear" not in {one.name for one in checks(plain)}
+
+    # Negative control two: a remote unlock under another bootloader lives in
+    # the system initramfs, and that image is not on the esp.
+    elsewhere = load(Path("tests/fixtures/vm-unlock.toml"))
+    assert elsewhere.kernel.remote_unlock.enabled
+    assert "zbm dropbear" not in {one.name for one in checks(elsewhere)}

--- a/tests/vm/installed.py
+++ b/tests/vm/installed.py
@@ -69,6 +69,21 @@ def checks(installation: InstallConfig) -> tuple[InstalledCheck, ...]:
                 re.escape(f"XMODIFIERS=@im={framework}"),
             )
         )
+    if (
+        installation.bootloader.kind is Bootloader.ZFSBOOTMENU
+        and installation.kernel.remote_unlock.enabled
+    ):
+        # ZFSBootMenu unlocks the pool from its own image, not the system
+        # initramfs, so the only place the ssh daemon can live is that EFI
+        # file. `zbm-unlock` failed three times saying nothing but that a
+        # forwarded port went unanswered.
+        result.append(
+            InstalledCheck(
+                "zbm dropbear",
+                "lsinitrd /efi/EFI/zbm/*.EFI 2>/dev/null | grep -ci dropbear",
+                r"[1-9]",
+            )
+        )
     if installation.disk.mode is DiskMode.IN_PLACE:
         # No graph to derive from: the layout belongs to the machine that was
         # converted, and the esp and root filesystem are whatever it already


### PR DESCRIPTION
`zbm-unlock` has never passed anywhere and every verdict said the same thing: no ssh daemon answered on a forwarded port. That cannot tell a daemon that was never built into ZFSBootMenu's EFI image from one that was built in and did not run.

The check asks the machine. Run against the installed disk:

```
--- zbm dropbear.txt ---
3
```

`lsinitrd /efi/EFI/zbm/*.EFI | grep -ci dropbear` answers 3, so the daemon is in the image and the remaining question is why it does not run — the console's `Error: ipv4: Address already assigned.` is the next thread. The same run reports the installed system booted with no failed unit, so only the unlock is broken.