### PR TITLE
cluster: a dropped console is not a dead guest

### DIFF
--- a/tests/unit/test_cluster.py
+++ b/tests/unit/test_cluster.py
@@ -1372,3 +1372,90 @@ def test_a_capacity_read_that_did_not_answer_does_not_end_the_schedule() -> None
     assert code.count("except ProxmoxTransientError") >= 2, code.count(
         "except ProxmoxTransientError"
     )
+
+
+def test_a_dropped_console_does_not_end_a_guest_that_is_still_working(
+    tmp_path: Path,
+) -> None:
+    """`vm-gnome` was at `[26/539]` compiling git when its websocket answered
+    `[Errno 104] Connection reset by peer`, and the verdict threw away 167
+    minutes. A silent console already asks the hypervisor's counters through
+    `ConsoleIdle`; a broken one did not ask at all, so the two ways a console
+    can stop carrying bytes had opposite answers about the same live guest.
+    """
+    from tests.vm.console import ConsoleClosed
+
+    class Console:
+        def expect(self, pattern: str, timeout: float, idle: float = 0.0) -> bytes:
+            raise ConsoleClosed("the connection broke: [Errno 104] Connection reset by peer")
+
+        def send(self, line: str) -> None:
+            return None
+
+        def close(self) -> None:
+            return None
+
+    opened: list[Console] = []
+    sampled: list[int] = []
+
+    def counters() -> int | None:
+        # A guest whose disk keeps growing while its console says nothing.
+        sampled.append(len(sampled))
+        return cluster.QUIET_BYTES * 2 * (len(sampled) + 1)
+
+    log = tmp_path / "serial.log"
+    log.write_bytes(b"")
+    watch = cluster.Watchdog(log=log, counters=counters)
+
+    def open_console() -> Any:
+        opened.append(Console())
+        return opened[-1]
+
+    link = cluster.Reconnecting(open_console, tries=2)
+    with pytest.raises(ConsoleClosed):
+        link.wait_for("emerge --ask=n @world", timeout=0.0, idle=1.0, watch=watch)
+
+    # Asked once per grant, and the last decision short-circuits on the count
+    # rather than taking a sample it will not use.
+    assert len(sampled) == cluster.RECONNECT_GRANTS, sampled
+    # It reconnected, and it stopped: a run that never gives up holds a node
+    # for the rest of the schedule.
+    assert 1 < len(opened) <= cluster.REOPEN_CEILING, len(opened)
+
+
+def test_a_dropped_console_still_ends_a_guest_that_moves_nothing(tmp_path: Path) -> None:
+    """The negative direction. Without it the change reads as "reconnect for
+    ever", which is how a dead guest holds a node until the schedule ends.
+    """
+    from tests.vm.console import ConsoleClosed
+
+    class Console:
+        def expect(self, pattern: str, timeout: float, idle: float = 0.0) -> bytes:
+            raise ConsoleClosed("the connection broke: [Errno 104] Connection reset by peer")
+
+        def send(self, line: str) -> None:
+            return None
+
+        def close(self) -> None:
+            return None
+
+    log = tmp_path / "serial.log"
+    log.write_bytes(b"")
+    opened: list[Console] = []
+
+    def open_console() -> Any:
+        opened.append(Console())
+        return opened[-1]
+
+    still = cluster.Watchdog(log=log, counters=lambda: 0)
+    link = cluster.Reconnecting(open_console, tries=2)
+    with pytest.raises(ConsoleClosed):
+        link.wait_for("emerge --ask=n @world", timeout=0.0, idle=1.0, watch=still)
+    assert len(opened) == 1, len(opened)
+
+    # And with no watchdog at all, which is what `run` and `expect_output` use.
+    opened.clear()
+    quiet = cluster.Reconnecting(open_console, tries=2)
+    with pytest.raises(ConsoleClosed):
+        quiet.wait_for("emerge --ask=n @world", timeout=0.0, idle=1.0)
+    assert len(opened) == 1, len(opened)

--- a/tests/vm/cluster.py
+++ b/tests/vm/cluster.py
@@ -414,6 +414,14 @@ class Job:
 QUIET_BYTES: Final[int] = 1024 * 1024
 
 
+#: What a guest still moving bytes buys back after its console dropped. The
+#: transport outage is not the guest's silence: `vm-gnome` was compiling git
+#: when one `Connection reset by peer` ended 167 minutes of work.
+RECONNECT_GRANT: Final[float] = 900.0
+#: At most this many, so a console that never comes back still ends the run.
+RECONNECT_GRANTS: Final[int] = 4
+
+
 @dataclass
 class Watchdog:
     """Whether a guest is still doing anything.
@@ -2174,7 +2182,7 @@ class Reconnecting:
                         f"{error}; console was silent for {idle:.0f}s and {reason}"
                     ) from error
 
-        self._with_reconnect(timeout, wait_once)
+        self._with_reconnect(timeout, wait_once, watch=watch)
 
     def expect_output(self, command: str, timeout: float = 120.0) -> bytes:
         """Run a command and answer with what it printed, and nothing else.
@@ -2201,20 +2209,38 @@ class Reconnecting:
         operation: Callable[[float], _Result],
         *,
         solicit_on_reconnect: bool = True,
+        watch: Watchdog | None = None,
     ) -> _Result:
+        """Run `operation`, reopening the console under it while time is left.
+
+        A `watch` makes the deadline conditional: the console going is not the
+        guest going, and `vm-gnome` lost 167 minutes of compiling to one
+        `Connection reset by peer` because the two were treated as the same
+        thing. A silent console already asks the counters through
+        `ConsoleIdle`; this asks them on the other failure as well.
+        """
         deadline = time.monotonic() + timeout
-        closed: ConsoleClosed | None = None
-        for attempt in range(self._tries):
-            if closed is not None and _remaining(deadline) <= 0.0:
-                raise closed
+        granted = 0
+        attempt = 0
+        while True:
             try:
                 return operation(deadline)
-            except ConsoleClosed as error:
-                closed = error
-                if attempt + 1 == self._tries or _remaining(deadline) <= 0.0:
-                    raise
+            except ConsoleClosed:
+                attempt += 1
+                if attempt >= self._tries or _remaining(deadline) <= 0.0:
+                    # `moved()` is asked once, and only here: it takes a sample
+                    # the scheduler's sweep also reads.
+                    if watch is None or granted >= RECONNECT_GRANTS or not watch.moved():
+                        raise
+                    granted += 1
+                    attempt = 0
+                    deadline = time.monotonic() + RECONNECT_GRANT
+                    print(
+                        f"… the console dropped and the guest is still working, "
+                        f"{RECONNECT_GRANT / 60:.0f}m more",
+                        flush=True,
+                    )
                 self.reopen(solicit_prompt=solicit_on_reconnect)
-        raise ConsoleClosed("the console could not be reopened")
 
     def send(self, line: str) -> None:
         self._reopen_if_closed()


### PR DESCRIPTION
`vm-gnome` was at `[26/539]` compiling git when its websocket answered `[Errno 104] Connection reset by peer`, and the verdict threw away 167 minutes on a node that was still writing to disk.

A console that goes *silent* already asks the hypervisor counters through `ConsoleIdle`; a console that *breaks* asked nothing and let the deadline end the run. `wait_for` now hands its watchdog to the reconnect loop, which buys back bounded time while the guest is proven to be moving bytes.