### PR TITLE
ram: a runner that arms a boot and reads what comes up

### DIFF
--- a/tests/fixtures/vm-ram.toml
+++ b/tests/fixtures/vm-ram.toml
@@ -1,0 +1,95 @@
+# What the memory environment is asked to install once it comes up. Plain
+# ext4 on UEFI: this fixture exists to verify the arming and the delivery,
+# and a layout with anything else in it would fail for reasons that belong to
+# another fixture.
+#
+# The hostname is not the cloud image's, so a console that answers to it is
+# the installed system rather than the machine that was replaced.
+#
+# The root hash below is `install`, produced by `openssl passwd -6`.
+config_version = 1
+
+[system]
+hostname = "rambox"
+timezone = "UTC"
+locales = ["en_US.UTF-8"]
+locale = "en_US.UTF-8"
+init = "systemd"
+sshd = true
+root_password_hash = "$6$gentooinst$IR3GrdJ862XljQYDqocr4tKniIRDIT.jQNFzIrHE3U75H6B6YSWZoSYoVd5edSHpqaYBdiNfXHCoIPRVgb9lT/"
+
+[portage]
+profile = "default/linux/amd64/23.0/systemd"
+makeopts = "-j4"
+
+[portage.mirrors]
+region = "global"
+
+[portage.binhost]
+official = true
+community = "off"
+
+[kernel]
+source = "dist-bin"
+
+[bootloader]
+kind = "grub"
+firmware = "uefi"
+kernel_params = ["console=ttyS0,115200"]
+
+[disk]
+root = "mnt-root"
+
+[[disk.devices]]
+kind = "existing"
+id = "disk"
+selector = "/dev/disk/by-id/virtio-target0"
+wipe = true
+
+[[disk.devices]]
+kind = "table"
+id = "table"
+disk = "disk"
+table = "gpt"
+
+[[disk.devices]]
+kind = "partition"
+id = "esp"
+table = "table"
+index = 1
+role = "esp"
+size = "512MiB"
+
+[[disk.devices]]
+kind = "partition"
+id = "rootpart"
+table = "table"
+index = 2
+role = "data"
+
+[[disk.devices]]
+kind = "filesystem"
+id = "espfs"
+device = "esp"
+type = "vfat"
+label = "ESP"
+
+[[disk.devices]]
+kind = "filesystem"
+id = "rootfs"
+device = "rootpart"
+type = "ext4"
+label = "gentoo"
+
+[[disk.devices]]
+kind = "mountpoint"
+id = "mnt-root"
+source = "rootfs"
+path = "/"
+
+[[disk.devices]]
+kind = "mountpoint"
+id = "mnt-esp"
+source = "espfs"
+path = "/efi"
+options = ["umask=0077"]

