### PR TITLE
netboot: take the modloop from the archive that was downloaded

### DIFF
--- a/gentoo_install/plan/netboot.py
+++ b/gentoo_install/plan/netboot.py
@@ -61,11 +61,30 @@ ALPINE_RELEASES: Final[str] = (
 )
 ALPINE_NETBOOT_FLAVOUR: Final[str] = "alpine-netboot"
 
-#: Alpine's own repository, which its netboot init fetches `modloop` and the
-#: packages from. `alpine_repo=auto` searches for a `.boot_repository` file and
-#: finds none on a machine that booted from a local kernel.
+#: Alpine's own repository, which its netboot init installs the packages from.
+#: `alpine_repo=auto` searches for a `.boot_repository` file and finds none on
+#: a machine that booted from a local kernel.
 ALPINE_REPOSITORY: Final[str] = (
     "https://dl-cdn.alpinelinux.org/alpine/latest-stable/main"
+)
+
+#: Where the kernel modules come from. `modloop=` is not read by
+#: `initramfs-init` at all: the reader is `/etc/init.d/modloop` in the booted
+#: root, which parses `/proc/cmdline` itself and `wget`s an `http://` value
+#: (`openrc/modloop.initd:16,78`). Both fields are filled from the netboot
+#: archive this run downloaded rather than written in, so an aarch64 machine
+#: composes an aarch64 URL and the modloop is the one built beside the kernel
+#: that will be running.
+ALPINE_MODLOOP: Final[str] = (
+    "https://dl-cdn.alpinelinux.org/alpine/latest-stable/releases/"
+    "{architecture}/netboot-{version}/modloop-lts"
+)
+
+#: What Alpine names a netboot archive. `netboot/` beside it holds whatever
+#: release is newest, so pinning the version keeps `modules/$(uname -r)` inside
+#: the modloop matching the kernel taken out of this archive.
+ALPINE_ARCHIVE = re.compile(
+    r"^alpine-netboot-(?P<version>.+)-(?P<architecture>[^-]+)\.tar\.gz$"
 )
 
 #: What the kernel calls a machine and what Gentoo calls the same one. Two
@@ -575,7 +594,7 @@ class WriteMemoryEntry(Operation):
             return tuple(words)
         words = [
             f"alpine_repo={ALPINE_REPOSITORY}",
-            f"modloop={ALPINE_REPOSITORY.rsplit('/', 1)[0]}/releases/x86_64/netboot/modloop-lts",
+            f"modloop={_alpine_modloop(_only_image(context, place, '.tar.gz'))}",
             "ip=dhcp",
         ]
         if self.launch.ssh_key:
@@ -773,6 +792,17 @@ def _only_image(context: Context, place: PurePosixPath, suffix: str) -> PurePosi
             f"{place} holds {len(names)} files ending {suffix} and this needs one"
         )
     return place / names[0]
+
+
+def _alpine_modloop(archive: PurePosixPath) -> str:
+    """The modloop belonging to the netboot archive this run downloaded."""
+    named = ALPINE_ARCHIVE.match(archive.name)
+    if named is None:
+        raise DownloadFailed(
+            f"{archive.name} is not named as an Alpine netboot archive, so the "
+            "modloop its kernel needs cannot be composed from it"
+        )
+    return ALPINE_MODLOOP.format(**named.groupdict())
 
 
 def _volume_label(context: Context, image: PurePosixPath) -> str:

--- a/tests/unit/test_plan_netboot.py
+++ b/tests/unit/test_plan_netboot.py
@@ -7,7 +7,7 @@ import json
 from dataclasses import replace
 from pathlib import Path, PurePosixPath
 from collections.abc import Callable
-from typing import Sequence
+from typing import Final, Sequence
 
 import pytest
 
@@ -79,7 +79,15 @@ def _launch(
     )
 
 
-def _answering(mode: MemoryMode = MemoryMode.RAM, *, digest: str = DIGEST) -> Recorder:
+ALPINE_ARCHIVE: Final[str] = "alpine-netboot-3.24.1-x86_64.tar.gz"
+
+
+def _answering(
+    mode: MemoryMode = MemoryMode.RAM,
+    *,
+    digest: str = DIGEST,
+    archive: str = ALPINE_ARCHIVE,
+) -> Recorder:
     """A machine that answers everything this plan asks it."""
 
     def answer(argv: Sequence[str]) -> str | None:
