### PR TITLE
system: install a machine that configures its own address

### DIFF
--- a/tests/fixtures/static-ip.toml
+++ b/tests/fixtures/static-ip.toml
@@ -1,0 +1,88 @@
+# The smallest installed system with a static address. The cluster's first VMID
+# receives 10.31.0.150/24; the gateway and resolvers are on that segment.
+config_version = 1
+
+[system]
+hostname = "staticip"
+timezone = "UTC"
+locales = ["en_US.UTF-8"]
+locale = "en_US.UTF-8"
+init = "systemd"
+interface = "ens18"
+addresses = ["10.31.0.150/24"]
+gateways = ["10.31.0.254"]
+dns = ["10.31.0.199", "10.31.0.254"]
+root_password_hash = "$6$gentooinst$IR3GrdJ862XljQYDqocr4tKniIRDIT.jQNFzIrHE3U75H6B6YSWZoSYoVd5edSHpqaYBdiNfXHCoIPRVgb9lT/"
+
+[portage]
+profile = "default/linux/amd64/23.0/systemd"
+makeopts = "-j4"
+
+[portage.binhost]
+official = true
+community = "off"
+
+[kernel]
+source = "dist-bin"
+
+[bootloader]
+kind = "grub"
+firmware = "uefi"
+kernel_params = ["console=ttyS0,115200"]
+
+[disk]
+root = "mnt-root"
+
+[[disk.devices]]
+kind = "existing"
+id = "disk"
+selector = "/dev/disk/by-id/virtio-target0"
+wipe = true
+
+[[disk.devices]]
+kind = "table"
+id = "table"
+disk = "disk"
+table = "gpt"
+
+[[disk.devices]]
+kind = "partition"
+id = "esp"
+table = "table"
+index = 1
+role = "esp"
+size = "512MiB"
+
+[[disk.devices]]
+kind = "partition"
+id = "rootpart"
+table = "table"
+index = 2
+role = "data"
+
+[[disk.devices]]
+kind = "filesystem"
+id = "espfs"
+device = "esp"
+type = "vfat"
+label = "ESP"
+
+[[disk.devices]]
+kind = "filesystem"
+id = "rootfs"
+device = "rootpart"
+type = "ext4"
+label = "gentoo"
+
+[[disk.devices]]
+kind = "mountpoint"
+id = "mnt-root"
+source = "rootfs"
+path = "/"
+
+[[disk.devices]]
+kind = "mountpoint"
+id = "mnt-esp"
+source = "espfs"
+path = "/efi"
+options = ["umask=0077"]

--- a/tests/golden/static-ip.txt
+++ b/tests/golden/static-ip.txt
@@ -1,0 +1,71 @@
+[partition]
+  release anything a previous run of this configuration left mounted or open
+  wipe existing signatures from disk
+  create a gpt partition table on disk as table
+  create partition 1 on disk as esp: esp, 512MiB
+  create partition 2 on disk as rootpart: data, the rest of the disk
+  reread the partition table of disk and wait for its nodes
+
+[format]
+  make a vfat filesystem on esp as espfs labelled ESP
+  make a ext4 filesystem on rootpart as rootfs labelled gentoo
+
+[mount]
+  mount rootpart at /
+  mount esp at /efi with umask=0077
+
+[stage3]
+  download the newest systemd stage3 from https://distfiles.gentoo.org directly, verify it against BB572E0E2D182910 and unpack it into the target
+
+[chroot]
+  mount transient proc, sys, dev and run filesystems into the target
+  seed the target's resolv.conf from the install medium
+
+[portage]
+  write /etc/portage/make.conf with MAKEOPTS, INPUT_DEVICES, ACCEPT_LICENSE, L10N, FEATURES; 2 mirrors in the configured order, 5 appended
+  configure Portage, wget, curl, git and gpg for direct connection
+  create the three autounmask files emerge writes its decisions into
+  run getuto so Portage has a keyring to verify binary packages against
+  add verified binary package host gentoo at https://distfiles.gentoo.org/releases/amd64/binpackages/23.0/x86-64
+  fetch the first ebuild repository snapshot with emerge-webrsync
+  select profile default/linux/amd64/23.0/systemd
+  install git, which every later repository sync needs: emerge dev-vcs/git
+  point repository gentoo at https://github.com/gentoo-mirror/gentoo.git, commit signatures verified
+  sync repository gentoo
+  set sys-kernel/installkernel to dracut
+  accept the linux-firmware licence
+  resolve sys-process/cronie sys-kernel/installkernel sys-kernel/dracut sys-kernel/linux-firmware sys-fs/dosfstools sys-fs/e2fsprogs sys-kernel/gentoo-kernel-bin sys-boot/grub sys-boot/efibootmgr together before installing the requested packages
+
+[system]
+  generate and verify locales en_US.UTF-8
+  set the system locale to en_US.UTF-8
+  set the timezone to UTC
+  set the console keymap to us and its font to default8x16
+  set the hostname to staticip
+  give the target its own machine id
+  write /etc/fstab with entries for /, /efi
+  treat the hardware clock as UTC
+  set the root password
+  configure ens18 as 10.31.0.150/24
+  enable systemd-networkd at boot
+  enable systemd-resolved at boot
+  install cron: emerge sys-process/cronie
+  enable cronie at boot
+
+[kernel]
+  install the hook that puts a kernel in /boot: emerge sys-kernel/installkernel
+  install the initramfs builder and firmware: emerge sys-kernel/dracut sys-kernel/linux-firmware
+  install the storage tools: emerge sys-fs/dosfstools sys-fs/e2fsprogs
+  install the kernel: emerge sys-kernel/gentoo-kernel-bin
+  rebuild the initramfs from sys-kernel/gentoo-kernel-bin with the modules written above
+  check the installkernel payload names existing kernel files
+
+[bootloader]
+  install the bootloader: emerge sys-boot/grub sys-boot/efibootmgr
+  write /etc/default/grub with cmdline console=ttyS0,115200, its menu on ttyS0
+  install GRUB for uefi on the esp at /efi
+
+[finish]
+  point /etc/resolv.conf at systemd-resolved rather than the install medium's
+  delete the downloaded stage3 from /var/cache/gentoo-install
+  unmount everything under the target

