### PR TITLE
qemu: exit the way that flushes the firmware variables

### DIFF
--- a/tests/unit/test_harness.py
+++ b/tests/unit/test_harness.py
@@ -2910,3 +2910,66 @@ def test_two_free_ports_in_a_row_differ() -> None:
 
     seen = {free_port() for _ in range(8)}
     assert len(seen) > 1, seen
+
+
+def test_a_vm_is_asked_to_quit_before_it_is_killed(tmp_path: Path) -> None:
+    """A Fedora conversion wrote a `Gentoo` NVRAM entry and `efibootmgr -v` in
+    that guest answered
+
+        BootOrder: 0002,0001,0003,0000,0004
+        Boot0002* Gentoo  ...\\EFI\\Gentoo\\grubx64.efi
+
+    with Gentoo first. The next VM in the same work directory booted
+    `Boot0001 "Fedora"` and stopped at a missing kernel, and the workdir's
+    `OVMF_VARS.fd` held neither name: `kill()` is SIGKILL, so the pflash write
+    stayed in the host page cache.
+    """
+    import socket as socket_module
+
+    from tests.vm.qemu import Vm
+
+    class Process:
+        def __init__(self) -> None:
+            self.killed = False
+
+        def poll(self) -> int | None:
+            return None
+
+        def wait(self, timeout: float | None = None) -> int:
+            return 0
+
+        def kill(self) -> None:
+            self.killed = True
+
+    monitor = tmp_path / "monitor.sock"
+    listener = socket_module.socket(socket_module.AF_UNIX)
+    listener.bind(str(monitor))
+    listener.listen(1)
+    try:
+        vm = Vm.__new__(Vm)
+        vm.monitor_socket = monitor
+        vm.serial_socket = tmp_path / "serial.sock"
+        process = Process()
+        vm._process = cast(Any, process)
+
+        vm.shut_down(timeout=5.0)
+        client, _ = listener.accept()
+        with client:
+            assert client.recv(64) == b"quit\n"
+    finally:
+        listener.close()
+    # And the kill still happens, because the monitor is the polite route and
+    # not the guaranteed one.
+    assert process.killed
+
+
+def test_a_vm_exit_takes_the_quit_path() -> None:
+    """The negative control: `__exit__` calling `kill()` straight is what lost
+    the firmware variables, so the path it takes is the contract."""
+    import inspect
+
+    from tests.vm.qemu import Vm
+
+    source = inspect.getsource(Vm.__exit__)
+    assert "self.shut_down()" in source, source
+    assert "self.kill()" not in source, source

--- a/tests/vm/qemu.py
+++ b/tests/vm/qemu.py
@@ -4,6 +4,7 @@
 from __future__ import annotations
 
 import shutil
+import socket
 import subprocess
 from dataclasses import dataclass
 from enum import Enum
@@ -191,6 +192,26 @@ class Vm:
             raise QemuError("the VM was never started")
         return self._process.wait(timeout=timeout)
 
+    def shut_down(self, timeout: float = 60.0) -> None:
+        """Exit qemu the way that flushes its block devices.
+
+        `kill()` is SIGKILL, so a pflash write stays in the host page cache and
+        is lost: a Fedora conversion wrote a `Gentoo` entry, `efibootmgr -v` in
+        that guest answered `BootOrder: 0002,0001,...` with Gentoo first, and
+        the next VM booted a firmware whose `OVMF_VARS.fd` held neither name.
+        """
+        if self._process is not None and self._process.poll() is None:
+            try:
+                with socket.socket(socket.AF_UNIX) as monitor:
+                    monitor.settimeout(10.0)
+                    monitor.connect(str(self.monitor_socket))
+                    monitor.sendall(b"quit\n")
+                self._process.wait(timeout=timeout)
+            except (OSError, subprocess.TimeoutExpired):
+                # The monitor is the polite route and not the guaranteed one.
+                pass
+        self.kill()
+
     def kill(self) -> None:
         if self._process is not None and self._process.poll() is None:
             self._process.kill()
@@ -208,4 +229,4 @@ class Vm:
         exc: BaseException | None,
         tb: TracebackType | None,
     ) -> None:
-        self.kill()
+        self.shut_down()


### PR DESCRIPTION
Measured, and it corrects what I reported an hour ago as a product defect. A Fedora conversion exits zero and `efibootmgr -v` inside that guest answers

    BootOrder: 0002,0001,0003,0000,0004
    Boot0002* Gentoo  HD(2,GPT,...)/\EFI\Gentoo\grubx64.efi
    Boot0001* Fedora  HD(2,GPT,...)/\EFI\fedora\shimx64.efi

with the new entry first, so `grub-install --bootloader-id=Gentoo` did its job. The next VM in the same work directory still booted `Boot0001 "Fedora"` and stopped at a missing kernel, and that workdir's `OVMF_VARS.fd` contains neither name in any encoding: the entries the guest saw were OVMF's own discovery, and the NVRAM write never reached the file because `__exit__` sent SIGKILL.

`shut_down()` asks the monitor to `quit`, which closes the block devices, and falls back to the kill when the monitor does not answer. So the in-place conversion on UEFI is not known-broken; it was never given a firmware that remembered.