### PR TITLE
netboot: deliver the installer and its configuration in the initramfs

### DIFF
--- a/gentoo_install/cli.py
+++ b/gentoo_install/cli.py
@@ -48,6 +48,7 @@ from .model.config import (
 )
 from .exec.config import load_source
 from .model import authorized
+from .model.serialise import to_toml
 from .model.validate import validate_memory_launch
 from .plan import convert, netboot
 from .plan.convert import SWAP_CONFIRMATION
@@ -258,7 +259,18 @@ def _arm_memory_environment(
     """
     probe = Probe(runner=Runner(log=lambda line: None), work=arguments.work)
     target = _boot_target(probe)
-    operations = netboot.build(launch=launch, target=target, bypass=arguments.bypass)
+    operations = netboot.build(
+        launch=launch,
+        target=target,
+        bypass=arguments.bypass,
+        # Rendered rather than the file the operator passed: a run from the
+        # menu has no file, and the environment must install what was chosen.
+        configuration=to_toml(config),
+        # Where this installer is, so the payload carries the revision that
+        # wrote that configuration.
+        source=str(Path(__file__).resolve().parent.parent),
+        keys=tuple(config.system.authorized_keys),
+    )
     if arguments.dry_run:
         print(render(operations), end="")
         print(summarise(operations))

--- a/gentoo_install/plan/netboot.py
+++ b/gentoo_install/plan/netboot.py
@@ -267,6 +267,130 @@ class PlaceMemoryKernel(Operation):
             )
 
 
+#: Where the payload lands inside the initramfs, and where the hook puts it
+#: in the live system. One name, because the hook that copies it and the
+#: installer that reads it are written apart.
+PAYLOAD: Final[str] = "/gentoo-install"
+
+#: What `local` runs at boot on an OpenRC live system. The Gentoo minimal ISO
+#: and the CJK one built from it are both OpenRC.
+AUTOSTART: Final[str] = "/etc/local.d/99-gentoo-install.start"
+
+
+@dataclass(frozen=True, kw_only=True)
+class AppendConfiguration(Operation):
+    """Put the configuration and the keys inside the initramfs.
+
+    A newc cpio appended to the compressed initramfs is unpacked by the kernel
+    and its hooks are run by dracut, which was measured on 2026-08-18 by
+    booting one: a `cmdline` hook in the appended segment printed its marker at
+    3.5 seconds. So a 1.5 KiB segment delivers everything rather than the whole
+    55 MiB image being repacked. `lsinitrd` does not list the appended segment,
+    so it cannot be used to check this.
+    """
+
+    stage: Stage = Stage.BOOTLOADER
+    target: BootTarget
+    launch: MemoryLaunch
+    #: The operator's configuration, already rendered. Carried rather than
+    #: read, because `plan/` does no I/O.
+    configuration: str
+    #: Where this installer is running from. Its own tree goes in the payload:
+    #: 1.4 MiB packed, and it guarantees the memory environment runs the
+    #: revision that wrote the configuration rather than whatever a later
+    #: download would bring.
+    source: str
+    keys: tuple[str, ...] = ()
+
+    def describe_parts(self) -> tuple[str, tuple[str, ...]]:
+        return "put the installer, the configuration and {} key(s) inside the initramfs", (
+            str(len(self.keys)),
+        )
+
+    def apply(self, context: Context) -> None:
+        staging = self.target.place / "payload"
+        inside = PurePosixPath(str(staging) + PAYLOAD)
+        context.run(["mkdir", "--parents", str(inside)])
+        context.write(inside / "config.toml", self.configuration)
+        if self.keys:
+            context.write(
+                inside / "authorized_keys",
+                "".join(f"{one}\n" for one in self.keys),
+                mode=0o600,
+            )
+        # `bootstrap.sh` runs the tree beside it, so both go in together.
+        context.run(
+            [
+                "sh",
+                "-c",
+                f"cd {self.source} && tar --create --exclude=__pycache__ "
+                f"gentoo_install bootstrap.sh | tar --extract --directory {inside}",
+            ]
+        )
+        context.write(inside / "start.sh", _start(), mode=0o755)
+        hooks = staging / "usr/lib/dracut/hooks/pre-pivot"
+        context.run(["mkdir", "--parents", str(hooks)])
+        context.write(hooks / "99-gentoo-install.sh", _handover(), mode=0o755)
+        # `find | cpio` from inside the staging directory, or every path in the
+        # archive carries the staging prefix and lands nowhere the hook looks.
+        context.run(
+            [
+                "sh",
+                "-c",
+                f"cd {staging} && find . | cpio --create --format=newc "
+                f">> {self.target.place / 'initramfs'}",
+            ]
+        )
+        context.run(["rm", "--recursive", "--force", str(staging)])
+
+
+def _start() -> str:
+    """What the live system runs at boot. It asks before it erases anything.
+
+    Two answers and no timeout: a countdown that ends in a partitioned disk is
+    a countdown nobody can lose safely, and this path is reached by rebooting
+    a machine whose operator may still be reconnecting to it.
+    """
+    return (
+        "#!/bin/sh\n"
+        f"cd {PAYLOAD} || exit 0\n"
+        "printf '\\n'\n"
+        "printf 'gentoo-install is in memory. The disk has not been touched.\\n'\n"
+        "printf '  install  reinstall this machine from the delivered configuration\\n'\n"
+        "printf '  shell    leave this and use the live system as a rescue medium\\n'\n"
+        "printf 'install or shell> '\n"
+        "read answer\n"
+        'case "$answer" in\n'
+        f"install) exec sh ./bootstrap.sh --config {PAYLOAD}/config.toml ;;\n"
+        "*) printf 'nothing was changed\\n' ;;\n"
+        "esac\n"
+    )
+
+
+def _handover() -> str:
+    """What runs in the initramfs to hand the payload to the live system.
+
+    `pre-pivot`, because `$NEWROOT` is mounted by then and writable: with
+    `rd.live.ram=1` the squashfs is read-only but `dmsquash-live-root` puts an
+    overlay over it, so what is written here survives that boot.
+    """
+    return (
+        "#!/bin/sh\n"
+        f'[ -d "$NEWROOT" ] || exit 0\n'
+        f'mkdir -p "$NEWROOT{PAYLOAD}" "$NEWROOT/root/.ssh"\n'
+        f'cp -a {PAYLOAD}/. "$NEWROOT{PAYLOAD}/" 2>/dev/null || exit 0\n'
+        f'if [ -f "$NEWROOT{PAYLOAD}/authorized_keys" ]; then\n'
+        f'    cp "$NEWROOT{PAYLOAD}/authorized_keys" "$NEWROOT/root/.ssh/authorized_keys"\n'
+        f'    chmod 700 "$NEWROOT/root/.ssh"\n'
+        f'    chmod 600 "$NEWROOT/root/.ssh/authorized_keys"\n'
+        "fi\n"
+        f'mkdir -p "$NEWROOT/etc/local.d"\n'
+        f'printf \'#!/bin/sh\\nexec /bin/sh {PAYLOAD}/start.sh\\n\' '
+        f'> "$NEWROOT{AUTOSTART}"\n'
+        f'chmod 755 "$NEWROOT{AUTOSTART}"\n'
+    )
+
+
 @dataclass(frozen=True, kw_only=True)
 class WriteMemoryEntry(Operation):
     """Write the entry the armed boot selects, in this machine's own format."""
@@ -409,7 +533,13 @@ class DisarmMemoryBoot(Operation):
 
 
 def build(
-    *, launch: MemoryLaunch, target: BootTarget, bypass: bool = False
+    *,
+    launch: MemoryLaunch,
+    target: BootTarget,
+    bypass: bool = False,
+    configuration: str = "",
+    source: str = "",
+    keys: tuple[str, ...] = (),
 ) -> list[Operation]:
     """Every operation that arms one boot into the memory environment.
 
@@ -421,14 +551,29 @@ def build(
     arming: Operation = (
         ReplaceDefaultBoot(target=target) if bypass else ArmOneShot(target=target)
     )
-    return [
+    operations: list[Operation] = [
         RefuseWithoutABootMethod(target=target),
         RefuseTooLittleMemory(mode=launch.mode),
         FetchMemoryImage(mode=launch.mode, target=target),
         PlaceMemoryKernel(mode=launch.mode, target=target),
+    ]
+    if configuration:
+        # After the kernel is placed and before the entry names it: the
+        # appended segment goes on the initramfs that operation just wrote.
+        operations.append(
+            AppendConfiguration(
+                target=target,
+                launch=launch,
+                configuration=configuration,
+                source=source,
+                keys=keys,
+            )
+        )
+    operations += [
         WriteMemoryEntry(mode=launch.mode, target=target, launch=launch),
         arming,
     ]
+    return operations
 
 
 def disarm(*, target: BootTarget) -> list[Operation]:

--- a/tests/unit/test_plan_netboot.py
+++ b/tests/unit/test_plan_netboot.py
@@ -418,3 +418,109 @@ def _relabelled(
         return previous(argv) if previous is not None else None
 
     return answer
+
+
+def _appended(recorder: Recorder, keys: tuple[str, ...] = ()) -> None:
+    netboot.AppendConfiguration(
+        target=_target(),
+        launch=_launch(),
+        configuration='[disk]\nmode = "partition"\n',
+        source="/opt/gentoo-install",
+        keys=keys,
+    ).apply(recorder)
+
+
+def test_the_payload_is_appended_to_the_initramfs_rather_than_repacked() -> None:
+    """A newc cpio appended to the compressed initramfs is unpacked by the
+    kernel and its hooks are run by dracut: measured on 2026-08-18 by booting
+    one, where a hook in the appended segment printed at 3.5 seconds. So 1.5
+    KiB of cpio delivers everything and the 55 MiB image is never rewritten.
+    """
+    recorder = _answering()
+    _appended(recorder)
+
+    appended = [
+        one for one in recorder.commands if one[0] == "sh" and "cpio --create" in one[-1]
+    ]
+    assert len(appended) == 1, recorder.commands
+    # Appended, not overwritten: `>` would leave an initramfs holding only the
+    # payload and a machine with no way to mount its root.
+    assert ">>" in appended[0][-1] and ">> " in appended[0][-1], appended
+    assert f"{netboot.PLACE}/initramfs" in appended[0][-1], appended
+
+
+def test_the_archive_is_made_from_inside_the_staging_directory() -> None:
+    """`find` from anywhere else writes the staging prefix into every path, so
+    the payload unpacks to a directory the hook does not look in."""
+    recorder = _answering()
+    _appended(recorder)
+
+    made = next(one for one in recorder.commands if "cpio --create" in one[-1])
+    assert made[-1].startswith("cd ") and "&& find . |" in made[-1], made
+
+
+def test_the_installer_travels_with_its_own_configuration() -> None:
+    """The configuration was written by this revision, so the environment runs
+    this revision rather than whatever a later download would bring."""
+    recorder = _answering()
+    _appended(recorder)
+
+    carried = next(
+        one for one in recorder.commands if one[0] == "sh" and "tar --create" in one[-1]
+    )
+    assert "cd /opt/gentoo-install" in carried[-1], carried
+    assert "gentoo_install bootstrap.sh" in carried[-1], carried
+    assert "__pycache__" in carried[-1], carried
+
+
+def test_a_key_is_written_where_sshd_reads_it_and_not_world_readable() -> None:
+    recorder = _answering()
+    _appended(recorder, keys=("ssh-ed25519 AAAA zakk@box",))
+
+    payload = PurePosixPath(f"{ESP}/{netboot.PLACE}/payload{netboot.PAYLOAD}")
+    assert recorder.files[payload / "authorized_keys"].endswith("zakk@box\n")
+    assert recorder.modes[payload / "authorized_keys"] == 0o600
+    hook = recorder.files[
+        PurePosixPath(f"{ESP}/{netboot.PLACE}/payload/usr/lib/dracut/hooks/pre-pivot/99-gentoo-install.sh")
+    ]
+    assert "/root/.ssh/authorized_keys" in hook, hook
+    assert "chmod 600" in hook, hook
+
+
+def test_the_live_system_asks_before_it_erases_anything() -> None:
+    """`docs/design.md` settles this: the first screen offers two things and
+    neither happens on a timer. A countdown that ends in a partitioned disk is
+    one nobody can lose safely."""
+    recorder = _answering()
+    _appended(recorder)
+
+    start = recorder.files[
+        PurePosixPath(f"{ESP}/{netboot.PLACE}/payload{netboot.PAYLOAD}/start.sh")
+    ]
+    assert "read answer" in start, start
+    assert "install)" in start and "bootstrap.sh --config" in start, start
+    # No timeout anywhere: `read -t` and `sleep` are both ways to answer for
+    # the operator, and the answer they would give erases a disk.
+    assert "read -t" not in start and "sleep" not in start, start
+
+
+def test_no_configuration_appends_nothing() -> None:
+    """`--ram` with no configuration is the rescue path, and a payload with an
+    empty `config.toml` would offer to install from it."""
+    plan = netboot.build(launch=_launch(), target=_target())
+    assert not any(isinstance(one, netboot.AppendConfiguration) for one in plan)
+
+    carrying = netboot.build(
+        launch=_launch(), target=_target(), configuration="x = 1\n", source="/opt/x"
+    )
+    at = next(
+        n for n, one in enumerate(carrying) if isinstance(one, netboot.AppendConfiguration)
+    )
+    placed = next(
+        n for n, one in enumerate(carrying) if isinstance(one, netboot.PlaceMemoryKernel)
+    )
+    entry = next(
+        n for n, one in enumerate(carrying) if isinstance(one, netboot.WriteMemoryEntry)
+    )
+    # After the initramfs is placed and before the entry names it.
+    assert placed < at < entry, [type(one).__name__ for one in carrying]


### PR DESCRIPTION
How the memory environment learns what to install. A newc cpio appended to the compressed initramfs is unpacked by the kernel and dracut runs its hooks: measured on 2026-08-18 by booting the CJK ISO's kernel with a 1.5 KiB segment appended, whose `cmdline` hook printed its marker at 3.5 seconds. So the 55 MiB image is never repacked. `lsinitrd` does not list the appended segment, which is why this was booted rather than inspected.

The payload carries the installer's own tree, 1.4 MiB packed, so the environment runs the revision that wrote the configuration rather than whatever a later download would bring. A `pre-pivot` hook copies it into `$NEWROOT` — writable, because `dmsquash-live-root` puts an overlay over the read-only squashfs — writes the keys to `/root/.ssh/authorized_keys` at 0600, and leaves an OpenRC `local.d` script. That script offers two answers and no timeout: a countdown that ends in a partitioned disk is one nobody can lose safely.