### PR TITLE
tests: hold the CPU flag table against five more CPUs and the tree

### DIFF
--- a/tests/unit/test_harness.py
+++ b/tests/unit/test_harness.py
@@ -2973,3 +2973,82 @@ def test_a_vm_exit_takes_the_quit_path() -> None:
     source = inspect.getsource(Vm.__exit__)
     assert "self.shut_down()" in source, source
     assert "self.kill()" not in source, source
+
+
+def _run_the_cpu_flags_check(tmp_path: Path, flags: str, known: tuple[str, ...]) -> str:
+    """Execute the installed-state command against a fake portage tree.
+
+    The command is run rather than read: it is shell, and a test that asserts
+    on its text passes for a command that does nothing.
+    """
+    import os
+    import subprocess
+
+    from tests.vm.installed import CPU_FLAGS_COMMAND
+
+    tree = tmp_path / "repo"
+    (tree / "profiles/desc").mkdir(parents=True)
+    (tree / "profiles/desc/cpu_flags_x86.desc").write_text(
+        "".join(f"{one} - Use the {one} instruction set\n" for one in known),
+        encoding="utf-8",
+    )
+    binaries = tmp_path / "bin"
+    binaries.mkdir()
+    portageq = binaries / "portageq"
+    portageq.write_text(
+        "#!/bin/sh\n"
+        'case "$1" in\n'
+        f'get_repo_path) printf \'%s\\n\' "{tree}" ;;\n'
+        f"envvar) printf '%s\\n' '{flags}' ;;\n"
+        "esac\n",
+        encoding="utf-8",
+    )
+    portageq.chmod(0o755)
+    environment = dict(os.environ, PATH=f"{binaries}:/usr/bin:/bin")
+    return subprocess.run(
+        ["sh", "-c", CPU_FLAGS_COMMAND],
+        capture_output=True,
+        text=True,
+        env=environment,
+        check=False,
+    ).stdout
+
+
+def test_a_cpu_flag_portage_does_not_define_is_reported(tmp_path: Path) -> None:
+    """`vaes` is a cpuinfo flag with no `CPU_FLAGS_X86` counterpart, and it
+    was written into `make.conf` for three weeks. The authority is a file only
+    the installed system has, so this is read there and nowhere else."""
+    said = _run_the_cpu_flags_check(
+        tmp_path, "aes avx2 vaes", ("aes", "avx", "avx2", "fma3")
+    )
+    assert "CPUFLAGS-UNKNOWN: vaes" in said, said
+    assert "CPUFLAGS-ALL-KNOWN" not in said, said
+
+
+def test_flags_the_tree_defines_pass(tmp_path: Path) -> None:
+    said = _run_the_cpu_flags_check(tmp_path, "aes avx2 fma3", ("aes", "avx", "avx2", "fma3"))
+    assert "CPUFLAGS-ALL-KNOWN" in said, said
+    assert "CPUFLAGS-UNKNOWN" not in said, said
+
+
+def test_a_prefix_of_a_known_flag_is_not_accepted_as_that_flag(tmp_path: Path) -> None:
+    """`grep -q "^$one - "` and not `grep -q "$one"`: `avx` appears inside
+    every `avx512*` line, so a substring check accepts a name the tree does
+    not define."""
+    said = _run_the_cpu_flags_check(tmp_path, "avx512", ("avx", "avx512f"))
+    assert "CPUFLAGS-UNKNOWN: avx512" in said, said
+
+
+def test_the_check_cannot_pass_by_the_tool_being_absent(tmp_path: Path) -> None:
+    """The installer does not merge `cpuid2cpuflags`, so a pattern that
+    accepted its absence would be a rule that never fires. The verdict comes
+    from the tree, and the tool's answer is printed beside it."""
+    from tests.vm.installed import CPU_FLAGS_COMMAND, checks
+    from tests.unit.layouts import config
+
+    said = _run_the_cpu_flags_check(tmp_path, "aes vaes", ("aes",))
+    assert "CPUFLAGS-ALL-KNOWN" not in said, said
+
+    wanted = next(one for one in checks(config()) if one.name == "cpu-flags")
+    assert wanted.pattern == "CPUFLAGS-ALL-KNOWN", wanted
+    assert "cpuid2cpuflags" in CPU_FLAGS_COMMAND

