### PR TITLE
proxmox: send an idempotent reset again when it times out

### DIFF
--- a/tests/unit/test_proxmox.py
+++ b/tests/unit/test_proxmox.py
@@ -3688,3 +3688,70 @@ def test_an_entry_that_booted_unedited_is_said_at_once() -> None:
 
     with pytest.raises(GrubNotReadable, match="booted before its countdown"):
         hold_the_menu(Console(), timeout=30.0)
+
+
+def test_a_reset_that_timed_out_is_sent_again(monkeypatch: pytest.MonkeyPatch) -> None:
+    """run63 lost `vm-unlock` at 1.2 minutes to
+
+        POST /nodes/infra-node3/qemu/9304/status/reset did not answer:
+        <urlopen error timed out>
+
+    A reset is idempotent: resetting a guest that was already reset does
+    nothing, and a request that timed out may well have arrived. So the one
+    call that cannot be made worse by repeating it was the one not repeated.
+    """
+    from tests.vm.proxmox import Guest, GuestSpec, ProxmoxTransientError
+
+    monkeypatch.setattr("tests.vm.proxmox.time.sleep", lambda seconds: None)
+    tries: list[str] = []
+
+    class Timing:
+        def call(self, method: str, path: str, **form: object) -> str:
+            tries.append(path)
+            if len(tries) < 3:
+                raise ProxmoxTransientError(f"{method} {path} did not answer: timed out")
+            return "UPID:done"
+
+        def wait(self, node: str, upid: str, patience: float = 0.0) -> None:
+            return None
+
+    guest = Guest(
+        api=cast(Any, Timing()),
+        node="infra-node3",
+        vmid=9304,
+        spec=GuestSpec(name="vm-unlock", iso="x"),
+    )
+    guest.reset()
+
+    assert len(tries) == 3, tries
+    assert all(one.endswith("/status/reset") for one in tries), tries
+
+
+def test_a_reset_that_never_answers_still_stops_the_run(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The negative direction: retrying for ever would hold a node until the
+    schedule ended, which is what the bounded count is for."""
+    from tests.vm.proxmox import Guest, GuestSpec, ProxmoxTransientError, RESET_TRIES
+
+    monkeypatch.setattr("tests.vm.proxmox.time.sleep", lambda seconds: None)
+    tries: list[str] = []
+
+    class Never:
+        def call(self, method: str, path: str, **form: object) -> str:
+            tries.append(path)
+            raise ProxmoxTransientError(f"{method} {path} did not answer: timed out")
+
+        def wait(self, node: str, upid: str, patience: float = 0.0) -> None:
+            return None
+
+    guest = Guest(
+        api=cast(Any, Never()),
+        node="infra-node3",
+        vmid=9304,
+        spec=GuestSpec(name="vm-unlock", iso="x"),
+    )
+    with pytest.raises(ProxmoxTransientError):
+        guest.reset()
+
+    assert len(tries) == RESET_TRIES, tries

--- a/tests/vm/proxmox.py
+++ b/tests/vm/proxmox.py
@@ -70,6 +70,12 @@ ISO_STORAGE: Final[str] = "local"
 #: Long enough for a stage3 to extract over a slow mirror, short enough that a
 #: node that stopped answering does not hold the whole campaign.
 API_TIMEOUT: Final[float] = 60.0
+
+#: A reset is idempotent, so a request that may or may not have arrived is
+#: safe to send again: resetting a guest that was already reset does nothing.
+#: run63 lost `vm-unlock` at 1.2 minutes to one `<urlopen error timed out>`.
+RESET_TRIES: Final[int] = 3
+RESET_PAUSE: Final[float] = 5.0
 TASK_POLL: Final[float] = 2.0
 
 #: What Proxmox writes as a task's exit status when it finished its work
@@ -552,9 +558,26 @@ class Guest:
         the run read an empty serial port for five minutes. Resetting once the
         console is up puts the whole boot on the wire.
         """
-        self.api.wait(
-            self.node, self.api.call("POST", f"/nodes/{self.node}/qemu/{self.vmid}/status/reset")
-        )
+        # Retried, because resetting a guest that was already reset does
+        # nothing and a request that timed out may well have arrived: run63
+        # lost `vm-unlock` at 1.2 minutes to one
+        # `POST .../status/reset did not answer: <urlopen error timed out>`.
+        last: ProxmoxTransientError | None = None
+        for attempt in range(RESET_TRIES):
+            try:
+                self.api.wait(
+                    self.node,
+                    self.api.call(
+                        "POST", f"/nodes/{self.node}/qemu/{self.vmid}/status/reset"
+                    ),
+                )
+                return
+            except ProxmoxTransientError as error:
+                last = error
+                if attempt + 1 < RESET_TRIES:
+                    time.sleep(RESET_PAUSE * (attempt + 1))
+        assert last is not None
+        raise last
 
     def transferred(self) -> int | None:
         """Bytes this guest has received and written since it started.


### PR DESCRIPTION
run63 lost `vm-unlock` at 1.2 minutes to

    POST /nodes/infra-node3/qemu/9304/status/reset did not answer: <urlopen error timed out>

A reset is idempotent: resetting a guest that was already reset does nothing, and a request that timed out may well have arrived. So the one call that cannot be made worse by repeating it was the one not repeated, and a transient API timeout threw away a guest a minute into its run.

Bounded at three tries, because retrying for ever holds a node until the schedule ends.