### PR TITLE
kernel: stop pointing a pool at a key ZFSBootMenu cannot open

### DIFF
--- a/gentoo_install/model/compat.py
+++ b/gentoo_install/model/compat.py
@@ -675,19 +675,6 @@ def boot_is_encrypted(graph: DeviceGraph) -> bool:
     return any(isinstance(graph[parent], Luks) for parent in graph.ancestors_of(boot.id))
 
 
-def boot_is_inside(graph: DeviceGraph, device: DeviceId) -> bool:
-    """Whether the kernel and initramfs land on something built from `device`.
-
-    A key file baked into the initramfs is only protected if the initramfs is
-    inside the thing that key unlocks; a separate /boot partition puts it in
-    the clear.
-    """
-    boot = _covering_mount(graph, _BOOT)
-    if boot is None:
-        return False
-    return device in graph.ancestors_of(boot.id)
-
-
 def _covering_mount(graph: DeviceGraph, path: PurePosixPath) -> Mountpoint | None:
     """The mount a file at `path` lands on: the deepest one `path` sits under."""
     covering = [mount for mount in graph.of_type(Mountpoint) if path.is_relative_to(mount.path)]

--- a/gentoo_install/plan/kernel.py
+++ b/gentoo_install/plan/kernel.py
@@ -325,41 +325,6 @@ class WriteDracutModules(Operation):
 
 
 @dataclass(frozen=True, kw_only=True)
-class StoreZfsKey(Operation):
-    """Move the pool off a boot-time prompt and onto a key file the target
-    initramfs carries, so the passphrase is asked for once.
-
-    ZFSBootMenu overrides a `file://` keylocation its own image cannot read and
-    prompts instead, and the file exists only in the target initramfs, which is
-    inside the pool that key unlocks.
-    """
-
-    stage: Stage = Stage.KERNEL
-    pool: DeviceId
-    name: str
-
-    @property
-    def key(self) -> PurePosixPath:
-        return PurePosixPath(f"/etc/zfs/{self.name}.key")
-
-    def describe(self) -> str:
-        return f"put the {self.name} key in {self.key} so only ZFSBootMenu asks for it"
-
-    def apply(self, context: Context) -> None:
-        # No trailing newline: `zfs load-key` trims one when it is there, so a
-        # file written without one is read the same either way.
-        context.write(self.key, context.passphrase(self.pool), mode=0o400)
-        context.write(
-            PurePosixPath("/etc/dracut.conf.d/zfs-key.conf"),
-            f'install_items+=" {self.key} "\n',
-        )
-        # On the installing system, not in the target: the pool is imported
-        # here, and a stage3 has no `zfs` binary until sys-fs/zfs is merged
-        # several operations later.
-        context.run(["zfs", "set", f"keylocation=file://{self.key}", self.name])
-
-
-@dataclass(frozen=True, kw_only=True)
 class AcceptFirmwareLicence(Operation):
     """Written rather than left to `--autounmask-license`, so the acceptance is
     a file the installed system keeps and not a decision buried in a log."""
@@ -765,9 +730,6 @@ def build(config: InstallConfig) -> list[Operation]:
         )
     if modules:
         operations.append(WriteDracutModules(modules=modules))
-    pool = _pool_the_initramfs_may_carry(config)
-    if pool is not None:
-        operations.append(StoreZfsKey(pool=pool.id, name=pool.name))
     # Delete first, then rebuild. The misnamed image `sys-fs/zfs` leaves is
     # often the only one in /boot, so deleting it last left generate-zbm with
     # `Unable to find latest kernel`. `emerge --config` reinstalls the image
@@ -791,22 +753,6 @@ def _module_builders(modules: tuple[str, ...]) -> tuple[str, ...]:
         if tool is not None and tool.modules and tool.atom not in wanted:
             wanted.append(tool.atom)
     return tuple(wanted)
-
-
-def _pool_the_initramfs_may_carry(config: InstallConfig) -> ZfsPool | None:
-    """The encrypted pool whose key can go into the initramfs without leaking.
-
-    ZFSBootMenu only, because it is the one bootloader that unlocks the pool
-    itself; without it the initramfs prompt is the only prompt and a key file
-    beside it would remove the passphrase from the boot path entirely.
-    """
-    if config.bootloader.kind is not Bootloader.ZFSBOOTMENU:
-        return None
-    graph = config.disk.graph
-    pools = [pool for pool in graph.of_type(ZfsPool) if pool.encrypted]
-    if len(pools) != 1 or not compat.boot_is_inside(graph, pools[0].id):
-        return None
-    return pools[0]
 
 
 def dracut_modules(config: InstallConfig) -> tuple[str, ...]:

