### PR TITLE
portage: rotate the keyserver when the refresh is refused

### DIFF
--- a/gentoo_install/plan/portage.py
+++ b/gentoo_install/plan/portage.py
@@ -55,6 +55,17 @@ AUTOUNMASK_FILES: Final[tuple[str, ...]] = (
 #: Where Gentoo publishes the keys gemato refreshes.
 KEY_SERVER: Final[str] = "hkps://keys.gentoo.org"
 
+#: Tried in order when the keyring refresh is refused. gemato is given the
+#: release key by path (`-K /usr/share/openpgp-keys/gentoo-release.asc`, in
+#: `emerge-webrsync`), so a keyserver only ever supplies updates to a key whose
+#: fingerprint is already pinned: a second host is a mirror of the same key,
+#: not a weaker check. Measured 2026-08-17: the cluster's guests got
+#: `KEYSERVER_TCP refused` for 140.211.166.190 while this workstation received
+#: the key from it, and `keyserver.ubuntu.com` answered for the same
+#: fingerprint. Asking one host four times cannot leave a window that host is
+#: refusing for.
+KEY_SERVERS: Final[tuple[str, ...]] = (KEY_SERVER, "hkps://keyserver.ubuntu.com")
+
 PROXY_BOOTSTRAP: Final[PurePosixPath] = PurePosixPath(
     "/etc/gentoo-install/proxy.toml"
 )
@@ -501,11 +512,17 @@ class WebrsyncRepository(Operation):
         # refreshes it from a keyserver, and gemato lets a `ReadTimeout` in the
         # WKD lookup out rather than falling back. `openrc-sdboot` ended a
         # cluster round there with the tree never fetched.
+        servers = _key_servers(server)
         last: CommandFailed | None = None
+        refused = 0
         for attempt in range(KEYRING_TRIES):
             try:
                 context.run_in_target(
-                    ["env", f"PORTAGE_GPG_KEY_SERVER={server}", "emerge-webrsync"]
+                    [
+                        "env",
+                        f"PORTAGE_GPG_KEY_SERVER={servers[refused % len(servers)]}",
+                        "emerge-webrsync",
+                    ]
                 )
                 return
             except CommandFailed as failed:
@@ -515,9 +532,10 @@ class WebrsyncRepository(Operation):
                 # A keyserver the whole round is asking at once needs longer
                 # than a mirror rewriting a Manifest, and the two failures are
                 # told apart before the wait rather than after it.
-                pause = (
-                    KEYRING_PAUSE if _keyring_refused(str(failed)) else SYNC_PAUSE
-                ) * (attempt + 1)
+                keyring = _keyring_refused(str(failed))
+                if keyring:
+                    refused += 1
+                pause = (KEYRING_PAUSE if keyring else SYNC_PAUSE) * (attempt + 1)
                 context.run(["sleep", f"{pause:g}"])
         assert last is not None
         raise last
@@ -549,6 +567,15 @@ KEYRING_REFUSED: Final[tuple[str, ...]] = (
 #: mismatch needs.
 KEYRING_TRIES: Final[int] = 4
 KEYRING_PAUSE: Final[float] = 90.0
+
+
+def _key_servers(first: str) -> tuple[str, ...]:
+    """The rotation, with whatever the stage3's own policy named at the front.
+
+    An operator or a stage3 that names a server has chosen it, so it is tried
+    before the fallbacks and is not repeated later in the rotation.
+    """
+    return (first, *(one for one in KEY_SERVERS if one != first))
 
 
 def _keyring_refused(output: str) -> bool:

--- a/tests/unit/test_plan_portage.py
+++ b/tests/unit/test_plan_portage.py
@@ -2139,3 +2139,76 @@ def test_a_manifest_mismatch_still_gets_the_short_wait() -> None:
         portage.SYNC_PAUSE * (n + 1) for n in range(portage.KEYRING_TRIES - 1)
     ], slept
     assert sum(slept) < 5 * 60, slept
+
+
+def test_a_refused_keyring_refresh_moves_to_another_keyserver() -> None:
+    """Waiting cannot leave a window one host is refusing for. Measured
+    2026-08-17: the cluster's guests read `KEYSERVER_TCP refused` for
+    140.211.166.190 while this workstation received the key from it, and eight
+    of nine run63 guests died after all four attempts asked that one host."""
+    from gentoo_install.errors import CommandFailed
+    from gentoo_install.plan.operations import CommandOutput
+    from gentoo_install.plan import portage as plan_portage
+    from .recorder import Recorder
+
+    asked: list[str] = []
+
+    def answer(argv: Sequence[str]) -> str | None:
+        if tuple(argv[:3]) == ("portageq", "envvar", "PORTAGE_GPG_KEY_SERVER"):
+            return CommandOutput("\n", 0)
+        if "emerge-webrsync" in argv:
+            asked.append(next(one for one in argv if one.startswith("PORTAGE_GPG_KEY")))
+            raise CommandFailed(
+                "emerge-webrsync ended with exit 1: [  ERROR] OpenPGP keyring "
+                "refresh failed: | gpg: keyserver refresh failed: Try again later"
+            )
+        return None
+
+    recorder = Recorder(answering=answer)
+    with pytest.raises(CommandFailed):
+        plan_portage.WebrsyncRepository().apply(recorder)
+
+    assert asked[0] == f"PORTAGE_GPG_KEY_SERVER={plan_portage.KEY_SERVER}"
+    assert len(set(asked)) > 1, asked
+    # Every host in the table is reached before the attempts run out, or a
+    # fallback that is never asked reads as coverage and is not.
+    assert {one.partition("=")[2] for one in asked} == set(plan_portage.KEY_SERVERS)
+
+
+def test_a_manifest_mismatch_keeps_asking_the_same_keyserver() -> None:
+    """The rotation answers a refused keyserver. A mirror rewriting its
+    Manifests is a different failure, and changing the keyserver for it would
+    make the next attempt fetch a key it had no reason to refetch."""
+    from gentoo_install.errors import CommandFailed
+    from gentoo_install.plan.operations import CommandOutput
+    from gentoo_install.plan import portage as plan_portage
+    from .recorder import Recorder
+
+    asked: list[str] = []
+
+    def answer(argv: Sequence[str]) -> str | None:
+        if tuple(argv[:3]) == ("portageq", "envvar", "PORTAGE_GPG_KEY_SERVER"):
+            return CommandOutput("\n", 0)
+        if "emerge-webrsync" in argv:
+            asked.append(next(one for one in argv if one.startswith("PORTAGE_GPG_KEY")))
+            raise CommandFailed("emerge-webrsync exited 1: Manifest mismatch")
+        return None
+
+    recorder = Recorder(answering=answer)
+    with pytest.raises(CommandFailed):
+        plan_portage.WebrsyncRepository().apply(recorder)
+
+    assert len(set(asked)) == 1, asked
+
+
+def test_the_keyserver_policy_the_stage3_names_is_not_asked_twice() -> None:
+    """A stage3 or an operator that names a server has chosen it, so it leads
+    the rotation and does not also appear later in it."""
+    from gentoo_install.plan import portage as plan_portage
+
+    assert plan_portage._key_servers(plan_portage.KEY_SERVER)[0] == plan_portage.KEY_SERVER
+    for chosen in (plan_portage.KEY_SERVER, "hkps://keys.example.invalid"):
+        rotation = plan_portage._key_servers(chosen)
+        assert len(rotation) == len(set(rotation)), rotation
+        assert rotation.count(chosen) == 1, rotation
+        assert set(plan_portage.KEY_SERVERS) <= set(rotation), rotation


### PR DESCRIPTION
run63 lost eight of nine guests to `gpg: keyserver refresh failed: Try again later`. The guests read `KEYSERVER_TCP refused` for 140.211.166.190 in the same minute this workstation received the key from it, so four attempts ninety seconds apart all landed inside one host's refusal window.

`emerge-webrsync` hands gemato the release key by path, so the fingerprint is pinned before any network call and a second keyserver supplies updates to that same key rather than a different one. On a refused refresh the next attempt asks the next host; a Manifest mismatch keeps the host it had.