### PR TITLE
bootloader: name the key types crypt-ssh may generate

### DIFF
--- a/gentoo_install/plan/bootloader.py
+++ b/gentoo_install/plan/bootloader.py
@@ -398,6 +398,12 @@ class ConfigureZfsBootMenuRemoteAccess(Operation):
                     # ZFSBootMenu deliberately omits the systemd module.
                     'omit_dracutmodules+=" systemd-networkd systemd-battery-check "',
                     f'install_optional_items+=" {ZBM_NETWORK_CONFIG} "',
+                    # The module's own default is `rsa ecdsa ed25519`, and it
+                    # generates each one with `ssh-keygen -m PEM`, which refuses
+                    # ed25519. Its `install()` returns at that failure, after
+                    # the two host keys and before the acl and the start hook,
+                    # which is exactly what the built image held.
+                    f'dropbear_keytypes="{" ".join(ZBM_HOST_KEY_TYPES)}"',
                     f'dropbear_port="{self.unlock.port}"',
                     f"dropbear_rsa_key={ZBM_KEY_DIRECTORY}/ssh_host_rsa_key",
                     f"dropbear_ecdsa_key={ZBM_KEY_DIRECTORY}/ssh_host_ecdsa_key",

--- a/tests/unit/test_plan_bootloader.py
+++ b/tests/unit/test_plan_bootloader.py
@@ -386,3 +386,39 @@ def test_an_image_built_without_the_unlock_daemon_is_said_rather_than_shipped() 
     replace(built, unlocks_remotely=False).apply(quiet)
     assert not quiet.degraded(bootloader.REMOTE_UNLOCK_IMAGE)
     assert not [one for one in quiet.in_target if one[0] == "lsinitrd"], quiet.in_target
+
+
+def test_the_unlock_names_the_key_types_the_module_may_generate() -> None:
+    """Read from `60crypt-ssh/module-setup.sh` v1.0.8, whose `install()` is:
+
+        [[ -z "${dropbear_keytypes}" ]] && dropbear_keytypes="rsa ecdsa ed25519"
+        ...
+        ssh-keygen -t $keyType -f $osshKey -q -N "" -m PEM || { derror; return 1; }
+        ...
+        inst $dropbearKey $installKey        # per key type, inside the loop
+        ...
+        inst_hook pre-udev 99 dropbear-start.sh
+        inst "${dropbear_acl}" /root/.ssh/authorized_keys
+
+    `ssh-keygen -m PEM` refuses ed25519, which is why `ZBM_HOST_KEY_TYPES` has
+    only two entries. Leaving the module on its default put it through the
+    ed25519 iteration, so it returned after installing the two host keys and
+    before the acl and the hook. The image an install produced held exactly
+    `etc/dropbear/dropbear_{ecdsa,rsa}_host_key` and nothing else.
+    """
+    installation = load(Path("tests/fixtures/zbm-unlock.toml"))
+    configured = next(
+        one
+        for one in bootloader.build(installation)
+        if isinstance(one, bootloader.ConfigureZfsBootMenuRemoteAccess)
+    )
+    recorder = Recorder()
+    configured.apply(recorder)
+    written = recorder.files[bootloader.ZBM_REMOTE_CONFIG]
+
+    assert 'dropbear_keytypes="rsa ecdsa"' in written, written
+    # One table, not two: the types the module may generate are the types this
+    # installer converts host keys for, and a second list would drift.
+    assert "ed25519" not in written, written
+    for keytype in bootloader.ZBM_HOST_KEY_TYPES:
+        assert f'dropbear_{keytype}_key=' in written, keytype


### PR DESCRIPTION
The `60crypt-ssh` module defaults to `rsa ecdsa ed25519` and generates each with `ssh-keygen -m PEM`, which refuses ed25519. Its `install()` returns at that failure, after the two host keys and before the acl and the `dropbear-start` hook — exactly what `lsinitrd` found in the image a cluster run produced.