--- a/tests/unit/test_harness.py
+++ b/tests/unit/test_harness.py
@@ -2024,6 +2024,35 @@ def test_a_cn_run_clones_the_overlay_from_a_chinese_mirror(tmp_path: Path) -> No
     assert overlay.sync_uri.startswith("https://mirrors.cernet.edu.cn/")
 
 
+def test_a_static_address_is_moved_to_the_one_the_scheduler_reserved(
+    tmp_path: Path,
+) -> None:
+    """A fixture pins one address; the scheduler hands each guest its own. A
+    machine installed on the pinned one comes up where nothing expects it, and
+    its own checks then read the address it was told to have."""
+    from gentoo_install.exec.config import load
+    from gentoo_install.model.config import MirrorRegion, Sync
+    from tests.vm import cluster
+
+    source = Path(__file__).resolve().parents[1] / "fixtures" / "static-ip.toml"
+    pinned = load(source).system.addresses
+    assert pinned, "this fixture exists to carry a static address"
+
+    job = cluster.Job(name="static-ip", fixture=source)
+    written = cluster.rewrite_fixtures(
+        [job],
+        tmp_path / "fixtures",
+        MirrorRegion.CN,
+        Sync.RSYNC,
+        unlock_addresses={"static-ip": "10.31.0.207"},
+    )
+    moved = load(written / source.name).system
+
+    assert moved.addresses == (f"10.31.0.207/{cluster.GUEST_PREFIX}",), moved.addresses
+    assert moved.gateways == (cluster.GUEST_GATEWAY,), moved.gateways
+    assert moved.dns == cluster.GUEST_RESOLVERS, moved.dns
+
+
 def test_a_check_whose_name_has_a_space_is_written_to_one_file() -> None:
     """`root filesystem` is a check name, and an unquoted redirection split it
     into two words: bash answered `syntax error near unexpected token` and the

--- a/tests/unit/test_plan_system.py
+++ b/tests/unit/test_plan_system.py
@@ -2,7 +2,7 @@
 from __future__ import annotations
 
 from dataclasses import replace
-from pathlib import PurePosixPath
+from pathlib import Path, PurePosixPath
 from typing import Any
 
 import pytest
@@ -614,6 +614,44 @@ def networked(installation: InstallConfig) -> Recorder:
 
 NETWORKD = PurePosixPath("/etc/systemd/network/20-wired.network")
 CONFD_NET = PurePosixPath("/etc/conf.d/net")
+
+
+def test_static_ip_fixture_validates_and_writes_the_configured_network_for_both_inits() -> None:
+    from gentoo_install.exec.config import load
+    from gentoo_install.model.validate import validate
+    from tests.vm.installed import checks
+
+    fixture = Path(__file__).resolve().parents[1] / "fixtures" / "static-ip.toml"
+    installation = load(fixture)
+    validate(installation)
+
+    assert installation.system.addresses == ("10.31.0.150/24",)
+    assert installation.system.gateways == ("10.31.0.254",)
+    assert installation.system.dns == ("10.31.0.199", "10.31.0.254")
+
+    expected_checks = {
+        ("address 10.31.0.150/24", "ip -o address show", r"10\.31\.0\.150/24"),
+        (
+            "default route 10.31.0.254",
+            "ip -4 route show default; ip -6 route show default",
+            r"default via 10\.31\.0\.254",
+        ),
+        ("resolver 10.31.0.199", "resolvectl dns", r"10\.31\.0\.199"),
+        ("resolver 10.31.0.254", "resolvectl dns", r"10\.31\.0\.254"),
+    }
+    actual_checks = {(check.name, check.command, check.pattern) for check in checks(installation)}
+    assert expected_checks <= actual_checks
+
+    networkd = networked(installation).files[NETWORKD]
+    assert "Address=10.31.0.150/24" in networkd
+    assert "Gateway=10.31.0.254" in networkd
+    assert "DNS=10.31.0.199" in networkd and "DNS=10.31.0.254" in networkd
+
+    openrc = replace(installation, system=replace(installation.system, init=InitSystem.OPENRC))
+    netifrc = networked(openrc).files[CONFD_NET]
+    assert 'config_ens18="10.31.0.150/24"' in netifrc
+    assert 'routes_ens18="default via 10.31.0.254"' in netifrc
+    assert 'dns_servers_ens18="10.31.0.199 10.31.0.254"' in netifrc
 
 
 def test_a_static_address_carries_its_gateway_and_its_resolvers() -> None:

--- a/tests/vm/campaign.py
+++ b/tests/vm/campaign.py
@@ -173,6 +173,12 @@ STAGES: Final[dict[str, tuple[Run, ...]]] = {
         # wrapped round them.
         Run("fixtures/vm-xfs.toml"),
         Run("fixtures/vm-btrfs.toml"),
+        # A machine that configures its own address instead of asking for one.
+        # The model has carried static addressing since the beginning and no
+        # fixture set it, so nothing had ever installed a machine that comes up
+        # on an address, a gateway and a resolver it was given. `cluster.py`
+        # rewrites the address to the one the scheduler reserved.
+        Run("fixtures/static-ip.toml"),
         Run("fixtures/vm-openrc-desktop.toml", weight=2, cpus=10),
         Run("fixtures/vm-gnome.toml", weight=2, cpus=10),
         # Three more nothing had ever installed: raidz needs a third disk,

--- a/tests/vm/cluster.py
+++ b/tests/vm/cluster.py
@@ -1159,6 +1159,20 @@ def rewrite_fixtures(
         # scheduler reserved for this guest: a fixture that pins a
         # documentation address is one the harness can never reach.
         given = (unlock_addresses or {}).get(job.name, "")
+        if given and moved.system.addresses:
+            # The installed system's own address, for the same reason: a
+            # fixture pinning one the scheduler did not reserve produces a
+            # machine on somebody else's address, and its own checks then read
+            # the address it was told to have rather than the one it has.
+            moved = replace(
+                moved,
+                system=replace(
+                    moved.system,
+                    addresses=(f"{given}/{GUEST_PREFIX}",),
+                    gateways=(GUEST_GATEWAY,),
+                    dns=GUEST_RESOLVERS,
+                ),
+            )
         if given and moved.kernel.remote_unlock.enabled:
             moved = replace(
                 moved,

--- a/tests/vm/installed.py
+++ b/tests/vm/installed.py
@@ -75,6 +75,32 @@ def checks(installation: InstallConfig) -> tuple[InstalledCheck, ...]:
         result.extend([InstalledCheck("units", "rc-update show default", "default"), InstalledCheck("failed", "test -z \"$(rc-status --crashed)\" && echo NO-FAILED-UNITS", "NO-FAILED-UNITS")])
     if installation.system.networking is not Networking.NONE:
         result.append(InstalledCheck("network", "systemctl list-unit-files --state=enabled --no-legend --no-pager; rc-update show default", re.escape(network_service(installation.system))))
+    if installation.system.addresses:
+        result.extend(
+            InstalledCheck(
+                f"address {address}",
+                "ip -o address show",
+                re.escape(address),
+            )
+            for address in installation.system.addresses
+        )
+        result.extend(
+            InstalledCheck(
+                f"default route {gateway}",
+                "ip -4 route show default; ip -6 route show default",
+                rf"default via {re.escape(gateway)}",
+            )
+            for gateway in installation.system.gateways
+        )
+        if installation.system.dns and installation.system.init is InitSystem.SYSTEMD:
+            result.extend(
+                InstalledCheck(
+                    f"resolver {resolver}",
+                    "resolvectl dns",
+                    re.escape(resolver),
+                )
+                for resolver in installation.system.dns
+            )
     groups = load_catalog()
     frameworks = {
         groups[name].input_framework


### PR DESCRIPTION
`system.addresses`, `system.gateways` and `system.dns` have been in the model since the beginning. No fixture set them, so no machine has ever been installed with a static address, and the cloud machine outside a DHCP network is exactly what this installer is for.

The fixture sets one address, one gateway and two resolvers on the plainest layout that leaves the checks about networking. Three installed-state checks read the machine rather than the files the installer wrote: `ip -o address show`, `ip route show default`, and `resolvectl dns` where systemd resolves. The plan tests assert what `networkd` and `netifrc` each receive, for both init systems.

`rewrite_fixtures` moves the address to the one the scheduler reserved, the way it already does for the initramfs unlock. Without that the fixture installs a machine on an address the campaign did not hand out, and its own checks read the address it was told to have instead of the one it has. The control fails on that assertion.

Written by an agent and reviewed here: both gates run in this tree, the fixture moved from a directory to the flat name the loader and the golden tests expect, its golden file regenerated in this commit, and the campaign names it, since a fixture nobody runs is a path nobody tests.