### PR TITLE
netboot: refuse a machine that enforces Secure Boot

### DIFF
--- a/gentoo_install/cli.py
+++ b/gentoo_install/cli.py
@@ -25,7 +25,13 @@ from .errors import GentooInstallError
 from .data import load_catalog
 from .exec import fetch, preflight, report
 from .exec.apply import Machine, already_degraded, apply, completed
-from .exec.probe import GRUB_DIRECTORIES, BootMethod, Probe, probe_storage_facts
+from .exec.probe import (
+    GRUB_DIRECTORIES,
+    BootMethod,
+    Probe,
+    probe_storage_facts,
+    secure_boot,
+)
 from .exec.runner import Runner
 from .model.device import StorageFacts, StorageLayout, ZfsPool
 from .model.size import Size
@@ -246,6 +252,7 @@ def _boot_target(probe: Probe) -> netboot.BootTarget:
             (str(one) for one in GRUB_DIRECTORIES if one.is_dir()), None
         ),
         boot_on_the_root_filesystem=layout.boot_same_filesystem,
+        secure_boot=secure_boot(),
     )
 
 

--- a/gentoo_install/exec/probe.py
+++ b/gentoo_install/exec/probe.py
@@ -61,6 +61,29 @@ GRUB_DIRECTORIES: Final[tuple[Path, ...]] = (
 )
 
 
