### PR TITLE
model: classify the five `--ssh-key` source forms

### DIFF
--- a/gentoo_install/model/authorized.py
+++ b/gentoo_install/model/authorized.py
@@ -1,0 +1,95 @@
+# SPDX-License-Identifier: GPL-2.0-or-later
+"""Where an `--ssh-key` value comes from, and what a fetched one has to be."""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+from enum import Enum
+
+from ..errors import ConfigError
+from . import sshkey
+
+
+class KeySourceKind(Enum):
+    """How the value is obtained. `github:` and `gitlab:` are URLs once they
+    have been expanded, so they are not separate kinds: what differs is the
+    address, and the fetch is the same."""
+
+    LITERAL = "literal"
+    PATH = "path"
+    URL = "url"
+
+
+@dataclass(frozen=True)
+class KeySource:
+    """A source, resolved no further than a string. `model/` does no I/O, so
+    reading the path or fetching the URL is the `exec/` layer's work."""
+
+    kind: KeySourceKind
+    value: str
+
+
+#: The shorthands and what each expands to. One table, so a service added here
+#: is a service the classifier answers.
+SHORTHANDS: dict[str, str] = {
+    "github": "https://github.com/{}.keys",
+    "gitlab": "https://gitlab.com/{}.keys",
+}
+
+#: A URL scheme this classifier accepts. `http` is here because the operator
+#: asked for it and `reinstall` takes it; nothing about the transport is
+#: checked, so a key fetched over it is only as trustworthy as the network
+#: between the machine and that host.
+SCHEMES: tuple[str, ...] = ("https://", "http://")
+
+_SCHEME = re.compile(r"[A-Za-z][A-Za-z0-9+.-]*:")
+
+
+def classify(value: str) -> KeySource:
+    """What kind of source this is, without reading or fetching anything."""
+    candidate = value.strip()
+    if not candidate:
+        raise ConfigError("the --ssh-key source is empty")
+
+    for service, template in SHORTHANDS.items():
+        if not candidate.startswith(f"{service}:"):
+            continue
+        user = candidate[len(service) + 1 :]
+        if not user or "/" in user or any(one.isspace() for one in user):
+            raise ConfigError(f"the {service}: shorthand has no valid username")
+        return KeySource(KeySourceKind.URL, template.format(user))
+
+    for scheme in SCHEMES:
+        if not candidate.startswith(scheme):
+            continue
+        if len(candidate) == len(scheme):
+            raise ConfigError(f"the key URL {candidate} has no host")
+        if any(one.isspace() for one in candidate):
+            raise ConfigError("the key URL contains whitespace")
+        return KeySource(KeySourceKind.URL, candidate)
+
+    if candidate.split(None, 1)[0] in sshkey.KEY_TYPES:
+        return KeySource(KeySourceKind.LITERAL, candidate)
+    # Before the path: `ftp://host/key` is a scheme this cannot fetch, and
+    # treating it as a filename reports a missing file instead of saying so.
+    named = _SCHEME.match(candidate)
+    if named is not None:
+        raise ConfigError(f"unknown --ssh-key source scheme: {named.group()[:-1]}")
+    return KeySource(KeySourceKind.PATH, candidate)
+
+
+def keys_in(text: str) -> tuple[str, ...]:
+    """Every key in a fetched or read value, each checked by `sshkey.check`.
+
+    `https://github.com/<user>.keys` answers one key per line, and a host that
+    is down answers an HTML page: the structural check is what tells them
+    apart, because a page that mentions `ssh-rsa` contains the word and not
+    the key.
+    """
+    if text.lstrip().startswith("-----BEGIN"):
+        raise ConfigError("that is a private key; --ssh-key takes the public one")
+    keys = tuple(sshkey.check(line) for line in text.splitlines() if line.strip())
+    if not keys:
+        raise ConfigError("the key source held no key")
+    return keys

