### PR TITLE
run: make the target size and the resolver command-line options

### DIFF
--- a/tests/unit/test_harness.py
+++ b/tests/unit/test_harness.py
@@ -2576,13 +2576,13 @@ def test_create_target_refuses_a_path_outside_the_run_directories(tmp_path: Path
     after the unlink is caught too late."""
     import pytest
 
-    from tests.vm.run import WORKROOT, create_target
+    from tests.vm.run import DEFAULT_TARGET_SIZE, WORKROOT, create_target
 
     keep = tmp_path / "debian-12-genericcloud-amd64.qcow2"
     keep.write_bytes(b"not really an image, but it stands for one")
 
     with pytest.raises(ValueError, match="deletes what it is given"):
-        create_target(keep)
+        create_target(keep, DEFAULT_TARGET_SIZE)
     assert keep.exists(), "the refusal has to come before the unlink"
     assert keep.read_bytes().startswith(b"not really"), "and leave it untouched"
 
@@ -2591,11 +2591,114 @@ def test_create_target_refuses_a_path_outside_the_run_directories(tmp_path: Path
     inside = WORKROOT / "unit-test-create-target" / "target.qcow2"
     inside.parent.mkdir(parents=True, exist_ok=True)
     try:
-        made = create_target(inside)
+        made = create_target(inside, DEFAULT_TARGET_SIZE)
         assert made.exists() and made.stat().st_size > 0
     finally:
         inside.unlink(missing_ok=True)
         inside.parent.rmdir()
+
+
+@pytest.mark.parametrize("seed", [(), ("mklabel", "msdos")])
+def test_requested_target_size_reaches_disk_creation(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, seed: tuple[str, ...]
+) -> None:
+    """A fixture larger than the former fixed size must reach qemu-img."""
+    from tests.vm import run as runner
+
+    launched: list[list[str]] = []
+
+    def records(command: list[str], **named: object) -> object:
+        launched.append(command)
+        return object()
+
+    monkeypatch.setattr(runner, "WORKROOT", tmp_path)
+    monkeypatch.setattr("tests.vm.run.subprocess.run", records)
+    target = tmp_path / ("seeded" if seed else "blank") / "target.qcow2"
+    target.parent.mkdir()
+
+    runner.create_target(target, "96G", seed)
+
+    creation = next(command for command in launched if command[:2] == ["qemu-img", "create"])
+    assert creation[-1] == "96G"
+
+
+def test_local_runner_options_preserve_defaults_and_accept_none(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """`--resolver` without an address is an explicit request to keep the medium."""
+    from tests.vm import run as runner
+
+    captured: list[object] = []
+    medium = SimpleNamespace(name="test", source_stamp=lambda: "test-medium")
+
+    def capture(args: object, received_medium: object, workdir: Path) -> int:
+        captured.append(args)
+        return 0
+
+    monkeypatch.setattr(runner, "MEDIA", {"test": medium})
+    monkeypatch.setattr(runner, "WORKROOT", tmp_path)
+    monkeypatch.setattr(runner, "_revision", lambda: "test-revision")
+    monkeypatch.setattr(runner, "_perform", capture)
+
+    assert runner.main(["--medium", "test"]) == 0
+    assert cast(Any, captured[0]).target_size == runner.DEFAULT_TARGET_SIZE
+    assert cast(Any, captured[0]).resolver == runner.DEFAULT_RESOLVERS
+
+    assert runner.main(
+        ["--medium", "test", "--target-size", "96G", "--resolver", "10.0.2.2"]
+    ) == 0
+    assert cast(Any, captured[1]).target_size == "96G"
+    assert cast(Any, captured[1]).resolver == ["10.0.2.2"]
+
+    assert runner.main(["--medium", "test", "--resolver"]) == 0
+    assert cast(Any, captured[2]).resolver == []
+
+
+def test_requested_resolver_replaces_the_medium_and_none_leaves_it_alone() -> None:
+    """A local mirror can run without either public nameserver."""
+    from tests.vm import run as runner
+    from tests.vm.console import SerialConsole
+
+    class Recording:
+        def __init__(self) -> None:
+            self.commands: list[str] = []
+
+        def run(self, command: str, timeout: float = 120.0) -> None:
+            self.commands.append(command)
+
+    requested = Recording()
+    runner.pin_resolver(cast(SerialConsole, requested), ("10.0.2.2",))
+    assert requested.commands == [
+        "printf %s 'nameserver 10.0.2.2\n' > /etc/resolv.conf"
+    ]
+
+    unchanged = Recording()
+    runner.pin_resolver(cast(SerialConsole, unchanged), ())
+    assert unchanged.commands == []
+
+
+def test_runner_records_the_size_and_effective_resolver() -> None:
+    """The result has enough runner inputs to replay an installation."""
+    from tests.vm import run as runner
+    from tests.vm.console import SerialConsole
+
+    class Recording:
+        def __init__(self) -> None:
+            self.commands: list[str] = []
+
+        def run(self, command: str, timeout: float = 120.0) -> None:
+            self.commands.append(command)
+
+    console = Recording()
+    runner.record_run_options(cast(SerialConsole, console), "96G", ("10.0.2.2",))
+    assert console.commands[0] == f"mkdir -p {runner.RESULT_DIR}"
+    assert "target_size=96G" in console.commands[1]
+    assert "requested_resolver=10.0.2.2" in console.commands[1]
+    assert "cat /etc/resolv.conf" in console.commands[1]
+
+    medium = Recording()
+    runner.record_run_options(cast(SerialConsole, medium), "96G", ())
+    assert "requested_resolver=medium" in medium.commands[1]
 
 
 def test_a_failed_remote_unlock_answers_rather_than_raising(

--- a/tests/vm/run.py
+++ b/tests/vm/run.py
@@ -49,7 +49,12 @@ from .installed import checks, stage_passphrase_commands
 
 WORKROOT = Path.home() / "code/gentoo-install/lab/vm/runs"
 #: Big enough for a stage3, a desktop and the swap a fixture may ask for.
-TARGET_SIZE = "40G"
+DEFAULT_TARGET_SIZE = "40G"
+#: Slirp reads the host's `/etc/resolv.conf` once at startup, so a host that
+#: changes resolver mid-run strands an install that is half an hour in with
+#: `Temporary failure in name resolution`. Pinning one is what avoids that;
+#: `--resolver` with no address leaves the medium's own alone instead.
+DEFAULT_RESOLVERS: Final[tuple[str, ...]] = ("1.1.1.1", "8.8.8.8")
 
 #: The password in `fixtures/vm-binpkg.toml`, as plain text. It exists so the
 #: harness can log into what it installed; nothing else uses it.
@@ -148,7 +153,9 @@ SEEDED: dict[str, tuple[str, ...]] = {
 }
 
 
-def create_target(path: Path, seed: tuple[str, ...] = ()) -> Path:
+def create_target(
+    path: Path, size: str = DEFAULT_TARGET_SIZE, seed: tuple[str, ...] = ()
+) -> Path:
     """A disk for the installer to partition, thrown away with the run.
 
     Seeded through a raw image and converted: `parted` writes to a file, and
@@ -164,7 +171,7 @@ def create_target(path: Path, seed: tuple[str, ...] = ()) -> Path:
     path.unlink(missing_ok=True)
     if not seed:
         subprocess.run(
-            ["qemu-img", "create", "-f", "qcow2", str(path), TARGET_SIZE],
+            ["qemu-img", "create", "-f", "qcow2", str(path), size],
             check=True,
             capture_output=True,
         )
@@ -172,7 +179,7 @@ def create_target(path: Path, seed: tuple[str, ...] = ()) -> Path:
     raw = path.with_suffix(".raw")
     raw.unlink(missing_ok=True)
     subprocess.run(
-        ["qemu-img", "create", "-f", "raw", str(raw), TARGET_SIZE],
+        ["qemu-img", "create", "-f", "raw", str(raw), size],
         check=True,
         capture_output=True,
     )
@@ -368,7 +375,7 @@ def remote_config(installation: InstallConfig, public_key: str) -> InstallConfig
     )
 
 