--- a/tests/golden/vm-zfs-encrypted.txt
+++ b/tests/golden/vm-zfs-encrypted.txt
@@ -68,7 +68,6 @@
   install the storage tools: emerge sys-fs/dosfstools
   install the kernel and the tools that build a module for it: emerge sys-kernel/gentoo-kernel-bin sys-fs/zfs, building sys-fs/zfs here
   tell dracut to carry zfs, and 13 cloud bus drivers whatever it detects
-  put the rpool key in /etc/zfs/rpool.key so only ZFSBootMenu asks for it
   copy the installing system's hostid into the target so the pool imports
   rebuild the initramfs from sys-kernel/gentoo-kernel-bin with the modules written above
   check the installkernel payload names existing kernel files

--- a/tests/golden/zbm-unlock.txt
+++ b/tests/golden/zbm-unlock.txt
@@ -83,7 +83,6 @@
   install the storage tools: emerge sys-fs/dosfstools
   install the kernel and the tools that build a module for it: emerge sys-kernel/gentoo-cjk-kernel-bin sys-fs/zfs, from source
   tell dracut to carry zfs, and 13 cloud bus drivers whatever it detects
-  put the zpcala key in /etc/zfs/zpcala.key so only ZFSBootMenu asks for it
   copy the installing system's hostid into the target so the pool imports
   rebuild the initramfs from sys-kernel/gentoo-cjk-kernel-bin with the modules written above
   check the installkernel payload names existing kernel files

--- a/tests/golden/zfs-zbm.txt
+++ b/tests/golden/zfs-zbm.txt
@@ -80,7 +80,6 @@
   install the storage tools: emerge sys-fs/dosfstools
   install the kernel and the tools that build a module for it: emerge sys-kernel/gentoo-cjk-kernel-bin sys-fs/zfs, from source
   tell dracut to carry zfs, and 13 cloud bus drivers whatever it detects
-  put the zpcala key in /etc/zfs/zpcala.key so only ZFSBootMenu asks for it
   copy the installing system's hostid into the target so the pool imports
   rebuild the initramfs from sys-kernel/gentoo-cjk-kernel-bin with the modules written above
   check the installkernel payload names existing kernel files

--- a/tests/unit/test_plan_boot.py
+++ b/tests/unit/test_plan_boot.py
@@ -697,67 +697,30 @@ def test_the_prebuilt_patched_kernel_sits_beside_the_source_one() -> None:
         assert any("from source" in line for line in described), source
 
 
-def test_zfsbootmenu_unlocks_once_rather_than_asking_the_initramfs_too() -> None:
-    """ZBM unlocks the pool to read the kernel and the initramfs then asks for
-    the same passphrase again, because kexec does not carry the loaded key."""
-    recorder = Recorder()
-    for operation in kernel.build(zfs_installation()):
-        if isinstance(operation, kernel.StoreZfsKey):
-            operation.apply(recorder)
-    key = PurePosixPath("/etc/zfs/zpcala.key")
-    # No trailing newline: `zfs load-key` trims one, so the file is read the
-    # same either way and this is the form that cannot be wrong.
-    assert recorder.files[key] == "a passphrase"
-    assert recorder.modes[key] == 0o400
-    assert recorder.files[PurePosixPath("/etc/dracut.conf.d/zfs-key.conf")] == (
-        'install_items+=" /etc/zfs/zpcala.key "\n'
-    )
-    # On the installing system: the pool is imported there, and the target has
-    # no `zfs` binary until sys-fs/zfs is merged later in the same stage.
-    assert ("zfs", "set", "keylocation=file:///etc/zfs/zpcala.key", "zpcala") in recorder.commands
-    assert not recorder.in_target
+def test_no_pool_is_pointed_at_a_key_file_zfsbootmenu_cannot_open() -> None:
+    """`zbm-unlock` installed in 75.3 minutes in run65 and then answered, in
+    ZFSBootMenu:
 
+        0 / 1 key(s) successfully loaded
+        Key load error: Failed to open key material file: No such file or directory
 
-def test_a_separate_boot_partition_keeps_the_prompt() -> None:
-    """The key file rides inside the initramfs, so an initramfs on a partition
-    outside the pool would publish the passphrase in the clear."""
-    nodes = [
-        *zfs_root(),
-        Partition(
-            id=i("bootpart"),
-            table=i("table"),
-            index=3,
-            role=PartitionRole.DATA,
-            size=Size.parse("1GiB"),
-        ),
-        Filesystem(id=i("bootfs"), device=i("bootpart"), kind=FilesystemType.EXT4),
-        Mountpoint(id=i("mnt-boot"), source=i("bootfs"), path=PurePosixPath("/boot")),
-    ]
-    outside = replace(zfs_installation(), disk=replace(
-        zfs_installation().disk, graph=DeviceGraph.build(nodes)
-    ))
-    assert not [one for one in kernel.build(outside) if isinstance(one, kernel.StoreZfsKey)]
+    The mechanism this replaced wrote the passphrase to `/etc/zfs/<pool>.key`,
+    packed it into the target initramfs and set `keylocation` to it, on the
+    premise that ZFSBootMenu prompts when its own image has no such path. It
+    does not: it fails, and the pool is then unlockable by nobody, not only by
+    the remote path. `keylocation` stays `prompt` and the second prompt in the
+    target initramfs is the accepted cost, which is what
+    `calamares-settings-gig` already accepts.
+    """
+    from gentoo_install.model.config import Bootloader
 
