### PR TITLE
vm: name the command a timed-out marker was waiting on

### DIFF
--- a/tests/unit/test_cluster.py
+++ b/tests/unit/test_cluster.py
@@ -1296,3 +1296,49 @@ def test_infra_node3_takes_guests_again() -> None:
 
     entry = inspect.getsource(cluster.main)
     assert "none are named" in entry, entry[:0] or "the empty case is unhandled"
+
+
+def test_a_timed_out_marker_names_the_command_it_was_waiting_on() -> None:
+    """`vm-convert` ended a 156-minute run with
+
+        never matched 'MARK_63_DONE'; last output was b'...grub-core/lib...'
+
+    A token is not a command, and reading which of sixty-three it was took the
+    source. The screen said GRUB was compiling; the message did not say which
+    step was waiting on it.
+    """
+    from tests.vm.console import ConsoleIdle, ConsoleTimeout
+
+    class Console:
+        def __init__(self, error: Exception) -> None:
+            self.error = error
+
+        def send(self, line: str) -> None:
+            return None
+
+        def expect(self, pattern: str, timeout: float, idle: float = 0.0) -> bytes:
+            raise self.error
+
+    link = cluster.Reconnecting(
+        lambda: cast(Any, Console(ConsoleTimeout("never matched 'MARK_63_DONE'"))), tries=1
+    )
+    with pytest.raises(ConsoleTimeout, match="emerge --sync") as caught:
+        link.run("emerge --sync gentoo")
+    assert "MARK_63_DONE" in str(caught.value), "the token is kept as well"
+
+    # Negative control one: the idle failure keeps its own type, or `wait_for`
+    # stops consulting the watchdog and every long build ends as a timeout.
+    idle_link = cluster.Reconnecting(
+        lambda: cast(Any, Console(ConsoleIdle("never matched 'MARK_9_DONE'"))), tries=1
+    )
+    with pytest.raises(ConsoleIdle):
+        idle_link.run("emerge --sync gentoo")
+
+    # Negative control two: a console that answers is not wrapped at all.
+    class Answering(Console):
+        def expect(self, pattern: str, timeout: float, idle: float = 0.0) -> bytes:
+            return b"done"
+
+    cluster.Reconnecting(
+        lambda: cast(Any, Answering(ConsoleTimeout("unused"))), tries=1
+    ).run("true")

--- a/tests/vm/cluster.py
+++ b/tests/vm/cluster.py
@@ -37,7 +37,8 @@ from enum import Enum
 from pathlib import Path
 from collections import Counter
 from collections.abc import Callable, Mapping
-from typing import Final, Protocol, TypeVar, cast, Sequence
+from contextlib import contextmanager
+from typing import Final, Iterator, Protocol, TypeVar, cast, Sequence
 
 from gentoo_install.model.config import Firmware as BootFirmware
 from gentoo_install.model.config import (
@@ -2020,6 +2021,21 @@ KNOWN_BAD_NODES: Final[frozenset[str]] = frozenset()
 REOPEN_CEILING: Final[int] = 24
 
 
+@contextmanager
+def _naming(command: str) -> Iterator[None]:
+    """Put the command into a marker's timeout, which otherwise names a token.
+
+    `vm-convert` ended a 156-minute run with `never matched 'MARK_63_DONE'`,
+    and reading which of sixty-three commands that was took the source.
+    """
+    try:
+        yield
+    except ConsoleIdle as error:
+        raise ConsoleIdle(f"{command!r}: {error}") from error
+    except ConsoleTimeout as error:
+        raise ConsoleTimeout(f"{command!r}: {error}") from error
+
+
 class Reconnecting:
     """A console that opens another one when the cluster drops it.
 
@@ -2098,7 +2114,8 @@ class Reconnecting:
         def run_once(deadline: float) -> None:
             token = next(self._marks)
             self.console.send(marked_command(command, token))
-            self.console.expect(command_done(token), _remaining(deadline))
+            with _naming(command):
+                self.console.expect(command_done(token), _remaining(deadline))
 
         self._with_reconnect(timeout, run_once)
 
@@ -2135,7 +2152,8 @@ class Reconnecting:
                 completion = rf"{completion}|{_ANY_ROOT_PROMPT}"
             while True:
                 try:
-                    self.console.expect(completion, _remaining(deadline), idle=idle)
+                    with _naming(command):
+                        self.console.expect(completion, _remaining(deadline), idle=idle)
                     return
                 except ConsoleIdle as error:
                     if watch is None:
@@ -2161,8 +2179,9 @@ class Reconnecting:
         def collect_once(deadline: float) -> bytes:
             token = next(self._marks)
             self.console.send(marked_command(command, token))
-            self.console.expect(command_begin(token), _remaining(deadline))
-            said = self.console.expect(command_done(token), _remaining(deadline))
+            with _naming(command):
+                self.console.expect(command_begin(token), _remaining(deadline))
+                said = self.console.expect(command_done(token), _remaining(deadline))
             return said.split(command_done(token).encode())[0]
 
         return self._with_reconnect(timeout, collect_once)


### PR DESCRIPTION
`vm-convert` ended run56 after 156.1 minutes with

```
never matched 'MARK_63_DONE'; last output was b'...grub-2.14/grub-core/lib/...'
```

The screen said GRUB was compiling. The message did not say which of sixty-three commands was waiting on it, and finding out took reading the source.

The command goes into the message and the token stays with it. `ConsoleIdle` keeps its own type, or `wait_for` stops consulting the watchdog and every long build ends as a timeout instead of an idle check — that is the first negative control.