### PR TITLE
tests: answer every recorder call with an exit code

### DIFF
--- a/tests/unit/recorder.py
+++ b/tests/unit/recorder.py
@@ -18,6 +18,14 @@ from gentoo_install.model.device import DeviceId
 from gentoo_install.model.validate import KernelCeiling
 
 
+def _answered(text: str, returncode: int) -> CommandOutput:
+    """A reply already carrying an exit code keeps it; a bare string takes the
+    caller's. `replies` is typed for `str`, and `CommandOutput` is one, so a
+    test that configures a failure would otherwise have it rebuilt as success.
+    """
+    return text if isinstance(text, CommandOutput) else CommandOutput(text, returncode)
+
+
 @dataclass
 class Recorder:
     target: PurePosixPath = PurePosixPath("/mnt/gentoo")
@@ -42,7 +50,7 @@ class Recorder:
 
     def run(
         self, argv: Sequence[str], *, check: bool = True, input_text: str | None = None
-    ) -> str:
+    ) -> CommandOutput:
         self.commands.append(tuple(argv))
         if input_text is not None:
             self.stdin.append(input_text)
@@ -50,31 +58,38 @@ class Recorder:
             raise CommandFailed(f"{argv[0]} exited 1")
         # A CommandOutput, the way the real runner answers: a double returning
         # a bare str hides every caller that reads the exit code for itself.
-        return CommandOutput(self.replies.get(argv[0], ""), 0)
+        return _answered(self.replies.get(argv[0], ""), 0)
 
