### PR TITLE
bootloader: say when ZFSBootMenu built no unlock daemon

### DIFF
--- a/gentoo_install/plan/bootloader.py
+++ b/gentoo_install/plan/bootloader.py
@@ -128,6 +128,12 @@ ZBM_HOST_KEY_TYPES: Final[tuple[str, ...]] = ("rsa", "ecdsa")
 #: all, and both bootloaders write it before asking for one.
 NVRAM_ENTRY: Final[str] = "efi boot entry"
 
+#: What proves the built image can answer an unlock: the acl the daemon reads,
+#: or the hook that starts it. Not the word `dropbear`, which the host-key
+#: paths under `etc/dropbear` match on an image that authenticates nobody.
+ZBM_UNLOCK_MARKERS: Final[tuple[str, ...]] = ("authorized_keys", "dropbear-start")
+REMOTE_UNLOCK_IMAGE: Final[str] = "zfsbootmenu remote unlock"
+
 
 def _try_the_nvram_entry(context: Context, argv: list[str]) -> None:
     """Ask the firmware for a boot entry, and carry on when it refuses.
@@ -414,6 +420,8 @@ class InstallZfsBootMenu(Operation):
     #: than defaulting to partition 1.
     esp_device: DeviceId
     kernel_params: tuple[str, ...]
+    #: Whether the image was configured to answer an unlock over ssh.
+    unlocks_remotely: bool = False
     #: `org.zfsbootmenu:commandline` is the command line of the system ZBM
     #: boots, not of ZBM itself, which is what prompts for a passphrase.
     serial: tuple[str, int] | None
@@ -446,6 +454,27 @@ class InstallZfsBootMenu(Operation):
             f"{kernel}"
         )
 
+    def _say_if_the_image_cannot_unlock(self, context: Context, image: str) -> None:
+        """Read the built image rather than trusting that dracut obeyed.
+
+        `generate-zbm` prints two lines and swallows dracut's own output, so a
+        module listed in the image whose files are not in it leaves a machine
+        that boots and can never be unlocked over ssh. Said rather than raised:
+        the passphrase prompt on the console still works.
+        """
+        listed = context.run_in_target(["lsinitrd", image], check=False)
+        if isinstance(listed, CommandOutput) and listed.returncode != 0:
+            context.degrade(
+                REMOTE_UNLOCK_IMAGE, f"{image} could not be read: {str(listed).strip()[:200]}"
+            )
+            return
+        if not any(marker in str(listed) for marker in ZBM_UNLOCK_MARKERS):
+            context.degrade(
+                REMOTE_UNLOCK_IMAGE,
+                f"{image} carries none of {', '.join(ZBM_UNLOCK_MARKERS)}, "
+                "so only the console can unlock this machine",
+            )
+
     def apply(self, context: Context) -> None:
         context.run_in_target(["zpool", "set", f"bootfs={self.dataset}", self.pool])
         context.run_in_target(
@@ -458,6 +487,8 @@ class InstallZfsBootMenu(Operation):
         context.write(PurePosixPath("/etc/zfsbootmenu/config.yaml"), self._config())
         context.run_in_target(["generate-zbm"])
         image = self._image(context)
+        if self.unlocks_remotely:
+            self._say_if_the_image_cannot_unlock(context, image)
         context.run_in_target(["install", "-D", "-m0644", image, f"{self.esp}/{FALLBACK_IMAGE}"])
         _try_the_nvram_entry(
             context,
@@ -562,6 +593,7 @@ def build(config: InstallConfig) -> list[Operation]:
                 esp_device=esp_device,
                 kernel_params=config.bootloader.kernel_params,
                 serial=serial_console(config),
+                unlocks_remotely=config.kernel.remote_unlock.enabled,
             ),
         ]
     return operations

--- a/tests/unit/test_plan_bootloader.py
+++ b/tests/unit/test_plan_bootloader.py
@@ -327,3 +327,62 @@ def test_zfsbootmenu_and_the_unlock_on_top_of_it_are_separate_fixtures() -> None
 
     # Two machines, so a guest that booted the wrong disk is told apart.
     assert plain.system.hostname != both.system.hostname
+
+
+def test_an_image_built_without_the_unlock_daemon_is_said_rather_than_shipped() -> None:
+    """`generate-zbm` prints two lines and swallows dracut's own output. Read
+    from the image an install produced, `etc/dropbear/` held the two host keys
+    and nothing else — no authorized key, no start hook — so the machine booted
+    and nothing ever answered on the forwarded port.
+
+    Said rather than raised: the console passphrase still unlocks it.
+    """
+    from gentoo_install.plan.operations import CommandOutput
+
+    installation = load(Path("tests/fixtures/zbm-unlock.toml"))
+    built = next(
+        one
+        for one in bootloader.build(installation)
+        if isinstance(one, bootloader.InstallZfsBootMenu)
+    )
+    assert built.unlocks_remotely
+
+    host_keys_only = "\n".join(
+        (
+            "etc/dropbear",
+            "etc/dropbear/dropbear_ecdsa_host_key",
+            "etc/dropbear/dropbear_rsa_host_key",
+        )
+    )
+
+    class Listing(Recorder):
+        answer = host_keys_only
+
+        def run_in_target(
+            self, argv: Sequence[str], *, check: bool = True, input_text: str | None = None
+        ) -> CommandOutput:
+            self.in_target.append(tuple(argv))
+            if argv[0] == "find":
+                return CommandOutput("/efi/EFI/zbm/kernel.EFI\n", 0)
+            if argv[0] == "lsinitrd":
+                return CommandOutput(self.answer, 0)
+            return CommandOutput("", 0)
+
+    recorder = Listing()
+    built.apply(recorder)
+    assert recorder.degraded(bootloader.REMOTE_UNLOCK_IMAGE), recorder.in_target
+
+    # Negative control one: an image carrying the acl is not degraded, or every
+    # working unlock would be reported as broken.
+    working = Listing()
+    working.answer = f"{host_keys_only}\nroot/.ssh/authorized_keys"
+    built.apply(working)
+    assert not working.degraded(bootloader.REMOTE_UNLOCK_IMAGE)
+
+    # Negative control two: an install that asked for no remote unlock never
+    # reads the image, so a missing daemon is not reported on it.
+    quiet = Listing()
+    quiet.answer = host_keys_only
+    replace(built, unlocks_remotely=False).apply(quiet)
+    assert not quiet.degraded(bootloader.REMOTE_UNLOCK_IMAGE)
+    assert not [one for one in quiet.in_target if one[0] == "lsinitrd"], quiet.in_target


### PR DESCRIPTION
Everything on the installed machine is right — `/etc/dropbear/root_key` is 89 bytes, `/usr/lib/dracut/modules.d/60crypt-ssh` holds `dropbear-start.sh`, `net-misc/dropbear-2025.89` is merged, and `dropbear.conf` names the port, both host keys and the acl. The image is not:

```
etc/dropbear
etc/dropbear/dropbear_ecdsa_host_key
etc/dropbear/dropbear_rsa_host_key
```

Three lines, all host keys. No authorized key, no start hook. And the whole of what `generate-zbm` printed was:

```
Creating ZFSBootMenu 3.1.0 from kernel /boot/kernel-6.18.44-gentoo-cjk-dist-bin
Created new UEFI image /efi/EFI/zbm/kernel.EFI
```

dracut's own output never reaches the log, so a module it listed and did not install is invisible. The image is read after it is built and the shortfall recorded, following `_try_the_nvram_entry` in the same file: said rather than raised, because the console passphrase still unlocks the machine.