### PR TITLE
cli: the memory-mode flags and what they cannot promise

### DIFF
--- a/gentoo_install/cli.py
+++ b/gentoo_install/cli.py
@@ -25,9 +25,9 @@ from .errors import GentooInstallError
 from .data import load_catalog
 from .exec import fetch, preflight, report
 from .exec.apply import Machine, already_degraded, apply, completed
-from .exec.probe import Probe, probe_storage_facts
+from .exec.probe import BootMethod, Probe, probe_storage_facts
 from .exec.runner import Runner
-from .model.device import StorageFacts, StorageLayout
+from .model.device import StorageFacts, StorageLayout, ZfsPool
 from .model.size import Size
 from .tui import app, screens
 from .tui.curses_screen import CursesScreen, too_small
@@ -40,11 +40,14 @@ from .model.config import (
     DiskMode,
     Firmware,
     InstallConfig,
+    MemoryLaunch,
+    MemoryMode,
     MirrorConfig,
     MirrorRegion,
     PortageConfig,
 )
 from .exec.config import load_source
+from .model.validate import validate_memory_launch
 from .plan import convert
 from .plan.convert import SWAP_CONFIRMATION
 from .plan.build import DEFAULT_MIRROR, build, running_config, stage3_mirror
@@ -131,13 +134,89 @@ def parser() -> argparse.ArgumentParser:
         action="store_true",
         help="install without checking the machine first, for a harness that knows what it booted",
     )
+    memory = parsed.add_mutually_exclusive_group()
+    memory.add_argument(
+        "--ram",
+        dest="memory_mode",
+        action="store_const",
+        const=MemoryMode.RAM,
+        help="boot the whole Gentoo CJK ISO in memory",
+    )
+    memory.add_argument(
+        "--lowram",
+        dest="memory_mode",
+        action="store_const",
+        const=MemoryMode.LOWRAM,
+        help="boot the Alpine netboot environment in memory",
+    )
+    parsed.add_argument(
+        "--ssh-key",
+        default="",
+        help="a readable public-key file or an ssh- prefixed public key for the memory environment",
+    )
+    parsed.add_argument(
+        "--ssh-port",
+        type=int,
+        help="the port where the memory environment's sshd listens",
+    )
+    parsed.add_argument(
+        "--root-password",
+        default="",
+        help="the root password for the memory environment",
+    )
     return parsed
+
+
+def _memory_launch(arguments: argparse.Namespace) -> MemoryLaunch | None:
+    mode = arguments.memory_mode
+    if mode is None:
+        if arguments.ssh_key or arguments.ssh_port is not None or arguments.root_password:
+            raise errors.ConfigError(
+                "--ssh-key, --ssh-port and --root-password require --ram or --lowram"
+            )
+        return None
+    if arguments.ssh_key and not (
+        arguments.ssh_key.startswith("ssh-") or _is_readable_file(arguments.ssh_key)
+    ):
+        raise errors.ConfigError(
+            "--ssh-key must be a readable file or an ssh- prefixed public key"
+        )
+    return MemoryLaunch(
+        mode=mode,
+        ssh_key=arguments.ssh_key,
+        ssh_port=arguments.ssh_port,
+        root_password=arguments.root_password,
+    )
+
+
+def _is_readable_file(name: str) -> bool:
+    try:
+        with Path(name).open("rb"):
+            return True
+    except OSError:
+        return False
+
+
+def _validate_memory_launch(
+    config: InstallConfig, launch: MemoryLaunch, probe: Probe
+) -> None:
+    validate_memory_launch(config, launch)
+    if probe.boot_method() is BootMethod.NONE:
+        raise errors.PreflightFailed(
+            f"--{launch.mode.value} cannot arm a one-shot boot entry on this machine"
+        )
+    if launch.mode is MemoryMode.RAM and not config.disk.graph.of_type(ZfsPool):
+        print(
+            "warning: --ram is slower for a layout without ZFS; --lowram uses the smaller Alpine netboot",
+            file=sys.stderr,
+        )
 
 
 def main(argv: Sequence[str] | None = None) -> int:
     arguments = parser().parse_args(argv)
     state = RunState(disk_was_written=bool(arguments.resume))
     try:
+        launch = _memory_launch(arguments)
         _require_root(arguments)
         if _needs_network(arguments):
             # Before any reachability check: an unset clock makes every HTTPS
