### PR TITLE
proxmox: ask the shell to redraw the prompt after reopening

### DIFF
--- a/tests/unit/test_proxmox.py
+++ b/tests/unit/test_proxmox.py
@@ -3879,6 +3879,7 @@ class _ClosesWhileNothingCrossesIt:
         self.console = self
         self.opened_at_lines = 0
         self.reopens = 0
+        self.solicited: list[bool] = []
 
     def expect(self, pattern: str, timeout: float, idle: float = 0.0) -> bytes:
         from tests.vm.console import ConsoleClosed, ConsoleTimeout
@@ -3894,6 +3895,7 @@ class _ClosesWhileNothingCrossesIt:
 
     def reopen(self, *, solicit_prompt: bool = True) -> None:
         self.reopens += 1
+        self.solicited.append(solicit_prompt)
         self.opened_at_lines = self.guest.lines
 
 
@@ -3916,6 +3918,11 @@ def test_the_console_watched_is_opened_after_the_line_is_typed(
 
     assert link.reopens == 1, link.reopens
     assert guest.lines == 1, guest.lines
+    # `agetty --autologin` prints one prompt as the shell starts and never
+    # prints again, so a session opened silently after the typing shows
+    # nothing for ever: `ext4-bios` matched nothing across fourteen attempts
+    # and sixteen minutes that way.
+    assert link.solicited == [True], link.solicited
 
 
 def test_the_typed_line_stays_short_because_every_character_is_a_request() -> None:

--- a/tests/vm/proxmox.py
+++ b/tests/vm/proxmox.py
@@ -1061,7 +1061,13 @@ def open_a_serial_shell_blind(
         # guest of its own: 68s of typing, then `ConsoleClosed` at 0.0s of
         # watching, four attempts out of four, with the guest silent
         # throughout. The console that is watched is opened after the typing.
-        link.reopen(solicit_prompt=False)
+        #
+        # Asking for a prompt, not merely opening: `agetty --autologin` prints
+        # one prompt when the shell starts and never prints again, so a
+        # session opened after that shows nothing for ever. Fourteen attempts
+        # over sixteen minutes on `ext4-bios` matched nothing at all with the
+        # session opened silently.
+        link.reopen(solicit_prompt=True)
         console = link.console
         try:
             console.expect(SERIAL_SHELL_SPEAKS, timeout=AUTOLOGIN_INTERVAL)


### PR DESCRIPTION
`#555` gave the blind path twelve attempts instead of five. run72 spent all fourteen of them:

    ERROR ext4-bios 18.8m no serial shell in 960s and 14 attempts ... never matched 'root@...'

So it was never about attempts. `#551` moved the watching onto a session opened after the typing, which fixed the close-during-typing — and lost the only thing that session was ever going to show. `agetty --autologin` prints one prompt as the shell starts; a shell nobody types into prints nothing more. Opening a session after that and waiting is waiting for a line that has already gone by.

A guest I drove by hand before `#551` answered on its third attempt, watching the session that was open while the shell started, which is the same fact from the other side.

The reopen now asks for a prompt — one newline into a shell that may not exist yet, which is harmless when it does not. The control fails on the assertion: with the silent reopen, the fake console that only answers a solicited prompt matches nothing.