--- a/tests/golden/vm-ram.txt
+++ b/tests/golden/vm-ram.txt
@@ -1,0 +1,75 @@
+[partition]
+  release anything a previous run of this configuration left mounted or open
+  wipe existing signatures from disk
+  create a gpt partition table on disk as table
+  create partition 1 on disk as esp: esp, 512MiB
+  create partition 2 on disk as rootpart: data, the rest of the disk
+  reread the partition table of disk and wait for its nodes
+
+[format]
+  make a vfat filesystem on esp as espfs labelled ESP
+  make a ext4 filesystem on rootpart as rootfs labelled gentoo
+
+[mount]
+  mount rootpart at /
+  mount esp at /efi with umask=0077
+
+[stage3]
+  download the newest systemd stage3 from https://distfiles.gentoo.org directly, verify it against BB572E0E2D182910 and unpack it into the target
+
+[chroot]
+  mount transient proc, sys, dev and run filesystems into the target
+  seed the target's resolv.conf from the install medium
+
+[portage]
+  write /etc/portage/make.conf with MAKEOPTS, INPUT_DEVICES, ACCEPT_LICENSE, L10N, FEATURES; 2 mirrors in the configured order, 5 appended
+  configure Portage, wget, curl, git and gpg for direct connection
+  create the three autounmask files emerge writes its decisions into
+  run getuto so Portage has a keyring to verify binary packages against
+  add verified binary package host gentoo at https://distfiles.gentoo.org/releases/amd64/binpackages/23.0/x86-64
+  fetch the first ebuild repository snapshot with emerge-webrsync
+  select profile default/linux/amd64/23.0/systemd
+  install git, which every later repository sync needs: emerge dev-vcs/git
+  point repository gentoo at https://github.com/gentoo-mirror/gentoo.git, commit signatures verified
+  sync repository gentoo
+  set sys-kernel/installkernel to dracut
+  accept the linux-firmware licence
+  resolve net-misc/openssh sys-process/cronie sys-kernel/installkernel sys-kernel/dracut sys-kernel/linux-firmware sys-fs/dosfstools sys-fs/e2fsprogs sys-kernel/gentoo-kernel-bin sys-boot/grub sys-boot/efibootmgr together before installing the requested packages
+
+[system]
+  generate and verify locales en_US.UTF-8
+  set the system locale to en_US.UTF-8
+  set the timezone to UTC
+  set the console keymap to us and its font to default8x16
+  set the hostname to rambox
+  give the target its own machine id
+  write /etc/fstab with entries for /, /efi
+  treat the hardware clock as UTC
+  set the root password
+  install sshd: emerge net-misc/openssh
+  ssh password login: off, root: off
+  enable sshd at boot
+  generate the ssh host keys
+  configure the wired interface for DHCP
+  enable systemd-networkd at boot
+  enable systemd-resolved at boot
+  install cron: emerge sys-process/cronie
+  enable cronie at boot
+
+[kernel]
+  install the hook that puts a kernel in /boot: emerge sys-kernel/installkernel
+  install the initramfs builder and firmware: emerge sys-kernel/dracut sys-kernel/linux-firmware
+  install the storage tools: emerge sys-fs/dosfstools sys-fs/e2fsprogs
+  install the kernel: emerge sys-kernel/gentoo-kernel-bin
+  rebuild the initramfs from sys-kernel/gentoo-kernel-bin with the modules written above
+  check the installkernel payload names existing kernel files
+
+[bootloader]
+  install the bootloader: emerge sys-boot/grub sys-boot/efibootmgr
+  write /etc/default/grub with cmdline console=ttyS0,115200, its menu on ttyS0
+  install GRUB for uefi on the esp at /efi
+
+[finish]
+  point /etc/resolv.conf at systemd-resolved rather than the install medium's
+  delete the downloaded stage3 from /var/cache/gentoo-install
+  unmount everything under the target

--- a/tests/unit/test_harness.py
+++ b/tests/unit/test_harness.py
@@ -142,6 +142,11 @@ NOT_IN_THE_CAMPAIGN: Final[frozenset[str]] = frozenset(
         # what has to boot is that file attached as a second disk. Nothing in
         # `tests/vm/campaign.py` boots a file yet.
         "vm-image.toml",
+        # What the memory environment is asked to install once it comes up.
+        # `tests/vm/ram.py` runs it against a cloud image rather than the
+        # medium the campaign boots, because the machine under test has to
+        # have a bootloader of its own to arm.
+        "vm-ram.toml",
     }
 )
 
@@ -3054,3 +3059,70 @@ def test_the_check_cannot_pass_by_the_tool_being_absent(tmp_path: Path) -> None:
     wanted = next(one for one in checks(config()) if one.name == "cpu-flags")
     assert wanted.pattern == "CPUFLAGS-ALL-KNOWN", wanted
     assert "cpuid2cpuflags" in CPU_FLAGS_COMMAND
