### PR TITLE
kernel: name the cloud bus drivers in the initramfs

### DIFF
--- a/gentoo_install/plan/kernel.py
+++ b/gentoo_install/plan/kernel.py
@@ -267,18 +267,60 @@ class RequestLegacyNetworkTools(Operation):
         ).apply(context)
 
 
+#: The bus and NIC drivers a cloud guest needs before it can find its root or
+#: its network. Gentoo's dracut is `hostonly="yes"` with
+#: `hostonly_mode="sloppy"` (`/usr/lib/dracut/dracut.conf.d/01-gentoo.conf`),
+#: so an initramfs carries what the hardware present at build time needs. A
+#: provider that attaches the disk differently on the next boot then has an
+#: image with no driver for it: `reinstall` records Azure NVMe as invisible
+#: without `pci_hyperv` in the initramfs, and an install that reports success
+#: and never boots again is unrecoverable without the provider's console.
+#:
+#: One list rather than a table keyed by provider, because the provider is not
+#: what decides: `reinstall` derives the driver from the device's own `/sys`
+#: ancestry, and a name in DMI says nothing about which bus the next boot uses.
+CLOUD_DRIVERS: Final[tuple[str, ...]] = (
+    # KVM, and what most providers present
+    "virtio_pci",
+    "virtio_blk",
+    "virtio_scsi",
+    "virtio_net",
+    # AWS: Nitro is NVMe and ena, and its older instances are Xen
+    "nvme",
+    "ena",
+    "xen_blkfront",
+    "xen_netfront",
+    # Azure: synthetic SCSI and NIC, and the bus its NVMe sits below
+    "hv_storvsc",
+    "hv_netvsc",
+    "pci_hyperv",
+    "mana",
+    # GCP's own NIC
+    "gve",
+)
+
+
 @dataclass(frozen=True, kw_only=True)
 class WriteDracutModules(Operation):
     stage: Stage = Stage.KERNEL
     modules: tuple[str, ...]
+    #: Drivers named regardless of what dracut detected. `add_drivers+=` is
+    #: dracut's own key for this (`dracut.conf(5)`).
+    drivers: tuple[str, ...] = CLOUD_DRIVERS
 
     def describe(self) -> str:
-        return f"tell dracut to carry {', '.join(self.modules)}"
+        carried = f"tell dracut to carry {', '.join(self.modules)}"
+        if not self.drivers:
+            return carried
+        return f"{carried}, and {len(self.drivers)} cloud bus drivers whatever it detects"
 
     def apply(self, context: Context) -> None:
+        lines = [f'add_dracutmodules+=" {" ".join(self.modules)} "']
+        if self.drivers:
+            lines.append(f'add_drivers+=" {" ".join(self.drivers)} "')
         context.write(
             PurePosixPath("/etc/dracut.conf.d/10-gentoo-install.conf"),
-            f'add_dracutmodules+=" {" ".join(self.modules)} "\n',
+            "\n".join(lines) + "\n",
         )
 
 

--- a/tests/golden/btrfs-luks.txt
+++ b/tests/golden/btrfs-luks.txt
@@ -85,7 +85,7 @@
   install the initramfs builder and firmware: emerge sys-kernel/dracut sys-kernel/linux-firmware
   install the storage tools: emerge sys-fs/cryptsetup sys-fs/btrfs-progs sys-fs/dosfstools
   install the kernel: emerge sys-kernel/gentoo-cjk-kernel-bin, from source
-  tell dracut to carry crypt, btrfs
+  tell dracut to carry crypt, btrfs, and 13 cloud bus drivers whatever it detects
   rebuild the initramfs from sys-kernel/gentoo-cjk-kernel-bin with the modules written above
   check the installkernel payload names existing kernel files
 

--- a/tests/golden/vm-bios-luks.txt
+++ b/tests/golden/vm-bios-luks.txt
@@ -64,7 +64,7 @@
   install the initramfs builder and firmware: emerge sys-kernel/dracut sys-kernel/linux-firmware
   install the storage tools: emerge sys-fs/cryptsetup sys-fs/e2fsprogs
   install the kernel: emerge sys-kernel/gentoo-kernel-bin
-  tell dracut to carry crypt
+  tell dracut to carry crypt, and 13 cloud bus drivers whatever it detects
   rebuild the initramfs from sys-kernel/gentoo-kernel-bin with the modules written above
   check the installkernel payload names existing kernel files
 

--- a/tests/golden/vm-btrfs.txt
+++ b/tests/golden/vm-btrfs.txt
@@ -60,7 +60,7 @@
   install the initramfs builder and firmware: emerge sys-kernel/dracut sys-kernel/linux-firmware
   install the storage tools: emerge sys-fs/btrfs-progs sys-fs/dosfstools
   install the kernel: emerge sys-kernel/gentoo-kernel-bin
