### PR TITLE
bootloader: refuse a grub.cfg that was never put in place

### DIFF
--- a/gentoo_install/plan/bootloader.py
+++ b/gentoo_install/plan/bootloader.py
@@ -197,6 +197,20 @@ class InstallGrub(Operation):
         ).strip()
         if not entries.isdigit() or int(entries) == 0:
             raise NothingToBoot("grub.cfg has no menu entry; /boot holds no kernel")
+        # grub-mkconfig writes `grub.cfg.new` and copies it over `grub.cfg`
+        # last (`util/grub-mkconfig.in`), so the new file surviving means the
+        # config in place is the one that was already there. A converted Debian
+        # machine kept its own single `menuentry` that way, counted it as
+        # success, and booted to `Failed to boot both default and fallback
+        # entries` against a kernel the conversion had replaced.
+        gone = context.run_in_target(
+            ["test", "!", "-e", "/boot/grub/grub.cfg.new"], check=False
+        )
+        if not isinstance(gone, CommandOutput) or gone.returncode != 0:
+            raise NothingToBoot(
+                "grub-mkconfig left /boot/grub/grub.cfg.new behind, so the "
+                "configuration in place is the one it was meant to replace"
+            )
 
 
 @dataclass(frozen=True, kw_only=True)

--- a/tests/unit/test_plan_bootloader.py
+++ b/tests/unit/test_plan_bootloader.py
@@ -456,3 +456,34 @@ def test_the_unlock_names_the_key_types_the_module_may_generate() -> None:
     assert "ed25519" not in written, written
     for keytype in bootloader.ZBM_HOST_KEY_TYPES:
         assert f'dropbear_{keytype}_key=' in written, keytype
+
+
+def test_a_config_grub_mkconfig_never_put_in_place_stops_the_install() -> None:
+    """`grub-mkconfig` writes `grub.cfg.new` and copies it over `grub.cfg`
+    last, so the new file surviving means the configuration in place is the
+    one it was meant to replace. A converted Debian machine kept its own
+    single `menuentry` that way — the count passed — and booted to `Failed to
+    boot both default and fallback entries` against a kernel the conversion
+    had already replaced. Read off that disk: `grub.cfg` dated 2026-08-06 and
+    `grub.cfg.new` dated 2026-08-18, 3231 bytes, beside a Gentoo kernel."""
+    from gentoo_install.errors import NothingToBoot
+    from gentoo_install.model.device import DeviceId
+
+    operation = bootloader.InstallGrub(
+        firmware=Firmware.BIOS,
+        esp=None,
+        boot_devices=(DeviceId("first"),),
+    )
+
+    class Disks(Recorder):
+        def containing_disk(self, device: DeviceId) -> str:
+            return f"/dev/{device}"
+
+    # `replies["test"]` non-empty is how this recorder says a `test` exits
+    # non-zero, which here is `test ! -e` finding the file still there.
+    left_behind = Disks(replies={"grep": "1", "test": "still there"})
+    with pytest.raises(NothingToBoot, match="grub.cfg.new"):
+        operation.apply(left_behind)
+
+    replaced = Disks(replies={"grep": "1"})
+    operation.apply(replaced)


### PR DESCRIPTION
A Debian conversion finished with exit 0, every installed-state check green, and a machine that does not boot: OVMF ends at `Failed to boot both default and fallback entries` after our GRUB 2.14 draws a **Debian** menu and tries `boot/vmlinuz-6.1.0-52-cloud-amd64`, a kernel the conversion replaced.

Read off that disk, booted under the install medium:

    -rw-r--r-- 5516  Aug  6 04:57  /boot/grub/grub.cfg
    -rw------- 3231  Aug 18 05:10  /boot/grub/grub.cfg.new
    /boot/kernel-6.18.43-gentoo-dist-bin      Aug 18 05:07

`grub-mkconfig` ran, found the Gentoo kernel and said `done`; its output is in `grub.cfg.new` and `grub.cfg` is the one Debian shipped. `util/grub-mkconfig.in` copies the new file over the old one as its last act, so the leftover is the signature of that step not happening.

The check that was supposed to catch this counted `^menuentry` — and Debian's stale config has exactly one, so it passed. Counting an entry says nothing about whose entry it is. The leftover file does, it costs one `test`, and it is exact: `grub-mkconfig` removes it on success.

Why the copy did not happen is not established, and this refusal does not depend on knowing: whatever the cause, the install now stops with the disk in a state the operator can see rather than producing a machine that boots to firmware.