### PR TITLE
disk: install ext2 and ext3

### DIFF
--- a/TESTED.md
+++ b/TESTED.md
@@ -186,7 +186,7 @@ its original system because the boot entry is one-shot.
 ## Not covered by any record
 
 greetd desktop sessions, ibus outside GNOME, binary-host failure fallback, and
-focused configuration tests for ext2 and ext3.
+end-to-end ext2 and ext3 installations.
 
 CJK text-console rendering is not covered either, and the `vm-cjk-kernel` row
 above does not cover it: that run establishes that the patched kernel merges,

--- a/tests/fixtures/ext2.toml
+++ b/tests/fixtures/ext2.toml
@@ -1,0 +1,74 @@
+# The oldest path still supported: MBR, BIOS boot, openrc, ext2, no overlay.
+config_version = 1
+
+[system]
+hostname = "plain"
+timezone = "UTC"
+locales = ["en_US.UTF-8"]
+locale = "en_US.UTF-8"
+init = "openrc"
+root_password_hash = "$6$gentooinst$IR3GrdJ862XljQYDqocr4tKniIRDIT.jQNFzIrHE3U75H6B6YSWZoSYoVd5edSHpqaYBdiNfXHCoIPRVgb9lT/"
+
+[portage]
+profile = "default/linux/amd64/23.0"
+makeopts = "-j4"
+
+[portage.binhost]
+official = false
+community = "off"
+
+[kernel]
+source = "dist-bin"
+
+[bootloader]
+kind = "grub"
+firmware = "bios"
+kernel_params = ["console=ttyS0,115200"]
+
+[disk]
+root = "mnt-root"
+
+[[disk.devices]]
+kind = "existing"
+id = "disk"
+selector = "/dev/disk/by-id/virtio-target0"
+wipe = true
+
+[[disk.devices]]
+kind = "table"
+id = "table"
+disk = "disk"
+table = "mbr"
+
+[[disk.devices]]
+kind = "partition"
+id = "swappart"
+table = "table"
+index = 1
+role = "swap"
+size = "2GiB"
+
+[[disk.devices]]
+kind = "partition"
+id = "rootpart"
+table = "table"
+index = 2
+role = "data"
+
+[[disk.devices]]
+kind = "swap"
+id = "swap"
+device = "swappart"
+
+[[disk.devices]]
+kind = "filesystem"
+id = "rootfs"
+device = "rootpart"
+type = "ext2"
+label = "root"
+
+[[disk.devices]]
+kind = "mountpoint"
+id = "mnt-root"
+source = "rootfs"
+path = "/"

--- a/tests/fixtures/ext3.toml
+++ b/tests/fixtures/ext3.toml
@@ -1,0 +1,74 @@
+# The oldest path still supported: MBR, BIOS boot, openrc, ext3, no overlay.
+config_version = 1
+
+[system]
+hostname = "plain"
+timezone = "UTC"
+locales = ["en_US.UTF-8"]
+locale = "en_US.UTF-8"
+init = "openrc"
+root_password_hash = "$6$gentooinst$IR3GrdJ862XljQYDqocr4tKniIRDIT.jQNFzIrHE3U75H6B6YSWZoSYoVd5edSHpqaYBdiNfXHCoIPRVgb9lT/"
+
+[portage]
+profile = "default/linux/amd64/23.0"
+makeopts = "-j4"
+
+[portage.binhost]
+official = false
+community = "off"
+
+[kernel]
+source = "dist-bin"
+
+[bootloader]
+kind = "grub"
+firmware = "bios"
+kernel_params = ["console=ttyS0,115200"]
+
+[disk]
+root = "mnt-root"
+
+[[disk.devices]]
+kind = "existing"
+id = "disk"
+selector = "/dev/disk/by-id/virtio-target0"
+wipe = true
+
+[[disk.devices]]
+kind = "table"
+id = "table"
+disk = "disk"
+table = "mbr"
+
+[[disk.devices]]
+kind = "partition"
+id = "swappart"
+table = "table"
+index = 1
+role = "swap"
+size = "2GiB"
+
+[[disk.devices]]
+kind = "partition"
+id = "rootpart"
+table = "table"
+index = 2
+role = "data"
+
+[[disk.devices]]
+kind = "swap"
+id = "swap"
+device = "swappart"
+
+[[disk.devices]]
+kind = "filesystem"
+id = "rootfs"
+device = "rootpart"
+type = "ext3"
+label = "root"
+
+[[disk.devices]]
+kind = "mountpoint"
+id = "mnt-root"
+source = "rootfs"
+path = "/"

