### PR TITLE
convert: a committed way to convert a cloud image, and read the firmware

### DIFF
--- a/tests/vm/convert.py
+++ b/tests/vm/convert.py
@@ -1,0 +1,343 @@
+# SPDX-License-Identifier: GPL-2.0-or-later
+"""Convert another distribution's cloud image in place, on this machine.
+
+The two conversion rows in `TESTED.md` were produced by commands nobody kept,
+so neither could be reproduced. This is the committed way to do it: pick an
+image, boot it, hand it the driver CD, and read the machine afterwards.
+
+The pristine download is never written to. Each run gets a qcow2 overlay over
+it, larger than the original so that cloud-init grows the root filesystem on
+first boot and the conversion has somewhere to unpack a stage3.
+"""
+
+from __future__ import annotations
+
+import argparse
+import re
+import shutil
+import subprocess
+import sys
+import time
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Final
+
+from gentoo_install.exec.config import load
+
+from .console import PASSWORD_PROMPT, SerialConsole
+from .driver import FIND_DRIVER, REPOSITORY, build as build_driver
+from .installed import checks
+from .media import MEDIA
+from .qemu import Firmware, Vm, VmSpec
+from .workdir import confined
+
+#: Where `pull.sh` keeps the images. A run reads them and writes none of them.
+CLOUD: Final[Path] = Path.home() / "code/gentoo-install/lab/vm/cloud"
+WORKROOT: Final[Path] = Path.home() / "code/gentoo-install/lab/vm/converts"
+
+#: What cloud-init is told to set, so the harness can log in over serial. The
+#: images ship no password at all and no key the harness holds.
+ROOT_PASSWORD: Final[str] = "install"
+
+#: Bigger than every image here, so cloud-init's `growpart` and `resizefs`
+#: run on first boot. A 5 GiB Fedora root cannot hold a stage3 and a kernel.
+OVERLAY_SIZE: Final[str] = "24G"
+
+#: How long the guest is given to finish cloud-init, which grows the
+#: filesystem and sets the password before a login is possible.
+CLOUD_INIT_PATIENCE: Final[float] = 600.0
+
+#: How long the converted machine is given to reach a login prompt. It boots
+#: the kernel the conversion installed, through the bootloader the conversion
+#: wrote, on the disk the old distribution was on.
+BOOT_PATIENCE: Final[float] = 900.0
+
+#: An in-place conversion compiles nothing by default but does emerge a
+#: dist-kernel, and a cloud image starts from an empty Portage cache.
+CONVERT_CEILING: Final[float] = 7200.0
+CONVERT_IDLE: Final[float] = 1800.0
+
+
+@dataclass(frozen=True)
+class CloudImage:
+    """One distribution's cloud image and what it needs before converting."""
+
+    name: str
+    filename: str
+    #: What the image's own package manager is called, for the line
+    #: `bootstrap.sh --missing-commands` prints. Read from the image rather
+    #: than guessed: the launcher already knows every one of these.
+    installer: str
+    #: What `--missing-commands` asks for is turned into this command.
+    install: str
+    #: The firmware the image can boot. `genericcloud` and Fedora Cloud Base
+    #: carry an ESP; the Alpine BIOS variant does not.
+    firmware: Firmware
+
+    @property
+    def image(self) -> Path:
+        return CLOUD / self.filename
+
+
+IMAGES: Final[dict[str, CloudImage]] = {
+    one.name: one
+    for one in (
+        CloudImage(
+            "fedora",
+            "Fedora-Cloud-Base-Generic-41-1.4.x86_64.qcow2",
+            "dnf",
+            "dnf install -y --setopt=install_weak_deps=False",
+            Firmware.UEFI,
+        ),
+        CloudImage(
+            "debian",
+            "debian-12-genericcloud-amd64.qcow2",
+            "apt-get",
+            "apt-get update && apt-get install -y --no-install-recommends",
+            Firmware.UEFI,
+        ),
+        CloudImage(
+            "arch",
+            "Arch-Linux-x86_64-cloudimg.qcow2",
+            "pacman",
+            "pacman -Sy --noconfirm",
+            Firmware.UEFI,
+        ),
+    )
+}
+
+
+def seed(workdir: Path) -> Path:
+    """A NoCloud seed ISO setting the root password and nothing else.
+
+    cloud-init finds it by the `cidata` label on any attached block device, so
+    it is handed over as a plain disk rather than a second CD: the driver CD
+    is already the only one and `FIND_DRIVER` looks for it there.
+    """
+    if shutil.which("xorriso") is None:
+        raise RuntimeError("xorriso is not installed, so the seed cannot be built")
+    source = workdir / "seed"
+    source.mkdir(parents=True, exist_ok=True)
+    (source / "user-data").write_text(
+        "#cloud-config\n"
+        "disable_root: false\n"
+        "ssh_pwauth: true\n"
+        "growpart:\n"
+        "  mode: auto\n"
+        "  devices: ['/']\n"
+        "resize_rootfs: true\n"
+        "chpasswd:\n"
+        "  expire: false\n"
+        "  list: |\n"
+        f"    root:{ROOT_PASSWORD}\n"
+    )
+    (source / "meta-data").write_text(
+        "instance-id: gentoo-install-convert\nlocal-hostname: beforeconvert\n"
+    )
+    output = workdir / "cidata.iso"
+    subprocess.run(
+        [
+            "xorriso", "-as", "mkisofs",
+            "-quiet",
+            "-output", str(output),
+            "-volid", "cidata",
+            "-joliet", "-rock",
+            str(source),
+        ],
+        check=True,
+        capture_output=True,
+    )
+    return output
+
+
+def overlay(image: Path, workdir: Path) -> Path:
+    """A writable copy of the image that leaves the download alone.
+
+    A backing file rather than a copy: the images are half a gigabyte each and
+    a run throws its overlay away.
+    """
+    if not image.is_file():
+        raise FileNotFoundError(f"{image} is not there; run lab/vm/cloud/pull.sh")
+    where = workdir / "root.qcow2"
+    where.unlink(missing_ok=True)
+    subprocess.run(
+        [
+            "qemu-img", "create", "-f", "qcow2",
+            "-F", "qcow2", "-b", str(image.resolve()),
+            str(where), OVERLAY_SIZE,
+        ],
+        check=True,
+        capture_output=True,
+    )
+    return where
+
+
+def reach_root(console: SerialConsole, chosen: CloudImage) -> None:
+    """Log in as root once cloud-init has set the password.
+
+    The wait is on cloud-init rather than on the login prompt: agetty offers
+    one before the password exists, and each rejected attempt is one of its
+    five tries.
+    """
+    console.expect(r"login:", timeout=CLOUD_INIT_PATIENCE)
+    console.send("root")
+    console.expect(PASSWORD_PROMPT, timeout=60.0)
+    console.send(ROOT_PASSWORD)
+    console.expect(r"#|\$", timeout=120.0)
+    # `--wait` rather than a sleep: growpart and resizefs run in the same pass
+    # that set the password, and a conversion started before they finish has a
+    # root filesystem the size of the download.
+    console.run("cloud-init status --wait || true", timeout=CLOUD_INIT_PATIENCE)
+    console.run("df -h / && lsblk || true", timeout=120.0)
+
+
+def install_tools(console: SerialConsole, chosen: CloudImage, config: str) -> None:
+    """Install what the launcher says is missing, the way an operator would."""
+    console.run(FIND_DRIVER, timeout=180.0)
+    said = console.expect_command(
+        f"sh /mnt/driver/install.sh --config {config} --missing-commands || true",
+        timeout=300.0,
+    ).decode("utf-8", "replace")
+    wanted = [
+        line.split(":", 1)[1].strip()
+        for line in said.splitlines()
+        if line.startswith("run: ") or "install" in line and chosen.installer in line
+    ]
+    for line in wanted:
+        if line:
+            console.run(line, timeout=1800.0)
+
+
+def convert(console: SerialConsole, config: str) -> None:
+    """Run the installer in place and keep everything it printed."""
+    console.run("mkdir -p /tmp/gentoo-install-results", timeout=60.0)
+    console.run(
+        f"{{ sh /mnt/driver/install.sh --config {config}; echo $? "
+        "> /tmp/gentoo-install-results/install.rc; } 2>&1 "
+        "| tee /tmp/gentoo-install-results/install.txt",
+        timeout=CONVERT_CEILING,
+    )
+
+
+def boot_and_check(root: Path, workdir: Path, chosen: CloudImage, config: str) -> str:
+    """Boot what the conversion produced and read it. Answer "" when it holds.
+
+    A conversion that exits zero has replaced a userland; whether the machine
+    boots the new kernel through the new bootloader is a different question,
+    and it is the one `TESTED.md` counts. The old distribution's hostname is
+    what tells a machine that booted the system it was replacing from one that
+    worked, so the fixture sets a different one.
+    """
+    installation = load(REPOSITORY / "tests" / config)
+    spec = VmSpec(
+        medium=MEDIA["official-minimal"],
+        workdir=workdir,
+        firmware=chosen.firmware,
+        memory="4G",
+        cpus=2,
+        targets=(root,),
+        boot_installed=True,
+    )
+    with Vm(spec) as vm:
+        console = SerialConsole.connect(vm.serial_socket, workdir / "boot.log")
+        console.expect(r"login:", timeout=BOOT_PATIENCE)
+        console.send("root")
+        console.expect(PASSWORD_PROMPT, timeout=120.0)
+        console.send(ROOT_PASSWORD)
+        console.expect(r"#|\$", timeout=180.0)
+        failed: list[str] = []
+        for check in checks(installation):
+            said = console.expect_command(check.command, timeout=180.0)
+            text = said.decode("utf-8", "replace")
+            if not re.search(check.pattern, text, re.MULTILINE):
+                failed.append(f"{check.name} does not match {check.pattern!r}: {text[-200:]!r}")
+        return "; ".join(failed)
+
+
+def read_the_boot_order(console: SerialConsole) -> str:
+    """What the firmware will choose next, read before anything reboots.
+
+    A Fedora conversion exited zero, wrote `\\EFI\\BOOT\\BOOTX64.EFI` and a
+    `Gentoo` entry with `Installation finished. No error reported.`, and the
+    machine then started `Boot0001 "Fedora"` and stopped at
+    `file '/vmlinuz-6.11.4-301.fc41.x86_64' not found`. Whether the new entry
+    exists, and where it sits in `BootOrder`, is the difference between those
+    two and cannot be inferred from `grub-install` saying nothing.
+    """
+    said = console.expect_command(
+        "efibootmgr -v 2>&1 || echo NO-EFIBOOTMGR", timeout=120.0
+    ).decode("utf-8", "replace")
+    print("--- firmware boot entries ---", flush=True)
+    print(said.strip(), flush=True)
+    return said
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--image", choices=sorted(IMAGES), default="fedora")
+    parser.add_argument(
+        "--config",
+        default="fixtures/vm-convert.toml",
+        help="the conversion configuration on the driver CD",
+    )
+    parser.add_argument("--memory", default="6G")
+    parser.add_argument("--cpus", type=int, default=6)
+    parser.add_argument(
+        "--keep",
+        action="store_true",
+        help="leave the overlay behind, which is the only copy of what went wrong",
+    )
+    arguments = parser.parse_args(argv)
+    chosen = IMAGES[arguments.image]
+
+    workdir = confined(WORKROOT / f"{chosen.name}-{int(time.time())}")
+    workdir.mkdir(parents=True)
+    print(f"work directory: {workdir}", flush=True)
+
+    driver = build_driver(workdir / "driver.iso")
+    root = overlay(chosen.image, workdir)
+    cidata = seed(workdir)
+
+    spec = VmSpec(
+        medium=MEDIA["official-minimal"],
+        workdir=workdir,
+        firmware=chosen.firmware,
+        memory=arguments.memory,
+        cpus=arguments.cpus,
+        driver_iso=driver,
+        targets=(root,),
+        disks=(cidata,),
+        boot_installed=True,
+    )
+    started = time.monotonic()
+    with Vm(spec) as vm:
+        console = SerialConsole.connect(vm.serial_socket, vm.serial_log)
+        reach_root(console, chosen)
+        print(f"[{time.monotonic() - started:5.1f}s] root shell on serial", flush=True)
+        install_tools(console, chosen, arguments.config)
+        convert(console, arguments.config)
+        code = console.expect_command(
+            "cat /tmp/gentoo-install-results/install.rc", timeout=60.0
+        )
+        read_the_boot_order(console)
+        print(f"[{time.monotonic() - started:5.1f}s] conversion exited {code!r}", flush=True)
+    if b"0" not in code:
+        if not arguments.keep:
+            root.unlink(missing_ok=True)
+        return 1
+    refused = boot_and_check(root, workdir, chosen, arguments.config)
+    if refused:
+        print(f"FAIL {refused}", flush=True)
+    else:
+        print(
+            f"[{time.monotonic() - started:5.1f}s] the converted machine booted "
+            "and holds what the conversion asked for",
+            flush=True,
+        )
+    if not arguments.keep:
+        root.unlink(missing_ok=True)
+    return 1 if refused else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
The two conversion rows in `TESTED.md` were produced by commands nobody kept, so neither could be reproduced. This is the committed way: a NoCloud seed ISO sets a root password, a qcow2 overlay leaves the download alone and is larger than it so cloud-init grows the root filesystem, the driver CD is handed over, and the machine is read afterwards.

It found what the two BIOS rows could not. A Fedora 41 conversion exits zero, writes `\EFI\BOOT\BOOTX64.EFI` and a `Gentoo` entry with `Installation finished. No error reported.`, and the machine then starts `Boot0001 "Fedora"` from `\EFI\fedora\shimx64.efi` and stops at

    error: file `/vmlinuz-6.11.4-301.fc41.x86_64' not found.
    error: you need to load the kernel first.

— the replaced distribution's loader looking for the kernel the conversion removed. `efibootmgr -v` is now read before anything reboots, because whether the new entry exists and where it sits in `BootOrder` is the difference between those two outcomes and `grub-install` reporting no error says neither.