--- a/tests/unit/test_model_authorized.py
+++ b/tests/unit/test_model_authorized.py
@@ -1,0 +1,125 @@
+# SPDX-License-Identifier: GPL-2.0-or-later
+"""Where an `--ssh-key` value comes from, and what a fetched one has to be."""
+
+from __future__ import annotations
+
+import base64
+
+import pytest
+
+from gentoo_install.errors import ConfigError
+from gentoo_install.model import sshkey
+from gentoo_install.model.authorized import (
+    SCHEMES,
+    SHORTHANDS,
+    KeySource,
+    KeySourceKind,
+    classify,
+    keys_in,
+)
+
+
+def _key(kind: str = "ssh-ed25519", comment: str = "zakk@box") -> str:
+    """A structurally valid key: the body's first length-prefixed field has to
+    repeat the type name, so a made-up base64 blob is rejected."""
+    body = len(kind).to_bytes(4, "big") + kind.encode() + (32).to_bytes(4, "big") + b"k" * 32
+    return f"{kind} {base64.b64encode(body).decode()} {comment}"
+
+
+CASES: tuple[tuple[str, KeySource], ...] = (
+    (_key(), KeySource(KeySourceKind.LITERAL, _key())),
+    ("~/.ssh/id_ed25519.pub", KeySource(KeySourceKind.PATH, "~/.ssh/id_ed25519.pub")),
+    ("/etc/keys/one.pub", KeySource(KeySourceKind.PATH, "/etc/keys/one.pub")),
+    (
+        "https://example.invalid/key.pub",
+        KeySource(KeySourceKind.URL, "https://example.invalid/key.pub"),
+    ),
+    (
+        "http://example.invalid/key.pub",
+        KeySource(KeySourceKind.URL, "http://example.invalid/key.pub"),
+    ),
+    ("github:zakkaus", KeySource(KeySourceKind.URL, "https://github.com/zakkaus.keys")),
+    ("gitlab:zakkaus", KeySource(KeySourceKind.URL, "https://gitlab.com/zakkaus.keys")),
+)
+
+
+@pytest.mark.parametrize(("value", "expected"), CASES)
+def test_each_source_form_is_classified(value: str, expected: KeySource) -> None:
+    assert classify(value) == expected
+
+
+def test_the_cases_cover_every_kind_and_every_shorthand() -> None:
+    """A form added to the tables without a case here fails, or a table entry
+    that is never exercised reads as coverage and is not."""
+    assert {one.kind for _, one in CASES} == set(KeySourceKind)
+    for service in SHORTHANDS:
+        assert any(value.startswith(f"{service}:") for value, _ in CASES), service
+    for scheme in SCHEMES:
+        assert any(value.startswith(scheme) for value, _ in CASES), scheme
+
+
+@pytest.mark.parametrize("value", ("", "   ", "\n"))
+def test_an_empty_source_is_named(value: str) -> None:
+    with pytest.raises(ConfigError, match="empty"):
+        classify(value)
+
+
+@pytest.mark.parametrize("value", ("github:", "gitlab:", "github:two names", "github:a/b"))
+def test_a_shorthand_without_a_usable_username_is_named(value: str) -> None:
+    with pytest.raises(ConfigError, match="username"):
+        classify(value)
+
+
+def test_a_scheme_that_cannot_be_fetched_is_named_rather_than_read_as_a_path() -> None:
+    """`ftp://host/key.pub` as a filename reports a missing file, which sends
+    the operator looking for a directory instead of at the scheme."""
+    with pytest.raises(ConfigError, match="scheme: ftp"):
+        classify("ftp://example.invalid/key.pub")
+
+
+@pytest.mark.parametrize("value", ("https://", "http://"))
+def test_a_url_with_no_host_is_named(value: str) -> None:
+    with pytest.raises(ConfigError, match="no host"):
+        classify(value)
+
+
+def test_a_private_key_is_refused_by_name() -> None:
+    """The operator pastes the wrong half of the pair, and `authorized_keys`
+    would take the line as a malformed key rather than say what happened."""
+    with pytest.raises(ConfigError, match="private key"):
+        keys_in("-----BEGIN OPENSSH PRIVATE KEY-----\nb3BlbnNzaA==\n")
+
+
+def test_every_key_a_dot_keys_answer_holds_is_returned() -> None:
+    """`https://github.com/<user>.keys` answers one key per line, and taking
+    only the first locks the operator out of their other machines."""
+    answer = f"{_key(comment='one')}\n\n{_key('ssh-rsa', comment='two')}\n"
+    assert keys_in(answer) == (_key(comment="one"), _key("ssh-rsa", comment="two"))
+
+
+def test_an_html_error_page_that_mentions_a_key_type_is_not_a_key() -> None:
+    """A host that is down answers a page, and `ssh-rsa` appearing in its text
+    is what a substring check accepts."""
+    page = (
+        "<!DOCTYPE html>\n<html><head><title>404 Not Found</title></head>\n"
+        "<body><p>No user has an ssh-rsa key at this address.</p></body></html>\n"
+    )
+    with pytest.raises(ConfigError):
+        keys_in(page)
+
+
+def test_a_source_that_held_nothing_is_named() -> None:
+    """An empty answer is a fetch that succeeded and returned no key, which
+    reads as success everywhere else."""
+    with pytest.raises(ConfigError, match="held no key"):
+        keys_in("\n  \n")
+
+
+def test_the_key_check_is_the_one_in_sshkey() -> None:
+    """One rule set: `parse.py` and the TUI already validate a key with
+    `sshkey.check`, and a second copy here would drift from it."""
+    truncated = _key().rsplit(" ", 1)[0][:-4] + " zakk"
+    with pytest.raises(ConfigError):
+        sshkey.check(truncated)
+    with pytest.raises(ConfigError):
+        keys_in(truncated)


### PR DESCRIPTION
`bash bootstrap.sh --ram --ssh-key <value>` takes what `reinstall` takes: a literal key, a path, an http or https URL, and the `github:`/`gitlab:` shorthands. Classification is pure, so the reading and the fetching stay in `exec/`, and the two shorthands expand to URLs rather than becoming kinds of their own.

The key check is `sshkey.check`, which `parse.py` and the TUI already use: a host that is down answers an HTML page, and a page whose text contains `ssh-rsa` is what a substring check accepts. A scheme this cannot fetch is named rather than read as a filename, because a missing-file error sends the operator looking in the wrong place.