### PR TITLE
convert: replace a mounted directory by its contents

### DIFF
--- a/gentoo_install/exec/convert.py
+++ b/gentoo_install/exec/convert.py
@@ -12,6 +12,71 @@ from typing import Sequence
 from ..errors import ConversionFailed
 
 
+#: Where a mounted directory's own entries are moved while it is replaced.
+#: Inside the mount, so every move is a rename on one filesystem.
+KEPT_ASIDE: str = ".gentoo-install.old"
+
+
+def _mounts_inside(directory: Path) -> list[str]:
+    """Name every entry of `directory` that is itself a mount point."""
+    try:
+        entries = sorted(os.listdir(directory))
+    except OSError:
+        return []
+    return [one for one in entries if os.path.ismount(directory / one)]
+
+
+def _replace_contents(destination: Path, staged: Path) -> None:
+    """Swap what is in a mount point, since the mount point cannot be renamed.
+
+    Not `cp`: every move here is a `rename(2)` on one filesystem, so the window
+    is the entry count rather than the size of `/usr`. `distro2gentoo` copies
+    instead, which also merges -- and this installer replaces `/etc` rather
+    than merging it.
+    """
+    aside = destination / KEPT_ASIDE
+    if os.path.lexists(aside):
+        raise ConversionFailed(f"{aside} is left from an earlier attempt")
+    os.mkdir(aside)
+    moved: list[str] = []
+    arrived: list[str] = []
+    try:
+        for name in sorted(os.listdir(destination)):
+            if name == KEPT_ASIDE:
+                continue
+            os.rename(destination / name, aside / name)
+            moved.append(name)
+        for name in sorted(os.listdir(staged)):
+            os.rename(staged / name, destination / name)
+            arrived.append(name)
+    except OSError as error:
+        for name in reversed(arrived):
+            try:
+                os.rename(destination / name, staged / name)
+            except OSError as rollback_error:
+                error.add_note(f"could not return {name} to the staging root: {rollback_error}")
+        for name in reversed(moved):
+            try:
+                os.rename(aside / name, destination / name)
+            except OSError as rollback_error:
+                error.add_note(f"could not restore {destination / name}: {rollback_error}")
+        raise ConversionFailed(
+            f"{destination} could not be replaced by content: {error}"
+        ) from error
+
+
+def _restore_contents(destination: Path, staged: Path) -> None:
+    """Undo `_replace_contents` when a later directory fails."""
+    aside = destination / KEPT_ASIDE
+    for name in sorted(os.listdir(destination)):
+        if name == KEPT_ASIDE:
+            continue
+        os.rename(destination / name, staged / name)
+    for name in sorted(os.listdir(aside)):
+        os.rename(aside / name, destination / name)
+    os.rmdir(aside)
+
+
 def convert(staging: Path, names: Sequence[str], *, root: Path = Path("/")) -> None:
     """Replace each named directory and remove backups after all swaps finish."""
     try:
@@ -23,7 +88,7 @@ def convert(staging: Path, names: Sequence[str], *, root: Path = Path("/")) -> N
         # step exists to avoid: the window would be the whole copy.
         raise ConversionFailed("the staging directory is not on the root filesystem")
 
-    destinations: list[tuple[str, Path, Path, Path, bool]] = []
+    destinations: list[tuple[str, Path, Path, Path, bool, bool]] = []
     for name in names:
         destination = root / name
         staged = staging / name
@@ -33,27 +98,38 @@ def convert(staging: Path, names: Sequence[str], *, root: Path = Path("/")) -> N
         if os.path.lexists(old):
             raise ConversionFailed(f"{old} is left from an earlier attempt")
         if os.path.ismount(destination):
-            # Refused here rather than discovered at the rename: a machine with
-            # a separate /var or /usr can never be converted this way, and the
-            # rollback that follows a half-done swap is not the place to learn
-            # it.
-            raise ConversionFailed(
-                f"{destination} is a separate mount, which rename cannot replace"
-            )
+            # Counted before anything moves: `rename(2)` answers EBUSY for a
+            # mount point, and finding that out halfway through the entries is
+            # a state with no clean rollback.
+            nested = _mounts_inside(destination)
+            if nested:
+                raise ConversionFailed(
+                    f"{destination} is a separate mount holding {', '.join(nested)}, "
+                    "which rename cannot move"
+                )
         # A distribution without one of these is converted, not refused: a
         # merged-usr Debian has no `/lib64` at all, and renaming what is not
         # there fails half way through with the rest already swapped.
-        destinations.append((name, destination, staged, old, os.path.lexists(destination)))
+        destinations.append(
+            (name, destination, staged, old, os.path.lexists(destination), os.path.ismount(destination))
+        )
+    # Mount points last: replacing one by content is the only step whose
+    # rollback touches more than two renames, so nothing else has to be undone
+    # after one of them succeeded.
+    destinations.sort(key=lambda entry: entry[5])
 
-    swapped: list[tuple[str, Path, Path, Path, bool]] = []
+    swapped: list[tuple[str, Path, Path, Path, bool, bool]] = []
     for entry in destinations:
