### PR TITLE
vm: do not spend an agetty attempt on the login prompt

### DIFF
--- a/tests/unit/test_cluster.py
+++ b/tests/unit/test_cluster.py
@@ -1239,9 +1239,35 @@ def test_the_login_wait_asks_again_after_the_console_is_reopened() -> None:
     assert b"login:" in link.observe(r"login:", timeout=30.0, solicit=True)
 
     # Negative control: the default is still the silent wait, because an empty
-    # line at a passphrase prompt is an attempt rather than a request. Without
-    # soliciting, the same guest never shows the prompt again.
+    # line at a login prompt spends one of agetty's attempts. `boot_and_check`
+    # takes that default and treats a missed prompt as a note rather than a
+    # verdict, since typing a name brings the prompt back for free.
     opened.clear()
     silent = cluster.Reconnecting(open_console, tries=4)
     with pytest.raises(ConsoleClosed):
         silent.observe(r"login:", timeout=30.0)
+
+
+def test_the_boot_check_does_not_spend_an_agetty_attempt_on_the_prompt() -> None:
+    """`vm-lvm` passed run54 in 21.6 minutes with one reconnect and no solicit,
+    and failed run56 in 74.4 minutes with two reconnects and
+
+        Maximum number of tries exceeded (5)
+        lvmbox login: install
+
+    An empty line at a login prompt is one of agetty's attempts. The wait keeps
+    the silent default, and a prompt that went by is carried into the verdict
+    rather than ending the run, because `_name_the_user` types a name and waits
+    for either prompt.
+    """
+    import inspect
+
+    source = inspect.getsource(cluster.boot_and_check)
+    waited = [line for line in source.splitlines() if "observe(r\"login:\"" in line]
+    assert waited, source
+    assert not any("solicit" in line for line in waited), waited
+    # And the miss is not a verdict on its own: nothing returns straight out of
+    # that except, or a machine whose one prompt went by is failed for it.
+    after = source.split("except (ConsoleTimeout, ConsoleClosed) as error:")[1]
+    head = after.split("try:")[0]
+    assert "return" not in head, head

--- a/tests/unit/test_proxmox.py
+++ b/tests/unit/test_proxmox.py
@@ -3527,6 +3527,9 @@ def test_a_boot_that_never_prompts_says_what_the_console_held(
         def observe(self, pattern: str, timeout: float, *, solicit: bool = False) -> bytes:
             raise ConsoleTimeout("never matched 'login:'")
 
+        def respond(self, line: str) -> None:
+            return None
+
     from gentoo_install.exec.config import load
 
     installation = load(Path("tests/fixtures/vm-xfs.toml"))
@@ -3536,6 +3539,9 @@ def test_a_boot_that_never_prompts_says_what_the_console_held(
     said = cluster.boot_and_check(
         cast(Any, Guest()), cast(Any, Silent(held)), Path("unused"), installation
     )
+    # Carried, not returned: a prompt that went by during a reconnect is not a
+    # verdict on its own, because typing a name brings it back. The screen still
+    # reaches the verdict the login exchange then produces.
     assert "did not reach a login prompt" in said
     assert "start job is running" in said, said
 

--- a/tests/vm/cluster.py
+++ b/tests/vm/cluster.py
@@ -2569,20 +2569,20 @@ def boot_and_check(
     unlocked = _unlock(guest, link, installation, remotely_unlocked)
     if unlocked.refused:
         return unlocked.refused
+    missed_the_prompt = ""
     if unlocked.state is InstalledBootState.WAIT_LOGIN:
         try:
-            # Solicited: run54 reopened the console between `Loading initial
-            # ramdisk` and the kernel's first line, and agetty prints `login:`
-            # once, so the whole patience was spent on a guest that had booted.
-            link.observe(r"login:", timeout=BOOT_PATIENCE, solicit=True)
+            # Unsolicited: the empty line a reconnect used to send is counted by
+            # agetty as one of its attempts, and `vm-lvm` came back with
+            # `Maximum number of tries exceeded (5)` after two reconnects where
+            # the same fixture passed with one and no solicit.
+            link.observe(r"login:", timeout=BOOT_PATIENCE)
         except (ConsoleTimeout, ConsoleClosed) as error:
-            # The same reason the refused login carries one: `never matched
-            # 'login:'` with the console banner as the last output says the
-            # guest was silent and nothing about what it was doing. This is the
-            # verdict `vm-sdboot` and `vm-convert` came back with, and a
-            # conversion that never reached its own stage is indistinguishable
-            # from one that failed in it.
-            return (
+            # Not fatal: agetty prints `login:` once, so a console reopened past
+            # it never sees the prompt again, while `_name_the_user` types a
+            # name and waits for either prompt and gets in anyway. Kept for the
+            # verdict, which otherwise says nothing about what the guest showed.
+            missed_the_prompt = (
                 f"the installed system did not reach a login prompt: {error}; "
                 f"the console held {_seen_since(link, b'')}"
             )[:VERDICT_BYTES]
@@ -2591,7 +2591,7 @@ def boot_and_check(
     except ConsoleClosed as error:
         return f"installed login response delivery is unknown: {error}"[:200]
     if refused:
-        return refused
+        return f"{missed_the_prompt}; {refused}"[:VERDICT_BYTES] if missed_the_prompt else refused
 
     for name, command, wanted in _asked_for(installation):
         said = link.expect_output(command, timeout=120.0)


### PR DESCRIPTION
`#447` made the boot check solicit a fresh `login:` after a console reconnect, because agetty prints it once. The empty line that does it is counted by agetty as one of its attempts, and the cost shows:

| run | reconnects | result |
|---|---|---|
| run54, before `#447` | 1 | ok, 21.6m |
| run56, after `#447` | 2 | FAIL, `Maximum number of tries exceeded (5)`, `lvmbox login: install` |

The wait keeps the silent default. A prompt that went by is no longer a verdict on its own, because `_name_the_user` types a name and waits for either prompt, so a machine whose one `login:` was missed still gets in — and the screen it was showing is carried into whatever verdict the login exchange then produces, which is what `#437` and `#441` were for.

The underlying phase slip (`login: install` is the password in the username field) is older than `#447` and is not touched here; it has had its three attempts and the note is in `memory/`.