### PR TITLE
netboot: fetch the CJK ISO from the mirror before the release index

### DIFF
--- a/gentoo_install/plan/netboot.py
+++ b/gentoo_install/plan/netboot.py
@@ -11,6 +11,7 @@ on the ordinary path, inside that environment.
 from __future__ import annotations
 
 import json
+import re
 from dataclasses import dataclass
 from pathlib import PurePosixPath
 from typing import Final
@@ -27,6 +28,26 @@ from .operations import CommandOutput, Context, Operation, Stage
 CJK_RELEASES: Final[str] = (
     "https://api.github.com/repos/gentoo-zh/gentoo-cjk-livecd/releases/latest"
 )
+
+#: The same images through CERNET, which answers 302 to whichever member
+#: mirror is closest. Measured on 2026-08-18: the index lists one directory
+#: per build (`20260813T073053Z/`), each holding the ISO, its `.sha256`, its
+#: `DIGESTS` and a `CONTENTS.gz`, and the redirect landed on
+#: `mirror.nyist.edu.cn` with the ISO at 989376512 bytes.
+#:
+#: Asked before the release index, because the machines this path exists for
+#: are in China and a gigabyte from GitHub's CDN is the slowest part of the
+#: whole run. GitHub answers when the mirror does not, so neither is a single
+#: point of failure.
+CJK_MIRROR: Final[str] = "https://mirrors.cernet.edu.cn/gentoo-zh/gentoo-cjk-livecd/"
+
+#: What a build directory is called there. Read rather than composed: the
+#: name carries a build timestamp and the newest is the greatest of them.
+CJK_BUILD = re.compile(r'href="(\d{8}T\d{6}Z)/"')
+
+#: What an asset is called inside one. The ISO and its checksum are matched
+#: by suffix so a build that adds a file does not confuse this.
+CJK_ASSET = re.compile(r'href="([^"?/]+\.(?:iso|iso\.sha256))"')
 
 #: Alpine publishes version, filename and SHA-256 for every flavour in one
 #: document per architecture, so the version is read rather than pinned here
@@ -782,6 +803,9 @@ def _cjk_release(context: Context, machine: str) -> tuple[str, str, str]:
             f"{machine} is not an architecture Gentoo names, so no ISO can be "
             f"chosen for it: {', '.join(sorted(GENTOO_ARCHITECTURES))} are"
         )
+    from_mirror = _cjk_from_mirror(context, named)
+    if from_mirror is not None:
+        return from_mirror
     said = context.run(["curl", "--fail", "--location", CJK_RELEASES])
     try:
         release = json.loads(said)
@@ -803,6 +827,30 @@ def _cjk_release(context: Context, machine: str) -> tuple[str, str, str]:
         raise DownloadFailed(f"{iso} is published with no companion .sha256")
     digest = context.run(["curl", "--fail", "--location", assets[f"{iso}.sha256"]])
     return iso, assets[iso], _first_word(digest, iso)
+
+
+def _cjk_from_mirror(context: Context, named: str) -> tuple[str, str, str] | None:
+    """The newest build on the mirror, or `None` when it does not answer.
+
+    `None` rather than an exception: a mirror that is down is not a reason to
+    stop, and the release index is asked next.
+    """
+    index = context.run(["curl", "--fail", "--location", CJK_MIRROR], check=False)
+    if isinstance(index, CommandOutput) and index.returncode != 0:
+        return None
+    builds = CJK_BUILD.findall(index)
+    if not builds:
+        return None
+    inside = f"{CJK_MIRROR.rstrip('/')}/{max(builds)}/"
+    listed = context.run(["curl", "--fail", "--location", inside], check=False)
+    if isinstance(listed, CommandOutput) and listed.returncode != 0:
+        return None
+    names = CJK_ASSET.findall(listed)
+    iso = next((one for one in names if one.endswith(".iso") and f"-{named}-" in one), "")
+    if not iso or f"{iso}.sha256" not in names:
+        return None
+    digest = context.run(["curl", "--fail", "--location", f"{inside}{iso}.sha256"])
+    return iso, f"{inside}{iso}", _first_word(digest, iso)
 
 
 def _alpine_release(context: Context, machine: str) -> tuple[str, str, str]:

--- a/tests/unit/test_plan_netboot.py
+++ b/tests/unit/test_plan_netboot.py
@@ -789,3 +789,97 @@ def test_the_boot_target_carries_no_fact_nothing_reads() -> None:
         # The declaration itself is one mention; a field nothing reads has
         # exactly that one.
         assert source.count(field.name) > 1, field.name
