### PR TITLE
media: hash the ISO instead of trusting its size and mtime

### DIFF
--- a/tests/unit/test_media.py
+++ b/tests/unit/test_media.py
@@ -1,0 +1,50 @@
+# SPDX-License-Identifier: GPL-2.0-or-later
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+import pytest
+
+from tests.vm import media
+
+
+def test_replacing_an_iso_with_preserved_metadata_re_extracts_its_boot_files(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A restored ISO may retain metadata while carrying a different kernel."""
+    extracted: list[Path] = []
+
+    def extract(iso: Path, files: dict[str, Path]) -> None:
+        extracted.append(iso)
+        for target in files.values():
+            target.parent.mkdir(parents=True, exist_ok=True)
+            target.write_bytes(iso.read_bytes())
+
+    first = b"first-build"
+    second = b"secondbuild"
+    # The premise: only content differs. An edit that changed the length would
+    # test the easy path and still pass.
+    assert len(first) == len(second)
+    iso = tmp_path / "rolling.iso"
+    iso.write_bytes(first)
+    medium = media.Medium(
+        name="rolling",
+        iso=iso,
+        volume_label="rolling",
+        kernel_in_iso="/boot/kernel",
+        initrd_in_iso="/boot/initrd",
+        root_prompt="# ",
+    )
+    monkeypatch.setattr(media, "CACHE", tmp_path / "cache")
+    monkeypatch.setattr(media, "_extract", extract)
+
+    kernel, initrd = medium.boot_files()
+    assert (kernel.read_bytes(), initrd.read_bytes()) == (first, first)
+    original = iso.stat()
+    iso.write_bytes(second)
+    os.utime(iso, ns=(original.st_atime_ns, original.st_mtime_ns))
+
+    kernel, initrd = medium.boot_files()
+    assert len(extracted) == 2, "a changed ISO was served from the cache"
+    assert (kernel.read_bytes(), initrd.read_bytes()) == (second, second)

--- a/tests/vm/media.py
+++ b/tests/vm/media.py
@@ -79,18 +79,8 @@ class Medium:
         return kernel, initrd
 
     def source_stamp(self) -> str:
-        """What identifies the ISO's content, for the cache and for the record
-        a campaign result carries. The digest is what actually decides; size and
-        mtime only keep a gigabyte from being hashed on every run."""
-        state = self.iso.stat()
-        quick = CACHE / self.name / f"{self.iso.stem}.quick"
-        seen = _read(quick).split()
-        if len(seen) == 3 and seen[0] == str(state.st_size) and seen[1] == str(state.st_mtime_ns):
-            return seen[2]
-        digest = _sha256(self.iso)
-        quick.parent.mkdir(parents=True, exist_ok=True)
-        quick.write_text(f"{state.st_size} {state.st_mtime_ns} {digest}")
-        return digest
+        """What identifies the ISO's content for the cache and campaign record."""
+        return _sha256(self.iso)
 
 
 def _read(path: Path) -> str:


### PR DESCRIPTION
The cache reused an extracted kernel and initrd whenever size and `st_mtime_ns` matched, so a restore or a copy that preserves the timestamp booted the old pair while the campaign recorded the new ISO revision. The largest medium here hashes in 4.4s against an install that takes tens of minutes.