### PR TITLE
convert: prove a converted machine still has its /home

### DIFF
--- a/tests/unit/test_harness.py
+++ b/tests/unit/test_harness.py
@@ -2939,6 +2939,51 @@ def test_every_driver_mount_goes_through_the_one_finder() -> None:
     assert "/dev/sr1 /dev/sr0" in FIND_DRIVER
 
 
+def test_a_conversion_marks_home_and_checks_the_marker_after_boot(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The marker write and read must both be wired to the conversion path."""
+    from gentoo_install.exec.config import load
+    from tests.vm import convert
+
+    class Console:
+        def __init__(self) -> None:
+            self.commands: list[str] = []
+            self.asked: list[str] = []
+            self.answer = b""
+
+        def run(self, command: str, timeout: float = 0.0) -> None:
+            self.commands.append(command)
+
+        def expect_output(self, command: str, timeout: float = 0.0) -> bytes:
+            self.asked.append(command)
+            return self.answer
+
+        def expect_command(self, command: str, timeout: float = 0.0) -> bytes:
+            raise AssertionError("the preservation check used expect_command")
+
+    console = Console()
+    convert.convert(cast(Any, console), "fixtures/vm-convert.toml")
+    assert console.commands[0] == (
+        f"printf '%s\\n' {convert.HOME_MARKER} > {convert.HOME_MARKER_PATH}"
+    )
+
+    installation = load(Path("tests/fixtures/vm-convert.toml"))
+    assert convert.HOME_MARKER_CHECK in convert.conversion_checks(installation)
+    monkeypatch.setattr(
+        convert,
+        "conversion_checks",
+        lambda _: (convert.HOME_MARKER_CHECK,),
+    )
+    console.answer = f"{convert.HOME_MARKER}\n".encode()
+    assert convert.check_installed(cast(Any, console), installation) == ""
+    assert console.asked == [convert.HOME_MARKER_CHECK.command]
+
+    for answer in (b"", b"not-the-home-marker\n"):
+        console.answer = answer
+        assert "home marker" in convert.check_installed(cast(Any, console), installation)
+
+
 def test_a_conversion_asks_for_a_port_nobody_holds() -> None:
     """Two runs asked for 2222 and the second died with
 

--- a/tests/unit/test_plan_convert.py
+++ b/tests/unit/test_plan_convert.py
@@ -232,10 +232,19 @@ def test_the_kernel_reaches_boot_between_the_swap_and_the_bootloader() -> None:
     assert swapped < populated < grub
 
 
-def test_boot_is_not_one_of_the_directories_that_are_renamed() -> None:
-    """A rename refuses a mount point and a directory holding one, and `/boot`
-    is one on many machines and holds the esp on many more."""
-    assert "boot" not in convert.REPLACED_DIRECTORIES
+@pytest.mark.parametrize(
+    ("name", "reason"),
+    (
+        ("home", "user files must survive the in-place conversion"),
+        ("root", "the root user's home must survive the in-place conversion"),
+        ("srv", "service data must survive the in-place conversion"),
+        ("opt", "optional software and data must survive the in-place conversion"),
+        ("boot", "mount points and the ESP cannot be atomically renamed"),
+    ),
+)
+def test_non_system_directories_are_not_replaced(name: str, reason: str) -> None:
+    """The swap covers system directories, not user data or mount points."""
+    assert name not in convert.REPLACED_DIRECTORIES, reason
 
 
 class _RunningContext:

--- a/tests/vm/convert.py
+++ b/tests/vm/convert.py
@@ -23,10 +23,11 @@ from pathlib import Path
 from typing import Final
 
 from gentoo_install.exec.config import load
+from gentoo_install.model.config import InstallConfig
 
 from .console import PASSWORD_PROMPT, SerialConsole
 from .driver import FIND_DRIVER, REPOSITORY, build as build_driver
-from .installed import checks
+from .installed import InstalledCheck, checks
 from .media import MEDIA
 from .qemu import Firmware, Vm, VmSpec
 from .run import free_port
@@ -39,6 +40,15 @@ WORKROOT: Final[Path] = Path.home() / "code/gentoo-install/lab/vm/converts"
 #: What cloud-init is told to set, so the harness can log in over serial. The
 #: images ship no password at all and no key the harness holds.
 ROOT_PASSWORD: Final[str] = "install"
+#: The payload is also part of the path: `expect_command` would otherwise match
+#: the shell's echo of `cat`, so the marker check must use `expect_output`.
+HOME_MARKER: Final[str] = "gentoo-install-home-survives-conversion-4f9d6e2a"
+HOME_MARKER_PATH: Final[Path] = Path("/home") / f".{HOME_MARKER}"
+HOME_MARKER_CHECK: Final[InstalledCheck] = InstalledCheck(
+    "home marker",
+    f"cat {HOME_MARKER_PATH}",
+    re.escape(HOME_MARKER),
+)
 
 #: Bigger than every image here, so cloud-init's `growpart` and `resizefs`
 #: run on first boot. A 5 GiB Fedora root cannot hold a stage3 and a kernel.
@@ -214,9 +224,33 @@ def install_tools(console: SerialConsole, chosen: CloudImage, config: str) -> No
     if wanted:
         console.run(f"{chosen.install} {' '.join(sorted(set(wanted)))}", timeout=1800.0)
 
+def write_home_marker(console: SerialConsole) -> None:
+    """Write the conversion's unique sentinel outside the replaced tree."""
+    console.run(
+        f"printf '%s\\n' {HOME_MARKER} > {HOME_MARKER_PATH}",
+        timeout=60.0,
+    )
+
+
+def conversion_checks(installation: InstallConfig) -> tuple[InstalledCheck, ...]:
+    """Add the in-place preservation check to the installed-state contract."""
+    return (*checks(installation), HOME_MARKER_CHECK)
+
+
+def check_installed(console: SerialConsole, installation: InstallConfig) -> str:
+    """Run installed-state checks and return the failures, if any."""
+    failed: list[str] = []
+    for check in conversion_checks(installation):
+        said = console.expect_output(check.command, timeout=180.0)
+        text = said.decode("utf-8", "replace")
+        if not re.search(check.pattern, text, re.MULTILINE):
+            failed.append(f"{check.name} does not match {check.pattern!r}: {text[-200:]!r}")
+    return "; ".join(failed)
+
 
 def convert(console: SerialConsole, config: str) -> None:
     """Run the installer in place and keep everything it printed."""
+    write_home_marker(console)
     console.run("mkdir -p /tmp/gentoo-install-results", timeout=60.0)
     console.run(
         f"{{ sh /mnt/driver/install.sh --config {config}; echo $? "
@@ -224,7 +258,6 @@ def convert(console: SerialConsole, config: str) -> None:
         "| tee /tmp/gentoo-install-results/install.txt",
         timeout=CONVERT_CEILING,
     )
-
 
 def boot_and_check(root: Path, workdir: Path, chosen: CloudImage, config: str) -> str:
     """Boot what the conversion produced and read it. Answer "" when it holds.
@@ -253,13 +286,7 @@ def boot_and_check(root: Path, workdir: Path, chosen: CloudImage, config: str) -
         console.expect(PASSWORD_PROMPT, timeout=120.0)
         console.send(ROOT_PASSWORD)
         console.expect(r"#|\$", timeout=180.0)
-        failed: list[str] = []
-        for check in checks(installation):
-            said = console.expect_output(check.command, timeout=180.0)
-            text = said.decode("utf-8", "replace")
-            if not re.search(check.pattern, text, re.MULTILINE):
-                failed.append(f"{check.name} does not match {check.pattern!r}: {text[-200:]!r}")
-        return "; ".join(failed)
+        return check_installed(console, installation)
 
 
 def read_the_boot_order(console: SerialConsole) -> str:


### PR DESCRIPTION
An in-place conversion replaces `bin sbin etc lib lib64 usr var` and nothing else, so `/home` survives. That promise was held by one tuple and by no test that reads a file back from a machine the conversion produced.

The runner writes a marker under `/home` before the conversion starts and reads it back after the converted system boots, as one more installed-state check. It uses `expect_output`: a check whose command names its own answer matches the shell's echo, which is how `RESOLVCONF-OK` passed on every machine until `#552`.

The directory test now names each directory and why it is absent — `home`, `root`, `srv`, `opt` for what is on them, `boot` because a rename refuses a mount point.

Both controls fail on their assertions, run here rather than taken on report: removing the marker write reddens the wiring test, and adding `home` to `REPLACED_DIRECTORIES` reddens the parametrised case for it.