### PR TITLE
netboot: take the architecture from the machine, not from a URL

### DIFF
--- a/gentoo_install/cli.py
+++ b/gentoo_install/cli.py
@@ -28,6 +28,7 @@ from .exec.apply import Machine, already_degraded, apply, completed
 from .exec.probe import (
     GRUB_DIRECTORIES,
     BootMethod,
+    architecture,
     Probe,
     probe_storage_facts,
     secure_boot,
@@ -253,6 +254,7 @@ def _boot_target(probe: Probe) -> netboot.BootTarget:
         ),
         boot_on_the_root_filesystem=layout.boot_same_filesystem,
         secure_boot=secure_boot(),
+        architecture=architecture(),
     )
 
 

--- a/gentoo_install/exec/probe.py
+++ b/gentoo_install/exec/probe.py
@@ -70,6 +70,17 @@ SECURE_BOOT: Final[Path] = (
 )
 
 
+def architecture() -> str:
+    """What the kernel calls this machine, as `/proc/cpuinfo`'s neighbours do.
+
+    `os.uname().machine` and not a package manager's answer: the memory
+    environments are published under the kernel's spelling on one side and
+    the distribution's on the other, and the conversion belongs where the two
+    names meet rather than here.
+    """
+    return os.uname().machine
+
+
 def secure_boot() -> bool | None:
     """Whether the firmware will refuse an unsigned kernel.
 

--- a/gentoo_install/plan/netboot.py
+++ b/gentoo_install/plan/netboot.py
@@ -29,9 +29,13 @@ CJK_RELEASES: Final[str] = (
 )
 
 #: Alpine publishes version, filename and SHA-256 for every flavour in one
-#: document, so the version is read rather than pinned here too.
+#: document per architecture, so the version is read rather than pinned here
+#: and the architecture is substituted rather than written in. Alpine spells
+#: it the way the kernel does: `x86_64` and `aarch64` both answer, checked on
+#: 2026-08-18, and the netboot flavour is present in each with the same
+#: fields.
 ALPINE_RELEASES: Final[str] = (
-    "https://dl-cdn.alpinelinux.org/alpine/latest-stable/releases/x86_64/"
+    "https://dl-cdn.alpinelinux.org/alpine/latest-stable/releases/{}/"
     "latest-releases.yaml"
 )
 ALPINE_NETBOOT_FLAVOUR: Final[str] = "alpine-netboot"
@@ -42,6 +46,18 @@ ALPINE_NETBOOT_FLAVOUR: Final[str] = "alpine-netboot"
 ALPINE_REPOSITORY: Final[str] = (
     "https://dl-cdn.alpinelinux.org/alpine/latest-stable/main"
 )
+
+#: What the kernel calls a machine and what Gentoo calls the same one. Two
+#: ecosystems name the same architecture differently, the way `fma` and `fma3`
+#: do: `uname -m` answers `x86_64` while the ISO is published as
+#: `install-amd64-…`. Gentoo's own names are the lines of
+#: `profiles/arch.list`. A machine outside this table is refused by name
+#: rather than sent to a URL composed from a guess.
+GENTOO_ARCHITECTURES: Final[dict[str, str]] = {
+    "x86_64": "amd64",
+    "aarch64": "arm64",
+    "i686": "x86",
+}
 
 #: One directory for everything this arms, on the filesystem the bootloader
 #: reads. Named rather than scattered, because disarming has to be able to
@@ -93,6 +109,11 @@ class BootTarget:
     """
 
     method: BootMethod
+    #: What `uname -m` answers here. Both environments are published per
+    #: architecture, so this decides which one is fetched rather than being
+    #: assumed: `--ram` works on any machine the CJK release publishes an ISO
+    #: for, the day it publishes one.
+    architecture: str = "x86_64"
     esp_mountpoint: str | None = None
     esp_device: str | None = None
     esp_disk: str | None = None
@@ -264,7 +285,9 @@ class FetchMemoryImage(Operation):
         place = self.target.place
         context.run(["mkdir", "--parents", str(place)])
         name, url, checksum = (
-            _cjk_release(context) if self.mode is MemoryMode.RAM else _alpine_release(context)
+            _cjk_release(context, self.target.architecture)
+            if self.mode is MemoryMode.RAM
+            else _alpine_release(context, self.target.architecture)
         )
         image = place / name
         context.run(["curl", "--fail", "--location", "--output", str(image), url])
@@ -743,8 +766,19 @@ def _total_mebibytes(said: str) -> int | None:
     return None
 
 