-  tell dracut to carry btrfs
+  tell dracut to carry btrfs, and 13 cloud bus drivers whatever it detects
   rebuild the initramfs from sys-kernel/gentoo-kernel-bin with the modules written above
   check the installkernel payload names existing kernel files
 

--- a/tests/golden/vm-luks.txt
+++ b/tests/golden/vm-luks.txt
@@ -67,7 +67,7 @@
   install the initramfs builder and firmware: emerge sys-kernel/dracut sys-kernel/linux-firmware
   install the storage tools: emerge sys-fs/cryptsetup sys-fs/btrfs-progs sys-fs/dosfstools
   install the kernel: emerge sys-kernel/gentoo-kernel-bin
-  tell dracut to carry crypt, btrfs
+  tell dracut to carry crypt, btrfs, and 13 cloud bus drivers whatever it detects
   rebuild the initramfs from sys-kernel/gentoo-kernel-bin with the modules written above
   check the installkernel payload names existing kernel files
 

--- a/tests/golden/vm-lvm.txt
+++ b/tests/golden/vm-lvm.txt
@@ -70,7 +70,7 @@
   install the storage tools: emerge sys-fs/dosfstools sys-fs/e2fsprogs
   install the storage tools that need a flag the default build lacks: emerge sys-fs/lvm2, from source
   install the kernel: emerge sys-kernel/gentoo-kernel-bin
-  tell dracut to carry lvm
+  tell dracut to carry lvm, and 13 cloud bus drivers whatever it detects
   rebuild the initramfs from sys-kernel/gentoo-kernel-bin with the modules written above
   check the installkernel payload names existing kernel files
 

--- a/tests/golden/vm-mdraid.txt
+++ b/tests/golden/vm-mdraid.txt
@@ -66,7 +66,7 @@
   install the initramfs builder and firmware: emerge sys-kernel/dracut sys-kernel/linux-firmware
   install the storage tools: emerge sys-fs/mdadm sys-fs/dosfstools sys-fs/e2fsprogs
   install the kernel: emerge sys-kernel/gentoo-kernel-bin
-  tell dracut to carry mdraid
+  tell dracut to carry mdraid, and 13 cloud bus drivers whatever it detects
   rebuild the initramfs from sys-kernel/gentoo-kernel-bin with the modules written above
   check the installkernel payload names existing kernel files
 

--- a/tests/golden/vm-proxy-dead.txt
+++ b/tests/golden/vm-proxy-dead.txt
@@ -61,7 +61,7 @@
   install the initramfs builder and firmware: emerge sys-kernel/dracut sys-kernel/linux-firmware
   install the storage tools: emerge sys-fs/btrfs-progs sys-fs/dosfstools
   install the kernel: emerge sys-kernel/gentoo-kernel-bin
-  tell dracut to carry btrfs
+  tell dracut to carry btrfs, and 13 cloud bus drivers whatever it detects
   rebuild the initramfs from sys-kernel/gentoo-kernel-bin with the modules written above
   check the installkernel payload names existing kernel files
 

--- a/tests/golden/vm-proxy-http.txt
+++ b/tests/golden/vm-proxy-http.txt
@@ -61,7 +61,7 @@
   install the initramfs builder and firmware: emerge sys-kernel/dracut sys-kernel/linux-firmware
   install the storage tools: emerge sys-fs/btrfs-progs sys-fs/dosfstools
   install the kernel: emerge sys-kernel/gentoo-kernel-bin
-  tell dracut to carry btrfs
+  tell dracut to carry btrfs, and 13 cloud bus drivers whatever it detects
   rebuild the initramfs from sys-kernel/gentoo-kernel-bin with the modules written above
   check the installkernel payload names existing kernel files
 

--- a/tests/golden/vm-proxy.txt
+++ b/tests/golden/vm-proxy.txt
@@ -61,7 +61,7 @@
   install the initramfs builder and firmware: emerge sys-kernel/dracut sys-kernel/linux-firmware
   install the storage tools: emerge sys-fs/btrfs-progs sys-fs/dosfstools
   install the kernel: emerge sys-kernel/gentoo-kernel-bin
-  tell dracut to carry btrfs
+  tell dracut to carry btrfs, and 13 cloud bus drivers whatever it detects
   rebuild the initramfs from sys-kernel/gentoo-kernel-bin with the modules written above
   check the installkernel payload names existing kernel files
 

