### PR TITLE
packages: declare the dbusmenu flag xfce4-panel requires

### DIFF
--- a/gentoo_install/data/profiles/xfce.toml
+++ b/gentoo_install/data/profiles/xfce.toml
@@ -1,3 +1,7 @@
 packages = ["xfce-base/xfce4-meta", "x11-base/xorg-server"]
 use = ["gtk", "networkmanager"]
+# `xfce4-meta` reaches `xfce4-panel[dbusmenu]` through
+# `thunar[trash-panel-plugin]`, and libdbusmenu's `gtk3` is not on by default,
+# so `emerge --pretend` rejected the whole group.
+package_use = ["dev-libs/libdbusmenu gtk3"]
 profile = "default/linux/amd64/23.0/desktop"

--- a/tests/golden/vm-openrc-desktop.txt
+++ b/tests/golden/vm-openrc-desktop.txt
@@ -34,6 +34,7 @@
   sync repository gentoo
   set sys-kernel/installkernel to dracut
   accept the linux-firmware licence
+  ask for dev-libs/libdbusmenu gtk3 for the xfce group
   ask for x11-misc/lightdm elogind; sys-auth/pambase elogind for the lightdm group
   ask for media-video/pipewire sound-server for the pipewire group
   resolve net-misc/openssh net-misc/networkmanager net-wireless/wpa_supplicant app-admin/sysklogd sys-process/cronie sys-kernel/installkernel sys-kernel/dracut sys-kernel/linux-firmware sys-fs/dosfstools sys-fs/e2fsprogs sys-kernel/gentoo-kernel-bin sys-boot/grub sys-boot/efibootmgr xfce-base/xfce4-meta x11-base/xorg-server x11-misc/lightdm x11-misc/lightdm-gtk-greeter gui-libs/display-manager-init media-video/pipewire media-video/wireplumber sys-apps/dbus sys-auth/elogind together before installing the requested packages

--- a/tests/unit/test_packages.py
+++ b/tests/unit/test_packages.py
@@ -134,6 +134,22 @@ def test_plasma_declares_the_minizip_compatibility_required_by_its_stack() -> No
         assert "sys-libs/minizip-ng compat" in catalog[profile].package_use
 
 
+def test_xfce_declares_the_dbusmenu_flag_its_panel_requires() -> None:
+    """`emerge --pretend` on a cluster run of `vm-openrc-desktop` answered:
+
+        # required by xfce-base/xfce4-panel-4.20.7::gentoo[dbusmenu]
+        # required by xfce-base/thunar-4.20.8::gentoo[trash-panel-plugin]
+        # required by xfce-base/thunar-volman-4.20.0::gentoo
+        # required by xfce-base/xfce4-meta-4.20::gentoo
+        >=dev-libs/libdbusmenu-16.04.0-r4 gtk3
+
+    The rejection is of the whole group, so nothing of the desktop is merged.
+    """
+    catalog = load_catalog()
+
+    assert "dev-libs/libdbusmenu gtk3" in catalog["xfce"].package_use
+
+
 def test_ibus_has_declared_chinese_engines() -> None:
     catalog = load_catalog()
     chinese = {


### PR DESCRIPTION
`xfce4-meta` reaches `xfce4-panel[dbusmenu]` through `thunar[trash-panel-plugin]`, and libdbusmenu is built without `gtk3` by default, so `emerge --pretend` rejected the whole `vm-openrc-desktop` group before anything was merged.