### PR TITLE
cluster: ask the probe whether the keyserver answers

### DIFF
--- a/tests/unit/test_cluster.py
+++ b/tests/unit/test_cluster.py
@@ -1610,14 +1610,23 @@ def test_the_probe_costs_less_than_its_own_budget() -> None:
     import subprocess
 
     probe = cluster.REACHABILITY_PROBE
-    # Two `getent` sites, each inside a five-iteration loop, so ten lookups run.
-    sites = probe.count("getent ")
-    assert sites == 2, sites
-    assert probe.count(f"timeout {cluster.LOOKUP_PATIENCE} getent ") == sites, probe
-    assert probe.count("for i in 1 2 3 4 5; do") == sites, probe
-    # The whole worst case against the 120s the three call sites give it: ten
-    # bounded lookups, three pings at `-W2`, and the `ip` and `dmesg` reads.
-    assert sites * 5 * cluster.LOOKUP_PATIENCE + 3 * 2 < 120
+    # Every lookup is bounded, wherever it sits.
+    lookups = probe.count("getent ")
+    assert lookups >= 2, lookups
+    assert probe.count(f"timeout {cluster.LOOKUP_PATIENCE} getent ") == lookups, probe
+    # Two of them are inside a five-iteration loop, so the worst case counts
+    # those five times and the rest once.
+    looped = probe.count("for i in 1 2 3 4 5; do")
+    assert looped == 2, looped
+    worst = (
+        looped * 5 * cluster.LOOKUP_PATIENCE
+        + (lookups - looped) * cluster.LOOKUP_PATIENCE
+        + 3 * 2
+        + cluster.KEYSERVER_PATIENCE
+    )
+    # Against the 120s the three call sites give it, with room for the `ip`
+    # and `dmesg` reads that follow.
+    assert worst < 90, worst
     assert subprocess.run(["bash", "-n", "-c", probe], capture_output=True).returncode == 0
 
 

--- a/tests/vm/cluster.py
+++ b/tests/vm/cluster.py
@@ -31,6 +31,7 @@ import sys
 import threading
 import time
 import uuid
+import urllib.parse
 import urllib.request
 from dataclasses import dataclass, field, replace
 from enum import Enum
@@ -60,6 +61,8 @@ from gentoo_install.model.config import MirrorRegion, Sync
 from gentoo_install.model import mirrors
 from gentoo_install.exec.config import load
 from gentoo_install.model.serialise import to_toml
+from gentoo_install.plan.portage import KEY_SERVER
+
 from .console import (
     DISK_PASSPHRASE,
     PASSPHRASE_PROMPT,
@@ -761,6 +764,14 @@ GUEST_RESOLVER: Final[str] = "10.31.0.199"
 GUEST_RESOLVERS: Final[tuple[str, ...]] = (GUEST_RESOLVER, GUEST_GATEWAY, "223.5.5.5")
 
 
+#: What the keyserver connect is given. Longer than a lookup because a TLS
+#: handshake is not a name: measured 1.3s from this workstation.
+KEYSERVER_PATIENCE: Final[int] = 5
+
+#: The host `WebrsyncRepository` hands gemato, derived from the installer's own
+#: constant rather than repeated: the probe asks about a name, not a URL.
+KEY_SERVER_HOST: Final[str] = urllib.parse.urlparse(KEY_SERVER).hostname or KEY_SERVER
+
 #: `resolv.conf(5)`: the defaults are `timeout:5 attempts:2`, so a first
 #: nameserver that has stopped answering costs ten seconds on every lookup
 #: before the second one is asked. Five guests of run61 had
@@ -791,6 +802,18 @@ REACHABILITY_PROBE: Final[str] = (
     "printf '\\nLOOKUPS_ANY '; for i in 1 2 3 4 5; do "
     f"timeout {LOOKUP_PATIENCE} getent ahosts mirrors.ustc.edu.cn >/dev/null 2>&1 "
     "&& printf 'ok ' || printf 'fail '; done; "
+    # The keyserver by name and by family, and a connect rather than a ping:
+    # nine guests of run62 stopped at `gpg: keyserver refresh failed: Try again
+    # later` with every mirror reachable, and that message says nothing about
+    # which of the name, the family or the route was missing. From this
+    # workstation the same host answers `HTTP 200` in 1.3s over IPv4.
+    f"printf '\\nKEYSERVER_V4 '; timeout {LOOKUP_PATIENCE} getent ahostsv4 "
+    f"{KEY_SERVER_HOST} 2>/dev/null | head -1 || printf 'unresolved'; "
+    f"printf '\\nKEYSERVER_ANY '; timeout {LOOKUP_PATIENCE} getent ahosts "
+    f"{KEY_SERVER_HOST} 2>/dev/null | head -1 || printf 'unresolved'; "
+    "printf '\\nKEYSERVER_TCP '; "
+    f"timeout {KEYSERVER_PATIENCE} bash -c '</dev/tcp/{KEY_SERVER_HOST}/443' 2>/dev/null "
+    "&& printf 'open' || printf 'refused'; "
     "printf '\\nLIBC '; getconf GNU_LIBC_VERSION; "
     # The state itself, not only whether it worked: sixty-one lookups answered
     # `ENETUNREACH` from a guest that had passed this probe a minute earlier,


### PR DESCRIPTION
Nine of run62's ten guests stopped at

    OpenPGP keyring refresh failed: | gpg: keyserver refresh failed: Try again later

with every mirror reachable and the whole round lost. That message names neither the address family nor the route, and from this workstation the same host answers `HTTP 200` in 1.3s over IPv4, so the difference is inside the guest and nothing in the log said what it was.

The probe now resolves the keyserver by name over each family and opens a TCP connection to it, all bounded: the worst case stays under a third of the 120s the three call sites give it. The host comes from `plan/portage.py`'s own `KEY_SERVER` rather than being repeated.

This measures; it does not fix. Working around a keyring refresh that cannot reach a keyserver means either verifying against the keys the stage3 shipped without a revocation check, or not verifying, and both change a security default.