-def _cjk_release(context: Context) -> tuple[str, str, str]:
-    """The newest CJK ISO: its name, its URL and its SHA-256."""
+def _cjk_release(context: Context, machine: str) -> tuple[str, str, str]:
+    """The newest CJK ISO for this machine: its name, its URL and its SHA-256.
+
+    Chosen by the name the release publishes rather than by a list here, so an
+    architecture the project starts building for works without this file
+    changing.
+    """
+    named = GENTOO_ARCHITECTURES.get(machine)
+    if named is None:
+        raise DownloadFailed(
+            f"{machine} is not an architecture Gentoo names, so no ISO can be "
+            f"chosen for it: {', '.join(sorted(GENTOO_ARCHITECTURES))} are"
+        )
     said = context.run(["curl", "--fail", "--location", CJK_RELEASES])
     try:
         release = json.loads(said)
@@ -754,23 +788,29 @@ def _cjk_release(context: Context) -> tuple[str, str, str]:
         str(one.get("name", "")): str(one.get("browser_download_url", ""))
         for one in release.get("assets", [])
     }
-    iso = next((one for one in assets if one.endswith(".iso")), "")
-    if not iso or not assets.get(f"{iso}.sha256"):
+    iso = next(
+        (one for one in assets if one.endswith(".iso") and f"-{named}-" in one), ""
+    )
+    if not iso:
         raise DownloadFailed(
-            "the newest CJK release publishes no ISO with a companion .sha256"
+            f"the newest CJK release publishes no {named} ISO, so --ram cannot "
+            f"run on this machine; --lowram is published for it"
         )
+    if not assets.get(f"{iso}.sha256"):
+        raise DownloadFailed(f"{iso} is published with no companion .sha256")
     digest = context.run(["curl", "--fail", "--location", assets[f"{iso}.sha256"]])
     return iso, assets[iso], _first_word(digest, iso)
 
 
-def _alpine_release(context: Context) -> tuple[str, str, str]:
+def _alpine_release(context: Context, machine: str) -> tuple[str, str, str]:
     """The newest Alpine netboot bundle: its name, its URL and its SHA-256.
 
     `latest-releases.yaml` is read as records separated by `-` at the start of
     a line rather than with a YAML parser, because no YAML parser is in the
     standard library and this file's shape is two levels deep.
     """
-    said = context.run(["curl", "--fail", "--location", ALPINE_RELEASES])
+    index = ALPINE_RELEASES.format(machine)
+    said = context.run(["curl", "--fail", "--location", index])
     for record in said.split("\n-\n"):
         fields = dict(_yaml_pairs(record))
         if fields.get("flavor") != ALPINE_NETBOOT_FLAVOUR:
@@ -778,10 +818,10 @@ def _alpine_release(context: Context) -> tuple[str, str, str]:
         name, digest = fields.get("file", ""), fields.get("sha256", "")
         if not name or not digest:
             break
-        base = ALPINE_RELEASES.rsplit("/", 1)[0]
+        base = index.rsplit("/", 1)[0]
         return name, f"{base}/{name}", digest
     raise DownloadFailed(
-        f"{ALPINE_RELEASES} names no {ALPINE_NETBOOT_FLAVOUR} with a sha256"
+        f"{index} names no {ALPINE_NETBOOT_FLAVOUR} with a sha256"
     )
 
 

--- a/tests/unit/test_plan_netboot.py
+++ b/tests/unit/test_plan_netboot.py
@@ -4,6 +4,7 @@
 from __future__ import annotations
 
 import json
+from dataclasses import replace
 from pathlib import PurePosixPath
 from collections.abc import Callable
 from typing import Sequence
@@ -89,7 +90,7 @@ def _answering(mode: MemoryMode = MemoryMode.RAM, *, digest: str = DIGEST) -> Re
             wanted = argv[-1]
             if wanted == netboot.CJK_RELEASES:
                 return CJK_INDEX
-            if wanted == netboot.ALPINE_RELEASES:
+            if wanted.endswith("latest-releases.yaml"):
                 return ALPINE_INDEX
             if wanted.endswith(".sha256"):
                 return f"{DIGEST}  {ISO}\n"
@@ -700,3 +701,76 @@ def test_disarming_and_clearing_ask_for_the_same_thing() -> None:
     netboot.ClearPreviousArming(target=_target()).apply(cleared)
 
     assert declined.commands == cleared.commands, (declined.commands, cleared.commands)
