### PR TITLE
portage: a signalled emerge that printed nothing is a binhost failure

### DIFF
--- a/gentoo_install/plan/portage.py
+++ b/gentoo_install/plan/portage.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 
 import json
 import re
+import signal
 from dataclasses import dataclass
 from enum import Enum
 from pathlib import PurePosixPath
@@ -768,14 +769,18 @@ class Emerge(Operation):
             else:
                 return
             context.degrade(BINARY_PACKAGES, f"selected binary package failed: {marker}")
-            retry_result = context.run_in_target(self._argv(context, source_only=True), check=False)
-            if isinstance(retry_result, CommandOutput) and retry_result.returncode != 0:
-                raise CommandFailed(
-                    f"source retry ended with {retry_result.ending}: "
-                    f"{str(retry_result).strip()}"
-                )
+            self._from_source(context)
             return
         if not isinstance(result, CommandOutput) or result.returncode == 0:
+            return
+        if (killed := _binhost_killed_emerge(result)) and not context.degraded(
+            BINARY_PACKAGES
+        ):
+            second = context.run_in_target(command, check=False)
+            if not isinstance(second, CommandOutput) or second.returncode == 0:
+                return
+            context.degrade(BINARY_PACKAGES, killed)
+            self._from_source(context)
             return
         if not _binpkg_failure(str(result)) or context.degraded(BINARY_PACKAGES):
             raise CommandFailed(f"emerge ended with {result.ending}: {str(result).strip()}")
@@ -784,10 +789,11 @@ class Emerge(Operation):
             marker = again
         else:
             return