+
+
+#: What the CERNET index and one build directory answered on 2026-08-18,
+#: trimmed to the lines these two patterns read. The mirror answers 302 to
+#: whichever member is closest, so what a machine sees is this after the
+#: redirect.
+MIRROR_INDEX = (
+    '<a href="/">Home</a><a href="../">../</a>\n'
+    '<a href="20260810T183054Z/">20260810T183054Z/</a>  10-Aug-2026 18:35  -\n'
+    '<a href="20260813T073053Z/">20260813T073053Z/</a>  13-Aug-2026 07:35  -\n'
+    '<a href="mailto:cips@nyist.edu.cn">contact</a>\n'
+)
+MIRROR_BUILD = (
+    '<a href="../">../</a>\n'
+    '<a href="install-amd64-cjk-minimal-20260813T073053Z.iso">…</a> 943M\n'
+    '<a href="install-amd64-cjk-minimal-20260813T073053Z.iso.CONTENTS.gz">…</a>\n'
+    '<a href="install-amd64-cjk-minimal-20260813T073053Z.iso.DIGESTS">…</a>\n'
+    '<a href="install-amd64-cjk-minimal-20260813T073053Z.iso.sha256">…</a>\n'
+)
+MIRROR_ISO = "install-amd64-cjk-minimal-20260813T073053Z.iso"
+
+
+def _mirroring(*, answers: bool = True, digest: str = DIGEST) -> Recorder:
+    def answer(argv: Sequence[str]) -> str | None:
+        if argv[0] != "curl":
+            if argv[0] == "sha256sum":
+                return f"{digest}  {argv[1]}\n"
+            if argv[0] == "ls":
+                return f"{MIRROR_ISO}\nkernel\ninitramfs\n"
+            if argv[0] == "blkid":
+                return "Gentoo-CJK-amd64-20260813\n"
+            return None
+        wanted = argv[-1]
+        if wanted.startswith(netboot.CJK_MIRROR):
+            if not answers:
+                return CommandOutput("", 7)
+            if wanted.endswith(".sha256"):
+                return f"{DIGEST}  {MIRROR_ISO}\n"
+            if wanted.rstrip("/").endswith("Z"):
+                # Each build lists its own name, so a run that took the wrong
+                # directory fetches a URL carrying the wrong timestamp.
+                build = wanted.rstrip("/").rsplit("/", 1)[1]
+                return MIRROR_BUILD.replace("20260813T073053Z", build)
+            return MIRROR_INDEX
+        if wanted == netboot.CJK_RELEASES:
+            return CJK_INDEX
+        if wanted.endswith(".sha256"):
+            return f"{DIGEST}  {ISO}\n"
+        return ""
+
+    recorder = Recorder()
+    recorder.answering = answer
+    return recorder
+
+
+def test_the_iso_comes_from_the_mirror_before_the_release_index() -> None:
+    """The machines this path exists for are in China, and a gigabyte from
+    GitHub's CDN is the slowest part of the whole run. CERNET answers 302 to
+    whichever member mirror is closest."""
+    recorder = _mirroring()
+    netboot.FetchMemoryImage(mode=MemoryMode.RAM, target=_target()).apply(recorder)
+
+    fetched = [one for one in _run(recorder, "curl") if "--output" in one]
+    assert fetched[0][-1].startswith(netboot.CJK_MIRROR), fetched
+    assert fetched[0][-1].endswith(MIRROR_ISO), fetched
+    # The newest build, not the first the index lists.
+    assert "/20260813T073053Z/" in fetched[0][-1], fetched
+    # The release index is not asked at all when the mirror answered.
+    assert not any(netboot.CJK_RELEASES in one for one in recorder.commands)
+
+
+def test_the_newest_build_is_taken_rather_than_the_first() -> None:
+    """The index lists every build it keeps, oldest first, and the newest is
+    the greatest timestamp rather than the last line."""
+    builds = netboot.CJK_BUILD.findall(MIRROR_INDEX)
+    assert builds == ["20260810T183054Z", "20260813T073053Z"], builds
+    assert max(builds) == "20260813T073053Z"
+
+
+def test_a_mirror_that_does_not_answer_falls_back_to_the_release_index() -> None:
+    """A mirror that is down is not a reason to stop: neither route is a
+    single point of failure."""
+    recorder = _mirroring(answers=False)
+    netboot.FetchMemoryImage(mode=MemoryMode.RAM, target=_target()).apply(recorder)
+
+    fetched = [one for one in _run(recorder, "curl") if "--output" in one]
+    assert fetched[0][-1] == f"https://host/{ISO}", fetched
+
+
+def test_only_the_iso_and_its_checksum_are_read_from_a_build() -> None:
+    """`DIGESTS` and `CONTENTS.gz` are in the same directory, and a pattern
+    that took any href would offer one of them as the image."""
+    names = netboot.CJK_ASSET.findall(MIRROR_BUILD)
+    assert names == [MIRROR_ISO, f"{MIRROR_ISO}.sha256"], names


### PR DESCRIPTION
There are two routes to the same images and `--ram` only knew one. Measured on 2026-08-18: `https://mirrors.cernet.edu.cn/gentoo-zh/gentoo-cjk-livecd/` answers 302 to whichever member mirror is closest — the redirect landed on `mirror.nyist.edu.cn` — and lists one directory per build, each holding the ISO, its `.sha256`, its `DIGESTS` and a `CONTENTS.gz`, with the ISO at 989376512 bytes. The GitHub release is the other route, through its CDN.

The mirror is asked first, because the machines this path exists for are in China and a gigabyte from GitHub is the slowest part of the whole run. Neither is a single point of failure: a mirror that does not answer falls back to the release index rather than stopping.

Nothing is composed from a guess. The build directory is the greatest timestamp the index lists, read rather than assembled, and the asset name is read from inside it — `DIGESTS` and `CONTENTS.gz` sit beside the ISO, and a pattern that took any href would offer one of them as the image. Both patterns were run against the pages the mirror actually served.

Three negative controls, each red on its assertion: not asking the mirror, taking the first build instead of the newest, and matching any href. The second and third were green at first — the fake answered every build directory identically, and the third mutation had not landed — so the fake was made to answer per directory and the mutation was checked with grep before it was believed.