### PR TITLE
netboot: carry the machine's own console into the armed entry

### DIFF
--- a/gentoo_install/plan/netboot.py
+++ b/gentoo_install/plan/netboot.py
@@ -127,6 +127,10 @@ CJK_CMDLINE: Final[tuple[str, ...]] = (
     "rd.live.ram=1",
 )
 
+#: What the machine this plan runs on booted with. Read through the runner
+#: rather than opened here: `plan/` touches no machine of its own.
+RUNNING_CMDLINE: Final[str] = "/proc/cmdline"
+
 #: `check_live_ram` in the ISO's initramfs enters an emergency shell when
 #: `MemTotal - image` is under `rd.minmem`, which defaults to 1024 MiB. The
 #: `image.squashfs` measured on 2026-08-17 is 824 MiB, so a machine under this
@@ -585,6 +589,7 @@ class WriteMemoryEntry(Operation):
                 f"root=live:CDLABEL={label}",
                 *CJK_CMDLINE,
                 f"iso-scan/filename={_relative_to_mount(self.target, image)}",
+                *_inherited_consoles(context),
             ]
             if self.launch.root_password:
                 # `dosshd` scrambles the root password, so it is documented as
@@ -596,6 +601,7 @@ class WriteMemoryEntry(Operation):
             f"alpine_repo={ALPINE_REPOSITORY}",
             f"modloop={_alpine_modloop(_only_image(context, place, '.tar.gz'))}",
             "ip=dhcp",
+            *_inherited_consoles(context),
         ]
         if self.launch.ssh_key:
             # Alpine's netboot init installs openssh and enables sshd when
@@ -792,6 +798,23 @@ def _only_image(context: Context, place: PurePosixPath, suffix: str) -> PurePosi
             f"{place} holds {len(names)} files ending {suffix} and this needs one"
         )
     return place / names[0]
+
+
+def _inherited_consoles(context: Context) -> tuple[str, ...]:
+    """The `console=` words this machine is running with, in their own order.
+
+    Written by neither environment and guessed by neither: the machine boots
+    today, so what it boots with is the evidence of which console answers
+    there. `fixinittab` on the CJK medium auto-detects `hvc0`, `ttyHV0` and
+    `ttyAMA0` only, and comments the medium's own `s0` line out, so an amd64
+    machine reached over `ttyS0` gets no getty at all unless `console=` names
+    it; on arm the auto-detect covers it, which is why one architecture would
+    have hidden this from the other.
+    """
+    said = context.run(["cat", RUNNING_CMDLINE], check=False)
+    if isinstance(said, CommandOutput) and said.returncode != 0:
+        return ()
+    return tuple(word for word in said.split() if word.startswith("console="))
 
 
 def _alpine_modloop(archive: PurePosixPath) -> str:

