### PR TITLE
readme: move the verification record into its own table

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -54,35 +54,13 @@ gentoo-install は Linux ライブ環境で動作し、amd64 アーキテクチ�
 
 ## 検証状況
 
-<!-- fact: verification-history -->
+<!-- fact: verification-scope -->
 
-過去のエンドツーエンド記録では、amd64 Gentoo minimal ISO と、インストーラリビジョン `a71f91b4735469bae8ec76af170201acb967a5fe` および `f7257793f95df4b21ebf2ac6a775a343f6205f1b` が使用されました。これらの記録は、一部の UEFI と BIOS インストール、systemd、OpenRC、ext4、btrfs、xfs、LUKS2、LVM、mdraid、Plasma、公式 binhost を対象としていましたが、その後のインストール経路の変更により、現在は過去の根拠としてのみ扱われます。
+[`TESTED.md`](TESTED.md) が検証記録です。実際に動かした経路ごとに 1 行あり、それが動作したインストーラのリビジョンと、動作した場所を記載します。実行が記録として数えられるのは、記録されたリビジョンがインストーラと一致し、インストールの終了コードが `0` で、導入されたシステムが起動し、起動後の設定チェックがすべて通った場合だけです。
 
-<!-- fact: verification-current -->
+ディスクへ導入する経路にはクラスタと単一マシンの記録があり、ext4、xfs、btrfs、f2fs、ZFS、LVM、mdraid、LUKS2 を、両方のファームウェアと両方の init システムで対象としています。動作中のシステムをインプレース変換する経路の記録は 2 件で、いずれも QEMU 上、いずれも BIOS です。RAM へ起動してから導入または イメージを書き込む経路は設計済みで、記録はありません。
 
