### PR TITLE
kernel: a fixture that builds the kernel instead of unpacking one

### DIFF
--- a/tests/fixtures/vm-source-kernel.toml
+++ b/tests/fixtures/vm-source-kernel.toml
@@ -1,0 +1,93 @@
+# What the VM harness installs: UEFI, GPT, ext4, systemd, a source kernel
+# and binary packages for its dependencies. No desktop or overlay, so the
+# long build is the kernel itself.
+#
+# The root hash below is `install`, produced by `openssl passwd -6`. It has to
+# be a real hash: a made-up one is accepted by `usermod --password` and only
+# shows up as a system nobody can log into.
+config_version = 1
+
+[system]
+hostname = "vmtest"
+timezone = "UTC"
+locales = ["en_US.UTF-8"]
+locale = "en_US.UTF-8"
+init = "systemd"
+sshd = true
+root_password_hash = "$6$gentooinst$IR3GrdJ862XljQYDqocr4tKniIRDIT.jQNFzIrHE3U75H6B6YSWZoSYoVd5edSHpqaYBdiNfXHCoIPRVgb9lT/"
+
+[portage]
+profile = "default/linux/amd64/23.0/systemd"
+makeopts = "-j4"
+
+[portage.mirrors]
+region = "global"
+
+[portage.binhost]
+official = true
+community = "off"
+
+[kernel]
+source = "dist-source"
+
+[bootloader]
+kind = "grub"
+firmware = "uefi"
+kernel_params = ["console=ttyS0,115200"]
+
+[disk]
+root = "mnt-root"
+
+[[disk.devices]]
+kind = "existing"
+id = "disk"
+selector = "/dev/disk/by-id/virtio-target0"
+wipe = true
+
+[[disk.devices]]
+kind = "table"
+id = "table"
+disk = "disk"
+table = "gpt"
+
+[[disk.devices]]
+kind = "partition"
+id = "esp"
+table = "table"
+index = 1
+role = "esp"
+size = "512MiB"
+
+[[disk.devices]]
+kind = "partition"
+id = "rootpart"
+table = "table"
+index = 2
+role = "data"
+
+[[disk.devices]]
+kind = "filesystem"
+id = "espfs"
+device = "esp"
+type = "vfat"
+label = "ESP"
+
+[[disk.devices]]
+kind = "filesystem"
+id = "rootfs"
+device = "rootpart"
+type = "ext4"
+label = "gentoo"
+
+[[disk.devices]]
+kind = "mountpoint"
+id = "mnt-root"
+source = "rootfs"
+path = "/"
+
+[[disk.devices]]
+kind = "mountpoint"
+id = "mnt-esp"
+source = "espfs"
+path = "/efi"
+options = ["umask=0077"]

--- a/tests/golden/vm-source-kernel.txt
+++ b/tests/golden/vm-source-kernel.txt
@@ -1,0 +1,75 @@
+[partition]
+  release anything a previous run of this configuration left mounted or open
+  wipe existing signatures from disk
+  create a gpt partition table on disk as table
+  create partition 1 on disk as esp: esp, 512MiB
+  create partition 2 on disk as rootpart: data, the rest of the disk
+  reread the partition table of disk and wait for its nodes
+
+[format]
+  make a vfat filesystem on esp as espfs labelled ESP
+  make a ext4 filesystem on rootpart as rootfs labelled gentoo
+
+[mount]
+  mount rootpart at /
+  mount esp at /efi with umask=0077
+
+[stage3]
+  download the newest systemd stage3 from https://distfiles.gentoo.org directly, verify it against BB572E0E2D182910 and unpack it into the target
+
+[chroot]
+  mount transient proc, sys, dev and run filesystems into the target
+  seed the target's resolv.conf from the install medium
+
+[portage]
+  write /etc/portage/make.conf with MAKEOPTS, INPUT_DEVICES, ACCEPT_LICENSE, L10N, FEATURES; 2 mirrors in the configured order, 5 appended
+  configure Portage, wget, curl, git and gpg for direct connection
+  create the three autounmask files emerge writes its decisions into
+  run getuto so Portage has a keyring to verify binary packages against
+  add verified binary package host gentoo at https://distfiles.gentoo.org/releases/amd64/binpackages/23.0/x86-64
+  fetch the first ebuild repository snapshot with emerge-webrsync
+  select profile default/linux/amd64/23.0/systemd
+  install git, which every later repository sync needs: emerge dev-vcs/git
+  point repository gentoo at https://github.com/gentoo-mirror/gentoo.git, commit signatures verified
+  sync repository gentoo
+  set sys-kernel/installkernel to dracut
+  accept the linux-firmware licence
+  resolve net-misc/openssh sys-process/cronie sys-kernel/installkernel sys-kernel/dracut sys-kernel/linux-firmware sys-fs/dosfstools sys-fs/e2fsprogs sys-kernel/gentoo-kernel sys-boot/grub sys-boot/efibootmgr together before installing the requested packages
+
+[system]
+  generate and verify locales en_US.UTF-8
+  set the system locale to en_US.UTF-8
+  set the timezone to UTC
+  set the console keymap to us and its font to default8x16
+  set the hostname to vmtest
+  give the target its own machine id
+  write /etc/fstab with entries for /, /efi
+  treat the hardware clock as UTC
+  set the root password
+  install sshd: emerge net-misc/openssh
+  ssh password login: off, root: off
+  enable sshd at boot
+  generate the ssh host keys
+  configure the wired interface for DHCP
+  enable systemd-networkd at boot
+  enable systemd-resolved at boot
+  install cron: emerge sys-process/cronie
+  enable cronie at boot
+
+[kernel]
+  install the hook that puts a kernel in /boot: emerge sys-kernel/installkernel
+  install the initramfs builder and firmware: emerge sys-kernel/dracut sys-kernel/linux-firmware
+  install the storage tools: emerge sys-fs/dosfstools sys-fs/e2fsprogs
+  install the kernel: emerge sys-kernel/gentoo-kernel, from source
+  rebuild the initramfs from sys-kernel/gentoo-kernel with the modules written above
+  check the installkernel payload names existing kernel files
+
+[bootloader]
+  install the bootloader: emerge sys-boot/grub sys-boot/efibootmgr
+  write /etc/default/grub with cmdline console=ttyS0,115200, its menu on ttyS0
+  install GRUB for uefi on the esp at /efi
+
+[finish]
+  point /etc/resolv.conf at systemd-resolved rather than the install medium's
+  delete the downloaded stage3 from /var/cache/gentoo-install
+  unmount everything under the target

