### PR TITLE
compat: the v3 binhost needs `fma3`, the name Portage uses

### DIFF
--- a/gentoo_install/model/compat.py
+++ b/gentoo_install/model/compat.py
@@ -87,9 +87,15 @@ _CJK_KERNEL_PACKAGES: Final[frozenset[str]] = frozenset(
 )
 
 
+#: What each official binary host needs, in the names `CPU_FLAGS_X86` uses.
+#: `fma3` and not `fma`: the psABI names the x86-64-v3 requirement `FMA` and
+#: Portage's variable spells the same instruction set `fma3`, so a requirement
+#: written the psABI way is a name `exec/probe.py` never produces and every
+#: machine is told it lacks it. `tests/unit/test_compat.py` holds the two
+#: vocabularies against each other.
 BINHOST_SUBARCH_REQUIREMENTS: Final[dict[str, frozenset[str]]] = {
     "x86-64": frozenset(),
-    "x86-64-v3": frozenset({"avx2", "bmi1", "bmi2", "f16c", "fma"}),
+    "x86-64-v3": frozenset({"avx2", "bmi1", "bmi2", "f16c", "fma3"}),
 }
 
 

--- a/tests/unit/test_compat.py
+++ b/tests/unit/test_compat.py
@@ -950,3 +950,66 @@ def test_every_way_of_unlocking_remotely_is_decided_and_none_is_decided_twice() 
     layouts = {"luks": luks(), "native": pool(True), "plain": pool(False)}
     for (name, kind), wanted in expected.items():
         assert refusals(layouts[name], kind) == wanted, (name, kind)
+
+
+def test_every_binhost_requirement_is_a_flag_the_probe_can_produce() -> None:
+    """A requirement written in the psABI's spelling is a name that never
+    arrives. The x86-64-v3 level is documented as needing `FMA`, and Portage's
+    `CPU_FLAGS_X86` spells that instruction set `fma3`, so `{"fma"}` made every
+    machine report the flag missing and refused the official v3 binary host on
+    all of them. The screen said `needs CPU flags fma, which this machine does
+    not provide` beside a flag list that read `fma3`.
+    """
+    from gentoo_install.exec.probe import CPU_FLAGS
+    from gentoo_install.model.compat import BINHOST_SUBARCH_REQUIREMENTS
+
+    produced = set(CPU_FLAGS.values())
+    for subarch, required in BINHOST_SUBARCH_REQUIREMENTS.items():
+        unreachable = sorted(required - produced)
+        assert not unreachable, (subarch, unreachable)
+
+
+def test_a_machine_with_the_v3_flags_is_not_refused_the_v3_binhost() -> None:
+    """The rule has to be able to pass. It could not: no configuration reached
+    `binhost_subarch_problems` with a flag named `fma`, because the probe maps
+    the kernel's `fma` to `fma3` before the configuration ever holds it."""
+    from gentoo_install.exec.probe import CPU_FLAGS
+    from gentoo_install.model.compat import (
+        BINHOST_SUBARCH_REQUIREMENTS,
+        binhost_subarch_problems,
+    )
+
+    # What this machine's own `/proc/cpuinfo` flags become, for the flags the
+    # level needs: the mapping is what the probe applies, not a second copy.
+    kernel_flags = {"avx2", "bmi1", "bmi2", "f16c", "fma"}
+    theirs = tuple(sorted({CPU_FLAGS[one] for one in kernel_flags}))
+    assert set(theirs) >= BINHOST_SUBARCH_REQUIREMENTS["x86-64-v3"], theirs
+
+    base = config()
+    chosen = replace(
+        base,
+        portage=replace(
+            base.portage,
+            cpu_flags=theirs,
+            binhost=replace(base.portage.binhost, official=True, subarch="x86-64-v3"),
+        ),
+    )
+    assert binhost_subarch_problems(chosen) == ()
+
+
+def test_a_machine_without_them_is_still_refused() -> None:
+    """The negative direction, or a rule loosened until it cannot fire reads
+    as a rule and is not one."""
+    from gentoo_install.model.compat import binhost_subarch_problems
+
+    base = config()
+    chosen = replace(
+        base,
+        portage=replace(
+            base.portage,
+            cpu_flags=("mmx", "sse2"),
+            binhost=replace(base.portage.binhost, official=True, subarch="x86-64-v3"),
+        ),
+    )
+    problems = binhost_subarch_problems(chosen)
+    assert problems and "fma3" in problems[0], problems

--- a/tests/unit/test_validate.py
+++ b/tests/unit/test_validate.py
@@ -452,7 +452,11 @@ def test_an_official_v3_binhost_passes_with_the_required_cpu_flags() -> None:
         base,
         portage=replace(
             base.portage,
-            cpu_flags=("avx2", "bmi1", "bmi2", "f16c", "fma"),
+            # `fma3`, the name `CPU_FLAGS_X86` uses and the one
+            # `exec/probe.py` produces. Written the psABI's way, this test
+            # asserted a vocabulary no machine ever has and passed while
+            # every real machine was refused the v3 binary host.
+            cpu_flags=("avx2", "bmi1", "bmi2", "f16c", "fma3"),
             binhost=replace(base.portage.binhost, subarch="x86-64-v3"),
         ),
     )


### PR DESCRIPTION
A machine whose flag list reads `aes avx avx2 bmi1 bmi2 f16c fma3 …` was told `official binhost subarch 'x86-64-v3' needs CPU flags fma, which this machine does not provide`. The psABI names the x86-64-v3 requirement `FMA`; `CPU_FLAGS_X86` spells that instruction set `fma3`, and `exec/probe.py` maps the kernel's `fma` to it. So the requirement named something no configuration can ever hold, and the official v3 binary host was refused on every machine that qualifies for it.

The test that covered the passing case wrote `fma` as well, so it asserted the same impossible vocabulary and stayed green. The new check holds the two vocabularies against each other: a requirement outside what the probe can produce fails, whichever way it is misspelt.