+#: Where the firmware publishes whether it is enforcing a signature chain.
+#: The file is the four attribute bytes and then the value, so the state is
+#: its last byte: read on this workstation it is `6 0 0 0 0`, and
+#: `bootctl status` on the same machine prints `Secure Boot: disabled`.
+SECURE_BOOT: Final[Path] = (
+    EFI_VARIABLES / "SecureBoot-8be4df61-93ca-11d2-aa0d-00e098032b8c"
+)
+
+
+def secure_boot() -> bool | None:
+    """Whether the firmware will refuse an unsigned kernel.
+
+    `None` when it cannot be read, which is a BIOS machine or one whose
+    efivarfs is not mounted. Read from the variable rather than through
+    `bootctl`, which a machine without systemd does not have.
+    """
+    try:
+        said = SECURE_BOOT.read_bytes()
+    except OSError:
+        return None
+    return bool(said[-1]) if said else None
+
+
 def _efi_variables() -> bool:
     """Whether efivarfs is mounted and populated.
 

--- a/gentoo_install/plan/netboot.py
+++ b/gentoo_install/plan/netboot.py
@@ -98,6 +98,9 @@ class BootTarget:
     esp_disk: str | None = None
     esp_partition: int | None = None
     grub_directory: str | None = None
+    #: Whether the firmware refuses an unsigned kernel. `None` is unread,
+    #: which is a BIOS machine or one whose efivarfs is not mounted.
+    secure_boot: bool | None = None
     #: Whether `/boot` is a directory on the root filesystem rather than a
     #: mount of its own. GRUB's paths are relative to the filesystem its
     #: `root` names, so the same file is `/gentoo-install-ram/kernel` when
@@ -150,6 +153,16 @@ class RefuseWithoutABootMethod(Operation):
             raise PreflightFailed(
                 "no bootloader here can be told to boot once: this needs "
                 "systemd-boot, a UEFI GRUB with efibootmgr, or a BIOS GRUB"
+            )
+        if self.target.secure_boot:
+            # Neither image is signed for this machine's own db, so the
+            # firmware rejects the kernel and the armed boot goes nowhere.
+            # `--bypass` makes that the default, which is a machine that does
+            # not boot at all, so this is refused before anything is fetched.
+            raise PreflightFailed(
+                "this machine enforces Secure Boot and neither memory "
+                "environment is signed for it: turn Secure Boot off in the "
+                "firmware setup, or install from a medium instead"
             )
         # Reading it forces the layout check in `place` before anything is
         # fetched, so a UEFI machine with no mounted esp stops here.

--- a/tests/unit/test_plan_netboot.py
+++ b/tests/unit/test_plan_netboot.py
@@ -599,3 +599,38 @@ def test_an_unread_boot_layout_is_treated_as_a_separate_partition() -> None:
     """Every layout this installer produces has one, so that is the answer
     when nothing read the machine."""
     assert netboot.BootTarget(method=BootMethod.BIOS_GRUB).grub_prefix == ""
+
+
+def test_a_machine_enforcing_secure_boot_is_refused_before_anything_is_fetched() -> None:
+    """Neither image is signed for this machine's own db, so the firmware
+    rejects the kernel and the armed boot goes nowhere. With `--bypass` that
+    entry is the default, which is a machine that does not boot at all."""
+    refusing = netboot.BootTarget(
+        method=BootMethod.BIOS_GRUB, grub_directory="/boot/grub", secure_boot=True
+    )
+    with pytest.raises(PreflightFailed, match="Secure Boot"):
+        netboot.RefuseWithoutABootMethod(target=refusing).apply(Recorder())
+
+
+def test_secure_boot_off_or_unread_is_not_a_refusal() -> None:
+    """A BIOS machine has no such variable, and refusing on a fact nobody
+    could read is a refusal nobody can act on."""
+    for state in (False, None):
+        netboot.RefuseWithoutABootMethod(
+            target=netboot.BootTarget(
+                method=BootMethod.BIOS_GRUB,
+                grub_directory="/boot/grub",
+                secure_boot=state,
+            )
+        ).apply(Recorder())
+
+
+def test_the_refusal_comes_before_the_fetch_in_the_plan() -> None:
+    """An arming half done is the failure this path must not have, so a
+    machine that cannot boot what would be fetched is refused first."""
+    plan = netboot.build(launch=_launch(), target=_target())
+    refusal = next(
+        n for n, one in enumerate(plan) if isinstance(one, netboot.RefuseWithoutABootMethod)
+    )
+    fetch = next(n for n, one in enumerate(plan) if isinstance(one, netboot.FetchMemoryImage))
+    assert refusal < fetch, [type(one).__name__ for one in plan]

--- a/tests/unit/test_probe.py
+++ b/tests/unit/test_probe.py
@@ -700,3 +700,29 @@ def test_the_uncovered_flags_are_the_ones_this_file_answers_for() -> None:
     for portage in sorted(unmeasured):
         kernel = next(k for k, v in CPU_FLAGS.items() if v == portage)
         assert kernel in KERNEL_PRINTS, (portage, kernel)
+
+
+def test_secure_boot_is_read_from_the_variable_rather_than_bootctl(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A machine without systemd has no `bootctl`. The variable is the four
+    attribute bytes and then the value, so the state is its last byte: read on
+    this workstation it is `6 0 0 0 0`, and `bootctl status` on the same
+    machine prints `Secure Boot: disabled`."""
+    written = tmp_path / "SecureBoot"
+    for content, wanted in (
+        (bytes([6, 0, 0, 0, 0]), False),
+        (bytes([6, 0, 0, 0, 1]), True),
+    ):
+        written.write_bytes(content)
+        monkeypatch.setattr(probe, "SECURE_BOOT", written)
+        assert probe.secure_boot() is wanted, content
+
+
+def test_a_machine_with_no_such_variable_answers_unread(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A BIOS machine, or one whose efivarfs is not mounted. Unread is not
+    `disabled`: a refusal built on it would be one nobody can act on."""
+    monkeypatch.setattr(probe, "SECURE_BOOT", tmp_path / "absent")
+    assert probe.secure_boot() is None


### PR DESCRIPTION
From the read-only audit against `bin456789/reinstall`, which refuses in `is_secure_boot_enabled()` before it processes an argument. Neither memory environment is signed for the machine's own db, so the firmware rejects the kernel and the armed boot goes nowhere; with `--bypass` that entry is the default and the machine does not boot at all. The refusal is in `PREFLIGHT`, so it happens before anything is fetched onto the boot filesystem.

Read from `/sys/firmware/efi/efivars/SecureBoot-8be4df61-…` rather than through `bootctl`, which a machine without systemd does not have. The file is four attribute bytes and then the value, so the state is its last byte: on this workstation it reads `6 0 0 0 0` and `bootctl status` prints `Secure Boot: disabled` for the same machine. Unread stays unread — a BIOS machine has no such variable, and refusing on a fact nobody could read is a refusal nobody can act on.

Three negative controls, each red on its assertion: not refusing at all, treating unread as enabled, and reading the attribute byte instead of the value.