### PR TITLE
portage: outlast a keyserver the whole round is asking

### DIFF
--- a/gentoo_install/plan/portage.py
+++ b/gentoo_install/plan/portage.py
@@ -502,7 +502,7 @@ class WebrsyncRepository(Operation):
         # WKD lookup out rather than falling back. `openrc-sdboot` ended a
         # cluster round there with the tree never fetched.
         last: CommandFailed | None = None
-        for attempt in range(SYNC_TRIES):
+        for attempt in range(KEYRING_TRIES):
             try:
                 context.run_in_target(
                     ["env", f"PORTAGE_GPG_KEY_SERVER={server}", "emerge-webrsync"]
@@ -510,8 +510,15 @@ class WebrsyncRepository(Operation):
                 return
             except CommandFailed as failed:
                 last = failed
-                if attempt + 1 < SYNC_TRIES:
-                    context.run(["sleep", f"{SYNC_PAUSE * (attempt + 1):g}"])
+                if attempt + 1 >= KEYRING_TRIES:
+                    break
+                # A keyserver the whole round is asking at once needs longer
+                # than a mirror rewriting a Manifest, and the two failures are
+                # told apart before the wait rather than after it.
+                pause = (
+                    KEYRING_PAUSE if _keyring_refused(str(failed)) else SYNC_PAUSE
+                ) * (attempt + 1)
+                context.run(["sleep", f"{pause:g}"])
         assert last is not None
         raise last
 
@@ -526,6 +533,29 @@ UNPACK_CHECKPOINT: Final[int] = 20000
 #: minute apart cover it without walking around a mismatch that is real.
 SYNC_TRIES: Final[int] = 3
 SYNC_PAUSE: Final[float] = 30.0
+
+#: What a keyserver under load answers. gemato refreshes the signing key to
+#: check revocations, and ten cluster guests asking one host inside three
+#: minutes got nine of these: run62 lost every fixture but `vm-f2fs`, which
+#: reached the same step at 49.6 minutes and passed.
+KEYRING_REFUSED: Final[tuple[str, ...]] = (
+    "keyserver refresh failed",
+    "openpgp keyring refresh failed",
+    "no keyserver available",
+)
+
+#: Tries and the first pause for that case only. Geometric, so four attempts
+#: span about twelve minutes rather than the ninety seconds a Manifest
+#: mismatch needs.
+KEYRING_TRIES: Final[int] = 4
+KEYRING_PAUSE: Final[float] = 90.0
+
+
+def _keyring_refused(output: str) -> bool:
+    """Whether the failure was the keyring refresh rather than the snapshot."""
+    lowered = output.lower()
+    return any(marker in lowered for marker in KEYRING_REFUSED)
+
 
 #: Portage's own default is 180, and a mirror that queues rather than refuses
 #: spends longer than that before it sends a byte: USTC answers `Upstream

--- a/tests/unit/test_plan_portage.py
+++ b/tests/unit/test_plan_portage.py
@@ -1770,7 +1770,10 @@ def test_a_snapshot_that_never_arrives_stops_the_install() -> None:
     with pytest.raises(CommandFailed):
         plan_portage.WebrsyncRepository().apply(recorder)
 
-    assert tries["n"] == plan_portage.SYNC_TRIES
+    # `KEYRING_TRIES`, not `SYNC_TRIES`: the first sync outlasts a keyserver a
+    # whole cluster round is asking at once, and how long it waits between
+    # attempts is what the failure decides.
+    assert tries["n"] == plan_portage.KEYRING_TRIES
 
 
 #: What `btrfs-luks` printed when the binary host dropped one TLS handshake
@@ -2076,3 +2079,63 @@ def test_a_signalled_emerge_that_printed_something_is_not_blamed_on_the_host() -
     with pytest.raises(CommandFailed, match="SIGKILL"):
         portage.Emerge(packages=("sys-devel/gcc",), summary="install gcc").apply(recorder)
     assert not recorder.degraded(portage.BINARY_PACKAGES)
+
+
+def test_a_keyserver_the_whole_round_is_asking_gets_longer_than_a_mirror() -> None:
+    """run62 dispatched ten guests and nine stopped inside ten minutes at
+
+        OpenPGP keyring refresh failed: | gpg: keyserver refresh failed:
+        Try again later
+
+    while `vm-f2fs` reached the same step at 49.6 minutes and passed. So the
+    keyserver was not unreachable, it was being asked by a whole round at once,
+    and three tries over ninety seconds is not enough to outlast that. A
+    Manifest mismatch is the opposite case and still gets the short wait.
+    """
+    refused = Recorder()
+
+    def refusing(argv: Sequence[str]) -> CommandOutput | None:
+        if argv[-1] != "emerge-webrsync":
+            return None
+        raise CommandFailed(
+            "emerge-webrsync ended with exit 1: [  ERROR] OpenPGP keyring "
+            "refresh failed: | gpg: keyserver refresh failed: Try again later"
+        )
+
+    refused.answering = refusing
+
+    with pytest.raises(CommandFailed):
+        portage.WebrsyncRepository().apply(refused)
+
+    slept = [argv for argv in refused.commands if argv and argv[0] == "sleep"]
+    assert len(slept) == portage.KEYRING_TRIES - 1, slept
+    assert [float(one[1]) for one in slept] == [
+        portage.KEYRING_PAUSE * (n + 1) for n in range(portage.KEYRING_TRIES - 1)
+    ], slept
+    # Twelve minutes rather than ninety seconds, which is what outlasts a round.
+    assert sum(float(one[1]) for one in slept) > 8 * 60
+
+
+def test_a_manifest_mismatch_still_gets_the_short_wait() -> None:
+    """The negative direction: a mirror rewriting its Manifests answers within
+    a minute, and waiting twelve for it turns a transient into a stall."""
+    mismatch = Recorder()
+
+    def mismatching(argv: Sequence[str]) -> CommandOutput | None:
+        if argv[-1] != "emerge-webrsync":
+            return None
+        raise CommandFailed(
+            "emerge-webrsync ended with exit 1: Manifest mismatch for "
+            "gui-apps/Manifest.gz __size__: expected: 5745, have: 5746"
+        )
+
+    mismatch.answering = mismatching
+
+    with pytest.raises(CommandFailed):
+        portage.WebrsyncRepository().apply(mismatch)
+
+    slept = [float(argv[1]) for argv in mismatch.commands if argv and argv[0] == "sleep"]
+    assert slept == [
+        portage.SYNC_PAUSE * (n + 1) for n in range(portage.KEYRING_TRIES - 1)
+    ], slept
+    assert sum(slept) < 5 * 60, slept


### PR DESCRIPTION
run62 dispatched ten guests. Nine stopped inside ten minutes at

    OpenPGP keyring refresh failed: | gpg: keyserver refresh failed: Try again later

and `vm-f2fs` reached the same step at 49.6 minutes and passed. So the keyserver was reachable and was being asked by a whole round at once; three tries over ninety seconds does not outlast that.

The first sync now takes four tries, and what it waits between them depends on which failure it was: a keyring refusal gets a geometric ninety seconds, spanning about twelve minutes, and a Manifest mismatch keeps the thirty it needs. Waiting twelve minutes for a mirror rewriting its Manifests would turn a transient into a stall, so the two are told apart before the wait rather than after it.