+
+
+def test_a_default_entry_that_moved_is_a_failure_and_a_one_shot_is_not() -> None:
+    """The whole promise of this mode is that the default does not change, so
+    it is read before and after rather than assumed. `next_entry` is the
+    one-shot and appears exactly because the arming worked; `saved_entry` and
+    the firmware's `BootOrder` are what must not move."""
+    from tests.vm.ram import _default_changed
+
+    before = b"saved_entry=Debian\n"
+    armed = b"saved_entry=Debian\nnext_entry=gentoo-install memory environment\n"
+    assert not _default_changed(before, armed), "the one-shot is the point"
+
+    moved = b"saved_entry=gentoo-install memory environment\n"
+    assert _default_changed(before, moved)
+
+    order_before = b"BootOrder: 0001,0002\n"
+    order_after = b"BootOrder: 0003,0001,0002\n"
+    assert _default_changed(order_before, order_after)
+
+
+def test_the_memory_run_checks_the_medium_and_the_payload_apart() -> None:
+    """A live medium that booted without the configuration is an environment
+    the operator has to drive by hand, which is not what was asked for. Two
+    claims, two waits, two messages."""
+    from typing import Any, cast
+
+    from tests.vm import ram
+    from tests.vm.console import ConsoleTimeout
+
+    class Booted:
+        """The medium speaks and the payload never does."""
+
+        def __init__(self) -> None:
+            self.asked: list[str] = []
+
+        def expect(self, pattern: str, timeout: float, idle: float = 0.0) -> bytes:
+            self.asked.append(pattern)
+            if pattern == ram.PAYLOAD_SPEAKS:
+                raise ConsoleTimeout("no first screen")
+            return b"livecd login: "
+
+    console = Booted()
+    said = ram.came_up(cast(Any, console), "ram")
+    assert "without its configuration" in said, said
+    assert console.asked == [ram.CJK_SPEAKS, ram.PAYLOAD_SPEAKS], console.asked
+
+
+def test_each_mode_waits_for_its_own_medium() -> None:
+    """`--lowram` boots Alpine and `--ram` boots the CJK ISO, and a run that
+    waited for the wrong banner would pass on a medium it did not ask for."""
+    from typing import Any, cast
+
+    from tests.vm import ram
+    from tests.vm.console import ConsoleTimeout
+
+    for mode, wanted in (("ram", ram.CJK_SPEAKS), ("lowram", ram.ALPINE_SPEAKS)):
+        asked: list[str] = []
+
+        class Silent:
+            def expect(self, pattern: str, timeout: float, idle: float = 0.0) -> bytes:
+                asked.append(pattern)
+                raise ConsoleTimeout("nothing")
+
+        assert "never spoke" in ram.came_up(cast(Any, Silent()), mode)
+        assert asked == [wanted], (mode, asked)
+    assert ram.CJK_SPEAKS != ram.ALPINE_SPEAKS

