### PR TITLE
probe: ask cpuid2cpuflags, and map every flag portage defines

### DIFF
--- a/gentoo_install/exec/probe.py
+++ b/gentoo_install/exec/probe.py
@@ -419,22 +419,51 @@ class Machine:
     efi_bits: int = 0
 
 
-#: What the kernel calls a CPU feature, and what portage calls it. Only the
-#: ones `CPU_FLAGS_X86` defines: a name portage does not know is a build
-#: failure, not an optimisation. A value differing from its key is a rename and
-#: nothing else: mapping one feature onto another wrote `avx2` for a Piledriver
-#: that has `bmi1` and no AVX2, and every package built for it died on SIGILL.
+#: Every value `CPU_FLAGS_X86` defines, keyed by what `/proc/cpuinfo` calls
+#: it. Three sources, all read on 2026-08-18 rather than remembered: the 48
+#: entries of `profiles/desc/cpu_flags_x86.desc`, the printed names in
+#: `arch/x86/include/asm/cpufeatures.h`, and `cpuid2cpuflags` run on this
+#: machine to check the result. A name portage does not know is a build
+#: failure, not an optimisation: this table wrote `vaes`, which is a cpuinfo
+#: flag with no portage counterpart, and `avx512vnni` for a flag portage
+#: spells `avx512_vnni`, so that one was never set on a CPU that has it.
+#:
+#: A value differing from its key is a rename and nothing else: mapping one
+#: feature onto another wrote `avx2` for a Piledriver that has `bmi1` and no
+#: AVX2, and every package built for it died on SIGILL.
 CPU_FLAGS: Final[dict[str, str]] = {
-    "aes": "aes", "avx": "avx", "avx2": "avx2", "avx512f": "avx512f",
-    "avx512bw": "avx512bw", "avx512cd": "avx512cd", "avx512dq": "avx512dq",
-    "avx512vl": "avx512vl", "avx512vbmi": "avx512vbmi", "avx512vnni": "avx512vnni",
-    "bmi1": "bmi1", "bmi2": "bmi2", "f16c": "f16c", "fma": "fma3",
-    "mmx": "mmx", "mmxext": "mmxext",
-    "pclmulqdq": "pclmul", "popcnt": "popcnt", "rdrand": "rdrand", "sha_ni": "sha",
-    "sse": "sse", "sse2": "sse2", "pni": "sse3", "sse4_1": "sse4_1",
-    "sse4_2": "sse4_2", "sse4a": "sse4a", "ssse3": "ssse3",
-    "vaes": "vaes", "vpclmulqdq": "vpclmulqdq",
+    "3dnow": "3dnow", "3dnowext": "3dnowext", "aes": "aes",
+    "amx_bf16": "amx_bf16", "amx_int8": "amx_int8", "amx_tile": "amx_tile",
+    "avx": "avx", "avx2": "avx2", "avx_vnni": "avx_vnni",
+    "avx512_4fmaps": "avx512_4fmaps", "avx512_4vnniw": "avx512_4vnniw",
+    "avx512_bf16": "avx512_bf16", "avx512_bitalg": "avx512_bitalg",
+    "avx512_fp16": "avx512_fp16", "avx512_vbmi2": "avx512_vbmi2",
+    "avx512_vnni": "avx512_vnni", "avx512_vp2intersect": "avx512_vp2intersect",
+    "avx512_vpopcntdq": "avx512_vpopcntdq", "avx512bw": "avx512bw",
+    "avx512cd": "avx512cd", "avx512dq": "avx512dq", "avx512er": "avx512er",
+    "avx512f": "avx512f", "avx512ifma": "avx512ifma", "avx512pf": "avx512pf",
+    "avx512vbmi": "avx512vbmi", "avx512vl": "avx512vl",
+    "bmi1": "bmi1", "bmi2": "bmi2", "f16c": "f16c",
+    # Where the two names differ. Four are annotated `[<cpuinfo>] in cpuinfo`
+    # in the description file; `sha_ni` is not, and comes from the kernel's
+    # own header. `popcnt` is annotated there and is the same on both sides.
+    "fma": "fma3", "phe": "padlock", "pclmulqdq": "pclmul", "pni": "sse3",
+    "sha_ni": "sha", "popcnt": "popcnt",
+    "fma4": "fma4", "mmx": "mmx", "mmxext": "mmxext", "rdrand": "rdrand",
+    "sse": "sse", "sse2": "sse2", "sse4_1": "sse4_1", "sse4_2": "sse4_2",
+    "sse4a": "sse4a", "ssse3": "ssse3", "vpclmulqdq": "vpclmulqdq",
+    "xop": "xop",
 }
