### PR TITLE
driver: find the driver CD rather than numbering it

### DIFF
--- a/tests/unit/test_harness.py
+++ b/tests/unit/test_harness.py
@@ -2765,3 +2765,83 @@ def test_a_zfsbootmenu_unlock_fixture_checks_the_image_that_carries_the_daemon()
     elsewhere = load(Path("tests/fixtures/vm-unlock.toml"))
     assert elsewhere.kernel.remote_unlock.enabled
     assert "zbm unlock key" not in {one.name for one in checks(elsewhere)}
+
+
+def test_the_driver_cd_is_found_rather_than_numbered(tmp_path: Path) -> None:
+    """`/dev/sr1` was hardcoded in four places. It is the second CD only when
+    an install medium is booted: a guest booting from its own disk, which is
+    what an in-place conversion of a cloud image does, has the driver as
+    `/dev/sr0` and every one of those four mounts failed.
+
+    Run against a fake `mount` on PATH, the one-line form tries each candidate
+    in turn, stops at the first that succeeds, and answers with `mountpoint`
+    rather than with the last failed mount.
+    """
+    import subprocess
+
+    from tests.vm.driver import ENTRY, FIND_DRIVER, PACKED_ENTRY
+
+    assert "\n" not in FIND_DRIVER, "a console sends this as one command"
+    assert FIND_DRIVER in ENTRY and FIND_DRIVER in PACKED_ENTRY
+
+    fake = tmp_path / "bin"
+    fake.mkdir()
+    calls = tmp_path / "calls"
+    (fake / "mount").write_text(
+        "#!/bin/sh\n"
+        f'printf "%s\\n" "$*" >> {calls}\n'
+        'for one in "$@"; do case "$one" in /dev/sr0) exit 0;; esac; done\n'
+        "exit 32\n"
+    )
+    (fake / "mountpoint").write_text(
+        f'#!/bin/sh\n[ -f {tmp_path}/is-mounted ] && exit 0\nexit 1\n'
+    )
+    (fake / "mkdir").write_text("#!/bin/sh\nexit 0\n")
+    for one in fake.iterdir():
+        one.chmod(0o755)
+    environment = {"PATH": f"{fake}:/usr/bin:/bin"}
+
+    refused = subprocess.run(
+        ["sh", "-c", FIND_DRIVER], env=environment, capture_output=True, text=True
+    )
+    assert refused.returncode != 0, refused
+    assert calls.read_text().split("\n")[:2] == [
+        "-o ro /dev/sr1 /mnt/driver",
+        "-o ro /dev/sr0 /mnt/driver",
+    ], calls.read_text()
+
+    (tmp_path / "is-mounted").touch()
+    accepted = subprocess.run(
+        ["sh", "-c", FIND_DRIVER], env=environment, capture_output=True, text=True
+    )
+    assert accepted.returncode == 0, accepted
+
+
+def test_every_driver_mount_goes_through_the_one_finder() -> None:
+    """The denominator: no caller keeps its own device number, so fixing one
+    place fixed all of them."""
+    from tests.vm.driver import REPOSITORY
+
+    from tests.vm.driver import FIND_DRIVER
+
+    offenders: list[str] = []
+    read: list[str] = []
+    for name in ("run.py", "cluster.py", "campaign.py"):
+        path = REPOSITORY / "tests" / "vm" / name
+        read.append(name)
+        for number, line in enumerate(path.read_text().splitlines(), 1):
+            if "/dev/sr" in line and not line.lstrip().startswith("#"):
+                offenders.append(f"{name}:{number}: {line.strip()}")
+    assert read == ["run.py", "cluster.py", "campaign.py"], read
+    assert not offenders, offenders
+
+    # And the one place that does name devices is the finder itself, so the
+    # count above is zero because the callers use it rather than because the
+    # scan missed them.
+    source = (REPOSITORY / "tests" / "vm" / "driver.py").read_text()
+    naming = [
+        line for line in source.splitlines()
+        if "/dev/sr" in line and not line.lstrip().startswith("#")
+    ]
+    assert len(naming) == 1, naming
+    assert "/dev/sr1 /dev/sr0" in FIND_DRIVER

--- a/tests/vm/cluster.py
+++ b/tests/vm/cluster.py
@@ -72,7 +72,7 @@ from .console import (
     command_done,
     marked_command,
 )
