### PR TITLE
convert: copy into a mount that rename cannot reach

### DIFF
--- a/gentoo_install/exec/convert.py
+++ b/gentoo_install/exec/convert.py
@@ -3,13 +3,20 @@
 
 from __future__ import annotations
 
+import errno
 import os
 import shutil
 import sys
+from enum import Enum
 from pathlib import Path
-from typing import Sequence
+from typing import Callable, Sequence
 
 from ..errors import ConversionFailed
+
+#: Copies one tree into a destination the caller names, preserving what a
+#: stage3 needs. The plan hands over `cp --archive`: `shutil.copytree` restores
+#: neither xattrs nor file capabilities.
+Copier = Callable[[Path, Path], None]
 
 
 #: Where a mounted directory's own entries are moved while it is replaced.
@@ -26,20 +33,40 @@ def _mounts_inside(directory: Path) -> list[str]:
     return [one for one in entries if os.path.ismount(directory / one)]
 
 
-def _replace_contents(destination: Path, staged: Path) -> None:
+class Arrival(Enum):
+    """How an entry reached the destination, because undoing the two differs.
+
+    A renamed entry goes back; a copied one is deleted, and its original is
+    still in the staging root.
+    """
+
+    COPIED = "copied"
+    RENAMED = "renamed"
+
+
+def _remove(path: Path) -> None:
+    """Delete a copy that arrived, on the way back out of a failure."""
+    if path.is_dir() and not path.is_symlink():
+        shutil.rmtree(path)
+    else:
+        path.unlink(missing_ok=True)
+
+
+def _replace_contents(destination: Path, staged: Path, copy: Copier) -> None:
     """Swap what is in a mount point, since the mount point cannot be renamed.
 
-    Not `cp`: every move here is a `rename(2)` on one filesystem, so the window
-    is the entry count rather than the size of `/usr`. `distro2gentoo` copies
-    instead, which also merges -- and this installer replaces `/etc` rather
-    than merging it.
+    Moving the destination's own entries aside is a `rename(2)` inside the
+    mount. Bringing the staged ones in crosses out of the staging root, and a
+    directory reaches this function precisely because it is a separate mount:
+    Fedora's `/var` is its own btrfs subvolume, so `rename` answered
+    `[Errno 18] Invalid cross-device link` on the first entry.
     """
     aside = destination / KEPT_ASIDE
     if os.path.lexists(aside):
         raise ConversionFailed(f"{aside} is left from an earlier attempt")
     os.mkdir(aside)
     moved: list[str] = []
-    arrived: list[str] = []
+    arrived: list[tuple[str, Arrival]] = []
     try:
         for name in sorted(os.listdir(destination)):
             if name == KEPT_ASIDE:
@@ -47,12 +74,22 @@ def _replace_contents(destination: Path, staged: Path) -> None:
             os.rename(destination / name, aside / name)
             moved.append(name)
         for name in sorted(os.listdir(staged)):
-            os.rename(staged / name, destination / name)
-            arrived.append(name)
-    except OSError as error:
-        for name in reversed(arrived):
             try:
-                os.rename(destination / name, staged / name)
+                os.rename(staged / name, destination / name)
+            except OSError as error:
+                if error.errno != errno.EXDEV:
+                    raise
+                copy(staged / name, destination / name)
+                arrived.append((name, Arrival.COPIED))
+                continue
+            arrived.append((name, Arrival.RENAMED))
+    except OSError as error:
+        for name, how in reversed(arrived):
+            try:
+                if how is Arrival.RENAMED:
+                    os.rename(destination / name, staged / name)
+                else:
+                    _remove(destination / name)
             except OSError as rollback_error:
                 error.add_note(f"could not return {name} to the staging root: {rollback_error}")
         for name in reversed(moved):
@@ -77,7 +114,9 @@ def _restore_contents(destination: Path, staged: Path) -> None:
     os.rmdir(aside)
 
 
-def convert(staging: Path, names: Sequence[str], *, root: Path = Path("/")) -> None:
+def convert(
+    staging: Path, names: Sequence[str], *, copy: Copier, root: Path = Path("/")
+) -> None:
     """Replace each named directory and remove backups after all swaps finish."""
     try:
         same = os.stat(staging).st_dev == os.stat(root).st_dev
