### PR TITLE
cluster: treat a reused VMID as a stale lease, not a refusal

### DIFF
--- a/tests/unit/test_harness.py
+++ b/tests/unit/test_harness.py
@@ -1155,6 +1155,44 @@ def test_reconcile_removes_only_an_expired_locally_leased_guest(
     assert not any(vmid == 9301 for vmid in api.deleted)
 
 
+def test_a_vmid_a_live_campaign_reused_leaves_the_lease_behind_and_nothing_else(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """One schedule died holding 9301; a second one started, was given that
+    VMID, and the third one refused to remove a guest whose nonce is not its
+    own — correctly, and then ended its own run with that exception. A lease
+    naming a guest somebody else now holds is a stale lease."""
+    from typing import Any
+
+    from tests.vm import cluster
+    from tests.vm.proxmox import Api, TAG
+
+    stale = cluster.Lease("node", 9301, "gi-dead-campaign", 10)
+    stale_path = cluster._write_lease(tmp_path, stale)
+
+    class Reused(Api):
+        def __init__(self) -> None:
+            self.deleted: list[int] = []
+
+        def ours(self) -> list[tuple[str, int]]:
+            return [("node", 9301)]
+
+        def call(self, method: str, path: str, **form: Any) -> Any:
+            if path.endswith("/config"):
+                return {"tags": f"{TAG};gi-the-live-campaign"}
+            if method == "DELETE":
+                self.deleted.append(9301)
+                return "UPID:node:delete"
+            raise AssertionError((method, path))
+
+    api = Reused()
+    monkeypatch.setattr(cluster, "_pid_alive", lambda pid: False)
+    cluster.reconcile(api, tmp_path)
+
+    assert api.deleted == [], api.deleted
+    assert not stale_path.exists()
+
+
 def test_workdirs_are_confined_before_any_vm_artifact_is_written(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:

--- a/tests/vm/cluster.py
+++ b/tests/vm/cluster.py
@@ -80,6 +80,7 @@ from .monitor import keys_for
 from .proxmox import (
     Api,
     CreateConflict,
+    ForeignGuest,
     Guest,
     GuestSpec,
     GrubNotReadable,
@@ -1258,7 +1259,12 @@ def reconcile(api: Api, workdir: Path) -> None:
             lease.vmid,
             GuestSpec(name="expired-lease", iso="", nonce=lease.nonce),
         )
-        guest.destroy()
+        try:
+            guest.destroy()
+        except ForeignGuest:
+            # A second campaign reused that VMID after this lease's process
+            # died, so the lease is stale and the guest belongs to that run.
+            pass
         path.unlink()
 
 

--- a/tests/vm/proxmox.py
+++ b/tests/vm/proxmox.py
@@ -103,6 +103,10 @@ class ProxmoxNotFound(ProxmoxError):
     """The requested cluster object no longer exists."""
 
 
+class ForeignGuest(ProxmoxError):
+    """That VMID holds a guest this run did not build, so it is not ours to remove."""
+
+
 class ProxmoxTransientError(ProxmoxError):
     """The call failed in a state the caller may retry."""
 
@@ -703,11 +707,11 @@ class Guest:
                 continue
             tags = str(config.get("tags", "")).split(";")
             if TAG not in tags:
-                raise ProxmoxError(
+                raise ForeignGuest(
                     f"vm {self.vmid} on {self.node} is not tagged {TAG!r}; refusing to remove it"
                 )
             if not self.spec.nonce or self.spec.nonce not in tags:
-                raise ProxmoxError(
+                raise ForeignGuest(
                     f"vm {self.vmid} on {self.node} is not the guest this run built; "
                     "refusing to remove it"
                 )


### PR DESCRIPTION
Starting a third campaign while two were running ended before it dispatched anything:

    tests.vm.proxmox.ProxmoxError: vm 9301 on infra-node6 is not the guest this run built; refusing to remove it

The refusal itself is right and stays. A lease file named 9301 with a dead pid, a campaign that started afterwards was given 9301 by the allocator — which reads the cluster, so it was free at the time — and `reconcile` then found a lease it could not act on and raised out of `run()`. The guest that survived belongs to a campaign still using it; the lease is what is stale.

`destroy` now raises `ForeignGuest` for the two cases that mean the guest is not this run's — untagged, or tagged with another nonce — and `reconcile` drops the lease for them instead of ending the run. Nothing else catches it, so a worker asked to remove a guest it does not own still fails loudly.

The control fails on the assertion: without the catch, the new test raises `ForeignGuest` at `proxmox.py:714`.