### PR TITLE
tested: three cluster rounds, and the login that took four to fix

### DIFF
--- a/TESTED.md
+++ b/TESTED.md
@@ -31,11 +31,15 @@ The ordinary path: partition, format, unpack a stage3, configure, boot.
 | `7cf09c2f9d9c` | `vm-btrfs`, `vm-binpkg`, `vm-luks`, `vm-mdraid`, `vm-f2fs`, `vm-zram`, `vm-zfs-encrypted` — the first cluster record of a ZFS root, of native ZFS encryption, and of the `gentoo-zh` overlay, which no earlier row's fixtures use |
 | `08015b221d73` | `vm-sdboot`, `vm-cjk-kernel` — the first cluster record of the patched CJK console kernel and of `system.console_cjk` |
 | `4ccd3aa34687` | `vm-xfs` |
+| `0d7ddcb22b8e` | `vm-zram`, `vm-sdboot`, `vm-cjk-kernel`, `vm-f2fs`, `zfs-zbm`, `vm-openrc-desktop` — `zfs-zbm` is the first record of a ZFS root under ZFSBootMenu since the key file that image cannot open was removed from that path |
+| `6d386174b295` | `vm-unlock`, `vm-mdraid`, `vm-xfs`, `zfs-zbm`, `vm-binpkg`, `vm-luks` |
+| `1aafd75c4359` | `openrc-sdboot`, `vm-lvm`, `vm-btrfs`, `vm-luks` — the first record of `openrc-sdboot` and `vm-lvm` since the installed-system login stopped being typed on a timer; both had failed in the four rounds before it |
 
-The last three rows ran `--region cn --site nju --sync webrsync --distfiles
-http://10.31.0.2/gentoo`, so what they establish about mirror selection is
-limited to that region, that site and a distfiles cache on the guests' own
-segment. The parameters the earlier rows used are not recorded.
+Every row from `08015b221d73` onward ran `--region cn --site nju --sync
+webrsync --distfiles http://10.31.0.2/gentoo`, so what they establish about
+mirror selection is limited to that region, that site and a distfiles cache on
+the guests' own segment. The parameters the earlier rows used are not
+recorded.
 
 ### Records from QEMU on one machine
 


### PR DESCRIPTION
Three rounds' records, each read from its own log rather than written from memory — the first draft of this attributed run66's fixtures to run67 and was corrected against the verdict lines.

The row that matters is `1aafd75c4359`: `openrc-sdboot` and `vm-lvm` passed at 31.0 and 34.7 minutes. Those two had failed in run64, run65, run66 and run67 with `root could not log into the installed system`, through two fixes aimed at theories that their own evidence later disproved. That revision is the one that stopped typing the login on a timer, after the same fixture was shown to pass under `tests/vm/run.py`, whose console types the name and the password the moment each prompt is read.

`zfs-zbm` at `0d7ddcb22b8e` is the first record of a ZFS root under ZFSBootMenu since the key file that image cannot open was removed from that path.

The paragraph about which rows ran with the local mirror said "the last three", which stopped being true as rows were added; it now names the revision the parameters start at.