### PR TITLE
runner: name the signal that killed a command

### DIFF
--- a/gentoo_install/exec/runner.py
+++ b/gentoo_install/exec/runner.py
@@ -24,6 +24,7 @@ from typing import Callable, Sequence
 from ..errors import CommandFailed
 from ..log import Journal
 from ..model.config import ProxyConfig
+from ..plan.operations import ending
 
 
 @dataclass(frozen=True)
@@ -37,6 +38,10 @@ class Result:
     @property
     def command(self) -> str:
         return shlex.join(_display_argv(self.argv))
+
+    @property
+    def ending(self) -> str:
+        return ending(self.returncode)
 
 
 @dataclass
@@ -104,7 +109,8 @@ class Runner:
                 self.journal.packages(result.stdout)
         if check and result.returncode != 0:
             raise CommandFailed(
-                f"{result.command} exited {result.returncode}: {_tail(result.stderr or result.stdout)}"
+                f"{result.command} ended with {result.ending}: "
+                f"{_tail(result.stderr or result.stdout)}"
             )
         return result
 

--- a/gentoo_install/plan/operations.py
+++ b/gentoo_install/plan/operations.py
@@ -12,6 +12,8 @@ keeps it a pure function of the configuration.
 
 from __future__ import annotations
 
+import signal
+
 from abc import ABC, abstractmethod
 from dataclasses import dataclass
 from enum import Enum
@@ -45,6 +47,20 @@ class Stage(Enum):
         return list(Stage).index(self)
 
 
+def ending(returncode: int) -> str:
+    """How a command ended, in words a reader can act on.
+
+    `subprocess` answers a negative code for a signal, and `emerge failed with
+    exit -13` sent a reader looking for an exit status that does not exist.
+    """
+    if returncode >= 0:
+        return f"exit {returncode}"
+    try:
+        return f"{signal.Signals(-returncode).name} ({-returncode})"
+    except ValueError:
+        return f"signal {-returncode}"
+
+
 class CommandOutput(str):
     """Command text with the exit status retained for callers that inspect it."""
 
@@ -54,6 +70,10 @@ class CommandOutput(str):
         output = super().__new__(cls, stdout)
         output.returncode = returncode
         return output
+
+    @property
+    def ending(self) -> str:
+        return ending(self.returncode)
 
 
 class Context(Protocol):

--- a/gentoo_install/plan/portage.py
+++ b/gentoo_install/plan/portage.py
@@ -764,14 +764,14 @@ class Emerge(Operation):
             retry_result = context.run_in_target(self._argv(context, source_only=True), check=False)
             if isinstance(retry_result, CommandOutput) and retry_result.returncode != 0:
                 raise CommandFailed(
-                    f"source retry failed with exit {retry_result.returncode}: "
+                    f"source retry ended with {retry_result.ending}: "
                     f"{str(retry_result).strip()}"
                 )
             return
         if not isinstance(result, CommandOutput) or result.returncode == 0:
             return
         if not _binpkg_failure(str(result)) or context.degraded(BINARY_PACKAGES):
-            raise CommandFailed(f"emerge failed with exit {result.returncode}: {str(result).strip()}")
+            raise CommandFailed(f"emerge ended with {result.ending}: {str(result).strip()}")
         marker = _binpkg_failure(str(result))
         if (again := self._one_more_binary_try(context, command)) is not None:
             marker = again
@@ -783,7 +783,7 @@ class Emerge(Operation):
         retry_result = context.run_in_target(retry, check=False)
         if isinstance(retry_result, CommandOutput) and retry_result.returncode != 0:
             raise CommandFailed(
-                f"source retry failed with exit {retry_result.returncode}: {str(retry_result).strip()}"
+                f"source retry ended with {retry_result.ending}: {str(retry_result).strip()}"
             )
 
     def _one_more_binary_try(self, context: Context, command: list[str]) -> str | None:

--- a/tests/unit/test_exec.py
+++ b/tests/unit/test_exec.py
@@ -130,7 +130,7 @@ def present() -> InstallConfig:
 
 
 def test_a_command_that_fails_raises_with_its_output(tmp_path: Path) -> None:
-    with pytest.raises(CommandFailed, match="exited 3"):
+    with pytest.raises(CommandFailed, match="ended with exit 3"):
         runner(tmp_path).run(["sh", "-c", "echo trouble >&2; exit 3"])
 
 

--- a/tests/unit/test_plan_portage.py
+++ b/tests/unit/test_plan_portage.py
@@ -708,7 +708,7 @@ def test_an_unrelated_emerge_failure_is_not_misclassified_as_a_binhost_failure()
     recorder = Recorder()
     recorder.answering = lambda argv: CommandOutput("compile failed", 1)
 
-    with pytest.raises(CommandFailed, match="emerge failed"):
+    with pytest.raises(CommandFailed, match="emerge ended with exit 1"):
         portage.Emerge(
             packages=("app-editors/nano",), summary="install the editor"
         ).apply(recorder)
@@ -1930,3 +1930,24 @@ def test_a_gpkg_for_one_package_does_not_excuse_another_failing() -> None:
         ).apply(recorder)
 
     assert not recorder.degraded(portage.BINARY_PACKAGES)
+
+
+def test_a_command_killed_by_a_signal_names_the_signal() -> None:
+    """`vm-xfs` lost 36.9 minutes to `emerge failed with exit -13`, which sent
+    a reader looking for an exit status that does not exist. `subprocess`
+    answers a negative code for a signal, and 13 is SIGPIPE.
+    """
+    from gentoo_install.plan.operations import CommandOutput, ending
+
+    assert ending(-13) == "SIGPIPE (13)"
+    assert CommandOutput("", -9).ending == "SIGKILL (9)"
+
+    # Negative control one: an ordinary status is still an exit status, or
+    # every failing command would read as though something killed it.
+    assert ending(1) == "exit 1"
+    assert ending(0) == "exit 0"
+    assert CommandOutput("", 4).ending == "exit 4"
+
+    # Negative control two: a number with no signal behind it says so rather
+    # than raising, because the message is what a failing run carries out.
+    assert ending(-999) == "signal 999"


### PR DESCRIPTION
`vm-xfs` ended run56 after 36.9 minutes with

```
the install stopped: CommandFailed: emerge failed with exit -13:
```

and no output before it. `subprocess` answers a negative code for a signal, so that is SIGPIPE, but the message reads like an exit status and sends the next reader looking for one.

One implementation in `plan/operations.py`, used by both `CommandOutput` and the runner's `Result`, so there is no second copy to drift. An unnamed number still answers rather than raising, because the message is what a failing run carries out with it.