### PR TITLE
system: match the wired interface by its MAC

### DIFF
--- a/gentoo_install/plan/system.py
+++ b/gentoo_install/plan/system.py
@@ -4,6 +4,7 @@
 from __future__ import annotations
 
 import json
+import re
 import shlex
 from dataclasses import dataclass
 from enum import Enum
@@ -37,7 +38,7 @@ from ..model.device import (
 )
 from .bootloader import serial_console
 from .mounts import resolve_mounts
-from .operations import Context, Operation, Stage
+from .operations import CommandOutput, Context, Operation, Stage
 from .portage import Emerge, PortageConfigKind, WritePortageConfig
 
 #: Console fonts `sys-apps/kbd` installs, by the cell size they draw.
@@ -584,24 +585,31 @@ class WriteNetworkConfig(Operation):
                 return
             # 0600 or NetworkManager refuses to read it, and says so only in
             # its own log while the machine sits with no address.
-            context.write(NM_PROFILE, self._networkmanager(), mode=0o600)
+            context.write(
+                NM_PROFILE,
+                self._networkmanager(self._permanent_address(context)),
+                mode=0o600,
+            )
             return
         if config is NetworkConfig.NETWORKD:
             context.write(
-                PurePosixPath("/etc/systemd/network/20-wired.network"), self._networkd()
+                PurePosixPath("/etc/systemd/network/20-wired.network"),
+                self._networkd(self._permanent_address(context)),
             )
             return
         if self.addresses and not self.interface:
             return
         context.write(PurePosixPath("/etc/conf.d/net"), self._netifrc())
 
-    def _networkmanager(self) -> str:
+    def _networkmanager(self, address: str = "") -> str:
         """A keyfile connection. The gateway rides on the first address of its
         own family, which is the form `nm-settings-keyfile` documents."""
         lines = [
             "[connection]\nid=wired\ntype=ethernet\nautoconnect=true\n",
         ]
-        if self.interface:
+        if address:
+            lines.append(f"\n[802-3-ethernet]\nmac-address={address}\n")
+        elif self.interface:
             lines.append(f"interface-name={self.interface}\n")
         for family, wanted in (("ipv4", self._of(4)), ("ipv6", self._of(6))):
             lines.append(f"\n[{family}]\n")
@@ -623,8 +631,41 @@ class WriteNetworkConfig(Operation):
     def _of(self, family: int) -> tuple[str, ...]:
         return tuple(one for one in self.addresses if _family(one) == str(family))
 
-    def _networkd(self) -> str:
-        match = f"Name={self.interface}\n" if self.interface else "Name=en*\nName=eth*\n"
+    def _permanent_address(self, context: Context) -> str:
+        """The interface's MAC, when exactly one link in this environment has it.
+
+        The target's kernel can name the same card differently from the kernel
+        this installer runs under, and a match nothing satisfies leaves the
+        installed machine with no address and no way in: `reinstall` records a
+        DMIT machine whose Debian normal and cloud kernels named one NIC two
+        ways (`fix-eth-name.sh:8-19`). Two links sharing a MAC is Azure's
+        accelerated networking, where the VF carries the synthetic NIC's
+        address, so there the operator's name is what tells them apart and the
+        name is kept.
+        """
+        if not self.interface:
+            return ""
+        said = context.run(["ip", "-o", "link", "show"], check=False)
+        if isinstance(said, CommandOutput) and said.returncode != 0:
+            return ""
+        addresses: dict[str, str] = {}
+        for line in said.splitlines():
+            name, _, rest = line.partition(": ")[2].partition(": ")
+            found = re.search(r"link/ether ([0-9a-f:]{17})", rest)
+            if found:
+                addresses[name.partition("@")[0]] = found.group(1)
+        mine = addresses.get(self.interface, "")
+        if not mine or list(addresses.values()).count(mine) != 1:
+            return ""
+        return mine
+
+    def _networkd(self, address: str = "") -> str:
+        if address:
+            match = f"MACAddress={address}\n"
+        elif self.interface:
+            match = f"Name={self.interface}\n"
+        else:
+            match = "Name=en*\nName=eth*\n"
         lines = [f"[Match]\n{match}", "[Network]\n"]
         if self.addresses:
             lines += [f"Address={one}\n" for one in self.addresses]

--- a/tests/unit/test_plan_system.py
+++ b/tests/unit/test_plan_system.py
@@ -1372,3 +1372,92 @@ def test_a_driver_list_of_nothing_writes_no_add_drivers_line() -> None:
 
     written = recorder.files[PurePosixPath("/etc/dracut.conf.d/10-gentoo-install.conf")]
     assert "add_drivers" not in written, written
