### PR TITLE
proxmox: size the blind deadline by what an attempt costs

### DIFF
--- a/tests/unit/test_proxmox.py
+++ b/tests/unit/test_proxmox.py
@@ -3936,8 +3936,16 @@ def test_the_deadline_outlasts_a_loaded_node_and_the_interval_does_not() -> None
     by screenshotting a SeaBIOS guest through the QEMU monitor. A node running
     twelve of them takes longer than any number written here, so the interval
     is short enough to keep trying and the deadline is the only guess."""
-    from tests.vm.proxmox import AUTOLOGIN_DEADLINE, AUTOLOGIN_INTERVAL
+    from tests.vm.proxmox import (
+        AUTOLOGIN_DEADLINE,
+        AUTOLOGIN_INTERVAL,
+        AUTOLOGIN_TYPING,
+    )
 
     assert AUTOLOGIN_INTERVAL <= 30.0, AUTOLOGIN_INTERVAL
-    assert AUTOLOGIN_DEADLINE >= 300.0, AUTOLOGIN_DEADLINE
-    assert AUTOLOGIN_DEADLINE / AUTOLOGIN_INTERVAL >= 10, "too few attempts"
+    # Against what an attempt costs, not against the interval alone: typing is
+    # most of it, so the old reading predicted eighteen attempts where five
+    # happened.
+    attempts = AUTOLOGIN_DEADLINE / (AUTOLOGIN_TYPING + AUTOLOGIN_INTERVAL)
+    assert attempts >= 10, f"{attempts:.0f} attempts is too few"
+    assert AUTOLOGIN_TYPING >= 48.7, "measured on infra-node5, the fastest of three"

--- a/tests/vm/proxmox.py
+++ b/tests/vm/proxmox.py
@@ -1014,7 +1014,19 @@ SERIAL_SHELL_SPEAKS: Final[str] = r"root@[^\s]+"
 #: right for both. So the line goes in again every interval until the port
 #: answers or the deadline passes, and the deadline is the only guess left.
 AUTOLOGIN_INTERVAL: Final[float] = 20.0
-AUTOLOGIN_DEADLINE: Final[float] = 360.0
+
+#: What one attempt costs before the port is looked at at all. `send_keys` is
+#: one API request per character with `KEY_PAUSE` after each, and the
+#: 38-character line measured 48.7s, 57.2s and 51.2s on `infra-node5`; the
+#: 61-character line it replaced measured 66s to 70s on `infra-node1`.
+AUTOLOGIN_TYPING: Final[float] = 60.0
+
+#: Twelve attempts at what one of them actually costs. A guest built for the
+#: question answered on its third try on an idle node; the 360s this replaces
+#: bought five on a loaded one, and every BIOS fixture in run71 spent all five
+#: without reaching a shell. The old arithmetic divided the deadline by the
+#: interval alone, which counts the watching and not the typing.
+AUTOLOGIN_DEADLINE: Final[float] = 12 * (AUTOLOGIN_TYPING + AUTOLOGIN_INTERVAL)
 
 
 def open_a_serial_shell_blind(


### PR DESCRIPTION
`#551` changed what run71's BIOS fixtures say from `the guest closed the serial connection` to `never matched 'root@...'` — the session survives now, and the guest is genuinely silent for all five attempts the deadline buys.

Five, not eighteen. `AUTOLOGIN_DEADLINE / AUTOLOGIN_INTERVAL >= 10` was the assertion holding that number, and it counts only the watching. Measured on a guest built for the question, the typing is most of an attempt:

    attempt 1: silent,   typing 48.7s, watching 20.1s
    attempt 2: CLOSED,   typing 57.2s
    attempt 3: ANSWERED, typing 51.2s, watching 0.1s

The blind path does work — that guest reached a root shell on its third try, on an idle node. A node running eight of them is slower, and 360 seconds does not hold three attempts there, let alone the ten this was meant to allow.

The deadline is now twelve times what one attempt costs, with the typing measured rather than assumed. The test asserts against the same arithmetic, and fails on that assertion with the old 360.