### PR TITLE
proxmox: ask the medium's auto-login for a serial shell

### DIFF
--- a/tests/unit/test_harness.py
+++ b/tests/unit/test_harness.py
@@ -1657,10 +1657,14 @@ def test_no_fixture_asks_for_more_jobs_than_a_test_guest_has() -> None:
 def test_a_bios_guest_whose_grub_speaks_is_read_before_it_is_typed_at_blind(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """The blind path exists for a GRUB that writes only to VGA. The official
+    """The fallback exists for a GRUB that writes only to VGA. The official
     minimal ISO answers `starting serial terminal on interface serial0` and can
-    be read; typing at it blind landed on no line and three fixtures ended at
-    `the kernel never spoke after editing GRUB blind`."""
+    be read, and a menu that can be read is never typed at blind.
+
+    What the fallback does changed: editing the menu blind never landed, and a
+    screenshot of the guest shows the live system already logged in on the VGA
+    console three seconds later. The medium's own auto-login is asked for a
+    shell on the serial port instead."""
     from typing import Any, cast
 
     from tests.vm import cluster
@@ -1668,13 +1672,13 @@ def test_a_bios_guest_whose_grub_speaks_is_read_before_it_is_typed_at_blind(
     read: list[str] = []
     monkeypatch.setattr(cluster, "append_to_cmdline", lambda link, extra: read.append("read"))
     monkeypatch.setattr(
-        cluster, "append_to_cmdline_blind", lambda guest, link, extra: read.append("blind")
+        cluster, "open_a_serial_shell_blind", lambda guest, link: read.append("shell")
     )
     cluster._edit_bios_cmdline(cast("Any", object()), cast("Any", object()))
     assert read == ["read"], "a menu that can be read is not typed at blind"
 
-    # A GRUB that says nothing still gets the blind attempt, from a menu the
-    # failed one did not touch.
+    # A GRUB that says nothing gets the auto-login attempt, from a fresh boot
+    # because the unreadable menu counted down while the serial wait ran.
     reset: list[str] = []
 
     class Guest:
@@ -1693,7 +1697,7 @@ def test_a_bios_guest_whose_grub_speaks_is_read_before_it_is_typed_at_blind(
     read.clear()
     monkeypatch.setattr(cluster, "append_to_cmdline", silent)
     cluster._edit_bios_cmdline(cast("Any", Guest()), cast("Any", Link()))
-    assert read == ["blind"]
+    assert read == ["shell"]
     assert reset == ["reset", "reopen:False"]
 
 

--- a/tests/unit/test_proxmox.py
+++ b/tests/unit/test_proxmox.py
@@ -3758,3 +3758,105 @@ def test_a_reset_that_never_answers_still_stops_the_run(
         guest.reset()
 
     assert len(tries) == RESET_TRIES, tries
+
+
+class _AutoLoginGuest:
+    """A SeaBIOS guest that answers on the serial port only once the line has
+    been typed into the auto-login shell the VGA console already holds."""
+
+    def __init__(self, answers_after: int = 1) -> None:
+        self.answers_after = answers_after
+        self.typed: list[str] = []
+        self.resets = 0
+
+    def send_keys(self, keys: list[str]) -> None:
+        self.typed.extend(keys)
+
+    def reset(self) -> None:
+        self.resets += 1
+
+
+class _SerialAfterTyping:
+    def __init__(self, guest: _AutoLoginGuest, needed: int) -> None:
+        self.guest = guest
+        self.needed = needed
+        self.console = self
+
+    def expect(self, pattern: str, timeout: float, idle: float = 0.0) -> bytes:
+        from tests.vm.console import ConsoleTimeout
+
+        if self.guest.resets >= self.needed:
+            return b"\r\nroot@livecd ~ # "
+        raise ConsoleTimeout("nothing on the serial port")
+
+    def reopen(self, *, solicit_prompt: bool = True) -> None:
+        return None
+
+
+def test_the_serial_shell_is_asked_for_by_typing_into_the_auto_login(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The blind GRUB edit this replaces never landed. A screenshot through
+    the QEMU monitor shows why: three seconds after the menu the live system
+    is logged in on the VGA console, so the keys reached a shell and the
+    screen held `bash: cserial: command not found`."""
+    from typing import Any, cast
+
+    from tests.vm import proxmox
+
+    monkeypatch.setattr("time.sleep", lambda seconds: None)
+    guest = _AutoLoginGuest()
+    link = _SerialAfterTyping(guest, needed=0)
+    proxmox.open_a_serial_shell_blind(cast("Any", guest), cast("Any", link))
+
+    typed = "".join(one for one in guest.typed if len(one) == 1)
+    assert "agetty" in "".join(guest.typed) or "agetty" in typed, guest.typed
+    # The command line is not touched: nothing types `console=` anywhere.
+    assert "console=" not in "".join(guest.typed), guest.typed
+    assert guest.resets == 0, "a first attempt that answers resets nothing"
+
+
+def test_a_medium_that_is_slower_gets_another_attempt(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A loaded node reaches its auto-login later than an idle one, and the
+    ladder is timed rather than read because nothing is readable until the
+    line lands."""
+    from typing import Any, cast
+
+    from tests.vm import proxmox
+
+    monkeypatch.setattr("time.sleep", lambda seconds: None)
+    guest = _AutoLoginGuest()
+    link = _SerialAfterTyping(guest, needed=2)
+    proxmox.open_a_serial_shell_blind(cast("Any", guest), cast("Any", link))
+
+    assert guest.resets == 2, guest.resets
+
+
+def test_a_medium_that_never_answers_stops_rather_than_holding_the_schedule(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from typing import Any, cast
+
+    from tests.vm import proxmox
+    from tests.vm.proxmox import AUTOLOGIN_ATTEMPTS, ProxmoxError
+
+    monkeypatch.setattr("time.sleep", lambda seconds: None)
+    guest = _AutoLoginGuest()
+    link = _SerialAfterTyping(guest, needed=99)
+    with pytest.raises(ProxmoxError, match="no serial shell"):
+        proxmox.open_a_serial_shell_blind(cast("Any", guest), cast("Any", link))
+
+    assert guest.resets == len(AUTOLOGIN_ATTEMPTS) - 1, guest.resets
+
+
+def test_the_ladder_outlasts_a_medium_that_is_merely_slow() -> None:
+    """Measured on 2026-08-18: a SeaBIOS guest was past GRUB and logged in at
+    about fifteen seconds. The first rung is above that, and the last is far
+    enough above it to cover a node under load."""
+    from tests.vm.proxmox import AUTOLOGIN_ATTEMPTS
+
+    assert AUTOLOGIN_ATTEMPTS[0] > 15.0, AUTOLOGIN_ATTEMPTS
+    assert AUTOLOGIN_ATTEMPTS[-1] >= 90.0, AUTOLOGIN_ATTEMPTS
+    assert list(AUTOLOGIN_ATTEMPTS) == sorted(AUTOLOGIN_ATTEMPTS), AUTOLOGIN_ATTEMPTS

--- a/tests/vm/cluster.py
+++ b/tests/vm/cluster.py
@@ -90,7 +90,7 @@ from .proxmox import (
     VMID_LAST,
     Line,
     append_to_cmdline,
-    append_to_cmdline_blind,
+    open_a_serial_shell_blind,
 )
 from .results import (
     CONSOLE_CLOSE,
@@ -2906,25 +2906,31 @@ def _abandon_jobs(scheduled: Mapping[str, Job]) -> None:
 
 
 def _edit_bios_cmdline(guest: Guest, link: "Reconnecting") -> None:
-    """Read the menu when GRUB speaks on the serial port, and type blind if not.
+    """Read the menu when GRUB speaks on the serial port, and otherwise ask
+    the medium's own auto-login for a shell on that port.
 
-    SeaBIOS hands over to a GRUB that on some media writes only to VGA, which
-    is why the blind path exists at all. The official minimal ISO answers
-    `starting serial terminal on interface serial0` and can be read, and typing
-    at it blind landed on no line: `vm-bios`, `vm-bios-luks` and `ext4-bios`
-    all ended at `the kernel never spoke after editing GRUB blind` with that
-    line in the log.
+    SeaBIOS hands over to a GRUB that on some media writes only to VGA. Typing
+    at that menu blind never landed: `vm-bios`, `vm-bios-luks` and `ext4-bios`
+    ended at `the kernel never spoke` in every round that tried it, and
+    run66's two took fourteen minutes each to do so. A screenshot taken
+    through the QEMU monitor says why — three seconds after the menu the live
+    system is logged in on the VGA console, so the keys reached a shell and
+    `bash: cserial: command not found` is what the screen held.
+
+    So the command line is left alone. The medium logs root in by itself, and
+    one typed line moves a getty onto the serial port, which is readable from
+    the first attempt.
     """
     try:
         append_to_cmdline(link, EXTRA_CMDLINE)
         return
     except GrubNotReadable:
         pass
-    # The unreadable menu may have counted down while the serial wait ran, so
-    # reset before timing the blind attempt from a fresh boot.
+    # The unreadable menu counted down while the serial wait ran, so the guest
+    # is already past it; the attempt below is timed from a fresh boot.
     guest.reset()
     link.reopen(solicit_prompt=False)
-    append_to_cmdline_blind(guest, link, EXTRA_CMDLINE)
+    open_a_serial_shell_blind(guest, link)
 
 
 def _unanswered(

--- a/tests/vm/proxmox.py
+++ b/tests/vm/proxmox.py
@@ -986,6 +986,69 @@ BIOS_ATTEMPTS: Final[tuple[tuple[float, int], ...]] = (
 KERNEL_SPEAKS: Final[str] = r"Linux version|Command line:|\[    0\.000000\]"
 
 
+#: What the live medium's own auto-login shell is asked to start, so the
+#: serial port carries a root shell without the kernel command line being
+#: touched. `--autologin root` because the medium scrambles the root password,
+#: and `&` because this is typed into a shell that has to stay usable.
+SERIAL_GETTY: Final[str] = "setsid agetty --autologin root --noclear ttyS0 115200 vt100 &"
+
+#: What that shell prints once it is on the serial port. `root@` and not `#`:
+#: the medium's prompt carries the user and the host, and `#` alone matches
+#: half the boot messages before it.
+SERIAL_SHELL_SPEAKS: Final[str] = r"root@[^\s]+"
+
+#: How long the medium is given to reach its auto-login before the line is
+#: typed, and how many times. Measured on 2026-08-18 by taking a screenshot of
+#: a SeaBIOS guest through the QEMU monitor: at fifteen seconds it was past
+#: GRUB, past the boot, and sitting at `livecd login: root (automatic login)`
+#: with a shell. The ladder covers a node under load, not a different medium.
+AUTOLOGIN_ATTEMPTS: Final[tuple[float, ...]] = (25.0, 45.0, 90.0)
+
+
+def open_a_serial_shell_blind(
+    guest: Guest, link: "Reopenable", patience: float = 45.0
+) -> None:
+    """Type into the medium's auto-login shell until the serial port answers.
+
+    The blind GRUB edit this replaces never landed. A screenshot of the guest
+    explains why: the menu is gone in about three seconds and the live system
+    is already logged in on the VGA console, so the keys arrived at a shell
+    rather than at GRUB — `bash: cserial: command not found` is what the
+    screen held. Nothing about the kernel command line has to change: the
+    medium logs root in by itself, and one line moves a getty onto the port.
+
+    Readable from the first attempt, unlike what it replaces: the shell
+    answers on the serial port or it does not, and the console says which.
+    """
+    console = link.console
+    last = ""
+    for attempt, delay in enumerate(AUTOLOGIN_ATTEMPTS):
+        # Timed, not read: this guest writes nothing to the serial port until
+        # the line below has been typed, so there is nothing to wait for.
+        time.sleep(delay)
+        # A bare newline first: the auto-login prints its welcome and leaves
+        # the cursor after a prompt, and a line typed into a console that has
+        # not finished drawing loses its first characters.
+        guest.send_keys(["ret"])
+        time.sleep(1.0)
+        guest.send_keys(keys_for(SERIAL_GETTY))
+        guest.send_keys(["ret"])
+        try:
+            console.expect(SERIAL_SHELL_SPEAKS, timeout=patience)
+            print(f"the serial shell answered after {delay:.0f}s", flush=True)
+            return
+        except (ConsoleTimeout, ConsoleClosed) as error:
+            last = str(error)[:200]
+        if attempt + 1 < len(AUTOLOGIN_ATTEMPTS):
+            guest.reset()
+            link.reopen(solicit_prompt=False)
+            console = link.console
+    raise ProxmoxError(
+        f"no serial shell after {len(AUTOLOGIN_ATTEMPTS)} attempts at the "
+        f"medium's auto-login: {last}"
+    )
+
+
 def append_to_cmdline_blind(
     guest: Guest, link: "Reopenable", extra: str, patience: float = 60.0
 ) -> None:


### PR DESCRIPTION
`vm-bios` and `ext4-bios` failed in run66 with `the kernel never spoke after 7 blind GRUB edits`, fourteen minutes each, and their whole console log was 512 bytes: one revision line and eight termproxy banners. The guests wrote nothing to the serial port at all.

A screenshot taken through the QEMU monitor, on a local guest configured the way the cluster configures one — `machine q35`, a real VGA, serial on its own port — says why. Twelve seconds in, the serial log is empty and the screen shows the live system booted, past GRUB, at `livecd login: root (automatic login)` with a shell. Keys typed at that point reach bash: the screen held `bash: cserial: command not found`. The blind edit was aiming at a menu that had been gone for ten seconds, which is why it never landed in any round.

Nothing about the kernel command line has to change. The medium logs root in by itself, so one typed line — `setsid agetty --autologin root --noclear ttyS0 115200 vt100 &` — moves a getty onto the serial port. Measured on the same guest: 1011 bytes arrived, ending in `root@livecd ~ #`. Unlike what it replaces this is readable from the first attempt, and its ladder is three rungs rather than seven.

Early boot messages stay off the serial port for these guests, because the command line is no longer edited. Making those readable needs the kernel and initramfs passed through `args:` instead of the ISO's own GRUB, which is a separate change.