-2026 年 8 月 11 日付のリビジョン付きエンドツーエンド記録は、Arch Linux、openSUSE、Debian、Fedora、自前でビルドした gentoo-cjk minimal ISO からのインストールと起動をそれぞれ 1 回ずつ対象としています。これらの記録は、インストーラリビジョン [`b931ef46fc15ed50385f70467f2bfb0a8d1fd154`](https://github.com/Zakkaus/gentoo-install/commit/b931ef46fc15ed50385f70467f2bfb0a8d1fd154) を対象としています。gentoo-cjk の記録は ZFS と ZFSBootMenu を使用し、ほかの 4 件は ext4 を使用しています。記録されたリビジョンがインストーラと一致し、インストールの終了コードが `0` で、インストール済みシステムが起動し、起動後の設定検査に合格した場合に限り、その実行を現在の根拠として扱います。
-
-2026 年 8 月 16 日付のクラスタ記録は、インストーラリビジョン [`a8bf2f3837b6`](https://github.com/Zakkaus/gentoo-install/commit/a8bf2f3837b6) を対象とし、amd64 Gentoo minimal ISO 上で `vm-luks`、`vm-mdraid`、`vm-xfs`、`vm-btrfs`、`vm-f2fs` の 5 件がそれぞれインストールと起動を完了し、起動後の設定チェックをすべて通過しています。`vm-lvm` はリビジョン `073997aa74d2` で同じチェックを通過しています。
-
-2026-08-17 のクラスタ記録は次を追加で対象とします。`openrc-sdboot` はリビジョン `40ea3d90f1cc`、`vm-binpkg`、`vm-btrfs`、`vm-desktop`、`vm-gnome` は `6ba5530fd3c8`、`vm-xfs` は `304dffa41602`、`vm-f2fs`、`vm-mdraid`、`vm-proxy-dead`、`vm-xfs`、`vm-zram` は `7ac43a1d5050` です。`d2bed50eed48` の記録は `vm-lvm`、`vm-sdboot`、`vm-unlock` を追加します。リビジョン [`7cf09c2f9d9c`](https://github.com/Zakkaus/gentoo-install/commit/7cf09c2f9d9c) の記録は `vm-btrfs`、`vm-binpkg`、`vm-luks` を追加します。`vm-unlock` は initramfs の SSH ロック解除に関する最初のクラスタ記録です。
-
-同じ日付で、クラスタではなく単一マシン上の QEMU による記録もあり、クラスタでは駆動できない経路を対象とします。クラスタの BIOS ゲストはカーネル起動までシリアルポートへ何も出力せず、root 以外の API トークンではスクリーンショットのエンドポイントもファームウェア引数の受け渡しも利用できません。したがって `vm-bios`、`vm-bios-luks`、`ext4-bios`、`mbr-edit` は `304dffa41602` で QEMU から記録しています。`zfs-zbm`、`vm-proxy`、`vm-proxy-http` は `15d45598637a` で同様です。プロキシ用の fixture は QEMU のユーザーモードネットワーク経由でホスト上のプロキシに接続しますが、ブリッジ接続のクラスタゲストにはそのアドレスがありません。
-
-インプレース変換にはエンドツーエンドの記録が 2 件あり、いずれもクラスタではなく単一マシンの QEMU によるものです。リビジョン [`bcc090fab621`](https://github.com/Zakkaus/gentoo-install/commit/bcc090fab621) はパーティション上に ext4 ルートを持つ Debian 12 genericcloud イメージ、リビジョン [`71e751cf14a1`](https://github.com/Zakkaus/gentoo-install/commit/71e751cf14a1) は btrfs ルートを持つ Arch Linux クラウドイメージで、後者では `/swap/swapfile` の行が新しい fstab に引き継がれました。いずれも `uname -r` は `6.18.43-gentoo-dist-bin` を報告し、`emerge` が存在し、元のディストリビューションのパッケージマネージャは存在せず、ルートデバイスは変わらず、実行の記録は `/var/log/gentoo-install` に保存されました。2 件とも BIOS です。UEFI、btrfs サブボリューム上のルート、`vm-convert` クラスタフィクスチャは未検証です。
-
-その他の実装済みの組み合わせは、エンドツーエンド未検証です。現在の根拠は、greetd のデスクトップセッション、GNOME 以外での ibus を対象としていません。公式 Gentoo minimal ISO または Gig-OS のライブメディア、binhost 障害時のフォールバックも対象としていません。
-
-Alpine のライブメディアは両方のファームウェアで根拠があります。リビジョン [`0827931289d0`](https://github.com/Zakkaus/gentoo-install/commit/0827931289d0) では `alpine-standard-3.24.1` が UEFI の systemd マシンを導入し、56 の操作、57 パッケージをバイナリホストから取得し 12 をコンパイルしました。リビジョン [`bc8ab3a0edcf`](https://github.com/Zakkaus/gentoo-install/commit/bc8ab3a0edcf) では同じメディアが ext4 ルートの BIOS OpenRC マシンを導入し、51 の操作、29 をバイナリホストから、51 をコンパイルしました。いずれもシリアルコンソール上で 59 秒以内に root シェルへ到達し、導入されたシステムは起動してレイアウトをマウントし、失敗したユニットはありませんでした。
-
-プロキシ経路には、SOCKS5 の DNS モード、dry-run 出力と公開設定での認証情報の除去、インストール済みシステムに残る認証情報なしのエンドポイントを対象とする単体テストと plan テストがあります。リビジョンを記録したクラスタ実行が逆方向を裏づけます。`vm-proxy-dead` フィクスチャは待ち受けのないポートをプロキシに指定し、インストールは stage3 のダウンロードで `Connection refused` により停止します。ミラーに到達する実行はプロキシが迂回されたことを示します。
-
-リビジョン `4d8512a496d` の二回の実行が順方向を裏づけます。`vm-proxy` はパスワードを要求する SOCKS5 プロキシを通してインストールを完了し、`vm-proxy-http` は HTTP プロキシを通して完了します。いずれも 57 個の操作を書き込み、93 個のパッケージはバイナリホストから、14 個はソースから構築されます。パスワードを要求する HTTP または HTTPS プロキシでは、メインツリーのスナップショットの署名を検証できません。`emerge-webrsync` が gemato に渡すのは認証情報を含まないエンドポイントだけだからです。dirmngr は SOCKS をまったく扱えないため、SOCKS5 では鍵の更新に keyserver への直接経路が必要です。
-
-CJK のテキストコンソール表示にも現在の検証根拠はありません。ext2 と ext3 には、各設定に対する自動テストもありません。`tests/fixtures/` のファイルは設定モデルのみを検証し、対応する組み合わせのインストールと起動を証明するものではありません。
-
-<!-- fact: verification-network -->
-
-IPv4 のみ、IPv6 のみ、デュアルスタックの VM 検査は、ディスクへアクセスする前に終了します。この検査は、アドレスファミリの検出、`bootstrap.sh --missing-commands`、stage3 pointer の取得だけを確認します。stage3 のダウンロード、リポジトリ同期、binhost へのアクセス、パッケージのインストール、ターゲットシステムの起動は検証しません。
+`tests/fixtures/` 以下のファイルが対象とするのは設定モデルであり、その存在は導入されたマシンについて何も示しません。
 
 ## 要件
 

--- a/README.ko.md
+++ b/README.ko.md
@@ -54,35 +54,13 @@ gentoo-install은 Linux 라이브 환경에서 실행되어 amd64 아키텍처�
 
 ## 검증 상태
 
-<!-- fact: verification-history -->
+<!-- fact: verification-scope -->
 
-과거 엔드투엔드 기록은 amd64 Gentoo minimal ISO와 설치 도구 리비전 `a71f91b4735469bae8ec76af170201acb967a5fe` 및 `f7257793f95df4b21ebf2ac6a775a343f6205f1b`를 사용했다. 해당 기록은 일부 UEFI와 BIOS 설치, systemd, OpenRC, ext4, btrfs, xfs, LUKS2, LVM, mdraid, Plasma, 공식 binhost를 다뤘지만 이후 설치 경로가 변경되어 현재는 과거 증거로만 인정된다.
+[`TESTED.md`](TESTED.md)이 검증 기록이다. 실제로 수행한 경로마다 한 행이 있으며, 그것이 동작한 설치기 리비전과 동작한 장소를 적는다. 어떤 실행이 기록으로 인정되려면 기록된 리비전이 설치기와 일치하고, 설치 종료 코드가 `0`이며, 설치된 시스템이 부팅하고, 부팅 후 구성 점검이 모두 통과해야 한다.
 
-<!-- fact: verification-current -->
+디스크에 설치하는 경로에는 클러스터와 단일 기계의 기록이 있으며 ext4, xfs, btrfs, f2fs, ZFS, LVM, mdraid, LUKS2를 두 펌웨어와 두 init 시스템에서 다룬다. 동작 중인 시스템을 인플레이스로 변환하는 경로의 기록은 둘이고, 모두 QEMU에서 나왔으며 모두 BIOS이다. RAM으로 부팅한 뒤 설치하거나 이미지를 기록하는 경로는 설계만 되어 있고 기록이 없다.
 
-2026년 8월 11일 자 리비전 표기 엔드투엔드 기록은 Arch Linux, openSUSE, Debian, Fedora, 자체 빌드한 gentoo-cjk minimal ISO에서 각각 한 번 설치하고 부팅한 결과를 다룬다. 이 기록은 설치 도구 리비전 [`b931ef46fc15ed50385f70467f2bfb0a8d1fd154`](https://github.com/Zakkaus/gentoo-install/commit/b931ef46fc15ed50385f70467f2bfb0a8d1fd154)을 대상으로 한다. gentoo-cjk 기록은 ZFS와 ZFSBootMenu를 사용하며, 나머지 네 건은 ext4를 사용한다. 기록된 리비전이 설치 도구와 일치하고 설치 종료 코드가 `0`이며 설치한 시스템이 부팅되고 부팅 후 설정 검사를 통과한 실행만 현재 증거로 인정된다.
-
-2026년 8월 16일 자 클러스터 기록은 설치 도구 리비전 [`a8bf2f3837b6`](https://github.com/Zakkaus/gentoo-install/commit/a8bf2f3837b6)을 대상으로 하며, amd64 Gentoo minimal ISO에서 `vm-luks`, `vm-mdraid`, `vm-xfs`, `vm-btrfs`, `vm-f2fs` 다섯 건이 각각 설치와 부팅을 마치고 부팅 후 설정 검사를 모두 통과했다. `vm-lvm`은 리비전 `073997aa74d2`에서 같은 검사를 통과했다.
-
-2026-08-17 클러스터 기록은 다음을 추가로 다룬다. `openrc-sdboot`는 리비전 `40ea3d90f1cc`, `vm-binpkg`, `vm-btrfs`, `vm-desktop`, `vm-gnome`은 `6ba5530fd3c8`, `vm-xfs`는 `304dffa41602`, `vm-f2fs`, `vm-mdraid`, `vm-proxy-dead`, `vm-xfs`, `vm-zram`은 `7ac43a1d5050`이다. `d2bed50eed48` 기록은 `vm-lvm`, `vm-sdboot`, `vm-unlock`을 추가한다. `vm-unlock`은 initramfs SSH 잠금 해제에 대한 첫 클러스터 기록이다. 리비전 [`7cf09c2f9d9c`](https://github.com/Zakkaus/gentoo-install/commit/7cf09c2f9d9c) 기록은 `vm-btrfs`, `vm-binpkg`, `vm-luks`를 추가한다.
-
-같은 날짜로 클러스터가 아니라 단일 machine에서 QEMU를 직접 실행한 기록도 있으며, 클러스터가 구동할 수 없는 경로를 다룬다. 클러스터의 BIOS 게스트는 커널이 시작하기 전까지 직렬 포트에 아무것도 출력하지 않고, root가 아닌 API 토큰으로는 스크린샷 엔드포인트도 펌웨어 인자 전달도 사용할 수 없다. 따라서 `vm-bios`, `vm-bios-luks`, `ext4-bios`, `mbr-edit`는 `304dffa41602`에서 QEMU로 기록했다. `zfs-zbm`, `vm-proxy`, `vm-proxy-http`는 `15d45598637a`에서 같은 방식이다. 프록시 fixture는 QEMU의 user-mode 네트워크를 통해 호스트의 프록시에 연결하는데, 브리지로 연결된 클러스터 게스트에는 그 주소가 없다.
-
-인플레이스 변환에는 엔드투엔드 기록이 둘 있으며, 모두 클러스터가 아니라 단일 기계의 QEMU에서 나왔다. 리비전 [`bcc090fab621`](https://github.com/Zakkaus/gentoo-install/commit/bcc090fab621)은 파티션 위에 ext4 루트를 둔 Debian 12 genericcloud 이미지이고, 리비전 [`71e751cf14a1`](https://github.com/Zakkaus/gentoo-install/commit/71e751cf14a1)은 btrfs 루트를 둔 Arch Linux 클라우드 이미지이며, 후자에서는 `/swap/swapfile` 줄이 새 fstab으로 옮겨졌다. 둘 다 `uname -r`가 `6.18.43-gentoo-dist-bin`을 보고했고, `emerge`가 존재했으며, 원래 배포판의 패키지 관리자는 존재하지 않았고, 루트 장치는 그대로였으며, 실행 기록은 `/var/log/gentoo-install`에 보관되었다. 두 기록 모두 BIOS이다. UEFI, btrfs 서브볼륨 위의 루트, `vm-convert` 클러스터 픽스처는 검증되지 않았다.
-
-그 밖의 구현된 조합은 엔드투엔드 검증을 거치지 않았다. 현재 증거는 greetd 데스크톱 세션, GNOME 외부의 ibus를 다루지 않는다. 공식 Gentoo minimal ISO 또는 Gig-OS 라이브 미디어, binhost 장애 시 전환도 다루지 않는다. 
-
-Alpine 라이브 미디어는 두 펌웨어 모두에서 증거가 있다. 리비전 [`0827931289d0`](https://github.com/Zakkaus/gentoo-install/commit/0827931289d0)에서 `alpine-standard-3.24.1`은 UEFI systemd 기계를 설치했고, 56개 동작과 바이너리 호스트에서 가져온 57개 패키지 및 12개 컴파일을 기록했다. 리비전 [`bc8ab3a0edcf`](https://github.com/Zakkaus/gentoo-install/commit/bc8ab3a0edcf)에서는 같은 미디어가 ext4 루트의 BIOS OpenRC 기계를 설치했고, 51개 동작과 바이너리 호스트에서 가져온 29개 및 51개 컴파일을 기록했다. 두 경우 모두 직렬 콘솔에서 59초 안에 root 셸에 도달했고, 설치된 시스템은 부팅하여 레이아웃을 마운트했고 실패한 유닛은 없었다.
-
-프록시 경로에는 SOCKS5 DNS 모드, dry-run 출력과 공개 설정의 인증 정보 제거, 설치된 시스템에 남는 인증 정보 없는 엔드포인트를 다루는 단위 테스트와 plan 테스트가 있다. 리비전이 기록된 클러스터 실행이 역방향을 뒷받침한다. `vm-proxy-dead` 픽스처는 수신 대기가 없는 포트를 프록시로 지정하며, 설치는 stage3 내려받기 단계에서 `Connection refused`로 중단된다. 미러에 도달하는 실행은 프록시가 우회되었음을 뜻한다. 
-
-리비전 `4d8512a496d`의 두 실행이 순방향을 뒷받침한다. `vm-proxy`는 비밀번호를 요구하는 SOCKS5 프록시를 통해 설치를 마치고, `vm-proxy-http`는 HTTP 프록시를 통해 마친다. 둘 다 57개의 작업을 기록하며 93개 패키지는 바이너리 호스트에서 오고 14개는 소스에서 빌드된다. 비밀번호를 요구하는 HTTP 또는 HTTPS 프록시로는 메인 트리 스냅숏의 서명을 검증할 수 없다. `emerge-webrsync`가 gemato에 넘기는 것은 인증 정보가 없는 엔드포인트뿐이기 때문이다. dirmngr는 SOCKS를 전혀 지원하지 않으므로 SOCKS5에서는 키 갱신에 keyserver로의 직접 경로가 필요하다.
-
-CJK 텍스트 콘솔 표시에도 현재 검증 증거가 없다. ext2와 ext3에는 해당 설정을 다루는 자동화 테스트도 없다. `tests/fixtures/`의 파일은 설정 모델만 검증하며 해당 조합의 설치와 부팅을 입증하지 않는다.
-
-<!-- fact: verification-network -->
-
-IPv4 전용, IPv6 전용, 듀얼 스택 VM 검사는 디스크에 접근하기 전에 끝난다. 이 검사는 주소 계열 감지, `bootstrap.sh --missing-commands`, stage3 pointer 가져오기만 확인한다. stage3 다운로드, 저장소 동기화, binhost 접근, 패키지 설치, 대상 시스템 부팅은 검증하지 않는다.
+`tests/fixtures/` 아래의 파일이 다루는 것은 구성 모델이며, 그 존재는 설치된 기계에 대해 아무것도 입증하지 않는다.
 
 ## 요구 사항
 

--- a/README.md
+++ b/README.md
@@ -54,35 +54,13 @@ After the proxy is selected, the configured proxy is used for stage3 and its sig
 
 ## Verification status
 
-<!-- fact: verification-history -->
+<!-- fact: verification-scope -->
 
-Historical end-to-end records used the amd64 Gentoo minimal ISO at installer revisions `a71f91b4735469bae8ec76af170201acb967a5fe` and `f7257793f95df4b21ebf2ac6a775a343f6205f1b`. Those records covered selected UEFI and BIOS installations, systemd and OpenRC, ext4, btrfs, xfs, LUKS2, LVM, mdraid, Plasma and the official binhost, but later installation-path changes made them historical evidence only.
+[`TESTED.md`](TESTED.md) is the verification record: one row for each exercised path, naming the installer revision it ran at and where it ran. A run counts only when its recorded revision matches the installer, its installation exit code is `0`, the installed system boots, and the post-boot configuration checks pass.
 
-<!-- fact: verification-current -->
+Installing onto a disk has cluster and single-machine records across ext4, xfs, btrfs, f2fs, ZFS, LVM, mdraid and LUKS2, on both firmwares and both init systems. Converting a running system in place has two records, both from QEMU and both BIOS. Booting into RAM to install or to write an image is designed and has no record at all.
 
-Revision-tagged end-to-end records dated 2026-08-11 cover one installation and boot from each of Arch Linux, openSUSE, Debian, Fedora and a self-built gentoo-cjk minimal ISO. The records cover installer revision [`b931ef46fc15ed50385f70467f2bfb0a8d1fd154`](https://github.com/Zakkaus/gentoo-install/commit/b931ef46fc15ed50385f70467f2bfb0a8d1fd154). The gentoo-cjk record uses ZFS and ZFSBootMenu; the other four use ext4. A run counts as current evidence only when its recorded revision matches the installer, its installation exit code is `0`, the installed system boots and the post-boot configuration checks pass.
-
-Revision-tagged cluster records dated 2026-08-16 cover installer revision [`a8bf2f3837b6`](https://github.com/Zakkaus/gentoo-install/commit/a8bf2f3837b6) on the amd64 Gentoo minimal ISO: `vm-luks`, `vm-mdraid`, `vm-xfs`, `vm-btrfs` and `vm-f2fs` each installed, booted and answered every post-boot configuration check. `vm-lvm` did so at revision `073997aa74d2`.
-
-Further cluster records dated 2026-08-17 cover `openrc-sdboot` at `40ea3d90f1cc`; `vm-binpkg`, `vm-btrfs`, `vm-desktop` and `vm-gnome` at `6ba5530fd3c8`; `vm-xfs` at `304dffa41602`; and `vm-f2fs`, `vm-mdraid`, `vm-proxy-dead`, `vm-xfs` and `vm-zram` at `7ac43a1d5050`. Records at `d2bed50eed48` add `vm-lvm`, `vm-sdboot` and `vm-unlock`, the first cluster record of the initramfs SSH unlock. Records at [`7cf09c2f9d9c`](https://github.com/Zakkaus/gentoo-install/commit/7cf09c2f9d9c) add `vm-btrfs`, `vm-binpkg` and `vm-luks`.
-
-Records of the same date from a single machine running QEMU directly, rather than the cluster, cover the paths the cluster cannot drive. A BIOS guest on this cluster writes nothing to its serial port before the kernel starts, and neither a screenshot endpoint nor a way to pass firmware arguments is available to a non-root API token, so `vm-bios`, `vm-bios-luks`, `ext4-bios` and `mbr-edit` are recorded at `304dffa41602` from QEMU. `zfs-zbm`, `vm-proxy` and `vm-proxy-http` are recorded at `15d45598637a` the same way: the proxy fixtures reach a proxy on the host through QEMU's user-mode network, which a bridged cluster guest does not have.
-
-The in-place conversion has two end-to-end records, both from QEMU on a single machine rather than the cluster. At [`bcc090fab621`](https://github.com/Zakkaus/gentoo-install/commit/bcc090fab621) a Debian 12 genericcloud image with an ext4 root on a partition was converted and booted as Gentoo; at [`71e751cf14a1`](https://github.com/Zakkaus/gentoo-install/commit/71e751cf14a1) an Arch Linux cloud image with a btrfs root did the same, and its `/swap/swapfile` line was carried into the new fstab. Both answered `6.18.43-gentoo-dist-bin` to `uname -r`, had `emerge` and neither distribution's package manager, kept the same root device, and kept the run's log in `/var/log/gentoo-install`. Both records are BIOS. UEFI, a btrfs subvolume root and the `vm-convert` cluster fixture remain unverified.
-
-Other implemented combinations remain unverified end to end. Current evidence does not cover greetd desktop sessions or ibus outside GNOME. It also does not cover the official Gentoo minimal ISO or Gig-OS live media, or binary-host failure fallback.
-
-The Alpine live medium is covered on both firmwares. At [`0827931289d0`](https://github.com/Zakkaus/gentoo-install/commit/0827931289d0) `alpine-standard-3.24.1` installed a UEFI systemd machine, 56 operations with 57 packages from a binary host and 12 compiled; at [`bc8ab3a0edcf`](https://github.com/Zakkaus/gentoo-install/commit/bc8ab3a0edcf) the same medium installed a BIOS OpenRC machine on ext4, 51 operations with 29 from a binary host and 51 compiled. Both reached a root shell on the serial console in 59 seconds, and both installed systems booted, mounted their layout and reported no failed unit.
-
-The proxy path has focused unit and plan coverage, including SOCKS5 DNS mode, redaction in dry-run output and published configuration, and the credential-free endpoint retained in the installed system. A revision-tagged cluster run covers the negative direction: the `vm-proxy-dead` fixture points the proxy at a port where nothing listens, and the install stops at the stage3 download with `Connection refused`, so a run that reached the mirror would show the proxy had been bypassed. 
-
-Two runs at revision `4d8512a496d` cover the positive direction: `vm-proxy` completes an installation through a SOCKS5 proxy that demands a password, and `vm-proxy-http` through an HTTP proxy, each writing 57 operations with 93 packages from a binary host and 14 compiled. An HTTP or HTTPS proxy that requires a password cannot check the tree snapshot's signature: `emerge-webrsync` hands gemato only the credential-free endpoint. dirmngr has no SOCKS support at all, so under SOCKS5 the key refresh needs a direct route to the keyserver.
-
-CJK text-console rendering has no current verification evidence. ext2 and ext3 additionally have no focused automated configuration test. Files under `tests/fixtures/` exercise the configuration model; their presence does not establish an end-to-end installation and boot result.
-
-<!-- fact: verification-network -->
-
-The IPv4-only, IPv6-only and dual-stack VM check stops before disk access. It checks address-family detection, `bootstrap.sh --missing-commands` and stage3 pointer retrieval; it does not verify stage3 download, repository synchronization, binhost access, package installation or a booted target system on those network modes.
+Files under `tests/fixtures/` exercise the configuration model; their presence establishes nothing about an installed machine.
 
 ## Requirements
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -54,35 +54,13 @@ gentoo-install 在 Linux live 环境中运行，用于安装 amd64 架构的 Gen
 
 ## 验证状态
 
-<!-- fact: verification-history -->
+<!-- fact: verification-scope -->
 
-历史端到端记录使用 amd64 Gentoo minimal ISO，安装程序修订版为 `a71f91b4735469bae8ec76af170201acb967a5fe` 和 `f7257793f95df4b21ebf2ac6a775a343f6205f1b`。这些记录覆盖部分 UEFI 和 BIOS 安装、systemd、OpenRC、ext4、btrfs、xfs、LUKS2、LVM 和 mdraid，也覆盖 Plasma 和官方 binhost。后续安装路径变更使其只能作为历史证据。
+[`TESTED.md`](TESTED.md) 是验证记录：每一条走过的路径各一行，写明它运行时的安装器修订版与运行的地点。一次运行要记录的修订版与安装器相符、安装退出码为 `0`、装出的系统能引导、且引导后的配置检查全部通过，才算数。
 
-<!-- fact: verification-current -->
+装到磁盘上的路径在集群与单机都有记录，覆盖 ext4、xfs、btrfs、f2fs、ZFS、LVM、mdraid 与 LUKS2,两种固件与两种 init 系统皆有。就地转换运行中的系统有两条记录，都来自 QEMU 且都是 BIOS。引导进内存再安装或写映像的模式已完成设计，尚无任何记录。
 
-2026 年 8 月 11 日的端到端记录均标有安装程序修订版，覆盖从 Arch Linux、openSUSE、Debian、Fedora 和自行构建的 gentoo-cjk minimal ISO 各安装并引导一次。这些记录覆盖安装程序修订版 [`b931ef46fc15ed50385f70467f2bfb0a8d1fd154`](https://github.com/Zakkaus/gentoo-install/commit/b931ef46fc15ed50385f70467f2bfb0a8d1fd154)。gentoo-cjk 记录使用 ZFS 和 ZFSBootMenu，其余四条记录使用 ext4。只有在记录的修订版与安装程序匹配、安装退出码为 `0`、已安装系统成功引导，且引导后配置检查通过时，该次运行才算当前证据。
-
-2026 年 8 月 16 日的集群记录标有安装程序修订版 [`a8bf2f3837b6`](https://github.com/Zakkaus/gentoo-install/commit/a8bf2f3837b6)，在 amd64 Gentoo minimal ISO 上覆盖 `vm-luks`、`vm-mdraid`、`vm-xfs`、`vm-btrfs` 和 `vm-f2fs`，五者各自完成安装、引导并通过全部引导后配置检查。`vm-lvm` 在修订版 `073997aa74d2` 完成同一组检查。
-
-2026-08-17 的集群记录另外涵盖：`openrc-sdboot` 于 `40ea3d90f1cc`；`vm-binpkg`、`vm-btrfs`、`vm-desktop`、`vm-gnome` 于 `6ba5530fd3c8`；`vm-xfs` 于 `304dffa41602`；`vm-f2fs`、`vm-mdraid`、`vm-proxy-dead`、`vm-xfs`、`vm-zram` 于 `7ac43a1d5050`。`d2bed50eed48` 的记录再加上 `vm-lvm`、`vm-sdboot` 与 `vm-unlock`，其中 `vm-unlock` 是 initramfs SSH 解锁的第一条集群记录。修订版 [`7cf09c2f9d9c`](https://github.com/Zakkaus/gentoo-install/commit/7cf09c2f9d9c) 的记录再加上 `vm-btrfs`、`vm-binpkg` 与 `vm-luks`。
-
-同一天另有一批记录来自单机直接运行 QEMU 而非集群，涵盖集群无法驱动的路径。集群上的 BIOS 客机在内核启动前不会向串口写入任何内容，而非 root 的 API token 调用屏幕截图端点会得到 501，也无法传递固件参数，因此 `vm-bios`、`vm-bios-luks`、`ext4-bios`、`mbr-edit` 的记录是 `304dffa41602`，由 QEMU 产生。`zfs-zbm`、`vm-proxy`、`vm-proxy-http` 于 `15d45598637a` 同样如此：代理 fixture 通过 QEMU 的 user-mode 网络连到宿主机上的代理，桥接的集群客机没有这个地址。
-
-就地转换已有两条端到端记录，均来自单机 QEMU 而非集群。修订版 [`bcc090fab621`](https://github.com/Zakkaus/gentoo-install/commit/bcc090fab621) 是一份根为分区上 ext4 的 Debian 12 genericcloud 映像，修订版 [`71e751cf14a1`](https://github.com/Zakkaus/gentoo-install/commit/71e751cf14a1) 是一份根为 btrfs 的 Arch Linux 云映像，后者的 `/swap/swapfile` 一行被带入新的 fstab。两者的 `uname -r` 都报告 `6.18.43-gentoo-dist-bin`，都有 `emerge` 而原发行版的包管理器均已不存在，根设备未变，执行记录都保存于 `/var/log/gentoo-install`。两条记录都是 BIOS。UEFI、位于 btrfs 子卷上的根，以及 `vm-convert` 集群 fixture 仍未验证。
-
-其他已实现组合仍未完成端到端验证。当前证据未覆盖 greetd 桌面会话或 GNOME 以外的 ibus。当前证据也未覆盖官方 Gentoo minimal ISO 或 Gig-OS live 介质，以及 binhost 失败时的降级。
-
-Alpine live 介质在两种固件上都有证据。修订版 [`0827931289d0`](https://github.com/Zakkaus/gentoo-install/commit/0827931289d0) 装出一台 UEFI 的 systemd 机器，56 个操作、57 个二进制软件包、12 个编译。修订版 [`bc8ab3a0edcf`](https://github.com/Zakkaus/gentoo-install/commit/bc8ab3a0edcf) 装出一台根为 ext4 的 BIOS OpenRC 机器，51 个操作、29 个二进制软件包、51 个编译。两次都在 59 秒内进入串口控制台的 root shell。装出的系统都引导、挂载其布局且无失败单元。
-
-代理路径已有聚焦单元测试和 plan 测试，覆盖 SOCKS5 DNS 模式、dry-run 输出与发布配置中的认证信息移除，以及已安装系统保留不含认证信息的端点。带版本标记的集群执行已覆盖反向：`vm-proxy-dead` fixture 把代理指向没有进程监听的端口，安装在 stage3 下载阶段以 `Connection refused` 停止，因此执行到达镜像就表示代理被绕过。
-
-版本 `4d8512a496d` 的两次执行覆盖正向：`vm-proxy` 通过要求密码的 SOCKS5 代理完成安装，`vm-proxy-http` 通过 HTTP 代理完成安装，两者都写入 57 个操作，其中 93 个二进制软件包来自二进制主机、14 个由源代码编译。要求密码的 HTTP 或 HTTPS 代理无法检查主树快照的签名，因为 `emerge-webrsync` 只把不含认证信息的端点交给 gemato。dirmngr 完全不支持 SOCKS，因此 SOCKS5 下密钥更新需要直连 keyserver。
-
-CJK 文本控制台显示目前没有验证证据。ext2 和 ext3 也没有针对其配置的自动化测试。`tests/fixtures/` 下的文件只验证配置模型；文件存在并不表示对应组合已完成端到端安装和引导验证。
-
-<!-- fact: verification-network -->
-
-纯 IPv4、纯 IPv6 和双栈的 VM 检查会在访问磁盘前结束。该检查只验证地址族检测、`bootstrap.sh --missing-commands` 和 stage3 pointer 读取，不验证 stage3 下载、仓库同步、binhost 访问、软件包安装或目标系统引导。
+`tests/fixtures/` 下的文件验证的是配置模型，它们存在并不代表任何一台装出来的机器。
 
 ## 要求
 

--- a/README.zh-TW.md
+++ b/README.zh-TW.md
@@ -54,35 +54,13 @@ gentoo-install 在 Linux live 環境中執行，用於安裝 amd64 架構的 Gen
 
 ## 驗證狀態
 
-<!-- fact: verification-history -->
+<!-- fact: verification-scope -->
 
-歷史端到端記錄使用 amd64 Gentoo minimal ISO，安裝器修訂版為 `a71f91b4735469bae8ec76af170201acb967a5fe` 與 `f7257793f95df4b21ebf2ac6a775a343f6205f1b`。這些記錄涵蓋部分 UEFI 與 BIOS 安裝、systemd、OpenRC、ext4、btrfs、xfs、LUKS2、LVM 與 mdraid，也涵蓋 Plasma 與官方 binhost。後續安裝路徑變更使其只能作為歷史實據。
+[`TESTED.md`](TESTED.md) 是驗證記錄：每一條走過的路徑各一列，寫明它執行時的安裝器修訂版與執行的地點。一次執行要記錄的修訂版與安裝器相符、安裝退出碼為 `0`、裝出的系統能開機、且開機後的設定檢查全部通過，才算數。
 
-<!-- fact: verification-current -->
+裝到磁碟上的路徑在叢集與單機都有記錄，涵蓋 ext4、xfs、btrfs、f2fs、ZFS、LVM、mdraid 與 LUKS2,兩種韌體與兩種 init 系統皆有。就地轉換執行中的系統有兩筆記錄，都來自 QEMU 且都是 BIOS。開進記憶體再安裝或寫映像檔的模式已完成設計，尚無任何記錄。
 
-2026 年 8 月 11 日的端到端記錄均標有安裝器修訂版，涵蓋從 Arch Linux、openSUSE、Debian、Fedora 與自行建置的 gentoo-cjk minimal ISO 各安裝並開機一次。這些記錄涵蓋安裝器修訂版 [`b931ef46fc15ed50385f70467f2bfb0a8d1fd154`](https://github.com/Zakkaus/gentoo-install/commit/b931ef46fc15ed50385f70467f2bfb0a8d1fd154)。gentoo-cjk 記錄使用 ZFS 與 ZFSBootMenu，其餘四筆使用 ext4。只有在記錄的修訂版與安裝器相符、安裝退出碼為 `0`、已安裝系統成功開機，且開機後設定檢查通過時，該次執行才算現行實據。
-
-2026 年 8 月 16 日的叢集記錄標有安裝器修訂版 [`a8bf2f3837b6`](https://github.com/Zakkaus/gentoo-install/commit/a8bf2f3837b6)，在 amd64 Gentoo minimal ISO 上涵蓋 `vm-luks`、`vm-mdraid`、`vm-xfs`、`vm-btrfs` 與 `vm-f2fs`，五者各自完成安裝、開機並通過全部開機後設定檢查。`vm-lvm` 在修訂版 `073997aa74d2` 完成同一組檢查。
-
-2026-08-17 的叢集記錄另外涵蓋：`openrc-sdboot` 於 `40ea3d90f1cc`；`vm-binpkg`、`vm-btrfs`、`vm-desktop`、`vm-gnome` 於 `6ba5530fd3c8`；`vm-xfs` 於 `304dffa41602`；`vm-f2fs`、`vm-mdraid`、`vm-proxy-dead`、`vm-xfs`、`vm-zram` 於 `7ac43a1d5050`。`d2bed50eed48` 的記錄再加上 `vm-lvm`、`vm-sdboot` 與 `vm-unlock`，其中 `vm-unlock` 是 initramfs SSH 解鎖的第一筆叢集記錄。修訂版 [`7cf09c2f9d9c`](https://github.com/Zakkaus/gentoo-install/commit/7cf09c2f9d9c) 的記錄再加上 `vm-btrfs`、`vm-binpkg` 與 `vm-luks`。
-
-同一天另有一批記錄來自單機直接執行 QEMU 而非叢集，涵蓋叢集無法驅動的路徑。叢集上的 BIOS 客機在核心啟動前不會向序列埠寫入任何內容，而非 root 的 API token 呼叫螢幕擷取端點會得到 501，也無法傳遞韌體參數，因此 `vm-bios`、`vm-bios-luks`、`ext4-bios`、`mbr-edit` 的記錄是 `304dffa41602`，由 QEMU 產生。`zfs-zbm`、`vm-proxy`、`vm-proxy-http` 於 `15d45598637a` 同樣如此：代理 fixture 透過 QEMU 的 user-mode 網路連到宿主機上的代理，橋接的叢集客機沒有這個位址。
-
-就地轉換已有兩筆端到端記錄，皆來自單機 QEMU 而非叢集。修訂版 [`bcc090fab621`](https://github.com/Zakkaus/gentoo-install/commit/bcc090fab621) 是一份根為分割區上 ext4 的 Debian 12 genericcloud 映像，修訂版 [`71e751cf14a1`](https://github.com/Zakkaus/gentoo-install/commit/71e751cf14a1) 是一份根為 btrfs 的 Arch Linux 雲映像，後者的 `/swap/swapfile` 一行被帶入新的 fstab。兩者的 `uname -r` 都回報 `6.18.43-gentoo-dist-bin`，都有 `emerge` 而原發行版的套件管理器皆已不存在，根裝置未變，執行記錄都保存於 `/var/log/gentoo-install`。兩筆記錄都是 BIOS。UEFI、位於 btrfs 子卷上的根，以及 `vm-convert` 叢集 fixture 仍未驗證。
-
-其他已實作組合仍未完成端到端驗證。現行實據未涵蓋 greetd 桌面工作階段或 GNOME 以外的 ibus。現行實據也未涵蓋官方 Gentoo minimal ISO 或 Gig-OS live 媒介，以及 binhost 失敗時的降級。
-
-Alpine live 媒介在兩種韌體上都有實據。修訂版 [`0827931289d0`](https://github.com/Zakkaus/gentoo-install/commit/0827931289d0) 裝出一台 UEFI 的 systemd 機器，56 個操作、57 個二進位套件、12 個編譯。修訂版 [`bc8ab3a0edcf`](https://github.com/Zakkaus/gentoo-install/commit/bc8ab3a0edcf) 裝出一台根為 ext4 的 BIOS OpenRC 機器，51 個操作、29 個二進位套件、51 個編譯。兩次都在 59 秒內進入序列主控台的 root shell。裝出的系統都開機、掛載其版面且無失敗單元。
-
-Proxy 路徑已有焦點單元測試與 plan 測試，涵蓋 SOCKS5 DNS 模式、dry-run 輸出與發佈設定的認證資訊移除，以及已安裝系統保留不含認證資訊的端點。帶版本標記的叢集執行已涵蓋反向：`vm-proxy-dead` fixture 把 Proxy 指向沒有程序監聽的埠，安裝在 stage3 下載階段以 `Connection refused` 停止，因此執行到達鏡像就表示 Proxy 被繞過。
-
-版本 `4d8512a496d` 的兩次執行涵蓋正向：`vm-proxy` 透過要求密碼的 SOCKS5 Proxy 完成安裝，`vm-proxy-http` 透過 HTTP Proxy 完成安裝，兩者都寫入 57 個操作，其中 93 個套件來自二進位主機、14 個由原始碼編譯。要求密碼的 HTTP 或 HTTPS Proxy 無法檢查主樹快照的簽章，因為 `emerge-webrsync` 只把不含認證資訊的端點交給 gemato。dirmngr 完全不支援 SOCKS，因此 SOCKS5 之下金鑰更新需要直連 keyserver。
-
-CJK 文字主控台顯示目前沒有驗證實據。ext2 與 ext3 也沒有針對其設定的自動化測試。`tests/fixtures/` 下的檔案只驗證設定模型；檔案存在不代表對應組合已完成端到端安裝與開機驗證。
-
-<!-- fact: verification-network -->
-
-純 IPv4、純 IPv6 與雙堆疊的 VM 檢查會在存取磁碟前結束。該檢查只驗證位址家族偵測、`bootstrap.sh --missing-commands` 與 stage3 pointer 讀取，不驗證 stage3 下載、儲存庫同步、binhost 存取、套件安裝或目標系統開機。
+`tests/fixtures/` 底下的檔案驗證的是設定模型，它們存在並不代表任何一台裝出來的機器。
 
 ## 需求
 

--- a/TESTED.md
+++ b/TESTED.md
@@ -1,0 +1,143 @@
+# Verification record
+
+Every claim this project makes about a path working is one row here. A row
+names what was exercised, the installer revision it ran at, and where it ran.
+Nothing is listed as tested because it is implemented; the README carries the
+boundary in prose and points here for the detail.
+
+A run counts only when its recorded revision matches the installer, its
+installation exit code is `0`, the installed system boots, and the post-boot
+configuration checks pass. `tests/fixtures/` files exercise the configuration
+model; their presence establishes nothing about an installed machine.
+
+Three modes are planned and this file has a section for each. Only the first
+two exist today, and the third's table is empty on purpose.
+
+## Mode 1: install onto a disk
+
+The ordinary path: partition, format, unpack a stage3, configure, boot.
+
+### Cluster records
+
+| Revision | Fixtures |
+|---|---|
+| `a8bf2f3837b6` | `vm-luks`, `vm-mdraid`, `vm-xfs`, `vm-btrfs`, `vm-f2fs` |
+| `073997aa74d2` | `vm-lvm` |
+| `40ea3d90f1cc` | `openrc-sdboot` |
+| `6ba5530fd3c8` | `vm-binpkg`, `vm-btrfs`, `vm-desktop`, `vm-gnome` |
+| `304dffa41602` | `vm-xfs` |
+| `7ac43a1d5050` | `vm-f2fs`, `vm-mdraid`, `vm-proxy-dead`, `vm-xfs`, `vm-zram` |
+| `d2bed50eed48` | `vm-lvm`, `vm-sdboot`, `vm-unlock` — the first cluster record of the initramfs SSH unlock |
+| `7cf09c2f9d9c` | `vm-btrfs`, `vm-binpkg`, `vm-luks` |
+
+### Records from QEMU on one machine
+
+These cover what the cluster cannot drive. A BIOS guest there writes nothing to
+its serial port before the kernel starts, and neither a screenshot endpoint nor
+a way to pass firmware arguments is available to a non-root API token.
+
+| Revision | Fixtures | Why not the cluster |
+|---|---|---|
+| `304dffa41602` | `vm-bios`, `vm-bios-luks`, `ext4-bios`, `mbr-edit` | BIOS serial console |
+| `15d45598637a` | `zfs-zbm`, `vm-proxy`, `vm-proxy-http` | the proxy fixtures reach a proxy on the host through QEMU's user-mode network, which a bridged cluster guest does not have |
+| `4d8512a496d` | `vm-proxy` (SOCKS5, password), `vm-proxy-http` | 57 operations, 93 packages from a binary host, 14 compiled |
+
+### Historical records
+
+Revisions `a71f91b4735469bae8ec76af170201acb967a5fe` and
+`f7257793f95df4b21ebf2ac6a775a343f6205f1b` on the amd64 Gentoo minimal ISO
+covered selected UEFI and BIOS installations, systemd and OpenRC, ext4, btrfs,
+xfs, LUKS2, LVM, mdraid, Plasma and the official binhost. Later
+installation-path changes made them historical evidence only.
+
+Revision `b931ef46fc15ed50385f70467f2bfb0a8d1fd154`, dated 2026-08-11, covers
+one installation and boot from each of Arch Linux, openSUSE, Debian, Fedora and
+a self-built gentoo-cjk minimal ISO. The gentoo-cjk record uses ZFS and
+ZFSBootMenu; the other four use ext4.
+
+### Install media
+
+| Medium | Revision | Result |
+|---|---|---|
+| `alpine-standard-3.24.1`, UEFI, systemd | `0827931289d0` | root shell on the serial console in 59s; 56 operations, 57 packages from a binary host, 12 compiled; booted with no failed unit |
+| `alpine-standard-3.24.1`, BIOS, OpenRC, ext4 | `bc8ab3a0edcf` | root shell in 59s; 51 operations, 29 from a binary host, 51 compiled; booted with no failed unit |
+
+The official Gentoo minimal ISO and the Gig-OS ISO are not tested here: they
+run the installer by script, and the gentoo-cjk minimal ISO record above covers
+that path.
+
+### Network modes
+
+The IPv4-only, IPv6-only and dual-stack check stops before disk access. It
+covers address-family detection, `bootstrap.sh --missing-commands` and stage3
+pointer retrieval. It does not cover stage3 download, repository
+synchronization, binhost access, package installation, or a booted target
+system on those network modes.
+
+### Proxy
+
+Focused unit and plan coverage exists for SOCKS5 DNS mode, redaction in dry-run
+output and in published configuration, and the credential-free endpoint
+retained in the installed system.
+
+The negative direction has a revision-tagged cluster run: the `vm-proxy-dead`
+fixture points the proxy at a port where nothing listens and the install stops
+at the stage3 download with `Connection refused`, so a run that reached the
+mirror would show the proxy had been bypassed.
+
+An HTTP or HTTPS proxy that requires a password cannot check the tree
+snapshot's signature: `emerge-webrsync` hands gemato only the credential-free
+endpoint. dirmngr has no SOCKS support at all, so under SOCKS5 the key refresh
+needs a direct route to the keyserver.
+
+## Mode 2: convert a running system in place
+
+Replaces the userland of a running distribution instead of partitioning a disk.
+
+### Records
+
+| Revision | Machine | Result |
+|---|---|---|
+| `bcc090fab621` | Debian 12 genericcloud, ext4 root on a partition, BIOS | converted and booted as Gentoo |
+| `71e751cf14a1` | Arch Linux cloud image, btrfs root, BIOS | converted and booted as Gentoo; `/swap/swapfile` carried into the new fstab |
+
+Both were read on the machine afterwards: `uname -r` gave
+`6.18.43-gentoo-dist-bin`, `emerge` was present and the original
+distribution's package manager was gone, the root device was unchanged, and
+the run's log was in `/var/log/gentoo-install`.
+
+Both records are from QEMU on one machine, and both are BIOS.
+
+### Refusals with a machine behind them
+
+Each of these was met on a real machine and is refused before anything is
+written.
+
+| Machine | Refusal |
+|---|---|
+| Alpine 3.21 cloud image | root is a whole disk with no partition, so `grub-install --target=i386-pc` answers `will not proceed with blocklists` |
+| Alpine 3.21 cloud image, before `apk add util-linux` | `findmnt` and `lsblk` are absent, so the layout reads back empty |
+| Fedora 41 cloud image | a replaced directory that is its own mount used to be refused; it is now replaced by its contents instead |
+
+### Not verified
+
+UEFI conversion, a btrfs subvolume root end to end, and the `vm-convert`
+cluster fixture.
+
+## Mode 3: boot into RAM, then install or write an image
+
+Designed, not implemented. See `docs/design.md` in the workspace.
+
+| Revision | What ran | Result |
+|---|---|---|
+| — | — | nothing yet |
+
+Rows land here for: a machine that boots into the RAM environment and installs
+Gentoo normally; a machine that writes an image with the `dd` mode; and, for
+each, a deliberately failed run proving the machine returns to its original
+system because the boot entry is one-shot.
+
+## Not covered by any record
+
+greetd desktop sessions, ibus outside GNOME, binary-host failure fallback, CJK
+text-console rendering, and focused configuration tests for ext2 and ext3.

--- a/tests/unit/test_readme.py
+++ b/tests/unit/test_readme.py
@@ -86,8 +86,8 @@ SECTIONS = {
 FACT_UNITS = (
     "identity", "capability-scope", "storage-device-graph", "zram-system",
     "in-place-conversion", "boot-system",
-    "desktop-language", "portage", "proxy", "plan-records", "verification-history",
-    "verification-current", "verification-network", "requirements-runtime",
+    "desktop-language", "portage", "proxy", "plan-records", "verification-scope",
+    "requirements-runtime",
     "requirements-version-sources", "requirements-network-filter", "requirements-bootstrap",
     "safety-destructive", "safety-review-backup", "install-download", "install-terminal",
     "install-config-workflow", "install-root-shell", "resume-behavior", "resume-limits",
@@ -160,15 +160,10 @@ def test_every_readme_carries_the_same_nonempty_factual_units() -> None:
 
 def test_reviewed_cross_locale_claims_stay_attached_to_their_factual_units() -> None:
     common = {
-        "verification-history": (
-            "amd64", "Gentoo minimal ISO", "a71f91b4735469bae8ec76af170201acb967a5fe",
-            "f7257793f95df4b21ebf2ac6a775a343f6205f1b",
-        ),
-        "verification-current": (
-            "ext2", "ext3", "tests/fixtures/",
-            "b931ef46fc15ed50385f70467f2bfb0a8d1fd154",
-        ),
-        "verification-network": ("IPv4", "IPv6", "bootstrap.sh --missing-commands", "stage3"),
+        # The records themselves live in `TESTED.md`, which is one file rather
+        # than five: what every README has to carry is the boundary and the
+        # pointer, or a reader takes an implemented path for a tested one.
+        "verification-scope": ("TESTED.md", "tests/fixtures/", "ext4", "LUKS2"),
         "requirements-version-sources": (
             "packages.gentoo.org", "api.github.com/repos/gentoo-zh/overlay/contents",
             "gitweb.gentoo.org",
@@ -216,13 +211,31 @@ def test_reviewed_cross_locale_claims_stay_attached_to_their_factual_units() -> 
         assert "zram" in bodies["zram-system"], name
 
 
-def test_current_verification_records_link_to_their_revision() -> None:
-    revision = "b931ef46fc15ed50385f70467f2bfb0a8d1fd154"
-    link = f"https://github.com/Zakkaus/gentoo-install/commit/{revision}"
+def test_the_record_file_holds_what_the_readmes_stopped_carrying() -> None:
+    """Five copies of a record set drift; one does not. What the READMEs keep
+    is the boundary and the pointer, and `TESTED.md` keeps the rows."""
+    from pathlib import Path
+
+    record = Path("TESTED.md").read_text(encoding="utf-8")
+    for revision in (
+        "b931ef46fc15ed50385f70467f2bfb0a8d1fd154",
+        "7cf09c2f9d9c",
+        "bcc090fab621",
+        "71e751cf14a1",
+        "0827931289d0",
+    ):
+        assert revision in record, revision
+    # A section for each mode, including the one with nothing in it yet: an
+    # absent section reads as an oversight, an empty one as a fact.
+    for heading in ("## Mode 1", "## Mode 2", "## Mode 3"):
+        assert heading in record, heading
+    assert "nothing yet" in record, "the unimplemented mode says so"
+
+    # And every README points at it rather than repeating it.
     for name in READMES:
-        body = fact_bodies(name)["verification-current"]
-        assert revision in body, name
-        assert link in body, name
+        body = fact_bodies(name)["verification-scope"]
+        assert "TESTED.md" in body, name
+        assert "b931ef46" not in body, f"{name} still carries a record"
 
 
 def test_proxy_is_documented_in_every_readme_and_the_example_parses() -> None:


### PR DESCRIPTION
The records were repeated in five READMEs, so every new run meant five edits and five chances to drift. `TESTED.md` holds them once, in English like the rest of the repository, with a section per mode:

- **Mode 1**, install onto a disk: cluster records, records from QEMU where the cluster cannot drive the path, historical records, install media, network modes, proxy.
- **Mode 2**, convert a running system: two records, and the refusals that were each met on a real machine.
- **Mode 3**, boot into RAM and install or write an image: designed, and its table says `nothing yet` rather than being absent — an absent section reads as an oversight, an empty one as a fact.

Each README keeps the boundary and the pointer. The test that checked a revision link in every README now checks that the record file holds the revisions and that no README carries one.