+
+#: A flag whose presence implies another the kernel does not print beside it.
+#: `mmxext` is `[sse] in cpuinfo` in the description file: AMD reports it and
+#: Intel does not, supporting it through SSE, and `cpuid2cpuflags` emits it
+#: for both. Without this an Intel machine loses the flag it qualifies for.
+IMPLIED_CPU_FLAGS: Final[dict[str, str]] = {"sse": "mmxext"}
+
+#: Named rather than written inline, so the fallback can be exercised against
+#: a file holding one CPU's flags instead of whatever this machine has.
+CPUINFO: Final[Path] = Path("/proc/cpuinfo")
 
 #: Directories under zoneinfo that are not regions: legacy aliases, and the
 #: right and posix trees, which repeat every zone with another leap-second
@@ -815,15 +844,25 @@ class Probe:
         return ("UTC", *found) if found else _carried_timezones()
 
     def cpu_flags(self) -> tuple[str, ...]:
-        """`CPU_FLAGS_X86` for this machine, from /proc/cpuinfo.
+        """`CPU_FLAGS_X86` for this machine.
 
-        Read here rather than run through `cpuid2cpuflags`: that is
-        app-portage/cpuid2cpuflags, which no install medium carries, and the
-        flag names it prints are a fixed mapping of the ones the kernel already
-        reports.
+        `cpuid2cpuflags` when the machine has it, because it is the
+        ecosystem's own answer and is versioned with the tree, so a flag added
+        to `CPU_FLAGS_X86` after this was written still reaches `make.conf`.
+        Both install media carry it: `app-portage/cpuid2cpuflags` is line 56 of
+        `releng`'s `installcd-stage1.spec` and is in the Gig-OS Live ISO's
+        `world`. Its output is taken unfiltered, or a flag newer than this
+        table would be dropped by the very check meant to keep bad ones out.
+
+        The table answers where it is absent, which is an in-place conversion
+        of somebody else's distribution rather than a run from a medium.
         """
+        said = self.runner.run(["cpuid2cpuflags"], check=False)
+        answer = said.stdout.strip()
+        if said.returncode == 0 and answer.startswith("CPU_FLAGS_X86:"):
+            return tuple(sorted(answer.partition(":")[2].split()))
         try:
-            text = Path("/proc/cpuinfo").read_text()
+            text = CPUINFO.read_text()
         except OSError:
             return ()
         reported: set[str] = set()
@@ -833,6 +872,9 @@ class Probe:
                 reported.update(value.split())
                 break
         found = [portage for kernel, portage in CPU_FLAGS.items() if kernel in reported]
+        found += [
+            portage for kernel, portage in IMPLIED_CPU_FLAGS.items() if kernel in reported
+        ]
         return tuple(sorted(set(found)))
 
     def storage_layout(self) -> StorageLayout:

--- a/tests/unit/test_exec.py
+++ b/tests/unit/test_exec.py
@@ -1036,7 +1036,17 @@ def test_a_cpu_flag_is_renamed_and_never_swapped_for_another(tmp_path: Path) -> 
     from gentoo_install.exec.probe import CPU_FLAGS
 
     renamed = {kernel: portage for kernel, portage in CPU_FLAGS.items() if kernel != portage}
-    assert renamed == {"fma": "fma3", "pclmulqdq": "pclmul", "sha_ni": "sha", "pni": "sse3"}
+    # `phe` was missing until the whole of `cpu_flags_x86.desc` was read: the
+    # five below are every name that differs between /proc/cpuinfo and that
+    # file, four of them annotated there as `[<cpuinfo>] in cpuinfo` and
+    # `sha_ni` taken from the kernel's own `cpufeatures.h`.
+    assert renamed == {
+        "fma": "fma3",
+        "pclmulqdq": "pclmul",
+        "phe": "padlock",
+        "sha_ni": "sha",
+        "pni": "sse3",
+    }
     assert CPU_FLAGS["bmi1"] == "bmi1" and CPU_FLAGS["bmi2"] == "bmi2"
     # One kernel name per portage name: two keys sharing a value is a swap.
     values = [portage for portage in CPU_FLAGS.values()]

--- a/tests/unit/test_probe.py
+++ b/tests/unit/test_probe.py
@@ -375,3 +375,172 @@ def test_a_bios_machine_is_found_by_its_grub_directory(
 
     (tmp_path / "grub2").mkdir()
     assert probe.Probe(runner=quiet, work=tmp_path).boot_method() is probe.BootMethod.BIOS_GRUB
+
+
+#: Every `CPU_FLAGS_X86` value Gentoo defines, read from
+#: `profiles/desc/cpu_flags_x86.desc` on 2026-08-18. Held here rather than
+#: read from `/var/db/repos` so the check runs where no repository is mounted,
+#: and so a value that quietly leaves the table is a failing test rather than
+#: a silently narrower one.
+PORTAGE_CPU_FLAGS: frozenset[str] = frozenset(
+    """
+    3dnow 3dnowext aes amx_bf16 amx_int8 amx_tile avx avx2 avx512_4fmaps
+    avx512_4vnniw avx512_bf16 avx512_bitalg avx512_fp16 avx512_vbmi2
+    avx512_vnni avx512_vp2intersect avx512_vpopcntdq avx512bw avx512cd
+    avx512dq avx512er avx512f avx512ifma avx512pf avx512vbmi avx512vl
+    avx_vnni bmi1 bmi2 f16c fma3 fma4 mmx mmxext padlock pclmul popcnt rdrand
+    sha sse sse2 sse3 sse4_1 sse4_2 sse4a ssse3 vpclmulqdq xop
+    """.split()
+)
+
+#: The six the description file records as spelt differently in cpuinfo, as
+#: `<flag> - ... ([<cpuinfo>] in cpuinfo)`. `sha` is the seventh rename and is
+#: not annotated there; it is `sha_ni` in the kernel's own header.
+DOCUMENTED_RENAMES: dict[str, str] = {
+    "fma": "fma3",
+    "phe": "padlock",
+    "pclmulqdq": "pclmul",
+    "pni": "sse3",
+    "popcnt": "popcnt",
+    "sha_ni": "sha",
+}
+
+
+def test_no_cpu_flag_is_a_name_portage_does_not_define() -> None:
+    """A value outside `CPU_FLAGS_X86` reaches `make.conf` and is a build
+    failure rather than an optimisation. This table held `vaes`, which is a
+    cpuinfo flag with no portage counterpart at all."""
+    from gentoo_install.exec.probe import CPU_FLAGS, IMPLIED_CPU_FLAGS
+
+    produced = set(CPU_FLAGS.values()) | set(IMPLIED_CPU_FLAGS.values())
+    assert produced <= PORTAGE_CPU_FLAGS, sorted(produced - PORTAGE_CPU_FLAGS)
+
+
+def test_every_flag_portage_defines_can_be_produced() -> None:
+    """A flag with no cpuinfo name is one no machine ever gets: `avx512_vnni`
+    was written `avx512vnni`, so a CPU that has it was never given it."""
+    from gentoo_install.exec.probe import CPU_FLAGS, IMPLIED_CPU_FLAGS
+
+    produced = set(CPU_FLAGS.values()) | set(IMPLIED_CPU_FLAGS.values())
+    assert PORTAGE_CPU_FLAGS <= produced, sorted(PORTAGE_CPU_FLAGS - produced)
+
+
+def test_each_documented_rename_is_the_one_the_table_uses() -> None:
+    """The description file records the cpuinfo name in brackets. Writing the
+    requirement the other way round is what refused the v3 binary host on
+    every machine that qualifies for it."""
+    from gentoo_install.exec.probe import CPU_FLAGS
+
+    for kernel, portage in DOCUMENTED_RENAMES.items():
+        assert CPU_FLAGS.get(kernel) == portage, (kernel, CPU_FLAGS.get(kernel))
+
+
+class WithoutTheTool(Runner):
+    """A machine with no `cpuid2cpuflags`, which is an in-place conversion of
+    somebody else's distribution rather than a run from a medium."""
+
+    def run(
+        self,
+        argv: Sequence[str],
+        *,
+        check: bool = True,
+        input_text: str | None = None,
+        timeout: float | None = None,
+    ) -> Result:
+        return Result(
+            argv=tuple(argv), returncode=127, stdout="", stderr="", seconds=0.0
+        )
+
+
+class WithTheTool(Runner):
+    """`cpuid2cpuflags` as this workstation printed it on 2026-08-18."""
+
+    ANSWER = (
+        "CPU_FLAGS_X86: aes avx avx2 avx512_bf16 avx512_vnni avx512f mmx "
+        "mmxext pclmul popcnt sha sse sse2 sse3 sse4_1 sse4_2 ssse3\n"
+    )
+
+    def run(
+        self,
+        argv: Sequence[str],
+        *,
+        check: bool = True,
+        input_text: str | None = None,
+        timeout: float | None = None,
+    ) -> Result:
+        return Result(
+            argv=tuple(argv), returncode=0, stdout=self.ANSWER, stderr="", seconds=0.0
+        )
+
+
+def test_the_tool_the_media_ship_is_asked_first() -> None:
+    """`app-portage/cpuid2cpuflags` is line 56 of `releng`'s
+    `installcd-stage1.spec` and is in the Gig-OS Live ISO's `world`, so both
+    media have it. It is versioned with the tree, so a flag added to
+    `CPU_FLAGS_X86` after this was written still reaches `make.conf`."""
+    flags = probe.Probe(runner=WithTheTool(log=lambda line: None), work=Path("/")).cpu_flags()
+
+    assert flags == tuple(sorted(WithTheTool.ANSWER.partition(":")[2].split())), flags
+
+
+def test_sse_alone_still_gives_mmxext(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The fallback, for a conversion where the tool is absent. `mmxext` is
+    `[sse] in cpuinfo`: AMD prints it and Intel does not, supporting it
+    through SSE, and `cpuid2cpuflags` emits it for both."""
+    written = tmp_path / "cpuinfo"
+    written.write_text("flags\t: fpu mmx sse sse2 pni\n", encoding="utf-8")
+    monkeypatch.setattr(probe, "CPUINFO", written)
+    reading = probe.Probe(runner=WithoutTheTool(log=lambda line: None), work=tmp_path)
+    flags = reading.cpu_flags()
+
+    assert "mmxext" in flags, flags
+    assert "sse3" in flags, flags
+    assert "fpu" not in flags, flags
+
+
+#: One machine's `/proc/cpuinfo` flags and what `cpuid2cpuflags` answered for
+#: it, both read on 2026-08-18 from the workstation this is developed on. A
+#: pair, because the fallback is only correct if it agrees with the tool on
+#: the same CPU, and that agreement is what no assertion about the table
+#: alone can show.
+SAMPLE_CPUINFO_FLAGS: str = (
+    "3dnowprefetch abm adx aes amd_lbr_pmc_freeze amd_lbr_v2 aperfmperf apic arat "
+    "avic avx avx2 avx512_bf16 avx512_bitalg avx512_vbmi2 avx512_vnni "
+    "avx512_vp2intersect avx512_vpopcntdq avx512bw avx512cd avx512dq avx512f "
+    "avx512ifma avx512vbmi avx512vl avx_vnni bmi1 bmi2 bpext bus_lock_detect cat_l3 "
+    "cdp_l3 clflush clflushopt clwb clzero cmov cmp_legacy constant_tsc cpb cppc "
+    "cpuid cpuid_fault cqm cqm_llc cqm_mbm_local cqm_mbm_total cqm_occup_llc "
+    "cr8_legacy cx16 cx8 de decodeassists erms extapic extd_apicid f16c flush_l1d "
+    "flushbyasid fma fpu fsgsbase fsrm fxsr fxsr_opt gfni ht hw_pstate ibpb ibrs "
+    "ibrs_enhanced ibs invpcid irperf lahf_lm lbrv lm mba mca mce misalignsse mmx "
+    "mmxext monitor movbe movdir64b movdiri msr mtrr mwaitx nonstop_tsc nopl npt "
+    "nrip_save nx ospke osvw overflow_recov pae pat pausefilter pclmulqdq pdpe1gb "
+    "perfctr_core perfctr_llc perfctr_nb perfmon_v2 pfthreshold pge pku pni popcnt "
+    "pse pse36 rapl rdpid rdpru rdrand rdseed rdt_a rdtscp rep_good sep sha_ni "
+    "skinit smap smca smep ssbd sse sse2 sse4_1 sse4_2 sse4a ssse3 stibp succor svm "
+    "svm_lock syscall tce topoext tsc tsc_adjust tsc_scale umip user_shstk "
+    "v_spec_ctrl v_vmsave_vmload vaes vgif vmcb_clean vme vmmcall vnmi vpclmulqdq "
+    "wbnoinvd wdt x2avic xgetbv1 xsave xsavec xsaveerptr xsaveopt xsaves xtopology "
+)
+
+SAMPLE_CPUID2CPUFLAGS: str = (
+    "CPU_FLAGS_X86: aes avx avx2 avx512_bf16 avx512_bitalg avx512_vbmi2 avx512_vnni avx512_vp2intersect avx512_vpopcntdq avx512bw avx512cd avx512dq avx512f avx512ifma avx512vbmi avx512vl avx_vnni bmi1 bmi2 f16c fma3 mmx mmxext pclmul popcnt rdrand sha sse sse2 sse3 sse4_1 sse4_2 sse4a ssse3 vpclmulqdq"
+)
+
+
+def test_the_fallback_agrees_with_the_tool_on_the_same_cpu(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A machine with no `cpuid2cpuflags` is an in-place conversion of another
+    distribution, and it gets `CPU_FLAGS_X86` from the table instead. The
+    table is only right if it answers what the tool would have: this pair was
+    35 flags on both sides with nothing on either difference."""
+    written = tmp_path / "cpuinfo"
+    written.write_text(f"flags\t: {SAMPLE_CPUINFO_FLAGS}\n", encoding="utf-8")
+    monkeypatch.setattr(probe, "CPUINFO", written)
+    reading = probe.Probe(runner=WithoutTheTool(log=lambda line: None), work=tmp_path)
+
+    expected = tuple(sorted(SAMPLE_CPUID2CPUFLAGS.partition(":")[2].split()))
+    assert reading.cpu_flags() == expected, set(expected) ^ set(reading.cpu_flags())


### PR DESCRIPTION
`app-portage/cpuid2cpuflags` is line 56 of `releng`'s `installcd-stage1.spec` and is in the Gig-OS Live ISO's `world`, so both media carry the tool the ecosystem maintains for this. It is asked first and its answer is taken unfiltered, because it is versioned with the tree and a flag newer than this table would otherwise be dropped by the check meant to keep bad ones out.

The table remains for an in-place conversion, where the running system is somebody else's distribution, and it was wrong: it produced `vaes`, which is a cpuinfo flag portage has no counterpart for, and `avx512vnni` for one portage spells `avx512_vnni`, so a CPU that has it never got it. Nineteen further values `cpu_flags_x86.desc` defines were not collected at all, and `mmxext` was missed on every Intel CPU, which reports it through `sse`. Measured on one machine: the fallback and the tool now answer the same 35 flags with no difference either way, and that pair is the test.