@@ -95,7 +103,7 @@ def _answering(mode: MemoryMode = MemoryMode.RAM, *, digest: str = DIGEST) -> Re
         if argv[0] == "sha256sum":
             return f"{digest}  {argv[1]}\n"
         if argv[0] == "ls":
-            name = ISO if mode is MemoryMode.RAM else "alpine-netboot-3.24.1-x86_64.tar.gz"
+            name = ISO if mode is MemoryMode.RAM else archive
             return f"{name}\nkernel\ninitramfs\n"
         if argv[0] == "blkid":
             return "Gentoo-CJK-amd64-20260813\n"
@@ -287,6 +295,46 @@ def test_the_lowram_cmdline_names_the_repository_alpine_fetches_modloop_from() -
     entry = recorder.files[PurePosixPath(f"{ESP}/loader/entries/{netboot.PLACE}.conf")]
     assert f"alpine_repo={netboot.ALPINE_REPOSITORY}" in entry, entry
     assert "modloop=" in entry and "ip=dhcp" in entry, entry
+
+
+def _modloop(entry: str) -> str:
+    words = [one for one in entry.split() if one.startswith("modloop=")]
+    assert len(words) == 1, entry
+    return words[0]
+
+
+def _lowram_entry(archive: str) -> str:
+    recorder = _answering(MemoryMode.LOWRAM, archive=archive)
+    netboot.WriteMemoryEntry(
+        mode=MemoryMode.LOWRAM, target=_target(), launch=_launch(MemoryMode.LOWRAM)
+    ).apply(recorder)
+    return recorder.files[PurePosixPath(f"{ESP}/loader/entries/{netboot.PLACE}.conf")]
+
+
+def test_the_modloop_is_the_one_beside_the_kernel_that_was_downloaded() -> None:
+    """`netboot/` holds whatever release is newest, so a machine armed the day
+    before an Alpine release would boot a kernel from one version and mount a
+    modloop from the next, whose `modules/$(uname -r)` does not exist."""
+    assert _modloop(_lowram_entry("alpine-netboot-3.24.1-x86_64.tar.gz")).endswith(
+        "/releases/x86_64/netboot-3.24.1/modloop-lts"
+    ), _lowram_entry("alpine-netboot-3.24.1-x86_64.tar.gz")
+
+
+def test_the_modloop_follows_the_machine_rather_than_this_file() -> None:
+    """Alpine publishes `netboot-<version>/modloop-lts` under every
+    architecture's own directory, checked against `latest-stable/releases/` for
+    `x86_64` and `aarch64` on 2026-08-18."""
+    word = _modloop(_lowram_entry("alpine-netboot-3.24.1-aarch64.tar.gz"))
+    assert "/releases/aarch64/netboot-3.24.1/" in word, word
+    assert "x86_64" not in word, word
+
+
+def test_an_archive_named_otherwise_is_refused_rather_than_guessed() -> None:
+    """A URL composed from a name that does not parse would be fetched by
+    `wget` inside the booted medium, where its failure is a warning on a screen
+    nobody is watching and a system with no modules."""
+    with pytest.raises(DownloadFailed):
+        _lowram_entry("netboot.tar.gz")
 
 
 def test_a_key_given_for_lowram_reaches_alpines_own_option() -> None:


### PR DESCRIPTION
`--lowram` boots Alpine's netboot kernel and initramfs, and the kernel modules come from the modloop the `modloop=` word names. That word carried `x86_64` and `netboot/` written in.

Two consequences, and the second is the one that bites on this machine. An aarch64 arming composed an x86_64 URL, which is the case the owner asked not to exist. And `netboot/` beside the versioned directories holds whatever release is newest: an arming the day before an Alpine release mounts a modloop built for a kernel that is not the one running, and `modules/$(uname -r)` inside it does not exist.

Both fields now come from the archive the run actually downloaded, `alpine-netboot-<version>-<arch>.tar.gz`, which is also where the kernel came from. A name that does not parse raises rather than composing a URL: the fetch happens inside the booted medium, where `wget` failing is a warning on a screen nobody is watching.

An earlier audit reported this word as dead because `modloop` is not in `initramfs-init`'s `myopts`. It is not the reader — `openrc/modloop.initd:16,78` parses `/proc/cmdline` itself and `wget`s an `http://` value.