### PR TITLE
netboot: never carry console=null into the armed entry

### DIFF
--- a/gentoo_install/plan/netboot.py
+++ b/gentoo_install/plan/netboot.py
@@ -131,6 +131,15 @@ CJK_CMDLINE: Final[tuple[str, ...]] = (
 #: rather than opened here: `plan/` touches no machine of its own.
 RUNNING_CMDLINE: Final[str] = "/proc/cmdline"
 
+#: The one `console=` value that means no console. Alpine's
+#: `setup_inittab_console` returns before writing a single getty when it is
+#: present (`initramfs-init.in:136-140`) and hands `switch_root -c /dev/null`,
+#: and `LIVECD_CONSOLE=null` puts the CJK medium's getty on `/dev/null`.
+#: Carrying it forward would turn "use what the machine uses" into "give the
+#: operator nothing", where writing none at least leaves both media's own
+#: detection to run.
+SILENT_CONSOLES: Final[frozenset[str]] = frozenset({"console=null"})
+
 #: `check_live_ram` in the ISO's initramfs enters an emergency shell when
 #: `MemTotal - image` is under `rd.minmem`, which defaults to 1024 MiB. The
 #: `image.squashfs` measured on 2026-08-17 is 824 MiB, so a machine under this
@@ -820,7 +829,12 @@ def _inherited_consoles(context: Context) -> tuple[str, ...]:
     said = context.run(["cat", RUNNING_CMDLINE], check=False)
     if isinstance(said, CommandOutput) and said.returncode != 0:
         return ()
-    return tuple(word for word in said.split() if word.startswith("console="))
+    return tuple(
+        word
+        for word in said.split()
+        if word.startswith("console=") and word not in SILENT_CONSOLES
+    )
+
 
 
 def _alpine_modloop(archive: PurePosixPath) -> str:

--- a/tests/unit/test_plan_netboot.py
+++ b/tests/unit/test_plan_netboot.py
@@ -391,6 +391,22 @@ def test_the_console_order_is_the_machines_own() -> None:
     assert options.index("console=ttyS0") < options.index("console=tty0"), options
 
 
+def test_the_value_that_means_no_console_is_not_carried_over() -> None:
+    """`console=null` is the one value that asks for nothing. Alpine's
+    `setup_inittab_console` returns before writing a single getty when it sees
+    it (`initramfs-init.in:136-140`) and `switch_root -c /dev/null` follows,
+    and `LIVECD_CONSOLE=null` puts the CJK medium's getty on `/dev/null`, so
+    carrying it forward is worse than carrying nothing."""
+    entry = _ram_entry("root=UUID=1e2c console=null\n")
+    assert "console=" not in entry, entry
+
+
+def test_a_real_console_beside_the_silent_one_still_comes_over() -> None:
+    entry = _ram_entry("root=UUID=1e2c console=null console=ttyS0,115200n8\n")
+    assert "console=ttyS0,115200n8" in entry, entry
+    assert "console=null" not in entry, entry
+
+
 def test_a_machine_that_names_no_console_is_left_alone() -> None:
     """An ordinary workstation boots without one, and writing `console=ttyS0`
     for it would move its first screen to a port that is not there."""


### PR DESCRIPTION
`#543` carries the machine's own `console=` words into the armed entry. One value has to be left behind.

`initramfs-init.in:136-140` is the whole reason:

    setup_inittab_console() {
        # Verify whether console=null is provided on the kernel command line
        for c in $KOPT_consoles; do
            [ "$c" = "null" ] && return

Alpine writes no getty at all, and `switch_root -c /dev/null` follows from the same word. On the CJK medium the mirror of it is `LIVECD_CONSOLE=null`, which sends `fixinittab`'s `agetty -a root` at `/dev/null`. A machine booted that way has no console by its owner's choice; the memory environment armed on it is a machine the operator has to reach, so writing none is the better answer — both media then run their own detection.

A real console beside the silent one still comes over; only the word itself is dropped.