### PR TITLE
build: do not stage what runs after the swap

### DIFF
--- a/gentoo_install/plan/build.py
+++ b/gentoo_install/plan/build.py
@@ -206,13 +206,25 @@ def _in_place(
             index for index, operation in enumerate(ordered) if operation.stage is Stage.PORTAGE
         ) + 1
         ordered.insert(after_configuration, portage.VerifyPackages(requests=requests))
+    # `cli.py` runs every `Stage.FINISH` operation after the body, so those run
+    # after the swap and the staging root they would be pointed at no longer has
+    # a userland: a Fedora conversion stopped at `chroot /gentoo-install.new ln`
+    # with `failed to run command 'ln': No such file or directory`, one
+    # operation from the end and with the machine already converted. They are
+    # placed here in the order they run rather than staged where they were.
+    closing = tuple(one for one in ordered if one.stage is Stage.FINISH)
     return (
-        *(convert.Staged(stage=operation.stage, inner=operation) for operation in ordered),
+        *(
+            convert.Staged(stage=operation.stage, inner=operation)
+            for operation in ordered
+            if operation.stage is not Stage.FINISH
+        ),
         convert.SwapDirectories(),
         # Between the swap and the bootloader: `grub-mkconfig` reads `/boot`,
         # and until this runs what is there belongs to the old distribution.
         convert.PopulateBoot(),
         *after_the_swap,
+        *closing,
         convert.LeaveStaging(),
     )
 

--- a/tests/golden/vm-convert.txt
+++ b/tests/golden/vm-convert.txt
@@ -58,5 +58,5 @@
   install GRUB for uefi on the esp at /efi
 
 [finish]
-  point /etc/resolv.conf at systemd-resolved rather than the install medium's, in /gentoo-install.new
+  point /etc/resolv.conf at systemd-resolved rather than the install medium's
   unmount and remove /gentoo-install.new

--- a/tests/unit/test_plan_convert.py
+++ b/tests/unit/test_plan_convert.py
@@ -894,3 +894,39 @@ def test_the_swap_copies_with_cp_archive_rather_than_a_python_copy() -> None:
             "/var/cache",
         )
     ], recorder.commands
+
+
+def test_nothing_that_runs_after_the_swap_is_pointed_at_the_staging_root() -> None:
+    """Read off a Fedora 41 machine, one operation from the end, with the swap
+    already done and GRUB already written to the real root:
+
+        [1/2 0:00:00] [finish] point /etc/resolv.conf at systemd-resolved
+        rather than the install medium's, in /gentoo-install.new
+        run: chroot /gentoo-install.new ln --symbolic --force ...
+        chroot: failed to run command 'ln': No such file or directory
+
+    `cli.py` runs every `Stage.FINISH` operation after the body, which is after
+    the swap, so the staging root those operations would be pointed at has no
+    userland left in it.
+    """
+    from gentoo_install.data import load_catalog
+    from gentoo_install.model.device import StorageFacts
+    from gentoo_install.plan.operations import Stage
+
+    operations = build(
+        _in_place(),
+        load_catalog(),
+        mirror="https://distfiles.gentoo.org",
+        storage_facts=StorageFacts(),
+        layout=_layout(),
+    )
+    closing = [one for one in operations if one.stage is Stage.FINISH]
+
+    assert closing, "the conversion has no closing stage at all"
+    assert not [one for one in closing if isinstance(one, convert.Staged)], [
+        type(one).__name__ for one in closing
+    ]
+    # And what runs before the swap is still staged, so this did not turn the
+    # wrapper off for everything.
+    body = [one for one in operations if one.stage is not Stage.FINISH]
+    assert [one for one in body if isinstance(one, convert.Staged)], len(body)


### PR DESCRIPTION
Read off a Fedora 41 machine, one operation from the end, with the swap already done and GRUB already written to the real root:

    [1/2 0:00:00] [finish] point /etc/resolv.conf at systemd-resolved rather
    than the install medium's, in /gentoo-install.new
    run: chroot /gentoo-install.new ln --symbolic --force ...
    chroot: failed to run command 'ln': No such file or directory

`cli.py` splits a plan into a body and a closing stage and runs the closing stage last, so a `Stage.FINISH` operation in a conversion runs after the swap has moved the staged userland to `/`. Those operations now run against the real root, which is where the files they touch live by then, and they are placed at the end of the plan so the printed sequence matches the order it runs.