-        name, destination, staged, old, present = entry
+        name, destination, staged, old, present, mounted = entry
         moved_old = False
         try:
-            if present:
-                os.rename(destination, old)
-                moved_old = True
-            os.rename(staged, destination)
+            if mounted:
+                _replace_contents(destination, staged)
+            else:
+                if present:
+                    os.rename(destination, old)
+                    moved_old = True
+                os.rename(staged, destination)
         except OSError as error:
             if moved_old:
                 try:
@@ -61,9 +137,22 @@ def convert(staging: Path, names: Sequence[str], *, root: Path = Path("/")) -> N
                 except OSError as rollback_error:
                     error.add_note(f"could not restore {name}: {rollback_error}")
             for entry_back in reversed(swapped):
-                swapped_name, swapped_destination, swapped_staged, swapped_old, was_there = (
-                    entry_back
-                )
+                (
+                    swapped_name,
+                    swapped_destination,
+                    swapped_staged,
+                    swapped_old,
+                    was_there,
+                    was_mounted,
+                ) = entry_back
+                if was_mounted:
+                    try:
+                        _restore_contents(swapped_destination, swapped_staged)
+                    except OSError as rollback_error:
+                        error.add_note(
+                            f"could not restore {swapped_name}: {rollback_error}"
+                        )
+                    continue
                 try:
                     os.rename(swapped_destination, swapped_staged)
                 except OSError as rollback_error:
@@ -83,13 +172,14 @@ def convert(staging: Path, names: Sequence[str], *, root: Path = Path("/")) -> N
 
     # Said rather than raised: every name is already swapped by now, so the
     # machine is converted and a directory left behind is not a failure of it.
-    for name, _, _, old, present in swapped:
-        if not present:
+    for name, destination, _, old, present, mounted in swapped:
+        kept = destination / KEPT_ASIDE if mounted else old
+        if not mounted and not present:
             continue
         try:
-            shutil.rmtree(old)
+            shutil.rmtree(kept)
         except OSError as error:
-            print(f"{old} stayed behind: {error}", file=sys.stderr)
+            print(f"{kept} stayed behind: {error}", file=sys.stderr)
 
 
 #: What a distribution names a kernel, an initramfs and the two files that go

--- a/gentoo_install/plan/convert.py
+++ b/gentoo_install/plan/convert.py
@@ -338,18 +338,6 @@ def layout_graph(layout: StorageLayout) -> DiskConfig:
         )
     if not layout.root_device or not layout.root_filesystem_type:
         raise ConversionUnsupported("the running root device could not be read")
-    # `exec/convert.py` refuses the same thing at the rename, which on a Fedora
-    # cloud image arrived at operation 44 of 46 with the whole system already
-    # emerged. The mount table says it before anything is written.
-    mounted = [
-        name for name in REPLACED_DIRECTORIES if f"/{name}" in layout.separate_mounts
-    ]
-    if mounted:
-        raise ConversionUnsupported(
-            f"{', '.join('/' + one for one in mounted)} "
-            f"{'is' if len(mounted) == 1 else 'are'} a separate mount, "
-            "which rename cannot replace"
-        )
     if not layout.uefi and layout.root_below_device is None:
         # Measured on an Alpine cloud image, whose ext4 sits on `/dev/vda`
         # itself: `grub-install --target=i386-pc` answers `will not proceed

--- a/tests/unit/test_convert.py
+++ b/tests/unit/test_convert.py
@@ -217,24 +217,68 @@ def test_a_file_that_is_not_a_kernel_image_is_left_alone(tmp_path: Path) -> None
     assert (root / "boot" / "memtest86+.bin").read_text() == "keep"
 
 