--- a/tests/golden/vm-raidz.txt
+++ b/tests/golden/vm-raidz.txt
@@ -75,7 +75,7 @@
   install the initramfs builder and firmware: emerge sys-kernel/dracut sys-kernel/linux-firmware
   install the storage tools: emerge sys-fs/dosfstools
   install the kernel and the tools that build a module for it: emerge sys-kernel/gentoo-kernel-bin sys-fs/zfs, building sys-fs/zfs here
-  tell dracut to carry zfs
+  tell dracut to carry zfs, and 13 cloud bus drivers whatever it detects
   copy the installing system's hostid into the target so the pool imports
   rebuild the initramfs from sys-kernel/gentoo-kernel-bin with the modules written above
   check the installkernel payload names existing kernel files

--- a/tests/golden/vm-unlock.txt
+++ b/tests/golden/vm-unlock.txt
@@ -78,7 +78,7 @@
   install the initramfs ssh daemon: emerge sys-kernel/dracut-crypt-ssh sys-apps/iproute2 net-misc/dhcp net-misc/iputils
   install the storage tools: emerge sys-fs/cryptsetup sys-fs/btrfs-progs sys-fs/dosfstools sys-fs/e2fsprogs
   install the kernel: emerge sys-kernel/gentoo-kernel-bin
-  tell dracut to carry crypt, btrfs, crypt-ssh, network-legacy
+  tell dracut to carry crypt, btrfs, crypt-ssh, network-legacy, and 13 cloud bus drivers whatever it detects
   rebuild the initramfs from sys-kernel/gentoo-kernel-bin with the modules written above
   check the installkernel payload names existing kernel files
 

--- a/tests/golden/vm-zfs-encrypted.txt
+++ b/tests/golden/vm-zfs-encrypted.txt
@@ -67,7 +67,7 @@
   install the initramfs builder and firmware: emerge sys-kernel/dracut sys-kernel/linux-firmware
   install the storage tools: emerge sys-fs/dosfstools
   install the kernel and the tools that build a module for it: emerge sys-kernel/gentoo-kernel-bin sys-fs/zfs, building sys-fs/zfs here
-  tell dracut to carry zfs
+  tell dracut to carry zfs, and 13 cloud bus drivers whatever it detects
   put the rpool key in /etc/zfs/rpool.key so only ZFSBootMenu asks for it
   copy the installing system's hostid into the target so the pool imports
   rebuild the initramfs from sys-kernel/gentoo-kernel-bin with the modules written above

--- a/tests/golden/vm-zfs-mirror.txt
+++ b/tests/golden/vm-zfs-mirror.txt
@@ -71,7 +71,7 @@
   install the initramfs builder and firmware: emerge sys-kernel/dracut sys-kernel/linux-firmware
   install the storage tools: emerge sys-fs/dosfstools
   install the kernel and the tools that build a module for it: emerge sys-kernel/gentoo-kernel-bin sys-fs/zfs, building sys-fs/zfs here
-  tell dracut to carry zfs
+  tell dracut to carry zfs, and 13 cloud bus drivers whatever it detects
   copy the installing system's hostid into the target so the pool imports
   rebuild the initramfs from sys-kernel/gentoo-kernel-bin with the modules written above
   check the installkernel payload names existing kernel files

--- a/tests/golden/vm-zfs.txt
+++ b/tests/golden/vm-zfs.txt
@@ -67,7 +67,7 @@
   install the initramfs builder and firmware: emerge sys-kernel/dracut sys-kernel/linux-firmware
   install the storage tools: emerge sys-fs/dosfstools
   install the kernel and the tools that build a module for it: emerge sys-kernel/gentoo-kernel-bin sys-fs/zfs, building sys-fs/zfs here
-  tell dracut to carry zfs
+  tell dracut to carry zfs, and 13 cloud bus drivers whatever it detects
   copy the installing system's hostid into the target so the pool imports
   rebuild the initramfs from sys-kernel/gentoo-kernel-bin with the modules written above
   check the installkernel payload names existing kernel files

--- a/tests/golden/zbm-unlock.txt
+++ b/tests/golden/zbm-unlock.txt
@@ -82,7 +82,7 @@
   install ZFSBootMenu ssh support: emerge sys-kernel/dracut-crypt-ssh sys-apps/iproute2 net-misc/dhcp net-misc/iputils
   install the storage tools: emerge sys-fs/dosfstools
   install the kernel and the tools that build a module for it: emerge sys-kernel/gentoo-cjk-kernel-bin sys-fs/zfs, from source