@@ -168,6 +247,8 @@ def main(argv: Sequence[str] | None = None) -> int:
             config = chosen
         else:
             config = load_source(arguments.config)
+        if launch is not None:
+            _validate_memory_launch(config, launch, _probe_for(arguments))
         if arguments.missing_commands:
             print(
                 "\n".join(

--- a/gentoo_install/model/config.py
+++ b/gentoo_install/model/config.py
@@ -38,6 +38,33 @@ class DiskMode(Enum):
     IMAGE = "image"
 
 
+class MemoryMode(Enum):
+    """Which live environment a one-shot boot entry starts in memory.
+
+    Two rather than one because the Alpine netboot kernel has no `zfs.ko`, so
+    a ZFS layout can only be installed from the Gentoo CJK ISO, which costs
+    gigabytes of memory rather than hundreds of megabytes.
+    """
+
+    RAM = "ram"
+    LOWRAM = "lowram"
+
+
+@dataclass(frozen=True)
+class MemoryLaunch:
+    """What the operator asked the memory environment to be reachable as.
+
+    Not part of `InstallConfig`: it describes the environment that runs the
+    install rather than the system being installed, and it comes from flags
+    because this path has no interface to put it on.
+    """
+
+    mode: MemoryMode
+    ssh_key: str = ""
+    ssh_port: int | None = None
+    root_password: str = ""
+
+
 class InitSystem(Enum):
     OPENRC = "openrc"
     SYSTEMD = "systemd"

--- a/gentoo_install/model/validate.py
+++ b/gentoo_install/model/validate.py
@@ -18,7 +18,16 @@ from typing import Collection, Final, Mapping
 from ..errors import CommandFailed, ValidationFailed
 from . import compat
 from .compat import Trait
-from .config import Bootloader, DiskMode, InitSystem, InstallConfig, Networking, ProxyKind
+from .config import (
+    Bootloader,
+    DiskMode,
+    InitSystem,
+    InstallConfig,
+    MemoryLaunch,
+    MemoryMode,
+    Networking,
+    ProxyKind,
+)
 from .device import (
     DeviceGraph,
     DeviceId,
@@ -215,6 +224,46 @@ def validate(
     if problems:
         raise ValidationFailed(
             "the configuration does not describe an installable system:\n  " + "\n  ".join(problems)
+        )
+
+
+#: What the LiveCD kernel command line accepts, read from
+#: `catalyst/livecd/files/README.txt` lines 96-98: `dosshd` starts sshd and
+#: `passwd=foo` sets the root password, which `dosshd` requires because it
+#: scrambles the password first. None of its 35 options names a key or a port.
+LIVECD_TAKES_A_KEY: Final[bool] = False
+
+
+def validate_memory_launch(config: InstallConfig, launch: MemoryLaunch) -> None:
+    """Refuse a memory environment that cannot do what was asked of it.
+
+    A password is the environment's own mechanism rather than a fallback, so it
+    is what the other two options depend on: a key and a port take effect only
+    once the installer has written them, and sshd is already listening on 22
+    with the command line's password by then.
+    """
+    problems: list[str] = []
+    if launch.mode is MemoryMode.LOWRAM and config.disk.graph.of_type(ZfsPool):
+        problems.append(
+            "the layout needs ZFS, the Alpine netboot kernel has no zfs.ko, "
+            "and --ram is the mode whose Gentoo CJK ISO carries it"
+        )
+    if launch.ssh_port is not None and not 1 <= launch.ssh_port <= 65535:
+        problems.append("--ssh-port must be between 1 and 65535")
+    later = [
+        name
+        for name, given in (("--ssh-key", launch.ssh_key), ("--ssh-port", launch.ssh_port))
+        if given
+    ]
+    if later and not launch.root_password and not LIVECD_TAKES_A_KEY:
+        problems.append(
+            f"{' and '.join(later)} take effect only after the installer writes them, "
+            "and until then sshd listens on 22 with the password the kernel command "
+            "line gave it, so --root-password is needed as well"
+        )
+    if problems:
+        raise ValidationFailed(
+            "the memory environment cannot start:\n  " + "\n  ".join(problems)
         )
 
 

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -15,11 +15,11 @@ import pytest
 from gentoo_install import cli
 from gentoo_install.exec import fetch
 from gentoo_install.exec import report
-from gentoo_install.exec.probe import Probe as RealProbe
+from gentoo_install.exec.probe import BootMethod, Probe as RealProbe
 from gentoo_install.exec.runner import Runner
 from gentoo_install.cli import EXIT_CONFIG, EXIT_INTEGRITY, EXIT_OK, EXIT_PREFLIGHT, main
 from gentoo_install.errors import ConfigError, IntegrityError
-from gentoo_install.model.config import DiskConfig, DiskMode
+from gentoo_install.model.config import DiskConfig, DiskMode, MemoryLaunch, MemoryMode
 from gentoo_install.model.device import DeviceGraph, DeviceId, StorageFacts, StorageLayout
 from gentoo_install.plan.build import DEFAULT_MIRROR
 from gentoo_install.exec.config import load
@@ -33,6 +33,73 @@ def test_a_dry_run_prints_every_stage_and_exits_clean(capsys: pytest.CaptureFixt
     assert code == EXIT_OK
     assert "[partition]" in printed and "[bootloader]" in printed
     assert "operations:" in printed.splitlines()[-1]
+
+
+@pytest.mark.parametrize(
+    ("flag", "mode"),
+    (("--ram", MemoryMode.RAM), ("--lowram", MemoryMode.LOWRAM)),
+)
+def test_memory_mode_flags_choose_the_named_environment(flag: str, mode: MemoryMode) -> None:
+    arguments = cli.parser().parse_args([flag])
+    assert cli._memory_launch(arguments) == MemoryLaunch(mode)
+    with_credentials = cli.parser().parse_args(
+        [
+            flag,
+            "--ssh-key",
+            "ssh-ed25519 public-key",
+            "--ssh-port",
+            "2222",
+            "--root-password",
+            "secret",
+        ]
+    )
+    assert cli._memory_launch(with_credentials) == MemoryLaunch(
+        mode,
+        ssh_key="ssh-ed25519 public-key",
+        ssh_port=2222,
+        root_password="secret",
+    )
+
+
+def test_memory_mode_flags_are_mutually_exclusive() -> None:
+    with pytest.raises(SystemExit):
+        cli.parser().parse_args(["--ram", "--lowram"])
+
+
+def test_memory_key_must_be_a_file_or_ssh_public_key(tmp_path: Path) -> None:
+    key = tmp_path / "key.pub"
+    key.write_text("public key", encoding="utf-8")
+    from_file = cli._memory_launch(
+        cli.parser().parse_args(["--ram", "--ssh-key", str(key)])
+    )
+    assert from_file is not None and from_file.ssh_key == str(key)
+    with pytest.raises(ConfigError, match="readable file or an ssh- prefixed"):
+        cli._memory_launch(
+            cli.parser().parse_args(["--ram", "--ssh-key", "not-a-public-key"])
+        )
+
+
+@pytest.mark.parametrize("mode", ("--ram", "--lowram"))
+def test_memory_modes_require_a_one_shot_boot_entry(
+    mode: str, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    monkeypatch.setattr(os, "geteuid", lambda: 0)
+    monkeypatch.setattr(RealProbe, "boot_method", lambda self: BootMethod.NONE)
+    code = main(["--config", str(FIXTURES / "btrfs-luks.toml"), "--dry-run", mode])
+    assert code == EXIT_PREFLIGHT
+    assert "cannot arm a one-shot boot entry" in capsys.readouterr().err
+
+
+def test_ram_warns_but_proceeds_for_a_layout_without_zfs(
+    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    monkeypatch.setattr(os, "geteuid", lambda: 0)
+    monkeypatch.setattr(RealProbe, "boot_method", lambda self: BootMethod.SYSTEMD_BOOT)
+    code = main(["--config", str(FIXTURES / "btrfs-luks.toml"), "--dry-run", "--ram"])
+    said = capsys.readouterr()
+    assert code == EXIT_OK
+    assert "warning: --ram is slower for a layout without ZFS" in said.err
+    assert "operations:" in said.out
 
 
 def test_a_dry_run_touches_nothing(monkeypatch: pytest.MonkeyPatch) -> None:

--- a/tests/unit/test_validate.py
+++ b/tests/unit/test_validate.py
@@ -10,7 +10,13 @@ import pytest
 
 from gentoo_install.errors import ConfigError, ValidationFailed
 from gentoo_install.model import compat
-from gentoo_install.model.config import DiskMode, InitSystem, InstallConfig
+from gentoo_install.model.config import (
+    DiskMode,
+    InitSystem,
+    InstallConfig,
+    MemoryLaunch,
+    MemoryMode,
+)
 from gentoo_install.model.device import DeviceGraph
 from gentoo_install.model.device import (
     Existing,
@@ -26,7 +32,7 @@ from gentoo_install.model.device import (
 from gentoo_install.model.size import Size
 from gentoo_install.exec.config import load
 from gentoo_install.exec.probe import amd64_profiles, profiles_from_eselect
-from gentoo_install.model.validate import validate, zfs_kernel_ceiling
+from gentoo_install.model.validate import validate, validate_memory_launch, zfs_kernel_ceiling
 from gentoo_install.model.parse import parse
 
 from .layouts import encrypted_root, config, ext4_on_gpt, i, unlockable_root, zfs_root
@@ -133,6 +139,50 @@ def test_partition_mode_is_unaffected() -> None:
     validate(config())
 def test_a_plain_uefi_install_validates() -> None:
     validate(config())
+
+
+def test_lowram_refuses_a_layout_that_needs_zfs() -> None:
+    with pytest.raises(ValidationFailed) as refused:
+        validate_memory_launch(config(zfs_root()), MemoryLaunch(MemoryMode.LOWRAM))
+    said = str(refused.value)
+    assert "layout needs ZFS" in said
+    assert "Alpine netboot kernel has no zfs.ko" in said
+    assert "--ram" in said
+
+
+@pytest.mark.parametrize("port", (0, 65536))
+def test_memory_launch_refuses_ssh_ports_outside_the_tcp_range(port: int) -> None:
+    with pytest.raises(ValidationFailed, match="--ssh-port must be between 1 and 65535"):
+        validate_memory_launch(
+            config(), MemoryLaunch(MemoryMode.RAM, ssh_key="ssh-ed25519 key", ssh_port=port)
+        )
+
+
+def test_a_key_or_a_port_needs_a_password_as_well() -> None:
+    """`catalyst/livecd/files/README.txt` lines 96-98: the LiveCD command line
+    takes `dosshd` and `passwd=foo`, and `dosshd` requires the password because
+    it scrambles the existing one. None of its 35 options names a key or a
+    port, so both of those take effect only once the installer has written
+    them, and sshd is already listening on 22 with the command line's password
+    by then. Asking for a key with no password leaves that window shut.
+    """
+    for launch in (
+        MemoryLaunch(MemoryMode.RAM, ssh_key="ssh-ed25519 AAAA"),
+        MemoryLaunch(MemoryMode.RAM, ssh_port=2222),
+    ):
+        with pytest.raises(ValidationFailed, match="--root-password is needed as well"):
+            validate_memory_launch(config(), launch)
+
+
+def test_a_password_on_its_own_is_the_environment_s_own_mechanism() -> None:
+    """The negative direction, and the case a rule written from expectation
+    rather than from the ISO refused: `--root-password` alone is exactly what
+    `dosshd` documents, so refusing it would refuse the documented way in."""
+    validate_memory_launch(config(), MemoryLaunch(MemoryMode.RAM, root_password="secret"))
+    validate_memory_launch(
+        config(),
+        MemoryLaunch(MemoryMode.RAM, ssh_key="ssh-ed25519 AAAA", root_password="secret"),
+    )
 
 
 def test_the_shipped_fixture_validates() -> None:


### PR DESCRIPTION
The surface for the memory environments, and nothing behind it yet:

    bash bootstrap.sh --ram      # the Gentoo CJK ISO, whole, in memory
    bash bootstrap.sh --lowram   # Alpine netboot

with `--ssh-key`, `--ssh-port` and `--root-password`. There is no interface for this path: it edits the boot entry and asks whether to reboot, the way bin456789/reinstall does, so the options are flags.

The refusals come from what the ISO actually accepts. `catalyst/livecd/files/README.txt` lines 96-98 document `dosshd` and `passwd=foo`, and that `dosshd` requires the password because it scrambles the existing one; none of its 35 command-line options names a key or a port. So a key or a port takes effect only once the installer has written it, and sshd is already listening on 22 with the command line's password by then — asking for either on its own leaves that window shut, and it is refused with that reason.

`--lowram` with a ZFS layout is refused because the Alpine netboot kernel has no `zfs.ko`. Verified separately: the CJK ISO's own `grub.cfg` passes `nodhcp`, so the entry this will later write has to add `dodhcp` or the environment comes up with no network at all.