### PR TITLE
netboot: start sshd when only a key was given

### DIFF
--- a/gentoo_install/plan/netboot.py
+++ b/gentoo_install/plan/netboot.py
@@ -591,11 +591,17 @@ class WriteMemoryEntry(Operation):
                 f"iso-scan/filename={_relative_to_mount(self.target, image)}",
                 *_inherited_consoles(context),
             ]
+            if self.launch.ssh_key or self.launch.root_password:
+                # `/etc/init.d/autoconfig:146,242` schedules sshd for `dosshd`
+                # and for nothing else, and the medium's default runlevel has
+                # no sshd in it. A key copied to `/root/.ssh` by the initramfs
+                # hook reaches a machine with no daemon listening without this.
+                words.append("dosshd")
             if self.launch.root_password:
-                # `dosshd` scrambles the root password, so it is documented as
-                # requiring `passwd=`: without one the machine comes up with
-                # sshd running and no way to authenticate to it.
-                words += ["dosshd", f"passwd={self.launch.root_password}"]
+                # The medium scrambles root's password when it starts sshd
+                # without one (`autoconfig:551-555`), so a password login needs
+                # this and a key login does not.
+                words.append(f"passwd={self.launch.root_password}")
             return tuple(words)
         words = [
             f"alpine_repo={ALPINE_REPOSITORY}",

--- a/tests/unit/test_plan_netboot.py
+++ b/tests/unit/test_plan_netboot.py
@@ -295,6 +295,23 @@ def test_no_root_password_writes_neither_half() -> None:
     assert "dosshd" not in entry and "passwd=" not in entry, entry
 
 
+def test_a_key_alone_starts_the_daemon_it_is_meant_to_authenticate_to() -> None:
+    """`/etc/init.d/autoconfig:146,242` schedules sshd for `dosshd` and for
+    nothing else, and the medium's default runlevel holds no sshd, so the key
+    the initramfs hook copies to `/root/.ssh` reached a machine with nothing
+    listening."""
+    recorder = _answering()
+    netboot.WriteMemoryEntry(
+        mode=MemoryMode.RAM,
+        target=_target(),
+        launch=_launch(ssh_key="https://github.com/zakkaus.keys"),
+    ).apply(recorder)
+
+    entry = recorder.files[PurePosixPath(f"{ESP}/loader/entries/{netboot.PLACE}.conf")]
+    assert "dosshd" in entry, entry
+    assert "passwd=" not in entry, entry
+
+
 def test_the_lowram_cmdline_names_the_repository_alpine_fetches_modloop_from() -> None:
     """`alpine_repo=auto` searches for a `.boot_repository` file and finds none
     on a machine that booted from a kernel placed on its own disk."""


### PR DESCRIPTION
`--ram --ssh-key` copied the key into `/root/.ssh/authorized_keys` from the initramfs hook and armed a machine with no daemon to present it to.

Read from the ISO's squashfs: `/etc/init.d/autoconfig:146` sets `SSHD=yes` for `dosshd` and for no other argument, `:242` schedules sshd only when `SSHD` is set, and the medium's default runlevel holds `NetworkManager`, `autoconfig`, `dbus`, `fixinittab`, `gpm`, `local` and `sysklogd` — no sshd. The word was emitted only beside a root password, so the key-only operator got network, a key on disk, and nothing on port 22.

`passwd=` stays tied to the password. The scrambling at `autoconfig:551-555` is what makes a password login need it; a key login authenticates against `authorized_keys` and does not.