### PR TITLE
proxmox: type until the serial port answers, not on a timer

### DIFF
--- a/tests/unit/test_proxmox.py
+++ b/tests/unit/test_proxmox.py
@@ -3768,15 +3768,23 @@ class _AutoLoginGuest:
         self.answers_after = answers_after
         self.typed: list[str] = []
         self.resets = 0
+        #: How many times the whole line went in. Counting a character would
+        #: count the line's own letters: `setsid agetty` holds four `s`.
+        self.lines = 0
 
     def send_keys(self, keys: list[str]) -> None:
         self.typed.extend(keys)
+        if len(keys) > 1:
+            self.lines += 1
 
     def reset(self) -> None:
         self.resets += 1
 
 
 class _SerialAfterTyping:
+    """A port that answers once the line has been typed `needed` times, which
+    is what a medium still booting looks like."""
+
     def __init__(self, guest: _AutoLoginGuest, needed: int) -> None:
         self.guest = guest
         self.needed = needed
@@ -3785,7 +3793,7 @@ class _SerialAfterTyping:
     def expect(self, pattern: str, timeout: float, idle: float = 0.0) -> bytes:
         from tests.vm.console import ConsoleTimeout
 
-        if self.guest.resets >= self.needed:
+        if self.guest.lines >= self.needed:
             return b"\r\nroot@livecd ~ # "
         raise ConsoleTimeout("nothing on the serial port")
 
