### PR TITLE
vm: check the key the ZFSBootMenu image authenticates with

### DIFF
--- a/tests/unit/test_harness.py
+++ b/tests/unit/test_harness.py
@@ -2589,18 +2589,23 @@ def test_a_zfsbootmenu_unlock_fixture_checks_the_image_that_carries_the_daemon()
 
     unlocking = load(Path("tests/fixtures/zbm-unlock.toml"))
     named = {one.name: one for one in checks(unlocking)}
-    assert "zbm dropbear" in named, sorted(named)
-    assert "/efi/EFI/zbm" in named["zbm dropbear"].command
+    assert "zbm unlock key" in named, sorted(named)
+    asked = named["zbm unlock key"].command
+    assert "/efi/EFI/zbm" in asked
+    # The acl or the hook, not the word `dropbear`: the image carries
+    # `etc/dropbear/ssh_host_rsa_key`, so counting that word answered 3 for an
+    # image with no authorized key and no start hook in it at all.
+    assert "authorized_keys" in asked and "dropbear-start" in asked, asked
 
     # Negative control one: ZFSBootMenu without the unlock has no daemon to
     # look for, and asking for one would fail every ordinary ZBM install.
     plain = load(Path("tests/fixtures/zfs-zbm.toml"))
     assert plain.bootloader.kind is unlocking.bootloader.kind
     assert not plain.kernel.remote_unlock.enabled
-    assert "zbm dropbear" not in {one.name for one in checks(plain)}
+    assert "zbm unlock key" not in {one.name for one in checks(plain)}
 
     # Negative control two: a remote unlock under another bootloader lives in
     # the system initramfs, and that image is not on the esp.
     elsewhere = load(Path("tests/fixtures/vm-unlock.toml"))
     assert elsewhere.kernel.remote_unlock.enabled
-    assert "zbm dropbear" not in {one.name for one in checks(elsewhere)}
+    assert "zbm unlock key" not in {one.name for one in checks(elsewhere)}

--- a/tests/vm/installed.py
+++ b/tests/vm/installed.py
@@ -77,10 +77,13 @@ def checks(installation: InstallConfig) -> tuple[InstalledCheck, ...]:
         # initramfs, so the only place the ssh daemon can live is that EFI
         # file. `zbm-unlock` failed three times saying nothing but that a
         # forwarded port went unanswered.
+        # The acl, not the daemon: `grep -ci dropbear` counts the `etc/dropbear`
+        # host-key paths and answered 3 on an image that authenticates nobody.
         result.append(
             InstalledCheck(
-                "zbm dropbear",
-                "lsinitrd /efi/EFI/zbm/*.EFI 2>/dev/null | grep -ci dropbear",
+                "zbm unlock key",
+                "lsinitrd /efi/EFI/zbm/*.EFI 2>/dev/null "
+                "| grep -cE 'authorized_keys|dropbear-start'",
                 r"[1-9]",
             )
         )


### PR DESCRIPTION
The check added yesterday passed for the wrong reason. Read from the image on the installed machine:

```
etc/dropbear
etc/dropbear/dropbear_ecdsa_host_key
etc/dropbear/dropbear_rsa_host_key
```

Three lines, all host-key paths, so `grep -ci dropbear` answered 3 while the image carries no authorized key and no `dropbear-start` hook — which is why nothing ever answered on the forwarded port.

Everything outside the image is correct on that machine: `/etc/dropbear/root_key` is 89 bytes, `/usr/lib/dracut/modules.d/60crypt-ssh` holds `dropbear-start.sh` and `module-setup.sh`, and `/etc/zfsbootmenu/dracut.conf.d/dropbear.conf` names the port, both host keys and the acl. The module is listed in the image and its files are not in it.