### PR TITLE
portage: jitter the wait between keyring refresh attempts

### DIFF
--- a/gentoo_install/plan/portage.py
+++ b/gentoo_install/plan/portage.py
@@ -9,6 +9,7 @@ before a key can be imported, an imported key stays untrusted until `lsign`, and
 from __future__ import annotations
 
 import json
+import random
 import re
 import signal
 from dataclasses import dataclass
@@ -536,6 +537,8 @@ class WebrsyncRepository(Operation):
                 if keyring:
                     refused += 1
                 pause = (KEYRING_PAUSE if keyring else SYNC_PAUSE) * (attempt + 1)
+                if keyring:
+                    pause *= random.uniform(*KEYRING_JITTER)
                 context.run(["sleep", f"{pause:g}"])
         assert last is not None
         raise last
@@ -567,6 +570,17 @@ KEYRING_REFUSED: Final[tuple[str, ...]] = (
 #: mismatch needs.
 KEYRING_TRIES: Final[int] = 4
 KEYRING_PAUSE: Final[float] = 90.0
+
+#: What the geometric pause is multiplied by, so a wave of machines that
+#: reached this step together does not ask again together. Measured in run64:
+#: eight guests dispatched in one wave all died 14 to 24 minutes in, while the
+#: five that reached the same step 44 to 107 minutes in all passed, and both
+#: keys answer from `keyserver.ubuntu.com` when one machine asks alone. Without
+#: this the whole wave waits the same 90, 180 and 270 seconds and asks again in
+#: lockstep, so four attempts are one attempt made four times. It only ever
+#: extends: a factor below one would undercut the twelve minutes the geometric
+#: pause exists to buy, and outlasting the round is the whole point.
+KEYRING_JITTER: Final[tuple[float, float]] = (1.0, 2.5)
 
 
 def _key_servers(first: str) -> tuple[str, ...]:

--- a/tests/unit/test_plan_portage.py
+++ b/tests/unit/test_plan_portage.py
@@ -2109,9 +2109,12 @@ def test_a_keyserver_the_whole_round_is_asking_gets_longer_than_a_mirror() -> No
 
     slept = [argv for argv in refused.commands if argv and argv[0] == "sleep"]
     assert len(slept) == portage.KEYRING_TRIES - 1, slept
-    assert [float(one[1]) for one in slept] == [
-        portage.KEYRING_PAUSE * (n + 1) for n in range(portage.KEYRING_TRIES - 1)
-    ], slept
+    # A band rather than the exact seconds: the pause carries a jitter so a
+    # wave does not ask again in lockstep, and it only ever extends.
+    low, high = portage.KEYRING_JITTER
+    for n, one in enumerate(slept):
+        base = portage.KEYRING_PAUSE * (n + 1)
+        assert base * low <= float(one[1]) <= base * high, slept
     # Twelve minutes rather than ninety seconds, which is what outlasts a round.
     assert sum(float(one[1]) for one in slept) > 8 * 60
 
@@ -2212,3 +2215,73 @@ def test_the_keyserver_policy_the_stage3_names_is_not_asked_twice() -> None:
         assert len(rotation) == len(set(rotation)), rotation
         assert rotation.count(chosen) == 1, rotation
         assert set(plan_portage.KEY_SERVERS) <= set(rotation), rotation
+
+
+def test_two_machines_refused_together_do_not_ask_again_together() -> None:
+    """run64 dispatched eight guests in one wave and all eight died 14 to 24
+    minutes in, while the five that reached the same step 44 to 107 minutes in
+    all passed. Without a jitter every machine in a wave waits the same 90, 180
+    and 270 seconds, so four attempts are one attempt made four times."""
+    from gentoo_install.errors import CommandFailed
+    from gentoo_install.plan.operations import CommandOutput
+    from gentoo_install.plan import portage as plan_portage
+    from .recorder import Recorder
+
+    def answer(argv: Sequence[str]) -> str | None:
+        if tuple(argv[:3]) == ("portageq", "envvar", "PORTAGE_GPG_KEY_SERVER"):
+            return CommandOutput("\n", 0)
+        if "emerge-webrsync" in argv:
+            raise CommandFailed(
+                "emerge-webrsync exited 1: gpg: keyserver refresh failed: "
+                "Try again later"
+            )
+        return None
+
+    def waits() -> tuple[float, ...]:
+        recorder = Recorder(answering=answer)
+        with pytest.raises(CommandFailed):
+            plan_portage.WebrsyncRepository().apply(recorder)
+        return tuple(
+            float(one[1]) for one in recorder.commands if one[0] == "sleep"
+        )
+
+    runs = [waits() for _ in range(8)]
+    assert all(len(one) == plan_portage.KEYRING_TRIES - 1 for one in runs), runs
+    assert len(set(runs)) > 1, runs
+    # The shipped band itself, before it is read as the bound below: a floor
+    # that lets the pause shrink to nearly nothing is not a backoff, and a
+    # bound taken from the constant cannot see that.
+    assert plan_portage.KEYRING_JITTER[0] >= 1.0, plan_portage.KEYRING_JITTER
+    assert plan_portage.KEYRING_JITTER[1] <= 4.0, plan_portage.KEYRING_JITTER
+    low, high = plan_portage.KEYRING_JITTER
+    for run in runs:
+        for attempt, waited in enumerate(run, start=1):
+            base = plan_portage.KEYRING_PAUSE * attempt
+            assert base * low <= waited <= base * high, (run, attempt)
+
+
+def test_a_manifest_mismatch_waits_the_same_every_time() -> None:
+    """The jitter answers a wave asking one keyserver at once. A mirror
+    rewriting its Manifests is one machine's problem, and a pause that varies
+    there makes a failure harder to read for nothing."""
+    from gentoo_install.errors import CommandFailed
+    from gentoo_install.plan.operations import CommandOutput
+    from gentoo_install.plan import portage as plan_portage
+    from .recorder import Recorder
+
+    def answer(argv: Sequence[str]) -> str | None:
+        if tuple(argv[:3]) == ("portageq", "envvar", "PORTAGE_GPG_KEY_SERVER"):
+            return CommandOutput("\n", 0)
+        if "emerge-webrsync" in argv:
+            raise CommandFailed("emerge-webrsync exited 1: Manifest mismatch")
+        return None
+
+    def waits() -> tuple[float, ...]:
+        recorder = Recorder(answering=answer)
+        with pytest.raises(CommandFailed):
+            plan_portage.WebrsyncRepository().apply(recorder)
+        return tuple(
+            float(one[1]) for one in recorder.commands if one[0] == "sleep"
+        )
+
+    assert len({waits() for _ in range(8)}) == 1


### PR DESCRIPTION
run64 dispatched fourteen guests: the eight that reached `emerge-webrsync` in the first wave all died 14 to 24 minutes in on `keyring refresh failed`, and the five that reached the same step 44 to 107 minutes in all passed. Both keys the refresh asks for answer from `keyserver.ubuntu.com` when one machine asks alone, so the host is not missing them; a wave asking at once is.

The geometric pause was identical on every machine, so a wave that failed together waited together and asked again together. The factor only ever extends, because a factor below one would give back the twelve minutes the pause exists to buy.