### PR TITLE
compat: let `ld.so` decide the v3 binhost, not a flag list

### DIFF
--- a/gentoo_install/cli.py
+++ b/gentoo_install/cli.py
@@ -349,6 +349,7 @@ def main(argv: Sequence[str] | None = None) -> int:
         if _needs_network(arguments):
             _require_mirror(config, arguments.mirror)
         storage_facts = StorageFacts()
+        loader_v3: bool | None = None
         layout: StorageLayout | None = None
         if config.disk.mode is DiskMode.IN_PLACE:
             # Even for a dry run: a conversion's whole plan is derived from the
@@ -360,15 +361,18 @@ def main(argv: Sequence[str] | None = None) -> int:
             # Before the plan is derived, because `build` validates: a reused
             # esp needs runtime metadata. A dry run remains independent of the
             # selected hardware.
-            storage_facts = probe_storage_facts(
-                config, Probe(runner=Runner(log=lambda line: None), work=arguments.work)
-            )
+            reading = Probe(runner=Runner(log=lambda line: None), work=arguments.work)
+            storage_facts = probe_storage_facts(config, reading)
+            # `ld.so --help`, the loader's own answer about this machine: a dry
+            # run stays independent of the hardware, so it is not read there.
+            loader_v3 = reading.supports_v3()
         operations = build(
             config,
             load_catalog(),
             mirror=arguments.mirror,
             storage_facts=storage_facts,
             layout=layout,
+            supports_v3=loader_v3,
         )
         if arguments.dry_run:
             print(render(operations), end="")

--- a/gentoo_install/model/compat.py
+++ b/gentoo_install/model/compat.py
@@ -87,31 +87,34 @@ _CJK_KERNEL_PACKAGES: Final[frozenset[str]] = frozenset(
 )
 
 
-#: What each official binary host needs, in the names `CPU_FLAGS_X86` uses.
-#: `fma3` and not `fma`: the psABI names the x86-64-v3 requirement `FMA` and
-#: Portage's variable spells the same instruction set `fma3`, so a requirement
-#: written the psABI way is a name `exec/probe.py` never produces and every
-#: machine is told it lacks it. `tests/unit/test_compat.py` holds the two
-#: vocabularies against each other.
-BINHOST_SUBARCH_REQUIREMENTS: Final[dict[str, frozenset[str]]] = {
-    "x86-64": frozenset(),
-    "x86-64-v3": frozenset({"avx2", "bmi1", "bmi2", "f16c", "fma3"}),
-}
+#: The official binary hosts this installer knows how to point Portage at.
+#: A subarchitecture outside this set is a refusal rather than a URL composed
+#: from it, because a host that does not exist answers 404 an hour in.
+BINHOST_SUBARCHS: Final[frozenset[str]] = frozenset({"x86-64", "x86-64-v3"})
 
 
-def binhost_subarch_problems(config: InstallConfig) -> tuple[str, ...]:
-    """Reject an official binary host whose instruction set the CPU lacks."""
+def binhost_subarch_problems(
+    config: InstallConfig, supports_v3: bool | None = None
+) -> tuple[str, ...]:
+    """Reject an official binary host this machine cannot run or reach.
+
+    `supports_v3` is `ld.so --help`'s own answer, read by `exec/probe.py`, and
+    `None` when no machine was read. The loader decides rather than a flag
+    list derived from `/proc/cpuinfo`: the psABI names the x86-64-v3
+    requirement `FMA` and `CPU_FLAGS_X86` spells that instruction set `fma3`,
+    and a second derivation written the psABI's way refused the v3 host on
+    every machine that qualifies for it. `docs/design.md` names the loader as
+    the source in two places; this is the only check that reads it.
+    """
     binhost = config.portage.binhost
     if not binhost.official:
         return ()
-    required = BINHOST_SUBARCH_REQUIREMENTS.get(binhost.subarch)
-    if required is None:
+    if binhost.subarch not in BINHOST_SUBARCHS:
         return (f"official binhost subarch {binhost.subarch!r} is not supported",)
-    missing = sorted(required.difference(config.portage.cpu_flags))
-    if missing:
+    if binhost.subarch == "x86-64-v3" and supports_v3 is False:
         return (
-            f"official binhost subarch {binhost.subarch!r} needs CPU flags "
-            f"{', '.join(missing)}, which this machine does not provide",
+            "official binhost subarch 'x86-64-v3' needs a CPU this one is not: "
+            "`ld.so --help` does not list x86-64-v3 as supported",
         )
     return ()
 

--- a/gentoo_install/model/validate.py
+++ b/gentoo_install/model/validate.py
@@ -193,6 +193,7 @@ def validate(
     zfs_kernel_max: str | None | _ZfsKernelCeilingNotChecked = (
         _ZFS_KERNEL_CEILING_NOT_CHECKED
     ),
+    supports_v3: bool | None = None,
 ) -> None:
     address_facts = _derive_address_facts(config)
     graph_problems: list[str] = []
