### PR TITLE
convert: name the packages that are not called what the command is

### DIFF
--- a/tests/unit/test_harness.py
+++ b/tests/unit/test_harness.py
@@ -3415,8 +3415,16 @@ class _MissingCommands:
     def run(self, command: str, timeout: float = 0.0) -> None:
         self.ran.append(command)
 
+    #: What the guest still lacks when the verification runs. Empty is a
+    #: machine where the package manager did what it was asked.
+    absent: tuple[str, ...] = ()
+    #: What `--missing-commands` prints, one bare name per line.
+    missing: tuple[str, ...] = ("gpg", "gpg-agent")
+
     def expect_output(self, command: str, timeout: float = 0.0) -> bytes:
-        return b"gpg\r\ngpg-agent\r\n"
+        if command.startswith("for one in "):
+            return "".join(f"absent={one}\r\n" for one in self.absent).encode()
+        return "".join(f"{one}\r\n" for one in self.missing).encode()
 
 
 def test_the_harness_installs_what_it_reads_the_machine_with() -> None:
@@ -3515,3 +3523,38 @@ def test_the_cluster_seeds_only_the_fixtures_that_ask_for_it() -> None:
 
     source = inspect.getsource(cluster)
     assert "SEEDED.get(job.fixture.stem, ())" in source, "one table, read by stem"
+
+
+def test_a_command_whose_package_is_named_otherwise_is_translated() -> None:
+    """`apt-get ... mkfs.vfat` answers `Unable to locate package mkfs.vfat`
+    and installs **nothing at all**, including the packages it did recognise.
+    The memory-mode arming then refused with `--lowram cannot arm a one-shot
+    boot entry on this machine`, whose only missing piece was `efibootmgr`."""
+    from typing import Any, cast
+
+    from tests.vm.convert import IMAGES, install_tools
+
+    console = _MissingCommands()
+    console.missing = ("gpg", "mkfs.vfat")
+    install_tools(cast(Any, console), IMAGES["debian"], "fixtures/vm-ram.toml")
+
+    installs = [one for one in console.ran if "apt-get" in one]
+    assert len(installs) == 1, console.ran
+    assert "dosfstools" in installs[0], installs[0]
+    assert "mkfs.vfat" not in installs[0], installs[0]
+
+
+def test_a_package_manager_that_installed_nothing_stops_the_run() -> None:
+    """It exits zero for a name it knows and non-zero for one it does not, and
+    either way the run reads the same. What the guest has is what decides."""
+    from typing import Any, cast
+
+    import pytest as _pytest
+
+    from tests.vm.media import MediaError
+    from tests.vm.convert import IMAGES, install_tools
+
+    console = _MissingCommands()
+    console.absent = ("efibootmgr", "dosfstools")
+    with _pytest.raises(MediaError, match="efibootmgr"):
+        install_tools(cast(Any, console), IMAGES["debian"], "fixtures/vm-ram.toml")

--- a/tests/vm/convert.py
+++ b/tests/vm/convert.py
@@ -27,6 +27,7 @@ from gentoo_install.model.config import InstallConfig
 
 from .console import PASSWORD_PROMPT, SerialConsole
 from .driver import FIND_DRIVER, REPOSITORY, build as build_driver
+from .media import MediaError
 from .installed import InstalledCheck, checks
 from .media import MEDIA
 from .qemu import Firmware, Vm, VmSpec
@@ -107,6 +108,8 @@ IMAGES: Final[dict[str, CloudImage]] = {
             "dnf",
             "dnf install -y --setopt=install_weak_deps=False",
             Firmware.UEFI,
+            {"mkfs.vfat": "dosfstools", "sgdisk": "gdisk", "mkfs.btrfs": "btrfs-progs",
+             "pvcreate": "lvm2", "partprobe": "parted"},
         ),
         CloudImage(
             "debian",
@@ -114,6 +117,9 @@ IMAGES: Final[dict[str, CloudImage]] = {
             "apt-get",
             "apt-get update && apt-get install -y --no-install-recommends",
             Firmware.UEFI,
+            {"mkfs.vfat": "dosfstools", "sgdisk": "gdisk", "mkfs.btrfs": "btrfs-progs",
+             "mkfs.xfs": "xfsprogs", "pvcreate": "lvm2", "partprobe": "parted",
+             "zpool": "zfsutils-linux"},
         ),
         CloudImage(
             "arch",
@@ -121,6 +127,9 @@ IMAGES: Final[dict[str, CloudImage]] = {
             "pacman",
             "pacman -Sy --noconfirm",
             Firmware.UEFI,
+            {"mkfs.vfat": "dosfstools", "sgdisk": "gptfdisk", "mkfs.btrfs": "btrfs-progs",
+             "mkfs.xfs": "xfsprogs", "pvcreate": "lvm2", "partprobe": "parted",
+             "zpool": "zfs-utils"},
         ),
     )
 }
@@ -226,9 +235,29 @@ def install_tools(console: SerialConsole, chosen: CloudImage, config: str) -> No
         for name in (line.strip() for line in said.splitlines())
         if name and " " not in name and not name.startswith("MARK_")
     ]
+    commands = [name for name in wanted]
     wanted += list(chosen.tools)
     if wanted:
         console.run(f"{chosen.install} {' '.join(sorted(set(wanted)))}", timeout=1800.0)
+    # Checked afterwards, because a package manager given one name it does not
+    # know installs nothing at all: `apt-get ... efibootmgr gpg gpg-agent
+    # mkfs.vfat` answered `Unable to locate package mkfs.vfat` and left the
+    # machine without any of them, and the arming then refused for a boot
+    # method whose only missing piece was `efibootmgr`.
+    asked = sorted(set(commands) | set(chosen.tools))
+    if not asked:
+        return
+    said = console.expect_output(
+        "for one in " + " ".join(asked) + "; do "
+        'command -v "$one" >/dev/null || printf "absent=%s\\n" "$one"; done',
+        timeout=300.0,
+    ).decode("utf-8", "replace")
+    absent = [line.split("=", 1)[1] for line in said.split() if line.startswith("absent=")]
+    if absent:
+        raise MediaError(
+            f"{chosen.install.split()[0]} left {', '.join(absent)} missing, "
+            "so the run would refuse for a command nobody installed"
+        )
 
 def write_home_marker(console: SerialConsole) -> None:
     """Write the conversion's unique sentinel outside the replaced tree."""


### PR DESCRIPTION
The first `--lowram` arming to get past the driver CD refused in 39 seconds:

    preflight: --lowram cannot arm a one-shot boot entry on this machine

`boot_method()` answers `NONE` for a UEFI machine with no `efibootmgr`, and the harness had asked for one. Its whole install line:

    apt-get ... --no-install-recommends efibootmgr gpg gpg-agent mkfs.vfat
    E: Unable to locate package mkfs.vfat

One name it does not know and apt installs **nothing**, including the three it recognised. `--missing-commands` prints commands; `mkfs.vfat` is a command in `dosfstools`, `sgdisk` is in `gdisk` or `gptfdisk` depending on the distribution, and so on. Each image now carries the entries whose package is not named after the command, which is the field `#553` added and never filled.

And the result is checked rather than assumed: after installing, the guest is asked which of those commands it still does not have, and the run stops naming them. A package manager exits zero for a name it knows and non-zero for one it does not, and either way the harness read the same thing — what the guest has is what decides.

Both controls fail on their assertions: dropping the `mkfs.vfat` entry puts the command back in the install line, and dropping the check lets a guest missing every one of them proceed.