--- a/tests/golden/ext2.txt
+++ b/tests/golden/ext2.txt
@@ -1,0 +1,70 @@
+[partition]
+  release anything a previous run of this configuration left mounted or open
+  wipe existing signatures from disk
+  create a mbr partition table on disk as table
+  create partition 1 on disk as swappart: swap, 2GiB
+  create partition 2 on disk as rootpart: data, the rest of the disk
+  reread the partition table of disk and wait for its nodes
+
+[format]
+  make a ext2 filesystem on rootpart as rootfs labelled root
+  make swap on swappart as swap
+
+[mount]
+  mount rootpart at /
+
+[stage3]
+  download the newest openrc stage3 from https://distfiles.gentoo.org directly, verify it against BB572E0E2D182910 and unpack it into the target
+
+[chroot]
+  mount transient proc, sys, dev and run filesystems into the target
+  seed the target's resolv.conf from the install medium
+
+[portage]
+  write /etc/portage/make.conf with MAKEOPTS, INPUT_DEVICES, ACCEPT_LICENSE, L10N; 2 mirrors in the configured order, 5 appended
+  configure Portage, wget, curl, git and gpg for direct connection
+  create the three autounmask files emerge writes its decisions into
+  fetch the first ebuild repository snapshot with emerge-webrsync
+  select profile default/linux/amd64/23.0
+  install git, which every later repository sync needs: emerge dev-vcs/git
+  point repository gentoo at https://github.com/gentoo-mirror/gentoo.git, commit signatures verified
+  sync repository gentoo
+  set sys-kernel/installkernel to dracut
+  accept the linux-firmware licence
+  resolve net-misc/netifrc net-misc/dhcpcd app-admin/sysklogd sys-process/cronie sys-kernel/installkernel sys-kernel/dracut sys-kernel/linux-firmware sys-fs/e2fsprogs sys-kernel/gentoo-kernel-bin sys-boot/grub together before installing the requested packages
+
+[system]
+  generate and verify locales en_US.UTF-8
+  set the system locale to en_US.UTF-8
+  set the timezone to UTC
+  set the console keymap to us and its font to default8x16
+  set the hostname to plain
+  give the target its own machine id
+  write /etc/fstab with entries for /, swap
+  treat the hardware clock as UTC
+  start a login on ttyS0 at 115200 baud
+  set the root password
+  install the network tools: emerge net-misc/netifrc net-misc/dhcpcd
+  configure the wired interface for DHCP
+  enable dhcpcd in the default runlevel
+  install the system logger: emerge app-admin/sysklogd
+  enable sysklogd in the default runlevel
+  install cron: emerge sys-process/cronie
+  enable cronie in the default runlevel
+
+[kernel]
+  install the hook that puts a kernel in /boot: emerge sys-kernel/installkernel
+  install the initramfs builder and firmware: emerge sys-kernel/dracut sys-kernel/linux-firmware
+  install the storage tools: emerge sys-fs/e2fsprogs
+  install the kernel: emerge sys-kernel/gentoo-kernel-bin
+  rebuild the initramfs from sys-kernel/gentoo-kernel-bin with the modules written above
+  check the installkernel payload names existing kernel files
+
+[bootloader]
+  install the bootloader: emerge sys-boot/grub
+  write /etc/default/grub with cmdline console=ttyS0,115200, its menu on ttyS0
+  install GRUB for bios on the disk under disk
+
+[finish]
+  delete the downloaded stage3 from /var/cache/gentoo-install
+  unmount everything under the target