-from .driver import build as build_driver, digest as driver_digest, remote_name
+from .driver import FIND_DRIVER, build as build_driver, digest as driver_digest, remote_name
 from .monitor import keys_for
 from .proxmox import (
     Api,
@@ -1545,8 +1545,7 @@ def install_one(
         # `Failed to connect to mirrors.tuna.tsinghua.edu.cn:443 after 111 ms`.
         wait_for_network(link, guest.vmid, held.address)
         stage_passphrases(link, load(job.fixture))
-        link.run("mkdir -p /mnt/driver")
-        link.run("mountpoint -q /mnt/driver || mount -o ro /dev/sr1 /mnt/driver")
+        link.run(FIND_DRIVER)
         link.run(f"mkdir -p {RESULT_DIR}")
         # tee, not a redirect: the serial console is the only way to watch a
         # run that takes half an hour, and it is what the watchdog reads to
@@ -2557,8 +2556,7 @@ def convert_and_check(
     """
     installation = load(fixture)
     wait_for_network(link, guest.vmid, address)
-    link.run("mkdir -p /mnt/driver")
-    link.run("mountpoint -q /mnt/driver || mount -o ro /dev/sr1 /mnt/driver")
+    link.run(FIND_DRIVER)
     link.run(f"mkdir -p {RESULT_DIR}")
     link.wait_for(
         f"{{ sh /mnt/driver/install.sh --config fixtures/{fixture.name}; "

--- a/tests/vm/driver.py
+++ b/tests/vm/driver.py
@@ -19,13 +19,22 @@ from .media import MediaError
 REPOSITORY = Path(__file__).resolve().parents[2]
 LABEL = "GENTOO-INSTALL"
 
-#: What the guest runs to put the installer on its PYTHONPATH. `/dev/sr1` is
-#: mounted read-only, so nothing is unpacked and nothing is written back.
-ENTRY = """#!/bin/sh
+#: How the guest finds the driver CD. It is the second one when an install
+#: medium is booted and the only one when a guest boots from its own disk.
+#: One line, because a caller sends it down a serial console as one command,
+#: and the exit status is `mountpoint`'s answer, not the last failed mount's.
+FIND_DRIVER = (
+    "mkdir -p /mnt/driver; mountpoint -q /mnt/driver || "
+    "for candidate in /dev/sr1 /dev/sr0; do "
+    'mount -o ro "$candidate" /mnt/driver 2>/dev/null && break; done; '
+    "mountpoint -q /mnt/driver"
+)
+
+#: What the guest runs to put the installer on its PYTHONPATH.
+ENTRY = f"""#!/bin/sh
 # Mount the driver CD and run the installer from it.
 set -e
-mkdir -p /mnt/driver
-mountpoint -q /mnt/driver || mount -o ro /dev/sr1 /mnt/driver
+{FIND_DRIVER}
 cd /mnt/driver
 # --no-shell: the harness drives a serial console, where stdin is a terminal,
 # and the offer of a root shell would sit there waiting for an answer.
@@ -43,8 +52,8 @@ UNPACKED = "/tmp/gentoo-install-driver"
 #: writes nothing there but Python still wants somewhere to put bytecode.
 PACKED_ENTRY = f"""#!/bin/sh
 set -e
-mkdir -p /mnt/driver {UNPACKED}
-mountpoint -q /mnt/driver || mount -o ro /dev/sr1 /mnt/driver
+mkdir -p {UNPACKED}
+{FIND_DRIVER}
 tar xzf /mnt/driver/{PAYLOAD} -C {UNPACKED}
 cd {UNPACKED}
 # Through the launcher, because that is the entry point an operator uses and

--- a/tests/vm/run.py
+++ b/tests/vm/run.py
@@ -41,7 +41,7 @@ from gentoo_install.model.manual import dataset_for
 
 from .console import DISK_PASSPHRASE, PASSPHRASE_PROMPT, PASSWORD_PROMPT, SerialConsole
 from .monitor import type_text
-from .driver import REPOSITORY, build as build_driver
+from .driver import FIND_DRIVER, REPOSITORY, build as build_driver
 from .media import MEDIA, Medium
 from .qemu import Firmware, Vm, VmSpec
 from .results import collect_command, create_disk, read_disk
@@ -491,8 +491,7 @@ def interrupt_and_resume(console: SerialConsole, config: str) -> None:
     that takes long enough to interrupt reliably, and everything before it is
     exactly the destructive part a resumed run must not repeat.
     """
-    console.run("mkdir -p /mnt/driver")
-    console.run("mountpoint -q /mnt/driver || mount -o ro /dev/sr1 /mnt/driver")
+    console.run(FIND_DRIVER)
     console.run(f"mkdir -p {RESULT_DIR}")
     # In the background, with a watcher that kills it once the log says the
     # partitioning is behind us. `pkill -f` on the module name: bootstrap.sh
@@ -526,8 +525,7 @@ def interrupt_and_resume(console: SerialConsole, config: str) -> None:
 
 def run_installer(console: SerialConsole, config: str, extra: str = "") -> None:
     """Run the installer from the driver CD and keep everything it printed."""
-    console.run("mkdir -p /mnt/driver")
-    console.run("mountpoint -q /mnt/driver || mount -o ro /dev/sr1 /mnt/driver")
+    console.run(FIND_DRIVER)
     console.run(f"mkdir -p {RESULT_DIR}")
     # tee, not a redirect: the serial console is the only way to watch a run
     # that takes half an hour, and a redirect makes it silent until it ends.


### PR DESCRIPTION
`/dev/sr1` was hardcoded in four places. It is the second CD only when an install medium is booted: a guest that boots from its own disk — which is what converting a cloud image in place does — has the driver as `/dev/sr0`, and every one of those mounts failed.

One constant now names both candidates, sent as a single line because a caller hands it to a serial console as one command. Verified against a fake `mount` on `PATH`: each candidate is tried in turn, the first success stops the loop, and the exit status is `mountpoint`'s answer rather than the last failed mount's.