### PR TITLE
cluster: a reopen before a write asks for no prompt

### DIFF
--- a/tests/unit/test_cluster.py
+++ b/tests/unit/test_cluster.py
@@ -1768,3 +1768,59 @@ def test_a_detail_with_no_newline_is_unchanged() -> None:
     """Most verdicts are one line already, and rewriting them would change
     every log this campaign has produced."""
     assert cluster._one_line("the installer exited b'4'") == "the installer exited b'4'"
+
+
+class _DroppedOnce:
+    """A console that has been closed and records what is written to it."""
+
+    def __init__(self) -> None:
+        self.sent: list[str] = []
+        self.closed = True
+
+    def send(self, line: str) -> None:
+        self.sent.append(line)
+
+    def send_raw(self, keys: str) -> None:
+        self.sent.append(keys)
+
+    def close(self) -> None:
+        self.closed = True
+
+
+def test_a_reopen_before_a_write_sends_no_empty_line() -> None:
+    """The line the caller is about to write is the request for a prompt, and
+    the empty one a solicit adds is a line the guest answers first. At a
+    `login:` prompt agetty takes it as an attempt and reprints its banner, so
+    every send after it answers the prompt before the one it was written for:
+    `vm-lvm` and `openrc-sdboot` failed that way in three rounds."""
+    opened: list[_DroppedOnce] = []
+
+    def open_console() -> _DroppedOnce:
+        made = _DroppedOnce()
+        made.closed = not opened  # the first is closed, the reopened one is not
+        opened.append(made)
+        return made
+
+    link = cluster.Reconnecting(cast("Any", open_console))
+    link.send("root")
+
+    assert len(opened) == 2, opened
+    assert opened[1].sent == ["root"], opened[1].sent
+    assert "" not in opened[1].sent, opened[1].sent
+
+
+def test_a_reopen_that_is_waiting_for_a_shell_still_asks_for_one() -> None:
+    """The other direction: a console reopened while nothing is being written
+    shows nothing until it is asked, and the waits below look for text."""
+    opened: list[_DroppedOnce] = []
+
+    def open_console() -> _DroppedOnce:
+        made = _DroppedOnce()
+        made.closed = False
+        opened.append(made)
+        return made
+
+    link = cluster.Reconnecting(cast("Any", open_console))
+    link.reopen()
+
+    assert opened[-1].sent == [""], opened[-1].sent

--- a/tests/unit/test_proxmox.py
+++ b/tests/unit/test_proxmox.py
@@ -1957,8 +1957,11 @@ def test_a_command_is_delivered_after_the_console_was_dropped() -> None:
     link = Reconnecting(open_console, tries=4)
     link.send("probe me")
     assert len(opened) == 2, "the closed console has to be replaced before the write"
-    # `reopen` sends an empty line first, to make the shell draw a prompt.
-    assert opened[1].sent == ["", "probe me"]
+    # The command and nothing else. This asserted `["", "probe me"]` while a
+    # reopen before a write also asked for a prompt, and that empty line is
+    # what agetty counted as a login attempt: `vm-lvm` and `openrc-sdboot`
+    # failed in three rounds with the password arriving one prompt late.
+    assert opened[1].sent == ["probe me"]
     assert opened[0].sent == [], "nothing goes into the dropped one"
 
 

--- a/tests/vm/cluster.py
+++ b/tests/vm/cluster.py
@@ -2339,12 +2339,22 @@ class Reconnecting:
         the command undelivered: `wait_for_network` sent its probe into a
         closed socket and then waited fifteen minutes for output that was
         never going to come. Eight guests failed that way in one round.
+
+        Unsolicited, because the caller is about to write: the line it sends
+        is the request for a prompt, and the empty one a solicit adds is a
+        line the guest answers first. At a `login:` prompt agetty takes it as
+        an attempt and reprints its banner, and every send after that answers
+        the prompt before the one it was written for. `vm-lvm` and
+        `openrc-sdboot` failed that way in run64, run65 and run66: the console
+        held `lvmbox login: ` with an empty line under it, then `root`,
+        `Password:`, an empty password, and `install` echoed at the next
+        `login:`.
         """
         if not self.console.closed:
             return
         for attempt in range(self._tries):
             try:
-                self.reopen()
+                self.reopen(solicit_prompt=False)
                 return
             except (ConsoleClosed, OSError):
                 if attempt + 1 == self._tries:


### PR DESCRIPTION
`vm-lvm` and `openrc-sdboot` failed in run64, run65 and run66 with `root could not log into the installed system`, and #521 did not fix it. The console shows why:

    lvmbox login: <CR><CR>
    This is lvmbox … 00:10:43        ← agetty counted the empty line and restarted
    lvmbox login: root
    Password:
    install                          ← echoed, one prompt late
    Login incorrect

`_reopen_if_closed` replaces a dropped console because the caller is about to write, and it reopened with the default solicit, which sends an empty line. That line lands on whatever prompt is showing. At `login:` agetty takes it as an attempt, reprints its banner, and the username then answers the prompt the empty line created — so the password arrives at a `login:` prompt and `login` gives up after its three tries.

The write itself is the request for a prompt, so this reopen asks for nothing. A reopen that happens while nothing is being written still solicits, because the waits below look for text. The existing test asserted `["", "probe me"]` — it documented the behaviour that caused this — and is corrected with the reason.