-        reason = f"selected binary package failed: {marker}"
-        context.degrade(BINARY_PACKAGES, reason)
-        retry = self._argv(context, source_only=True)
-        retry_result = context.run_in_target(retry, check=False)
+        context.degrade(BINARY_PACKAGES, f"selected binary package failed: {marker}")
+        self._from_source(context)
+
+    def _from_source(self, context: Context) -> None:
+        retry_result = context.run_in_target(self._argv(context, source_only=True), check=False)
         if isinstance(retry_result, CommandOutput) and retry_result.returncode != 0:
             raise CommandFailed(
                 f"source retry ended with {retry_result.ending}: {str(retry_result).strip()}"
@@ -829,6 +835,20 @@ class Emerge(Operation):
 #: Portage's own binary package extension, which is what proves a fetch was a
 #: binary one when the path is the only line naming it.
 GPKG_SUFFIX: Final[str] = ".gpkg.tar"
+
+
+def _binhost_killed_emerge(result: CommandOutput) -> str | None:
+    """Whether emerge died on a signal before printing a single byte.
+
+    Its stdout is a pipe and therefore block-buffered, so a signal loses
+    everything it had written, and the only network it touches before its
+    first line is the binary host. `vm-xfs` died with `SIGPIPE (13)` and no
+    output on the install's first emerge, seventy-seven lines after
+    `mirrors.nju.edu.cn` dropped a TLS handshake mid-fetch.
+    """
+    if result.returncode != -signal.SIGPIPE or str(result).strip():
+        return None
+    return "the binary host killed emerge with SIGPIPE before it printed anything"
 
 
 def _binpkg_failure(output: str) -> str | None:

--- a/tests/unit/recorder.py
+++ b/tests/unit/recorder.py
@@ -41,6 +41,9 @@ class Recorder:
     #: Commands whose first word is here raise instead of returning.
     failures: set[str] = field(default_factory=set)
     given_up: set[str] = field(default_factory=set)
+    #: Why each one was given up. The reason is what `install.jsonl` records
+    #: and what an operator reads, so a double that drops it cannot hold it.
+    degradations: dict[str, str] = field(default_factory=dict)
     #: Consulted before the replies table, and injected rather than assigned
     #: over the bound method: five tests replaced `run_in_target` itself, which
     #: mypy accepted only under `# type: ignore[method-assign]`. Answering
@@ -131,6 +134,7 @@ class Recorder:
 
     def degrade(self, what: str, reason: str) -> None:
         self.given_up.add(what)
+        self.degradations[what] = reason
 
     def degraded(self, what: str) -> bool:
         return what in self.given_up

--- a/tests/unit/test_plan_portage.py
+++ b/tests/unit/test_plan_portage.py
@@ -2018,3 +2018,61 @@ def test_a_sync_that_ran_out_of_sites_says_how_many_it_tried(
     plan_portage.SyncRepository(
         name="gentoo-zh", location=location, alternates=alternates
     ).apply(SecondSiteAnswers())
+
+
+def test_an_emerge_the_binary_host_killed_falls_back_to_source() -> None:
+    """`run56/vm-xfs.log`, the install's first emerge:
+
+        2641: !!! [gentoo] Error fetching binhost package info from
+              'https://mirrors.nju.edu.cn/gentoo/releases/amd64/...'
+        2642: !!! [gentoo] <urlopen error [SSL: UNEXPECTED_EOF_WHILE_READING]>
+        2718: [34/51] [system] install sshd: emerge net-misc/openssh
+        2720: the install stopped: CommandFailed: emerge failed with exit -13
+
+    Portage's stdout is a pipe and therefore block-buffered, so the signal
+    lost every line it had printed and `_binpkg_failure` had no text to read.
+    A binary host that kills emerge is a binary host failure, and the policy
+    for one is a warning and a source build, not a stopped install.
+    """
+    import signal
+
+    recorder = Recorder()
+    tries: list[int] = []
+
+    def answering(argv: Sequence[str]) -> CommandOutput | None:
+        if argv[0] != "emerge":
+            return None
+        if "--usepkg=n" in argv:
+            return CommandOutput("[ebuild] net-misc/openssh-10.4", 0)
+        tries.append(len(tries))
+        return CommandOutput("", -signal.SIGPIPE)
+
+    recorder.answering = answering
+    portage.Emerge(packages=("net-misc/openssh",), summary="install sshd").apply(recorder)
+
+    emerges = [argv for argv in recorder.in_target if argv[0] == "emerge"]
+    # Binaries, binaries again because one dropped handshake is not the host
+    # being gone, then source.
+    assert len(emerges) == 3, emerges
+    assert "--getbinpkg=n" in emerges[-1] and "--usepkg=n" in emerges[-1]
+    assert recorder.degraded(portage.BINARY_PACKAGES)
+    assert "SIGPIPE" in recorder.degradations[portage.BINARY_PACKAGES]
+
+
+def test_a_signalled_emerge_that_printed_something_is_not_blamed_on_the_host() -> None:
+    """The negative control. A build killed by the out-of-memory killer prints
+    plenty first, and calling that a binhost failure would rebuild it from
+    source and be killed the same way an hour later.
+    """
+    import signal
+
+    recorder = Recorder()
+    recorder.answering = lambda argv: (
+        CommandOutput(">>> Compiling source in /var/tmp/portage/...", -signal.SIGKILL)
+        if argv[0] == "emerge"
+        else None
+    )
+
+    with pytest.raises(CommandFailed, match="SIGKILL"):
+        portage.Emerge(packages=("sys-devel/gcc",), summary="install gcc").apply(recorder)
+    assert not recorder.degraded(portage.BINARY_PACKAGES)


### PR DESCRIPTION
Read off `run56/vm-xfs.log`: line 2641 `mirrors.nju.edu.cn` drops a TLS handshake mid-fetch, line 2718 the install reaches its first emerge, line 2720 `emerge failed with exit -13` and not one byte of output. Portage block-buffers its stdout into a pipe, so `SIGPIPE` lost every line it had printed and the text-based binhost check had nothing to read.

A binary host that kills emerge is a binary host failure, and the policy for one is a warning and a source build. It retries with binaries once first, because a single dropped handshake is not the host being gone.