@@ -219,7 +220,7 @@ def validate(
         *_unlock_problems(config, address_facts.remote_unlock),
         *_locale_problems(config),
         *_l10n_problems(config),
-        *compat.binhost_subarch_problems(config),
+        *compat.binhost_subarch_problems(config, supports_v3),
     ]
     if problems:
         raise ValidationFailed(

--- a/gentoo_install/plan/build.py
+++ b/gentoo_install/plan/build.py
@@ -100,12 +100,13 @@ def build(
     mirror: str = DEFAULT_MIRROR,
     storage_facts: StorageFacts | None = None,
     layout: StorageLayout | None = None,
+    supports_v3: bool | None = None,
 ) -> tuple[Operation, ...]:
     """Validate, then derive the whole install. Nothing here touches a machine."""
     facts = storage_facts if storage_facts is not None else StorageFacts()
     if config.disk.mode is DiskMode.IN_PLACE:
-        return _in_place(config, catalog, mirror, layout)
-    validate(config, storage_facts=facts)
+        return _in_place(config, catalog, mirror, layout, supports_v3)
+    validate(config, storage_facts=facts, supports_v3=supports_v3)
     chosen = packages.groups(config, catalog)
     operations: list[Operation] = [
         *disk.build(config, facts),
@@ -154,6 +155,7 @@ def _in_place(
     catalog: packages.Catalog,
     mirror: str,
     layout: StorageLayout | None,
+    supports_v3: bool | None = None,
 ) -> tuple[Operation, ...]:
     """Derive the conversion of a running system, in the order it must run.
 
@@ -166,13 +168,14 @@ def _in_place(
         raise ConversionUnsupported("the running layout was not read")
     # The operator's own configuration first, because that is where the rule
     # against writing a device graph beside the mode applies.
-    validate(config, storage_facts=StorageFacts())
+    validate(config, storage_facts=StorageFacts(), supports_v3=supports_v3)
     derived = running_config(config, layout)
     # And the derived one as an ordinary layout: it describes concrete devices
     # now, so the compatibility table has something to check.
     validate(
         replace(derived, disk=replace(derived.disk, mode=DiskMode.PARTITION)),
         storage_facts=StorageFacts(),
+        supports_v3=supports_v3,
     )
     chosen = packages.groups(derived, catalog)
     boot = bootloader.build(derived)

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -141,7 +141,7 @@ def test_a_dry_run_touches_nothing(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setattr(
         cli,
         "build",
-        lambda chosen, catalog, *, mirror, storage_facts, layout: (operation,),
+        lambda chosen, catalog, *, mirror, storage_facts, layout, supports_v3: (operation,),
     )
     code = main(["--config", str(FIXTURES / "ext4-bios.toml"), "--dry-run"])
     assert code == EXIT_OK
@@ -798,7 +798,7 @@ def test_a_finish_failure_releases_the_machine_and_keeps_its_exit_code(
     monkeypatch.setattr(
         cli,
         "build",
-        lambda chosen, catalog, *, mirror, storage_facts, layout: (
+        lambda chosen, catalog, *, mirror, storage_facts, layout, supports_v3: (
             Partition(),
             FailFinish(),
             FailRelease(),
@@ -850,7 +850,7 @@ def test_a_failure_after_partitioning_says_the_disk_may_not_boot(
     monkeypatch.setattr(
         cli,
         "build",
-        lambda chosen, catalog, *, mirror, storage_facts, layout: (FailPartition(),),
+        lambda chosen, catalog, *, mirror, storage_facts, layout, supports_v3: (FailPartition(),),
     )
     monkeypatch.setattr(report, "keep_log", lambda work, target, record: None)
 
@@ -928,7 +928,7 @@ def test_a_body_failure_before_partitioning_says_nothing_was_written(
     monkeypatch.setattr(
         cli,
         "build",
-        lambda chosen, catalog, *, mirror, storage_facts, layout: (
+        lambda chosen, catalog, *, mirror, storage_facts, layout, supports_v3: (
             FailBeforePartition(),
             Partition(),
         ),

--- a/tests/unit/test_compat.py
+++ b/tests/unit/test_compat.py
@@ -952,64 +952,56 @@ def test_every_way_of_unlocking_remotely_is_decided_and_none_is_decided_twice() 
         assert refusals(layouts[name], kind) == wanted, (name, kind)
 
 
-def test_every_binhost_requirement_is_a_flag_the_probe_can_produce() -> None:
-    """A requirement written in the psABI's spelling is a name that never
-    arrives. The x86-64-v3 level is documented as needing `FMA`, and Portage's
-    `CPU_FLAGS_X86` spells that instruction set `fma3`, so `{"fma"}` made every
-    machine report the flag missing and refused the official v3 binary host on
-    all of them. The screen said `needs CPU flags fma, which this machine does
-    not provide` beside a flag list that read `fma3`.
+def test_the_loader_and_not_a_flag_list_decides_the_v3_binhost() -> None:
+    """`ld.so --help` lists the subarchitectures it would search, and
+    `docs/design.md` names it as the source in two places. Deriving the same
+    fact a second time from `/proc/cpuinfo` refused the v3 host on every
+    machine that qualifies for it: the psABI names the requirement `FMA` and
+    `CPU_FLAGS_X86` spells that instruction set `fma3`, so the requirement was
+    a name no configuration can hold and the test covering it wrote `fma` too.
     """
-    from gentoo_install.exec.probe import CPU_FLAGS
-    from gentoo_install.model.compat import BINHOST_SUBARCH_REQUIREMENTS
-
-    produced = set(CPU_FLAGS.values())
-    for subarch, required in BINHOST_SUBARCH_REQUIREMENTS.items():
-        unreachable = sorted(required - produced)
-        assert not unreachable, (subarch, unreachable)
-
-
-def test_a_machine_with_the_v3_flags_is_not_refused_the_v3_binhost() -> None:
-    """The rule has to be able to pass. It could not: no configuration reached
-    `binhost_subarch_problems` with a flag named `fma`, because the probe maps
-    the kernel's `fma` to `fma3` before the configuration ever holds it."""
-    from gentoo_install.exec.probe import CPU_FLAGS
-    from gentoo_install.model.compat import (
-        BINHOST_SUBARCH_REQUIREMENTS,
-        binhost_subarch_problems,
-    )
-
-    # What this machine's own `/proc/cpuinfo` flags become, for the flags the
-    # level needs: the mapping is what the probe applies, not a second copy.
-    kernel_flags = {"avx2", "bmi1", "bmi2", "f16c", "fma"}
-    theirs = tuple(sorted({CPU_FLAGS[one] for one in kernel_flags}))
-    assert set(theirs) >= BINHOST_SUBARCH_REQUIREMENTS["x86-64-v3"], theirs
-
-    base = config()
-    chosen = replace(
-        base,
-        portage=replace(
-            base.portage,
-            cpu_flags=theirs,
-            binhost=replace(base.portage.binhost, official=True, subarch="x86-64-v3"),
-        ),
-    )
-    assert binhost_subarch_problems(chosen) == ()
-
-
-def test_a_machine_without_them_is_still_refused() -> None:
-    """The negative direction, or a rule loosened until it cannot fire reads
-    as a rule and is not one."""
     from gentoo_install.model.compat import binhost_subarch_problems
 
     base = config()
-    chosen = replace(
+    v3 = replace(
         base,
         portage=replace(
             base.portage,
-            cpu_flags=("mmx", "sse2"),
+            # Deliberately empty: the flag list is no longer what decides, so
+            # a machine whose loader says yes is not refused for lacking one.
+            cpu_flags=(),
             binhost=replace(base.portage.binhost, official=True, subarch="x86-64-v3"),
         ),
     )
-    problems = binhost_subarch_problems(chosen)
-    assert problems and "fma3" in problems[0], problems
+    assert binhost_subarch_problems(v3, True) == ()
+    refused = binhost_subarch_problems(v3, False)
+    assert refused and "ld.so --help" in refused[0], refused
+    # Unread is not the same as unsupported: a dry run reads no machine, and
+    # refusing there would refuse a configuration written for another one.
+    assert binhost_subarch_problems(v3, None) == ()
+
+
+def test_a_subarch_no_official_host_publishes_is_refused() -> None:
+    """A host that does not exist answers 404 an hour into the install."""
+    from gentoo_install.model.compat import binhost_subarch_problems
+
+    base = config()
+    invented = replace(
+        base,
+        portage=replace(
+            base.portage,
+            binhost=replace(base.portage.binhost, official=True, subarch="x86-64-v9"),
+        ),
+    )
+    assert binhost_subarch_problems(invented, True), "an unknown subarch has to be refused"
+
+
+def test_the_subarch_table_holds_what_the_menu_offers() -> None:
+    """One table: the screen that offers a subarchitecture and the check that
+    validates it read the same set, or the menu offers what validation
+    refuses."""
+    from gentoo_install.model.compat import BINHOST_SUBARCHS
+    from gentoo_install.tui.screens import BINHOSTS
+
+    offered = {subarch for (_, subarch), _ in BINHOSTS}
+    assert offered <= BINHOST_SUBARCHS, offered - BINHOST_SUBARCHS

--- a/tests/unit/test_plan_disk.py
+++ b/tests/unit/test_plan_disk.py
@@ -726,7 +726,10 @@ def test_the_whole_plan_passes_one_facts_value_to_validation_and_disk_derivation
     seen: list[StorageFacts] = []
 
     def validated(
-        installation: InstallConfig, *, storage_facts: StorageFacts
+        installation: InstallConfig,
+        *,
+        storage_facts: StorageFacts,
+        supports_v3: bool | None = None,
     ) -> None:
         seen.append(storage_facts)
 

--- a/tests/unit/test_tui_app.py
+++ b/tests/unit/test_tui_app.py
@@ -3206,3 +3206,21 @@ def test_choosing_the_conversion_drops_the_device_graph() -> None:
     kept = screens.install_mode_screen(staying, built, offering).unwrap()
     assert kept.disk.mode is DiskMode.PARTITION
     assert kept.disk.graph.nodes == built.disk.graph.nodes
+
+
+def test_a_cpu_that_cannot_run_v3_cannot_be_made_to_choose_it() -> None:
+    """The row is shown with its reason rather than hidden, because an option
+    that vanishes reads as a broken installer. Shown is not selectable: the
+    cursor skips a disabled row, so an operator pressing down past the end of
+    the list still leaves with `x86-64`. Held by the skip in `_move`, which is
+    what a control removing it turns red; `Menu._accept` refuses a disabled
+    row as well, and removing that alone changes nothing because the cursor
+    never reaches one."""
+    old = context()
+    old.supports_v3 = False
+    screen = FakeScreen(keys=["KEY_DOWN", "KEY_DOWN", "KEY_DOWN", "\n"])
+    answer = screens._edit_binhost(screen, old, config())
+
+    assert answer is not None
+    assert answer.portage.binhost.subarch == "x86-64", answer.portage.binhost
+    assert "this CPU cannot run it" in screen.last

--- a/tests/unit/test_validate.py
+++ b/tests/unit/test_validate.py
@@ -431,37 +431,48 @@ def test_a_root_with_room_passes() -> None:
     validate(config(nodes))
 
 
-def test_an_official_v3_binhost_requires_the_cpu_flags_it_serves() -> None:
+def test_an_official_v3_binhost_is_refused_when_the_loader_says_no() -> None:
+    """`ld.so --help` decides, not a flag list: it is what `docs/design.md`
+    names and what the menu greys the row out on."""
     base = config()
     selected = replace(
         base,
         portage=replace(
             base.portage,
-            cpu_flags=("sse2",),
             binhost=replace(base.portage.binhost, subarch="x86-64-v3"),
         ),
     )
 
-    with pytest.raises(ValidationFailed, match="x86-64-v3.*avx2"):
-        validate(selected)
+    with pytest.raises(ValidationFailed, match="ld.so --help"):
+        validate(selected, supports_v3=False)
 
 
-def test_an_official_v3_binhost_passes_with_the_required_cpu_flags() -> None:
+def test_an_official_v3_binhost_passes_when_the_loader_says_yes() -> None:
     base = config()
     selected = replace(
         base,
         portage=replace(
             base.portage,
-            # `fma3`, the name `CPU_FLAGS_X86` uses and the one
-            # `exec/probe.py` produces. Written the psABI's way, this test
-            # asserted a vocabulary no machine ever has and passed while
-            # every real machine was refused the v3 binary host.
-            cpu_flags=("avx2", "bmi1", "bmi2", "f16c", "fma3"),
             binhost=replace(base.portage.binhost, subarch="x86-64-v3"),
         ),
     )
 
-    validate(selected)
+    validate(selected, supports_v3=True)
+
+
+def test_a_configuration_validated_without_a_machine_is_not_refused_v3() -> None:
+    """A dry run reads no machine. Refusing there refuses a configuration
+    written for another one, which is what `--dry-run` is for."""
+    base = config()
+    validate(
+        replace(
+            base,
+            portage=replace(
+                base.portage,
+                binhost=replace(base.portage.binhost, subarch="x86-64-v3"),
+            ),
+        )
+    )
 
 
 def test_a_profile_that_disagrees_with_the_init_is_refused() -> None:


### PR DESCRIPTION
`ld.so --help` lists the subarchitectures the loader would search. `docs/design.md` names it as the source in two places, `exec/probe.py` reads it, the menu greys the v3 row out on it and the cursor skips the disabled row. Validation derived the same fact a second time from `/proc/cpuinfo` flags, and that derivation is the one that broke: the requirement was written the psABI's way as `fma` while `CPU_FLAGS_X86` spells the instruction set `fma3`, so every qualifying machine was refused.

The loader's answer is now threaded to validation the way `storage_facts` already is, and absent means unread rather than unsupported, so a dry run of a configuration written for another machine is not refused. `CPU_FLAGS_X86` is still probed and still written to `make.conf`; it is only no longer asked a question the loader answers.