### PR TITLE
console: read a check's output rather than the echo of its question

### DIFF
--- a/tests/unit/test_harness.py
+++ b/tests/unit/test_harness.py
@@ -3243,3 +3243,57 @@ def test_a_guest_that_never_sees_the_cd_says_so(
     console = _CdAppearsLate(ready_after=10**9)
     with pytest.raises(DriverNotFound, match="driver=1"):
         wait_for_driver(cast(Any, console), patience=0.0)
+
+
+class _EchoingChannel:
+    """A shell as a `Channel`: it echoes the line it was given, then answers.
+
+    Every real shell does this, and it is what the check below exists for.
+    """
+
+    def __init__(self) -> None:
+        self.pending = b""
+        self.sent: list[bytes] = []
+
+    def recv(self, size: int) -> bytes:
+        chunk, self.pending = self.pending[:size], self.pending[size:]
+        return chunk
+
+    def sendall(self, data: bytes) -> None:
+        self.sent.append(data)
+        line = data.decode().strip()
+        token = line.split("' ", 1)[1].split(";", 1)[0]
+        self.pending += (
+            f"{line}\r\nMARK_{token}_BEGIN\r\nRESOLVCONF-EMPTY\r\n"
+            f"MARK_{token}_DONE\r\n"
+        ).encode()
+
+    def close(self) -> None:
+        return None
+
+    @property
+    def closed(self) -> bool:
+        return False
+
+
+def test_a_check_reads_the_output_and_not_the_question(tmp_path: Path) -> None:
+    """`checks()` holds commands that name both answers — `echo RESOLVCONF-OK
+    || echo RESOLVCONF-EMPTY` — and the conversion runner matched the pattern
+    against everything up to the marker, which begins with the shell's echo of
+    the command. Every such check passed on any machine."""
+    from typing import Any, cast
+
+    from tests.vm.console import SerialConsole
+
+    channel = _EchoingChannel()
+    with (tmp_path / "console.log").open("wb") as log:
+        console = SerialConsole(cast(Any, channel), log)
+        command = (
+            "test -s /etc/resolv.conf && echo RESOLVCONF-OK || echo RESOLVCONF-EMPTY"
+        )
+        said = console.expect_output(command, timeout=5.0)
+        whole = console.expect_command(command, timeout=5.0)
+
+    assert b"RESOLVCONF-OK" not in said, said
+    assert b"RESOLVCONF-EMPTY" in said, said
+    assert b"RESOLVCONF-OK" in whole, "the echo is what the old reading carried"

--- a/tests/vm/console.py
+++ b/tests/vm/console.py
@@ -273,6 +273,20 @@ class SerialConsole:
         said = self.expect(command_done(token), timeout)
         return said.split(command_done(token).encode())[0]
 
+    def expect_output(self, command: str, timeout: float = 120.0) -> bytes:
+        """Run a command and answer with what it printed, and nothing else.
+
+        Between the two markers, not up to the last one: the shell echoes the
+        line it was given, so what `expect_command` answers begins with the
+        command itself. A check whose command names its own answer — `echo
+        RESOLVCONF-OK || echo RESOLVCONF-EMPTY` — then matches the question.
+        """
+        token = next(self._tokens)
+        self.send(marked_command(command, token))
+        self.expect(command_begin(token), timeout)
+        said = self.expect(command_done(token), timeout)
+        return said.split(command_done(token).encode())[0]
+
     def login(self, user: str, password: str | None, prompt: str) -> None:
         self.expect(r"login:", timeout=300.0)
         self.send(user)

--- a/tests/vm/convert.py
+++ b/tests/vm/convert.py
@@ -195,7 +195,7 @@ def reach_root(console: SerialConsole, chosen: CloudImage) -> None:
 def install_tools(console: SerialConsole, chosen: CloudImage, config: str) -> None:
     """Install what the launcher says is missing, the way an operator would."""
     console.run(FIND_DRIVER, timeout=180.0)
-    said = console.expect_command(
+    said = console.expect_output(
         f"sh /mnt/driver/install.sh --config {config} --missing-commands || true",
         timeout=300.0,
     ).decode("utf-8", "replace")
@@ -249,7 +249,7 @@ def boot_and_check(root: Path, workdir: Path, chosen: CloudImage, config: str) -
         console.expect(r"#|\$", timeout=180.0)
         failed: list[str] = []
         for check in checks(installation):
-            said = console.expect_command(check.command, timeout=180.0)
+            said = console.expect_output(check.command, timeout=180.0)
             text = said.decode("utf-8", "replace")
             if not re.search(check.pattern, text, re.MULTILINE):
                 failed.append(f"{check.name} does not match {check.pattern!r}: {text[-200:]!r}")

--- a/tests/vm/ram.py
+++ b/tests/vm/ram.py
@@ -77,7 +77,7 @@ def read_the_default_entry(console: SerialConsole) -> bytes:
     than assumed: an arming that quietly became the default is the failure
     `--bypass` exists to make explicit.
     """
-    return console.expect_command(
+    return console.expect_output(
         "grub-editenv list 2>/dev/null; efibootmgr 2>/dev/null | grep -i bootorder "
         "|| echo NO-BOOTORDER",
         timeout=60.0,


### PR DESCRIPTION
Half the installed-state checks name both of their own answers:

    test -s /etc/resolv.conf && echo RESOLVCONF-OK || echo RESOLVCONF-EMPTY
    emerge --info >/dev/null 2>&1 && echo EMERGE-OK || echo EMERGE-FAIL

`boot_and_check` in the conversion runner matched each pattern against `expect_command`, which answers with everything up to the done marker — and a shell echoes the line it was given first. So `RESOLVCONF-OK` was in the reply before the command ran. Those checks could not fail on any machine, on the path that decides whether a converted system is usable.

`expect_output` reads between the begin and done markers instead, which is what `Reconnecting.expect_output` already does for the cluster. The conversion checks use it, as do the two reads whose commands also carry their own answers.

Found while fixing the same defect one layer down: `wait_for_driver` asked `echo DRIVER-READY || echo DRIVER-ABSENT` and always saw READY, which is why the first memory-mode run armed nothing.

The control fails on the assertion: with `expect_command`, the reply carries `RESOLVCONF-OK` on a machine whose resolv.conf is empty. The fake is a real `SerialConsole` over a channel that echoes, because a fake that answers only the output is what hid this.