-def test_a_separately_mounted_directory_is_refused_before_any_rename(
+def test_a_separately_mounted_directory_is_replaced_by_its_contents(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
-    """A machine with a separate /var can never be converted by renaming, and
-    the rollback after a half-done swap is not the place to learn it."""
+    """Fedora mounts `/var` as its own btrfs subvolume, and `rename(2)` cannot
+    replace a mount point. Refusing it kept the whole RPM family out, so the
+    entries move instead: every one is a rename on the same filesystem, which
+    is what `distro2gentoo`'s `cp -a` is not."""
     root = tmp_path / "root"
     staging = root / "new"
     for name in ("usr", "var"):
         (root / name).mkdir(parents=True)
         (staging / name).mkdir(parents=True)
     (root / "usr" / "kept.txt").write_text("old")
+    (root / "var" / "old-log").write_text("from the distribution being replaced")
+    (staging / "usr" / "new.txt").write_text("new")
+    (staging / "var" / "portage").mkdir()
 
     real = os.path.ismount
     monkeypatch.setattr(
         "os.path.ismount", lambda path: str(path).endswith("/var") or real(path)
     )
+    # The directory itself, not its contents: a rename would put a different
+    # directory at that path, which is exactly what a mount point forbids. In a
+    # temporary directory nothing is really mounted, so the inode is what tells
+    # the two paths apart.
+    was = os.stat(root / "var").st_ino
+    ordinary = os.stat(root / "usr").st_ino
 
-    with pytest.raises(ConversionFailed, match="separate mount"):
+    convert.convert(staging, ("usr", "var"), root=root)
+
+    assert os.stat(root / "var").st_ino == was, "the mount point was replaced"
+    assert os.stat(root / "usr").st_ino != ordinary, "an ordinary directory is renamed"
+    # The mount point itself is untouched, and what is in it is the staged set.
+    assert (root / "var" / "portage").is_dir()
+    assert not (root / "var" / "old-log").exists(), "replaced, not merged"
+    assert not (root / "var" / convert.KEPT_ASIDE).exists(), "the kept set is removed"
+    # And the ordinary directory still went by rename.
+    assert (root / "usr" / "new.txt").read_text() == "new"
+    assert not (root / "usr" / "kept.txt").exists()
+
+
+def test_a_mount_inside_a_mounted_directory_is_refused_before_any_move(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Negative control for the above. `rename(2)` answers EBUSY for a mount
+    point, so a `/var` with something mounted under it cannot have its entries
+    moved, and finding that out halfway through has no clean rollback."""
+    root = tmp_path / "root"
+    staging = root / "new"
+    for name in ("usr", "var"):
+        (root / name).mkdir(parents=True)
+        (staging / name).mkdir(parents=True)
+    (root / "var" / "lib").mkdir()
+    (root / "usr" / "kept.txt").write_text("old")
+
+    real = os.path.ismount
+    monkeypatch.setattr(
+        "os.path.ismount",
+        lambda path: str(path).endswith(("/var", "/var/lib")) or real(path),
+    )
+
+    with pytest.raises(ConversionFailed, match="holding lib"):
         convert.convert(staging, ("usr", "var"), root=root)
 
-    assert (root / "usr" / "kept.txt").read_text() == "old", "nothing was renamed"
+    assert (root / "usr" / "kept.txt").read_text() == "old", "nothing was moved"

--- a/tests/unit/test_plan_convert.py
+++ b/tests/unit/test_plan_convert.py
@@ -769,26 +769,20 @@ def test_a_failed_conversion_still_unmounts_the_staging_root() -> None:
     assert not any(one.releases_the_machine for one in others), others
 
 
-def test_a_conversion_refuses_a_replaced_directory_that_is_its_own_mount() -> None:
+def test_a_replaced_directory_that_is_its_own_mount_no_longer_refuses() -> None:
     """A Fedora 41 cloud image mounts `/var` and `/home` as their own btrfs
-    subvolumes. `exec/convert.py` refuses that at the rename, which arrived at
-    operation 44 of 46 with the whole system already emerged and the staging
-    root left behind; the mount table says it before anything is written.
+    subvolumes. Refusing that kept the whole RPM family out; `exec/convert.py`
+    replaces a mount point's contents instead, every move a rename on the one
+    filesystem, so the graph has nothing to object to.
     """
     fedora = replace(_layout(), separate_mounts=("/boot", "/home", "/proc", "/var"))
-    with pytest.raises(ConversionUnsupported, match=r"/var is a separate mount"):
-        convert.layout_graph(fedora)
+    assert convert.layout_graph(fedora).mode is DiskMode.IN_PLACE
 
-    # Negative control one: a mount that is not replaced is not a reason to
-    # refuse, or every machine with a separate /home would be turned away.
-    ordinary = replace(fedora, separate_mounts=("/boot", "/home", "/proc"))
-    assert convert.layout_graph(ordinary).mode is DiskMode.IN_PLACE
-
-    # Negative control two: the message names every one of them, because an
-    # operator who moves /var only to be refused for /usr has learned nothing.
-    both = replace(fedora, separate_mounts=("/usr", "/var"))
-    with pytest.raises(ConversionUnsupported, match=r"/usr, /var are a separate mount"):
-        convert.layout_graph(both)
+    # Negative control: the layers the graph genuinely cannot describe are
+    # still refused, so this did not turn the whole check off.
+    on_lvm = replace(fedora, root_on_lvm=True)
+    with pytest.raises(ConversionUnsupported, match="below LVM"):
+        convert.layout_graph(on_lvm)
 
 
 def test_the_staging_root_is_unmounted_from_the_deepest_mount_up() -> None:


### PR DESCRIPTION
`rename(2)` cannot replace a mount point, so a machine whose `/var` or `/usr` is its own filesystem was refused — which keeps the whole RPM family out. A Fedora 41 cloud image mounts `/var` as its own btrfs subvolume.

`distro2gentoo` avoids the problem by never renaming: it runs the new system's own `cp` through its own `ld.so` and writes into the mount point. That also merges, and this installer replaces `/etc` rather than merging it.

So a mount point's entries are moved instead: each into `.gentoo-install.old/` inside the mount, then the staged entries in, then the kept set removed. Every move is a `rename(2)` on the one filesystem, so the window is the entry count rather than the size of `/usr`. That window is real and is written down in `docs/design.md`, which this changes first.

Mount points are done last, since theirs is the only rollback that touches more than two renames. A mount inside one is still refused, because `rename(2)` answers EBUSY for it and finding that out halfway has no clean rollback.

On the Fedora machine the offer now answers `('/dev/vda4 on btrfs', '')` where it named `/var` before.