### PR TITLE
cluster: accept the prompt the medium's own shell gives

### DIFF
--- a/tests/unit/test_cluster.py
+++ b/tests/unit/test_cluster.py
@@ -1842,3 +1842,28 @@ def test_the_first_password_is_sent_the_moment_the_prompt_is_read(
     assert cluster._log_in(cast(cluster.Reconnecting, console), "install") == ""
     assert settles == [0.0], settles
     assert cluster.PASSWORD_ECHO_OFF_AFTER == 0.0, cluster.PASSWORD_ECHO_OFF_AFTER
+
+
+def test_the_prompt_a_medium_started_shell_gives_is_a_root_prompt() -> None:
+    """`vm-bios` opened a root shell on the serial port and then waited
+    fifteen minutes for a prompt it was already looking at: the console's last
+    output was ` ~ # `, and the pattern wanted the medium's own hostname in
+    front of it. A shell started by the medium's auto-login carries none,
+    because nothing has set one in that environment yet."""
+    import re
+
+    for prompt in (b"livecd ~ # ", b"localhost ~ # ", b" ~ # ", b"root@livecd ~ # "):
+        assert re.search(cluster.ROOT_PROMPT.encode(), prompt), prompt
+
+
+def test_a_line_that_is_not_a_prompt_is_not_taken_for_one() -> None:
+    """The negative direction: `#` alone appears in half the boot messages,
+    which is why the pattern asks for the tilde and the space around it."""
+    import re
+
+    for other in (
+        b"[    0.000000] Command line: console=ttyS0",
+        b"#### partitioning",
+        b"Load keymap",
+    ):
+        assert not re.search(cluster.ROOT_PROMPT.encode(), other), other

--- a/tests/vm/cluster.py
+++ b/tests/vm/cluster.py
@@ -981,12 +981,21 @@ KEYMAP_QUESTION: Final[str] = r"Load keymap|keymap \(Enter for default\)"
 PROMPT_PATIENCE: Final[float] = 900.0
 
 
+#: What a root prompt looks like on a medium this drives. The first two are
+#: the hostname the medium sets; the third is the prompt a shell started by
+#: the medium's own auto-login gives, which carries no hostname because
+#: nothing has set one in that environment yet. `vm-bios` reached exactly
+#: that and waited fifteen minutes for a prompt it was already looking at:
+#: the console's last output was ` ~ # `.
+ROOT_PROMPT: Final[str] = r"livecd .*#|localhost .*#|~ #"
+
+
 def reach_prompt(link: Reconnecting, patience: float = PROMPT_PATIENCE) -> None:
     """Wait for a root prompt, answering the medium's questions on the way."""
     deadline = time.monotonic() + patience
     while time.monotonic() < deadline:
         said = link.expect(
-            rf"livecd .*#|localhost .*#|{KEYMAP_QUESTION}",
+            rf"{ROOT_PROMPT}|{KEYMAP_QUESTION}",
             timeout=max(30.0, deadline - time.monotonic()),
         )
         if not re.search(KEYMAP_QUESTION.encode(), said):


### PR DESCRIPTION
run69 moved the BIOS failure one layer on, which is what #535 was for. `vm-bios` and `ext4-bios` no longer fail at the serial shell: they fail after it, and the verdict carries the reason — `never matched 'livecd .\*#|localhost .\*#|Load keymap…', 900s of 900s elapsed; last output was b' ~ # '`.

That is a root prompt. The pattern wanted the medium's own hostname in front of it, and a shell started by the medium's auto-login carries none because nothing has set one in that environment yet. So the guest sat at a prompt for fifteen minutes while the harness waited for the same prompt spelled differently.

The tilde and the spaces around it are what keep this from matching anything:  alone appears in half the boot messages, and a control that loosens it to bare  turns the negative test red.