+
+
+#: The architectures Gentoo names, read from `profiles/arch.list` on this
+#: machine on 2026-08-18. Held here so the check runs where no repository is
+#: mounted.
+GENTOO_ARCH_NAMES: frozenset[str] = frozenset({"amd64", "arm64", "x86"})
+
+
+def test_every_architecture_this_maps_is_one_gentoo_names() -> None:
+    """`uname -m` answers `x86_64` and the ISO is published as
+    `install-amd64-…`: two ecosystems naming the same machine, the way `fma`
+    and `fma3` do. A name Gentoo does not use finds no asset and the failure
+    reads as a missing release."""
+    assert set(netboot.GENTOO_ARCHITECTURES.values()) <= GENTOO_ARCH_NAMES, sorted(
+        set(netboot.GENTOO_ARCHITECTURES.values()) - GENTOO_ARCH_NAMES
+    )
+
+
+def test_the_alpine_index_is_asked_for_this_machine() -> None:
+    """Alpine publishes one document per architecture and spells it the way
+    the kernel does; `x86_64` and `aarch64` both answer with a netboot flavour
+    and a sha256, checked on 2026-08-18."""
+    for machine in ("x86_64", "aarch64"):
+        assert netboot.ALPINE_RELEASES.format(machine).endswith(
+            f"releases/{machine}/latest-releases.yaml"
+        ), machine
+
+
+def test_the_iso_is_chosen_by_the_name_the_release_publishes() -> None:
+    """So an architecture the project starts building for works the day it
+    does, without this file changing."""
+    recorder = _answering()
+    netboot.FetchMemoryImage(
+        mode=MemoryMode.RAM,
+        target=replace(_target(), architecture="x86_64"),
+    ).apply(recorder)
+
+    fetched = [one for one in _run(recorder, "curl") if "--output" in one]
+    assert fetched[0][-1].endswith(ISO), fetched
+
+
+def test_an_architecture_the_release_has_no_iso_for_is_named() -> None:
+    """`--ram` on a machine the CJK project does not build for is a refusal
+    that says which mode is published for it, rather than a 404 an hour in."""
+    recorder = _answering()
+    with pytest.raises(DownloadFailed, match="arm64 ISO"):
+        netboot.FetchMemoryImage(
+            mode=MemoryMode.RAM,
+            target=replace(_target(), architecture="aarch64"),
+        ).apply(recorder)
+
+
+def test_an_architecture_gentoo_does_not_name_is_refused_by_name() -> None:
+    recorder = _answering()
+    with pytest.raises(DownloadFailed, match="not an architecture Gentoo names"):
+        netboot.FetchMemoryImage(
+            mode=MemoryMode.RAM,
+            target=replace(_target(), architecture="riscv64"),
+        ).apply(recorder)
+
+
+def test_no_address_carries_an_architecture_of_its_own() -> None:
+    """The one place a machine's name is written is the table. A copy inside
+    an address is what has to be found and changed the day arm is tested, and
+    the one that is missed sends that machine to another machine's image."""
+    assert "{}" in netboot.ALPINE_RELEASES, netboot.ALPINE_RELEASES
+    for address in (
+        netboot.ALPINE_RELEASES,
+        netboot.ALPINE_REPOSITORY,
+        netboot.CJK_RELEASES,
+    ):
+        for named in ("x86_64", "amd64", "aarch64", "arm64", "i686", "x86"):
+            assert named not in address, (address, named)


### PR DESCRIPTION
`--lowram` carried `x86_64` inside the Alpine index address, so an arm machine would have armed an image built for another one. The architecture is now read with `uname -m` and carried on `BootTarget`, and the address is composed from it. Measured on 2026-08-18: `releases/x86_64/latest-releases.yaml` and `releases/aarch64/latest-releases.yaml` both answer, both carry the `alpine-netboot` flavour, and both give a filename and a sha256 — so `--lowram` needs no further change to be tested on arm.

`--ram` picks the ISO by the name the CJK release publishes rather than by a list here, so an architecture that project starts building for works the day it does. Today it publishes `install-amd64-…` only, and an arm machine is refused by name with the mode that *is* published for it rather than meeting a 404 an hour in.

One table maps the two spellings — `uname -m` says `x86_64` where Gentoo says `amd64`, the way `fma` and `fma3` differ — and it is checked against the names in `profiles/arch.list`. A test holds that no published address carries an architecture of its own, because the copy that gets missed is what sends a machine to another machine's image.