### PR TITLE
netboot: download the image to the root filesystem, not the esp

### DIFF
--- a/gentoo_install/plan/netboot.py
+++ b/gentoo_install/plan/netboot.py
@@ -104,6 +104,14 @@ GENTOO_ARCHITECTURES: Final[dict[str, str]] = {
 #: delete exactly what arming wrote.
 PLACE: Final[str] = "gentoo-install-ram"
 
+#: Where the download lands, on the root filesystem rather than the esp. The
+#: esp is whatever size that machine was given — 124 MiB on a Debian cloud
+#: image — and the images are 373 MB and about a gigabyte, so the first real
+#: `--lowram` run ended at `curl: (23) Failure writing output to destination`
+#: with 111 MB written. The firmware only ever reads a kernel and an initramfs
+#: from the esp, and those are tens of megabytes.
+STAGING: Final[PurePosixPath] = PurePosixPath("/") / PLACE
+
 #: What the entry is called wherever the boot method keeps names.
 ENTRY_LABEL: Final[str] = "gentoo-install memory environment"
 
@@ -301,7 +309,8 @@ class ClearPreviousArming(Operation):
 
     def apply(self, context: Context) -> None:
         _disarm(context, self.target)
-        context.run(["rm", "--recursive", "--force", str(self.target.place)], check=False)
+        for gone in (self.target.place, STAGING):
+            context.run(["rm", "--recursive", "--force", str(gone)], check=False)
 
 
 def _disarm(context: Context, target: BootTarget) -> None:
@@ -338,7 +347,7 @@ class FetchMemoryImage(Operation):
         return "fetch the {} image and verify its checksum", (self.mode.value,)
 
     def apply(self, context: Context) -> None:
-        place = self.target.place
+        place = STAGING
         context.run(["mkdir", "--parents", str(place)])
         name, url, checksum = (
             _cjk_release(context, self.target.architecture)
@@ -378,8 +387,9 @@ class PlaceMemoryKernel(Operation):
 
     def apply(self, context: Context) -> None:
         place = self.target.place
+        context.run(["mkdir", "--parents", str(place)])
         if self.mode is MemoryMode.RAM:
-            image = _only_image(context, place, ".iso")
+            image = _only_image(context, STAGING, ".iso")
             for member, name in (("/boot/gentoo", "kernel"), ("/boot/gentoo.igz", "initramfs")):
                 context.run(
                     [
@@ -394,7 +404,7 @@ class PlaceMemoryKernel(Operation):
                     ]
                 )
             return
-        archive = _only_image(context, place, ".tar.gz")
+        archive = _only_image(context, STAGING, ".tar.gz")
         for member, name in (
             ("boot/vmlinuz-lts", "kernel"),
             ("boot/initramfs-lts", "initramfs"),
@@ -412,6 +422,10 @@ class PlaceMemoryKernel(Operation):
                     member,
                 ]
             )
+        # The archive is transport and nothing reads it again: `modloop=` names
+        # a URL, not this file, and 373 MB on the root filesystem of a machine
+        # about to reboot into memory is 373 MB nobody asked for.
+        context.run(["rm", "--force", str(archive)])
 
 
 #: Where the payload lands inside the initramfs, and where the hook puts it
@@ -592,12 +606,15 @@ class WriteMemoryEntry(Operation):
 
     def _cmdline(self, context: Context, place: PurePosixPath) -> tuple[str, ...]:
         if self.mode is MemoryMode.RAM:
-            image = _only_image(context, place, ".iso")
+            image = _only_image(context, STAGING, ".iso")
             label = _volume_label(context, image)
             words = [
                 f"root=live:CDLABEL={label}",
                 *CJK_CMDLINE,
-                f"iso-scan/filename={_relative_to_mount(self.target, image)}",
+                # The path as it is: `STAGING` is at the root of the root
+                # filesystem, and iso-scan mounts each `by-uuid` device and
+                # looks for that path inside it.
+                f"iso-scan/filename={image}",
                 *_inherited_consoles(context),
             ]
             if self.launch.ssh_key or self.launch.root_password:
@@ -614,7 +631,7 @@ class WriteMemoryEntry(Operation):
             return tuple(words)
         words = [
             f"alpine_repo={ALPINE_REPOSITORY}",
-            f"modloop={_alpine_modloop(_only_image(context, place, '.tar.gz'))}",
+            f"modloop={_alpine_modloop(_only_image(context, STAGING, '.tar.gz'))}",
             "ip=dhcp",
             *_inherited_consoles(context),
         ]
@@ -693,7 +710,8 @@ class DisarmMemoryBoot(Operation):
 
     def apply(self, context: Context) -> None:
         _disarm(context, self.target)
-        context.run(["rm", "--recursive", "--force", str(self.target.place)], check=False)
+        for gone in (self.target.place, STAGING):
+            context.run(["rm", "--recursive", "--force", str(gone)], check=False)
 
 
 def build(
@@ -787,17 +805,6 @@ def _without_previous(text: str) -> str:
     before, _, rest = text.partition(CUSTOM_BEGIN)
     _, _, after = rest.partition(CUSTOM_END)
     return before + after.lstrip("\n")
-
-
-def _relative_to_mount(target: BootTarget, image: PurePosixPath) -> str:
-    """`iso-scan/filename` is relative to the filesystem the file is on.
-
-    iso-scan mounts each `/dev/disk/by-uuid/*` and looks for that path inside
-    it, so an absolute path that includes the mount point finds nothing.
-    """
-    if target.method is BootMethod.BIOS_GRUB or target.esp_mountpoint is None:
-        return f"/{image.relative_to('/boot')}" if _under(image, "/boot") else str(image)
-    return f"/{image.relative_to(target.esp_mountpoint)}"
 
 
 def _under(path: PurePosixPath, parent: str) -> bool:

--- a/tests/unit/test_plan_netboot.py
+++ b/tests/unit/test_plan_netboot.py
@@ -218,7 +218,11 @@ def test_the_iso_is_taken_from_the_newest_release_rather_than_a_pinned_name() ->
     fetched = [one for one in _run(recorder, "curl") if "--output" in one]
     assert len(fetched) == 1, fetched
     assert fetched[0][-1] == f"https://host/{ISO}", fetched
-    assert f"{ESP}/{netboot.PLACE}/{ISO}" in fetched[0], fetched
+    # On the root filesystem, not the esp: the esp is whatever size that
+    # machine was given, 124 MiB on a Debian cloud image, and this file is
+    # about a gigabyte.
+    assert f"/{netboot.PLACE}/{ISO}" in fetched[0], fetched
+    assert ESP not in " ".join(fetched[0]), fetched
 
 
 def test_an_image_whose_checksum_does_not_match_is_deleted_and_named() -> None:
@@ -1106,3 +1110,56 @@ def test_a_missing_payload_does_not_end_the_operators_session(
     said = _sourced(where, "install")
     assert "LOGIN-SHELL-ALIVE" in said, said
     assert "BOOTSTRAP" not in said, said
+
+
+def test_the_image_is_not_written_where_the_firmware_reads() -> None:
+    """The first real `--lowram` run ended at `curl: (23) Failure writing
+    output to destination` with 111 MB of a 373 MB archive written: the esp on
+    a Debian cloud image is 124 MiB, and it is whatever size that machine was
+    given. The firmware only ever reads a kernel and an initramfs from it."""
+    recorder = _answering(
+        MemoryMode.LOWRAM,
+        digest="9a7769ea8fa1737b1b49d82f1bdd53d0a17338d6d3b7cfc6f2c3ec5158596d8b",
+    )
+    netboot.FetchMemoryImage(mode=MemoryMode.LOWRAM, target=_target()).apply(recorder)
+
+    written = [one for one in _run(recorder, "curl") if "--output" in one]
+    assert len(written) == 1, written
+    output = written[0][written[0].index("--output") + 1]
+    assert output.startswith(f"/{netboot.PLACE}/"), output
+    assert not output.startswith(ESP), output
+
+
+def test_the_kernel_still_lands_where_the_firmware_reads() -> None:
+    """The other half of the same rule: two files of tens of megabytes go to
+    the esp, because that is the only filesystem the firmware reads."""
+    recorder = _answering(MemoryMode.LOWRAM)
+    netboot.PlaceMemoryKernel(mode=MemoryMode.LOWRAM, target=_target()).apply(recorder)
+
+    unpacked = [one for one in _run(recorder, "tar") if "--directory" in one]
+    assert len(unpacked) == 2, unpacked
+    for argv in unpacked:
+        assert argv[argv.index("--directory") + 1] == f"{ESP}/{netboot.PLACE}", argv
+
+
+def test_the_lowram_archive_is_deleted_once_its_two_files_are_out() -> None:
+    """`modloop=` names a URL rather than this file, so nothing reads it
+    again, and it is 373 MB on the root filesystem of a machine that is about
+    to reboot into memory."""
+    recorder = _answering(MemoryMode.LOWRAM)
+    netboot.PlaceMemoryKernel(mode=MemoryMode.LOWRAM, target=_target()).apply(recorder)
+
+    removed = [one for one in _run(recorder, "rm") if any(".tar.gz" in a for a in one)]
+    assert len(removed) == 1, recorder.commands
+
+
+def test_the_ram_image_stays_where_iso_scan_will_look_for_it() -> None:
+    """`iso-scan/filename` is why the ISO does not have to be on the esp: it
+    mounts each `by-uuid` device and looks for that path inside it."""
+    entry = _ram_entry(RUNNING_CMDLINE)
+    word = next(one for one in entry.split() if one.startswith("iso-scan/filename="))
+
+    assert word.endswith(f"/{netboot.PLACE}/{ISO}"), word
+    assert ESP not in word, word
+    removed = [one for one in entry.split() if one.startswith("rm")]
+    assert not removed, "the ISO is read at boot and is not deleted here"


### PR DESCRIPTION
The first `--lowram` run to get past every earlier defect died here:

    curl --output /boot/efi/gentoo-install-ram/alpine-netboot-3.24.1-x86_64.tar.gz …
    curl: (23) Failure writing output to destination

111 MB of a 373 MB archive written into a 124 MiB esp. That esp is not ours to size — the machine came with it — and the CJK ISO is about a gigabyte, so no arrangement of that path could work.

The firmware reads a kernel and an initramfs, tens of megabytes, and nothing else. So the download lands in `/gentoo-install-ram/` on the root filesystem, which has room, and only those two files are put where the firmware reads. `--lowram` then deletes the archive: `modloop=` names a URL rather than that file, so nothing reads it again.

For `--ram` the ISO stays there, which is the reason `iso-scan/filename` was chosen in the first place — it mounts each `by-uuid` device and looks for the path inside it, so the root filesystem serves as well as the esp and is the only one big enough. `_relative_to_mount` computed a path relative to the esp and had no caller left; it is gone rather than kept unreachable.

Disarming removes both directories, and the existing test that holds the two ways of disarming to the same commands is what caught the half that had not been changed. `docs/design.md` carries this in the same work item.

Two controls, each red on its assertion: downloading into `target.place` again, and leaving the archive behind.