-
-def test_a_pool_that_is_not_encrypted_needs_no_key_file() -> None:
-    plain = [
-        node if not isinstance(node, ZfsPool) else replace(node, encrypted=False)
-        for node in zfs_root()
-    ]
-    open_pool = replace(zfs_installation(), disk=replace(
-        zfs_installation().disk, graph=DeviceGraph.build(plain)
-    ))
-    assert not [one for one in kernel.build(open_pool) if isinstance(one, kernel.StoreZfsKey)]
-
-
-def test_only_zfsbootmenu_moves_the_key_off_the_prompt() -> None:
-    """Under any other bootloader the initramfs prompt is the only prompt, and
-    a key file beside it would take the passphrase out of the boot path."""
-    grub = replace(
-        zfs_installation(),
-        bootloader=BootloaderConfig(kind=Bootloader.GRUB, firmware=Firmware.UEFI),
-    )
-    assert not [one for one in kernel.build(grub) if isinstance(one, kernel.StoreZfsKey)]
+    for named in (zfs_installation(), replace(zfs_installation(), bootloader=replace(
+        zfs_installation().bootloader, kind=Bootloader.ZFSBOOTMENU
+    ))):
+        for operation in kernel.build(named):
+            described = operation.describe()
+            assert "keylocation" not in described, described
+            assert ".key" not in described, described
 
 
 def test_the_kernel_is_merged_before_anything_that_builds_a_module_for_it() -> None:
@@ -774,16 +737,6 @@ def test_the_kernel_is_merged_before_anything_that_builds_a_module_for_it() -> N
         at for at, one in enumerate(described) if one.startswith("tell dracut to carry zfs")
     )
     assert told < merged < listed < initramfs
-
-
-def test_the_zfs_key_is_set_from_the_installing_system() -> None:
-    """A stage3 has no `zfs` binary until sys-fs/zfs is merged, which happens
-    later in the same stage; the pool is imported here in any case."""
-    recorder = Recorder()
-    for operation in kernel.build(zfs_installation()):
-        if isinstance(operation, kernel.StoreZfsKey):
-            operation.apply(recorder)
-    assert recorder.commands and not recorder.in_target
 
 
 def test_a_tool_that_builds_no_module_is_installed_before_the_kernel() -> None:


### PR DESCRIPTION
`zbm-unlock` in run65 installed for 75.3 minutes and then answered, in ZFSBootMenu:

    0 / 1 key(s) successfully loaded
    Key load error: Failed to open key material file: No such file or directory

The removed mechanism wrote the passphrase to `/etc/zfs/<pool>.key`, packed it into the target initramfs with `install_items+=` and set `keylocation` to it, so the passphrase would be asked for once instead of twice. The premise was that ZFSBootMenu prompts when its own image has no such path. It does not: it fails, and the pool is then unlockable by nobody — the interactive path as much as the remote one. An installed machine that never boots again is the worst shape this class of defect takes, and no unit test could see it.

`keylocation` stays `prompt`. The second prompt in the target initramfs is the accepted cost, which is what `calamares-settings-gig` already accepts in `gigos-zfs-bootmenu.sh`. `docs/design.md` carried the false premise and is corrected in the same change.