### PR TITLE
packages: declare the flags flclash and plasma-meta require

### DIFF
--- a/gentoo_install/data/packages/flclash.toml
+++ b/gentoo_install/data/packages/flclash.toml
@@ -3,3 +3,6 @@
 # packages the prebuilt one.
 packages = ["net-proxy/flclash-bin"]
 repositories = ["gentoo-zh"]
+# `libayatana-appindicator` needs libdbusmenu's `gtk3`, which is off by
+# default, so `emerge --pretend` rejected every package the run asked for.
+package_use = ["dev-libs/libdbusmenu gtk3"]

--- a/gentoo_install/data/profiles/base/plasma.toml
+++ b/gentoo_install/data/profiles/base/plasma.toml
@@ -1,12 +1,16 @@
 use = ["wayland", "qt6", "networkmanager"]
-# `kcm` is a local flag of `app-i18n/fcitx-configtool`, and its `kcm?` block
-# pulls nine kde-frameworks packages plus libplasma. Declared by the desktop
-# that already has them rather than by the fcitx5 group, which would install
-# Plasma alongside GNOME. Harmless when fcitx5 is not chosen: the line names a
-# package that is not merged.
 package_use = [
+    # `kcm` is a local flag of `app-i18n/fcitx-configtool`, and its `kcm?` block
+    # pulls nine kde-frameworks packages plus libplasma. Declared by the desktop
+    # that already has them rather than by the fcitx5 group, which would install
+    # Plasma alongside GNOME. Harmless when fcitx5 is not chosen: the line names
+    # a package that is not merged.
     "app-i18n/fcitx-configtool kcm",
     "sys-libs/minizip-ng compat",
+    # `plasma-meta` requires `kwin[lock]` and, through its `X` flag,
+    # `kwin-x11[lock]`; neither is on by default in the desktop/plasma profile.
+    "kde-plasma/kwin lock",
+    "kde-plasma/kwin-x11 lock",
 ]
 wayland = true
 profile = "default/linux/amd64/23.0/desktop/plasma"

--- a/tests/golden/btrfs-luks.txt
+++ b/tests/golden/btrfs-luks.txt
@@ -50,8 +50,9 @@
   accept the linux-firmware licence
   accept sys-kernel/gentoo-cjk-kernel-bin as testing, with cjk off
   unmask virtual/dist-kernel, which the cjk kernel depends on by revision
-  ask for app-i18n/fcitx-configtool kcm; sys-libs/minizip-ng compat for the plasma group
+  ask for app-i18n/fcitx-configtool kcm; sys-libs/minizip-ng compat; kde-plasma/kwin lock; kde-plasma/kwin-x11 lock for the plasma group
   ask for app-i18n/rime-data extra for the rime-simplified group
+  ask for dev-libs/libdbusmenu gtk3 for the flclash group
   resolve app-admin/sudo net-misc/openssh sys-process/cronie sys-kernel/installkernel sys-apps/systemd sys-kernel/dracut sys-kernel/linux-firmware sys-fs/cryptsetup sys-fs/btrfs-progs sys-fs/dosfstools sys-kernel/gentoo-cjk-kernel-bin sys-boot/grub sys-boot/efibootmgr kde-plasma/plasma-meta x11-base/xorg-server kde-apps/konsole kde-apps/dolphin app-i18n/fcitx app-i18n/fcitx-gtk app-i18n/fcitx-qt app-i18n/fcitx-configtool app-i18n/fcitx-rime app-i18n/rime-data media-fonts/noto-cjk media-fonts/noto media-libs/fontconfig net-proxy/flclash-bin together before installing the requested packages
 
 [system]

--- a/tests/golden/vm-desktop.txt
+++ b/tests/golden/vm-desktop.txt
@@ -34,7 +34,7 @@
   sync repository gentoo
   set sys-kernel/installkernel to dracut
   accept the linux-firmware licence