--- a/tests/golden/ext3.txt
+++ b/tests/golden/ext3.txt
@@ -1,0 +1,70 @@
+[partition]
+  release anything a previous run of this configuration left mounted or open
+  wipe existing signatures from disk
+  create a mbr partition table on disk as table
+  create partition 1 on disk as swappart: swap, 2GiB
+  create partition 2 on disk as rootpart: data, the rest of the disk
+  reread the partition table of disk and wait for its nodes
+
+[format]
+  make a ext3 filesystem on rootpart as rootfs labelled root
+  make swap on swappart as swap
+
+[mount]
+  mount rootpart at /
+
+[stage3]
+  download the newest openrc stage3 from https://distfiles.gentoo.org directly, verify it against BB572E0E2D182910 and unpack it into the target
+
+[chroot]
+  mount transient proc, sys, dev and run filesystems into the target
+  seed the target's resolv.conf from the install medium
+
+[portage]
+  write /etc/portage/make.conf with MAKEOPTS, INPUT_DEVICES, ACCEPT_LICENSE, L10N; 2 mirrors in the configured order, 5 appended
+  configure Portage, wget, curl, git and gpg for direct connection
+  create the three autounmask files emerge writes its decisions into
+  fetch the first ebuild repository snapshot with emerge-webrsync
+  select profile default/linux/amd64/23.0
+  install git, which every later repository sync needs: emerge dev-vcs/git
+  point repository gentoo at https://github.com/gentoo-mirror/gentoo.git, commit signatures verified
+  sync repository gentoo
+  set sys-kernel/installkernel to dracut
+  accept the linux-firmware licence
+  resolve net-misc/netifrc net-misc/dhcpcd app-admin/sysklogd sys-process/cronie sys-kernel/installkernel sys-kernel/dracut sys-kernel/linux-firmware sys-fs/e2fsprogs sys-kernel/gentoo-kernel-bin sys-boot/grub together before installing the requested packages
+
+[system]
+  generate and verify locales en_US.UTF-8
+  set the system locale to en_US.UTF-8
+  set the timezone to UTC
+  set the console keymap to us and its font to default8x16
+  set the hostname to plain
+  give the target its own machine id
+  write /etc/fstab with entries for /, swap
+  treat the hardware clock as UTC
+  start a login on ttyS0 at 115200 baud
+  set the root password
+  install the network tools: emerge net-misc/netifrc net-misc/dhcpcd
+  configure the wired interface for DHCP
+  enable dhcpcd in the default runlevel
+  install the system logger: emerge app-admin/sysklogd
+  enable sysklogd in the default runlevel
+  install cron: emerge sys-process/cronie
+  enable cronie in the default runlevel
+
+[kernel]
+  install the hook that puts a kernel in /boot: emerge sys-kernel/installkernel
+  install the initramfs builder and firmware: emerge sys-kernel/dracut sys-kernel/linux-firmware
+  install the storage tools: emerge sys-fs/e2fsprogs
+  install the kernel: emerge sys-kernel/gentoo-kernel-bin
+  rebuild the initramfs from sys-kernel/gentoo-kernel-bin with the modules written above
+  check the installkernel payload names existing kernel files
+
+[bootloader]
+  install the bootloader: emerge sys-boot/grub
+  write /etc/default/grub with cmdline console=ttyS0,115200, its menu on ttyS0
+  install GRUB for bios on the disk under disk
+
+[finish]
+  delete the downloaded stage3 from /var/cache/gentoo-install
+  unmount everything under the target

--- a/tests/unit/test_compat.py
+++ b/tests/unit/test_compat.py
@@ -2,7 +2,7 @@
 from __future__ import annotations
 
 from dataclasses import replace
-from pathlib import PurePosixPath
+from pathlib import Path, PurePosixPath
 from typing import Callable
 
 import pytest
@@ -48,6 +48,7 @@ from gentoo_install.model.device import (
     ZfsDataset,
     ZfsPool,
 )
+from gentoo_install.exec.config import load
 from gentoo_install.model.size import Size
 
 from .layouts import config, ext4_on_gpt, i, zfs_root
@@ -338,6 +339,24 @@ def test_each_rule_fires_on_a_configuration_that_breaks_it(
     build: Callable[[], InstallConfig], when: Trait, excludes: Trait
 ) -> None:
     assert (when, excludes) in {(rule.when, rule.excludes) for rule in violations(build())}
+
+
+@pytest.mark.parametrize("name", ["ext2", "ext3"])
+def test_each_legacy_ext_fixture_rejects_a_label_over_16_bytes(name: str) -> None:
+    installation = load(Path("tests/fixtures") / f"{name}.toml")
+    nodes = [
+        replace(node, label="x" * 17)
+        if isinstance(node, Filesystem) and node.id == i("rootfs")
+        else node
+        for node in installation.disk.graph.nodes.values()
+    ]
+    broken = replace(
+        installation,
+        disk=replace(installation.disk, graph=DeviceGraph.build(nodes)),
+    )
+    assert compat.filesystem_label_problems(broken) == (
+        f"filesystem rootfs has a {name} label of 17 bytes, but {name} labels are limited to 16 bytes",
+    )
 
 
 def test_every_rule_in_the_table_has_a_case_that_breaks_it() -> None:

