### PR TITLE
cli: run the memory plan and ask about the reboot

### DIFF
--- a/gentoo_install/cli.py
+++ b/gentoo_install/cli.py
@@ -25,7 +25,7 @@ from .errors import GentooInstallError
 from .data import load_catalog
 from .exec import fetch, preflight, report
 from .exec.apply import Machine, already_degraded, apply, completed
-from .exec.probe import BootMethod, Probe, probe_storage_facts
+from .exec.probe import GRUB_DIRECTORIES, BootMethod, Probe, probe_storage_facts
 from .exec.runner import Runner
 from .model.device import StorageFacts, StorageLayout, ZfsPool
 from .model.size import Size
@@ -47,8 +47,9 @@ from .model.config import (
     PortageConfig,
 )
 from .exec.config import load_source
+from .model import authorized
 from .model.validate import validate_memory_launch
-from .plan import convert
+from .plan import convert, netboot
 from .plan.convert import SWAP_CONFIRMATION
 from .plan.build import DEFAULT_MIRROR, build, running_config, stage3_mirror
 from .plan.operations import Context, Operation, Stage
@@ -164,29 +165,12 @@ def parser() -> argparse.ArgumentParser:
         default="",
         help="the root password for the memory environment",
     )
-    return parsed
-
-
-def _memory_launch(arguments: argparse.Namespace) -> MemoryLaunch | None:
-    mode = arguments.memory_mode
-    if mode is None:
-        if arguments.ssh_key or arguments.ssh_port is not None or arguments.root_password:
-            raise errors.ConfigError(
-                "--ssh-key, --ssh-port and --root-password require --ram or --lowram"
-            )
-        return None
-    if arguments.ssh_key and not (
-        arguments.ssh_key.startswith("ssh-") or _is_readable_file(arguments.ssh_key)
-    ):
-        raise errors.ConfigError(
-            "--ssh-key must be a readable file or an ssh- prefixed public key"
-        )
-    return MemoryLaunch(
-        mode=mode,
-        ssh_key=arguments.ssh_key,
-        ssh_port=arguments.ssh_port,
-        root_password=arguments.root_password,
+    parsed.add_argument(
+        "--bypass",
+        action="store_true",
+        help="replace the default boot entry instead of arming one boot",
     )
+    return parsed
 
 
 def _is_readable_file(name: str) -> bool:
@@ -195,6 +179,41 @@ def _is_readable_file(name: str) -> bool:
             return True
     except OSError:
         return False
+
+
+def _memory_launch(arguments: argparse.Namespace) -> MemoryLaunch | None:
+    mode = arguments.memory_mode
+    if mode is None:
+        if (
+            arguments.ssh_key
+            or arguments.ssh_port is not None
+            or arguments.root_password
+            or arguments.bypass
+        ):
+            raise errors.ConfigError(
+                "--ssh-key, --ssh-port, --root-password and --bypass require "
+                "--ram or --lowram"
+            )
+        return None
+    if arguments.ssh_key:
+        # Classified here so `github:zakkaus` and a URL are accepted, and a
+        # path is checked while the operator is still at the keyboard: a
+        # filename that is a typo otherwise fails after the reboot, in the
+        # environment they can no longer log in to.
+        source = authorized.classify(arguments.ssh_key)
+        if source.kind is authorized.KeySourceKind.PATH and not _is_readable_file(
+            source.value
+        ):
+            raise errors.ConfigError(
+                f"--ssh-key {source.value} is not a readable file, an ssh- "
+                "prefixed public key, a URL, or github:/gitlab: and a username"
+            )
+    return MemoryLaunch(
+        mode=mode,
+        ssh_key=arguments.ssh_key,
+        ssh_port=arguments.ssh_port,
+        root_password=arguments.root_password,
+    )
 
 
 def _validate_memory_launch(
@@ -210,6 +229,72 @@ def _validate_memory_launch(
             "warning: --ram is slower for a layout without ZFS; --lowram uses the smaller Alpine netboot",
             file=sys.stderr,
         )
+
+
+def _boot_target(probe: Probe) -> netboot.BootTarget:
+    """What `plan/netboot.py` needs about this machine's own bootloader."""
+    layout = probe.storage_layout()
+    esp = layout.esp_device
+    return netboot.BootTarget(
+        method=probe.boot_method(),
+        esp_mountpoint=layout.esp_mountpoint,
+        esp_device=esp,
+        esp_disk=probe.disk_of_path(esp) if esp is not None else None,
+        esp_partition=probe.partition_number_of_path(esp) if esp is not None else None,
+        grub_directory=next(
+            (str(one) for one in GRUB_DIRECTORIES if one.is_dir()), None
+        ),
+    )
+
+
+def _arm_memory_environment(
+    config: InstallConfig, launch: MemoryLaunch, arguments: argparse.Namespace
+) -> int:
+    """Place the environment and arm one boot into it, then ask about rebooting.
+
+    This path returns instead of installing: what it arms happens after the
+    reboot, and running the install now would install onto the disk the
+    operator asked to be erased from a live environment.
+    """
+    probe = Probe(runner=Runner(log=lambda line: None), work=arguments.work)
+    target = _boot_target(probe)
+    operations = netboot.build(launch=launch, target=target, bypass=arguments.bypass)
+    if arguments.dry_run:
+        print(render(operations), end="")
+        print(summarise(operations))
+        return EXIT_OK
+    machine = Machine(
+        config=config,
+        runner=probe.runner,
+        probe=probe,
+        work=arguments.work,
+        # `/`, not a mounted new system: everything this places goes on the
+        # machine the operator is logged into.
+        mountpoint=Path("/"),
+    )
+    apply(operations, machine, on_start=lambda one: print(one.describe()))
+    return _reboot_or_disarm(target, arguments, machine)
+
+
+def _reboot_or_disarm(
+    target: netboot.BootTarget, arguments: argparse.Namespace, machine: Machine
+) -> int:
+    """Ask, or say what is armed and leave it to the operator.
+
+    A question on a run nobody is watching is a run that waits for ever, so an
+    unattended one is told what was armed and returns rather than rebooting a
+    machine on its own.
+    """
+    if _unattended(arguments):
+        print("armed. `reboot` when ready; `--disarm` takes it back.")
+        return EXIT_OK
+    print("The memory environment is armed for the next boot.")
+    print("Type reboot to restart into it, anything else to take it back.")
+    if input("> ").strip() == "reboot":
+        machine.run(["reboot"])
+        return EXIT_OK
+    apply(netboot.disarm(target=target), machine, on_start=lambda one: print(one.describe()))
+    return EXIT_ABORTED
 
 
 def main(argv: Sequence[str] | None = None) -> int:
@@ -249,6 +334,7 @@ def main(argv: Sequence[str] | None = None) -> int:
             config = load_source(arguments.config)
         if launch is not None:
             _validate_memory_launch(config, launch, _probe_for(arguments))
+            return _arm_memory_environment(config, launch, arguments)
         if arguments.missing_commands:
             print(
                 "\n".join(

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -73,9 +73,24 @@ def test_memory_key_must_be_a_file_or_ssh_public_key(tmp_path: Path) -> None:
         cli.parser().parse_args(["--ram", "--ssh-key", str(key)])
     )
     assert from_file is not None and from_file.ssh_key == str(key)
-    with pytest.raises(ConfigError, match="readable file or an ssh- prefixed"):
+    with pytest.raises(ConfigError, match="not a readable file"):
         cli._memory_launch(
             cli.parser().parse_args(["--ram", "--ssh-key", "not-a-public-key"])
+        )
+
+    # The four other forms reach the executor without being read here.
+    for value in (
+        "github:zakkaus",
+        "gitlab:zakkaus",
+        "https://example.invalid/key.pub",
+        "ssh-ed25519 AAAAC3Nz zakk@box",
+    ):
+        given = cli._memory_launch(cli.parser().parse_args(["--ram", "--ssh-key", value]))
+        assert given is not None and given.ssh_key == value, value
+
+    with pytest.raises(ConfigError, match="scheme: ftp"):
+        cli._memory_launch(
+            cli.parser().parse_args(["--ram", "--ssh-key", "ftp://host/key.pub"])
         )
 
 
@@ -1447,3 +1462,68 @@ def test_a_local_configuration_never_reaches_the_network(
     monkeypatch.setattr(fetch, "read_text", refuse)
     assert main(["--config", str(FIXTURES / "ext4-bios.toml"), "--dry-run"]) == EXIT_OK
     assert "operations:" in capsys.readouterr().out.splitlines()[-1]
+
+
+def _memory_machine(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A UEFI machine with a mounted esp, so the memory plan can be derived."""
+    from gentoo_install.model.device import StorageLayout
+
+    monkeypatch.setattr(os, "geteuid", lambda: 0)
+    monkeypatch.setattr(RealProbe, "boot_method", lambda self: BootMethod.SYSTEMD_BOOT)
+    monkeypatch.setattr(
+        RealProbe,
+        "storage_layout",
+        lambda self: StorageLayout(
+            root_device="/dev/vda2",
+            root_filesystem_type="btrfs",
+            root_uuid=None,
+            root_on_lvm=None,
+            root_on_luks=None,
+            root_on_mdraid=None,
+            root_below_device=None,
+            boot_device=None,
+            boot_filesystem_type=None,
+            boot_same_filesystem=True,
+            esp_device="/dev/vda1",
+            esp_mountpoint="/boot/efi",
+            uefi=True,
+            root_free_bytes=None,
+        ),
+    )
+    monkeypatch.setattr(RealProbe, "disk_of_path", lambda self, path: "/dev/vda")
+    monkeypatch.setattr(RealProbe, "partition_number_of_path", lambda self, path: 1)
+
+
+def test_a_memory_run_prints_the_arming_plan_and_not_the_install(
+    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """What `--ram` arms happens after the reboot. Falling through to the
+    install would partition the disk now, from the system being replaced."""
+    _memory_machine(monkeypatch)
+    code = main(["--config", str(FIXTURES / "btrfs-luks.toml"), "--dry-run", "--ram"])
+    said = capsys.readouterr()
+    assert code == EXIT_OK
+    assert "arm one boot into the memory environment" in said.out, said.out
+    assert "partition" not in said.out.lower(), said.out
+
+
+def test_bypass_prints_the_replacing_operation_instead(
+    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """`--bypass` is the path for firmware that drops a one-shot write, and it
+    is the only one that touches the default entry."""
+    _memory_machine(monkeypatch)
+    code = main(
+        ["--config", str(FIXTURES / "btrfs-luks.toml"), "--dry-run", "--ram", "--bypass"]
+    )
+    said = capsys.readouterr()
+    assert code == EXIT_OK
+    assert "replace the default boot entry" in said.out, said.out
+    assert "arm one boot" not in said.out, said.out
+
+
+def test_bypass_without_a_memory_mode_is_refused() -> None:
+    """It changes what a machine boots by default, so it may not be a flag
+    that does nothing when the mode it belongs to was not asked for."""
+    with pytest.raises(ConfigError, match="require --ram or --lowram"):
+        cli._memory_launch(cli.parser().parse_args(["--bypass"]))


### PR DESCRIPTION
`--ram` and `--lowram` were parsed, validated and then ignored: the run fell through to the ordinary install, which would partition the disk immediately, from the system the operator asked to have replaced. The memory run now builds `plan/netboot.py`, applies it with `/` as the target, and returns.

`--bypass` selects the arming that replaces the default entry rather than the one that arms a single boot; without `--ram` or `--lowram` it is refused rather than silently doing nothing. The reboot question is skipped on an unattended run, which is told what is armed instead: a question added to that path is a serial console that waits for ever. `--ssh-key` now takes all five source forms, and a path is checked for readability while the operator is still at the keyboard.