### PR TITLE
cluster: type the login the way the run that passes types it

### DIFF
--- a/tests/unit/test_cluster.py
+++ b/tests/unit/test_cluster.py
@@ -708,12 +708,12 @@ def test_a_password_the_console_echoed_is_not_counted_as_a_refusal(
     assert cluster._log_in(cast(cluster.Reconnecting, console), "install") == ""
     assert console.sent.count("install") == 4, console.sent
 
-    # The settle grows on each catch rather than staying at a guess.
-    waited = [one for one in settles if one not in (cluster.AGETTY_FLUSHES_AFTER,)]
-    assert waited == [
+    # Every sleep, unfiltered: the settle's second step is `AGETTY_FLUSHES_AFTER`
+    # itself now that the first is zero, and a filter by value drops it.
+    assert settles == [
         cluster.PASSWORD_ECHO_OFF_AFTER + n * cluster.PASSWORD_ECHO_BACKOFF
         for n in range(4)
-    ], waited
+    ], settles
 
     # Negative control: a refusal with no echo is the installed system saying
     # no, and it must end after the ordinary budget rather than be absorbed.
@@ -1824,3 +1824,21 @@ def test_a_reopen_that_is_waiting_for_a_shell_still_asks_for_one() -> None:
     link.reopen()
 
     assert opened[-1].sent == [""], opened[-1].sent
+
+
+def test_the_first_password_is_sent_the_moment_the_prompt_is_read(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """`tests/vm/run.py` sends it at once and passes: `vm-lvm` installs and
+    logs in locally on the same fixture and the same installer revision, and
+    failed on the cluster in four rounds where a second went first. `login`
+    turns the echo off before it writes the prompt, so there is no window to
+    wait out; the growth stays for the console that proves otherwise by
+    echoing."""
+    settles: list[float] = []
+    monkeypatch.setattr("time.sleep", lambda seconds: settles.append(seconds))
+    console = _LoginConsole(refusals=0)
+
+    assert cluster._log_in(cast(cluster.Reconnecting, console), "install") == ""
+    assert settles == [0.0], settles
+    assert cluster.PASSWORD_ECHO_OFF_AFTER == 0.0, cluster.PASSWORD_ECHO_OFF_AFTER

--- a/tests/unit/test_harness.py
+++ b/tests/unit/test_harness.py
@@ -2346,11 +2346,9 @@ def test_a_worker_cannot_hold_the_interpreter_open_after_the_schedule_ends() -> 
 def test_a_name_typed_the_moment_the_prompt_appears_is_offered_again(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """agetty sleeps a second after writing `login:` and then flushes the
-    serial line, so a name sent at once is thrown away and the empty line
-    behind it brings the prompt back. `openrc-sdboot` and `vm-bios` printed
-    their issue three times and were failed for a password prompt that was
-    never coming."""
+    """A prompt that comes back means the name did not take, and it is offered
+    again. `openrc-sdboot` and `vm-bios` printed their issue three times and
+    were failed for a password prompt that was never coming."""
     from tests.vm import cluster
 
     monkeypatch.setattr(cluster, "AGETTY_FLUSHES_AFTER", 0.0)
@@ -2365,7 +2363,7 @@ def test_a_name_typed_the_moment_the_prompt_appears_is_offered_again(
             return said.pop(0)
 
     assert cluster._name_the_user(cast(Any, Prompting()))
-    assert offered == ["root", "root", "root"], "the flushed name is offered again"
+    assert offered == ["root", "root", "root"], "the name is offered again"
 
 
 def test_a_prompt_that_never_takes_a_name_ends_rather_than_answers_for_ever(

--- a/tests/vm/cluster.py
+++ b/tests/vm/cluster.py
@@ -2408,8 +2408,16 @@ def _name_the_user(link: Reconnecting) -> bool:
     their issue three times and were failed for a password prompt that was
     never coming.
     """
-    for _ in range(LOGIN_TRIES):
-        time.sleep(AGETTY_FLUSHES_AFTER)
+    for attempt in range(LOGIN_TRIES):
+        # Nothing before the first name. `tests/vm/run.py` types it the moment
+        # the prompt is read and passes: `vm-lvm` installs and logs in locally
+        # on the same fixture and the same revision, and failed on the cluster
+        # in four rounds where a blind two seconds went first. The caller has
+        # already waited for `login:`, so the prompt is there.
+        if attempt:
+            # It came back, so that name did not take. This is the wait agetty
+            # needs, and it belongs where the console has proved it.
+            time.sleep(AGETTY_FLUSHES_AFTER)
         link.respond("root")
         try:
             said = link.observe(rf"{PASSWORD_PROMPT}|login:", timeout=60.0)
@@ -2420,11 +2428,13 @@ def _name_the_user(link: Reconnecting) -> bool:
     return False
 
 
-#: What `login` takes between writing `Password:` and turning the echo off. A
-#: password sent inside that window is echoed and read as an empty one:
-#: `vm-lvm` printed `install` under the prompt and answered `Login incorrect`
-#: after an install that was otherwise complete.
-PASSWORD_ECHO_OFF_AFTER: Final[float] = 1.0
+#: What is waited after `Password:` before the password is sent. Zero: the
+#: implementation that passes sends it the moment the prompt is read, and
+#: `vm-lvm` failed on the cluster in four rounds where it was sent a second
+#: later. `login` turns the echo off before it writes the prompt, so there is
+#: no window to wait out; the growth below is kept for the console that proves
+#: otherwise by echoing.
+PASSWORD_ECHO_OFF_AFTER: Final[float] = 0.0
 
 #: Added to the settle each time the console proves it lost that race, and how
 #: many of those are absorbed. A fixed wait is a guess about a machine whose


### PR DESCRIPTION
`vm-lvm` and `openrc-sdboot` failed with `root could not log into the installed system` in run64, run65, run66 and run67. Two earlier fixes were aimed at theories and neither helped. This one is aimed at a working implementation.

`vm-lvm` was run locally, same fixture and same installer revision, and it **passed** — installed, booted, logged in, all installed-state checks green. So the installed system is not the problem: its `/etc/shadow`, its PAM stack and its inittab are the same ones that work. Two other things were ruled out on the way: the hash in the fixture is `install` (`openssl passwd -6 -salt gentooinst install` matches it byte for byte), and the same `agetty -L 115200 … vt100` line that `EnableSerialGetty` writes was driven by hand on a live OpenRC medium at the harness's own pace and logged in without echoing anything.

What is left is the difference between the two harnesses. `console.login` in `tests/vm/run.py` reads `login:` and sends the name at once, reads `Password:` and sends the password at once. The cluster path slept two seconds before the name and one before the password. Those waits are gone from the first attempt; the two-second one stays for a retry, where the console has proved the name did not take, and the growing settle stays for a console that proves the echo race by echoing.

Both failing fixtures are OpenRC and both passing ones are systemd, which is recorded in `memory/` with the two theories this replaces.