### PR TITLE
cluster: lead an idle verdict with the counters, not the console tail

### DIFF
--- a/tests/unit/test_harness.py
+++ b/tests/unit/test_harness.py
@@ -1874,6 +1874,30 @@ def test_wait_for_does_not_accept_the_original_command_echo() -> None:
         link.wait_for("install --config vm-raidz.toml", timeout=10.0)
 
 
+def test_an_idle_verdict_names_the_counters_before_the_console_tail() -> None:
+    """A verdict is cut to `OUTCOME_BYTES`, and `zbm-unlock`'s console tail
+    filled all 300 of them, so the round could not say whether the guest's
+    counters had moved — which is the whole question a STUCK asks. The reason
+    goes first, where truncation cannot reach it."""
+    from tests.vm import cluster
+    from tests.vm.console import ConsoleIdle, ConsoleTimeout
+
+    sent: list[str] = []
+    idle = ConsoleIdle(
+        "never matched 'MARK_26_DONE', nothing arrived for 1200s; last output "
+        "was " + "b'0.1/src/shared/data-fd-util.c [294/2044] compiling'" * 6
+    )
+    link = cluster.Reconnecting(lambda: _PatternConsole(idle, sent))
+    watch = cluster.Watchdog(log=Path("/nonexistent"), counters=lambda: 0)
+
+    with pytest.raises(ConsoleTimeout) as raised:
+        link.wait_for("sh install.sh", timeout=10.0, idle=1200.0, watch=watch)
+
+    said = str(raised.value)[: cluster.OUTCOME_BYTES]
+    assert "counters were flat" in said, said
+    assert said.startswith("the console was silent for 1200s"), said
+
+
 def test_wait_for_still_accepts_the_done_marker() -> None:
     from tests.vm import cluster
 

--- a/tests/vm/cluster.py
+++ b/tests/vm/cluster.py
@@ -2248,8 +2248,12 @@ class Reconnecting:
                     reason = watch.idle_reason()
                     if reason is None:
                         continue
+                    # The reason first and the console tail after it: a
+                    # verdict is cut to `OUTCOME_BYTES`, and the console tail
+                    # alone filled all 300 of `zbm-unlock`'s, so the round
+                    # could not say whether its counters had moved.
                     raise ConsoleTimeout(
-                        f"{error}; console was silent for {idle:.0f}s and {reason}"
+                        f"the console was silent for {idle:.0f}s and {reason}: {error}"
                     ) from error
 
         self._with_reconnect(timeout, wait_once, watch=watch)


### PR DESCRIPTION
`zbm-unlock` came back `STUCK 123.3m ... never matched 'MARK_26_DONE', nothing arrived for 1200s; last output was b'0.1/src/shared/data-fd-util.c [294/2044] x86_64-pc-` and that is where the verdict ended. The watchdog had already asked the hypervisor whether the guest was moving bytes and put its answer in the same message — behind a console tail long enough to consume all 300 bytes a verdict is cut to. The round could not say whether the guest was dead or merely quiet, which is the only question a STUCK asks.

The reason goes first now. The console tail is what truncation eats.

Worth recording about that guest: its `install.rc` is `0` and its log carries `MARK_27_DONE` and `MARK_28_DONE`. The install finished and the results were collected after the harness had given up on it; the failed prompts later in that log are systemd-ask-password timing out three times with nobody at the console, not a rejected passphrase.

The control fails on the assertion and reproduces the original: with the old order, `counters were flat` is outside the first 300 bytes.