--- a/tests/vm/ram.py
+++ b/tests/vm/ram.py
@@ -1,0 +1,200 @@
+# SPDX-License-Identifier: GPL-2.0-or-later
+"""Arm one boot into a memory environment on a running machine, and read it.
+
+The other runners install onto a disk or convert a running system. This one
+verifies the step before either: `--ram` and `--lowram` place a kernel where
+the machine's own bootloader reads one, arm a single boot, and leave the
+default entry alone. Nothing else in the suite reboots a machine into
+something this installer put there, which is why `TESTED.md` has no row for
+it.
+
+A cloud image is the machine under test, the same one `convert.py` uses: it
+has a bootloader, a disk layout and a distribution that is not Gentoo, so a
+console that comes up Gentoo is the memory environment and nothing else.
+"""
+
+from __future__ import annotations
+
+import argparse
+import re
+import sys
+import time
+from pathlib import Path
+from typing import Final
+
+from .console import ConsoleClosed, ConsoleTimeout, SerialConsole
+from .convert import IMAGES, CloudImage, install_tools, overlay, reach_root, seed
+from .driver import build as build_driver
+from .media import MEDIA
+from .qemu import Vm, VmSpec
+from .run import free_port
+from .workdir import confined
+
+WORKROOT: Final[Path] = Path.home() / "code/gentoo-install/lab/vm/ram"
+
+#: How long the arming is given. It downloads an image of about a gigabyte
+#: from the publisher, which is the whole of the wait; the rest is a `tar` and
+#: three small writes.
+ARM_CEILING: Final[float] = 3600.0
+
+#: How long the memory environment is given to come up after the reboot. It
+#: reads the image into RAM before it starts, which the console reports.
+MEMORY_BOOT_PATIENCE: Final[float] = 900.0
+
+#: What the CJK medium prints once it is running. `livecd login:` and not the
+#: kernel banner: the banner appears for the machine's own kernel too, and
+#: this has to tell one boot from the other.
+CJK_SPEAKS: Final[str] = r"livecd login:|Gentoo Linux Minimal Installation CD"
+
+#: What the Alpine netboot medium prints instead.
+ALPINE_SPEAKS: Final[str] = r"Welcome to Alpine Linux|localhost login:"
+
+#: What the delivered payload's own first screen prints. It is the proof the
+#: configuration arrived, not merely that a live medium booted.
+PAYLOAD_SPEAKS: Final[str] = r"install or shell>"
+
+#: How long that screen is given after the medium speaks. The payload is
+#: copied by a `pre-pivot` hook and started by the medium's own `local`
+#: service, so it follows the login prompt rather than racing it.
+PAYLOAD_PATIENCE: Final[float] = 300.0
+
+
+def arm(console: SerialConsole, config: str, mode: str) -> None:
+    """Run the installer in its memory mode and keep everything it printed."""
+    console.run("mkdir -p /tmp/gentoo-install-results", timeout=60.0)
+    console.run(
+        f"{{ sh /mnt/driver/install.sh --config {config} --{mode}; echo $? "
+        "> /tmp/gentoo-install-results/arm.rc; } 2>&1 "
+        "| tee /tmp/gentoo-install-results/arm.txt",
+        timeout=ARM_CEILING,
+    )
+
+
+def read_the_default_entry(console: SerialConsole) -> bytes:
+    """What the machine boots by default, before and after the arming.
+
+    The promise of this path is that it does not change, so it is read rather
+    than assumed: an arming that quietly became the default is the failure
+    `--bypass` exists to make explicit.
+    """
+    return console.expect_command(
+        "grub-editenv list 2>/dev/null; efibootmgr 2>/dev/null | grep -i bootorder "
+        "|| echo NO-BOOTORDER",
+        timeout=60.0,
+    )
+
+
+def came_up(console: SerialConsole, mode: str) -> str:
+    """Whether the memory environment answered. Empty when it did.
+
+    The medium and the payload are two separate claims and both are checked:
+    a live medium that booted without the configuration is an environment the
+    operator has to drive by hand, which is not what was asked for.
+    """
+    speaks = CJK_SPEAKS if mode == "ram" else ALPINE_SPEAKS
+    try:
+        console.expect(speaks, timeout=MEMORY_BOOT_PATIENCE)
+    except (ConsoleTimeout, ConsoleClosed) as error:
+        return f"the memory environment never spoke: {error}"[:600]
+    try:
+        console.expect(PAYLOAD_SPEAKS, timeout=PAYLOAD_PATIENCE)
+    except (ConsoleTimeout, ConsoleClosed) as error:
+        return f"the environment booted without its configuration: {error}"[:600]
+    return ""
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--image", choices=sorted(IMAGES), default="debian")
+    parser.add_argument("--mode", choices=("ram", "lowram"), default="lowram")
+    parser.add_argument(
+        "--config",
+        default="fixtures/vm-ram.toml",
+        help="what the memory environment is asked to install",
+    )
+    parser.add_argument("--memory", default="4G")
+    parser.add_argument("--cpus", type=int, default=4)
+    parser.add_argument("--keep", action="store_true")
+    arguments = parser.parse_args(argv)
+    chosen: CloudImage = IMAGES[arguments.image]
+
+    workdir = confined(WORKROOT / f"{arguments.mode}-{int(time.time())}")
+    workdir.mkdir(parents=True)
+    print(f"work directory: {workdir}", flush=True)
+
+    driver = build_driver(workdir / "driver.iso")
+    root = overlay(chosen.image, workdir)
+    cidata = seed(workdir)
+
+    spec = VmSpec(
+        medium=MEDIA["official-minimal"],
+        workdir=workdir,
+        firmware=chosen.firmware,
+        memory=arguments.memory,
+        cpus=arguments.cpus,
+        ssh_port=free_port(),
+        driver_iso=driver,
+        targets=(root,),
+        disks=(cidata,),
+        boot_installed=True,
+    )
+    started = time.monotonic()
+    refused = ""
+    with Vm(spec) as vm:
+        console = SerialConsole.connect(vm.serial_socket, vm.serial_log)
+        reach_root(console, chosen)
+        print(f"[{time.monotonic() - started:5.1f}s] root shell on serial", flush=True)
+        before = read_the_default_entry(console)
+        install_tools(console, chosen, arguments.config)
+        arm(console, arguments.config, arguments.mode)
+        code = console.expect_command(
+            "cat /tmp/gentoo-install-results/arm.rc", timeout=60.0
+        )
+        after = read_the_default_entry(console)
+        print(f"[{time.monotonic() - started:5.1f}s] arming exited {code!r}", flush=True)
+        if b"0" not in code:
+            refused = f"the arming exited {code!r}"
+        elif _default_changed(before, after):
+            refused = (
+                "the default boot entry changed, which this mode promises not to do: "
+                f"{before!r} then {after!r}"
+            )[:600]
+        else:
+            console.run("reboot", timeout=60.0)
+            refused = came_up(console, arguments.mode)
+    if refused:
+        print(f"FAIL {refused}", flush=True)
+    else:
+        print(
+            f"[{time.monotonic() - started:5.1f}s] the machine rebooted into the "
+            "memory environment and it holds the delivered configuration",
+            flush=True,
+        )
+    if not arguments.keep:
+        root.unlink(missing_ok=True)
+    return 1 if refused else 0
+
+
+def _default_changed(before: bytes, after: bytes) -> bool:
+    """Whether the default entry moved, ignoring the one-shot beside it.
+
+    `grub-editenv list` prints `next_entry` once armed, which is the whole
+    point; `saved_entry` and the firmware's `BootOrder` are what must not
+    move.
+    """
+    return _kept(before) != _kept(after)
+
+
+def _kept(said: bytes) -> tuple[str, ...]:
+    text = said.decode("utf-8", "replace")
+    return tuple(
+        sorted(
+            line.strip()
+            for line in text.splitlines()
+            if re.match(r"\s*(saved_entry=|BootOrder:)", line)
+        )
+    )
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
`TESTED.md` has no row for the memory environment because nothing in the suite reboots a machine into something this installer put there. `tests/vm/ram.py` is that runner. It reuses `convert.py`'s cloud image — a machine with a bootloader, a layout and a distribution that is not Gentoo, so a console that comes up Gentoo is the memory environment and nothing else.

Three things are read rather than assumed. The default boot entry is taken before and after the arming and must not have moved, which is the promise of this mode; `next_entry` appearing beside it is the one-shot and is not a change. The medium and the payload are two separate claims with two messages: a live medium that booted without the configuration is an environment the operator has to drive by hand, which is not what was asked for. And each mode waits for its own banner, so a run cannot pass on a medium it did not ask for.

`vm-ram.toml` is plain ext4 on UEFI with a hostname the cloud image does not have. It is listed as outside the campaign, with the reason: the machine under test has to have a bootloader of its own to arm, which the campaign's medium does not.

Nothing has been run against a real guest yet — this is the harness, and the row it fills in comes after it runs.