### PR TITLE
tests: check four contracts against what they name

### DIFF
--- a/tests/unit/test_bootstrap.py
+++ b/tests/unit/test_bootstrap.py
@@ -42,17 +42,22 @@ def only_python(tmp_path: Path) -> str:
     return str(directory)
 
 
-def run(tmp_path: Path, release: str, *arguments: str, path: str) -> str:
+def run(
+    tmp_path: Path, release: str, *arguments: str, path: str
+) -> subprocess.CompletedProcess[str]:
     """Drive the launcher with another distribution's /etc/os-release."""
     where = tmp_path / "os-release"
     where.write_text(release)
-    finished = subprocess.run(
+    return subprocess.run(
         [SHELL, str(LAUNCHER), *arguments],
         cwd=REPOSITORY,
         env={"OS_RELEASE": str(where), "PATH": path},
         capture_output=True,
         text=True,
     )
+
+
+def output(finished: subprocess.CompletedProcess[str]) -> str:
     return finished.stdout + finished.stderr
 
 
@@ -123,7 +128,9 @@ def test_each_live_system_gets_its_own_package_manager(
     tmp_path: Path, release: str, manager: str
 ) -> None:
     """With no python on PATH the launcher still has to say how to get one."""
-    said = run(tmp_path, release, path="/nonexistent")
+    finished = run(tmp_path, release, path="/nonexistent")
+    said = output(finished)
+    assert finished.returncode == 1
     assert "needs python 3.11 or newer" in said
     assert f"{manager} python3" in said
 
@@ -131,7 +138,7 @@ def test_each_live_system_gets_its_own_package_manager(
 def test_a_broken_path_still_reaches_the_message(tmp_path: Path) -> None:
     """`dirname` is on PATH too, so finding the script's own directory must not
     need it: the operator would otherwise get a shell error and no reason."""
-    said = run(tmp_path, "ID=debian\n", path="/nonexistent")
+    said = output(run(tmp_path, "ID=debian\n", path="/nonexistent"))
     assert "command not found" not in said
     assert "needs python 3.11" in said
 
@@ -141,8 +148,8 @@ def test_a_missing_tool_is_named_as_the_package_of_that_distribution(tmp_path: P
     comes from gdisk on Debian and from gptfdisk everywhere else."""
     arguments = ("--config", "tests/fixtures/vm-luks.toml")
     lean = only_python(tmp_path)
-    debian = run(tmp_path, "ID=debian\n", *arguments, path=lean)
-    arch = run(tmp_path, "ID=arch\n", *arguments, path=lean)
+    debian = output(run(tmp_path, "ID=debian\n", *arguments, path=lean))
+    arch = output(run(tmp_path, "ID=arch\n", *arguments, path=lean))
     assert "missing commands:" in debian
     assert "apt-get install -y" in debian and "gdisk" in debian
     assert "pacman" in arch and "gptfdisk" in arch
@@ -151,13 +158,13 @@ def test_a_missing_tool_is_named_as_the_package_of_that_distribution(tmp_path: P
 def test_a_package_is_never_named_twice(tmp_path: Path) -> None:
     """`btrfs` and `mkfs.btrfs` both come from btrfs-progs, and naming it twice
     reads as though it has to be installed twice."""
-    said = run(
+    said = output(run(
         tmp_path,
         "ID=arch\n",
         "--config",
         "tests/fixtures/vm-luks.toml",
         path=only_python(tmp_path),
-    )
+    ))
     listed = [line for line in said.splitlines() if line.startswith("run: ")]
     assert listed, said
     packages = listed[0].removeprefix("run: ").split()
@@ -168,7 +175,7 @@ def test_a_dry_run_needs_none_of_the_tools(tmp_path: Path) -> None:
     """It performs nothing, and refusing it on a machine without them takes
     away the one way to check a file before reaching the target. Found by
     running the launcher on the Live ISO, which ships no lvm."""
-    said = run(
+    finished = run(
         tmp_path,
         "ID=gentoo\n",
         "--config",
@@ -176,17 +183,21 @@ def test_a_dry_run_needs_none_of_the_tools(tmp_path: Path) -> None:
         "--dry-run",
         path=only_python(tmp_path),
     )
+    said = output(finished)
+    assert finished.returncode == 0
     assert "missing commands:" not in said
 
 
 def test_an_install_still_names_what_is_missing(tmp_path: Path) -> None:
-    said = run(
+    finished = run(
         tmp_path,
         "ID=gentoo\n",
         "--config",
         "tests/fixtures/vm-lvm.toml",
         path=only_python(tmp_path),
     )
+    said = output(finished)
+    assert finished.returncode == 1
     assert "missing commands:" in said
 
 
@@ -218,7 +229,7 @@ def test_fedora_gets_the_package_that_actually_ships_sgdisk(tmp_path: Path) -> N
     none of the other packages on the line either."""
     arguments = ("--config", "tests/fixtures/vm-luks.toml")
     for release in ("ID=fedora\n", 'ID=rocky\nID_LIKE="rhel centos fedora"\n'):
-        said = run(tmp_path, release, *arguments, path=only_python(tmp_path))
+        said = output(run(tmp_path, release, *arguments, path=only_python(tmp_path)))
         assert "gdisk" in said and "gptfdisk" not in said
 
 
@@ -226,8 +237,15 @@ def test_alpine_names_each_util_linux_tool_on_its_own(tmp_path: Path) -> None:
     """Alpine's `util-linux` package is a 1.5 kB placeholder that installs
     nothing; the tools are one package each, so `apk add util-linux` left the
     same commands missing and the operator looping on the same message."""
-    said = run(tmp_path, "ID=alpine\n", "--config", "tests/fixtures/vm-luks.toml",
-               path=only_python(tmp_path))
+    said = output(
+        run(
+            tmp_path,
+            "ID=alpine\n",
+            "--config",
+            "tests/fixtures/vm-luks.toml",
+            path=only_python(tmp_path),
+        )
+    )
     assert "apk add" in said
     for named in ("lsblk", "findmnt", "blkid"):
         assert named in said, named
@@ -239,8 +257,15 @@ def test_no_distribution_is_told_to_install_a_package_named_chroot(tmp_path: Pat
     """`chroot` and `hostid` are coreutils everywhere; no distribution ships a
     package under either name."""
     for release in ("ID=alpine\n", "ID=arch\n", "ID=fedora\n", "ID=debian\n"):
-        said = run(tmp_path, release, "--config", "tests/fixtures/vm-zfs.toml",
-                   path=only_python(tmp_path))
+        said = output(
+            run(
+                tmp_path,
+                release,
+                "--config",
+                "tests/fixtures/vm-zfs.toml",
+                path=only_python(tmp_path),
+            )
+        )
         # The install line only: the line above it lists the missing commands,
         # where the word `chroot` belongs.
         line = next(one for one in said.splitlines() if one.startswith("run: "))
@@ -313,13 +338,13 @@ def test_arch_is_told_what_it_cannot_supply_instead_of_a_failing_command(
     names every missing command. The zfs pair has no official package, so the
     line for them says so rather than putting them in a `pacman` command that
     answers `target not found`."""
-    said = run(
+    said = output(run(
         tmp_path,
         "ID=arch\n",
         "--config",
         "tests/fixtures/vm-zfs.toml",
         path=only_python(tmp_path),
-    )
+    ))
     assert "missing commands:" in said
     assert "this system has no package for:" in said
     for command in ("zpool", "zfs"):

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -35,12 +35,44 @@ def test_a_dry_run_prints_every_stage_and_exits_clean(capsys: pytest.CaptureFixt
     assert "operations:" in printed.splitlines()[-1]
 
 
-def test_a_dry_run_touches_nothing(capsys: pytest.CaptureFixture[str]) -> None:
-    """The only proof available at this layer: no operation was applied, and the
-    text names devices by id rather than by a path it went looking for."""
+def test_a_dry_run_touches_nothing(monkeypatch: pytest.MonkeyPatch) -> None:
+    """The preview never invokes an operation's executor."""
+    from collections.abc import Callable
+    from dataclasses import dataclass
+
+    from gentoo_install.plan.operations import Context, Operation, Stage
+
+    executed: list[Context] = []
+
+    @dataclass(frozen=True, kw_only=True)
+    class RecordingOperation(Operation):
+        stage: Stage = Stage.PARTITION
+        executor: Callable[[Context], None]
+
+        def describe(self) -> str:
+            return "record execution"
+
+        def apply(self, context: Context) -> None:
+            self.executor(context)
+
+    operation = RecordingOperation(executor=executed.append)
+    monkeypatch.setattr(
+        cli,
+        "build",
+        lambda chosen, catalog, *, mirror, storage_facts, layout: (operation,),
+    )
+    code = main(["--config", str(FIXTURES / "ext4-bios.toml"), "--dry-run"])
+    assert code == EXIT_OK
+    assert executed == []
+
+
+def test_a_dry_run_names_devices_by_id_rather_than_by_path(
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """A separate property from applying nothing: the preview must not have
+    gone looking for a node under `/dev` to print."""
     main(["--config", str(FIXTURES / "ext4-bios.toml"), "--dry-run"])
-    printed = capsys.readouterr().out
-    assert "/dev/" not in printed
+    assert "/dev/" not in capsys.readouterr().out
 
 
 def test_a_missing_file_is_a_configuration_error(capsys: pytest.CaptureFixture[str]) -> None:

--- a/tests/unit/test_layers.py
+++ b/tests/unit/test_layers.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 
 import ast
 import re
+from collections.abc import Mapping
 from pathlib import Path
 from typing import Final
 
@@ -22,6 +23,39 @@ _READERS = frozenset({"read_text", "read_bytes", "write_text", "write_bytes", "o
 
 def _modules(layer: str) -> list[Path]:
     return sorted(one for one in (PACKAGE / layer).rglob("*.py") if one.is_file())
+
+
+def _imports(tree: ast.AST) -> set[str]:
+    """Return the modules named by ordinary and from-import statements."""
+    imported: set[str] = set()
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Import):
+            imported.update(alias.name for alias in node.names)
+        elif isinstance(node, ast.ImportFrom):
+            prefix = "." * node.level
+            if node.level == 0 and node.module == "gentoo_install":
+                imported.update(f"{node.module}.{alias.name}" for alias in node.names)
+            elif node.module is not None:
+                imported.add(prefix + node.module)
+            else:
+                imported.update(prefix + alias.name for alias in node.names)
+    return imported
+
+
+def _imports_module(imported: str, module: str) -> bool:
+    return imported == module or imported.startswith(f"{module}.")
+
+
+def test_import_scan_handles_import_and_from_import() -> None:
+    """`from subprocess import run` bypassed the Import-only command boundary."""
+    assert _imports(ast.parse("import subprocess")) == {"subprocess"}
+    assert _imports(ast.parse("from subprocess import run")) == {"subprocess"}
+
+
+def test_import_scan_handles_relative_and_package_imports() -> None:
+    """Both spellings can cross a layer boundary."""
+    tree = ast.parse("from ..exec import Machine\nfrom gentoo_install import tui")
+    assert _imports(tree) == {"..exec", "gentoo_install.tui"}
 
 
 def _calls(tree: ast.AST) -> list[tuple[str, int]]:
@@ -52,14 +86,11 @@ def test_the_model_layer_runs_no_command() -> None:
     """`exec/runner.py` is the only module allowed to import subprocess."""
     for layer in ("model", "plan"):
         for module in _modules(layer):
-            tree = ast.parse(module.read_text())
-            imported = {
-                alias.name
-                for node in ast.walk(tree)
-                if isinstance(node, ast.Import)
-                for alias in node.names
-            }
-            assert "subprocess" not in imported, module
+            imported = _imports(ast.parse(module.read_text()))
+            offenders = sorted(
+                name for name in imported if _imports_module(name, "subprocess")
+            )
+            assert not offenders, f"{module}: imports {offenders}"
 
 
 def test_the_model_layer_imports_nothing_below_it() -> None:
@@ -68,10 +99,15 @@ def test_the_model_layer_imports_nothing_below_it() -> None:
     forbidden = {"model": ("plan", "exec", "tui"), "plan": ("exec", "tui")}
     for layer, below in forbidden.items():
         for module in _modules(layer):
-            source = module.read_text()
+            imported = _imports(ast.parse(module.read_text()))
             for other in below:
-                assert f"from ..{other}" not in source, f"{module}: imports {other}"
-                assert f"from gentoo_install.{other}" not in source, f"{module}: {other}"
+                forbidden_modules = (f"..{other}", f"gentoo_install.{other}")
+                offenders = sorted(
+                    name
+                    for name in imported
+                    if any(_imports_module(name, forbidden) for forbidden in forbidden_modules)
+                )
+                assert not offenders, f"{module}: imports {offenders}"
 
 
 def test_no_suppression_hides_a_finding() -> None:
@@ -132,43 +168,118 @@ def test_every_source_file_states_the_licence() -> None:
     assert any(one.suffix == ".sh" for one in read), read[:5]
 
 
+Reference = tuple[Path, int, int]
+ReferenceGraph = dict[str, list[Reference]]
+
+
+def _import_aliases(tree: ast.AST) -> dict[str, str]:
+    aliases: dict[str, str] = {}
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.ImportFrom):
+            continue
+        for alias in node.names:
+            if alias.asname is not None:
+                aliases[alias.asname] = alias.name
+    return aliases
+
+
+def _reference_graph(trees: Mapping[Path, ast.AST]) -> ReferenceGraph:
+    """Map every loaded name and attribute to its source location."""
+    graph: ReferenceGraph = {}
+    for path, tree in trees.items():
+        aliases = _import_aliases(tree)
+        for node in ast.walk(tree):
+            if isinstance(node, ast.Name) and isinstance(node.ctx, ast.Load):
+                name = aliases.get(node.id, node.id)
+            elif isinstance(node, ast.Attribute) and isinstance(node.ctx, ast.Load):
+                name = node.attr
+            else:
+                continue
+            assert node.end_lineno is not None
+            graph.setdefault(name, []).append((path, node.lineno, node.end_lineno))
+    return graph
+
+
+def _defined_names(tree: ast.Module) -> list[tuple[ast.stmt, str]]:
+    definitions: list[tuple[ast.stmt, str]] = []
+    for node in tree.body:
+        if isinstance(node, (ast.FunctionDef, ast.ClassDef)):
+            definitions.append((node, node.name))
+        elif isinstance(node, ast.AnnAssign) and isinstance(node.target, ast.Name):
+            definitions.append((node, node.target.id))
+        elif isinstance(node, ast.Assign):
+            definitions.extend(
+                (node, target.id) for target in node.targets if isinstance(target, ast.Name)
+            )
+    return definitions
+
+
+def _referenced_outside(
+    name: str, path: Path, definition: ast.stmt, graph: ReferenceGraph
+) -> bool:
+    end_line = definition.end_lineno
+    assert end_line is not None
+    for reference_path, line, reference_end in graph.get(name, []):
+        inside_definition = (
+            reference_path == path
+            and definition.lineno <= line
+            and reference_end <= end_line
+        )
+        if not inside_definition:
+            return True
+    return False
+
+
+def test_reference_graph_ignores_comments_and_strings() -> None:
+    """A name in prose is not a reachable definition."""
+    declaring = Path("declaring.py")
+    definition_tree = ast.parse("class Forgotten:\n    pass\n")
+    definition = definition_tree.body[0]
+    assert isinstance(definition, ast.ClassDef)
+    graph = _reference_graph(
+        {
+            declaring: definition_tree,
+            Path("commentary.py"): ast.parse('# Forgotten\nmessage = "Forgotten"\n'),
+        }
+    )
+    assert not _referenced_outside("Forgotten", declaring, definition, graph)
+    graph = _reference_graph(
+        {
+            declaring: definition_tree,
+            Path("consumer.py"): ast.parse("Forgotten()"),
+        }
+    )
+    assert _referenced_outside("Forgotten", declaring, definition, graph)
+    alias_graph = _reference_graph(
+        {
+            declaring: definition_tree,
+            Path("consumer.py"): ast.parse(
+                "from declaring import Forgotten as remembered\nremembered()"
+            ),
+        }
+    )
+    assert _referenced_outside("Forgotten", declaring, definition, alias_graph)
+
+
 def test_no_definition_in_the_package_is_unreachable() -> None:
     """A rebase left `RemoveUnbootableKernels` and its five helpers in the tree
     after the operation it replaced them with had landed: the class was there,
     nothing built it, and nothing tested it."""
-    import ast
-    import re
-
     root = Path(__file__).resolve().parents[2]
-    everything = "\n".join(
-        path.read_text()
+    source_paths = [
+        path
         for where in ("gentoo_install", "tests")
         for path in sorted((root / where).rglob("*.py"))
-    )
+    ]
+    trees = {path: ast.parse(path.read_text()) for path in source_paths}
+    graph = _reference_graph(trees)
     orphans: list[str] = []
     for path in sorted((root / "gentoo_install").rglob("*.py")):
-        lines = path.read_text().splitlines()
-        for node in ast.parse(path.read_text()).body:
-            named: list[str] = []
-            if isinstance(node, (ast.FunctionDef, ast.ClassDef)):
-                named = [node.name]
-            elif isinstance(node, ast.AnnAssign) and isinstance(node.target, ast.Name):
-                named = [node.target.id]
-            elif isinstance(node, ast.Assign):
-                named = [one.id for one in node.targets if isinstance(one, ast.Name)]
-            # The definition's own text is not a reference to it: a recursive
-            # helper names itself, so counting the whole tree accepted one that
-            # nothing calls.
-            own = "\n".join(lines[node.lineno - 1 : node.end_lineno])
-            for name in named:
-                if name.startswith("__"):
-                    continue
-                pattern = rf"\b{re.escape(name)}\b"
-                outside = len(re.findall(pattern, everything)) - len(
-                    re.findall(pattern, own)
-                )
-                if outside == 0:
-                    orphans.append(f"{path.relative_to(root)}:{node.lineno} {name}")
+        for node, name in _defined_names(trees[path]):
+            if name.startswith("__"):
+                continue
+            if not _referenced_outside(name, path, node, graph):
+                orphans.append(f"{path.relative_to(root)}:{node.lineno} {name}")
     assert orphans == [], orphans
 
 

--- a/tests/unit/test_proxy.py
+++ b/tests/unit/test_proxy.py
@@ -93,7 +93,13 @@ def test_socks_scheme_controls_local_name_resolution(
     fetch._socks_connect(ProxyConfig(kind=ProxyKind.SOCKS5, host="proxy.example", port=1080), "internal.example", 80, 3.0)
 
     request = sent[-1]
-    assert request[3] == 3
+    assert request[:4] == b"\x05\x01\x00\x03"
+    host_end = 5 + request[4]
+    host = request[5:host_end].decode("ascii")
+    port = request[host_end:]
+    assert host == "internal.example"
+    assert len(port) == 2
+    assert int.from_bytes(port, "big") == 80
 
 
 def test_runner_redacts_proxy_credentials_in_dry_run_and_result_command() -> None:


### PR DESCRIPTION
Each of these passed on a case that breaks the contract it is named for, verified by breaking the code and reading the exit status.

The layer boundary walked only `ast.Import`, so `from subprocess import run` in `plan/portage.py` left it green. The dry-run check grepped the printed text for `/dev/`, so an operation that ran silently passed. The bootstrap double returned stdout and stderr only, so a launcher that printed the right thing and exited non-zero passed. The SOCKS5 check read the address-type byte, so the host, the port and the encoding were all free to be wrong.