### PR TITLE
console: say which bound was reached before dumping the screen

### DIFF
--- a/tests/unit/test_cluster.py
+++ b/tests/unit/test_cluster.py
@@ -1546,3 +1546,51 @@ def test_the_closing_probe_is_still_asked_when_it_can_answer() -> None:
 
     cluster._note_the_closing_probe(cast(Any, Answering()))
     assert answered == [cluster.REACHABILITY_PROBE], answered
+
+
+def test_a_truncated_verdict_still_says_which_bound_was_reached() -> None:
+    """`vm-unlock` was recorded in run59 as
+
+        '{ sh /mnt/driver/install.sh --config fixtures/vm-unlock.toml; ... }':
+        never matched 'MARK_27_DONE|root@[A-Za-z0-9._-]+ ~ # '; last output was
+        b'msoft-float -fno-omit-frame-pointer -fno-dwarf2-cfi-asm -m
+
+    and that is the whole verdict: `VERDICT_BYTES` cut it there. Whether the
+    guest went quiet or ran out of ceiling decides whether the next question is
+    about the installer or about the schedule, and the message said neither
+    because the reason came after the screen.
+    """
+    from tests.vm.console import ConsoleIdle, ConsoleTimeout, SerialConsole
+
+    class Silent:
+        closed = False
+
+        def recv(self, size: int) -> bytes:
+            return b""
+
+        def sendall(self, data: bytes) -> None:
+            return None
+
+        def close(self) -> None:
+            return None
+
+    def console(log: Path) -> SerialConsole:
+        return SerialConsole(cast(Any, Silent()), log.open("wb"))
+
+    import tempfile
+
+    with tempfile.TemporaryDirectory() as where:
+        quiet = console(Path(where) / "a.log")
+        quiet._buffer = b"x" * 4000
+        with pytest.raises(ConsoleIdle) as idled:
+            quiet.expect("never-here", timeout=30.0, idle=0.2)
+        spent = console(Path(where) / "b.log")
+        with pytest.raises(ConsoleTimeout) as ceilinged:
+            spent.expect("never-here", timeout=0.2)
+
+    for raised, wanted in ((idled, "nothing arrived for"), (ceilinged, "elapsed")):
+        said = str(raised.value)
+        assert wanted in said, said
+        # Before the screen, so a verdict cut to VERDICT_BYTES keeps it.
+        assert said.index(wanted) < said.index("last output was"), said
+        assert said.index(wanted) < cluster.OUTCOME_BYTES, said

--- a/tests/vm/cluster.py
+++ b/tests/vm/cluster.py
@@ -208,6 +208,11 @@ STAGGER: Final[float] = 20.0
 #: minutes with eighteen jobs waiting.
 POLL_WHILE_QUEUED: Final[float] = 20.0
 
+#: How much of an exception reaches the schedule's one-line outcome. Three
+#: call sites each wrote `300`, and `VERDICT_BYTES` is twelve times that, so a
+#: reader of one number could not tell what a verdict had room for.
+OUTCOME_BYTES: Final[int] = 300
+
 #: The outer bound, reached only by a guest that keeps printing and never
 #: finishes. Twelve of one round hit the three-hour version of it with a
 #: repository listing still scrolling, so the ceiling is generous and
@@ -1655,7 +1660,7 @@ def install_one(
             job.name,
             verdict,
             time.monotonic() - started,
-            dropped or str(error)[:300],
+            dropped or str(error)[:OUTCOME_BYTES],
             log,
             phase=phase,
             revision=revision,
@@ -1667,7 +1672,7 @@ def install_one(
             job.name,
             Verdict.ERROR,
             time.monotonic() - started,
-            str(error)[:300],
+            str(error)[:OUTCOME_BYTES],
             log,
             phase=phase,
             revision=revision,
@@ -1730,7 +1735,7 @@ def answer_once(
                 job.name,
                 Verdict.ERROR,
                 0.0,
-                f"{type(error).__name__}: {error}"[:300],
+                f"{type(error).__name__}: {error}"[:OUTCOME_BYTES],
                 removed=False,
                 revision=revision,
                 vmid=vmid,

--- a/tests/vm/console.py
+++ b/tests/vm/console.py
@@ -185,8 +185,9 @@ class SerialConsole:
         matcher = re.compile(pattern.encode())
         # Two deadlines, whichever comes first: the ceiling bounds a guest that
         # prints for ever, and the idle window ends one that stopped.
-        ceiling = time.monotonic() + timeout
-        idle_deadline = time.monotonic() + idle if idle else ceiling
+        started = time.monotonic()
+        ceiling = started + timeout
+        idle_deadline = started + idle if idle else ceiling
         deadline = min(ceiling, idle_deadline)
         seen = len(self._buffer)
         while time.monotonic() < deadline:
@@ -202,9 +203,19 @@ class SerialConsole:
                 seen = len(self._buffer)
                 idle_deadline = time.monotonic() + idle
                 deadline = min(ceiling, idle_deadline)
-        error = ConsoleIdle if idle and idle_deadline < ceiling else ConsoleTimeout
+        silent = bool(idle) and idle_deadline < ceiling
+        error = ConsoleIdle if silent else ConsoleTimeout
+        # Which bound was reached, before the screen rather than after it: a
+        # verdict is truncated to a few hundred bytes, and `vm-unlock` reported
+        # only the pattern and a gcc line, so whether it went quiet or ran out
+        # of ceiling could not be told from the verdict at all.
+        why = (
+            f"nothing arrived for {idle:.0f}s"
+            if silent
+            else f"{time.monotonic() - started:.0f}s of {timeout:.0f}s elapsed"
+        )
         raise error(
-            f"never matched {pattern!r}; "
+            f"never matched {pattern!r}, {why}; "
             f"last output was {strip_ansi(self._buffer)[-600:]!r}"
         )
 


### PR DESCRIPTION
run59 recorded `vm-unlock` as

    never matched 'MARK_27_DONE|root@[A-Za-z0-9._-]+ ~ # '; last output was
    b'msoft-float -fno-omit-frame-pointer -fno-dwarf2-cfi-asm -m

and that is the whole verdict. Both the idle window and the ceiling raised the same sentence, differing only in exception class, and the outcome is cut to 300 bytes, so which one fired was unrecoverable from the verdict. Whether a guest went quiet or ran out of ceiling decides whether the next question is about the installer or about the schedule.

The reason now precedes the screen. The three call sites that each wrote `300` share one named constant, because `VERDICT_BYTES` is twelve times that and a reader of one number could not tell what a verdict had room for.