### PR TITLE
driver: stop the CD check from matching its own question

### DIFF
--- a/tests/unit/test_harness.py
+++ b/tests/unit/test_harness.py
@@ -3192,7 +3192,13 @@ def test_each_mode_waits_for_its_own_medium() -> None:
 
 class _CdAppearsLate:
     """A guest whose shell answers before its ATAPI devices are enumerated,
-    which a Debian cloud image under KVM did at 7.3 seconds."""
+    which a Debian cloud image under KVM did at 7.3 seconds.
+
+    The command is echoed back before its output, because a real shell echoes
+    the line it was given and `expect_command` answers with everything up to
+    the marker. A fake that answers only the output is what let a check match
+    its own question for two revisions.
+    """
 
     def __init__(self, ready_after: int) -> None:
         self.ready_after = ready_after
@@ -3203,9 +3209,8 @@ class _CdAppearsLate:
 
     def expect_command(self, command: str, timeout: float = 0.0) -> bytes:
         self.tries += 1
-        if self.tries > self.ready_after:
-            return b"DRIVER-READY\r\n"
-        return b"DRIVER-ABSENT\r\n"
+        code = 0 if self.tries > self.ready_after else 1
+        return f"{command}\r\ndriver={code}\r\n".encode()
 
 
 def test_the_driver_cd_is_waited_for_rather_than_asked_once(
@@ -3236,5 +3241,5 @@ def test_a_guest_that_never_sees_the_cd_says_so(
 
     monkeypatch.setattr("time.sleep", lambda seconds: None)
     console = _CdAppearsLate(ready_after=10**9)
-    with pytest.raises(DriverNotFound, match="DRIVER-ABSENT"):
+    with pytest.raises(DriverNotFound, match="driver=1"):
         wait_for_driver(cast(Any, console), patience=0.0)

--- a/tests/vm/driver.py
+++ b/tests/vm/driver.py
@@ -59,11 +59,13 @@ def wait_for_driver(console: Console, patience: float = DRIVER_PATIENCE) -> None
     deadline = time.monotonic() + patience
     while True:
         console.run(FIND_DRIVER, timeout=180.0)
+        # `expect_command` answers with everything up to the marker, and the
+        # shell echoes the line it was given, so a command naming both answers
+        # carries both in its own echo. The value is computed, never typed.
         said = console.expect_command(
-            "mountpoint -q /mnt/driver && echo DRIVER-READY || echo DRIVER-ABSENT",
-            timeout=60.0,
+            "mountpoint -q /mnt/driver; echo driver=$?", timeout=60.0
         )
-        if b"DRIVER-READY" in said:
+        if b"driver=0" in said:
             return
         if time.monotonic() >= deadline:
             raise DriverNotFound(


### PR DESCRIPTION
The first run of `tests/vm/ram.py` ended in eight seconds with `arming exited 2`. `sh` exits 2 for a script it cannot open, so `/mnt/driver/install.sh` was not there — and `wait_for_driver`, which exists to prevent exactly that, had returned instantly.

It asked `mountpoint -q /mnt/driver && echo DRIVER-READY || echo DRIVER-ABSENT` and looked for `DRIVER-READY` in the reply. `expect_command` answers with everything up to the marker, and a shell echoes the line it was given, so both answers are in the reply before the command has run. The check could not fail.

It now asks for a value that is computed rather than typed: `mountpoint -q /mnt/driver; echo driver=$?`, matched against `driver=0`.

The unit test passed throughout because its fake answered only the output. A real console echoes first, so the fake does now, and that is what makes the control red: with the old command, `wait_for_driver` returns on the first try instead of the fourth.