--- a/tests/unit/test_plan_boot.py
+++ b/tests/unit/test_plan_boot.py
@@ -174,6 +174,51 @@ def test_the_patched_kernel_is_keyworded_and_its_cjk_flag_is_left_alone() -> Non
     )
 
 
+def test_the_source_kernel_fixture_builds_and_rebuilds_the_kernel() -> None:
+    installation = load(Path("tests/fixtures/vm-source-kernel.toml"))
+    assert installation.kernel.source is KernelSource.DIST_SOURCE
+
+    from gentoo_install.plan.kernel import (
+        ConfigureInstallKernel,
+        RebuildInitramfs,
+        RequireKernelImage,
+    )
+
+    operations = kernel.build(installation)
+    merges = [
+        one
+        for one in operations
+        if isinstance(one, Emerge) and one.summary == "install the kernel"
+    ]
+    assert len(merges) == 1, merges
+    merge = merges[0]
+    installkernel = next(one for one in operations if isinstance(one, ConfigureInstallKernel))
+    rebuild = next(one for one in operations if isinstance(one, RebuildInitramfs))
+    require = next(one for one in operations if isinstance(one, RequireKernelImage))
+
+    assert merge.packages == ("sys-kernel/gentoo-kernel",)
+    assert merge.source == SourcePolicy.build_all()
+    assert operations.index(installkernel) < operations.index(merge) < operations.index(rebuild)
+    assert operations.index(rebuild) < operations.index(require)
+
+
+def test_the_source_kernel_is_excluded_from_binary_packages() -> None:
+    installation = load(Path("tests/fixtures/vm-source-kernel.toml"))
+    merge = next(
+        one
+        for one in kernel.build(installation)
+        if isinstance(one, Emerge) and one.summary == "install the kernel"
+    )
+    recorder = Recorder()
+    merge.apply(recorder)
+
+    command = recorder.only("emerge")
+    excluded = command[command.index("--usepkg-exclude") + 1]
+    assert command[command.index("--getbinpkg=y")] == "--getbinpkg=y"
+    assert "sys-kernel/gentoo-kernel" in excluded.split()
+    assert command[-1] == "sys-kernel/gentoo-kernel"
+
+
 def test_a_sources_package_is_refused_rather_than_left_unbuilt() -> None:
     """It would unpack a tree nothing compiles, and the failure would be a
     bootloader pointing at an empty /boot an hour after the disks were written."""

--- a/tests/vm/campaign.py
+++ b/tests/vm/campaign.py
@@ -178,6 +178,11 @@ STAGES: Final[dict[str, tuple[Run, ...]]] = {
         # initramfs support are one path each, and neither had been walked.
         Run("fixtures/ext2.toml", firmware="bios"),
         Run("fixtures/ext3.toml", firmware="bios"),
+        # The kernel every other fixture takes as a binary package. Building it
+        # is a different path: the configuration, the build, `installkernel`
+        # and the initramfs are produced rather than unpacked, and about an
+        # hour on four cores, so it gets the weight a desktop gets.
+        Run("fixtures/vm-source-kernel.toml", weight=2, cpus=10),
         # A machine that configures its own address instead of asking for one.
         # The model has carried static addressing since the beginning and no
         # fixture set it, so nothing had ever installed a machine that comes up


### PR DESCRIPTION
Every kernel fixture in the tree takes a binary package — `DIST_BIN` or `CJK_BIN`. `KernelSource.DIST_SOURCE` is a different path through `plan/kernel.py`: the configuration, the build, `installkernel` and the initramfs are produced rather than unpacked, and nothing had ever produced them.

One fixture on the plainest layout, so what the run is about is the kernel. The tests hold what the plan does differently for it: the kernel is built rather than fetched, and it is in `--usepkg-exclude` so `FEATURES=getbinpkg` cannot quietly hand it a binary anyway — the trap that once merged `sys-fs/zfs` against the wrong `KV_FULL`.

Written by an agent, reviewed here. Both gates run in this tree and one control repeated: setting the fixture's `source` back to `dist-bin` reddens both tests on their assertions. It was told not to touch `tests/vm/campaign.py`, so its entry is added here with the weight a desktop gets — the agent measured about an hour on four cores against `TIMEOUT=5400` and `RUN_CEILING` of eight hours, and `INSTALL_IDLE` only ends a guest that is silent *and* moving no bytes.