-def reach_shell(console: SerialConsole, medium: Medium) -> None:
+def reach_shell(console: SerialConsole, medium: Medium, resolvers: Sequence[str]) -> None:
     if medium.login_user is None:
         console.expect(medium.root_prompt, timeout=300.0)
     else:
@@ -376,7 +383,7 @@ def reach_shell(console: SerialConsole, medium: Medium) -> None:
     if medium.become_root:
         console.send(medium.become_root)
         console.expect(r"root@", timeout=60.0)
-    pin_resolver(console)
+    pin_resolver(console, resolvers)
     for command in medium.prepare:
         # `bootstrap.sh` prints the package manager line and stops rather than
         # running it, which is what an operator wants and what left every
@@ -384,14 +391,24 @@ def reach_shell(console: SerialConsole, medium: Medium) -> None:
         console.run(command, timeout=600.0)
 
 
-def pin_resolver(console: SerialConsole) -> None:
-    """Point the guest at a fixed resolver rather than at qemu's forwarder.
+def pin_resolver(console: SerialConsole, resolvers: Sequence[str]) -> None:
+    """Use requested nameservers, or keep the install medium's configuration."""
+    if resolvers:
+        contents = "".join(f"nameserver {resolver}\n" for resolver in resolvers)
+        console.run(f"printf %s {shlex.quote(contents)} > /etc/resolv.conf")
 
