### PR TITLE
proxmox: watch a console opened after the line is typed

### DIFF
--- a/tests/unit/test_proxmox.py
+++ b/tests/unit/test_proxmox.py
@@ -3864,6 +3864,73 @@ def test_a_medium_that_never_answers_stops_rather_than_holding_the_schedule(
     assert guest.typed, "it has to have tried"
 
 
+class _ClosesWhileNothingCrossesIt:
+    """A node's serial session as it behaves during the typing.
+
+    The keys go through the API, so no byte crosses the console for the whole
+    minute the line takes. Measured on a guest built for the question: the
+    session was gone at 0.0s of watching on four attempts out of four, with
+    the guest silent the whole time and the log holding only the node's own
+    `starting serial terminal on interface serial0`.
+    """
+
+    def __init__(self, guest: "_AutoLoginGuest") -> None:
+        self.guest = guest
+        self.console = self
+        self.opened_at_lines = 0
+        self.reopens = 0
+
+    def expect(self, pattern: str, timeout: float, idle: float = 0.0) -> bytes:
+        from tests.vm.console import ConsoleClosed, ConsoleTimeout
+
+        if self.opened_at_lines < self.guest.lines:
+            raise ConsoleClosed(
+                "the guest closed the serial connection",
+                write_may_have_reached_guest=False,
+            )
+        if self.guest.lines >= 1:
+            return b"\r\nroot@livecd ~ # "
+        raise ConsoleTimeout("nothing on the serial port")
+
+    def reopen(self, *, solicit_prompt: bool = True) -> None:
+        self.reopens += 1
+        self.opened_at_lines = self.guest.lines
+
+
+def test_the_console_watched_is_opened_after_the_line_is_typed(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Typing one line is 38 characters of one API request each, which took 68
+    seconds on `infra-node1`, and the node closes a session that carries
+    nothing for that long. Watching the session that was open before the
+    typing is watching a session that is already gone."""
+    from typing import Any, cast
+
+    from tests.vm import proxmox
+
+    monkeypatch.setattr("time.sleep", lambda seconds: None)
+    guest = _AutoLoginGuest()
+    link = _ClosesWhileNothingCrossesIt(guest)
+
+    proxmox.open_a_serial_shell_blind(cast("Any", guest), cast("Any", link))
+
+    assert link.reopens == 1, link.reopens
+    assert guest.lines == 1, guest.lines
+
+
+def test_the_typed_line_stays_short_because_every_character_is_a_request() -> None:
+    """`KEY_PAUSE` alone is 0.12s per character before the request itself, so
+    the length of this line is a fifth of the deadline. Measured: 61 characters
+    took 68s of a 360s budget, leaving five attempts of which none watched a
+    live console."""
+    from tests.vm.proxmox import SERIAL_GETTY
+
+    assert len(SERIAL_GETTY) <= 40, SERIAL_GETTY
+    assert "agetty" in SERIAL_GETTY and "ttyS0" in SERIAL_GETTY, SERIAL_GETTY
+    assert "115200" in SERIAL_GETTY, "the baud has to match the medium's port"
+    assert SERIAL_GETTY.rstrip().endswith("&"), "it cannot hold the shell"
+
+
 def test_the_deadline_outlasts_a_loaded_node_and_the_interval_does_not() -> None:
     """An idle node reaches the auto-login in about fifteen seconds, measured
     by screenshotting a SeaBIOS guest through the QEMU monitor. A node running

--- a/tests/vm/proxmox.py
+++ b/tests/vm/proxmox.py
@@ -994,7 +994,11 @@ KERNEL_SPEAKS: Final[str] = r"Linux version|Command line:|\[    0\.000000\]"
 #: serial port carries a root shell without the kernel command line being
 #: touched. `--autologin root` because the medium scrambles the root password,
 #: and `&` because this is typed into a shell that has to stay usable.
-SERIAL_GETTY: Final[str] = "setsid agetty --autologin root --noclear ttyS0 115200 vt100 &"
+#: Short because every character is one API request with a pause after it:
+#: 61 characters measured 68s per attempt on `infra-node1`, which is a fifth of
+#: the deadline spent typing. `-a` is `--autologin`, `-L` is the medium's own
+#: commented `s0` line, and `agetty` defaults TERM to `vt100` on a serial line.
+SERIAL_GETTY: Final[str] = "setsid agetty -a root -L 115200 ttyS0&"
 
 #: What that shell prints once it is on the serial port. `root@` and not `#`:
 #: the medium's prompt carries the user and the host, and `#` alone matches
@@ -1040,6 +1044,13 @@ def open_a_serial_shell_blind(
         guest.send_keys(["ret"])
         guest.send_keys(keys_for(SERIAL_GETTY))
         guest.send_keys(["ret"])
+        # The keys go through the API, so nothing crosses the console while
+        # they are typed and the node closes an idle session. Measured on a
+        # guest of its own: 68s of typing, then `ConsoleClosed` at 0.0s of
+        # watching, four attempts out of four, with the guest silent
+        # throughout. The console that is watched is opened after the typing.
+        link.reopen(solicit_prompt=False)
+        console = link.console
         try:
             console.expect(SERIAL_SHELL_SPEAKS, timeout=AUTOLOGIN_INTERVAL)
             print(f"the serial shell answered on attempt {typed}", flush=True)


### PR DESCRIPTION
`run70` failed both BIOS fixtures on two different nodes with `no serial shell in 360s and 5 attempts`, and `ext4-bios.log` held six repetitions of the node's own `starting serial terminal on interface serial0` and not one byte from the guest.

Measured on a guest built for the question rather than inferred:

    attempt 1: CLOSED after 0.0s of watching, typing took 68.5s
    attempt 2: CLOSED after 0.0s of watching, typing took 69.9s
    attempt 3: CLOSED after 0.0s of watching, typing took 66.0s
    attempt 4: CLOSED after 0.0s of watching, typing took 70.8s

`send_keys` is one API request per character with a pause after each, so a 61-character line takes over a minute during which nothing crosses the console, and the node closes a session that carries nothing. Every attempt then watched a session that was already gone, and the 360-second deadline bought five of those.

Two changes, both from that measurement. The console watched is opened after the typing. And the line is 38 characters instead of 61 — `setsid agetty -a root -L 115200 ttyS0&`, which is the medium's own commented `s0` line plus autologin; `agetty` defaults TERM to `vt100` on a serial line.

The same fixture passes end to end locally under `tests/vm/run.py`, where QEMU gives the guest a serial console from the start, so the installer and the medium were never the problem.