### PR TITLE
cluster: do not wait ten seconds on a dead resolver

### DIFF
--- a/tests/unit/test_cluster.py
+++ b/tests/unit/test_cluster.py
@@ -1634,3 +1634,29 @@ def test_no_reachability_probe_is_ever_the_verdict() -> None:
     # And the one place that does run it swallows a timeout, which the tests
     # above hold.
     assert "link.run(REACHABILITY_PROBE" in inspect.getsource(cluster._note_the_probe)
+
+
+def test_a_dead_first_resolver_costs_one_second_and_not_ten() -> None:
+    """`resolv.conf(5)` on this machine: `timeout:n` is "the amount of time the
+    resolver will wait for a response from a remote name server before retrying
+    the query via a different name server", default `RES_TIMEOUT`, and
+    `attempts:n` defaults to 2. So a first nameserver that has stopped
+    answering costs ten seconds on every lookup.
+
+    Five guests of run61 had `REACH 10.31.0.199=down` with the gateway and
+    `223.5.5.5` both answering ping, `LOOKUPS_V4 ok fail fail fail fail`, and
+    no install started; two more failed at `OpenPGP keyring refresh failed`,
+    which is the same lookups from inside `emerge-webrsync`.
+    """
+    written = cluster.use_our_resolvers()
+
+    assert f"options no-aaaa {cluster.RESOLVER_OPTIONS}" in written, written
+    assert "timeout:1" in cluster.RESOLVER_OPTIONS, cluster.RESOLVER_OPTIONS
+    # Every resolver is still offered, in order: the point is what a dead one
+    # costs, not dropping it.
+    for one in cluster.GUEST_RESOLVERS:
+        assert f"nameserver {one}" in written, one
+    # The whole worst case now fits the probe's budget, which it did not before.
+    attempts = int(cluster.RESOLVER_OPTIONS.split("attempts:")[1])
+    seconds = int(cluster.RESOLVER_OPTIONS.split("timeout:")[1].split()[0])
+    assert seconds * attempts <= cluster.LOOKUP_PATIENCE, cluster.RESOLVER_OPTIONS

--- a/tests/vm/cluster.py
+++ b/tests/vm/cluster.py
@@ -761,6 +761,13 @@ GUEST_RESOLVER: Final[str] = "10.31.0.199"
 GUEST_RESOLVERS: Final[tuple[str, ...]] = (GUEST_RESOLVER, GUEST_GATEWAY, "223.5.5.5")
 
 
+#: `resolv.conf(5)`: the defaults are `timeout:5 attempts:2`, so a first
+#: nameserver that has stopped answering costs ten seconds on every lookup
+#: before the second one is asked. Five guests of run61 had
+#: `REACH 10.31.0.199=down` with the gateway and `223.5.5.5` both answering,
+#: and their installs never started.
+RESOLVER_OPTIONS: Final[str] = "timeout:1 attempts:2"
+
 #: What each lookup in the probe is given. A resolver that has stopped
 #: answering makes `getent` wait for its own timeout, and ten of them cost more
 #: than the probe's whole budget: five guests of run61 were ended at three
@@ -883,7 +890,7 @@ def use_our_resolvers() -> str:
     # `no-aaaa` as well as the servers: an `AF_UNSPEC` lookup asks for the AAAA
     # too, and a resolver that does not answer turns that into `EAI_AGAIN` for
     # the whole call even when the A record arrived.
-    resolvers = "options no-aaaa\\n" + "".join(
+    resolvers = f"options no-aaaa {RESOLVER_OPTIONS}\\n" + "".join(
         f"nameserver {one}\\n" for one in GUEST_RESOLVERS
     )
     return f"printf '{resolvers}' > /etc/resolv.conf"


### PR DESCRIPTION
The probe's own output names the cause. Five guests of run61:

    REACH 10.31.0.199=down 10.31.0.254=up 223.5.5.5=up
    LOOKUPS_V4 ok fail fail fail fail

The gateway and `223.5.5.5` answered ping; the cluster resolver written into every guest did not. `resolv.conf(5)` defaults to `timeout:5 attempts:2`, so a first nameserver that has stopped answering costs ten seconds on every lookup before the second is asked. That ended five installs before they started and two more at `OpenPGP keyring refresh failed`, which is the same lookups from inside `emerge-webrsync`.

Every resolver is still offered in the same order: what changes is what a dead one costs.