### PR TITLE
netboot: unpack the kernel without the ownership it was stored with

### DIFF
--- a/gentoo_install/plan/netboot.py
+++ b/gentoo_install/plan/netboot.py
@@ -413,6 +413,13 @@ class PlaceMemoryKernel(Operation):
                 [
                     "tar",
                     "--extract",
+                    # Alpine stores these as uid 1000 and GNU tar restores
+                    # ownership as root, which the esp cannot express: the
+                    # first run to get this far answered `tar: kernel: Cannot
+                    # change ownership to uid 1000, gid 1000: Operation not
+                    # permitted` and exited 2 with the kernel half written.
+                    "--no-same-owner",
+                    "--no-same-permissions",
                     "--file",
                     str(archive),
                     "--directory",

--- a/tests/unit/test_plan_netboot.py
+++ b/tests/unit/test_plan_netboot.py
@@ -1163,3 +1163,18 @@ def test_the_ram_image_stays_where_iso_scan_will_look_for_it() -> None:
     assert ESP not in word, word
     removed = [one for one in entry.split() if one.startswith("rm")]
     assert not removed, "the ISO is read at boot and is not deleted here"
+
+
+def test_the_kernel_is_unpacked_without_the_ownership_it_was_stored_with() -> None:
+    """Alpine stores these as uid 1000, GNU tar restores ownership when it runs
+    as root, and the esp is vfat and cannot express it: the first run to reach
+    this step answered `tar: kernel: Cannot change ownership to uid 1000, gid
+    1000: Operation not permitted` and exited 2."""
+    recorder = _answering(MemoryMode.LOWRAM)
+    netboot.PlaceMemoryKernel(mode=MemoryMode.LOWRAM, target=_target()).apply(recorder)
+
+    unpacked = [one for one in _run(recorder, "tar") if "--extract" in one]
+    assert len(unpacked) == 2, unpacked
+    for argv in unpacked:
+        assert "--no-same-owner" in argv, argv
+        assert "--no-same-permissions" in argv, argv


### PR DESCRIPTION
With `#569` the 373 MB archive lands where there is room, and the run reached the next step and stopped there:

    tar --extract --file /gentoo-install-ram/alpine-netboot-3.24.1-x86_64.tar.gz
        --directory /boot/efi/gentoo-install-ram --transform 's|.*|kernel|' boot/vmlinuz-lts
    tar: kernel: Cannot change ownership to uid 1000, gid 1000: Operation not permitted
    tar: Exiting with failure status due to previous errors

Alpine stores those two files as uid 1000, GNU tar restores ownership when it runs as root, and the destination is the esp — vfat, which has no owners and no permission bits. The extraction fails after writing the file, so the kernel is there and the run is not.

Ownership on a kernel the firmware loads means nothing, so neither is restored.