### PR TITLE
convert: flush what the conversion wrote before anything reboots

### DIFF
--- a/gentoo_install/plan/build.py
+++ b/gentoo_install/plan/build.py
@@ -231,6 +231,9 @@ def _in_place(
         *after_the_swap,
         *closing,
         convert.LeaveStaging(),
+        # Last, after the staging root is gone: everything above it wrote into
+        # a filesystem that stays mounted, and nothing else will flush it.
+        convert.FlushToDisk(),
     )
 
 

--- a/gentoo_install/plan/convert.py
+++ b/gentoo_install/plan/convert.py
@@ -219,6 +219,31 @@ class PrepareStaging(Operation):
 
 
 @dataclass(frozen=True, kw_only=True)
+class FlushToDisk(Operation):
+    """Write the page cache out before anything reboots this machine.
+
+    An ordinary install unmounts the target, which flushes it. A conversion
+    never unmounts anything: its target is `/`, still mounted and still
+    running. What that cost was measured twice on a converted Debian guest —
+    `grub-mkconfig` reported the new kernel and exited, and the file on disk
+    was still the one the distribution shipped, naming a kernel the conversion
+    had deleted. The machine came up in GRUB and stopped at `Failed to boot
+    both default and fallback entries`.
+    """
+
+    stage: Stage = Stage.FINISH
+
+    def required_host_commands(self) -> frozenset[str]:
+        return frozenset({"sync"})
+
+    def describe(self) -> str:
+        return "write everything this conversion changed out to the disk"
+
+    def apply(self, context: Context) -> None:
+        context.run(["sync"])
+
+
+@dataclass(frozen=True, kw_only=True)
 class LeaveStaging(Operation):
     """Unmount what the chroot bound under the staging root and remove it.
 

--- a/tests/golden/vm-convert.txt
+++ b/tests/golden/vm-convert.txt
@@ -60,3 +60,4 @@
 [finish]
   point /etc/resolv.conf at systemd-resolved rather than the install medium's
   unmount and remove /gentoo-install.new
+  write everything this conversion changed out to the disk

--- a/tests/unit/test_plan_convert.py
+++ b/tests/unit/test_plan_convert.py
@@ -287,7 +287,10 @@ def test_a_staging_root_with_something_still_mounted_is_left_alone() -> None:
 
 def test_the_conversion_ends_by_leaving_no_staging_root() -> None:
     operations = build(_in_place(), CATALOG, layout=_layout())
-    assert isinstance(operations[-1], convert.LeaveStaging)
+    # Second to last: the flush is after it, because removing the staging root
+    # is itself a write into a filesystem nothing will unmount.
+    assert isinstance(operations[-2], convert.LeaveStaging)
+    assert isinstance(operations[-1], convert.FlushToDisk)
 
 
 def test_only_the_esp_and_boot_sector_writes_wait_for_the_swap() -> None:
@@ -939,3 +942,31 @@ def test_nothing_that_runs_after_the_swap_is_pointed_at_the_staging_root() -> No
     # wrapper off for everything.
     body = [one for one in operations if one.stage is not Stage.FINISH]
     assert [one for one in body if isinstance(one, convert.Staged)], len(body)
+
+
+def test_a_conversion_flushes_before_anything_reboots_the_machine() -> None:
+    """An ordinary install unmounts the target, which flushes it. A conversion
+    never unmounts anything — its target is `/`, still mounted and running —
+    and the cost was measured twice on a converted Debian guest: `grub-mkconfig`
+    reported the new kernel and exited, and `/boot/grub/grub.cfg` on disk was
+    still the one Debian shipped, naming a kernel the conversion had deleted.
+    Run again from a live medium against the same disk, the same command wrote
+    the file in one second."""
+    operations = build(_in_place(), CATALOG, layout=_layout())
+    flushes = [one for one in operations if isinstance(one, convert.FlushToDisk)]
+
+    assert len(flushes) == 1, [one.describe() for one in operations[-6:]]
+    assert flushes[0].stage is Stage.FINISH, flushes[0]
+    # After everything, including the staging root's removal: that unmounts
+    # and deletes, and its writes need flushing too.
+    assert operations.index(flushes[0]) == len(operations) - 1, [
+        one.describe() for one in operations[-4:]
+    ]
+    assert _in_place().disk.mode is DiskMode.IN_PLACE
+
+
+def test_an_ordinary_install_does_not_carry_that_operation() -> None:
+    """It unmounts the target, and the unmount is the flush."""
+    operations = build(config(), CATALOG)
+
+    assert not [one for one in operations if isinstance(one, convert.FlushToDisk)]


### PR DESCRIPTION
Two Debian conversions in a row exited 0 and produced a machine that stops at `Failed to boot both default and fallback entries`, with our GRUB drawing the **old** distribution's menu and loading a kernel the conversion had deleted.

Read off the disk afterwards, twice: `/boot/grub/grub.cfg` still names `/boot/vmlinuz-6.1.0-52-cloud-amd64`, while the run's own log shows

    run: chroot / grub-mkconfig --output /boot/grub/grub.cfg
    | Found linux image: /boot/kernel-6.18.43-gentoo-dist-bin
    | done

Booting that same disk under the install medium and running that same command in a chroot writes the file in one second — `menuentry 'GNU/Linux'`, 4244 bytes, no immutable attribute, `/boot` on the root filesystem. So neither the command nor the filesystem is the problem.

What is: an ordinary install unmounts the target when it finishes, and the unmount is the flush. A conversion unmounts nothing — its target is `/`, still mounted and still running — so the last writes were in the page cache when the machine went away. It cost the run its bootloader configuration, which is the last thing written and the one thing that has to survive.

One `sync` at the very end, after the staging root's removal, since that is a write too. The control fails on its assertion, and the golden file for `vm-convert` carries the new line.