### PR TITLE
exec: close two paths that write outside their intended mode and root

### DIFF
--- a/gentoo_install/exec/report.py
+++ b/gentoo_install/exec/report.py
@@ -3,13 +3,16 @@
 
 from __future__ import annotations
 
+import os
 import shutil
+import stat
 import tomllib
 from collections.abc import Callable, Iterable, Iterator
 from contextlib import contextmanager
 from dataclasses import dataclass
 from enum import Enum
-from pathlib import Path
+from typing import Final
+from pathlib import Path, PurePosixPath
 
 from .. import errors
 from ..errors import GentooInstallError
@@ -20,7 +23,7 @@ from ..model.config import InstallConfig
 from ..model.serialise import to_toml
 from . import fetch, preflight
 from .probe import Probe
-from .runner import write_file
+from .runner import TargetEscape, open_in_target, write_file
 
 
 class RunFile(Enum):
@@ -65,6 +68,12 @@ def recording(work: Path, target: Path) -> Iterator[ActiveReport]:
         )
 
 
+#: Target-absolute, so `open_in_target` refuses a symlink on the way. A
+#: conversion replaces a running system's userland, where `/var/log` is
+#: whatever that distribution left there.
+LOG_DIRECTORY: Final[PurePosixPath] = PurePosixPath("/var/log/gentoo-install")
+
+
 def keep_log(work: Path, target: Path, record: Callable[[str], None]) -> None:
     """Copy the run's log onto the installed system."""
     if not target.is_mount():
@@ -73,12 +82,20 @@ def keep_log(work: Path, target: Path, record: Callable[[str], None]) -> None:
         return
     kept = target / "var/log/gentoo-install"
     try:
-        kept.mkdir(parents=True, exist_ok=True)
         for name in RunFile:
             source = work / name.value
-            if source.is_file():
-                shutil.copy2(source, kept / name.value)
-    except OSError as error:
+            if not source.is_file():
+                continue
+            handle = open_in_target(
+                target,
+                LOG_DIRECTORY / name.value,
+                os.O_WRONLY | os.O_CREAT | os.O_TRUNC,
+                stat.S_IMODE(source.stat().st_mode),
+                parents=True,
+            )
+            with os.fdopen(handle, "wb") as opened:
+                opened.write(source.read_bytes())
+    except (OSError, TargetEscape) as error:
         record(f"warning: the log could not be copied to {kept}: {error}")
         return
     # The target is about to be unmounted, while the work copy lasts to reboot.