-    Slirp reads the host's `/etc/resolv.conf` once at startup, so a host that
-    changes resolver mid-run strands an install that is half an hour in with
-    `Temporary failure in name resolution`.
-    """
-    console.run("printf 'nameserver 1.1.1.1\\nnameserver 8.8.8.8\\n' > /etc/resolv.conf")
+
+def record_run_options(console: SerialConsole, target_size: str, resolvers: Sequence[str]) -> None:
+    """Save the selected inputs and effective resolver for result replay."""
+    selected = "".join(f"requested_resolver={resolver}\n" for resolver in resolvers)
+    if not selected:
+        selected = "requested_resolver=medium\n"
+    contents = f"target_size={target_size}\n{selected}resolv.conf:\n"
+    console.run(f"mkdir -p {RESULT_DIR}")
+    console.run(
+        f"{{ printf %s {shlex.quote(contents)}; cat /etc/resolv.conf; }} "
+        f"> {RESULT_DIR}/runner.txt"
+    )
 
 
 
@@ -569,6 +586,19 @@ def main(argv: list[str] | None = None) -> int:
     parser.add_argument("--medium", choices=sorted(MEDIA), default="official-minimal")
     parser.add_argument("--firmware", choices=[f.value for f in Firmware], default="uefi")
     parser.add_argument(
+        "--target-size",
+        default=DEFAULT_TARGET_SIZE,
+        metavar="SIZE",
+        help="size passed to qemu-img for each target disk",
+    )
+    parser.add_argument(
+        "--resolver",
+        nargs="*",
+        default=DEFAULT_RESOLVERS,
+        metavar="ADDRESS",
+        help="nameservers written to the medium; pass without ADDRESS to preserve its resolver",
+    )
+    parser.add_argument(
         "--ssh-port",
         type=int,
         default=0,
@@ -687,7 +717,7 @@ def _perform(args: argparse.Namespace, medium: Medium, workdir: Path) -> int:
             targets = wanted
         else:
             seed = SEEDED.get(Path(args.install).stem if args.install else "", ())
-            targets = tuple(create_target(path, seed) for path in wanted)
+            targets = tuple(create_target(path, args.target_size, seed) for path in wanted)
 
     spec = VmSpec(
         medium=medium,
@@ -741,7 +771,9 @@ def _perform(args: argparse.Namespace, medium: Medium, workdir: Path) -> int:
                     # keeps its disk: that is the only copy of what went wrong.
                     _discard(targets, keep=args.keep)
                 return code
-            reach_shell(console, medium)
+            resolvers = tuple(args.resolver)
+            reach_shell(console, medium, resolvers)
+            record_run_options(console, args.target_size, resolvers)
             print(f"[{time.monotonic() - started:5.1f}s] root shell on serial")
 
             install_key(console, key.with_suffix(".pub").read_text().strip())


### PR DESCRIPTION
A layout larger than 40 GiB could not be expressed by the local runner at all, and every guest had `/etc/resolv.conf` overwritten with `1.1.1.1` and `8.8.8.8` whatever the fixture needed, so a public resolver policy or an isolated network turned into a reported installer failure.

Both are now options with the measured values as defaults, `--resolver` with no address leaves the medium alone, and the values used are recorded in the run so a later campaign can be reproduced. The reason the default exists — slirp reads the host resolver once at startup — stays beside it.