### PR TITLE
netboot: take back an earlier arming before this run writes

### DIFF
--- a/gentoo_install/plan/netboot.py
+++ b/gentoo_install/plan/netboot.py
@@ -203,6 +203,49 @@ class RefuseTooLittleMemory(Operation):
 
 
 @dataclass(frozen=True, kw_only=True)
+class ClearPreviousArming(Operation):
+    """Take back whatever an earlier run armed, before this one writes.
+
+    A second run that stops at the download or the unpack otherwise leaves the
+    first one's arming in place, and the next reboot — months later, for
+    another reason — enters a memory environment carrying a configuration
+    nobody meant to install any more. `reinstall` clears its own state before
+    it fetches for the same reason (`reinstall.sh:4485-4547`, called at 5016).
+
+    The placed directory goes too: a stale image beside the new one makes the
+    one this plan looks for ambiguous.
+    """
+
+    stage: Stage = Stage.PREFLIGHT
+    target: BootTarget
+
+    def describe_parts(self) -> tuple[str, tuple[str, ...]]:
+        return "take back anything an earlier run armed", ()
+
+    def apply(self, context: Context) -> None:
+        _disarm(context, self.target)
+        context.run(["rm", "--recursive", "--force", str(self.target.place)], check=False)
+
+
+def _disarm(context: Context, target: BootTarget) -> None:
+    """Clear the one-shot this module sets, whichever way it was set.
+
+    `bootctl set-oneshot ""` and not a named entry: `bootctl(1)` says an empty
+    ID unsets the variable, while any other value is another entry to boot
+    next. This asked for `auto-reboot-to-firmware-setup`, which is not a
+    disarm — it is a machine that reboots into its firmware setup instead.
+    """
+    if target.method is BootMethod.SYSTEMD_BOOT:
+        context.run(["bootctl", "set-oneshot", ""], check=False)
+        return
+    if target.grub_directory is not None:
+        context.run(
+            ["grub-editenv", f"{target.grub_directory}/grubenv", "unset", "next_entry"],
+            check=False,
+        )
+
+
+@dataclass(frozen=True, kw_only=True)
 class FetchMemoryImage(Operation):
     """Download the image and check it against the checksum its publisher gives.
 
@@ -547,13 +590,7 @@ class DisarmMemoryBoot(Operation):
         return "take back the armed boot and delete what it placed", ()
 
     def apply(self, context: Context) -> None:
-        if self.target.method is BootMethod.SYSTEMD_BOOT:
-            context.run(["bootctl", "set-oneshot", "auto-reboot-to-firmware-setup"], check=False)
-        elif self.target.grub_directory is not None:
-            context.run(
-                ["grub-editenv", f"{self.target.grub_directory}/grubenv", "unset", "next_entry"],
-                check=False,
-            )
+        _disarm(context, self.target)
         context.run(["rm", "--recursive", "--force", str(self.target.place)], check=False)
 
 
@@ -579,6 +616,9 @@ def build(
     operations: list[Operation] = [
         RefuseWithoutABootMethod(target=target),
         RefuseTooLittleMemory(mode=launch.mode),
+        # After the refusals and before the fetch: a machine this refuses is
+        # one whose earlier arming is not this run's to take back.
+        ClearPreviousArming(target=target),
         FetchMemoryImage(mode=launch.mode, target=target),
         PlaceMemoryKernel(mode=launch.mode, target=target),
     ]

--- a/tests/unit/test_plan_netboot.py
+++ b/tests/unit/test_plan_netboot.py
@@ -634,3 +634,69 @@ def test_the_refusal_comes_before_the_fetch_in_the_plan() -> None:
     )
     fetch = next(n for n, one in enumerate(plan) if isinstance(one, netboot.FetchMemoryImage))
     assert refusal < fetch, [type(one).__name__ for one in plan]
+
+
+def test_an_earlier_arming_is_taken_back_before_this_run_writes() -> None:
+    """A second run that stops at the download otherwise leaves the first
+    one's arming in place, and the next reboot — months later, for another
+    reason — enters a memory environment carrying a configuration nobody
+    meant to install any more."""
+    plan = netboot.build(launch=_launch(), target=_target())
+    cleared = next(
+        n for n, one in enumerate(plan) if isinstance(one, netboot.ClearPreviousArming)
+    )
+    refused = next(
+        n for n, one in enumerate(plan) if isinstance(one, netboot.RefuseWithoutABootMethod)
+    )
+    fetch = next(n for n, one in enumerate(plan) if isinstance(one, netboot.FetchMemoryImage))
+    # After the refusals: a machine this refuses is one whose earlier arming
+    # is not this run's to take back.
+    assert refused < cleared < fetch, [type(one).__name__ for one in plan]
+
+
+def test_clearing_unsets_the_one_shot_rather_than_pointing_it_elsewhere() -> None:
+    """`bootctl(1)`: an empty ID unsets the variable, and any other value is
+    another entry to boot next. This asked for
+    `auto-reboot-to-firmware-setup`, which is not a disarm but a machine that
+    reboots into its firmware setup."""
+    recorder = _answering()
+    netboot.ClearPreviousArming(target=_target()).apply(recorder)
+
+    asked = [one for one in recorder.commands if one[0] == "bootctl"]
+    assert asked == [("bootctl", "set-oneshot", "")], asked
+    assert not any("firmware-setup" in " ".join(one) for one in recorder.commands)
+
+
+def test_clearing_a_grub_machine_unsets_next_entry() -> None:
+    recorder = _answering()
+    netboot.ClearPreviousArming(target=_target(BootMethod.BIOS_GRUB)).apply(recorder)
+
+    assert (
+        "grub-editenv",
+        "/boot/grub/grubenv",
+        "unset",
+        "next_entry",
+    ) in recorder.commands, recorder.commands
+
+
+def test_the_placed_directory_goes_with_the_arming() -> None:
+    """A stale image beside the new one makes the one this plan looks for
+    ambiguous, and `_only_image` then refuses a download that succeeded."""
+    recorder = _answering()
+    netboot.ClearPreviousArming(target=_target()).apply(recorder)
+
+    assert any(
+        one[0] == "rm" and str(_target().place) in one for one in recorder.commands
+    ), recorder.commands
+
+
+def test_disarming_and_clearing_ask_for_the_same_thing() -> None:
+    """One way of taking an arming back, or the two drift and the operator
+    who answers no is left with a machine armed differently from one whose
+    run failed."""
+    declined = _answering()
+    _apply(netboot.disarm(target=_target()), declined)
+    cleared = _answering()
+    netboot.ClearPreviousArming(target=_target()).apply(cleared)
+
+    assert declined.commands == cleared.commands, (declined.commands, cleared.commands)


### PR DESCRIPTION
Two defects in the same concern, from the read-only audit against `bin456789/reinstall`, which clears its own state before it fetches for exactly this reason.

**A failed second run left the first one armed.** Nothing cleared a prior one-shot before the download, so a run that stopped at the fetch, the unpack or the payload left an earlier arming in place. The next reboot — months later, for an unrelated reason — entered a memory environment carrying a configuration nobody meant to install any more. The clearing step is after the refusals and before the fetch: a machine this refuses is one whose earlier arming is not this run's to take back. The placed directory goes with it, because a stale image beside the new one makes the one this plan looks for ambiguous.

**Disarming did not disarm.** It ran `bootctl set-oneshot auto-reboot-to-firmware-setup`, which is not a clear — it is another entry to boot next, so an operator who answered no to the reboot got a machine that reboots into its firmware setup. `bootctl(1)` says an empty ID unsets the variable, and that is what both paths now use. A test holds that clearing and disarming ask for the same thing, so the two cannot drift again.

Three negative controls, each red on its assertion.