@@ -124,7 +163,7 @@ def convert(staging: Path, names: Sequence[str], *, root: Path = Path("/")) -> N
         moved_old = False
         try:
             if mounted:
-                _replace_contents(destination, staged)
+                _replace_contents(destination, staged, copy)
             else:
                 if present:
                     os.rename(destination, old)

--- a/gentoo_install/plan/convert.py
+++ b/gentoo_install/plan/convert.py
@@ -6,7 +6,7 @@ from __future__ import annotations
 import importlib
 from dataclasses import dataclass, replace
 from pathlib import Path, PurePosixPath
-from typing import Any, Final, Protocol, Sequence, cast
+from typing import Any, Callable, Final, Protocol, Sequence, cast
 
 from ..errors import ConversionFailed, ConversionUnsupported
 from ..model.config import DiskConfig, DiskMode
@@ -40,7 +40,14 @@ REPLACED_DIRECTORIES: tuple[str, ...] = (
 
 
 class _Converter(Protocol):
-    def convert(self, staging: Path, names: Sequence[str], *, root: Path = Path("/")) -> None: ...
+    def convert(
+        self,
+        staging: Path,
+        names: Sequence[str],
+        *,
+        copy: Callable[[Path, Path], None],
+        root: Path = Path("/"),
+    ) -> None: ...
 
 
 @dataclass(frozen=True, kw_only=True)
@@ -127,7 +134,15 @@ class SwapDirectories(Operation):
     def apply(self, context: Context) -> None:
         module = importlib.import_module("gentoo_install.exec.convert")
         converter = cast(_Converter, module)
-        converter.convert(Path(str(self.staging)), self.names)
+
+        def copy(source: Path, destination: Path) -> None:
+            # `cp --archive`, not `shutil.copytree`: a stage3 carries file
+            # capabilities and xattrs that Python's copy does not restore.
+            context.run(
+                ["cp", "--archive", "--one-file-system", str(source), str(destination)]
+            )
+
+        converter.convert(Path(str(self.staging)), self.names, copy=copy)
 
 
 FSTAB: Final[PurePosixPath] = PurePosixPath("/etc/fstab")

--- a/tests/unit/test_convert.py
+++ b/tests/unit/test_convert.py
@@ -10,6 +10,21 @@ from gentoo_install.errors import ConversionFailed
 from gentoo_install.exec import convert
 
 
+def _copy(source: Path, destination: Path) -> None:
+    """What the plan hands over as `cp --archive`, in the test's own terms.
+
+    `copytree` here rather than a runner: what these tests hold is the ordering
+    and the rollback, and the plan's own test holds that the command really is
+    `cp --archive`.
+    """
+    import shutil
+
+    if source.is_dir() and not source.is_symlink():
+        shutil.copytree(source, destination, symlinks=True)
+    else:
+        shutil.copy2(source, destination, follow_symlinks=False)
+
+
 def _directory(path: Path, content: str) -> None:
     path.mkdir()
     (path / "content").write_text(content)
@@ -25,7 +40,7 @@ def test_swapping_several_directories_removes_backups(tmp_path: Path) -> None:
         _directory(root / name, f"old {name}")
         _directory(staging / name, f"new {name}")
 
-    convert.convert(staging, names, root=root)
+    convert.convert(staging, names, copy=_copy, root=root)
 
     for name in names:
         assert (root / name / "content").read_text() == f"new {name}"
@@ -56,7 +71,7 @@ def test_different_filesystem_is_refused_before_any_rename(
     monkeypatch.setattr(os, "stat", fake_stat)
 
     with pytest.raises(ConversionFailed, match="not on the root filesystem"):
-        convert.convert(staging, ("etc",), root=root)
+        convert.convert(staging, ("etc",), copy=_copy, root=root)
     assert (root / "etc" / "content").read_text() == "old"
     assert (staging / "etc" / "content").read_text() == "new"
 
@@ -87,7 +102,7 @@ def test_rename_failure_restores_previous_swaps(
     # Wrapped, not re-raised: `errors.py` owns what leaves this package, and
     # the message still carries what the kernel said.
     with pytest.raises(ConversionFailed, match="injected rename failure"):
-        convert.convert(staging, names, root=root)
+        convert.convert(staging, names, copy=_copy, root=root)
 
     for name in names:
         assert (root / name / "content").read_text() == f"old {name}"
@@ -106,7 +121,7 @@ def test_existing_backup_is_refused_before_any_rename(tmp_path: Path) -> None:
     _directory(root / "etc.gentoo-install.old", "previous")
 
     with pytest.raises(ConversionFailed, match="left from an earlier attempt"):
-        convert.convert(staging, ("etc",), root=root)
+        convert.convert(staging, ("etc",), copy=_copy, root=root)
 
     assert (root / "etc" / "content").read_text() == "old"
     assert (root / "etc.gentoo-install.old" / "content").read_text() == "previous"
@@ -125,7 +140,7 @@ def test_a_directory_the_machine_lacks_is_moved_into_place(tmp_path: Path) -> No
     (staging / "lib64").mkdir()
     (staging / "lib64" / "new.txt").write_text("new")
 
-    convert.convert(staging, ("usr", "lib64"), root=root)
+    convert.convert(staging, ("usr", "lib64"), copy=_copy, root=root)
 
     assert (root / "usr" / "new.txt").read_text() == "new"
     assert (root / "lib64" / "new.txt").read_text() == "new"
@@ -153,7 +168,7 @@ def test_a_rollback_takes_back_a_directory_the_machine_lacked(
 
     monkeypatch.setattr("os.rename", failing)
     with pytest.raises(ConversionFailed, match="usr could not be swapped"):
-        convert.convert(staging, ("lib64", "usr"), root=root)
+        convert.convert(staging, ("lib64", "usr"), copy=_copy, root=root)
 
     assert (staging / "lib64").is_dir(), "the staged one has to go back"
     assert not (root / "lib64").exists()
@@ -245,7 +260,7 @@ def test_a_separately_mounted_directory_is_replaced_by_its_contents(
     was = os.stat(root / "var").st_ino
     ordinary = os.stat(root / "usr").st_ino
 
-    convert.convert(staging, ("usr", "var"), root=root)
+    convert.convert(staging, ("usr", "var"), copy=_copy, root=root)
 
     assert os.stat(root / "var").st_ino == was, "the mount point was replaced"
     assert os.stat(root / "usr").st_ino != ordinary, "an ordinary directory is renamed"
@@ -279,6 +294,64 @@ def test_a_mount_inside_a_mounted_directory_is_refused_before_any_move(
     )
 
     with pytest.raises(ConversionFailed, match="holding lib"):
-        convert.convert(staging, ("usr", "var"), root=root)
+        convert.convert(staging, ("usr", "var"), copy=_copy, root=root)
 
     assert (root / "usr" / "kept.txt").read_text() == "old", "nothing was moved"
+
+
+def test_a_mounted_directory_is_filled_by_copy_when_rename_cannot_cross(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Read off a Fedora 41 machine, at operation 46 of 48:
+
+        [bootloader] atomically swap /bin, /sbin, /etc, /lib, /lib64, /usr, /var
+        the install stopped: ConversionFailed: /var could not be replaced by
+        content: [Errno 18] Invalid cross-device link:
+        '/gentoo-install.new/var/cache' -> '/var/cache'
+
+    A directory reaches this path precisely because it is a separate mount, and
+    Fedora's `/var` is its own btrfs subvolume, so its `st_dev` differs from
+    the staging root's and `rename(2)` cannot reach it. Everything before this
+    had succeeded: the whole userland was built and the swap was the last step.
+    """
+    import errno
+
+    root = tmp_path / "root"
+    staging = root / "new"
+    for name in ("usr", "var"):
+        (root / name).mkdir(parents=True)
+        (staging / name).mkdir(parents=True)
+    (root / "var" / "old-log").mkdir()
+    (staging / "var" / "cache").mkdir()
+    (staging / "var" / "db").mkdir()
+    (staging / "usr" / "new.txt").write_text("new")
+
+    real_mount = os.path.ismount
+    monkeypatch.setattr(
+        "os.path.ismount", lambda path: str(path).endswith("/var") or real_mount(path)
+    )
+    real_rename = os.rename
+    crossed: list[tuple[str, str]] = []
+
+    def rename(source: Path | str, destination: Path | str) -> None:
+        pair = (str(source), str(destination))
+        if str(staging / "var") in pair[0]:
+            crossed.append(pair)
+            raise OSError(errno.EXDEV, "Invalid cross-device link", pair[0], None, pair[1])
+        real_rename(pair[0], pair[1])
+
+    copied: list[tuple[str, str]] = []
+
+    def copy(source: Path, destination: Path) -> None:
+        copied.append((source.name, destination.name))
+        _copy(source, destination)
+
+    monkeypatch.setattr("os.rename", rename)
+    convert.convert(staging, ("usr", "var"), copy=copy, root=root)
+
+    assert crossed, "the test did not reproduce a cross-device rename"
+    assert copied == [("cache", "cache"), ("db", "db")], copied
+    assert (root / "var" / "cache").is_dir() and (root / "var" / "db").is_dir()
+    assert not (root / "var" / "old-log").exists(), "replaced, not merged"
+    assert not (root / "var" / convert.KEPT_ASIDE).exists(), "the kept set is removed"
+    assert (root / "usr" / "new.txt").read_text() == "new", "an ordinary directory renames"

--- a/tests/unit/test_plan_convert.py
+++ b/tests/unit/test_plan_convert.py
@@ -56,7 +56,7 @@ def test_partition_mode_keeps_the_ordinary_list() -> None:
 def test_conversion_operation_describes_and_applies(monkeypatch: pytest.MonkeyPatch) -> None:
     called: list[tuple[Path, tuple[str, ...]]] = []
 
-    def convert(staging: Any, names: tuple[str, ...]) -> None:
+    def convert(staging: Any, names: tuple[str, ...], *, copy: Any) -> None:
         called.append((staging, names))
 
     from gentoo_install.exec import convert as executor
@@ -841,3 +841,56 @@ def test_the_staging_root_is_unmounted_from_the_deepest_mount_up() -> None:
 
     # Negative control two: a mount outside the staging root is not touched.
     assert not any(one.endswith("/home") for one in unmounted), unmounted
+
+
+def test_the_swap_copies_with_cp_archive_rather_than_a_python_copy() -> None:
+    """A mount point rename cannot cross is filled by copy, and what does the
+    copying decides whether the new userland keeps its file capabilities.
+    `shutil.copytree` restores neither those nor xattrs, and the same reason
+    already made the stage3 unpack use GNU tar rather than `tarfile`.
+    """
+    from pathlib import Path
+
+    from .recorder import Recorder
+
+    recorder = Recorder()
+    copied: list[tuple[str, str]] = []
+
+    class Module:
+        @staticmethod
+        def convert(
+            staging: Path,
+            names: object,
+            *,
+            copy: object,
+            root: Path = Path("/"),
+        ) -> None:
+            assert callable(copy)
+            copy(Path("/gentoo-install.new/var/cache"), Path("/var/cache"))
+            copied.append((str(staging), str(root)))
+
+    import importlib
+
+    original = importlib.import_module
+
+    def importing(name: str, package: str | None = None) -> Any:
+        return Module if name == "gentoo_install.exec.convert" else original(name, package)
+
+    saved = importlib.import_module
+    importlib.import_module = importing
+    try:
+        SwapDirectories(names=("var",)).apply(recorder)
+    finally:
+        importlib.import_module = saved
+
+    assert copied, "the converter was never called"
+    written = [argv for argv in recorder.commands if argv and argv[0] == "cp"]
+    assert written == [
+        (
+            "cp",
+            "--archive",
+            "--one-file-system",
+            "/gentoo-install.new/var/cache",
+            "/var/cache",
+        )
+    ], recorder.commands


### PR DESCRIPTION
Read off a Fedora 41 machine, at operation 46 of 48 with the whole userland already built:

    the install stopped: ConversionFailed: /var could not be replaced by content:
    [Errno 18] Invalid cross-device link: '/gentoo-install.new/var/cache' -> '/var/cache'

A directory reaches the content-replacement path precisely because it is a separate mount, and Fedora's `/var` is its own btrfs subvolume, so its `st_dev` differs from the staging root's and `rename(2)` cannot reach it. Moving the destination's own entries aside is still a rename inside the mount; only the inbound direction crosses.

The copier is `cp --archive`, not `shutil.copytree`, for the reason that already made the stage3 unpack use GNU tar: Python's copy restores neither xattrs nor file capabilities.