### PR TITLE
convert: install what the harness reads the machine with

### DIFF
--- a/tests/unit/test_harness.py
+++ b/tests/unit/test_harness.py
@@ -3419,6 +3419,24 @@ class _MissingCommands:
         return b"gpg\r\ngpg-agent\r\n"
 
 
+def test_the_harness_installs_what_it_reads_the_machine_with() -> None:
+    """`read_the_boot_order` printed `NO-EFIBOOTMGR` on every conversion,
+    because the cloud images have no `efibootmgr` and the installer never asks
+    for one — it merges `sys-boot/efibootmgr` into the target instead. That
+    reading is the only place a Fedora conversion's surviving `Boot0001
+    "Fedora"` was ever visible."""
+    from typing import Any, cast
+
+    from tests.vm.convert import IMAGES, install_tools
+
+    console = _MissingCommands()
+    install_tools(cast(Any, console), IMAGES["debian"], "fixtures/vm-convert.toml")
+
+    installs = [one for one in console.ran if "apt-get" in one]
+    assert len(installs) == 1, console.ran
+    assert "efibootmgr" in installs[0], installs[0]
+
+
 def test_the_missing_commands_are_installed_before_the_conversion() -> None:
     """`--missing-commands` prints bare names. The reading this replaces looked
     for `run: ` and for the package manager's own name, matched neither,
@@ -3433,7 +3451,7 @@ def test_the_missing_commands_are_installed_before_the_conversion() -> None:
 
     installs = [one for one in console.ran if "apt-get" in one]
     assert len(installs) == 1, console.ran
-    assert installs[0].endswith("gpg gpg-agent"), installs[0]
+    assert "gpg gpg-agent" in installs[0], installs[0]
 
 
 def test_the_checks_come_from_the_config_the_guest_was_handed(tmp_path: Path) -> None:

--- a/tests/vm/convert.py
+++ b/tests/vm/convert.py
@@ -87,6 +87,11 @@ class CloudImage:
     #: A command whose package is not named after it. Every other name goes to
     #: the package manager as it was printed.
     packages: dict[str, str] = field(default_factory=dict)
+    #: What the harness itself reads the machine with, which the installer
+    #: never asks for. `efibootmgr` is the whole of it: `read_the_boot_order`
+    #: printed `NO-EFIBOOTMGR` on every conversion, and that reading is the
+    #: only place a Fedora conversion's `Boot0001 "Fedora"` was ever visible.
+    tools: tuple[str, ...] = ("efibootmgr",)
 
     @property
     def image(self) -> Path:
@@ -221,6 +226,7 @@ def install_tools(console: SerialConsole, chosen: CloudImage, config: str) -> No
         for name in (line.strip() for line in said.splitlines())
         if name and " " not in name and not name.startswith("MARK_")
     ]
+    wanted += list(chosen.tools)
     if wanted:
         console.run(f"{chosen.install} {' '.join(sorted(set(wanted)))}", timeout=1800.0)
 
@@ -299,7 +305,7 @@ def read_the_boot_order(console: SerialConsole) -> str:
     exists, and where it sits in `BootOrder`, is the difference between those
     two and cannot be inferred from `grub-install` saying nothing.
     """
-    said = console.expect_command(
+    said = console.expect_output(
         "efibootmgr -v 2>&1 || echo NO-EFIBOOTMGR", timeout=120.0
     ).decode("utf-8", "replace")
     print("--- firmware boot entries ---", flush=True)


### PR DESCRIPTION
Every conversion run printed `NO-EFIBOOTMGR` where the firmware's boot entries should be. The cloud images ship no `efibootmgr`, and the installer never asks the host for one — it merges `sys-boot/efibootmgr` into the target and runs it there.

That reading is not decoration. A Fedora conversion once exited zero, wrote `\EFI\BOOT\BOOTX64.EFI` and a `Gentoo` entry, and the machine then started `Boot0001 "Fedora"` and stopped at a kernel that was gone. `read_the_boot_order` exists for exactly that, and it has been blind on every run since.

The image gains a list of what the harness itself needs, installed beside what the launcher asks for. And the reading uses `expect_output`: `efibootmgr -v 2>&1 || echo NO-EFIBOOTMGR` names its own fallback, so matched against the shell's echo it would report the fallback on a machine that answered properly.

The control fails on the assertion: without the addition, the install command carries `gpg gpg-agent` and no `efibootmgr`.