-    def run_in_target(self, argv: Sequence[str], *, check: bool = True) -> str:
+    def run_in_target(self, argv: Sequence[str], *, check: bool = True) -> CommandOutput:
         """`check=False` returns the output and raises nothing, the way the real
         one does: a double that raises anyway hides every caller that reads an
-        exit code for itself."""
+        exit code for itself.
+
+        Every branch answers a `CommandOutput`, so a caller that degrades or
+        retries on a non-zero code is exercised rather than handed a bare `str`
+        whose truth value reads as success.
+        """
         self.in_target.append(tuple(argv))
         if self.answering is not None:
             said = self.answering(argv)
             if said is not None:
-                return said
+                return _answered(said, 0)
         if argv[0] in self.failures:
             if check:
                 raise CommandFailed(f"{argv[0]} exited 1")
-            return self.replies.get(argv[0], "")
+            return _answered(self.replies.get(argv[0], ""), 1)
         if argv[:3] == ["portageq", "best_visible", "/"]:
             return CommandOutput(f"{argv[-1]}-1\n", 0)
         if argv[:4] == ["portageq", "metadata", "/", "ebuild"]:
             return CommandOutput("+dracut systemd systemd-boot boot kernel-install cryptsetup "
                                  "client server arping dist-kernel cjk elogind\n\n", 0)
         if argv[0] == "test":
-            return CommandOutput(self.replies.get("test", ""), 1 if self.replies.get("test") else 0)
+            return _answered(
+                self.replies.get("test", ""), 1 if self.replies.get("test") else 0
+            )
         if argv[0] == "qlist":
             return CommandOutput("/boot/kernel-6.18.41-gentoo-dist-bin\n/boot/initramfs-6.18.41-gentoo-dist-bin.img\n", 0)
-        return self.replies.get(argv[0], "1")
+        return _answered(self.replies.get(argv[0], "1"), 0)
 
     def write(self, path: PurePosixPath, content: str, *, mode: int = 0o644) -> None:
         self.files[path] = content

--- a/tests/unit/test_plan.py
+++ b/tests/unit/test_plan.py
@@ -770,3 +770,55 @@ def test_the_anthy_group_names_no_backend_of_its_own() -> None:
     group = load_catalog()["anthy"]
     assert group.packages == ("app-i18n/fcitx-anthy",)
     assert not any(name.endswith(("/anthy", "/anthy-unicode")) for name in group.packages)
+
+
+def test_every_recorder_answer_carries_an_exit_code() -> None:
+    """The real `Context.run_in_target` answers a `CommandOutput`, and three
+    of the double's branches answered a bare `str`: a failing command under
+    `check=False`, an injected `answering`, and the fallback. A caller that
+    degrades or retries on a non-zero code was therefore handed an object with
+    no `returncode`, and a non-empty string reads as success.
+    """
+    from gentoo_install.plan.operations import CommandOutput
+
+    recorder = Recorder(replies={"grep": "found"}, failures={"lsblk"})
+    answers = [
+        recorder.run(["grep", "one"]),
+        recorder.run(["unconfigured"]),
+        recorder.run_in_target(["grep", "one"]),
+        recorder.run_in_target(["unconfigured"]),
+        recorder.run_in_target(["lsblk"], check=False),
+        recorder.run_in_target(["portageq", "best_visible", "/", "sys-apps/portage"]),
+    ]
+    assert all(isinstance(one, CommandOutput) for one in answers), [
+        type(one).__name__ for one in answers
+    ]
+
+    injected = Recorder(answering=lambda argv: "said" if argv[0] == "hostnamectl" else None)
+    said = injected.run_in_target(["hostnamectl"])
+    assert isinstance(said, CommandOutput), type(said).__name__
+    assert said == "said"
+
+
+def test_a_failing_command_under_no_check_answers_a_non_zero_code() -> None:
+    """`check=False` is the path a caller takes when it means to read the code
+    itself, so the double answering `0` there makes the failure invisible.
+    """
+    recorder = Recorder(failures={"findmnt"})
+
+    answered = recorder.run_in_target(["findmnt", "/mnt/gentoo"], check=False)
+    assert answered.returncode != 0, answered.returncode
+    assert recorder.run_in_target(["ls"]).returncode == 0
+
+
+def test_a_configured_exit_code_is_not_rebuilt_as_success() -> None:
+    """`replies` is typed for `str` and `CommandOutput` is one, so wrapping
+    every reply discarded the code a test had configured. `VerifyPackages`
+    reads exactly that code to tell a missing ebuild from a working search.
+    """
+    from gentoo_install.plan.operations import CommandOutput
+
+    recorder = Recorder(replies={"emerge": CommandOutput("no ebuild matches", 1)})
+
+    assert recorder.run_in_target(["emerge", "--pretend"]).returncode == 1
+    assert recorder.run(["emerge", "--pretend"]).returncode == 1

--- a/tests/unit/test_plan_bootloader.py
+++ b/tests/unit/test_plan_bootloader.py
@@ -10,6 +10,7 @@ from typing import Sequence
 from gentoo_install.exec.config import load
 from gentoo_install.model.config import Bootloader, BootloaderConfig, Firmware, InstallConfig, RemoteUnlock
 from gentoo_install.plan import bootloader, kernel
+from gentoo_install.plan.operations import CommandOutput
 
 from .recorder import Recorder
 
@@ -245,7 +246,7 @@ def test_a_firmware_that_refuses_a_boot_entry_still_leaves_a_bootable_machine() 
         #: hold: without it the order assertion below passes either way.
         attempts: list[tuple[str, ...]] = []
 
-        def run_in_target(self, argv: Sequence[str], *, check: bool = True) -> str:
+        def run_in_target(self, argv: Sequence[str], *, check: bool = True) -> CommandOutput:
             self.attempts.append(tuple(argv))
             if "--bootloader-id=Gentoo" in argv or argv[0] == "efibootmgr":
                 raise CommandFailed(
@@ -281,7 +282,7 @@ def test_a_firmware_that_refuses_a_boot_entry_still_leaves_a_bootable_machine() 
     # Negative control: a `grub-install` that fails for any other reason is not
     # a refused boot entry and still stops the install.
     class Broken(Recorder):
-        def run_in_target(self, argv: Sequence[str], *, check: bool = True) -> str:
+        def run_in_target(self, argv: Sequence[str], *, check: bool = True) -> CommandOutput:
             if argv[0] == "grub-install":
                 raise CommandFailed("grub-install: error: cannot find EFI directory")
             return super().run_in_target(argv, check=check)
@@ -337,7 +338,6 @@ def test_an_image_built_without_the_unlock_daemon_is_said_rather_than_shipped() 
 
     Said rather than raised: the console passphrase still unlocks it.
     """
-    from gentoo_install.plan.operations import CommandOutput
 
     installation = load(Path("tests/fixtures/zbm-unlock.toml"))
     built = next(

--- a/tests/unit/test_plan_disk.py
+++ b/tests/unit/test_plan_disk.py
@@ -165,7 +165,7 @@ def test_a_btrfs_scratch_unmount_failure_stops_the_install() -> None:
     class UnmountFails(Recorder):
         def run(
             self, argv: Sequence[str], *, check: bool = True, input_text: str | None = None
-        ) -> str:
+        ) -> CommandOutput:
             if argv[0] == "umount":
                 self.commands.append(tuple(argv))
                 return CommandOutput("target is busy", 1)