-  tell dracut to carry zfs
+  tell dracut to carry zfs, and 13 cloud bus drivers whatever it detects
   put the zpcala key in /etc/zfs/zpcala.key so only ZFSBootMenu asks for it
   copy the installing system's hostid into the target so the pool imports
   rebuild the initramfs from sys-kernel/gentoo-cjk-kernel-bin with the modules written above

--- a/tests/golden/zfs-zbm.txt
+++ b/tests/golden/zfs-zbm.txt
@@ -79,7 +79,7 @@
   install the initramfs builder and firmware: emerge sys-kernel/dracut sys-kernel/linux-firmware
   install the storage tools: emerge sys-fs/dosfstools
   install the kernel and the tools that build a module for it: emerge sys-kernel/gentoo-cjk-kernel-bin sys-fs/zfs, from source
-  tell dracut to carry zfs
+  tell dracut to carry zfs, and 13 cloud bus drivers whatever it detects
   put the zpcala key in /etc/zfs/zpcala.key so only ZFSBootMenu asks for it
   copy the installing system's hostid into the target so the pool imports
   rebuild the initramfs from sys-kernel/gentoo-cjk-kernel-bin with the modules written above

--- a/tests/unit/test_plan_boot.py
+++ b/tests/unit/test_plan_boot.py
@@ -770,7 +770,9 @@ def test_the_kernel_is_merged_before_anything_that_builds_a_module_for_it() -> N
     initramfs = next(at for at, one in enumerate(described) if one.startswith("rebuild the initramfs"))
     # The dracut module list is written after the merge, or the kernel's own
     # postinst asks for a zfs module whose userland is not installed yet.
-    listed = next(at for at, one in enumerate(described) if one == "tell dracut to carry zfs")
+    listed = next(
+        at for at, one in enumerate(described) if one.startswith("tell dracut to carry zfs")
+    )
     assert told < merged < listed < initramfs
 
 

--- a/tests/unit/test_plan_system.py
+++ b/tests/unit/test_plan_system.py
@@ -1332,3 +1332,43 @@ def test_a_configured_proxy_still_reaches_the_installed_system() -> None:
 
     assert len(written) == 1
     assert "secret" not in written[0].describe()
+
+
+def test_the_initramfs_carries_the_cloud_bus_drivers_whatever_dracut_detected() -> None:
+    """Gentoo's dracut is `hostonly="yes"` with `hostonly_mode="sloppy"`, read
+    from `/usr/lib/dracut/dracut.conf.d/01-gentoo.conf`, so an initramfs
+    carries what the hardware present at build time needs. A provider that
+    attaches the disk by a different bus on the next boot then has an image
+    with no driver for it. `reinstall` records Azure NVMe as invisible without
+    `pci_hyperv` in the initramfs, and that failure is an install that reported
+    success and never booted again.
+
+    `add_drivers+=` is dracut's own key for naming a module regardless of
+    detection (`dracut.conf(5)`).
+    """
+    from gentoo_install.plan.kernel import CLOUD_DRIVERS, WriteDracutModules
+
+    recorder = Recorder()
+    WriteDracutModules(modules=("btrfs",)).apply(recorder)
+
+    written = recorder.files[PurePosixPath("/etc/dracut.conf.d/10-gentoo-install.conf")]
+    assert 'add_dracutmodules+=" btrfs "' in written, written
+    assert "add_drivers+=" in written, written
+    # The three that decide whether a machine finds its root at all on the
+    # three providers whose bus differs from the one it installed on.
+    for driver in ("pci_hyperv", "nvme", "virtio_blk"):
+        assert driver in written, driver
+    assert all(one in written for one in CLOUD_DRIVERS), written
+
+
+def test_a_driver_list_of_nothing_writes_no_add_drivers_line() -> None:
+    """The negative direction: the key is only written when there is something
+    to name, so an empty list is not `add_drivers+=" "`, which dracut reads as
+    a driver whose name is the empty string."""
+    from gentoo_install.plan.kernel import WriteDracutModules
+
+    recorder = Recorder()
+    WriteDracutModules(modules=("btrfs",), drivers=()).apply(recorder)
+
+    written = recorder.files[PurePosixPath("/etc/dracut.conf.d/10-gentoo-install.conf")]
+    assert "add_drivers" not in written, written


### PR DESCRIPTION
Gentoo's dracut is `hostonly="yes"` with `hostonly_mode="sloppy"`, so an initramfs carries drivers for the hardware present when it was built. A provider that attaches the disk by another bus on the next boot then leaves an installed system that reported success and never boots again, which is unrecoverable without the provider's console.

`add_drivers+=" … "` names virtio, NVMe, ena, Xen, Hyper-V and gve regardless of what dracut detected. One list rather than a table keyed by provider, because a name in DMI says nothing about which bus the next boot uses.