### PR TITLE
portage: degrade when the community key cannot be merged

### DIFF
--- a/gentoo_install/plan/portage.py
+++ b/gentoo_install/plan/portage.py
@@ -839,6 +839,10 @@ class Emerge(Operation):
     repository_bootstrap: bool = False
     mode: InstallMode = InstallMode.NORMAL
     source: SourcePolicy = SourcePolicy.binaries_allowed()
+    #: What to degrade rather than fail, when this emerge is what enables an
+    #: optional path. Empty means the install stops, which is right for
+    #: everything the machine needs to boot.
+    degrades: str = ""
 
     def __post_init__(self) -> None:
         self.source.built_from(self.packages)
@@ -870,6 +874,8 @@ class Emerge(Operation):
         except CommandFailed as error:
             marker = _binpkg_failure(str(error))
             if marker is None or context.degraded(BINARY_PACKAGES):
+                if self._optional(context, str(error)):
+                    return
                 raise
             if (again := self._one_more_binary_try(context, command)) is not None:
                 marker = again
@@ -890,6 +896,8 @@ class Emerge(Operation):
             self._from_source(context)
             return
         if not _binpkg_failure(str(result)) or context.degraded(BINARY_PACKAGES):
+            if self._optional(context, str(result)):
+                return
             raise CommandFailed(f"emerge ended with {result.ending}: {str(result).strip()}")
         marker = _binpkg_failure(str(result))
         if (again := self._one_more_binary_try(context, command)) is not None:
@@ -898,6 +906,19 @@ class Emerge(Operation):
             return
         context.degrade(BINARY_PACKAGES, f"selected binary package failed: {marker}")
         self._from_source(context)
+
+    def _optional(self, context: Context, said: str) -> bool:
+        """Whether this failure degrades a path instead of ending the install.
+
+        `sec-keys/openpgp-keys-gentoozh` is the whole of it today: its distfile
+        is not on the Gentoo mirrors, so a machine whose only route to
+        `distfiles.gentoozh.org` is down took the install down with it, exit 4
+        with the disk already partitioned and the stage3 unpacked.
+        """
+        if not self.degrades:
+            return False
+        context.degrade(self.degrades, f"{' '.join(self.packages)} did not merge: {said.strip()[:200]}")
+        return True
 
     def _from_source(self, context: Context) -> None:
         retry_result = context.run_in_target(self._argv(context, source_only=True), check=False)
@@ -1421,6 +1442,7 @@ def build(
                 summary="install the key the community binary packages are signed with",
                 source=SourcePolicy.build_all(),
                 repository_bootstrap=True,
+                degrades=BINARY_PACKAGES,
             ),
             TrustBinhostKey(
                 binhost="gentoo-zh",

--- a/tests/unit/test_plan_portage.py
+++ b/tests/unit/test_plan_portage.py
@@ -2285,3 +2285,63 @@ def test_a_manifest_mismatch_waits_the_same_every_time() -> None:
         )
 
     assert len({waits() for _ in range(8)}) == 1
+
+
+def test_an_overlay_key_that_cannot_be_fetched_degrades_rather_than_ends_the_run() -> None:
+    """`sec-keys/openpgp-keys-gentoozh` carries the key the community binary
+    packages are signed with, and its distfile is on no Gentoo mirror: a guest
+    whose route to `distfiles.gentoozh.org` was down answered `404` from the
+    local mirror, `Temporary failure in name resolution` from the rest, and
+    the whole install ended with exit 4 — disk partitioned, stage3 unpacked,
+    machine unusable. Every binary-host failure degrades to source."""
+    from gentoo_install.plan.portage import BINARY_PACKAGES, Emerge, SourcePolicy
+
+    recorder = Recorder()
+    recorder.failures.add("emerge")
+    operation = Emerge(
+        packages=("sec-keys/openpgp-keys-gentoozh",),
+        summary="install the key the community binary packages are signed with",
+        source=SourcePolicy.build_all(),
+        repository_bootstrap=True,
+        degrades=BINARY_PACKAGES,
+    )
+
+    operation.apply(recorder)
+
+    assert recorder.degraded(BINARY_PACKAGES), recorder.given_up
+    assert "openpgp-keys-gentoozh" in recorder.degradations[BINARY_PACKAGES]
+
+
+def test_the_plan_marks_that_key_as_one_the_run_may_lose() -> None:
+    """The operation degrades only because the plan says it may. Without this
+    the constructor test above passes on an object no planner ever builds."""
+    from gentoo_install.plan.portage import BINARY_PACKAGES, Emerge
+
+    installation = with_portage(
+        binhost=Binhost(official=True, community=BinhostChannel.STABLE)
+    )
+    operations = portage.build(installation, MIRROR)
+    keys = [
+        one
+        for one in operations
+        if isinstance(one, Emerge) and "openpgp-keys-gentoozh" in " ".join(one.packages)
+    ]
+
+    assert len(keys) == 1, [one.describe() for one in operations]
+    assert keys[0].degrades == BINARY_PACKAGES, keys[0]
+
+
+def test_an_emerge_the_machine_needs_still_ends_the_run() -> None:
+    """The same failure without `degrades` is what every package the machine
+    has to boot with uses, and it has to stop the install."""
+    import pytest as _pytest
+
+    from gentoo_install.errors import CommandFailed
+    from gentoo_install.plan.portage import Emerge
+
+    recorder = Recorder()
+    recorder.failures.add("emerge")
+    operation = Emerge(packages=("sys-kernel/gentoo-kernel-bin",), summary="the kernel")
+
+    with _pytest.raises(CommandFailed):
+        operation.apply(recorder)


### PR DESCRIPTION
`btrfs-luks` in run70 ended `the installer exited 4` after fourteen minutes. Its log:

    >>> Downloading 'http://10.31.0.2/gentoo/distfiles/31/openpgp-keys-gentoozh-20260726.asc'
    HTTP request sent, awaiting response... 404 Not Found
    >>> Downloading 'https://mirror.nju.edu.cn/gentoo-zh/distfiles/openpgp-keys-gentoozh-20260726.asc'
    Resolving mirror.nju.edu.cn... 210.28.130.3 ... 404 Not Found
    >>> Downloading 'https://distfiles.gentoozh.org/distfiles/openpgp-keys-gentoozh-20260726.asc'
    Resolving distfiles.gentoozh.org... failed: Temporary failure in name resolution.

The local mirror carries Gentoo's distfiles and not the overlay's, `mirror.nju.edu.cn` answered 404 for the same file, and the only host that has it did not resolve. The key is what makes the community binary host verifiable, and the repository's own rule is that every binary-host failure degrades to compiling from source with a visible warning. This one took the machine with it: partitioned disk, unpacked stage3, exit 4.

`Emerge` gains one field naming what a failure degrades, empty everywhere else, so nothing the machine needs to boot becomes optional. `TrustBinhostKey` and `ConfigureBinhost` already skip a degraded subject, and the reason lands in `install.jsonl`.

The first control passed with the field removed — the constructor test builds its own `Emerge`, which no planner produces — so a second test asserts the plan itself marks that one, and that one fails on its assertion.