@@ -3806,7 +3814,7 @@ def test_the_serial_shell_is_asked_for_by_typing_into_the_auto_login(
 
     monkeypatch.setattr("time.sleep", lambda seconds: None)
     guest = _AutoLoginGuest()
-    link = _SerialAfterTyping(guest, needed=0)
+    link = _SerialAfterTyping(guest, needed=1)
     proxmox.open_a_serial_shell_blind(cast("Any", guest), cast("Any", link))
 
     typed = "".join(one for one in guest.typed if len(one) == 1)
@@ -3816,22 +3824,24 @@ def test_the_serial_shell_is_asked_for_by_typing_into_the_auto_login(
     assert guest.resets == 0, "a first attempt that answers resets nothing"
 
 
-def test_a_medium_that_is_slower_gets_another_attempt(
+def test_a_medium_that_is_slower_is_typed_at_again(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """A loaded node reaches its auto-login later than an idle one, and the
-    ladder is timed rather than read because nothing is readable until the
-    line lands."""
+    """No ladder of fixed delays: every timing guess this replaces failed on a
+    loaded cluster, and `vm-bios` passed only in a round where it was the one
+    guest. The line goes in again until the port answers, and the medium is
+    never reset for being slow."""
     from typing import Any, cast
 
     from tests.vm import proxmox
 
     monkeypatch.setattr("time.sleep", lambda seconds: None)
     guest = _AutoLoginGuest()
-    link = _SerialAfterTyping(guest, needed=2)
+    link = _SerialAfterTyping(guest, needed=3)
     proxmox.open_a_serial_shell_blind(cast("Any", guest), cast("Any", link))
 
-    assert guest.resets == 2, guest.resets
+    assert guest.resets == 0, "a slow medium is typed at again, not reset"
+    assert guest.lines == 3, guest.lines
 
 
 def test_a_medium_that_never_answers_stops_rather_than_holding_the_schedule(
@@ -3840,23 +3850,27 @@ def test_a_medium_that_never_answers_stops_rather_than_holding_the_schedule(
     from typing import Any, cast
 
     from tests.vm import proxmox
-    from tests.vm.proxmox import AUTOLOGIN_ATTEMPTS, ProxmoxError
+    from tests.vm.proxmox import ProxmoxError
 
     monkeypatch.setattr("time.sleep", lambda seconds: None)
     guest = _AutoLoginGuest()
-    link = _SerialAfterTyping(guest, needed=99)
+    # A port that never answers, however many times the line goes in.
+    link = _SerialAfterTyping(guest, needed=10**9)
     with pytest.raises(ProxmoxError, match="no serial shell"):
-        proxmox.open_a_serial_shell_blind(cast("Any", guest), cast("Any", link))
+        proxmox.open_a_serial_shell_blind(
+            cast("Any", guest), cast("Any", link), patience=0.5
+        )
 
-    assert guest.resets == len(AUTOLOGIN_ATTEMPTS) - 1, guest.resets
+    assert guest.typed, "it has to have tried"
 
 
-def test_the_ladder_outlasts_a_medium_that_is_merely_slow() -> None:
-    """Measured on 2026-08-18: a SeaBIOS guest was past GRUB and logged in at
-    about fifteen seconds. The first rung is above that, and the last is far
-    enough above it to cover a node under load."""
-    from tests.vm.proxmox import AUTOLOGIN_ATTEMPTS
+def test_the_deadline_outlasts_a_loaded_node_and_the_interval_does_not() -> None:
+    """An idle node reaches the auto-login in about fifteen seconds, measured
+    by screenshotting a SeaBIOS guest through the QEMU monitor. A node running
+    twelve of them takes longer than any number written here, so the interval
+    is short enough to keep trying and the deadline is the only guess."""
+    from tests.vm.proxmox import AUTOLOGIN_DEADLINE, AUTOLOGIN_INTERVAL
 
-    assert AUTOLOGIN_ATTEMPTS[0] > 15.0, AUTOLOGIN_ATTEMPTS
-    assert AUTOLOGIN_ATTEMPTS[-1] >= 90.0, AUTOLOGIN_ATTEMPTS
-    assert list(AUTOLOGIN_ATTEMPTS) == sorted(AUTOLOGIN_ATTEMPTS), AUTOLOGIN_ATTEMPTS
+    assert AUTOLOGIN_INTERVAL <= 30.0, AUTOLOGIN_INTERVAL
+    assert AUTOLOGIN_DEADLINE >= 300.0, AUTOLOGIN_DEADLINE
+    assert AUTOLOGIN_DEADLINE / AUTOLOGIN_INTERVAL >= 10, "too few attempts"

--- a/tests/vm/proxmox.py
+++ b/tests/vm/proxmox.py
@@ -997,16 +997,20 @@ SERIAL_GETTY: Final[str] = "setsid agetty --autologin root --noclear ttyS0 11520
 #: half the boot messages before it.
 SERIAL_SHELL_SPEAKS: Final[str] = r"root@[^\s]+"
 
-#: How long the medium is given to reach its auto-login before the line is
-#: typed, and how many times. Measured on 2026-08-18 by taking a screenshot of
-#: a SeaBIOS guest through the QEMU monitor: at fifteen seconds it was past
-#: GRUB, past the boot, and sitting at `livecd login: root (automatic login)`
-#: with a shell. The ladder covers a node under load, not a different medium.
-AUTOLOGIN_ATTEMPTS: Final[tuple[float, ...]] = (25.0, 45.0, 90.0)
+#: How often the line is typed again, and for how long altogether. Not a
+#: ladder of fixed delays: every timing guess this replaces failed on a loaded
+#: cluster and `vm-bios` passed only in a round where it was the one guest.
+#: An idle node reaches the auto-login in about fifteen seconds, measured by
+#: screenshotting a SeaBIOS guest through the QEMU monitor; a node running
+#: twelve of them takes as long as it takes, and no number written here is
+#: right for both. So the line goes in again every interval until the port
+#: answers or the deadline passes, and the deadline is the only guess left.
+AUTOLOGIN_INTERVAL: Final[float] = 20.0
+AUTOLOGIN_DEADLINE: Final[float] = 360.0
 
 
 def open_a_serial_shell_blind(
-    guest: Guest, link: "Reopenable", patience: float = 45.0
+    guest: Guest, link: "Reopenable", patience: float = AUTOLOGIN_DEADLINE
 ) -> None:
     """Type into the medium's auto-login shell until the serial port answers.
 
@@ -1022,29 +1026,31 @@ def open_a_serial_shell_blind(
     """
     console = link.console
     last = ""
-    for attempt, delay in enumerate(AUTOLOGIN_ATTEMPTS):
-        # Timed, not read: this guest writes nothing to the serial port until
-        # the line below has been typed, so there is nothing to wait for.
-        time.sleep(delay)
+    typed = 0
+    deadline = time.monotonic() + patience
+    while time.monotonic() < deadline:
+        typed += 1
         # A bare newline first: the auto-login prints its welcome and leaves
         # the cursor after a prompt, and a line typed into a console that has
         # not finished drawing loses its first characters.
         guest.send_keys(["ret"])
-        time.sleep(1.0)
         guest.send_keys(keys_for(SERIAL_GETTY))
         guest.send_keys(["ret"])
         try:
-            console.expect(SERIAL_SHELL_SPEAKS, timeout=patience)
-            print(f"the serial shell answered after {delay:.0f}s", flush=True)
+            console.expect(SERIAL_SHELL_SPEAKS, timeout=AUTOLOGIN_INTERVAL)
+            print(f"the serial shell answered on attempt {typed}", flush=True)
             return
-        except (ConsoleTimeout, ConsoleClosed) as error:
+        except ConsoleTimeout as error:
+            # Typed into a medium that has not reached its shell yet, which is
+            # what a loaded node looks like. The line is harmless there and
+            # goes in again rather than the guest being reset.
             last = str(error)[:200]
-        if attempt + 1 < len(AUTOLOGIN_ATTEMPTS):
-            guest.reset()
+        except ConsoleClosed as error:
+            last = str(error)[:200]
             link.reopen(solicit_prompt=False)
             console = link.console
     raise ProxmoxError(
-        f"no serial shell after {len(AUTOLOGIN_ATTEMPTS)} attempts at the "
+        f"no serial shell in {patience:.0f}s and {typed} attempts at the "
         f"medium's auto-login: {last}"
     )
 


### PR DESCRIPTION
#529 replaced seven blind GRUB edits with three timed attempts at the medium's auto-login, and run68 measured it: `ext4-bios` and `vm-bios` failed in 8.2 minutes instead of 14, with a readable reason. Better, still wrong.

The verdicts across every round say why. `vm-bios` has passed on the cluster exactly once, in a run where it was the only guest — `(0 waiting)` — and has failed in every round where it shared the cluster with nine others. Both blind paths were timed, and an idle node reaches the auto-login in about fifteen seconds while a node running twelve guests takes as long as it takes. No number written here is right for both.

So nothing is timed any more. The line goes in, the port is watched for twenty seconds, and if nothing answers the line goes in again, up to six minutes. A medium that is merely slow is typed at again rather than reset, which is what the earlier ladder did to a guest that was still booting. The deadline is the only guess left, and a test holds that it outlasts a loaded node while the interval stays short enough to keep trying.