--- a/tests/unit/test_plan_disk.py
+++ b/tests/unit/test_plan_disk.py
@@ -38,7 +38,7 @@ from gentoo_install.model.device import (
 )
 from gentoo_install.exec.config import load
 from gentoo_install.model.size import Size
-from gentoo_install.plan import disk
+from gentoo_install.plan import disk, system
 from gentoo_install.plan.operations import Stage
 
 from .layouts import config, ext4_on_gpt, i, zfs_root
@@ -48,6 +48,13 @@ from .recorder import Recorder
 def apply_all(nodes: list[Node]) -> Recorder:
     recorder = Recorder()
     for operation in disk.build(config(nodes)):
+        operation.apply(recorder)
+    return recorder
+
+
+def apply_installation(installation: InstallConfig) -> Recorder:
+    recorder = Recorder()
+    for operation in disk.build(installation):
         operation.apply(recorder)
     return recorder
 
@@ -194,6 +201,25 @@ def test_a_filesystem_is_made_with_the_label_option_its_tool_uses() -> None:
     vfat = recorder.only("mkfs.vfat")
     assert vfat[1:4] == ("-F", "32", "-n")
     assert "ESP" in vfat
+
+
+@pytest.mark.parametrize(
+    ("name", "command"),
+    [("ext2", "mkfs.ext2"), ("ext3", "mkfs.ext3")],
+)
+def test_each_legacy_ext_fixture_uses_its_mkfs_command(name: str, command: str) -> None:
+    installation = load(Path("tests/fixtures") / f"{name}.toml")
+    made = apply_installation(installation).argv_starting(command)
+    assert made == ((command, "-F", "-L", "root", "/dev/mapper/rootpart"),)
+
+
+@pytest.mark.parametrize("name", ["ext2", "ext3"])
+def test_each_legacy_ext_fixture_writes_its_fstab_entry(name: str) -> None:
+    installation = load(Path("tests/fixtures") / f"{name}.toml")
+    recorder = Recorder()
+    system.WriteFstab(entries=system.fstab_entries(installation)).apply(recorder)
+    lines = recorder.files[PurePosixPath("/etc/fstab")].splitlines()
+    assert lines[1] == f"UUID=uuid-of-rootpart\t/\t{name}\tdefaults\t0\t1"
 
 
 def test_swap_is_made_and_then_left_alone() -> None:

--- a/tests/vm/campaign.py
+++ b/tests/vm/campaign.py
@@ -173,6 +173,11 @@ STAGES: Final[dict[str, tuple[Run, ...]]] = {
         # wrapped round them.
         Run("fixtures/vm-xfs.toml"),
         Run("fixtures/vm-btrfs.toml"),
+        # The two filesystems `compat.py` carries a label rule apiece for and
+        # nothing had ever made: `mkfs`, the label, the fstab line and the
+        # initramfs support are one path each, and neither had been walked.
+        Run("fixtures/ext2.toml", firmware="bios"),
+        Run("fixtures/ext3.toml", firmware="bios"),
         # A machine that configures its own address instead of asking for one.
         # The model has carried static addressing since the beginning and no
         # fixture set it, so nothing had ever installed a machine that comes up


### PR DESCRIPTION
`model/compat.py` carries a 16-byte label rule for ext2 and another for ext3, and no fixture made either filesystem: `TESTED.md` listed them under what no record covers. Two rules that no configuration could reach, and four paths — `mkfs`, the label, the fstab line, the initramfs support — that nothing walked.

One fixture each, on the plainest layout, plus the tests that hold what is different about them: the `mkfs` the plan derives, the fstab entry it writes, and the label rule each one owns.

Written by an agent, reviewed and completed here. It was told not to touch `tests/vm/campaign.py` and put both fixtures in `NOT_IN_THE_CAMPAIGN` instead; a fixture nobody runs is a path nobody tests, so they are in the matrix now, with the BIOS firmware their configurations ask for — the test that holds that pairing is what caught it. Both gates run here, and I repeated one control myself: raising the ext2 label ceiling from 16 to 17 reddens its case on the assertion.