### PR TITLE
cluster: read a partly echoed password as the race it is

### DIFF
--- a/tests/unit/test_cluster.py
+++ b/tests/unit/test_cluster.py
@@ -1669,3 +1669,70 @@ def test_a_dead_first_resolver_costs_one_second_and_not_ten() -> None:
     attempts = int(cluster.RESOLVER_OPTIONS.split("attempts:")[1])
     seconds = int(cluster.RESOLVER_OPTIONS.split("timeout:")[1].split()[0])
     assert seconds * attempts <= cluster.LOOKUP_PATIENCE, cluster.RESOLVER_OPTIONS
+
+
+class _PartlyEchoingConsole:
+    """`login` turning the echo off partway through the password.
+
+    Taken from `openrc-sdboot` in run65 and `vm-lvm` in run64: the console
+    held a fragment of the password rather than the whole of it, so the
+    whole-word check read the attempt as the installed system refusing a
+    password that was in fact never delivered whole.
+    """
+
+    def __init__(self, echoes: int, keep: int = 1) -> None:
+        self.echoes = echoes
+        #: How many characters `login` swallowed before the echo stopped.
+        self.keep = keep
+        self.sent: list[str] = []
+        self.answers: list[bytes] = []
+        self.console = _Screen(b"openrcsdbox login: ")
+
+    def respond(self, line: str) -> None:
+        self.sent.append(line)
+        if line == "root":
+            self.answers.append(b"Password: ")
+        elif self.echoes > 0:
+            self.echoes -= 1
+            fragment = line[self.keep :]
+            self.answers.append(f"{fragment}\r\n\r\nLogin incorrect\r\nlogin: ".encode())
+        else:
+            self.answers.append(b"openrcsdbox ~ # ")
+
+    def observe(self, pattern: str, timeout: float = 0.0) -> bytes:
+        return self.answers.pop(0) if self.answers else b""
+
+
+def test_a_password_the_console_echoed_part_of_is_not_counted_as_a_refusal(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """`login` turns the echo off between two characters, so what comes back
+    is a fragment. Counting that as the installed system's refusal spends the
+    harness's whole budget on a race, and `login` gives up after three of its
+    own: `openrc-sdboot` was failed at 41.3 minutes for an install that had
+    completed."""
+    monkeypatch.setattr("time.sleep", lambda seconds: None)
+    # One more race than the harness has catches for, so a fragment counted as
+    # a refusal spends the whole budget and the login ends with no clean
+    # attempt ever made. Three would leave one, and the test would pass
+    # whether the fragment was seen or not.
+    races = cluster.PASSWORD_ECHO_CATCHES + 1
+    for swallowed in (1, 2, 5):
+        console = _PartlyEchoingConsole(echoes=races, keep=swallowed)
+        assert cluster._log_in(cast(cluster.Reconnecting, console), "install") == "", (
+            swallowed,
+            console.sent,
+        )
+        assert console.sent.count("install") == races + 1, (swallowed, console.sent)
+
+
+def test_a_refusal_holding_none_of_the_password_still_ends_the_login() -> None:
+    """The direction that has to keep working: a genuinely wrong password
+    echoes nothing, and absorbing that would hold the schedule open on a
+    machine nobody can log into."""
+    assert not cluster._echoed_back(b"Login incorrect\r\nlogin: ", "install")
+    # The refusal and the prompt carry letters of their own, and searching
+    # them makes every refusal read as this harness's own race.
+    assert not cluster._echoed_back(b"Login incorrect\r\nlogin: ", "loginx")
+    assert cluster._echoed_back(b"nstall\r\nLogin incorrect", "install")
+    assert cluster._echoed_back(b"inst\r\nLogin incorrect", "install")

--- a/tests/vm/cluster.py
+++ b/tests/vm/cluster.py
@@ -2448,6 +2448,35 @@ def _seen_since(link: Reconnecting, said: bytes) -> str:
     return repr(held) if held else "nothing"
 
 
+#: How much of the password has to come back before the attempt is read as
+#: this harness losing the echo race rather than the system refusing a
+#: password. Two characters: `login` turns the echo off partway through, so
+#: what reaches the console is a fragment. `openrc-sdboot` was failed for a
+#: refusal whose console held `nstall` under `Password:`, which the whole-word
+#: check did not see, and the fragment then went to `login` as the password.
+ECHO_FRAGMENT: Final[int] = 2
+
+#: What `login` writes when it will not take a password.
+REFUSED: Final[bytes] = b"Login incorrect"
+
+
+def _echoed_back(said: bytes, password: str) -> bool:
+    """Whether any of the password reached the console.
+
+    Every fragment of it, not the whole word: the echo is turned off between
+    two characters, so which part arrives depends on where that landed. Only
+    what came before `Login incorrect` is searched, because the refusal and
+    the prompt that follows it carry letters of their own: `Login incorrect`
+    holds `in`, and so does `install`.
+    """
+    echo = said.partition(REFUSED)[0]
+    return any(
+        password[at : at + width].encode() in echo
+        for width in range(len(password), ECHO_FRAGMENT - 1, -1)
+        for at in range(len(password) - width + 1)
+    )
+
+
 def _log_in(link: Reconnecting, password: str) -> str:
     """Log root in, and say what is wrong when it does not happen.
 
@@ -2474,7 +2503,7 @@ def _log_in(link: Reconnecting, password: str) -> str:
             )[:VERDICT_BYTES]
         if b"Login incorrect" not in said:
             return ""
-        if password.encode() in said and echoed < PASSWORD_ECHO_CATCHES:
+        if _echoed_back(said, password) and echoed < PASSWORD_ECHO_CATCHES:
             echoed += 1
             settle += PASSWORD_ECHO_BACKOFF
             continue


### PR DESCRIPTION
`vm-lvm` in run64 and `openrc-sdboot` in run65 were both failed with `root could not log into the installed system` on installs that had completed: the same hash reached `usermod --password` in the passing and the failing fixtures, and the console showed a fragment of the password under `Password:` rather than the whole of it.

`login` turns the echo off partway through, so which part arrives depends on where that landed. The whole-word check saw nothing, counted the attempt as the installed system refusing a password, and spent the harness's four tries on a race `login` gives up on after three of its own. Only the text before `Login incorrect` is searched, because the refusal and the prompt carry letters of their own — `Login incorrect` holds `in`, and so does `install`.