-  ask for app-i18n/fcitx-configtool kcm; sys-libs/minizip-ng compat for the plasma group
+  ask for app-i18n/fcitx-configtool kcm; sys-libs/minizip-ng compat; kde-plasma/kwin lock; kde-plasma/kwin-x11 lock for the plasma group
   ask for app-i18n/rime-data extra for the rime-simplified group
   ask for media-video/pipewire sound-server for the pipewire group
   resolve net-misc/openssh net-misc/networkmanager net-wireless/wpa_supplicant sys-process/cronie sys-kernel/installkernel sys-kernel/dracut sys-kernel/linux-firmware sys-fs/dosfstools sys-fs/e2fsprogs sys-kernel/gentoo-kernel-bin sys-boot/grub sys-boot/efibootmgr kde-plasma/plasma-meta x11-base/xorg-server kde-apps/konsole kde-apps/dolphin app-i18n/fcitx app-i18n/fcitx-gtk app-i18n/fcitx-qt app-i18n/fcitx-configtool app-i18n/fcitx-rime app-i18n/rime-data media-fonts/noto-cjk media-fonts/noto media-libs/fontconfig media-video/pipewire media-video/wireplumber together before installing the requested packages

--- a/tests/unit/test_packages.py
+++ b/tests/unit/test_packages.py
@@ -154,6 +154,8 @@ def test_desktop_profiles_preserve_their_composed_values() -> None:
             package_use=(
                 "app-i18n/fcitx-configtool kcm",
                 "sys-libs/minizip-ng compat",
+                "kde-plasma/kwin lock",
+                "kde-plasma/kwin-x11 lock",
             ),
             input_method_launcher=(
                 "/usr/share/applications/fcitx5-wayland-launcher.desktop"
@@ -172,6 +174,8 @@ def test_desktop_profiles_preserve_their_composed_values() -> None:
             package_use=(
                 "app-i18n/fcitx-configtool kcm",
                 "sys-libs/minizip-ng compat",
+                "kde-plasma/kwin lock",
+                "kde-plasma/kwin-x11 lock",
             ),
             input_method_launcher=(
                 "/usr/share/applications/fcitx5-wayland-launcher.desktop"
@@ -232,6 +236,38 @@ def test_xfce_declares_the_dbusmenu_flag_its_panel_requires() -> None:
     catalog = load_catalog()
 
     assert "dev-libs/libdbusmenu gtk3" in catalog["xfce"].package_use
+
+
+def test_flclash_declares_the_dbusmenu_flag_its_indicator_requires() -> None:
+    """A second group needs the same flag for a different reason, so it is
+    declared twice rather than once somewhere neither group names.
+    `run59/btrfs-luks.log`, `emerge --pretend` at operation 20:
+
+        # required by dev-libs/libayatana-appindicator-0.5.94::gentoo
+        # required by net-proxy/flclash-bin-0.8.95::gentoo-zh
+        # required by net-proxy/flclash-bin (argument)
+        >=dev-libs/libdbusmenu-16.04.0-r4 gtk3
+    """
+    catalog = load_catalog()
+
+    assert "dev-libs/libdbusmenu gtk3" in catalog["flclash"].package_use
+
+
+def test_plasma_declares_the_screen_lock_its_session_requires() -> None:
+    """From the same run:
+
+        # required by kde-plasma/plasma-meta-6.6.6::gentoo
+        >=kde-plasma/kwin-6.6.6 lock
+        # required by kde-plasma/plasma-meta-6.6.6::gentoo[X]
+        >=kde-plasma/kwin-x11-6.6.6 lock
+
+    Both variants need it, so it belongs to the base rather than to either.
+    """
+    catalog = load_catalog()
+
+    for profile in ("plasma", "plasma-full"):
+        assert "kde-plasma/kwin lock" in catalog[profile].package_use, profile
+        assert "kde-plasma/kwin-x11 lock" in catalog[profile].package_use, profile
 
 
 def test_ibus_has_declared_chinese_engines() -> None:


### PR DESCRIPTION
Read off `run59/btrfs-luks.log`, 103 minutes in, where `emerge --pretend` rejected every package the run had asked for:

    # required by dev-libs/libayatana-appindicator-0.5.94::gentoo
    # required by net-proxy/flclash-bin-0.8.95::gentoo-zh
    >=dev-libs/libdbusmenu-16.04.0-r4 gtk3
    # required by kde-plasma/plasma-meta-6.6.6::gentoo
    >=kde-plasma/kwin-6.6.6 lock
    # required by kde-plasma/plasma-meta-6.6.6::gentoo[X]
    >=kde-plasma/kwin-x11-6.6.6 lock

`flclash` needs libdbusmenu for a different reason than `xfce` does, so it declares it itself; the kwin pair belongs to the Plasma base both variants read.