### PR TITLE
convert: ask for a port nobody holds

### DIFF
--- a/tests/unit/test_harness.py
+++ b/tests/unit/test_harness.py
@@ -2867,3 +2867,46 @@ def test_every_driver_mount_goes_through_the_one_finder() -> None:
     ]
     assert len(naming) == 1, naming
     assert "/dev/sr1 /dev/sr0" in FIND_DRIVER
+
+
+def test_a_conversion_asks_for_a_port_nobody_holds() -> None:
+    """Two runs asked for 2222 and the second died with
+
+        qemu-system-x86_64: -netdev user,...,hostfwd=tcp::2222-:22:
+        Could not set up host forwarding rule 'tcp::2222-:22'
+
+    which names the rule and not the port, and not what already had it.
+    `tests/vm/run.py` has `free_port()` for exactly this; the conversion runner
+    took `VmSpec`'s default instead.
+    """
+    import ast
+    import inspect
+
+    from tests.vm import convert
+
+    for where in (convert.main, convert.boot_and_check):
+        tree = ast.parse(inspect.getsource(where).lstrip())
+        specs = [
+            node
+            for node in ast.walk(tree)
+            if isinstance(node, ast.Call)
+            and isinstance(node.func, ast.Name)
+            and node.func.id == "VmSpec"
+        ]
+        assert specs, where.__name__
+        for spec in specs:
+            named = {
+                keyword.arg
+                for keyword in spec.keywords
+                if keyword.arg is not None
+            }
+            assert "ssh_port" in named, f"{where.__name__} takes the default port"
+
+
+def test_two_free_ports_in_a_row_differ() -> None:
+    """The negative control for the above: a `free_port()` that answered the
+    same number twice would satisfy the check and collide anyway."""
+    from tests.vm.run import free_port
+
+    seen = {free_port() for _ in range(8)}
+    assert len(seen) > 1, seen

--- a/tests/vm/convert.py
+++ b/tests/vm/convert.py
@@ -29,6 +29,7 @@ from .driver import FIND_DRIVER, REPOSITORY, build as build_driver
 from .installed import checks
 from .media import MEDIA
 from .qemu import Firmware, Vm, VmSpec
+from .run import free_port
 from .workdir import confined
 
 #: Where `pull.sh` keeps the images. A run reads them and writes none of them.
@@ -235,6 +236,7 @@ def boot_and_check(root: Path, workdir: Path, chosen: CloudImage, config: str) -
         firmware=chosen.firmware,
         memory="4G",
         cpus=2,
+        ssh_port=free_port(),
         targets=(root,),
         boot_installed=True,
     )
@@ -304,6 +306,10 @@ def main(argv: list[str] | None = None) -> int:
         firmware=chosen.firmware,
         memory=arguments.memory,
         cpus=arguments.cpus,
+        # A free one rather than the default: two conversions, or a conversion
+        # beside a local install, both asked for 2222 and the second died with
+        # `Could not set up host forwarding rule` and no mention of the port.
+        ssh_port=free_port(),
         driver_iso=driver,
         targets=(root,),
         disks=(cidata,),


### PR DESCRIPTION
A second conversion died before its guest existed:

    qemu-system-x86_64: -netdev user,...,hostfwd=tcp::2222-:22:
    Could not set up host forwarding rule 'tcp::2222-:22'

The message names the rule and not the port, and nothing about what already had it. Both `VmSpec` calls took the default 2222; `tests/vm/run.py` has `free_port()` for exactly this, and its `--ssh-port 0` help already says a free one "is what keeps two runs from colliding".