### PR TITLE
cluster: keep a verdict on one line

### DIFF
--- a/tests/unit/test_cluster.py
+++ b/tests/unit/test_cluster.py
@@ -1736,3 +1736,35 @@ def test_a_refusal_holding_none_of_the_password_still_ends_the_login() -> None:
     assert not cluster._echoed_back(b"Login incorrect\r\nlogin: ", "loginx")
     assert cluster._echoed_back(b"nstall\r\nLogin incorrect", "install")
     assert cluster._echoed_back(b"inst\r\nLogin incorrect", "install")
+
+
+def test_a_verdict_stays_on_one_line_however_many_the_guest_used() -> None:
+    """`zbm-unlock`'s verdict ran to three lines in run65 because the remote
+    command's output reached it whole. The first line held only ssh's
+    known-hosts warning, so a reader taking one line per verdict read the
+    failure as a bare warning and the two lines carrying `Key load error:
+    Failed to open key material file` as unrelated records."""
+    detail = (
+        "remote unlock failed: remote unlock failed: Warning: Permanently "
+        "added '[10.31.0.150]:2222' (ECDSA) to the list of known hosts.\n"
+        "0 / 1 key(s) successfully loaded\n"
+        "Key load error: Failed to open key material file: No such file or directory"
+    )
+    folded = cluster._one_line(detail)
+
+    assert "\n" not in folded, folded
+    assert "Key load error" in folded, folded
+    assert "0 / 1 key(s)" in folded, folded
+    # Joined visibly, or two sentences run together into a third that was
+    # never printed.
+    assert folded.count(" | ") == 2, folded
+
+
+def test_folding_drops_the_blank_lines_a_console_leaves() -> None:
+    assert cluster._one_line("first\n\n  \nsecond\n") == "first | second"
+
+
+def test_a_detail_with_no_newline_is_unchanged() -> None:
+    """Most verdicts are one line already, and rewriting them would change
+    every log this campaign has produced."""
+    assert cluster._one_line("the installer exited b'4'") == "the installer exited b'4'"

--- a/tests/vm/cluster.py
+++ b/tests/vm/cluster.py
@@ -2013,7 +2013,7 @@ def run(
                 print(f"  {job.node} takes no more guests this campaign", file=sys.stderr)
             print(
                 f"{outcome.verdict.value:6} {outcome.name:34} {outcome.seconds / 60:5.1f}m "
-                f"{outcome.detail}",
+                f"{_one_line(outcome.detail)}",
                 flush=True,
             )
     finally:
@@ -2433,6 +2433,18 @@ VERDICT_BYTES: Final[int] = 3600
 #: attempt. `login` writes it at once, so this only has to outlast a loaded
 #: node rather than anything the guest is doing.
 REPROMPT_PATIENCE: Final[float] = 30.0
+
+
+def _one_line(detail: str) -> str:
+    """The detail with its newlines folded, so a verdict is one line.
+
+    A remote command's output reaches the verdict whole, and `zbm-unlock`'s
+    ran to three lines: the first held only ssh's known-hosts warning, and the
+    two that carried `Key load error: Failed to open key material file` read as
+    unrelated records. A reader looking for one verdict per line finds the
+    wrong one.
+    """
+    return " | ".join(one.strip() for one in detail.splitlines() if one.strip())
 
 
 def _seen_since(link: Reconnecting, said: bytes) -> str:


### PR DESCRIPTION
`zbm-unlock`'s verdict in run65 ran to three lines, because the remote command's output reaches the detail whole. The first line held only ssh's `Warning: Permanently added …`, so a reader taking one line per verdict saw a failure whose whole content was a known-hosts warning, and the two lines carrying

    0 / 1 key(s) successfully loaded
    Key load error: Failed to open key material file: No such file or directory

read as unrelated records. That is how #523 was first triaged from the wrong line.

Newlines in the detail are folded to ` | ` at the point it is printed, so the stored outcome keeps its shape and the schedule's output stays one record per line.