### PR TITLE
qemu: hand the driver medium to the guest over virtio

### DIFF
--- a/tests/unit/test_harness.py
+++ b/tests/unit/test_harness.py
@@ -2896,7 +2896,8 @@ def test_the_driver_cd_is_found_rather_than_numbered(tmp_path: Path) -> None:
         ["sh", "-c", FIND_DRIVER], env=environment, capture_output=True, text=True
     )
     assert refused.returncode != 0, refused
-    assert calls.read_text().split("\n")[:2] == [
+    assert calls.read_text().split("\n")[:3] == [
+        "-o ro /dev/disk/by-label/GENTOO-INSTALL /mnt/driver",
         "-o ro /dev/sr1 /mnt/driver",
         "-o ro /dev/sr0 /mnt/driver",
     ], calls.read_text()
@@ -3297,3 +3298,65 @@ def test_a_check_reads_the_output_and_not_the_question(tmp_path: Path) -> None:
     assert b"RESOLVCONF-OK" not in said, said
     assert b"RESOLVCONF-EMPTY" in said, said
     assert b"RESOLVCONF-OK" in whole, "the echo is what the old reading carried"
+
+
+def test_the_driver_medium_reaches_a_guest_with_no_ata_driver(tmp_path: Path) -> None:
+    """The Debian genericcloud kernel builds no ATA or AHCI driver, so a
+    `media=cdrom` drive gave the guest no `/dev/sr*` at all: measured inside
+    one, `lsblk` listed `vda` and `vdb` and nothing else, and both the
+    conversion and the memory-mode runner died in seven seconds with
+    `/dev/sr0: Can't open blockdev`."""
+    from tests.vm.media import MEDIA
+    from tests.vm.qemu import Vm, VmSpec
+
+    spec = VmSpec(
+        medium=MEDIA["official-minimal"],
+        workdir=tmp_path,
+        driver_iso=tmp_path / "driver.iso",
+        boot_installed=True,
+    )
+    argv = Vm(spec)._argv()
+
+    assert "virtio-blk-pci,drive=driver" in argv, argv
+    assert not any("media=cdrom" in one and "driver" in one for one in argv), argv
+
+
+def test_the_driver_medium_is_found_by_its_label_first() -> None:
+    """A device node names where this run attached it; the label names what it
+    is. The guest above has the medium at `/dev/vda`, and no list of `sr`
+    nodes reaches it."""
+    from tests.vm.driver import FIND_DRIVER, LABEL
+
+    assert f"/dev/disk/by-label/{LABEL}" in FIND_DRIVER, FIND_DRIVER
+    assert FIND_DRIVER.index(LABEL) < FIND_DRIVER.index("/dev/sr"), FIND_DRIVER
+
+
+class _MissingCommands:
+    """A guest whose launcher prints the commands its preflight will refuse
+    for: one bare name per line, which is what `--missing-commands` prints."""
+
+    def __init__(self) -> None:
+        self.ran: list[str] = []
+
+    def run(self, command: str, timeout: float = 0.0) -> None:
+        self.ran.append(command)
+
+    def expect_output(self, command: str, timeout: float = 0.0) -> bytes:
+        return b"gpg\r\ngpg-agent\r\n"
+
+
+def test_the_missing_commands_are_installed_before_the_conversion() -> None:
+    """`--missing-commands` prints bare names. The reading this replaces looked
+    for `run: ` and for the package manager's own name, matched neither,
+    installed nothing, and let the conversion reach `preflight: these commands
+    are missing: gpg, gpg-agent` with exit code 4."""
+    from typing import Any, cast
+
+    from tests.vm.convert import IMAGES, install_tools
+
+    console = _MissingCommands()
+    install_tools(cast(Any, console), IMAGES["debian"], "fixtures/vm-convert.toml")
+
+    installs = [one for one in console.ran if "apt-get" in one]
+    assert len(installs) == 1, console.ran
+    assert installs[0].endswith("gpg gpg-agent"), installs[0]

--- a/tests/vm/convert.py
+++ b/tests/vm/convert.py
@@ -18,7 +18,7 @@ import shutil
 import subprocess
 import sys
 import time
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Final
 
@@ -74,6 +74,9 @@ class CloudImage:
     #: The firmware the image can boot. `genericcloud` and Fedora Cloud Base
     #: carry an ESP; the Alpine BIOS variant does not.
     firmware: Firmware
+    #: A command whose package is not named after it. Every other name goes to
+    #: the package manager as it was printed.
+    packages: dict[str, str] = field(default_factory=dict)
 
     @property
     def image(self) -> Path:
@@ -199,14 +202,17 @@ def install_tools(console: SerialConsole, chosen: CloudImage, config: str) -> No
         f"sh /mnt/driver/install.sh --config {config} --missing-commands || true",
         timeout=300.0,
     ).decode("utf-8", "replace")
