### PR TITLE
netboot: write a GRUB path relative to the filesystem holding it

### DIFF
--- a/gentoo_install/cli.py
+++ b/gentoo_install/cli.py
@@ -245,6 +245,7 @@ def _boot_target(probe: Probe) -> netboot.BootTarget:
         grub_directory=next(
             (str(one) for one in GRUB_DIRECTORIES if one.is_dir()), None
         ),
+        boot_on_the_root_filesystem=layout.boot_same_filesystem,
     )
 
 

--- a/gentoo_install/plan/netboot.py
+++ b/gentoo_install/plan/netboot.py
@@ -98,6 +98,18 @@ class BootTarget:
     esp_disk: str | None = None
     esp_partition: int | None = None
     grub_directory: str | None = None
+    #: Whether `/boot` is a directory on the root filesystem rather than a
+    #: mount of its own. GRUB's paths are relative to the filesystem its
+    #: `root` names, so the same file is `/gentoo-install-ram/kernel` when
+    #: `/boot` is its own partition and `/boot/gentoo-install-ram/kernel` when
+    #: it is not. `None` is unread, and is treated as separate because that is
+    #: what every layout this installer produces has.
+    boot_on_the_root_filesystem: bool | None = None
+
+    @property
+    def grub_prefix(self) -> str:
+        """What a path in a GRUB entry has to start with on this machine."""
+        return "/boot" if self.boot_on_the_root_filesystem else ""
 
     @property
     def place(self) -> PurePosixPath:
@@ -595,12 +607,18 @@ def _write_custom(
             "so there is nowhere an entry would be read from"
         )
     custom = PurePosixPath(target.grub_directory) / "custom.cfg"
