### PR TITLE
exec: keep a failed rename and a long label from escaping their handlers

### DIFF
--- a/gentoo_install/exec/fetch.py
+++ b/gentoo_install/exec/fetch.py
@@ -1044,6 +1044,7 @@ def _download_once(
                 if log is not None and time.monotonic() - said >= PROGRESS_INTERVAL:
                     said = time.monotonic()
                     log(_progress(target.name, got, total))
+        partial.replace(target)
     # `http.client.HTTPException` beside the rest: `IncompleteRead` is one and
     # is not an `OSError`, so a server closing the connection with bytes still
     # promised escaped this handler, left the `.part` file behind and stopped
@@ -1051,7 +1052,6 @@ def _download_once(
     except (urllib.error.URLError, TimeoutError, OSError, http.client.HTTPException) as error:
         partial.unlink(missing_ok=True)
         raise DownloadFailed(f"{url} could not be fetched: {error}") from error
-    partial.replace(target)
 
 
 def _verify_signature(digests: Path, fingerprint: str, runner: Runner) -> None:

--- a/gentoo_install/tui/widgets.py
+++ b/gentoo_install/tui/widgets.py
@@ -642,12 +642,13 @@ class Form:
             screen.write(1, 2, truncate(message, columns - 2), style=Style.REQUIRED)
             offset = 3
         widest = max((width(field.label) for field in self.fields), default=0)
-        room = columns - widest - 10
+        room = max(2, columns - widest - 10)
+        widest = min(widest, columns - room - 10)
         for index, field in enumerate(self.fields):
             row = index + offset
             if row >= lines - 1:
                 break
-            screen.write(row, 2, field.label)
+            screen.write(row, 2, truncate(field.label, widest))
             if field.toggle:
                 screen.write(
                     row,

--- a/tests/unit/test_fetch.py
+++ b/tests/unit/test_fetch.py
@@ -316,3 +316,64 @@ def test_a_body_that_stops_early_is_a_download_failure(
     # The partial file goes with it, or the next mirror verifies this one.
     assert not target.with_suffix(target.suffix + ".part").exists()
     assert not target.exists()
+
+
+def test_an_unreplaceable_stage3_tries_the_next_mirror_and_cleans_up(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """The rename sat after the `except`, so a full disk or a changed
+    permission left the raw `OSError`: the mirror fallback never ran, the CLI
+    never classified it, and the `.part` file stayed behind.
+    """
+    mirrors: list[str] = []
+    notices: list[str] = []
+
+    class Response:
+        def __init__(self) -> None:
+            self.headers: dict[str, str] = {}
+            self.body = b"stage3"
+
+        def __enter__(self) -> "Response":
+            return self
+
+        def __exit__(self, *unused: object) -> None:
+            return None
+
+        def read(self, size: int = 0) -> bytes:
+            body, self.body = self.body, b""
+            return body
+
+    def newest(builds: str, variant: str, proxy: object = None) -> str:
+        mirrors.append(builds)
+        return "stage3.tar.xz"
+
+    def opening(*unused: object, **ignored: object) -> Response:
+        return Response()
+
+    def unreplaceable(self: Path, target: Path) -> Path:
+        raise OSError("No space left on device")
+
+    monkeypatch.setattr(fetch, "_newest", newest)
+    monkeypatch.setattr(fetch, "_urlopen", opening)
+    monkeypatch.setattr(fetch, "ONLINE_PAUSE", 0.0)
+    monkeypatch.setattr(Path, "replace", unreplaceable)
+
+    with pytest.raises(DownloadFailed, match="could not be fetched"):
+        fetch.stage3(
+            "https://first.example",
+            "systemd",
+            "0" * 40,
+            tmp_path,
+            Runner(log=notices.append),
+            fallbacks=("https://second.example",),
+        )
+
+    assert mirrors == [
+        f"https://first.example/{fetch.STAGE3_PATH}",
+        f"https://second.example/{fetch.STAGE3_PATH}",
+    ]
+    assert len(notices) == 2
+    assert all("did not serve the stage3" in notice for notice in notices)
+    archive = tmp_path / "stage3.tar.xz"
+    assert not archive.exists()
+    assert not archive.with_suffix(archive.suffix + ".part").exists()

--- a/tests/unit/test_tui_widgets.py
+++ b/tests/unit/test_tui_widgets.py
@@ -286,6 +286,17 @@ def test_a_form_shows_every_field_at_once() -> None:
     assert any("Done" in line for line in drawn)
 
 
+def test_a_form_with_an_overlong_wide_label_still_accepts_input() -> None:
+    """`room` was `columns - widest - 10`, which goes negative once a label is
+    wider than the terminal. The trimming loop then deleted a string that was
+    already empty, so the redraw never ended and the form never took a key.
+    """
+    form = Form(title="Network", fields=[Field(label=WIDE * 60)])
+    screen = FakeScreen(keys=["KEY_DOWN", "\n"], lines=24, columns=80)
+
+    assert form.run(screen).unwrap() == [""]
+
+
 def test_escape_leaves_a_form_without_an_answer() -> None:
     form = Form(title="t", fields=[Field(label="a")])
     assert form.run(FakeScreen(keys=["\x1b"])).outcome is Outcome.CANCELLED


### PR DESCRIPTION
The stage3 rename sat after the `except`, so a full disk or a changed permission left the raw `OSError`: the mirror fallback never ran, the CLI never classified it, and the `.part` file stayed behind.

The form computed `columns - widest - 10` without a floor, so a label wider than the terminal made it negative and the trimming loop deleted an already empty string for ever. No shipped label reaches that today; the next translation could.