### PR TITLE
cluster: seed the table an editing fixture starts from

### DIFF
--- a/tests/unit/test_harness.py
+++ b/tests/unit/test_harness.py
@@ -3482,3 +3482,36 @@ def test_the_checks_come_from_the_config_the_guest_was_handed(tmp_path: Path) ->
     patterns = {check.pattern for check in checks(handed)}
     assert any("10\\.31\\.0\\.207" in one for one in patterns), sorted(patterns)
     assert not any("10\\.31\\.0\\.150" in one for one in patterns), sorted(patterns)
+
+
+def test_an_editing_fixture_gets_its_table_before_the_installer_runs() -> None:
+    """`mbr-edit` describes a table the operator already has. `run.py` writes
+    it into the qcow2 before the guest starts; the cluster's disk is made by
+    the hypervisor, so nothing wrote one and the installer refused in five
+    minutes: `/dev/disk/by-id/virtio-target0 did not report its partitions, so
+    what table keeps cannot be counted`."""
+    from gentoo_install.exec.config import load
+    from tests.vm import cluster
+    from tests.vm.run import SEEDED
+
+    assert "mbr-edit" in SEEDED, sorted(SEEDED)
+    source = Path(__file__).resolve().parents[1] / "fixtures" / "mbr-edit.toml"
+    selector = cluster._first_selector(load(source))
+
+    assert selector == "/dev/disk/by-id/virtio-target0", selector
+    # The seed reaches the guest as one `parted` line naming that selector.
+    line = f"parted --script {selector} {' '.join(SEEDED['mbr-edit'])}"
+    assert "mklabel msdos" in line and "mkpart" in line, line
+    assert "/dev/vda" not in line, "the fixture's own selector, not a guessed node"
+
+
+def test_the_cluster_seeds_only_the_fixtures_that_ask_for_it() -> None:
+    """Every other fixture describes a table it creates, and a seeded one
+    would leave the installer keeping partitions the configuration never
+    mentioned."""
+    import inspect
+
+    from tests.vm import cluster
+
+    source = inspect.getsource(cluster)
+    assert "SEEDED.get(job.fixture.stem, ())" in source, "one table, read by stem"

--- a/tests/vm/cluster.py
+++ b/tests/vm/cluster.py
@@ -102,7 +102,7 @@ from .results import (
 )
 from .workdir import WorkdirError, confined
 from .installed import checks, stage_passphrase_commands
-from .run import remote_config, remote_unlock, ssh_keypair
+from .run import SEEDED, remote_config, remote_unlock, ssh_keypair
 
 REPOSITORY: Final[Path] = Path(__file__).resolve().parents[2]
 WORKROOT: Final[Path] = Path.home() / "code/gentoo-install/lab/vm/cluster"
@@ -1288,6 +1288,20 @@ def reconcile(api: Api, workdir: Path) -> None:
         path.unlink()
 
 
+def _first_selector(installation: InstallConfig) -> str:
+    """The disk an editing fixture starts from, named as the fixture names it.
+
+    From the configuration rather than from `/dev/vda`: the fixture chooses a
+    `by-id` path so the guest renumbering its disks cannot move the target,
+    and seeding a different device would leave the installer refusing the one
+    it was given.
+    """
+    for node in installation.disk.graph.of_type(Existing):
+        if node.selector:
+            return node.selector
+    raise ProxmoxError(f"{installation.disk.mode.value} names no disk to seed")
+
+
 def revision_identity(driver: Path) -> str:
     """Git state and exact driver bytes represented by a campaign outcome."""
 
@@ -1646,6 +1660,17 @@ def install_one(
         # Again, immediately before the installer: the first measurement is
         # taken a minute earlier and passed on every guest of round 27, whose
         # installers then found no route at all. This one splits that window.
+        # The table an editing fixture starts from. `run.py` writes it into the
+        # qcow2 before the guest starts; a cluster disk is made by the
+        # hypervisor, so the medium's own `parted` writes it here instead.
+        # Without it `mbr-edit` refuses in five minutes with
+        # `did not report its partitions, so what table keeps cannot be counted`.
+        seeded = SEEDED.get(job.fixture.stem, ())
+        if seeded:
+            selector = _first_selector(load(job.installed_config or job.fixture))
+            link.run(
+                f"parted --script {selector} {' '.join(seeded)}", timeout=180.0
+            )
         _note_the_probe(link, "pre-install")
         phase = Phase.INSTALL
         link.wait_for(


### PR DESCRIPTION
`mbr-edit` reached a shell on the cluster for the first time — `#560` — and refused five minutes later:

    preflight: this machine cannot run the install:
      /dev/disk/by-id/virtio-target0 did not report its partitions, so what table keeps cannot be counted

It is the one fixture whose target already holds a table: it describes partitions the operator has and the installer keeps. `run.py` writes that table into the qcow2 with `parted` before the guest starts. A cluster disk is created by the hypervisor, so nothing wrote one, and the fixture could never have passed there.

The medium's own `parted` writes it now, from the same `SEEDED` table `run.py` reads, so the two runners cannot describe different starting states. The selector comes from the configuration rather than `/dev/vda`: the fixture chooses a `by-id` path so a guest renumbering its disks cannot move the target, and seeding a different device would leave the installer refusing the one it was given.

The control fails on the assertion: with the lookup replaced by an empty tuple, the test that reads the source for it reddens.