@@ -182,7 +182,7 @@ def test_a_btrfs_scratch_unmount_does_not_replace_creation_failure() -> None:
     class BothFail(Recorder):
         def run(
             self, argv: Sequence[str], *, check: bool = True, input_text: str | None = None
-        ) -> str:
+        ) -> CommandOutput:
             if argv[0] == "umount":
                 self.commands.append(tuple(argv))
                 return CommandOutput("target is busy", 1)
@@ -705,7 +705,7 @@ def test_a_pool_still_busy_after_the_lazy_unmount_is_exported_on_a_later_try(
 
         def run(
             self, argv: Sequence[str], *, check: bool = True, input_text: str | None = None
-        ) -> str:
+        ) -> CommandOutput:
             if tuple(argv[:2]) == ("zpool", "export"):
                 self.attempts += 1
                 if self.refusals:
@@ -726,7 +726,7 @@ def test_a_pool_still_busy_after_the_lazy_unmount_is_exported_on_a_later_try(
 
         def run(
             self, argv: Sequence[str], *, check: bool = True, input_text: str | None = None
-        ) -> str:
+        ) -> CommandOutput:
             if argv[0] == "findmnt":
                 return CommandOutput("/mnt/gentoo" if self.mounted else "", 0 if self.mounted else 1)
             if tuple(argv[:2]) == ("zfs", "list"):
@@ -774,7 +774,7 @@ def test_a_pool_still_busy_after_the_lazy_unmount_is_exported_on_a_later_try(
     class MountedDataset(Clean):
         def run(
             self, argv: Sequence[str], *, check: bool = True, input_text: str | None = None
-        ) -> str:
+        ) -> CommandOutput:
             if tuple(argv[:2]) == ("zfs", "list"):
                 return CommandOutput("rpool\tyes\n", 0)
             return super().run(argv, check=check, input_text=input_text)
@@ -806,7 +806,7 @@ def test_a_pool_busy_with_nothing_mounted_is_named_rather_than_forced(
 
         def run(
             self, argv: Sequence[str], *, check: bool = True, input_text: str | None = None
-        ) -> str:
+        ) -> CommandOutput:
             if tuple(argv[:2]) == ("zpool", "export") and "-f" not in argv:
                 raise CommandFailed("zpool export rpool exited 1: pool is busy")
             if tuple(argv[:2]) == ("zfs", "list"):

--- a/tests/unit/test_plan_portage.py
+++ b/tests/unit/test_plan_portage.py
@@ -1249,7 +1249,7 @@ def test_a_mirror_rewriting_its_manifests_is_retried_rather_than_fatal(
         refusals: int = 2
         attempts: int = 0
 
-        def run_in_target(self, argv: Sequence[str], *, check: bool = True) -> str:
+        def run_in_target(self, argv: Sequence[str], *, check: bool = True) -> CommandOutput:
             if "--sync" in argv:
                 self.attempts += 1
                 if self.refusals:
@@ -1331,7 +1331,7 @@ def test_an_unreachable_overlay_site_moves_to_the_next_one(
         pointed: str = "https://mirror.nju.edu.cn/git/gentoo-zh.git"
         attempts: int = 0
 
-        def run_in_target(self, argv: Sequence[str], *, check: bool = True) -> str:
+        def run_in_target(self, argv: Sequence[str], *, check: bool = True) -> CommandOutput:
             if "--sync" in argv:
                 self.attempts += 1
                 if self.pointed != self.reachable:
@@ -1383,7 +1383,7 @@ def test_an_unreachable_overlay_site_moves_to_the_next_one(
         attempts: int = 0
         pointed_at: list[str] = []
 
-        def run_in_target(self, argv: Sequence[str], *, check: bool = True) -> str:
+        def run_in_target(self, argv: Sequence[str], *, check: bool = True) -> CommandOutput:
             if "--sync" in argv:
                 self.attempts += 1
                 raise CommandFailed(_MID_UPDATE_SAYS)


### PR DESCRIPTION
The real `Context` answers a `CommandOutput`; three branches of the double answered a bare `str` — a failing command under `check=False`, an injected `answering`, and the fallback. A caller that degrades or retries on a non-zero code was handed an object with no `returncode`, and a non-empty string reads as success.

A reply already carrying a code keeps it: `replies` is typed for `str` and `CommandOutput` is one, so wrapping unconditionally rebuilt a configured failure as a success and broke `VerifyPackages`.