### PR TITLE
data: give each desktop policy one place both variants read

### DIFF
--- a/gentoo_install/data.py
+++ b/gentoo_install/data.py
@@ -19,6 +19,7 @@ DATA: Final[Path] = Path(__file__).resolve().parent / "data"
 KEYS: Final[frozenset[str]] = frozenset(
     {
         "packages", "services", "use", "repositories", "video_cards", "files",
+        "base",
         "input_method", "schemas", "wayland", "package_use", "accept_license",
         "display_manager", "profile", "input_framework", "input_method_launcher",
         "wayland_files", "user_groups", "user_services", "accept_keywords",
@@ -44,15 +45,7 @@ def load_catalog(root: Path | None = None) -> Catalog:
 
 
 def _load(path: Path) -> Group:
-    try:
-        raw = tomllib.loads(path.read_text(encoding="utf-8"))
-    except OSError as error:
-        raise ConfigError(f"{path}: {error}") from error
-    except tomllib.TOMLDecodeError as error:
-        raise ConfigError(f"{path}: {error}") from error
-    unknown = sorted(set(raw) - KEYS)
-    if unknown:
-        raise ConfigError(f"{path} has unknown keys: {', '.join(unknown)}")
+    raw = _compose(path)
     return Group(
         name=path.stem,
         label=_text(raw, "label", path),
@@ -84,6 +77,40 @@ def _load(path: Path) -> Group:
         user_groups=_strings(raw, "user_groups", path),
         user_services=_strings(raw, "user_services", path),
     )
+
+
+def _compose(
+    path: Path, ancestors: frozenset[Path] = frozenset()
+) -> dict[str, object]:
+    resolved = path.resolve()
+    if resolved in ancestors:
+        raise ConfigError(f"{path}: base profiles form a cycle")
+    raw = _read(path)
+    base = raw.pop("base", None)
+    if base is None:
+        return raw
+    if not isinstance(base, str):
+        raise ConfigError(f"{path}: base must be a string")
+    inherited = _compose(path.parent / base, ancestors | {resolved})
+    overlap = sorted(set(inherited) & set(raw))
+    if overlap:
+        raise ConfigError(
+            f"{path}: base and variant both define: {', '.join(overlap)}"
+        )
+    return inherited | raw
+
+
+def _read(path: Path) -> dict[str, object]:
+    try:
+        raw = tomllib.loads(path.read_text(encoding="utf-8"))
+    except OSError as error:
+        raise ConfigError(f"{path}: {error}") from error
+    except tomllib.TOMLDecodeError as error:
+        raise ConfigError(f"{path}: {error}") from error
+    unknown = sorted(set(raw) - KEYS)
+    if unknown:
+        raise ConfigError(f"{path} has unknown keys: {', '.join(unknown)}")
+    return raw
 
 
 def _files(raw: dict[str, object], path: Path, key: str = "files") -> tuple[GroupFile, ...]:

--- a/gentoo_install/data/profiles/base/gnome.toml
+++ b/gentoo_install/data/profiles/base/gnome.toml
@@ -1,0 +1,3 @@
+use = ["wayland", "gnome", "networkmanager", "gtk"]
+wayland = true
+profile = "default/linux/amd64/23.0/desktop/gnome"

--- a/gentoo_install/data/profiles/base/plasma.toml
+++ b/gentoo_install/data/profiles/base/plasma.toml
@@ -1,0 +1,17 @@
+use = ["wayland", "qt6", "networkmanager"]
+# `kcm` is a local flag of `app-i18n/fcitx-configtool`, and its `kcm?` block
+# pulls nine kde-frameworks packages plus libplasma. Declared by the desktop
+# that already has them rather than by the fcitx5 group, which would install
+# Plasma alongside GNOME. Harmless when fcitx5 is not chosen: the line names a
+# package that is not merged.
+package_use = [
+    "app-i18n/fcitx-configtool kcm",
+    "sys-libs/minizip-ng compat",
+]
+wayland = true
+profile = "default/linux/amd64/23.0/desktop/plasma"
+
+# KWin starts the input method itself on a Wayland session, and this is the key
+# the Virtual keyboard KCM writes. The launcher entry speaks input-method-v2;
+# `org.fcitx.Fcitx5.desktop` is the autostart entry and integrates incorrectly.
+input_method_launcher = "/usr/share/applications/fcitx5-wayland-launcher.desktop"

--- a/gentoo_install/data/profiles/gnome-full.toml
+++ b/gentoo_install/data/profiles/gnome-full.toml
@@ -1,5 +1,4 @@
 # GNOME with the applications a GNOME release ships.
+base = "base/gnome.toml"
+
 packages = ["gnome-base/gnome", "x11-base/xorg-server"]
-use = ["wayland", "gnome", "networkmanager", "gtk"]
-wayland = true
-profile = "default/linux/amd64/23.0/desktop/gnome"

--- a/gentoo_install/data/profiles/gnome.toml
+++ b/gentoo_install/data/profiles/gnome.toml
@@ -1,6 +1,5 @@
 # GNOME without the full application set. `gnome-light` is the session and its
 # own tools; `gnome` adds the applications.
+base = "base/gnome.toml"
+
 packages = ["gnome-base/gnome-light", "x11-base/xorg-server"]
-use = ["wayland", "gnome", "networkmanager", "gtk"]
-wayland = true
-profile = "default/linux/amd64/23.0/desktop/gnome"

--- a/gentoo_install/data/profiles/plasma-full.toml
+++ b/gentoo_install/data/profiles/plasma-full.toml
@@ -1,24 +1,9 @@
 # KDE Plasma with the KDE application set, which is what a Plasma release
 # ships and what `kde-apps-meta` pulls in.
+base = "base/plasma.toml"
+
 packages = [
     "kde-plasma/plasma-meta",
     "kde-apps/kde-apps-meta",
     "x11-base/xorg-server",
 ]
-use = ["wayland", "qt6", "networkmanager"]
-# `kcm` is a local flag of `app-i18n/fcitx-configtool`, and its `kcm?` block
-# pulls nine kde-frameworks packages plus libplasma. Declared by the desktop
-# that already has them rather than by the fcitx5 group, which would install
-# Plasma alongside GNOME. Harmless when fcitx5 is not chosen: the line names a
-# package that is not merged.
-package_use = [
-    "app-i18n/fcitx-configtool kcm",
-    "sys-libs/minizip-ng compat",
-]
-wayland = true
-profile = "default/linux/amd64/23.0/desktop/plasma"
-
-# KWin starts the input method itself on a Wayland session, and this is the key
-# the Virtual keyboard KCM writes. The launcher entry speaks input-method-v2;
-# `org.fcitx.Fcitx5.desktop` is the autostart entry and integrates incorrectly.
-input_method_launcher = "/usr/share/applications/fcitx5-wayland-launcher.desktop"

--- a/gentoo_install/data/profiles/plasma.toml
+++ b/gentoo_install/data/profiles/plasma.toml
@@ -1,25 +1,10 @@
 # KDE Plasma, the session and nothing more. `plasma-full` adds the application
 # set; this is the choice between a desktop and a distribution's worth of it.
+base = "base/plasma.toml"
+
 packages = [
     "kde-plasma/plasma-meta",
     "x11-base/xorg-server",
     "kde-apps/konsole",
     "kde-apps/dolphin",
 ]
-use = ["wayland", "qt6", "networkmanager"]
-# `kcm` is a local flag of `app-i18n/fcitx-configtool`, and its `kcm?` block
-# pulls nine kde-frameworks packages plus libplasma. Declared by the desktop
-# that already has them rather than by the fcitx5 group, which would install
-# Plasma alongside GNOME. Harmless when fcitx5 is not chosen: the line names a
-# package that is not merged.
-package_use = [
-    "app-i18n/fcitx-configtool kcm",
-    "sys-libs/minizip-ng compat",
-]
-wayland = true
-profile = "default/linux/amd64/23.0/desktop/plasma"
-
-# KWin starts the input method itself on a Wayland session, and this is the key
-# the Virtual keyboard KCM writes. The launcher entry speaks input-method-v2;
-# `org.fcitx.Fcitx5.desktop` is the autostart entry and integrates incorrectly.
-input_method_launcher = "/usr/share/applications/fcitx5-wayland-launcher.desktop"

--- a/tests/unit/test_packages.py
+++ b/tests/unit/test_packages.py
@@ -1,14 +1,14 @@
 # SPDX-License-Identifier: GPL-2.0-or-later
 from dataclasses import replace
-from pathlib import PurePosixPath
+from pathlib import Path, PurePosixPath
 
 import pytest
 
 from gentoo_install.data import load_catalog
-from gentoo_install.errors import CommandFailed
+from gentoo_install.errors import CommandFailed, ConfigError
 from gentoo_install.model.config import ConsoleFontSize, InstallConfig, Overlay, User
 from gentoo_install.plan import packages as plan_packages
-from gentoo_install.plan.packages import build
+from gentoo_install.plan.packages import Group, build
 from gentoo_install.plan.portage import Emerge
 
 from .recorder import Recorder
@@ -132,6 +132,90 @@ def test_plasma_declares_the_minizip_compatibility_required_by_its_stack() -> No
 
     for profile in ("plasma", "plasma-full"):
         assert "sys-libs/minizip-ng compat" in catalog[profile].package_use
+
+
+def test_desktop_profiles_preserve_their_composed_values() -> None:
+    catalog = load_catalog()
+
+    assert {
+        name: catalog[name]
+        for name in ("plasma", "plasma-full", "gnome", "gnome-full")
+    } == {
+        "plasma": Group(
+            name="plasma",
+            packages=(
+                "kde-plasma/plasma-meta",
+                "x11-base/xorg-server",
+                "kde-apps/konsole",
+                "kde-apps/dolphin",
+            ),
+            use=("wayland", "qt6", "networkmanager"),
+            profile="default/linux/amd64/23.0/desktop/plasma",
+            package_use=(
+                "app-i18n/fcitx-configtool kcm",
+                "sys-libs/minizip-ng compat",
+            ),
+            input_method_launcher=(
+                "/usr/share/applications/fcitx5-wayland-launcher.desktop"
+            ),
+            wayland=True,
+        ),
+        "plasma-full": Group(
+            name="plasma-full",
+            packages=(
+                "kde-plasma/plasma-meta",
+                "kde-apps/kde-apps-meta",
+                "x11-base/xorg-server",
+            ),
+            use=("wayland", "qt6", "networkmanager"),
+            profile="default/linux/amd64/23.0/desktop/plasma",
+            package_use=(
+                "app-i18n/fcitx-configtool kcm",
+                "sys-libs/minizip-ng compat",
+            ),
+            input_method_launcher=(
+                "/usr/share/applications/fcitx5-wayland-launcher.desktop"
+            ),
+            wayland=True,
+        ),
+        "gnome": Group(
+            name="gnome",
+            packages=("gnome-base/gnome-light", "x11-base/xorg-server"),
+            use=("wayland", "gnome", "networkmanager", "gtk"),
+            profile="default/linux/amd64/23.0/desktop/gnome",
+            wayland=True,
+        ),
+        "gnome-full": Group(
+            name="gnome-full",
+            packages=("gnome-base/gnome", "x11-base/xorg-server"),
+            use=("wayland", "gnome", "networkmanager", "gtk"),
+            profile="default/linux/amd64/23.0/desktop/gnome",
+            wayland=True,
+        ),
+    }
+
+
+def test_profile_base_rejects_an_overlapping_variant_field(tmp_path: Path) -> None:
+    profiles = tmp_path / "profiles"
+    bases = profiles / "base"
+    bases.mkdir(parents=True)
+    (bases / "desktop.toml").write_text('use = ["base"]\n', encoding="utf-8")
+    (profiles / "variant.toml").write_text(
+        'base = "base/desktop.toml"\nuse = ["variant"]\n', encoding="utf-8"
+    )
+
+    with pytest.raises(ConfigError, match=r"base and variant both define: use"):
+        load_catalog(tmp_path)
+
+
+def test_profile_base_cycle_is_rejected(tmp_path: Path) -> None:
+    profiles = tmp_path / "profiles"
+    profiles.mkdir()
+    (profiles / "first.toml").write_text('base = "second.toml"\n', encoding="utf-8")
+    (profiles / "second.toml").write_text('base = "first.toml"\n', encoding="utf-8")
+
+    with pytest.raises(ConfigError, match="base profiles form a cycle"):
+        load_catalog(tmp_path)
 
 
 def test_xfce_declares_the_dbusmenu_flag_its_panel_requires() -> None:


### PR DESCRIPTION
The light and full variants of Plasma and GNOME each repeated `use`, `package_use`, `wayland`, `profile` and the input-method launcher, so a maintainer could change the profile path or the Wayland setting in one and leave the other behind with nothing to notice.

A variant now names a base and carries only its package difference. A field defined in both is a refusal rather than a silent override, and a base that reaches itself is refused instead of recursing. The four composed groups are byte-identical to what they were.