### PR TITLE
driver: wait for the CD the guest has not enumerated yet

### DIFF
--- a/tests/unit/test_harness.py
+++ b/tests/unit/test_harness.py
@@ -3126,3 +3126,53 @@ def test_each_mode_waits_for_its_own_medium() -> None:
         assert "never spoke" in ram.came_up(cast(Any, Silent()), mode)
         assert asked == [wanted], (mode, asked)
     assert ram.CJK_SPEAKS != ram.ALPINE_SPEAKS
+
+
+class _CdAppearsLate:
+    """A guest whose shell answers before its ATAPI devices are enumerated,
+    which a Debian cloud image under KVM did at 7.3 seconds."""
+
+    def __init__(self, ready_after: int) -> None:
+        self.ready_after = ready_after
+        self.tries = 0
+
+    def run(self, command: str, timeout: float = 0.0) -> None:
+        return None
+
+    def expect_command(self, command: str, timeout: float = 0.0) -> bytes:
+        self.tries += 1
+        if self.tries > self.ready_after:
+            return b"DRIVER-READY\r\n"
+        return b"DRIVER-ABSENT\r\n"
+
+
+def test_the_driver_cd_is_waited_for_rather_than_asked_once(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """`sh` exits 2 for a script it cannot open, which reads as the installer
+    refusing: the first memory-mode run failed that way with both `/dev/sr0`
+    and `/dev/sr1` answering `Can't open blockdev`."""
+    from typing import Any, cast
+
+    from tests.vm.driver import wait_for_driver
+
+    monkeypatch.setattr("time.sleep", lambda seconds: None)
+    console = _CdAppearsLate(ready_after=3)
+    wait_for_driver(cast(Any, console))
+
+    assert console.tries == 4, console.tries
+
+
+def test_a_guest_that_never_sees_the_cd_says_so(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Bounded: a CD that is genuinely absent has to end the run rather than
+    hold it, and the message carries what the guest answered."""
+    from typing import Any, cast
+
+    from tests.vm.driver import DriverNotFound, wait_for_driver
+
+    monkeypatch.setattr("time.sleep", lambda seconds: None)
+    console = _CdAppearsLate(ready_after=10**9)
+    with pytest.raises(DriverNotFound, match="DRIVER-ABSENT"):
+        wait_for_driver(cast(Any, console), patience=0.0)

--- a/tests/vm/driver.py
+++ b/tests/vm/driver.py
@@ -12,7 +12,9 @@ import shutil
 import subprocess
 import tempfile
 import hashlib
+import time
 from pathlib import Path
+from typing import Final, Protocol
 
 from .media import MediaError
 
@@ -29,6 +31,47 @@ FIND_DRIVER = (
     'mount -o ro "$candidate" /mnt/driver 2>/dev/null && break; done; '
     "mountpoint -q /mnt/driver"
 )
+
+class DriverNotFound(RuntimeError):
+    """The guest never saw the CD the harness attached."""
+
+
+class Console(Protocol):
+    """The two console calls this needs, so either runner's console fits."""
+
+    def run(self, command: str, timeout: float = ...) -> None: ...
+
+    def expect_command(self, command: str, timeout: float = ...) -> bytes: ...
+
+
+#: How long the driver CD is waited for, and how often it is tried again. The
+#: guest's ATAPI devices are not enumerated when its shell first answers: a
+#: Debian cloud image under KVM reached a root prompt at 7.3 seconds and both
+#: `/dev/sr0` and `/dev/sr1` answered `Can't open blockdev`, so the installer
+#: was started with `sh /mnt/driver/install.sh` against nothing and `sh` exited
+#: 2 for a file it could not open.
+DRIVER_PATIENCE: Final[float] = 120.0
+DRIVER_RETRY: Final[float] = 3.0
+
+
+def wait_for_driver(console: Console, patience: float = DRIVER_PATIENCE) -> None:
+    """Mount the driver CD, waiting for the guest to notice it has one."""
+    deadline = time.monotonic() + patience
+    while True:
+        console.run(FIND_DRIVER, timeout=180.0)
+        said = console.expect_command(
+            "mountpoint -q /mnt/driver && echo DRIVER-READY || echo DRIVER-ABSENT",
+            timeout=60.0,
+        )
+        if b"DRIVER-READY" in said:
+            return
+        if time.monotonic() >= deadline:
+            raise DriverNotFound(
+                f"no driver CD at /mnt/driver after {patience:.0f}s; the guest "
+                f"answered {said!r}"
+            )
+        time.sleep(DRIVER_RETRY)
+
 
 #: What the guest runs to put the installer on its PYTHONPATH.
 ENTRY = f"""#!/bin/sh

--- a/tests/vm/ram.py
+++ b/tests/vm/ram.py
@@ -24,7 +24,7 @@ from typing import Final
 
 from .console import ConsoleClosed, ConsoleTimeout, SerialConsole
 from .convert import IMAGES, CloudImage, install_tools, overlay, reach_root, seed
-from .driver import build as build_driver
+from .driver import build as build_driver, wait_for_driver
 from .media import MEDIA
 from .qemu import Vm, VmSpec
 from .run import free_port
@@ -145,6 +145,10 @@ def main(argv: list[str] | None = None) -> int:
         reach_root(console, chosen)
         print(f"[{time.monotonic() - started:5.1f}s] root shell on serial", flush=True)
         before = read_the_default_entry(console)
+        # Before anything asks the CD for a file: the guest's shell answers
+        # before its ATAPI devices are enumerated, and `sh` exits 2 for a
+        # script it cannot open, which reads as the installer refusing.
+        wait_for_driver(console)
         install_tools(console, chosen, arguments.config)
         arm(console, arguments.config, arguments.mode)
         code = console.expect_command(


### PR DESCRIPTION
The first run of `tests/vm/ram.py` against a real guest failed at 7.4 seconds with the arming exiting 2. The console says why: the Debian cloud image answered a root prompt at 7.3 seconds and both `/dev/sr0` and `/dev/sr1` reported `Can't open blockdev`, so `sh /mnt/driver/install.sh` ran against nothing and `sh` exits 2 for a file it cannot open — which reads as the installer refusing at preflight.

`FIND_DRIVER` tried each device once. It is now retried until the guest sees the CD or two minutes pass, and a guest that never sees it ends the run with what it answered in the message. The wait is bounded, and a control that removes the bound hangs.

The runner is the same one this found the defect in: this is what a harness is for, and reading it beat writing another assertion about it.