+
+
+#: One real `ip -o link show`, read from this workstation on 2026-08-17. The
+#: escaped `\   ` before `link/ether` and the `altname` fields are what the
+#: command actually prints, and a parser written against a tidier idea of the
+#: format finds no address at all.
+IP_LINK_SAMPLE = (
+    "1: lo: <LOOPBACK,UP,LOWER_UP> mtu 65536 qdisc noqueue state UNKNOWN mode "
+    "DEFAULT group default qlen 1000\\    link/loopback 00:00:00:00:00:00 brd "
+    "00:00:00:00:00:00\n"
+    "2: enp14s0: <NO-CARRIER,BROADCAST,MULTICAST,UP> mtu 1500 qdisc fq state DOWN "
+    "mode DEFAULT group default qlen 1000\\    link/ether a0:ad:9f:bd:f0:5f brd "
+    "ff:ff:ff:ff:ff:ff\\    altname enxa0ad9fbdf05f\n"
+    "3: eno1: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 1500 qdisc mq state UP mode "
+    "DEFAULT group default qlen 1000\\    link/ether a0:ad:9f:bd:f0:5e brd "
+    "ff:ff:ff:ff:ff:ff\\    altname enp13s0\\    altname enxa0ad9fbdf05e\n"
+    "8: tailscale0: <POINTOPOINT,MULTICAST,NOARP,UP,LOWER_UP> mtu 1280 qdisc fq "
+    "state UNKNOWN mode DEFAULT group default qlen 500\\    link/none \n"
+)
+
+
+def _wired(
+    *,
+    interface: str = "eno1",
+    networking: Networking | None = None,
+) -> system.WriteNetworkConfig:
+    from gentoo_install.model.config import InitSystem, Networking as Backend
+
+    return system.WriteNetworkConfig(
+        networking=networking if networking is not None else Backend.BUILTIN,
+        init=InitSystem.SYSTEMD,
+        interface=interface,
+        addresses=("192.0.2.7/24",),
+        gateways=("192.0.2.1",),
+        dns=(),
+    )
+
+
+def _linked(sample: str = IP_LINK_SAMPLE) -> Recorder:
+    """`run` reads `replies`, keyed by the first word; `answering` is the hook
+    `run_in_target` consults and this operation does not go through it."""
+    return Recorder(replies={"ip": sample})
+
+
+def test_a_static_address_is_matched_by_mac_rather_than_by_interface_name() -> None:
+    """The target's kernel can name the same card differently from the kernel
+    the installer runs under, and a `Name=` nothing matches leaves the machine
+    with no address and no way in. `reinstall` records a DMIT machine whose
+    Debian normal and cloud kernels named one NIC two ways."""
+    recorder = _linked()
+    _wired().apply(recorder)
+
+    written = recorder.files[PurePosixPath("/etc/systemd/network/20-wired.network")]
+    assert "MACAddress=a0:ad:9f:bd:f0:5e" in written, written
+    assert "Name=" not in written, written
+
+
+def test_two_links_sharing_one_mac_keep_the_name() -> None:
+    """Azure's accelerated networking gives the VF the synthetic NIC's address,
+    so a MAC match would match both and the operator's name is the only thing
+    that tells them apart."""
+    doubled = IP_LINK_SAMPLE.replace("a0:ad:9f:bd:f0:5f", "a0:ad:9f:bd:f0:5e")
+    recorder = _linked(doubled)
+    _wired().apply(recorder)
+
+    written = recorder.files[PurePosixPath("/etc/systemd/network/20-wired.network")]
+    assert "Name=eno1" in written, written
+    assert "MACAddress" not in written, written
+
+
+def test_an_interface_this_environment_does_not_have_keeps_the_name() -> None:
+    """The operator may name the interface the target will have rather than one
+    present now, and a MAC that cannot be read is not a reason to write none."""
+    recorder = _linked()
+    _wired(interface="eth0").apply(recorder)
+
+    written = recorder.files[PurePosixPath("/etc/systemd/network/20-wired.network")]
+    assert "Name=eth0" in written, written
+
+
+def test_networkmanager_is_matched_by_mac_too() -> None:
+    """`interface-name` has the same failure as `Name=`, and the keyfile's own
+    key for the address is `[802-3-ethernet] mac-address`."""
+    recorder = _linked()
+    _wired(networking=Networking.NETWORKMANAGER_WPA).apply(recorder)
+
+    written = recorder.files[system.NM_PROFILE]
+    assert "mac-address=a0:ad:9f:bd:f0:5e" in written, written
+    assert "interface-name" not in written, written


### PR DESCRIPTION
A static target configuration is written from the interface name the operator typed, and that name comes from the kernel the installer runs under. `reinstall` records a DMIT machine whose Debian normal and cloud kernels gave one NIC two predictable names, so a `Name=` the target never matches leaves an installed machine with no address and no console.

The MAC is read from `ip -o link show` while the installer is still running, and used for the systemd-networkd `[Match]` and the NetworkManager keyfile. Two links carrying one address is Azure's accelerated networking, where the VF shares the synthetic NIC's MAC; there the name is the only selector and it is kept.