### PR TITLE
cluster: a capacity read that did not answer is not the end

### DIFF
--- a/tests/unit/test_cluster.py
+++ b/tests/unit/test_cluster.py
@@ -1342,3 +1342,33 @@ def test_a_timed_out_marker_names_the_command_it_was_waiting_on() -> None:
     cluster.Reconnecting(
         lambda: cast(Any, Answering(ConsoleTimeout("unused"))), tries=1
     ).run("true")
+
+
+def test_a_capacity_read_that_did_not_answer_does_not_end_the_schedule() -> None:
+    """run58 lost seven fixtures to one line:
+
+        ProxmoxTransientError: GET /nodes did not answer:
+        Remote end closed connection without response
+
+    Every guest was still installing. The dispatch already treats a transient
+    refusal as the node's problem and puts the job back; the capacity read
+    beside it had no such guard, so the exception left the loop and the closing
+    path removed the guests.
+    """
+    import inspect
+
+    code = inspect.getsource(cluster.run)
+    slots = code.index("free_slots(api")
+    guarded = code.index("except ProxmoxTransientError", 0, slots + 400)
+    assert guarded > slots, "the capacity read is inside the guard"
+    # It answers with no slots rather than swallowing the failure silently:
+    # a schedule that can never place anything ends on `capacity_since`.
+    after = code[guarded:guarded + 600]
+    assert "slots = []" in after, after
+    assert "capacity_since" in code, "the timeout that ends a hopeless schedule"
+
+    # Negative control: the dispatch's own guard is a different one and stays,
+    # or a node that refuses a guest would take every following job too.
+    assert code.count("except ProxmoxTransientError") >= 2, code.count(
+        "except ProxmoxTransientError"
+    )

--- a/tests/vm/cluster.py
+++ b/tests/vm/cluster.py
@@ -1782,11 +1782,20 @@ def run(
             running = [job for job in scheduled.values() if job.running]
             placed = _reserved_bytes(scheduled)
             cores_placed = _reserved_cores(scheduled)
-            slots = [
-                node
-                for node in free_slots(api, placed, cores_placed)
-                if node.name not in unreachable
-            ]
+            try:
+                slots = [
+                    node
+                    for node in free_slots(api, placed, cores_placed)
+                    if node.name not in unreachable
+                ]
+            except ProxmoxTransientError as error:
+                # No slots this round, not the end of the schedule: run58 lost
+                # seven fixtures to one `GET /nodes did not answer: Remote end
+                # closed connection without response`, with every guest still
+                # installing. `capacity_since` below is what ends a schedule
+                # that genuinely has nowhere to run.
+                print(f"the cluster's capacity could not be read: {error}", flush=True)
+                slots = []
             if limit:
                 slots = slots[: max(0, limit - len(running))]
             if waiting and not running and not slots:


### PR DESCRIPTION
run58's scheduler ended with

```
ProxmoxTransientError: GET /nodes did not answer:
Remote end closed connection without response
```

and seven fixtures went with it while every guest was still installing. The dispatch a few lines below already catches the same exception and treats it as the node's problem, putting the job back on the queue; the capacity read had no guard at all, so one unanswered request left the loop and the closing path removed the guests.

It now answers with no slots for that round. A schedule that genuinely has nowhere to place anything still ends, on the `capacity_since` timeout that was already there — that is the second negative control, alongside the dispatch's own guard staying separate.