### PR TITLE
tests: replace the last four weak contracts with behaviour

### DIFF
--- a/tests/unit/test_automatic.py
+++ b/tests/unit/test_automatic.py
@@ -26,7 +26,7 @@ from gentoo_install.model.config import (
 from gentoo_install.plan import automatic, bootloader as plan_bootloader, kernel as plan_kernel
 from gentoo_install.tui import screens
 from gentoo_install.tui.overview import overview_screen
-from gentoo_install.tui.widgets import Answer, Outcome
+from gentoo_install.tui.widgets import Answer, Outcome, Screen
 
 from .layouts import config, encrypted_root, ext4_on_gpt, zfs_root
 from .recorder import Recorder
@@ -381,30 +381,74 @@ def test_a_profile_only_change_offers_no_row_to_open() -> None:
     assert "VIDEO_CARDS" not in drawn, drawn
 
 
-def test_every_screen_that_picks_a_group_carrying_use_confirms_it() -> None:
-    """Four screens choose groups and three of them carried USE. `sddm`,
-    `pipewire` and `bluetooth` were each added silently, so the operator met
-    them in `make.conf` afterwards.
+def test_every_screen_that_picks_a_group_carrying_use_confirms_it(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A selected group writes its implied make.conf values only after the
+    confirmation shared by every group picker."""
+    from tests.unit.fake_screen import FakeScreen
+    from tests.unit.test_tui_app import context, down
 
-    Read from the catalog rather than listed here: a group given a USE flag
-    later has to fail this rather than slip through.
-    """
-    import inspect
+    calls: list[InstallConfig] = []
+    real_settle = screens.settle
 
+    def record_settle(
+        screen: Screen,
+        context_: screens.Context,
+        before: InstallConfig,
+        after: InstallConfig,
+        kept_display_manager: str = "",
+    ) -> Answer[InstallConfig]:
+        calls.append(after)
+        return real_settle(screen, context_, before, after, kept_display_manager)
+
+    monkeypatch.setattr(screens, "settle", record_settle)
+    with_desktop = config(ext4_on_gpt())
+    with_desktop = replace(
+        with_desktop,
+        packages=replace(with_desktop.packages, desktop="plasma"),
+    )
+    choices = (
+        (
+            "plasma",
+            screens.desktop_screen(
+                FakeScreen(keys=[*down(4), "\n", "\n"], lines=30),
+                config(ext4_on_gpt()),
+                context(),
+            ),
+        ),
+        (
+            "nvidia",
+            screens.graphics_screen(
+                FakeScreen(keys=[*down(4), " ", "\n", "\n"], lines=30),
+                config(ext4_on_gpt()),
+                context(),
+            ),
+        ),
+        (
+            "sddm",
+            screens.display_manager_screen(
+                FakeScreen(keys=["KEY_DOWN", "\n", "\n"], lines=30),
+                with_desktop,
+                context(),
+            ),
+        ),
+        (
+            "bluetooth",
+            screens.packages_screen(
+                FakeScreen(keys=["KEY_DOWN", " ", "\n", "\n"], lines=30),
+                config(ext4_on_gpt()),
+                context(),
+            ),
+        ),
+    )
+    assert len(calls) == len(choices)
     catalog = load_catalog()
-    carries = {name for name, group in catalog.items() if group.use or group.video_cards}
-    assert carries, "the catalog is meant to have groups that set make.conf"
-    picks = {
-        "desktop_screen": set(catalog),
-        "graphics_screen": {name for name, _ in screens.GRAPHICS if name},
-        "display_manager_screen": {name for name, _ in screens.DISPLAY_MANAGERS if name},
-        "packages_screen": set(catalog),
-    }
-    for name, chooses in picks.items():
-        if not (chooses & carries):
-            continue
-        source = inspect.getsource(getattr(screens, name))
-        assert "settle(" in source, f"{name} picks a group that sets make.conf and never asks"
+    for name, answer in choices:
+        assert answer.chosen
+        chosen = answer.unwrap()
+        assert set(catalog[name].use) <= set(chosen.portage.use)
+        assert set(catalog[name].video_cards) <= set(chosen.portage.video_cards)
 
 
 #: The Gentoo tree, when this machine has one. The group files are edited here,

--- a/tests/unit/test_cluster.py
+++ b/tests/unit/test_cluster.py
@@ -447,15 +447,64 @@ def test_the_address_does_not_depend_on_the_default_route_being_absent() -> None
     assert "addr add 10.31.0.150/24" in command
 
 
-def test_the_network_is_measured_once_more_after_the_install() -> None:
-    """A console that still has its routes when the installer saw none puts the
-    loss in the installer's view of the machine rather than in the machine."""
-    import inspect
+def test_the_network_is_measured_once_more_after_the_install(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """The post-install probe has to precede collection of the guest results."""
+    events: list[str] = []
 
-    code = inspect.getsource(cluster.install_one)
-    started = code.index("install.sh --config")
-    collected = code.index("files = collect(")
-    assert "REACHABILITY_PROBE" in code[started:collected]
+    class Guest:
+        vmid = 9301
+
+        def start(self) -> None:
+            return None
+
+        def reset(self) -> None:
+            return None
+
+        def destroy(self) -> None:
+            return None
+
+    class Link:
+        console = object()
+
+        def run(self, command: str, timeout: float = 0.0) -> None:
+            events.append(command)
+
+        def wait_for(
+            self, command: str, timeout: float, idle: float, watch: cluster.Watchdog
+        ) -> None:
+            events.append(command)
+
+    def collect(guest: object, link: object, log: Path) -> dict[str, bytes]:
+        events.append("collect")
+        return {"install.rc": b"1"}
+
+    guest = Guest()
+    log = tmp_path / "network.log"
+    job = cluster.Job("network", FIXTURES / "ext4-bios.toml")
+    held = cluster.Running(
+        guest=cast(Any, guest),
+        watch=cluster.Watchdog(log, lambda: 0),
+        reservation_bytes=0,
+        created=True,
+    )
+    link = Link()
+    monkeypatch.setattr(cluster.Reconnecting, "to", lambda guest, log: link)
+    monkeypatch.setattr(cluster, "reach_prompt", lambda link: None)
+    monkeypatch.setattr(cluster, "append_to_cmdline", lambda link, extra: None)
+    monkeypatch.setattr(cluster, "wait_for_network", lambda link, vmid, address: None)
+    monkeypatch.setattr(cluster, "stage_passphrases", lambda link, config: None)
+    monkeypatch.setattr(cluster, "collect", collect)
+    outcome = cluster.install_one(
+        cast(Api, object()), "node", job, "driver.iso", tmp_path, execution=held
+    )
+
+    installed = next(index for index, event in enumerate(events) if "install.sh --config" in event)
+    probes = [index for index, event in enumerate(events) if event == cluster.REACHABILITY_PROBE]
+    assert outcome.verdict is cluster.Verdict.FAIL
+    assert len(probes) == 2
+    assert probes[0] < installed < probes[1] < events.index("collect")
 
 
 def test_the_keeper_puts_the_address_back_and_counts_it() -> None:

--- a/tests/unit/test_compat.py
+++ b/tests/unit/test_compat.py
@@ -1,7 +1,6 @@
 # SPDX-License-Identifier: GPL-2.0-or-later
 from __future__ import annotations
 
-import re
 from dataclasses import replace
 from pathlib import PurePosixPath
 from typing import Callable
@@ -601,15 +600,28 @@ def test_formatting_a_partition_the_operator_kept_counts_as_destruction() -> Non
 
 
 def test_the_erase_row_and_the_in_use_check_read_the_same_rule() -> None:
-    """Two lists of destructive targets drift, and the one that drifted was the
-    preflight copy: it named the disk only when a table was written."""
-    import inspect
-
+    """Formatting a retained partition must block both the preflight and the
+    main-menu confirmation until the operator names it."""
     from gentoo_install.exec import preflight
     from gentoo_install.tui import settings
+    from tests.unit.test_tui_app import context
 
-    for source in (inspect.getsource(preflight._disks_at_risk), inspect.getsource(settings._erase)):
-        assert "compat.destroyed(" in source, source
+    installation = config(
+        [
+            Existing(id=i("part"), selector="/dev/sda2", wipe=False),
+            Filesystem(
+                id=i("fs"), device=i("part"), kind=FilesystemType.EXT4, create=True
+            ),
+            Mountpoint(id=i("root"), source=i("fs"), path=PurePosixPath("/")),
+        ]
+    )
+    assert [one.selector for one in preflight._disks_at_risk(installation.disk.graph)] == [
+        "/dev/sda2"
+    ]
+    at = context()
+    assert settings._erase(installation, at) == settings.UNSET
+    at.confirmed = {"/dev/sda2"}
+    assert settings._erase(installation, at) == at.translate("confirmed")
 
 
 def test_an_encrypted_boot_beside_a_plain_esp_is_a_working_layout() -> None:
@@ -807,19 +819,17 @@ def test_every_way_of_writing_over_a_kept_device_names_it(layout: str) -> None:
     assert [one.selector for one in named] == ["/dev/sda2"]
 
 
-def test_the_cases_cover_every_entry_in_the_write_table() -> None:
-    """An entry added to `_writes_over` without a layout here is one nothing
-    proves, and it reads as covered."""
-    import inspect
+def test_every_write_case_leaves_the_erase_row_unanswered() -> None:
+    """Each write over a retained partition needs an explicit confirmation."""
+    from gentoo_install.tui import settings
+    from tests.unit.test_tui_app import context
 
-    in_table = set(re.findall(r"isinstance\(node, \(?([\w, ]+)\)?\)", inspect.getsource(compat._writes_over)))
-    named = {one.strip() for group in in_table for one in group.split(",")}
-    exercised = {
-        type(node).__name__
-        for layout in OVER_A_KEPT_PARTITION.values()
-        for node in layout
-    }
-    assert named - exercised == set(), named - exercised
+    for name, nodes in OVER_A_KEPT_PARTITION.items():
+        at = context()
+        installation = config(nodes)
+        assert settings._erase(installation, at) == settings.UNSET, name
+        at.confirmed = {"/dev/sda2"}
+        assert settings._erase(installation, at) == at.translate("confirmed"), name
 
 
 def test_writing_over_a_partition_this_plan_creates_does_not_condemn_the_disk() -> None:

--- a/tests/unit/test_every_row.py
+++ b/tests/unit/test_every_row.py
@@ -180,33 +180,23 @@ def test_a_row_that_reads_the_machine_still_offers_something_when_it_finds_nothi
 
 
 def test_the_timezone_screen_offers_cities_behind_a_region() -> None:
-    """The first screen is four region shortcuts, so a list with nothing in it
-    still draws four rows. The defect an operator met was one level down:
-    `Asia` opened on nothing, and `UTC` was the only reachable answer.
-
-    The list handed in is the one the installer really passes, so this fails
-    if `Probe.timezones` ever answers empty again.
-    """
-    from pathlib import Path
-
-    from gentoo_install.exec.probe import Probe
-    from gentoo_install.exec.runner import Runner
-
-    real = Probe(runner=Runner(log=lambda line: None), work=Path("/tmp")).timezones()
-    assert len(real) > 300, len(real)
-
+    """The menu first chooses a region, then a city from that region."""
     at = context()
     at.columns = 100
-    at.timezones = real
+    at.timezones = ("UTC", "Asia/Shanghai", "Asia/Taipei", "Europe/London")
     row = next(one for one in every_row() if one.key == "timezone")
     assert row.edit is not None
-    # Enter the first region, then leave: the frame after the first is the
-    # city list, and a region with no cities is the failure.
-    screen = FakeScreen(keys=["\n", *LEAVE], lines=30, columns=100)
-    row.edit(screen, config(ext4_on_gpt()), at)
-    cities = [line for line in screen.frames[1] if line.strip()]
-    assert len(cities) > 5, cities
+    before = config(ext4_on_gpt())
+    before = replace(before, system=replace(before.system, timezone="UTC"))
 
+    screen = FakeScreen(keys=["KEY_DOWN", "\n", "KEY_DOWN", "\n"], lines=30, columns=100)
+    answer = row.edit(screen, before, at)
+
+    assert answer.outcome is Outcome.CHOSE
+    assert answer.unwrap().system.timezone == "Asia/Taipei"
+    frames = tuple("\n".join(frame) for frame in screen.frames)
+    assert any(all(region in frame for region in ("UTC", "Asia", "Europe")) for frame in frames)
+    assert any(all(city in frame for city in ("Shanghai", "Taipei")) for frame in frames)
 
 def test_reopening_root_login_over_ssh_does_not_widen_it() -> None:
     """The cursor started on `allowed`, so an operator who had refused root

--- a/tests/unit/test_i18n.py
+++ b/tests/unit/test_i18n.py
@@ -15,6 +15,13 @@ def shipped(tag: str) -> dict[str, str]:
     raw = tomllib.loads((LOCALES / f"{tag}.toml").read_text(encoding="utf-8"))
     return {str(key): str(value) for key, value in raw["strings"].items()}
 
+REPRESENTATIVE: dict[str, str] = {
+    "ja": "\u30c7\u30a3\u30b9\u30af",
+    "ko": "\ub514\uc2a4\ud06c",
+    "zh-CN": "\u78c1\u76d8",
+    "zh-TW": "\u78c1\u789f",
+}
+
 
 def test_the_first_variable_that_is_set_decides() -> None:
     """`locale(7)` order, and a variable set to C is a request for the
@@ -69,12 +76,11 @@ def test_every_shipped_catalog_translates_the_same_keys() -> None:
     halfway down."""
     tags = sorted(path.stem for path in LOCALES.glob("*.toml"))
     assert tags == ["ja", "ko", "zh-CN", "zh-TW"]
+    assert set(REPRESENTATIVE) == set(tags)
     keys = [set(shipped(tag)) for tag in tags]
     assert all(other == keys[0] for other in keys[1:])
-    for tag in tags:
-        catalog = Catalog(tag)
-        for key, value in shipped(tag).items():
-            assert value and catalog(key) == value, key
+    for tag, expected in REPRESENTATIVE.items():
+        assert Catalog(tag)("Disks") == expected
 
 
 #: A wide character and a combining mark, by codepoint: no CJK literal belongs

--- a/tests/unit/test_plan_convert.py
+++ b/tests/unit/test_plan_convert.py
@@ -44,9 +44,13 @@ def _in_place() -> InstallConfig:
 
 
 def test_partition_mode_keeps_the_ordinary_list() -> None:
-    ordinary = build(config(), CATALOG)
-    explicit = build(replace(config(), disk=replace(config().disk)), CATALOG)
-    assert tuple(type(operation) for operation in explicit) == tuple(type(operation) for operation in ordinary)
+    partitioned = build(
+        replace(config(), disk=replace(config().disk, mode=DiskMode.PARTITION)),
+        CATALOG,
+    )
+    conversion = build(_in_place(), CATALOG, layout=_layout())
+    assert any(isinstance(operation, plan_disk.CreatePartition) for operation in partitioned)
+    assert not any(isinstance(operation, plan_disk.CreatePartition) for operation in conversion)
 
 
 def test_conversion_operation_describes_and_applies(monkeypatch: pytest.MonkeyPatch) -> None:

--- a/tests/unit/test_plan_disk.py
+++ b/tests/unit/test_plan_disk.py
@@ -252,11 +252,23 @@ def test_a_reference_to_the_wrong_kind_of_node_is_named_rather_than_asserted() -
         disk.build(config(nodes))
 
 
-def test_the_topological_order_is_the_same_every_time() -> None:
-    graph = DeviceGraph.build(ext4_on_gpt())
-    assert [node.id for node in disk.topological(graph)] == [
-        node.id for node in disk.topological(graph)
-    ]
+def test_the_topological_order_ignores_the_order_of_the_graph_input() -> None:
+    expected = (
+        i("disk"),
+        i("table"),
+        i("esp"),
+        i("rootpart"),
+        i("espfs"),
+        i("rootfs"),
+        i("mnt-esp"),
+        i("mnt-root"),
+    )
+    nodes = ext4_on_gpt()
+    graphs = (DeviceGraph.build(nodes), DeviceGraph.build(reversed(nodes)))
+    assert tuple(tuple(node.id for node in disk.topological(graph)) for graph in graphs) == (
+        expected,
+        expected,
+    )
 
 
 def test_every_disk_operation_lands_in_a_disk_stage() -> None:

--- a/tests/unit/test_serialise.py
+++ b/tests/unit/test_serialise.py
@@ -10,8 +10,8 @@ import pytest
 from gentoo_install.exec.config import load
 from gentoo_install.model.config import InstallConfig, Overlay, PortageConfig, ProxyConfig, User
 from gentoo_install.model.config import ProxyKind
-from gentoo_install.model.device import DeviceGraph, DeviceId, Existing, PartitionTable
-from gentoo_install.model.parse import _NODES, parse
+from gentoo_install.model.device import DeviceGraph, DeviceId, Existing, Node, PartitionTable
+from gentoo_install.model.parse import parse
 from gentoo_install.model.serialise import KINDS, REDACTED, SECRET, to_toml
 
 FIXTURES = Path(__file__).resolve().parents[1] / "fixtures"
@@ -32,8 +32,14 @@ def test_runtime_storage_facts_are_not_configuration_fields() -> None:
     assert "free_extents" not in {field.name for field in fields(PartitionTable)}
 
 
-def test_every_node_kind_can_be_written() -> None:
-    assert set(KINDS.values()) == set(_NODES)
+@pytest.mark.parametrize("kind", tuple(KINDS), ids=lambda kind: KINDS[kind])
+def test_every_node_kind_survives_a_toml_round_trip(kind: type[Node]) -> None:
+    for path in sorted(FIXTURES.glob("*.toml")):
+        config = parse(tomllib.loads(path.read_text()))
+        if any(isinstance(node, kind) for node in config.disk.graph.nodes.values()):
+            assert _round_trip(config) == config
+            return
+    raise AssertionError(f"no fixture carries {kind.__name__}")
 
 
 def test_a_table_edited_in_place_survives() -> None:

--- a/tests/unit/test_tui_app.py
+++ b/tests/unit/test_tui_app.py
@@ -38,6 +38,15 @@ from .layouts import config, encrypted_root, unlockable_root, zfs_root
 
 DISKS = [("/dev/disk/by-id/virtio-target0", "20 GiB"), ("/dev/disk/by-id/virtio-target1", "40 GiB")]
 
+REQUIRED_ROW_VALUES: dict[str, str] = {
+    "mirror": "required",
+    "mode": "partition a disk and install onto it",
+    "storage": "virtio-target, gpt +2",
+    "compiler": "stage3 default, -O2 -pipe (stage3 default) +3",
+    "root": "set",
+    "erase": "required",
+}
+
 #: A real key, from ssh-keygen: the checker walks the body, so a made-up
 #: string would fail for the wrong reason.
 GOOD_KEY = "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIB+85deBslaLOMFw71dx23wo7fFT76GVcEyQS9IdVvvT test@example"
@@ -88,12 +97,24 @@ def test_every_row_is_reachable_and_shows_its_current_value() -> None:
     """More rows than an 80x24 console holds, so the list scrolls and the test
     walks it rather than reading one frame."""
     at = context()
+    installation = config()
     screen = FakeScreen(keys=[*down(len(settings.SETTINGS)), "q", "KEY_DOWN", "\n"])
-    run(screen, config(), at)
+    run(screen, installation, at)
     seen = "\n".join("\n".join(frame) for frame in screen.frames)
+    assert {setting.key for setting in settings.SETTINGS if setting.required} == set(
+        REQUIRED_ROW_VALUES
+    )
     for setting in settings.SETTINGS:
         assert setting.label in seen, setting.label
-        assert setting.value(config(), at) in seen or setting.required, setting.label
+        if setting.required:
+            expected = REQUIRED_ROW_VALUES[setting.key]
+            assert any(
+                setting.label in line and line.rstrip().endswith(f"  {expected}")
+                for frame in screen.frames
+                for line in frame
+            ), setting.label
+        else:
+            assert setting.value(installation, at) in seen, setting.label
 
 
 def test_the_firmware_row_is_shown_and_not_chosen() -> None:


### PR DESCRIPTION
The remaining four rows of the review's test-evidence table. Three tautologies compared a function against a second call of itself, a config against one with the same values, and a registry set against itself. Three checks asserted on `inspect.getsource()` output, which a comment satisfies and a reasonable refactor breaks. Two catalog checks compared key sets and non-empty values, so a wrong translation passed. One asserted the host has more than 300 timezones, which fails in a minimal container and tests none of the menu behaviour it is named for.

Verified by breaking the code each one covers: dropping the topological sort's tie-break, dropping the `Filesystem.kind` rename, and dropping the post-install reachability probe each turn their test red at the assertion rather than on a crash.