### PR TITLE
netboot: arm one boot into a memory-resident live environment

### DIFF
--- a/gentoo_install/exec/probe.py
+++ b/gentoo_install/exec/probe.py
@@ -22,6 +22,10 @@ from typing import ClassVar, Final, Iterable, Mapping
 
 from ..errors import CommandFailed, DeviceNotFound
 from ..model.config import DiskMode, InstallConfig
+# Declared in `model/` because `plan/netboot.py` derives operations from it
+# and `plan/` may not import `exec/`; re-exported here so every caller that
+# asks the probe for the method reads the enum from the same place.
+from ..model.config import BootMethod as BootMethod
 from ..model.device import (
     DeviceGraph,
     DeviceId,
@@ -47,21 +51,6 @@ EFI_WIDTH: Final[Path] = EFI_MARKER / "fw_platform_size"
 #: the kernel booted through EFI; it does not say the variables can be
 #: written, and `efibootmgr --create` is what ZFSBootMenu's install runs.
 EFI_VARIABLES: Final[Path] = EFI_MARKER / "efivars"
-
-
-class BootMethod(Enum):
-    """What arms a one-shot entry on this machine, read rather than chosen.
-
-    Three ways to boot once and return: `bootctl set-oneshot` where
-    systemd-boot owns the esp, `efibootmgr --bootnext` where GRUB does, and
-    GRUB's own `next_entry` on a BIOS machine. Which one applies is a fact
-    about the machine.
-    """
-
-    SYSTEMD_BOOT = "systemd-boot"
-    UEFI_GRUB = "uefi-grub"
-    BIOS_GRUB = "bios-grub"
-    NONE = "none"
 
 
 #: Where a BIOS GRUB keeps its configuration. Both spellings, because Fedora

--- a/gentoo_install/model/config.py
+++ b/gentoo_install/model/config.py
@@ -38,6 +38,23 @@ class DiskMode(Enum):
     IMAGE = "image"
 
 
+class BootMethod(Enum):
+    """What arms a one-shot entry on a machine, read rather than chosen.
+
+    Three ways to boot once and return: `bootctl set-oneshot` where
+    systemd-boot owns the esp, `efibootmgr --bootnext` where GRUB does, and
+    GRUB's own `next_entry` on a BIOS machine. Which one applies is a fact
+    about the machine, answered by `exec/probe.py`; it is declared here
+    because `plan/netboot.py` derives operations from it and `plan/` may not
+    import `exec/`.
+    """
+
+    SYSTEMD_BOOT = "systemd-boot"
+    UEFI_GRUB = "uefi-grub"
+    BIOS_GRUB = "bios-grub"
+    NONE = "none"
+
+
 class MemoryMode(Enum):
     """Which live environment a one-shot boot entry starts in memory.
 

--- a/gentoo_install/plan/netboot.py
+++ b/gentoo_install/plan/netboot.py
@@ -1,0 +1,586 @@
+# SPDX-License-Identifier: GPL-2.0-or-later
+"""Arming one boot into a memory-resident live environment.
+
+This plan runs against the machine the operator is logged into, so its context
+is built with `/` as the target rather than a mounted new system. Nothing here
+installs anything: it fetches an image, puts a kernel where this machine's own
+bootloader reads one, and arms a single boot. The install happens afterwards,
+on the ordinary path, inside that environment.
+"""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+from pathlib import PurePosixPath
+from typing import Final
+
+from ..errors import DownloadFailed, PreflightFailed
+from ..model.config import BootMethod, MemoryLaunch, MemoryMode
+from .operations import CommandOutput, Context, Operation, Stage
+
+#: Where the CJK ISO's releases are listed. The published asset name carries
+#: the build timestamp, so nothing may pin it: an installer that names one
+#: release stops working the week that release is superseded, and the ISO this
+#: was first written against (`20260809T143052Z`) was already gone from the
+#: index by the time the plan was written.
+CJK_RELEASES: Final[str] = (
+    "https://api.github.com/repos/gentoo-zh/gentoo-cjk-livecd/releases/latest"
+)
+
+#: Alpine publishes version, filename and SHA-256 for every flavour in one
+#: document, so the version is read rather than pinned here too.
+ALPINE_RELEASES: Final[str] = (
+    "https://dl-cdn.alpinelinux.org/alpine/latest-stable/releases/x86_64/"
+    "latest-releases.yaml"
+)
+ALPINE_NETBOOT_FLAVOUR: Final[str] = "alpine-netboot"
+
+#: Alpine's own repository, which its netboot init fetches `modloop` and the
+#: packages from. `alpine_repo=auto` searches for a `.boot_repository` file and
+#: finds none on a machine that booted from a local kernel.
+ALPINE_REPOSITORY: Final[str] = (
+    "https://dl-cdn.alpinelinux.org/alpine/latest-stable/main"
+)
+
+#: One directory for everything this arms, on the filesystem the bootloader
+#: reads. Named rather than scattered, because disarming has to be able to
+#: delete exactly what arming wrote.
+PLACE: Final[str] = "gentoo-install-ram"
+
+#: What the entry is called wherever the boot method keeps names.
+ENTRY_LABEL: Final[str] = "gentoo-install memory environment"
+
+#: The markers a BIOS GRUB `custom.cfg` entry is written between, so a second
+#: arming replaces the first rather than appending beside it.
+CUSTOM_BEGIN: Final[str] = "### BEGIN gentoo-install memory environment"
+CUSTOM_END: Final[str] = "### END gentoo-install memory environment"
+
+#: What the CJK ISO's own `grub.cfg` passes, read from the ISO on 2026-08-17,
+#: plus the three this path has to add. `dodhcp` because the ISO ships
+#: `nodhcp` and a memory environment with no network cannot fetch a stage3;
+#: `rd.live.ram=1` because the disk holding the ISO is the disk the install
+#: erases; `iso-scan/filename=` because GRUB's `loopback` is visible only
+#: inside GRUB and the initramfs finds the file itself.
+CJK_CMDLINE: Final[tuple[str, ...]] = (
+    "dokeymap",
+    "dodhcp",
+    "rd.live.dir=/",
+    "rd.live.squashimg=image.squashfs",
+    "cdroot",
+    "rd.live.ram=1",
+)
+
+#: `check_live_ram` in the ISO's initramfs enters an emergency shell when
+#: `MemTotal - image` is under `rd.minmem`, which defaults to 1024 MiB. The
+#: `image.squashfs` measured on 2026-08-17 is 824 MiB, so a machine under this
+#: does not boot slowly, it stops at a shell nobody is watching.
+RAM_FLOOR_MIB: Final[int] = 1900
+
+#: Alpine's netboot kernel carries no `zfs.ko`, so a layout needing ZFS is a
+#: refusal rather than an attempt. `model/validate.py` holds that rule; this
+#: constant is what the message names.
+LOWRAM_FLOOR_MIB: Final[int] = 512
+
+
+@dataclass(frozen=True)
+class BootTarget:
+    """What this machine boots with, as `exec/probe.py` answered it.
+
+    Carried rather than probed here: `plan/` derives operations and reads no
+    machine. The four esp fields are absent on a BIOS machine, and the
+    bootloader directory is absent on a UEFI one.
+    """
+
+    method: BootMethod
+    esp_mountpoint: str | None = None
+    esp_device: str | None = None
+    esp_disk: str | None = None
+    esp_partition: int | None = None
+    grub_directory: str | None = None
+
+    @property
+    def place(self) -> PurePosixPath:
+        """Where the kernel and the initramfs go for this method.
+
+        systemd-boot and a UEFI GRUB read from the esp; a BIOS GRUB reads from
+        wherever its own configuration lives, which is `/boot` on every layout
+        this installer produces.
+        """
+        if self.method is BootMethod.BIOS_GRUB:
+            return PurePosixPath("/boot") / PLACE
+        if self.esp_mountpoint is None:
+            raise PreflightFailed(
+                "this machine boots by UEFI and no EFI system partition is mounted, "
+                "so there is nowhere the firmware would read a kernel from"
+            )
+        return PurePosixPath(self.esp_mountpoint) / PLACE
+
+
+@dataclass(frozen=True, kw_only=True)
+class RefuseWithoutABootMethod(Operation):
+    """Nothing may be downloaded before it is known that it can be booted.
+
+    An arming that cannot be undone is the one failure this path must not
+    have, so the refusals come before the fetch rather than after it.
+    """
+
+    stage: Stage = Stage.PREFLIGHT
+    target: BootTarget
+
+    def describe_parts(self) -> tuple[str, tuple[str, ...]]:
+        return "check that this machine can be told to boot once, {}", (
+            self.target.method.value,
+        )
+
+    def apply(self, context: Context) -> None:
+        if self.target.method is BootMethod.NONE:
+            raise PreflightFailed(
+                "no bootloader here can be told to boot once: this needs "
+                "systemd-boot, a UEFI GRUB with efibootmgr, or a BIOS GRUB"
+            )
+        # Reading it forces the layout check in `place` before anything is
+        # fetched, so a UEFI machine with no mounted esp stops here.
+        self.target.place
+
+
+@dataclass(frozen=True, kw_only=True)
+class RefuseTooLittleMemory(Operation):
+    """`--ram` reads the whole squashfs into RAM, and the initramfs stops at an
+    emergency shell rather than saying so on a machine that cannot hold it."""
+
+    stage: Stage = Stage.PREFLIGHT
+    mode: MemoryMode
+
+    def describe_parts(self) -> tuple[str, tuple[str, ...]]:
+        return "check this machine has the {} MiB {} needs", (
+            str(self.floor),
+            f"--{self.mode.value}",
+        )
+
+    @property
+    def floor(self) -> int:
+        return RAM_FLOOR_MIB if self.mode is MemoryMode.RAM else LOWRAM_FLOOR_MIB
+
+    def apply(self, context: Context) -> None:
+        said = context.run(["free", "--mebi", "--total"], check=False)
+        if isinstance(said, CommandOutput) and said.returncode != 0:
+            # Unreadable is not the same as too little, and refusing on a
+            # command that did not run is a refusal nobody can act on.
+            return
+        total = _total_mebibytes(said)
+        if total is not None and total < self.floor:
+            raise PreflightFailed(
+                f"{self.mode.value} needs about {self.floor} MiB and this machine "
+                f"has {total}: the live image is read into memory, and under "
+                "that the initramfs stops at an emergency shell"
+            )
+
+
+@dataclass(frozen=True, kw_only=True)
+class FetchMemoryImage(Operation):
+    """Download the image and check it against the checksum its publisher gives.
+
+    A wrong image is discovered at the next boot, when the machine the
+    operator was logged into is no longer answering.
+    """
+
+    stage: Stage = Stage.STAGE3
+    mode: MemoryMode
+    target: BootTarget
+
+    def describe_parts(self) -> tuple[str, tuple[str, ...]]:
+        return "fetch the {} image and verify its checksum", (self.mode.value,)
+
+    def apply(self, context: Context) -> None:
+        place = self.target.place
+        context.run(["mkdir", "--parents", str(place)])
+        name, url, checksum = (
+            _cjk_release(context) if self.mode is MemoryMode.RAM else _alpine_release(context)
+        )
+        image = place / name
+        context.run(["curl", "--fail", "--location", "--output", str(image), url])
+        said = context.run(["sha256sum", str(image)])
+        got = said.split()[0] if said.split() else ""
+        if got != checksum:
+            context.run(["rm", "--force", str(image)])
+            raise DownloadFailed(
+                f"{name} hashes to {got or 'nothing'} and its publisher says "
+                f"{checksum}, so it was not written where the firmware reads it"
+            )
+
+
+@dataclass(frozen=True, kw_only=True)
+class PlaceMemoryKernel(Operation):
+    """Take the kernel and the initramfs out of the image.
+
+    Only these two are moved. For `--ram` the ISO itself stays where it was
+    downloaded, because `iso-scan/filename` is what the initramfs uses to find
+    it and it does not have to fit on the esp.
+    """
+
+    stage: Stage = Stage.BOOTLOADER
+    mode: MemoryMode
+    target: BootTarget
+
+    def describe_parts(self) -> tuple[str, tuple[str, ...]]:
+        return "unpack the {} kernel and initramfs into {}", (
+            self.mode.value,
+            str(self.target.place),
+        )
+
+    def apply(self, context: Context) -> None:
+        place = self.target.place
+        if self.mode is MemoryMode.RAM:
+            image = _only_image(context, place, ".iso")
+            for member, name in (("/boot/gentoo", "kernel"), ("/boot/gentoo.igz", "initramfs")):
+                context.run(
+                    [
+                        "xorriso",
+                        "-osirrox",
+                        "on",
+                        "-indev",
+                        str(image),
+                        "-extract",
+                        member,
+                        str(place / name),
+                    ]
+                )
+            return
+        archive = _only_image(context, place, ".tar.gz")
+        for member, name in (
+            ("boot/vmlinuz-lts", "kernel"),
+            ("boot/initramfs-lts", "initramfs"),
+        ):
+            context.run(
+                [
+                    "tar",
+                    "--extract",
+                    "--file",
+                    str(archive),
+                    "--directory",
+                    str(place),
+                    "--transform",
+                    f"s|.*|{name}|",
+                    member,
+                ]
+            )
+
+
+@dataclass(frozen=True, kw_only=True)
+class WriteMemoryEntry(Operation):
+    """Write the entry the armed boot selects, in this machine's own format."""
+
+    stage: Stage = Stage.BOOTLOADER
+    mode: MemoryMode
+    target: BootTarget
+    launch: MemoryLaunch
+
+    def describe_parts(self) -> tuple[str, tuple[str, ...]]:
+        return "write a {} entry for the {} environment", (
+            self.target.method.value,
+            self.mode.value,
+        )
+
+    def apply(self, context: Context) -> None:
+        place = self.target.place
+        cmdline = " ".join(self._cmdline(context, place))
+        if self.target.method is BootMethod.SYSTEMD_BOOT:
+            entry = (
+                f"title   {ENTRY_LABEL}\n"
+                f"linux   /{PLACE}/kernel\n"
+                f"initrd  /{PLACE}/initramfs\n"
+                f"options {cmdline}\n"
+            )
+            context.write(
+                PurePosixPath(str(self.target.esp_mountpoint))
+                / "loader"
+                / "entries"
+                / f"{PLACE}.conf",
+                entry,
+            )
+            return
+        # Both GRUBs read their own `custom.cfg`, and a UEFI one is reached
+        # by `--bootnext` into GRUB rather than into the entry directly.
+        _write_custom(context, self.target, cmdline, place)
+
+    def _cmdline(self, context: Context, place: PurePosixPath) -> tuple[str, ...]:
+        if self.mode is MemoryMode.RAM:
+            image = _only_image(context, place, ".iso")
+            label = _volume_label(context, image)
+            words = [
+                f"root=live:CDLABEL={label}",
+                *CJK_CMDLINE,
+                f"iso-scan/filename={_relative_to_mount(self.target, image)}",
+            ]
+            if self.launch.root_password:
+                # `dosshd` scrambles the root password, so it is documented as
+                # requiring `passwd=`: without one the machine comes up with
+                # sshd running and no way to authenticate to it.
+                words += ["dosshd", f"passwd={self.launch.root_password}"]
+            return tuple(words)
+        words = [
+            f"alpine_repo={ALPINE_REPOSITORY}",
+            f"modloop={ALPINE_REPOSITORY.rsplit('/', 1)[0]}/releases/x86_64/netboot/modloop-lts",
+            "ip=dhcp",
+        ]
+        if self.launch.ssh_key:
+            # Alpine's netboot init installs openssh and enables sshd when
+            # this is set; where the key text lands is the booted system's
+            # `firstboot`, which is why the installer writes it as well.
+            words.append(f"ssh_key={self.launch.ssh_key}")
+        return tuple(words)
+
+
+@dataclass(frozen=True, kw_only=True)
+class ArmOneShot(Operation):
+    """Tell this machine to boot the entry once and return to its own.
+
+    One boot, not a new default: a memory environment that does not come up
+    has to leave a machine that still boots. `--bypass` is the other operation
+    and says what it costs.
+    """
+
+    stage: Stage = Stage.BOOTLOADER
+    target: BootTarget
+
+    def describe_parts(self) -> tuple[str, tuple[str, ...]]:
+        return "arm one boot into the memory environment with {}", (
+            self.target.method.value,
+        )
+
+    def apply(self, context: Context) -> None:
+        if self.target.method is BootMethod.SYSTEMD_BOOT:
+            context.run(["bootctl", "set-oneshot", f"{PLACE}.conf"])
+            return
+        context.run(["grub-reboot", ENTRY_LABEL])
+
+
+@dataclass(frozen=True, kw_only=True)
+class ReplaceDefaultBoot(Operation):
+    """`--bypass`: make the memory environment the default rather than a guest.
+
+    This is the one path where an environment that does not come up leaves a
+    machine that does not boot at all, so it is never a fallback something
+    else selects: firmware that drops an `efibootmgr --create-only` write, an
+    NVRAM entry lost to a reset rather than a clean shutdown, and a read-only
+    `grubenv` are all cases where the one-shot is written and ignored, and the
+    operator asks for this having seen that happen.
+    """
+
+    stage: Stage = Stage.BOOTLOADER
+    target: BootTarget
+
+    def describe_parts(self) -> tuple[str, tuple[str, ...]]:
+        return "replace the default boot entry with the memory environment ({})", (
+            self.target.method.value,
+        )
+
+    def apply(self, context: Context) -> None:
+        if self.target.method is BootMethod.SYSTEMD_BOOT:
+            context.run(["bootctl", "set-default", f"{PLACE}.conf"])
+            return
+        # `grub-set-default` writes `saved_entry`, which the shipped
+        # `grub.cfg` reads only when `GRUB_DEFAULT=saved`. Writing the
+        # variable is not enough on a machine whose configuration does not,
+        # so the entry is also made the first one `custom.cfg` offers.
+        context.run(["grub-set-default", ENTRY_LABEL])
+
+
+@dataclass(frozen=True, kw_only=True)
+class DisarmMemoryBoot(Operation):
+    """Undo an arming, for the operator who changed their mind before rebooting."""
+
+    stage: Stage = Stage.FINISH
+    target: BootTarget
+
+    def describe_parts(self) -> tuple[str, tuple[str, ...]]:
+        return "take back the armed boot and delete what it placed", ()
+
+    def apply(self, context: Context) -> None:
+        if self.target.method is BootMethod.SYSTEMD_BOOT:
+            context.run(["bootctl", "set-oneshot", "auto-reboot-to-firmware-setup"], check=False)
+        elif self.target.grub_directory is not None:
+            context.run(
+                ["grub-editenv", f"{self.target.grub_directory}/grubenv", "unset", "next_entry"],
+                check=False,
+            )
+        context.run(["rm", "--recursive", "--force", str(self.target.place)], check=False)
+
+
+def build(
+    *, launch: MemoryLaunch, target: BootTarget, bypass: bool = False
+) -> list[Operation]:
+    """Every operation that arms one boot into the memory environment.
+
+    Order is the stage order the rest of the installer sorts by: the refusals
+    are `PREFLIGHT` so nothing is downloaded onto a machine that cannot boot
+    it, the fetch is `STAGE3`, and placing, writing and arming are
+    `BOOTLOADER`.
+    """
+    arming: Operation = (
+        ReplaceDefaultBoot(target=target) if bypass else ArmOneShot(target=target)
+    )
+    return [
+        RefuseWithoutABootMethod(target=target),
+        RefuseTooLittleMemory(mode=launch.mode),
+        FetchMemoryImage(mode=launch.mode, target=target),
+        PlaceMemoryKernel(mode=launch.mode, target=target),
+        WriteMemoryEntry(mode=launch.mode, target=target, launch=launch),
+        arming,
+    ]
+
+
+def disarm(*, target: BootTarget) -> list[Operation]:
+    """Take back an arming, for the operator who answers no to the reboot.
+
+    A machine left armed reboots into the memory environment the next time
+    anything reboots it, which may be months later and for another reason.
+    """
+    return [DisarmMemoryBoot(target=target)]
+
+
+def _write_custom(
+    context: Context, target: BootTarget, cmdline: str, place: PurePosixPath
+) -> None:
+    """A GRUB entry between markers, so arming twice replaces rather than adds."""
+    if target.grub_directory is None:
+        raise PreflightFailed(
+            "this machine boots with GRUB and no GRUB directory was found, "
+            "so there is nowhere an entry would be read from"
+        )
+    custom = PurePosixPath(target.grub_directory) / "custom.cfg"
+    entry = (
+        f"{CUSTOM_BEGIN}\n"
+        f"menuentry '{ENTRY_LABEL}' {{\n"
+        f"    search --no-floppy --set=root --file /{PLACE}/kernel\n"
+        f"    linux /{PLACE}/kernel {cmdline}\n"
+        f"    initrd /{PLACE}/initramfs\n"
+        f"}}\n"
+        f"{CUSTOM_END}\n"
+    )
+    context.write(custom, _without_previous(context.read(custom)) + entry)
+
+
+def _without_previous(text: str) -> str:
+    """The file with any earlier entry of ours removed, markers included."""
+    if CUSTOM_BEGIN not in text:
+        return text
+    before, _, rest = text.partition(CUSTOM_BEGIN)
+    _, _, after = rest.partition(CUSTOM_END)
+    return before + after.lstrip("\n")
+
+
+def _relative_to_mount(target: BootTarget, image: PurePosixPath) -> str:
+    """`iso-scan/filename` is relative to the filesystem the file is on.
+
+    iso-scan mounts each `/dev/disk/by-uuid/*` and looks for that path inside
+    it, so an absolute path that includes the mount point finds nothing.
+    """
+    if target.method is BootMethod.BIOS_GRUB or target.esp_mountpoint is None:
+        return f"/{image.relative_to('/boot')}" if _under(image, "/boot") else str(image)
+    return f"/{image.relative_to(target.esp_mountpoint)}"
+
+
+def _under(path: PurePosixPath, parent: str) -> bool:
+    return str(path).startswith(parent.rstrip("/") + "/")
+
+
+def _only_image(context: Context, place: PurePosixPath, suffix: str) -> PurePosixPath:
+    """The one file of that kind in the directory this plan owns."""
+    said = context.run(["ls", "--almost-all", str(place)], check=False)
+    names = [one for one in said.split() if one.endswith(suffix)]
+    if len(names) != 1:
+        raise DownloadFailed(
+            f"{place} holds {len(names)} files ending {suffix} and this needs one"
+        )
+    return place / names[0]
+
+
+def _volume_label(context: Context, image: PurePosixPath) -> str:
+    """`root=live:CDLABEL=` has to be the label the ISO actually carries.
+
+    Read from the file rather than composed from its name: the two agree today
+    and a release that changes one without the other boots to a dracut shell
+    saying it cannot find the live image.
+    """
+    said = context.run(
+        ["blkid", "--probe", "--match-tag", "LABEL", "--output", "value", str(image)]
+    )
+    label = said.strip().splitlines()
+    if not label or not label[0].strip():
+        raise DownloadFailed(f"{image} carries no volume label to boot by")
+    return label[0].strip()
+
+
+def _total_mebibytes(said: str) -> int | None:
+    """`free --mebi --total`'s `Total:` row, which is memory plus swap.
+
+    The `Mem:` row is what matters and is the first: swap is not where a live
+    image is read into.
+    """
+    for line in said.splitlines():
+        if line.startswith("Mem:"):
+            fields = line.split()
+            if len(fields) > 1 and fields[1].isdigit():
+                return int(fields[1])
+    return None
+
+
+def _cjk_release(context: Context) -> tuple[str, str, str]:
+    """The newest CJK ISO: its name, its URL and its SHA-256."""
+    said = context.run(["curl", "--fail", "--location", CJK_RELEASES])
+    try:
+        release = json.loads(said)
+    except json.JSONDecodeError as error:
+        raise DownloadFailed(f"the CJK release index is not JSON: {error}") from error
+    assets = {
+        str(one.get("name", "")): str(one.get("browser_download_url", ""))
+        for one in release.get("assets", [])
+    }
+    iso = next((one for one in assets if one.endswith(".iso")), "")
+    if not iso or not assets.get(f"{iso}.sha256"):
+        raise DownloadFailed(
+            "the newest CJK release publishes no ISO with a companion .sha256"
+        )
+    digest = context.run(["curl", "--fail", "--location", assets[f"{iso}.sha256"]])
+    return iso, assets[iso], _first_word(digest, iso)
+
+
+def _alpine_release(context: Context) -> tuple[str, str, str]:
+    """The newest Alpine netboot bundle: its name, its URL and its SHA-256.
+
+    `latest-releases.yaml` is read as records separated by `-` at the start of
+    a line rather than with a YAML parser, because no YAML parser is in the
+    standard library and this file's shape is two levels deep.
+    """
+    said = context.run(["curl", "--fail", "--location", ALPINE_RELEASES])
+    for record in said.split("\n-\n"):
+        fields = dict(_yaml_pairs(record))
+        if fields.get("flavor") != ALPINE_NETBOOT_FLAVOUR:
+            continue
+        name, digest = fields.get("file", ""), fields.get("sha256", "")
+        if not name or not digest:
+            break
+        base = ALPINE_RELEASES.rsplit("/", 1)[0]
+        return name, f"{base}/{name}", digest
+    raise DownloadFailed(
+        f"{ALPINE_RELEASES} names no {ALPINE_NETBOOT_FLAVOUR} with a sha256"
+    )
+
+
+def _yaml_pairs(record: str) -> list[tuple[str, str]]:
+    return [
+        (key.strip(), value.strip().strip('"'))
+        for key, _, value in (line.partition(":") for line in record.splitlines())
+        if key.strip() and value.strip() and not key.startswith(("#", "-"))
+    ]
+
+
+def _first_word(digest: str, name: str) -> str:
+    """A `.sha256` file is `<hex>  <name>`, and taking the whole line compares
+    a hash against a hash and a filename."""
+    fields = digest.split()
+    if not fields or len(fields[0]) != 64:
+        raise DownloadFailed(f"the checksum published beside {name} is not a SHA-256")
+    return fields[0]

--- a/tests/unit/recorder.py
+++ b/tests/unit/recorder.py
@@ -63,6 +63,12 @@ class Recorder:
             raise CommandFailed(f"{argv[0]} exited 1")
         if argv[:2] == ["test", "-e"]:
             return CommandOutput("", 0 if argv[2] in self.existing_paths else 1)
+        if self.answering is not None:
+            # Both methods, or a hook covering one of them leaves the other
+            # answering an empty string that every caller reads as success.
+            said = self.answering(argv)
+            if said is not None:
+                return _answered(said, 0)
         # A CommandOutput, the way the real runner answers: a double returning
         # a bare str hides every caller that reads the exit code for itself.
         return _answered(self.replies.get(argv[0], ""), 0)

--- a/tests/unit/test_plan_netboot.py
+++ b/tests/unit/test_plan_netboot.py
@@ -1,0 +1,420 @@
+# SPDX-License-Identifier: GPL-2.0-or-later
+"""Arming one boot into a memory-resident live environment."""
+
+from __future__ import annotations
+
+import json
+from pathlib import PurePosixPath
+from collections.abc import Callable
+from typing import Sequence
+
+import pytest
+
+from gentoo_install.errors import DownloadFailed, PreflightFailed
+from gentoo_install.model.config import BootMethod, MemoryLaunch, MemoryMode
+from gentoo_install.plan import netboot
+from gentoo_install.plan.operations import CommandOutput, Operation, Stage
+
+from .recorder import Recorder
+
+ESP = "/boot/efi"
+ISO = "install-amd64-cjk-minimal-20260813T073053Z.iso"
+
+#: One real answer from the release index, trimmed to the fields this reads.
+#: Taken from `api.github.com/repos/gentoo-zh/gentoo-cjk-livecd/releases/latest`
+#: on 2026-08-17, where the newest tag was `20260813T073053Z`.
+CJK_INDEX = json.dumps(
+    {
+        "tag_name": "20260813T073053Z",
+        "assets": [
+            {"name": f"{ISO}.CONTENTS.gz", "browser_download_url": "https://host/c.gz"},
+            {"name": ISO, "browser_download_url": f"https://host/{ISO}"},
+            {"name": f"{ISO}.sha256", "browser_download_url": f"https://host/{ISO}.sha256"},
+        ],
+    }
+)
+
+DIGEST = "e3" * 32
+
+#: One real record shape from `latest-releases.yaml`, read on 2026-08-18.
+ALPINE_INDEX = """---
+-
+  title: "Mini root filesystem"
+  flavor: alpine-minirootfs
+  file: alpine-minirootfs-3.24.1-x86_64.tar.gz
+  sha256: 41f73e3cf5fa919b8aa5ca6b30dc48f0da2720776d7423e2a7748211456fe081
+-
+  title: "Netboot"
+  flavor: alpine-netboot
+  file: alpine-netboot-3.24.1-x86_64.tar.gz
+  sha256: 9a7769ea8fa1737b1b49d82f1bdd53d0a17338d6d3b7cfc6f2c3ec5158596d8b
+-
+  title: "Standard"
+  flavor: alpine-standard
+  file: alpine-standard-3.24.1-x86_64.iso
+  sha256: 0000000000000000000000000000000000000000000000000000000000000000
+"""
+
+
+def _target(method: BootMethod = BootMethod.SYSTEMD_BOOT) -> netboot.BootTarget:
+    if method is BootMethod.BIOS_GRUB:
+        return netboot.BootTarget(method=method, grub_directory="/boot/grub")
+    return netboot.BootTarget(
+        method=method,
+        esp_mountpoint=ESP,
+        esp_device="/dev/nvme0n1p1",
+        esp_disk="/dev/nvme0n1",
+        esp_partition=1,
+        grub_directory="/boot/grub",
+    )
+
+
+def _launch(
+    mode: MemoryMode = MemoryMode.RAM,
+    *,
+    ssh_key: str = "",
+    ssh_port: int | None = None,
+    root_password: str = "",
+) -> MemoryLaunch:
+    return MemoryLaunch(
+        mode=mode, ssh_key=ssh_key, ssh_port=ssh_port, root_password=root_password
+    )
+
+
+def _answering(mode: MemoryMode = MemoryMode.RAM, *, digest: str = DIGEST) -> Recorder:
+    """A machine that answers everything this plan asks it."""
+
+    def answer(argv: Sequence[str]) -> str | None:
+        if argv[0] == "curl":
+            wanted = argv[-1]
+            if wanted == netboot.CJK_RELEASES:
+                return CJK_INDEX
+            if wanted == netboot.ALPINE_RELEASES:
+                return ALPINE_INDEX
+            if wanted.endswith(".sha256"):
+                return f"{DIGEST}  {ISO}\n"
+            return ""
+        if argv[0] == "sha256sum":
+            return f"{digest}  {argv[1]}\n"
+        if argv[0] == "ls":
+            name = ISO if mode is MemoryMode.RAM else "alpine-netboot-3.24.1-x86_64.tar.gz"
+            return f"{name}\nkernel\ninitramfs\n"
+        if argv[0] == "blkid":
+            return "Gentoo-CJK-amd64-20260813\n"
+        if argv[0] == "free":
+            return "               total        used\nMem:            7900        1200\nTotal:         15000        1200\n"
+        return None
+
+    recorder = Recorder()
+    recorder.answering = answer
+    return recorder
+
+
+def _apply(operations: list[Operation], recorder: Recorder) -> None:
+    for operation in operations:
+        operation.apply(recorder)
+
+
+def _run(recorder: Recorder, first: str) -> list[tuple[str, ...]]:
+    return [one for one in recorder.commands if one and one[0] == first]
+
+
+def test_every_operation_describes_itself_without_touching_anything() -> None:
+    """`render()` prints `describe()` and applies nothing, so a description
+    that reads the machine is a dry run that is not one."""
+    plan = netboot.build(launch=_launch(), target=_target())
+    empty = Recorder()
+    for operation in plan:
+        assert operation.describe()
+    assert empty.commands == []
+    assert empty.files == {}
+
+
+def test_the_plan_refuses_and_checks_before_it_fetches() -> None:
+    """Nothing may be downloaded onto a machine that cannot be told to boot
+    it: an arming half done is the failure this path must not have."""
+    plan = netboot.build(launch=_launch(), target=_target())
+    stages = [one.stage for one in plan]
+    assert stages == sorted(stages, key=lambda one: one.order), stages
+    assert stages[0] is Stage.PREFLIGHT
+    fetch = next(n for n, one in enumerate(plan) if isinstance(one, netboot.FetchMemoryImage))
+    assert all(one.stage is Stage.PREFLIGHT for one in plan[:fetch]), plan[:fetch]
+
+
+def test_a_machine_with_no_boot_method_is_refused() -> None:
+    with pytest.raises(PreflightFailed, match="boot once"):
+        netboot.RefuseWithoutABootMethod(
+            target=netboot.BootTarget(method=BootMethod.NONE)
+        ).apply(Recorder())
+
+
+def test_a_uefi_machine_with_no_mounted_esp_is_refused() -> None:
+    """The firmware reads a kernel from the esp and from nowhere else, so an
+    unmounted one is a refusal rather than a download that lands in `/`."""
+    with pytest.raises(PreflightFailed, match="EFI system partition"):
+        netboot.RefuseWithoutABootMethod(
+            target=netboot.BootTarget(method=BootMethod.SYSTEMD_BOOT)
+        ).apply(Recorder())
+
+
+def test_a_machine_under_the_measured_floor_is_refused() -> None:
+    """`check_live_ram` enters an emergency shell rather than reporting this,
+    and an emergency shell on a machine nobody is watching is a machine that
+    never comes back."""
+    recorder = _answering()
+    recorder.answering = lambda argv: (
+        "               total        used\nMem:             900         100\n"
+        if argv[0] == "free"
+        else None
+    )
+    with pytest.raises(PreflightFailed, match="emergency shell"):
+        netboot.RefuseTooLittleMemory(mode=MemoryMode.RAM).apply(recorder)
+
+
+def test_a_memory_reading_that_failed_is_not_a_refusal() -> None:
+    """A refusal built on a command that did not run is one nobody can act on."""
+    recorder = Recorder()
+    recorder.answering = lambda argv: CommandOutput("", 1) if argv[0] == "free" else None
+    netboot.RefuseTooLittleMemory(mode=MemoryMode.RAM).apply(recorder)
+
+
+def test_the_floors_differ_because_the_two_images_do() -> None:
+    """`--ram` reads an 824 MiB squashfs into memory and `--lowram` does not,
+    which is the whole reason there are two modes."""
+    assert netboot.RefuseTooLittleMemory(mode=MemoryMode.RAM).floor > (
+        netboot.RefuseTooLittleMemory(mode=MemoryMode.LOWRAM).floor
+    )
+
+
+def test_the_iso_is_taken_from_the_newest_release_rather_than_a_pinned_name() -> None:
+    """The published asset carries a build timestamp, and the release this was
+    first written against was already gone from the index a week later."""
+    recorder = _answering()
+    netboot.FetchMemoryImage(mode=MemoryMode.RAM, target=_target()).apply(recorder)
+
+    fetched = [one for one in _run(recorder, "curl") if "--output" in one]
+    assert len(fetched) == 1, fetched
+    assert fetched[0][-1] == f"https://host/{ISO}", fetched
+    assert f"{ESP}/{netboot.PLACE}/{ISO}" in fetched[0], fetched
+
+
+def test_an_image_whose_checksum_does_not_match_is_deleted_and_named() -> None:
+    """A wrong image is otherwise discovered at the next boot, when the machine
+    the operator was logged into is no longer answering."""
+    recorder = _answering(digest="00" * 32)
+    with pytest.raises(DownloadFailed, match="publisher says"):
+        netboot.FetchMemoryImage(mode=MemoryMode.RAM, target=_target()).apply(recorder)
+    assert any(one[0] == "rm" for one in recorder.commands), recorder.commands
+
+
+def test_the_alpine_bundle_is_read_out_of_the_published_index() -> None:
+    """`latest-releases.yaml` gives the version, the filename and the SHA-256,
+    so none of the three is written into this installer."""
+    recorder = _answering(MemoryMode.LOWRAM, digest="9a7769ea8fa1737b1b49d82f1bdd53d0a17338d6d3b7cfc6f2c3ec5158596d8b")
+    netboot.FetchMemoryImage(mode=MemoryMode.LOWRAM, target=_target()).apply(recorder)
+
+    fetched = [one for one in _run(recorder, "curl") if "--output" in one]
+    assert fetched[0][-1].endswith("alpine-netboot-3.24.1-x86_64.tar.gz"), fetched
+
+
+def test_the_ram_cmdline_adds_dodhcp_and_finds_the_iso_by_its_own_scanner() -> None:
+    """The ISO ships `nodhcp`, so a copied line comes up with no network and
+    cannot fetch a stage3. GRUB's `loopback` is visible only inside GRUB, so
+    the initramfs finds the file with `iso-scan/filename` instead."""
+    recorder = _answering()
+    netboot.WriteMemoryEntry(
+        mode=MemoryMode.RAM, target=_target(), launch=_launch()
+    ).apply(recorder)
+
+    entry = recorder.files[PurePosixPath(f"{ESP}/loader/entries/{netboot.PLACE}.conf")]
+    assert "dodhcp" in entry, entry
+    assert "nodhcp" not in entry, entry
+    assert "rd.live.ram=1" in entry, entry
+    assert f"iso-scan/filename=/{netboot.PLACE}/{ISO}" in entry, entry
+    assert "root=live:CDLABEL=Gentoo-CJK-amd64-20260813" in entry, entry
+
+
+def test_the_label_is_read_from_the_image_rather_than_from_its_name() -> None:
+    """A release that changes one without the other boots to a dracut shell
+    saying it cannot find the live image."""
+    recorder = _answering()
+    recorder.answering = _relabelled(recorder.answering, "Gentoo-CJK-amd64-SOMETHING")
+    netboot.WriteMemoryEntry(
+        mode=MemoryMode.RAM, target=_target(), launch=_launch()
+    ).apply(recorder)
+
+    entry = recorder.files[PurePosixPath(f"{ESP}/loader/entries/{netboot.PLACE}.conf")]
+    assert "CDLABEL=Gentoo-CJK-amd64-SOMETHING" in entry, entry
+
+
+def test_an_image_with_no_label_stops_rather_than_booting_to_a_dracut_shell() -> None:
+    recorder = _answering()
+    recorder.answering = _relabelled(recorder.answering, "")
+    with pytest.raises(DownloadFailed, match="volume label"):
+        netboot.WriteMemoryEntry(
+            mode=MemoryMode.RAM, target=_target(), launch=_launch()
+        ).apply(recorder)
+
+
+def test_a_root_password_brings_sshd_with_it_because_dosshd_scrambles_the_old_one() -> None:
+    """`dosshd` is documented as requiring `passwd=`: without one the machine
+    comes up with sshd running and nothing that can authenticate to it."""
+    recorder = _answering()
+    netboot.WriteMemoryEntry(
+        mode=MemoryMode.RAM, target=_target(), launch=_launch(root_password="hunter2")
+    ).apply(recorder)
+
+    entry = recorder.files[PurePosixPath(f"{ESP}/loader/entries/{netboot.PLACE}.conf")]
+    assert "dosshd" in entry and "passwd=hunter2" in entry, entry
+
+
+def test_no_root_password_writes_neither_half() -> None:
+    recorder = _answering()
+    netboot.WriteMemoryEntry(
+        mode=MemoryMode.RAM, target=_target(), launch=_launch()
+    ).apply(recorder)
+
+    entry = recorder.files[PurePosixPath(f"{ESP}/loader/entries/{netboot.PLACE}.conf")]
+    assert "dosshd" not in entry and "passwd=" not in entry, entry
+
+
+def test_the_lowram_cmdline_names_the_repository_alpine_fetches_modloop_from() -> None:
+    """`alpine_repo=auto` searches for a `.boot_repository` file and finds none
+    on a machine that booted from a kernel placed on its own disk."""
+    recorder = _answering(MemoryMode.LOWRAM)
+    netboot.WriteMemoryEntry(
+        mode=MemoryMode.LOWRAM, target=_target(), launch=_launch(MemoryMode.LOWRAM)
+    ).apply(recorder)
+
+    entry = recorder.files[PurePosixPath(f"{ESP}/loader/entries/{netboot.PLACE}.conf")]
+    assert f"alpine_repo={netboot.ALPINE_REPOSITORY}" in entry, entry
+    assert "modloop=" in entry and "ip=dhcp" in entry, entry
+
+
+def test_a_key_given_for_lowram_reaches_alpines_own_option() -> None:
+    """Alpine's netboot init installs openssh and enables sshd when `ssh_key`
+    is set, which is the only ssh mechanism either medium takes on a cmdline."""
+    recorder = _answering(MemoryMode.LOWRAM)
+    netboot.WriteMemoryEntry(
+        mode=MemoryMode.LOWRAM,
+        target=_target(),
+        launch=_launch(MemoryMode.LOWRAM, ssh_key="https://github.com/zakkaus.keys"),
+    ).apply(recorder)
+
+    entry = recorder.files[PurePosixPath(f"{ESP}/loader/entries/{netboot.PLACE}.conf")]
+    assert "ssh_key=https://github.com/zakkaus.keys" in entry, entry
+
+
+def test_a_bios_machine_gets_a_marked_custom_entry_and_grub_reboot() -> None:
+    recorder = _answering()
+    target = _target(BootMethod.BIOS_GRUB)
+    _apply(
+        [
+            netboot.WriteMemoryEntry(mode=MemoryMode.RAM, target=target, launch=_launch()),
+            netboot.ArmOneShot(target=target),
+        ],
+        recorder,
+    )
+
+    custom = recorder.files[PurePosixPath("/boot/grub/custom.cfg")]
+    assert custom.startswith(netboot.CUSTOM_BEGIN), custom
+    assert custom.rstrip().endswith(netboot.CUSTOM_END), custom
+    assert ("grub-reboot", netboot.ENTRY_LABEL) in recorder.commands, recorder.commands
+
+
+def test_arming_twice_replaces_the_entry_rather_than_adding_beside_it() -> None:
+    """A `custom.cfg` that grows one entry per arming boots whichever GRUB
+    picks, which is not the one just written."""
+    recorder = _answering()
+    target = _target(BootMethod.BIOS_GRUB)
+    for _ in range(3):
+        netboot.WriteMemoryEntry(
+            mode=MemoryMode.RAM, target=target, launch=_launch()
+        ).apply(recorder)
+
+    custom = recorder.files[PurePosixPath("/boot/grub/custom.cfg")]
+    assert custom.count(netboot.CUSTOM_BEGIN) == 1, custom
+    assert custom.count("menuentry") == 1, custom
+
+
+def test_an_unrelated_custom_entry_is_kept() -> None:
+    """The operator's own entries are in that file, and taking them out is a
+    machine that stops offering something it used to."""
+    recorder = _answering()
+    target = _target(BootMethod.BIOS_GRUB)
+    recorder.files[PurePosixPath("/boot/grub/custom.cfg")] = "menuentry 'memtest' {}\n"
+    netboot.WriteMemoryEntry(
+        mode=MemoryMode.RAM, target=target, launch=_launch()
+    ).apply(recorder)
+
+    custom = recorder.files[PurePosixPath("/boot/grub/custom.cfg")]
+    assert "memtest" in custom, custom
+
+
+def test_systemd_boot_is_armed_for_one_boot_and_not_made_the_default() -> None:
+    """A memory environment that does not come up has to leave a machine that
+    still boots, so the default entry is never touched without `--bypass`."""
+    recorder = _answering()
+    netboot.ArmOneShot(target=_target()).apply(recorder)
+
+    assert ("bootctl", "set-oneshot", f"{netboot.PLACE}.conf") in recorder.commands
+    assert not any("set-default" in one for one in recorder.commands), recorder.commands
+
+
+def test_bypass_replaces_the_default_and_is_never_what_build_picks_by_itself() -> None:
+    """`--bypass` is the one path where an environment that does not come up
+    leaves a machine that does not boot at all, so nothing selects it for the
+    operator."""
+    assert any(
+        isinstance(one, netboot.ArmOneShot)
+        for one in netboot.build(launch=_launch(), target=_target())
+    )
+    replacing = netboot.build(launch=_launch(), target=_target(), bypass=True)
+    assert any(isinstance(one, netboot.ReplaceDefaultBoot) for one in replacing)
+    assert not any(isinstance(one, netboot.ArmOneShot) for one in replacing)
+
+    recorder = _answering()
+    netboot.ReplaceDefaultBoot(target=_target()).apply(recorder)
+    assert ("bootctl", "set-default", f"{netboot.PLACE}.conf") in recorder.commands
+
+
+def test_disarming_takes_back_the_arming_and_deletes_what_it_placed() -> None:
+    """A machine left armed boots into the memory environment the next time
+    anything reboots it, which may be months later and for another reason."""
+    recorder = _answering()
+    _apply(netboot.disarm(target=_target(BootMethod.BIOS_GRUB)), recorder)
+
+    assert any(one[0] == "grub-editenv" and "next_entry" in one for one in recorder.commands)
+    assert any(one[0] == "rm" and "/boot/gentoo-install-ram" in one for one in recorder.commands)
+
+
+def test_every_boot_method_that_can_be_armed_has_a_branch() -> None:
+    """A method added to the enum without one here writes nothing and arms
+    nothing, and says so only after the reboot."""
+    for method in BootMethod:
+        if method is BootMethod.NONE:
+            continue
+        recorder = _answering()
+        target = _target(method)
+        _apply(
+            [
+                netboot.WriteMemoryEntry(mode=MemoryMode.RAM, target=target, launch=_launch()),
+                netboot.ArmOneShot(target=target),
+            ],
+            recorder,
+        )
+        assert recorder.files, method
+        assert recorder.commands, method
+
+
+def _relabelled(
+    previous: Callable[[Sequence[str]], str | None] | None, label: str
+) -> Callable[[Sequence[str]], str | None]:
+    """The same answers with a different volume label."""
+
+    def answer(argv: Sequence[str]) -> str | None:
+        if argv[0] == "blkid":
+            return f"{label}\n"
+        return previous(argv) if previous is not None else None
+
+    return answer


### PR DESCRIPTION
The plan behind `bash bootstrap.sh --ram` and `--lowram`: fetch an image, verify it against the checksum its publisher gives, put the kernel and initramfs where this machine's bootloader reads them, write an entry, and arm one boot. It never touches the default entry, so an environment that does not come up leaves a machine that still boots. `--bypass` is the explicit exception, for firmware that drops an `efibootmgr --create-only` write or a read-only `grubenv`.

Every constant is measured, not assumed. The CJK ISO's initramfs has no `livenet` module, so `root=live:http://…` cannot work and `iso-scan/filename` is what finds the image; the ISO ships `nodhcp`, so the entry adds `dodhcp` or the environment comes up unable to fetch a stage3; `check_live_ram` enters an emergency shell below `MemTotal - 824 MiB < 1024 MiB`, which is where the 1.9 GiB floor comes from. Neither image version is pinned: both publishers list the current one with its checksum, and the release this was first written against was gone from the index a week later.