### PR TITLE
convert: verify the command, not the package that carries it

### DIFF
--- a/tests/unit/test_harness.py
+++ b/tests/unit/test_harness.py
@@ -3411,6 +3411,7 @@ class _MissingCommands:
 
     def __init__(self) -> None:
         self.ran: list[str] = []
+        self.asked: list[str] = []
 
     def run(self, command: str, timeout: float = 0.0) -> None:
         self.ran.append(command)
@@ -3422,6 +3423,7 @@ class _MissingCommands:
     missing: tuple[str, ...] = ("gpg", "gpg-agent")
 
     def expect_output(self, command: str, timeout: float = 0.0) -> bytes:
+        self.asked.append(command)
         if command.startswith("for one in "):
             return "".join(f"absent={one}\r\n" for one in self.absent).encode()
         return "".join(f"{one}\r\n" for one in self.missing).encode()
@@ -3542,6 +3544,13 @@ def test_a_command_whose_package_is_named_otherwise_is_translated() -> None:
     assert len(installs) == 1, console.ran
     assert "dosfstools" in installs[0], installs[0]
     assert "mkfs.vfat" not in installs[0], installs[0]
+    # And the guest is asked for the command, not for the package: `command -v
+    # dosfstools` is false on a machine that has `mkfs.vfat`, which is what
+    # the package installed.
+    asked = [one for one in console.asked if one.startswith("for one in ")]
+    assert len(asked) == 1, console.asked
+    assert "mkfs.vfat" in asked[0], asked[0]
+    assert "dosfstools" not in asked[0], asked[0]
 
 
 def test_a_package_manager_that_installed_nothing_stops_the_run() -> None:

--- a/tests/vm/convert.py
+++ b/tests/vm/convert.py
@@ -230,12 +230,14 @@ def install_tools(console: SerialConsole, chosen: CloudImage, config: str) -> No
     # prints: an earlier reading looked for `run: ` and for the installer's own
     # name, found neither, installed nothing, and let the conversion reach a
     # preflight that refused with `these commands are missing: gpg, gpg-agent`.
-    wanted = [
-        chosen.packages.get(name, name)
+    commands = [
+        name
         for name in (line.strip() for line in said.splitlines())
         if name and " " not in name and not name.startswith("MARK_")
     ]
-    commands = [name for name in wanted]
+    # The package names to install; the command names are what is checked
+    # afterwards, and the two differ exactly where `packages` says they do.
+    wanted = [chosen.packages.get(name, name) for name in commands]
     wanted += list(chosen.tools)
     if wanted:
         console.run(f"{chosen.install} {' '.join(sorted(set(wanted)))}", timeout=1800.0)


### PR DESCRIPTION
`#565` translates a command to the package that carries it and then checks the guest afterwards. It checked the translated list:

    tests.vm.media.MediaError: apt-get left dosfstools missing, so the run
    would refuse for a command nobody installed

`command -v dosfstools` is false on every machine, including one that has `mkfs.vfat` — which is what the package installed and what the installer asked for. The two lists are the same everywhere except where `packages` says they differ, which is exactly where it mattered.

The names to install are the packages; the names to check are the commands. The control fails on the assertion: with the check reading the package list, the run reports `dosfstools` missing on a guest that has everything.