### PR TITLE
probe: read what this machine boots with

### DIFF
--- a/gentoo_install/exec/probe.py
+++ b/gentoo_install/exec/probe.py
@@ -16,6 +16,7 @@ import re
 import shutil
 import time
 from dataclasses import dataclass, field
+from enum import Enum
 from pathlib import Path
 from typing import ClassVar, Final, Iterable, Mapping
 
@@ -46,6 +47,29 @@ EFI_WIDTH: Final[Path] = EFI_MARKER / "fw_platform_size"
 #: the kernel booted through EFI; it does not say the variables can be
 #: written, and `efibootmgr --create` is what ZFSBootMenu's install runs.
 EFI_VARIABLES: Final[Path] = EFI_MARKER / "efivars"
+
+
+class BootMethod(Enum):
+    """What arms a one-shot entry on this machine, read rather than chosen.
+
+    Three ways to boot once and return: `bootctl set-oneshot` where
+    systemd-boot owns the esp, `efibootmgr --bootnext` where GRUB does, and
+    GRUB's own `next_entry` on a BIOS machine. Which one applies is a fact
+    about the machine.
+    """
+
+    SYSTEMD_BOOT = "systemd-boot"
+    UEFI_GRUB = "uefi-grub"
+    BIOS_GRUB = "bios-grub"
+    NONE = "none"
+
+
+#: Where a BIOS GRUB keeps its configuration. Both spellings, because Fedora
+#: and openSUSE use `grub2` and Debian and Arch use `grub`.
+GRUB_DIRECTORIES: Final[tuple[Path, ...]] = (
+    Path("/boot/grub"),
+    Path("/boot/grub2"),
+)
 
 
 def _efi_variables() -> bool:
@@ -995,6 +1019,24 @@ class Probe:
         if kind in self.LIVE_ROOT_TYPES:
             return f"the root filesystem is {kind}"
         return ""
+
+    def boot_method(self) -> BootMethod:
+        """How a one-shot entry is armed here, or `NONE` when none of the three is.
+
+        `bootctl status` before `efibootmgr`: a machine with systemd-boot on
+        its esp also has writable efivars, so asking about the variables first
+        would answer `UEFI_GRUB` for a machine GRUB does not manage.
+        """
+        if _efi_variables():
+            said = self.runner.run(["bootctl", "status"], check=False)
+            if said.returncode == 0 and "systemd-boot" in said.stdout:
+                return BootMethod.SYSTEMD_BOOT
+            if shutil.which("efibootmgr") is not None:
+                return BootMethod.UEFI_GRUB
+            return BootMethod.NONE
+        if any(one.is_dir() for one in GRUB_DIRECTORIES):
+            return BootMethod.BIOS_GRUB
+        return BootMethod.NONE
 
     def root_source(self) -> str:
         """What `/` is mounted from, for the warning that names it."""

--- a/tests/unit/test_probe.py
+++ b/tests/unit/test_probe.py
@@ -308,3 +308,70 @@ def test_a_top_level_btrfs_root_is_not_called_a_subvolume(tmp_path: Path) -> Non
     layout = probe.Probe(runner=TopLevel(log=lambda line: None), work=tmp_path).storage_layout()
     assert layout.root_device == "/dev/vda3"
     assert layout.root_subvolume is None
+
+
+def test_systemd_boot_is_asked_about_before_the_efi_variables(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A machine with systemd-boot on its esp also has writable efivars, so
+    reading the variables first answers `uefi-grub` for a machine GRUB does not
+    manage and arms the wrong one-shot: `bootctl set-oneshot` is what that
+    machine understands, and `efibootmgr --bootnext` names an entry GRUB never
+    wrote.
+    """
+    monkeypatch.setattr(probe, "_efi_variables", lambda: True)
+    monkeypatch.setattr("shutil.which", lambda name: f"/usr/bin/{name}")
+    asked: list[tuple[str, ...]] = []
+
+    class Bootctl(Runner):
+        def run(self, argv: Sequence[str], **rest: object) -> Result:
+            asked.append(tuple(argv))
+            return Result(
+                argv=tuple(argv),
+                returncode=0,
+                stdout="System:\n     Firmware: UEFI 2.70\n Boot Loader: systemd-boot 257\n",
+                stderr="",
+                seconds=0.0,
+            )
+
+    method = probe.Probe(runner=Bootctl(log=lambda line: None), work=tmp_path).boot_method()
+
+    assert method is probe.BootMethod.SYSTEMD_BOOT
+    assert asked and asked[0][0] == "bootctl", asked
+
+
+def test_a_uefi_machine_without_systemd_boot_uses_efibootmgr(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setattr(probe, "_efi_variables", lambda: True)
+    monkeypatch.setattr("shutil.which", lambda name: f"/usr/bin/{name}")
+
+    class NoBootctl(Runner):
+        def run(self, argv: Sequence[str], **rest: object) -> Result:
+            return Result(argv=tuple(argv), returncode=1, stdout="", stderr="", seconds=0.0)
+
+    method = probe.Probe(runner=NoBootctl(log=lambda line: None), work=tmp_path).boot_method()
+
+    assert method is probe.BootMethod.UEFI_GRUB
+
+
+def test_a_bios_machine_is_found_by_its_grub_directory(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Both spellings: Fedora and openSUSE use `grub2`, Debian and Arch use
+    `grub`, and a machine with neither has no way to be armed."""
+    # The shipped value first, because the patch below replaces it and a check
+    # that only reads the patched one cannot notice a spelling going missing.
+    assert {one.name for one in probe.GRUB_DIRECTORIES} == {"grub", "grub2"}, (
+        probe.GRUB_DIRECTORIES
+    )
+
+    monkeypatch.setattr(probe, "_efi_variables", lambda: False)
+    absent = tmp_path / "absent"
+    monkeypatch.setattr(probe, "GRUB_DIRECTORIES", (absent, tmp_path / "grub2"))
+
+    quiet = Runner(log=lambda line: None)
+    assert probe.Probe(runner=quiet, work=tmp_path).boot_method() is probe.BootMethod.NONE
+
+    (tmp_path / "grub2").mkdir()
+    assert probe.Probe(runner=quiet, work=tmp_path).boot_method() is probe.BootMethod.BIOS_GRUB


### PR DESCRIPTION
The foundation for the one-shot boot entry, and nothing else yet. There are three ways to boot once and return to the machine's own system — `bootctl set-oneshot` where systemd-boot owns the esp, `efibootmgr --bootnext` where GRUB does, and GRUB's `next_entry` on BIOS — and which one applies is a fact to read rather than a choice to make.

`bootctl status` is asked before the EFI variables: a machine running systemd-boot also has writable efivars, so reading the variables first answers `uefi-grub` and arms an entry GRUB never wrote. Both `grub` and `grub2` are looked for, because Fedora and openSUSE use one spelling and Debian and Arch the other.