--- a/gentoo_install/exec/runner.py
+++ b/gentoo_install/exec/runner.py
@@ -252,9 +252,11 @@ def write_file(path: Path, content: str, mode: int = 0o644) -> None:
     """
     path.parent.mkdir(parents=True, exist_ok=True)
     handle = os.open(path, os.O_WRONLY | os.O_CREAT | os.O_TRUNC, mode)
+    # `os.open` applies its mode only when it creates the file, so an existing
+    # 0644 file stays readable through the write without this.
+    os.fchmod(handle, mode)
     with os.fdopen(handle, "w") as opened:
         opened.write(content)
-    path.chmod(mode)
 
 
 def _kill_group(process: subprocess.Popen[str]) -> None:

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -1255,3 +1255,57 @@ def test_an_unattended_conversion_still_records_that_ssh_stops() -> None:
     # tells the operator nothing they can act on.
     assert "ssh" in cli.SESSION_IS_THE_LIFELINE
     assert "reboot" in cli.SESSION_IS_THE_LIFELINE
+
+
+def test_a_symlinked_log_directory_in_the_target_is_refused(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The copy ran as root through a lexical `target / "var/log/..."` join and
+    a plain `shutil.copy2`, so a `var/log/gentoo-install` symlink in the target
+    wrote the run's log outside it. A conversion replaces a running system's
+    userland, where `/var/log` holds whatever that distribution left there.
+    """
+    from gentoo_install.exec.report import keep_log
+
+    outside = tmp_path / "outside"
+    outside.mkdir()
+    (tmp_path / "install.log").write_text("the run\n")
+
+    target = tmp_path / "target"
+    (target / "var/log").mkdir(parents=True)
+    # A directory, not a file: `mkdir(exist_ok=True)` refuses a symlink to a
+    # file by itself, so only this shape reaches `copy2` and writes outside.
+    (target / "var/log/gentoo-install").symlink_to(outside, target_is_directory=True)
+
+    monkeypatch.setattr(Path, "is_mount", lambda self: self == target)
+    said: list[str] = []
+    keep_log(tmp_path, target, said.append)
+
+    assert list(outside.iterdir()) == [], list(outside.iterdir())
+    assert said and "could not be copied" in said[0], said
+
+
+def test_a_log_directory_that_is_a_real_directory_still_receives_the_log(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The negative control for the refusal above: the ordinary target, where
+    nothing on the way is a symlink, still gets both run files."""
+    import stat
+
+    from gentoo_install.exec.report import keep_log
+
+    (tmp_path / "install.log").write_text("the run\n")
+    (tmp_path / "install.log").chmod(0o600)
+    (tmp_path / "install.jsonl").write_text('{"one": 1}\n')
+
+    target = tmp_path / "target"
+    target.mkdir()
+    monkeypatch.setattr(Path, "is_mount", lambda self: self == target)
+    said: list[str] = []
+    keep_log(tmp_path, target, said.append)
+
+    kept = target / "var/log/gentoo-install"
+    assert (kept / "install.log").read_text() == "the run\n"
+    assert (kept / "install.jsonl").read_text() == '{"one": 1}\n'
+    assert stat.S_IMODE((kept / "install.log").stat().st_mode) == 0o600
+    assert said and "the log of this run is in" in said[0], said

--- a/tests/unit/test_exec.py
+++ b/tests/unit/test_exec.py
@@ -5,7 +5,7 @@ import os
 
 from dataclasses import replace
 from pathlib import Path, PurePosixPath
-from typing import AbstractSet, Iterable, Mapping, Sequence
+from typing import IO, AbstractSet, Iterable, Mapping, Sequence
 
 import tempfile
 
@@ -2372,3 +2372,34 @@ def test_a_configuration_url_refuses_a_body_past_the_ceiling() -> None:
     exact = Response(64)
     with mock.patch.object(fetch, "_urlopen", lambda *rest: exact):
         assert fetch.read_text("https://example.invalid/ok", ceiling=64) == "x" * 64
+
+
+def test_an_existing_file_is_narrowed_before_the_secret_reaches_it(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """`os.open` applies its mode argument only when it creates the file, so
+    an existing `0644` file stayed world-readable until the `chmod` that once
+    followed the write. `preflight.py` writes LUKS passphrases through this
+    function, and a reused work directory is exactly where an existing file
+    with the wrong mode comes from.
+    """
+    import stat
+
+    from gentoo_install.exec.runner import write_file
+
+    where = tmp_path / "passphrase"
+    where.write_text("older")
+    where.chmod(0o644)
+
+    seen: list[int] = []
+
+    def watched(handle: int, how: str) -> IO[str]:
+        seen.append(stat.S_IMODE(os.fstat(handle).st_mode))
+        return open(handle, how, closefd=True)
+
+    monkeypatch.setattr(os, "fdopen", watched)
+    write_file(where, "secret", 0o600)
+
+    assert seen == [0o600], [oct(one) for one in seen]
+    assert stat.S_IMODE(where.stat().st_mode) == 0o600
+    assert where.read_text() == "secret"


### PR DESCRIPTION
POSIX ignores the mode argument of `os.open` for a file that already exists, so a reused work directory left a staged passphrase at `0644` until the `chmod` that followed the write.

The log copy joined `target / "var/log/gentoo-install"` lexically and used `shutil.copy2`, so a symlink there — the ordinary case in a conversion, where `/var/log` is whatever the replaced distribution left — wrote the run log outside the target as root. It now goes through `open_in_target`, which refuses a symlink on the way.