### PR TITLE
cluster: the probe after the install is a note, not a verdict

### DIFF
--- a/tests/unit/test_cluster.py
+++ b/tests/unit/test_cluster.py
@@ -1508,3 +1508,41 @@ def test_a_dropped_console_still_ends_a_guest_that_moves_nothing(tmp_path: Path)
     with pytest.raises(ConsoleClosed):
         quiet.wait_for("emerge --ask=n @world", timeout=0.0, idle=1.0)
     assert len(opened) == 1, len(opened)
+
+
+def test_the_probe_after_the_install_cannot_fail_the_run() -> None:
+    """`vm-btrfs` and `vm-mdraid` were both recorded `ERROR` in run60 at 96 and
+    81 minutes with
+
+        installed 54 operations into /mnt/gentoo; 0 packages from a binary host
+        installed 58 operations into /mnt/gentoo; 0 packages from a binary host
+
+    already in their logs. The install had finished and written its exit code,
+    and what timed out was the reachability probe that runs after it, whose
+    `getent` calls block on a resolver that has stopped answering. That probe
+    answers a question about a failure; it is not one.
+    """
+    from tests.vm.console import ConsoleTimeout
+
+    asked: list[str] = []
+
+    class Timing:
+        def run(self, command: str, timeout: float = 120.0) -> None:
+            asked.append(command)
+            raise ConsoleTimeout("never matched a marker")
+
+    cluster._note_the_closing_probe(cast(Any, Timing()))
+    assert asked == [cluster.REACHABILITY_PROBE], asked
+
+
+def test_the_closing_probe_is_still_asked_when_it_can_answer() -> None:
+    """Swallowing the failure must not mean skipping the probe, or the
+    diagnosis it exists for goes with it."""
+    answered: list[str] = []
+
+    class Answering:
+        def run(self, command: str, timeout: float = 120.0) -> None:
+            answered.append(command)
+
+    cluster._note_the_closing_probe(cast(Any, Answering()))
+    assert answered == [cluster.REACHABILITY_PROBE], answered

--- a/tests/vm/cluster.py
+++ b/tests/vm/cluster.py
@@ -1496,6 +1496,20 @@ def _reserve_job(
     raise conflict
 
 
+def _note_the_closing_probe(link: Reconnecting) -> None:
+    """The probe after the install answers a question, never the verdict.
+
+    Its `getent` calls block on a resolver that has stopped answering, and
+    `vm-btrfs` and `vm-mdraid` were both recorded `ERROR` in run60 at 96 and
+    81 minutes with `installed 54 operations` and `installed 58 operations`
+    already in their logs. The install had finished and written its exit code.
+    """
+    try:
+        link.run(REACHABILITY_PROBE, timeout=120.0)
+    except (ConsoleTimeout, ConsoleClosed) as error:
+        print(f"the closing reachability probe did not answer: {error}", flush=True)
+
+
 def install_one(
     api: Api,
     node: str,
@@ -1567,7 +1581,7 @@ def install_one(
         # A third time, after the install: a console that still has its routes
         # when the installer saw none puts the loss in the installer's own
         # view of the machine rather than in the machine.
-        link.run(REACHABILITY_PROBE, timeout=120.0)
+        _note_the_closing_probe(link)
         files = collect(guest, link, log)
         keep_results(log, files)
         code = files.get("install.rc", b"").strip()


### PR DESCRIPTION
run60 recorded `vm-btrfs` at 96 minutes and `vm-mdraid` at 81 minutes as `ERROR`, and both logs end with `installed 54 operations into /mnt/gentoo` and `installed 58 operations into /mnt/gentoo`. The install had finished and written its exit code; what timed out was the reachability probe that runs after it, whose `getent` calls block on a resolver that had stopped answering — visible in the same log as `LOOKUPS_V4 ok fail fail fail fail`.

That probe exists to tell an installer that saw no route from a machine that had none. It answers a question about a failure; it is not one.