### PR TITLE
netboot: drop the boot facts nothing reads

### DIFF
--- a/gentoo_install/cli.py
+++ b/gentoo_install/cli.py
@@ -242,13 +242,9 @@ def _validate_memory_launch(
 def _boot_target(probe: Probe) -> netboot.BootTarget:
     """What `plan/netboot.py` needs about this machine's own bootloader."""
     layout = probe.storage_layout()
-    esp = layout.esp_device
     return netboot.BootTarget(
         method=probe.boot_method(),
         esp_mountpoint=layout.esp_mountpoint,
-        esp_device=esp,
-        esp_disk=probe.disk_of_path(esp) if esp is not None else None,
-        esp_partition=probe.partition_number_of_path(esp) if esp is not None else None,
         grub_directory=next(
             (str(one) for one in GRUB_DIRECTORIES if one.is_dir()), None
         ),

--- a/gentoo_install/plan/netboot.py
+++ b/gentoo_install/plan/netboot.py
@@ -104,8 +104,14 @@ class BootTarget:
     """What this machine boots with, as `exec/probe.py` answered it.
 
     Carried rather than probed here: `plan/` derives operations and reads no
-    machine. The four esp fields are absent on a BIOS machine, and the
-    bootloader directory is absent on a UEFI one.
+    machine. The esp fields are absent on a BIOS machine, and the bootloader
+    directory is absent on a UEFI one.
+
+    No disk and partition number: both GRUBs are armed by writing a marked
+    entry and `grub-reboot`, so nothing here composes an `efibootmgr
+    --create-only` call. Carrying the two facts an unwritten call would need
+    reads as though it were written, which is the shape of a promise the code
+    does not keep.
     """
 
     method: BootMethod
@@ -115,9 +121,6 @@ class BootTarget:
     #: for, the day it publishes one.
     architecture: str = "x86_64"
     esp_mountpoint: str | None = None
-    esp_device: str | None = None
-    esp_disk: str | None = None
-    esp_partition: int | None = None
     grub_directory: str | None = None
     #: Whether the firmware refuses an unsigned kernel. `None` is unread,
     #: which is a BIOS machine or one whose efivarfs is not mounted.

--- a/tests/unit/test_plan_netboot.py
+++ b/tests/unit/test_plan_netboot.py
@@ -63,9 +63,6 @@ def _target(method: BootMethod = BootMethod.SYSTEMD_BOOT) -> netboot.BootTarget:
     return netboot.BootTarget(
         method=method,
         esp_mountpoint=ESP,
-        esp_device="/dev/nvme0n1p1",
-        esp_disk="/dev/nvme0n1",
-        esp_partition=1,
         grub_directory="/boot/grub",
     )
 
@@ -774,3 +771,21 @@ def test_no_address_carries_an_architecture_of_its_own() -> None:
     ):
         for named in ("x86_64", "amd64", "aarch64", "arm64", "i686", "x86"):
             assert named not in address, (address, named)
+
+
+def test_the_boot_target_carries_no_fact_nothing_reads() -> None:
+    """`esp_disk` and `esp_partition` were computed on every run and read by
+    nothing: both GRUBs are armed with `custom.cfg` and `grub-reboot`, so no
+    `efibootmgr --create-only` call is composed anywhere. Carrying the two
+    facts such a call would need reads as though it were written.
+
+    `test_no_definition_in_the_package_is_unreachable` does not see a dataclass
+    field, so this is what holds it."""
+    import dataclasses
+    import inspect
+
+    source = inspect.getsource(netboot)
+    for field in dataclasses.fields(netboot.BootTarget):
+        # The declaration itself is one mention; a field nothing reads has
+        # exactly that one.
+        assert source.count(field.name) > 1, field.name


### PR DESCRIPTION
From the read-only audit: `_boot_target` derived the ESP's disk and partition number on every run and `plan/netboot.py` never used them. Writing the test that holds this found a third — `esp_device` — read by nothing either, since `place` uses the mount point.

Both GRUBs are armed by writing a marked `custom.cfg` entry and calling `grub-reboot`, so nothing composes an `efibootmgr --create-only` call. Carrying the facts such a call would need reads as though it were written. `docs/design.md` promised `efibootmgr --create-only` plus `--bootnext` for the UEFI GRUB path and is corrected to describe what exists, with the boundary named rather than left in the promise: `boot_method()` calls a machine `UEFI_GRUB` when efivarfs has content and `efibootmgr` is on PATH, so a machine booting through rEFInd or a vendor loader with a stale `/boot/grub` is accepted, its `custom.cfg` is read by nobody, and the one-shot is simply not armed. The original system still boots, which is the lightest way this path fails.

The check named `test_no_definition_in_the_package_is_unreachable` does not see a dataclass field, so a test that counts each field's mentions holds it; adding a field back turns it red.