--- a/tests/unit/test_plan_netboot.py
+++ b/tests/unit/test_plan_netboot.py
@@ -81,16 +81,27 @@ def _launch(
 
 ALPINE_ARCHIVE: Final[str] = "alpine-netboot-3.24.1-x86_64.tar.gz"
 
+#: What a machine reached over a serial port boots with. Taken from the cloud
+#: image `tests/vm/convert.py` drives, which is the machine these two modes are
+#: armed on in the harness.
+RUNNING_CMDLINE: Final[str] = (
+    "BOOT_IMAGE=/boot/vmlinuz root=UUID=1e2c ro console=tty0 "
+    "console=ttyS0,115200n8 quiet\n"
+)
+
 
 def _answering(
     mode: MemoryMode = MemoryMode.RAM,
     *,
     digest: str = DIGEST,
     archive: str = ALPINE_ARCHIVE,
+    cmdline: str = RUNNING_CMDLINE,
 ) -> Recorder:
     """A machine that answers everything this plan asks it."""
 
     def answer(argv: Sequence[str]) -> str | None:
+        if argv[0] == "cat" and argv[-1] == netboot.RUNNING_CMDLINE:
+            return cmdline
         if argv[0] == "curl":
             wanted = argv[-1]
             if wanted == netboot.CJK_RELEASES:
@@ -327,6 +338,54 @@ def test_the_modloop_follows_the_machine_rather_than_this_file() -> None:
     word = _modloop(_lowram_entry("alpine-netboot-3.24.1-aarch64.tar.gz"))
     assert "/releases/aarch64/netboot-3.24.1/" in word, word
     assert "x86_64" not in word, word
+
+
+def _ram_entry(cmdline: str) -> str:
+    recorder = _answering(cmdline=cmdline)
+    netboot.WriteMemoryEntry(
+        mode=MemoryMode.RAM, target=_target(), launch=_launch()
+    ).apply(recorder)
+    return recorder.files[PurePosixPath(f"{ESP}/loader/entries/{netboot.PLACE}.conf")]
+
+
+def test_the_entry_carries_the_console_the_machine_already_answers_on() -> None:
+    """`fixinittab` on the CJK medium auto-detects `hvc0`, `ttyHV0` and
+    `ttyAMA0` only, and comments the medium's own `s0` line out, so an amd64
+    machine driven over `ttyS0` gets no getty and shows the operator nothing.
+    Read from `/etc/init.d/fixinittab:24-42,104-105` in the ISO's squashfs."""
+    entry = _ram_entry(RUNNING_CMDLINE)
+    assert "console=tty0" in entry and "console=ttyS0,115200n8" in entry, entry
+
+
+def test_the_console_order_is_the_machines_own() -> None:
+    """The last `console=` is what the kernel gives `/dev/console`, and
+    `livecd-functions.sh:119-136` takes the last one into `LIVECD_CONSOLE` the
+    same way, so reordering them moves the first screen to another device."""
+    entry = _ram_entry("root=UUID=1e2c console=ttyS0,115200n8 console=tty0\n")
+    options = next(
+        line for line in entry.splitlines() if line.startswith("options")
+    )
+    assert options.index("console=ttyS0") < options.index("console=tty0"), options
+
+
+def test_a_machine_that_names_no_console_is_left_alone() -> None:
+    """An ordinary workstation boots without one, and writing `console=ttyS0`
+    for it would move its first screen to a port that is not there."""
+    entry = _ram_entry("BOOT_IMAGE=/boot/vmlinuz root=UUID=1e2c ro quiet\n")
+    assert "console=" not in entry, entry
+
+
+def test_the_lowram_entry_carries_the_console_too() -> None:
+    """Alpine's `initramfs-init` reads `console=` outside `myopts` and passes
+    it to `switch_root -c`, so the same argument decides where its own first
+    screen lands."""
+    recorder = _answering(MemoryMode.LOWRAM, cmdline=RUNNING_CMDLINE)
+    netboot.WriteMemoryEntry(
+        mode=MemoryMode.LOWRAM, target=_target(), launch=_launch(MemoryMode.LOWRAM)
+    ).apply(recorder)
+
+    entry = recorder.files[PurePosixPath(f"{ESP}/loader/entries/{netboot.PLACE}.conf")]
+    assert "console=ttyS0,115200n8" in entry, entry
 
 
 def test_an_archive_named_otherwise_is_refused_rather_than_guessed() -> None:


### PR DESCRIPTION
Neither armed entry named a console, so both environments came up wherever the kernel's default console is. On the CJK medium that decides whether the first screen exists at all.

Read from the ISO's own squashfs. `/etc/init.d/fixinittab:24` comments the medium's `s0` and `s1` inittab lines out, and its auto-detect at `:28-42` tries `hvc0`, `ttyHV0` and `ttyAMA0` — not `ttyS0`. A getty on `ttyS0` is added only at `:104-105`, from `LIVECD_CONSOLE`, which `usr/bin/livecd-functions.sh:119-136` sets from a `console=` argument. So an amd64 machine reached over a serial port booted the environment, copied the payload, and printed the question to a tty nobody was looking at. On aarch64 the auto-detect covers `ttyAMA0`, which is why one architecture would have hidden this from the other.

The words are the machine's own, read from `/proc/cmdline` at arming time and kept in their order, because the last `console=` is the one the kernel gives `/dev/console` and `livecd-functions.sh` takes the last one too. A machine that names no console gets none written: an ordinary workstation boots that way, and `console=ttyS0` would move its first screen to a port that is not there.

Alpine reads `console=` outside its `myopts` table and passes it to `switch_root -c`, so `--lowram` carries it as well.