### PR TITLE
config: accept a url as the configuration source

### DIFF
--- a/gentoo_install/exec/config.py
+++ b/gentoo_install/exec/config.py
@@ -12,9 +12,25 @@ from __future__ import annotations
 import tomllib
 from pathlib import Path
 
-from ..errors import ConfigError
+from ..errors import ConfigError, GentooInstallError
 from ..model.config import InstallConfig
 from ..model.parse import parse
+
+
+#: What a configuration read over the network may weigh. A configuration is a
+#: few kilobytes of TOML, and a body past this is a mistake or a redirect into
+#: something else, not a file worth parsing.
+URL_CEILING: int = 1 << 20
+
+#: What makes a source a URL rather than a path. `file://` is deliberately not
+#: here: a path is how a local file is given, and two ways to say one thing is
+#: the class of bug this file exists to avoid.
+URL_SCHEMES: tuple[str, ...] = ("http://", "https://")
+
+
+def looks_like_a_url(source: str) -> bool:
+    """Whether this source is fetched rather than opened."""
+    return source.startswith(URL_SCHEMES)
 
 
 def load(path: Path) -> InstallConfig:
@@ -25,4 +41,26 @@ def load(path: Path) -> InstallConfig:
         raise ConfigError(f"{path}: {error}") from error
     except OSError as error:
         raise ConfigError(f"{path}: {error}") from error
+    return parse(raw)
+
+
+def load_source(source: str) -> InstallConfig:
+    """Read a configuration from a path or from a URL.
+
+    One entry point for both, because every mode takes its configuration the
+    same way: what differs between installing, converting and writing an image
+    is what the configuration says, not where it came from.
+    """
+    if not looks_like_a_url(source):
+        return load(Path(source))
+    from . import fetch
+
+    try:
+        body = fetch.read_text(source, ceiling=URL_CEILING)
+    except GentooInstallError as error:
+        raise ConfigError(f"{source}: {error}") from error
+    try:
+        raw = tomllib.loads(body)
+    except tomllib.TOMLDecodeError as error:
+        raise ConfigError(f"{source}: {error}") from error
     return parse(raw)

--- a/gentoo_install/exec/fetch.py
+++ b/gentoo_install/exec/fetch.py
@@ -888,6 +888,24 @@ def _resolvers(path: Path) -> str:
     return f"nameservers {servers}" if servers else "no nameserver line"
 
 
+def read_text(url: str, *, ceiling: int) -> str:
+    """Read a small document, refusing a body past `ceiling`.
+
+    One byte past the cap is read on purpose: a body exactly at the cap is
+    allowed, and anything longer is refused without the rest of it ever being
+    read. A configuration is kilobytes, and a redirect into an ISO is the case
+    this exists to stop.
+    """
+    try:
+        with _urlopen(_asked(url), _CURRENT_PROXY.get(), TIMEOUT) as response:
+            body = response.read(ceiling + 1)
+    except (urllib.error.URLError, TimeoutError, OSError, http.client.HTTPException) as error:
+        raise DownloadFailed(f"{url} could not be read: {error}{_resolver_state(url)}") from error
+    if len(body) > ceiling:
+        raise DownloadFailed(f"{url} is larger than {ceiling} bytes")
+    return str(body.decode("utf-8", "replace"))
+
+
 def _read_once(url: str, proxy: ProxyConfig | None = None) -> str:
     try:
         with _urlopen(_asked(url), proxy, TIMEOUT) as response:

--- a/tests/unit/test_exec.py
+++ b/tests/unit/test_exec.py
@@ -2305,3 +2305,70 @@ def test_a_symlink_at_the_destination_is_refused_rather_than_replaced(tmp_path: 
 
     assert (target / "etc" / "mtab").is_symlink()
     assert not list((target / "etc").glob(".mtab*")), "the temporary file was removed"
+
+
+def test_a_configuration_can_be_read_from_a_url(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Every mode takes its configuration the same way, so where it came from
+    is not what tells installing, converting and writing an image apart. A URL
+    is fetched; anything else is a path."""
+    from gentoo_install.exec import config as loader
+    from gentoo_install.exec import fetch
+
+    body = Path("tests/fixtures/vm-binpkg.toml").read_text(encoding="utf-8")
+    asked: list[str] = []
+
+    def answer(url: str, *, ceiling: int) -> str:
+        asked.append(url)
+        assert ceiling == loader.URL_CEILING
+        return body
+
+    monkeypatch.setattr(fetch, "read_text", answer)
+    from_url = loader.load_source("https://example.invalid/machine.toml")
+    assert asked == ["https://example.invalid/machine.toml"]
+
+    # Negative control one: a path is still opened, not fetched.
+    asked.clear()
+    from_path = loader.load_source("tests/fixtures/vm-binpkg.toml")
+    assert not asked, asked
+    assert from_path == from_url, "one source, one configuration"
+
+    # Negative control two: a body that is not TOML names the URL rather than
+    # a temporary file nobody can look at.
+    monkeypatch.setattr(fetch, "read_text", lambda url, *, ceiling: "<html>404</html>")
+    with pytest.raises(ConfigError, match="example.invalid/machine.toml"):
+        loader.load_source("https://example.invalid/machine.toml")
+
+
+def test_a_configuration_url_refuses_a_body_past_the_ceiling() -> None:
+    """A configuration is kilobytes. A redirect into an ISO is what the cap is
+    for, and it is refused without the rest of the body being read."""
+    from unittest import mock
+
+    from gentoo_install.exec import fetch
+    from gentoo_install.errors import DownloadFailed
+
+    class Response:
+        def __init__(self, size: int) -> None:
+            self.size = size
+            self.asked: list[int] = []
+
+        def read(self, amount: int) -> bytes:
+            self.asked.append(amount)
+            return b"x" * min(self.size, amount)
+
+        def __enter__(self) -> "Response":
+            return self
+
+        def __exit__(self, *rest: object) -> None:
+            return None
+
+    huge = Response(1 << 24)
+    with mock.patch.object(fetch, "_urlopen", lambda *rest: huge):
+        with pytest.raises(DownloadFailed, match="larger than 64 bytes"):
+            fetch.read_text("https://example.invalid/big", ceiling=64)
+    assert huge.asked == [65], "one byte past the cap, not the whole body"
+
+    # Negative control: a body at the cap is allowed.
+    exact = Response(64)
+    with mock.patch.object(fetch, "_urlopen", lambda *rest: exact):
+        assert fetch.read_text("https://example.invalid/ok", ceiling=64) == "x" * 64


### PR DESCRIPTION
`load_source` is one entry point for a path and a URL, because what differs between installing, converting and writing an image is what the configuration says, not where it came from. The TUI and the command line will both take a URL through it.

`fetch.read_text` reads one byte past the cap on purpose: a body at the cap is allowed and anything longer is refused without the rest ever being read. A configuration is kilobytes; a redirect into an ISO is what the cap exists to stop, and the negative control asserts the read asked for 65 bytes rather than the whole body.

`file://` is not a URL scheme here. A path is how a local file is given, and two ways to say one thing is the class of bug this module's docstring already names.