### PR TITLE
cluster: check the configuration the guest was handed

### DIFF
--- a/tests/unit/test_harness.py
+++ b/tests/unit/test_harness.py
@@ -3434,3 +3434,33 @@ def test_the_missing_commands_are_installed_before_the_conversion() -> None:
     installs = [one for one in console.ran if "apt-get" in one]
     assert len(installs) == 1, console.ran
     assert installs[0].endswith("gpg gpg-agent"), installs[0]
+
+
+def test_the_checks_come_from_the_config_the_guest_was_handed(tmp_path: Path) -> None:
+    """`rewrite_fixtures` moves the mirror, the sync and, for a fixture that
+    pins one, the machine's own address. `static-ip` installed on the address
+    the scheduler reserved and was failed for not having the one its fixture
+    names: `address 10.31.0.150/24: the installed system does not say
+    '10\\.31\\.0\\.150/24'`."""
+    from gentoo_install.exec.config import load
+    from gentoo_install.model.config import MirrorRegion, Sync
+    from tests.vm import cluster
+    from tests.vm.installed import checks
+
+    source = Path(__file__).resolve().parents[1] / "fixtures" / "static-ip.toml"
+    job = cluster.Job(name="static-ip", fixture=source)
+    written = cluster.rewrite_fixtures(
+        [job],
+        tmp_path / "fixtures",
+        MirrorRegion.CN,
+        Sync.RSYNC,
+        unlock_addresses={"static-ip": "10.31.0.207"},
+    )
+    from dataclasses import replace as _replace
+
+    job = _replace(job, installed_config=written / source.name)
+
+    handed = load(job.installed_config or job.fixture)
+    patterns = {check.pattern for check in checks(handed)}
+    assert any("10\\.31\\.0\\.207" in one for one in patterns), sorted(patterns)
+    assert not any("10\\.31\\.0\\.150" in one for one in patterns), sorted(patterns)

--- a/tests/vm/cluster.py
+++ b/tests/vm/cluster.py
@@ -308,6 +308,12 @@ class Job:
     #: The in-place fixture to run once the installed system is up. Set for a
     #: conversion job, whose `fixture` is the ordinary install it converts.
     convert_to: Path | None = None
+    #: Where `rewrite_fixtures` put the copy the guest is handed. The checks
+    #: come from that copy and not from `fixture`: the rewrite moves the
+    #: mirror, the sync and, for a fixture that pins one, the machine's own
+    #: address, so a check derived from the original asserts what the guest
+    #: was never asked to install.
+    installed_config: Path | None = None
     status: JobStatus = JobStatus.WAITING
     vmid: int = 0
     node: str | None = None
@@ -1629,7 +1635,7 @@ def install_one(
         # Writing IPv4 resolvers over it left every mirror unreachable:
         # `Failed to connect to mirrors.tuna.tsinghua.edu.cn:443 after 111 ms`.
         wait_for_network(link, guest.vmid, held.address)
-        stage_passphrases(link, load(job.fixture))
+        stage_passphrases(link, load(job.installed_config or job.fixture))
         link.run(FIND_DRIVER)
         link.run(f"mkdir -p {RESULT_DIR}")
         # tee, not a redirect: the serial console is the only way to watch a
@@ -1684,7 +1690,14 @@ def install_one(
         # the machine it produced comes up and carries what was asked for, and
         # nothing in the log above can answer that.
         phase = Phase.BOOT_INSTALLED
-        wrong = boot_and_check(guest, link, log, load(job.fixture), remote_key, held.address)
+        wrong = boot_and_check(
+            guest,
+            link,
+            log,
+            load(job.installed_config or job.fixture),
+            remote_key,
+            held.address,
+        )
         if wrong:
             outcome = Outcome(
                 job.name,
@@ -1851,6 +1864,9 @@ def run(
     rewritten = rewrite_fixtures(
         jobs, fixture_dir, region, sync, public_key, site, unlock_addresses, distfiles
     )
+    # Rebuilt rather than mutated: `Job` is frozen so that a scheduler state
+    # change is always a new object.
+    jobs = [replace(job, installed_config=rewritten / job.fixture.name) for job in jobs]
     built_path = build_driver(staging, packed=True, fixtures=rewritten)
     driver_path = retain_driver(workdir, built_path)
     driver = driver_path.name


### PR DESCRIPTION
run72's first `static-ip` verdict:

    FAIL static-ip 22.5m address 10.31.0.150/24: the installed system does not say '10\.31\.0\.150/24'

The machine was right and the check was wrong. `#557` made `rewrite_fixtures` move a pinned static address onto the one the scheduler reserved, because a fixture that pins one pins an address the campaign did not hand out. The installed-state checks were still derived from the original fixture, so they asserted the address the guest was never asked to install.

Every earlier fixture survived that split because the rewrite only touched mirrors and sync, which no check reads. The address is the first rewritten field a check asserts, and it will not be the last.

The job now carries where the rewritten copy landed, and both the passphrase staging and the installed-state checks load that copy. The control fails on the assertion: with the address rewrite disabled, the checks name `10.31.0.150` again.