--- a/tests/unit/test_probe.py
+++ b/tests/unit/test_probe.py
@@ -544,3 +544,159 @@ def test_the_fallback_agrees_with_the_tool_on_the_same_cpu(
 
     expected = tuple(sorted(SAMPLE_CPUID2CPUFLAGS.partition(":")[2].split()))
     assert reading.cpu_flags() == expected, set(expected) ^ set(reading.cpu_flags())
+
+
+#: One `/proc/cpuinfo` flags line and the `cpuid2cpuflags` answer for the same
+#: CPU, taken on 2026-08-18 by booting the Gentoo CJK ISO under QEMU once per
+#: model. The ISO carries `app-portage/cpuid2cpuflags`, so both halves come
+#: from the same guest and the pair is evidence rather than a transcription.
+#:
+#: Five models, chosen for what they disagree about: `qemu64` has almost
+#: nothing, `Nehalem` is an Intel that reports no `mmxext` and is given one
+#: through `sse`, `Opteron_G3` is an AMD that reports `sse4a`, and `EPYC` and
+#: `Skylake-Client` carry `fma3` and the `bmi` pair. The workstation this was
+#: developed on is a sixth, with the AVX-512 family.
+CPU_SAMPLES: dict[str, tuple[str, str]] = {
+    "EPYC": (
+        (
+            "3dnowprefetch abm adx aes apic arat avx avx2 bmi1 bmi2 clflush clflushopt "
+            "cmov cpuid cr8_legacy cx16 cx8 de extd_apicid f16c fma fpu fsgsbase fxsr "
+            "fxsr_opt hypervisor lahf_lm lm mca mce misalignsse mmx mmxext movbe msr mtrr "
+            "nopl nx osvw pae pat pclmulqdq pdpe1gb pge pni popcnt pse pse36 rdrand "
+            "rdseed rdtscp rep_good sep sha_ni smap smep sse sse2 sse4_1 sse4_2 sse4a "
+            "ssse3 syscall topoext tsc tsc_known_freq vme vmmcall x2apic xgetbv1 xsave "
+            "xsavec xsaveopt xtopology"
+        ),
+        (
+            "aes avx avx2 bmi1 bmi2 f16c fma3 mmx mmxext pclmul popcnt rdrand sha sse "
+            "sse2 sse3 sse4_1 sse4_2 sse4a ssse3"
+        ),
+    ),
+    "Opteron_G3": (
+        (
+            "3dnowprefetch abm apic clflush cmov cpuid cx16 cx8 de extd_apicid fpu fxsr "
+            "hypervisor lahf_lm lm mca mce misalignsse mmx msr mtrr nopl nx pae pat pge "
+            "pni popcnt pse pse36 rdtscp rep_good sep sse sse2 sse4a syscall tsc "
+            "tsc_known_freq vme vmmcall x2apic"
+        ),
+        (
+            "mmx mmxext popcnt sse sse2 sse3 sse4a"
+        ),
+    ),
+    "Skylake-Client": (
+        (
+            "3dnowprefetch abm adx aes apic arat avx avx2 bmi1 bmi2 clflush cmov cpuid "
+            "cx16 cx8 de erms f16c fma fpu fsgsbase fxsr hypervisor invpcid lahf_lm lm "
+            "mca mce mmx movbe msr mtrr nopl nx pae pat pclmulqdq pge pni popcnt pse "
+            "pse36 rdrand rdseed rdtscp sep smap smep sse sse2 sse4_1 sse4_2 ssse3 "
+            "syscall tsc tsc_deadline_timer tsc_known_freq vme vmmcall x2apic xgetbv1 "
+            "xsave xsavec xsaveopt xtopology"
+        ),
+        (
+            "aes avx avx2 bmi1 bmi2 f16c fma3 mmx mmxext pclmul popcnt rdrand sse sse2 "
+            "sse3 sse4_1 sse4_2 ssse3"
+        ),
+    ),
+    "nehalem": (
+        (
+            "3dnowprefetch apic clflush cmov cpuid cx16 cx8 de fpu fxsr hypervisor "
+            "lahf_lm lm mca mce mmx msr mtrr nopl nx pae pat pge pni popcnt pse pse36 sep "
+            "sse sse2 sse4_1 sse4_2 ssse3 syscall tsc tsc_known_freq vme vmmcall x2apic "
+            "xtopology"
+        ),
+        (
+            "mmx mmxext popcnt sse sse2 sse3 sse4_1 sse4_2 ssse3"
+        ),
+    ),
+    "qemu64": (
+        (
+            "3dnowprefetch apic clflush cmov cpuid cx16 cx8 de extd_apicid fpu fxsr "
+            "hypervisor lahf_lm lm mca mce mmx msr mtrr nopl nx pae pat pge pni pse pse36 "
+            "rep_good sep sse sse2 syscall tsc tsc_known_freq vmmcall x2apic xtopology"
+        ),
+        (
+            "mmx mmxext sse sse2 sse3"
+        ),
+    ),
+}
+
+
+@pytest.mark.parametrize("model", sorted(CPU_SAMPLES))
+def test_the_fallback_answers_what_the_tool_answers_on_that_cpu(
+    model: str, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The table is only right if it agrees with `cpuid2cpuflags` on the same
+    CPU, and one machine cannot show that: `mmxext` is absent from Intel's
+    cpuinfo and present in the tool's answer, and `sse4a` appears on AMD only.
+    """
+    cpuinfo, expected = CPU_SAMPLES[model]
+    written = tmp_path / "cpuinfo"
+    written.write_text(f"flags\t: {cpuinfo}\n", encoding="utf-8")
+    monkeypatch.setattr(probe, "CPUINFO", written)
+    reading = probe.Probe(runner=WithoutTheTool(log=lambda line: None), work=tmp_path)
+
+    assert reading.cpu_flags() == tuple(expected.split()), (
+        model,
+        set(expected.split()) ^ set(reading.cpu_flags()),
+    )
+
+
+def test_the_samples_cover_the_cases_one_machine_cannot_show() -> None:
+    """A sample set that agrees about everything proves only that the tests
+    ran. These four disagreements are why five machines were booted."""
+    answers = {name: set(truth.split()) for name, (_, truth) in CPU_SAMPLES.items()}
+    assert any("sse4a" in one for one in answers.values()), "no AMD sample"
+    assert any("fma3" in one for one in answers.values()), "nothing with FMA3"
+    assert any(len(one) < 6 for one in answers.values()), "nothing minimal"
+    # The implied flag, on a CPU whose own cpuinfo does not name it.
+    intel = {
+        name
+        for name, (cpuinfo, truth) in CPU_SAMPLES.items()
+        if "mmxext" in truth.split() and "mmxext" not in cpuinfo.split()
+    }
+    assert intel, "no sample exercises mmxext being implied by sse"
+
+
+#: What the kernel prints in `/proc/cpuinfo` for each feature this maps, read
+#: from `arch/x86/include/asm/cpufeatures.h` of the running 6.18 kernel on
+#: 2026-08-18. Held here because thirteen of the flags portage defines are on
+#: no CPU any sample was taken from — `3dnow`, `fma4`, `xop`, `padlock`, the
+#: `amx_*` set and four AVX-512 members — so for those this file is the only
+#: evidence that the name on the left of the table is one a machine will ever
+#: report. A key that is not a printed name is a branch that can never fire.
+KERNEL_PRINTS: frozenset[str] = frozenset(
+    (
+    "3dnow 3dnowext aes amx_bf16 amx_int8 amx_tile avx avx2 avx512_4fmaps "
+    "avx512_4vnniw avx512_bf16 avx512_bitalg avx512_fp16 avx512_vbmi2 "
+    "avx512_vnni avx512_vp2intersect avx512_vpopcntdq avx512bw avx512cd "
+    "avx512dq avx512er avx512f avx512ifma avx512pf avx512vbmi avx512vl avx_vnni "
+    "bmi1 bmi2 f16c fma fma4 mmx mmxext pclmulqdq phe pni popcnt rdrand sha_ni "
+    "sse sse2 sse4_1 sse4_2 sse4a ssse3 vpclmulqdq xop"
+    ).split()
+)
+
+
+def test_every_cpuinfo_name_is_one_the_kernel_prints() -> None:
+    """`sha` and `sha_ni` are the shape of this mistake: portage's flag is
+    `sha` and the kernel prints `sha_ni`, so a table keyed by the portage name
+    would match nothing on any machine and say nothing about it."""
+    from gentoo_install.exec.probe import CPU_FLAGS, IMPLIED_CPU_FLAGS
+
+    keys = set(CPU_FLAGS) | set(IMPLIED_CPU_FLAGS)
+    assert keys <= KERNEL_PRINTS, sorted(keys - KERNEL_PRINTS)
+
+
+def test_the_uncovered_flags_are_the_ones_this_file_answers_for() -> None:
+    """Naming the gap, so it is a boundary rather than an omission: these are
+    the flags no sampled CPU has, and the kernel header is what holds their
+    spelling."""
+    covered: set[str] = set()
+    for _, truth in CPU_SAMPLES.values():
+        covered |= set(truth.split())
+    unmeasured = PORTAGE_CPU_FLAGS - covered
+    assert unmeasured, "every flag is measured; this test has nothing left to say"
+    from gentoo_install.exec.probe import CPU_FLAGS
+
+    for portage in sorted(unmeasured):
+        kernel = next(k for k, v in CPU_FLAGS.items() if v == portage)
+        assert kernel in KERNEL_PRINTS, (portage, kernel)

--- a/tests/vm/installed.py
+++ b/tests/vm/installed.py
@@ -31,6 +31,29 @@ class InstalledCheck:
     pattern: str
 
 
+#: Read on the installed machine, against the tree that machine has: every
+#: `CPU_FLAGS_X86` value portage accepts is one line of
+#: `profiles/desc/cpu_flags_x86.desc`, so a name that is not there is a name
+#: portage does not know. `vaes` was written for three weeks and is a cpuinfo
+#: flag with no portage counterpart at all; nothing in the unit tests could
+#: see it, because the authority is a file only the installed system has.
+#:
+#: The comparison against `cpuid2cpuflags` is printed when the tool is there
+#: and is not what the check passes on: the installer does not merge it, so a
+#: pattern accepting its absence would be a rule that cannot fail.
+CPU_FLAGS_COMMAND: str = (
+    "desc=$(portageq get_repo_path / gentoo)/profiles/desc/cpu_flags_x86.desc; "
+    "unknown=''; "
+    "for one in $(portageq envvar CPU_FLAGS_X86); do "
+    'grep -q "^$one - " "$desc" || unknown="$unknown $one"; '
+    "done; "
+    'if [ -n "$unknown" ]; then printf \'CPUFLAGS-UNKNOWN:%s\\n\' "$unknown"; '
+    "else echo CPUFLAGS-ALL-KNOWN; fi; "
+    "command -v cpuid2cpuflags >/dev/null 2>&1 && "
+    "printf 'CPUFLAGS-TOOL %s\\n' \"$(cpuid2cpuflags)\" || true"
+)
+
+
 def checks(installation: InstallConfig) -> tuple[InstalledCheck, ...]:
     """Derive every installed-state check from the configuration."""
     result = [
@@ -43,6 +66,7 @@ def checks(installation: InstallConfig) -> tuple[InstalledCheck, ...]:
                        _kernel_pattern(installation)),
         InstalledCheck("resolver", "readlink -f /etc/resolv.conf; test -s /etc/resolv.conf && echo RESOLVCONF-OK || echo RESOLVCONF-EMPTY", "RESOLVCONF-OK"),
         InstalledCheck("portage", "emerge --info >/dev/null 2>&1 && echo EMERGE-OK || echo EMERGE-FAIL", "EMERGE-OK"),
+        InstalledCheck("cpu-flags", CPU_FLAGS_COMMAND, "CPUFLAGS-ALL-KNOWN"),
         InstalledCheck("init", "test -d /run/openrc && echo openrc || { test -d /run/systemd/system && echo systemd || echo unknown; }", "systemd" if installation.system.init is InitSystem.SYSTEMD else "openrc"),
     ]
     if installation.system.init is InitSystem.SYSTEMD:


### PR DESCRIPTION
The `fma`/`fma3` defect shipped because the only check on the table was one machine's agreement with `cpuid2cpuflags`, and that machine has FMA3. Three things now hold it.

**Five more CPUs, measured.** The Gentoo CJK ISO carries `app-portage/cpuid2cpuflags`, so booting it under QEMU once per `-cpu` model gives `/proc/cpuinfo` and the tool's answer from the same guest. `qemu64`, `Nehalem`, `Opteron_G3`, `EPYC` and `Skylake-Client` are the samples; they disagree about the things one machine cannot show — `mmxext` is absent from Intel's cpuinfo and present in the tool's answer, `sse4a` appears on AMD only. All five agree with the fallback exactly, as does this workstation, which is a sixth.

**The thirteen flags no sample has** — `3dnow`, `fma4`, `xop`, `padlock`, the `amx_*` set and four AVX-512 members — are held against the printed names in the kernel's `cpufeatures.h`, and a test names that gap rather than leaving it silent. Misspelling `xop` turns two tests red.

**The installed machine checks itself.** Every value in its `CPU_FLAGS_X86` must be a line of that machine's own `profiles/desc/cpu_flags_x86.desc`, which is the authority for what portage accepts and exists only there. `vaes` would have failed it. The check cannot pass by `cpuid2cpuflags` being absent, because the installer does not merge it.