+    # One bare command name per line, which is what `--missing-commands`
+    # prints: an earlier reading looked for `run: ` and for the installer's own
+    # name, found neither, installed nothing, and let the conversion reach a
+    # preflight that refused with `these commands are missing: gpg, gpg-agent`.
     wanted = [
-        line.split(":", 1)[1].strip()
-        for line in said.splitlines()
-        if line.startswith("run: ") or "install" in line and chosen.installer in line
+        chosen.packages.get(name, name)
+        for name in (line.strip() for line in said.splitlines())
+        if name and " " not in name and not name.startswith("MARK_")
     ]
-    for line in wanted:
-        if line:
-            console.run(line, timeout=1800.0)
+    if wanted:
+        console.run(f"{chosen.install} {' '.join(sorted(set(wanted)))}", timeout=1800.0)
 
 
 def convert(console: SerialConsole, config: str) -> None:

--- a/tests/vm/driver.py
+++ b/tests/vm/driver.py
@@ -25,9 +25,13 @@ LABEL = "GENTOO-INSTALL"
 #: medium is booted and the only one when a guest boots from its own disk.
 #: One line, because a caller sends it down a serial console as one command,
 #: and the exit status is `mountpoint`'s answer, not the last failed mount's.
+#: The label first and the device nodes after it: the medium is found by what
+#: it is rather than by where this run happened to attach it. Measured on the
+#: Debian genericcloud image, which builds no ATA or AHCI driver at all and so
+#: has no `/dev/sr*` for a CD to appear at.
 FIND_DRIVER = (
     "mkdir -p /mnt/driver; mountpoint -q /mnt/driver || "
-    "for candidate in /dev/sr1 /dev/sr0; do "
+    f"for candidate in /dev/disk/by-label/{LABEL} /dev/sr1 /dev/sr0; do "
     'mount -o ro "$candidate" /mnt/driver 2>/dev/null && break; done; '
     "mountpoint -q /mnt/driver"
 )

--- a/tests/vm/qemu.py
+++ b/tests/vm/qemu.py
@@ -124,7 +124,18 @@ class Vm:
         if self.spec.firmware is Firmware.UEFI:
             argv += self._ovmf_args()
         if self.spec.driver_iso is not None:
-            argv += ["-drive", f"file={self.spec.driver_iso},media=cdrom,readonly=on"]
+            # Bound to the machine's AHCI bus rather than left for QEMU to
+            # place: a bare `-drive media=cdrom` lands on q35's legacy IDE,
+            # which the Debian genericcloud kernel does not build, so the
+            # guest enumerated no CD at all and both runners died in seven
+            # seconds with `/dev/sr0: Can't open blockdev`.
+            argv += [
+                "-drive",
+                f"file={self.spec.driver_iso},format=raw,readonly=on,"
+                "if=none,id=driver",
+                "-device",
+                "virtio-blk-pci,drive=driver",
+            ]
         for index, disk in enumerate(self.spec.disks):
             argv += [
                 "-drive", f"file={disk},format=raw,if=none,id=disk{index}",


### PR DESCRIPTION
Both local runners that drive a cloud image — the in-place conversion and the memory environment — died in seven seconds with the installer exiting 2, which is what `sh` answers for a script it cannot open. Asked from inside one of those guests:

    $ ls -l /dev/sr* /dev/cdrom
    ls: cannot access '/dev/sr*': No such file or directory
    $ lsblk
    vda 2M  vdb 370K  vdc 24G
    $ dmesg | grep -i -e cdrom -e ahci -e ata1
    (nothing)

The Debian genericcloud kernel builds no ATA or AHCI driver at all, so a `media=cdrom` drive is attached by QEMU and invisible to the guest. Binding it to the machine's AHCI bus does not help for the same reason. It goes over virtio now, which is the only transport that image has.

Two changes follow from that. The medium is found by `/dev/disk/by-label/GENTOO-INSTALL` before any device node, because a node names where this run attached it and the label names what it is. And `install_tools` reads `--missing-commands` as what it prints — one bare command name per line — instead of looking for `run: ` and the package manager's own name, which matched nothing, installed nothing, and let the conversion reach `preflight: these commands are missing: gpg, gpg-agent`.

Measured after the change: the same conversion reaches the guest's shell at 7.3s, installs `gpg gpg-agent`, and is merging `linux-firmware` — the first time this path has run past its own preflight on this workstation.