+    # Relative to the filesystem GRUB's `root` names, which is the partition
+    # holding `/boot` when that is a mount and the root filesystem when it is
+    # a directory. Written the first way on a machine of the second kind, the
+    # `search` matches nothing, `root` is left alone, and the entry stops in
+    # GRUB with the kernel not found.
+    at = f"{target.grub_prefix}/{PLACE}"
     entry = (
         f"{CUSTOM_BEGIN}\n"
         f"menuentry '{ENTRY_LABEL}' {{\n"
-        f"    search --no-floppy --set=root --file /{PLACE}/kernel\n"
-        f"    linux /{PLACE}/kernel {cmdline}\n"
-        f"    initrd /{PLACE}/initramfs\n"
+        f"    search --no-floppy --set=root --file {at}/kernel\n"
+        f"    linux {at}/kernel {cmdline}\n"
+        f"    initrd {at}/initramfs\n"
         f"}}\n"
         f"{CUSTOM_END}\n"
     )

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -1527,3 +1527,38 @@ def test_bypass_without_a_memory_mode_is_refused() -> None:
     that does nothing when the mode it belongs to was not asked for."""
     with pytest.raises(ConfigError, match="require --ram or --lowram"):
         cli._memory_launch(cli.parser().parse_args(["--bypass"]))
+
+
+def test_the_boot_target_carries_whether_boot_is_its_own_filesystem(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """GRUB's paths are relative to the filesystem its `root` names, so an
+    entry written without this fact points at `/gentoo-install-ram/kernel` on
+    a machine whose file is at `/boot/gentoo-install-ram/kernel`, and the
+    armed boot stops in GRUB. The probe answers it; this holds the wiring."""
+    from gentoo_install.model.device import StorageLayout
+
+    for same in (True, False, None):
+        monkeypatch.setattr(
+            RealProbe,
+            "storage_layout",
+            lambda self, answer=same: StorageLayout(
+                root_device="/dev/vda2",
+                root_filesystem_type="ext4",
+                root_uuid=None,
+                root_on_lvm=None,
+                root_on_luks=None,
+                root_on_mdraid=None,
+                root_below_device=None,
+                boot_device=None,
+                boot_filesystem_type=None,
+                boot_same_filesystem=answer,
+                esp_device=None,
+                esp_mountpoint=None,
+                uefi=False,
+                root_free_bytes=None,
+            ),
+        )
+        monkeypatch.setattr(RealProbe, "boot_method", lambda self: BootMethod.BIOS_GRUB)
+        probe = RealProbe(runner=Runner(log=lambda line: None), work=Path("/tmp"))
+        assert cli._boot_target(probe).boot_on_the_root_filesystem is same, same

--- a/tests/unit/test_plan_netboot.py
+++ b/tests/unit/test_plan_netboot.py
@@ -524,3 +524,78 @@ def test_no_configuration_appends_nothing() -> None:
     )
     # After the initramfs is placed and before the entry names it.
     assert placed < at < entry, [type(one).__name__ for one in carrying]
+
+
+def _custom(recorder: Recorder) -> str:
+    return recorder.files[PurePosixPath("/boot/grub/custom.cfg")]
+
+
+def test_a_separate_boot_partition_gets_a_path_relative_to_itself() -> None:
+    """GRUB's paths are relative to the filesystem its `root` names, which is
+    the `/boot` partition when there is one."""
+    recorder = _answering()
+    target = netboot.BootTarget(
+        method=BootMethod.BIOS_GRUB,
+        grub_directory="/boot/grub",
+        boot_on_the_root_filesystem=False,
+    )
+    netboot.WriteMemoryEntry(mode=MemoryMode.RAM, target=target, launch=_launch()).apply(
+        recorder
+    )
+
+    written = _custom(recorder)
+    assert f"linux /{netboot.PLACE}/kernel" in written, written
+    assert "/boot/gentoo-install-ram" not in written, written
+
+
+def test_boot_on_the_root_filesystem_gets_the_boot_prefix() -> None:
+    """The same file is `/boot/gentoo-install-ram/kernel` to GRUB when `/boot`
+    is a directory rather than a mount. Written the other way, the `search`
+    matches nothing, `root` is left alone, and the entry stops in GRUB with
+    the kernel not found — the machine still boots its own system, and the
+    armed one never runs."""
+    recorder = _answering()
+    target = netboot.BootTarget(
+        method=BootMethod.BIOS_GRUB,
+        grub_directory="/boot/grub",
+        boot_on_the_root_filesystem=True,
+    )
+    netboot.WriteMemoryEntry(mode=MemoryMode.RAM, target=target, launch=_launch()).apply(
+        recorder
+    )
+
+    written = _custom(recorder)
+    for line in ("search", "linux", "initrd"):
+        named = next(one for one in written.splitlines() if one.strip().startswith(line))
+        assert f"/boot/{netboot.PLACE}/" in named, named
+
+
+def test_the_three_lines_of_an_entry_never_disagree_about_the_path() -> None:
+    """`search` sets `root` by finding that exact path, so a `linux` line
+    naming another one is an entry that finds a filesystem and then asks it
+    for a file it does not have."""
+    for on_root in (True, False, None):
+        recorder = _answering()
+        target = netboot.BootTarget(
+            method=BootMethod.BIOS_GRUB,
+            grub_directory="/boot/grub",
+            boot_on_the_root_filesystem=on_root,
+        )
+        netboot.WriteMemoryEntry(
+            mode=MemoryMode.RAM, target=target, launch=_launch()
+        ).apply(recorder)
+
+        written = _custom(recorder)
+        searched = next(
+            one.split()[-1] for one in written.splitlines() if "search" in one
+        )
+        loaded = next(
+            one.split()[1] for one in written.splitlines() if one.strip().startswith("linux")
+        )
+        assert searched == loaded, (on_root, searched, loaded)
+
+
+def test_an_unread_boot_layout_is_treated_as_a_separate_partition() -> None:
+    """Every layout this installer produces has one, so that is the answer
+    when nothing read the machine."""
+    assert netboot.BootTarget(method=BootMethod.BIOS_GRUB).grub_prefix == ""


### PR DESCRIPTION
A read-only audit against `bin456789/reinstall` found this and it is confirmed by reading the emitted entry: the payload goes to `/boot/gentoo-install-ram/` on a BIOS machine, and the entry named `/gentoo-install-ram/kernel` in all cases. That path is correct only when `/boot` is a mount of its own, because GRUB resolves against the filesystem its `root` names. Where `/boot` is a directory on `/`, the `search --file` matches nothing, `root` is left as it was, and the entry stops in GRUB with the kernel not found — the machine still boots its own system, and the armed one never runs.

`StorageLayout.boot_same_filesystem` already answers this and the probe already computes it; `_boot_target` now carries it. Unread is treated as a separate partition, which is what every layout this installer produces has.

Three tests, three negative controls, each red on its assertion: never prefixing, letting `search` and `linux` disagree about the path, and dropping the `cli` wiring. The third was green at first — nothing held that wiring — so a test for it was added.