### PR TITLE
portage: hold the binary-host degradation through the runner

### DIFF
--- a/tests/fixtures/vm-binhost-fallback.toml
+++ b/tests/fixtures/vm-binhost-fallback.toml
@@ -1,0 +1,90 @@
+# xTom returned HTTP 404 for its binary package index on 2026-08-18, so Portage
+# must drop it and compile from source; its no-releases entry sends stage3 to USTC.
+config_version = 1
+
+[system]
+hostname = "binhost-fallback"
+timezone = "UTC"
+locales = ["en_US.UTF-8"]
+locale = "en_US.UTF-8"
+init = "systemd"
+sshd = true
+root_password_hash = "$6$gentooinst$IR3GrdJ862XljQYDqocr4tKniIRDIT.jQNFzIrHE3U75H6B6YSWZoSYoVd5edSHpqaYBdiNfXHCoIPRVgb9lT/"
+
+[portage]
+profile = "default/linux/amd64/23.0/systemd"
+sync = "webrsync"
+makeopts = "-j4"
+
+[portage.mirrors]
+region = "cn"
+site = "xtom-hk"
+
+[portage.binhost]
+official = true
+community = "off"
+
+[kernel]
+source = "dist-bin"
+
+[bootloader]
+kind = "grub"
+firmware = "uefi"
+kernel_params = ["console=ttyS0,115200"]
+
+[disk]
+root = "mnt-root"
+
+[[disk.devices]]
+kind = "existing"
+id = "disk"
+selector = "/dev/disk/by-id/virtio-target0"
+wipe = true
+
+[[disk.devices]]
+kind = "table"
+id = "table"
+disk = "disk"
+table = "gpt"
+
+[[disk.devices]]
+kind = "partition"
+id = "esp"
+table = "table"
+index = 1
+role = "esp"
+size = "512MiB"
+
+[[disk.devices]]
+kind = "partition"
+id = "rootpart"
+table = "table"
+index = 2
+role = "data"
+
+[[disk.devices]]
+kind = "filesystem"
+id = "espfs"
+device = "esp"
+type = "vfat"
+label = "ESP"
+
+[[disk.devices]]
+kind = "filesystem"
+id = "rootfs"
+device = "rootpart"
+type = "ext4"
+label = "gentoo"
+
+[[disk.devices]]
+kind = "mountpoint"
+id = "mnt-root"
+source = "rootfs"
+path = "/"
+
+[[disk.devices]]
+kind = "mountpoint"
+id = "mnt-esp"
+source = "espfs"
+path = "/efi"
+options = ["umask=0077"]

--- a/tests/golden/vm-binhost-fallback.txt
+++ b/tests/golden/vm-binhost-fallback.txt
@@ -1,0 +1,73 @@
+[partition]
+  release anything a previous run of this configuration left mounted or open
+  wipe existing signatures from disk
+  create a gpt partition table on disk as table
+  create partition 1 on disk as esp: esp, 512MiB
+  create partition 2 on disk as rootpart: data, the rest of the disk
+  reread the partition table of disk and wait for its nodes
+
+[format]
+  make a vfat filesystem on esp as espfs labelled ESP
+  make a ext4 filesystem on rootpart as rootfs labelled gentoo
+
+[mount]
+  mount rootpart at /
+  mount esp at /efi with umask=0077
+
+[stage3]
+  download the newest systemd stage3 from https://mirrors.ustc.edu.cn/gentoo directly, verify it against BB572E0E2D182910 and unpack it into the target
+
+[chroot]
+  mount transient proc, sys, dev and run filesystems into the target
+  seed the target's resolv.conf from the install medium
+
+[portage]
+  write /etc/portage/make.conf with MAKEOPTS, INPUT_DEVICES, ACCEPT_LICENSE, L10N, FEATURES; 23 mirrors in the configured order, 5 appended
+  configure Portage, wget, curl, git and gpg for direct connection
+  create the three autounmask files emerge writes its decisions into
+  run getuto so Portage has a keyring to verify binary packages against
+  add verified binary package host gentoo at https://mirror.xtom.com.hk/gentoo/releases/amd64/binpackages/23.0/x86-64
+  fetch the first ebuild repository snapshot with emerge-webrsync
+  select profile default/linux/amd64/23.0/systemd
+  configure repository gentoo to sync with emerge-webrsync
+  set sys-kernel/installkernel to dracut
+  accept the linux-firmware licence
+  resolve net-misc/openssh sys-process/cronie sys-kernel/installkernel sys-kernel/dracut sys-kernel/linux-firmware sys-fs/dosfstools sys-fs/e2fsprogs sys-kernel/gentoo-kernel-bin sys-boot/grub sys-boot/efibootmgr together before installing the requested packages
+
+[system]
+  generate and verify locales en_US.UTF-8
+  set the system locale to en_US.UTF-8
+  set the timezone to UTC
+  set the console keymap to us and its font to default8x16
+  set the hostname to binhost-fallback
+  give the target its own machine id
+  write /etc/fstab with entries for /, /efi
+  treat the hardware clock as UTC
+  set the root password
+  install sshd: emerge net-misc/openssh
+  ssh password login: off, root: off
+  enable sshd at boot
+  generate the ssh host keys
+  configure the wired interface for DHCP
+  enable systemd-networkd at boot
+  enable systemd-resolved at boot
+  install cron: emerge sys-process/cronie
+  enable cronie at boot
+
+[kernel]
+  install the hook that puts a kernel in /boot: emerge sys-kernel/installkernel
+  install the initramfs builder and firmware: emerge sys-kernel/dracut sys-kernel/linux-firmware
+  install the storage tools: emerge sys-fs/dosfstools sys-fs/e2fsprogs
+  install the kernel: emerge sys-kernel/gentoo-kernel-bin
+  rebuild the initramfs from sys-kernel/gentoo-kernel-bin with the modules written above
+  check the installkernel payload names existing kernel files
+
+[bootloader]
+  install the bootloader: emerge sys-boot/grub sys-boot/efibootmgr
+  write /etc/default/grub with cmdline console=ttyS0,115200, its menu on ttyS0
+  install GRUB for uefi on the esp at /efi
+
+[finish]
+  point /etc/resolv.conf at systemd-resolved rather than the install medium's
+  delete the downloaded stage3 from /var/cache/gentoo-install
+  unmount everything under the target

--- a/tests/unit/test_exec.py
+++ b/tests/unit/test_exec.py
@@ -20,6 +20,8 @@ from gentoo_install.errors import (
     PreflightFailed,
 )
 from gentoo_install.exec import apply, fetch, preflight, report as exec_report
+from gentoo_install.exec.config import load
+from gentoo_install.log import Journal
 from gentoo_install.exec.probe import Machine as ProbedMachine
 from gentoo_install.exec.probe import Probe, probe_storage_facts
 from gentoo_install.exec.runner import Result, Runner, under
@@ -27,6 +29,7 @@ from gentoo_install.model.config import Bootloader, BootloaderConfig, DiskMode, 
 from gentoo_install.model.device import DeviceId, Existing, Luks, Node
 from gentoo_install.model.size import Size
 from gentoo_install.plan.operations import CommandOutput
+from gentoo_install.plan import portage
 
 from .layouts import config, encrypted_root, ext4_on_gpt, i, zfs_root
 
@@ -258,6 +261,83 @@ def test_a_live_command_keeps_its_nonzero_status_with_output(tmp_path: Path) -> 
     assert isinstance(output, CommandOutput)
     assert output.returncode == 1
     assert "not a mountpoint" in output
+
+def test_an_unreadable_binhost_is_journalled_and_the_run_finishes(tmp_path: Path) -> None:
+    installation = load(Path("tests/fixtures/vm-binhost-fallback.toml"))
+    endpoint = "https://mirror.xtom.com.hk/gentoo/releases/amd64/binpackages/23.0/x86-64"
+    unreadable = (
+        f"!!! [gentoo] Error fetching binhost package info from '{endpoint}'\n"
+        "!!! HTTP Error 404: Not Found\n"
+    )
+    reason = f"binary host index unreadable: [gentoo] Error fetching binhost package info from '{endpoint}'"
+    messages: list[str] = []
+    journal = Journal(path=tmp_path / "install.jsonl")
+
+    class BinhostUnavailable(Runner):
+        def __init__(self) -> None:
+            super().__init__(log=messages.append, journal=journal)
+            self.commands: list[tuple[str, ...]] = []
+
+        def in_target(self, target: Path) -> Runner:
+            return self
+
+        def run(
+            self,
+            argv: Sequence[str],
+            *,
+            check: bool = True,
+            input_text: str | None = None,
+            timeout: float | None = None,
+        ) -> Result:
+            command = tuple(argv)
+            self.commands.append(command)
+            if command[0] != "emerge":
+                raise AssertionError(command)
+            if "--pretend" in command:
+                output = (
+                    "[ebuild  N    ] app-editors/nano-8\n"
+                    if "--getbinpkg=n" in command
+                    else unreadable
+                )
+                return Result(command, 0 if "--getbinpkg=n" in command else 1, output, "", 0.0)
+            assert "--usepkg=n" in command and "--getbinpkg=n" in command
+            return Result(command, 0, "[ebuild  N    ] app-editors/nano-8\n", "", 0.0)
+
+    runner = BinhostUnavailable()
+    machine = apply.Machine(
+        config=installation,
+        runner=runner,
+        probe=Probe(runner=runner, work=tmp_path),
+        work=tmp_path,
+    )
+    operations = (
+        portage.VerifyPackages(
+            requests=(
+                portage.PackageRequest(
+                    atom="app-editors/nano",
+                    requesters=("the `editor` group",),
+                ),
+            )
+        ),
+        portage.Emerge(packages=("app-editors/nano",), summary="install the editor"),
+    )
+
+    apply.apply(operations, machine)
+
+    recorded = list(journal.replay())
+    degraded = [entry for entry in recorded if entry["event"] == "degraded"]
+    completed = [entry for entry in recorded if entry["event"] == "operation"]
+    assert degraded == [
+        {
+            "event": "degraded",
+            "what": portage.BINARY_PACKAGES,
+            "reason": reason,
+        }
+    ]
+    assert messages.count(f"WARNING: {portage.BINARY_PACKAGES} is unavailable, so {reason}") == 1
+    assert [entry["status"] for entry in completed] == ["done", "done"]
+    assert [entry["describe"] for entry in completed][-1] == "install the editor: emerge app-editors/nano"
+    assert [("--getbinpkg=n" in command) for command in runner.commands] == [False, False, True, True]
 
 
 def test_a_live_findmnt_result_enables_the_lazy_unmount_fallback(tmp_path: Path) -> None:

--- a/tests/unit/test_harness.py
+++ b/tests/unit/test_harness.py
@@ -147,6 +147,11 @@ NOT_IN_THE_CAMPAIGN: Final[frozenset[str]] = frozenset(
         # medium the campaign boots, because the machine under test has to
         # have a bootloader of its own to arm.
         "vm-ram.toml",
+        # The input to the tests that hold what a binary host failing does,
+        # rather than a machine to install: what it describes is a host that
+        # cannot answer, and the cluster has no way to arrange one. The rule
+        # itself is held in `test_exec.py`, through the runner and the journal.
+        "vm-binhost-fallback.toml",
     }
 )
 

--- a/tests/unit/test_plan_portage.py
+++ b/tests/unit/test_plan_portage.py
@@ -6,7 +6,7 @@ import subprocess
 import pytest
 
 from dataclasses import fields, replace
-from pathlib import PurePosixPath
+from pathlib import Path, PurePosixPath
 from typing import Any, Final, Sequence
 
 from gentoo_install.model.config import (
@@ -897,6 +897,55 @@ BINHOST_TIMED_OUT: Final[str] = (
     "!!! [gentoo] <urlopen error timed out>\n"
     "[ebuild  N    ] dev-perl/Error-0.170.300-r1\n"
 )
+
+
+
+def test_the_binhost_fallback_fixture_degrades_the_plan_to_source() -> None:
+    from gentoo_install.exec.config import load
+    from gentoo_install.plan.build import stage3_mirror
+
+    installation = load(Path("tests/fixtures/vm-binhost-fallback.toml"))
+    endpoint = "https://mirror.xtom.com.hk/gentoo/releases/amd64/binpackages/23.0/x86-64"
+    configured = [
+        operation
+        for operation in portage.build(installation, MIRROR)
+        if isinstance(operation, portage.ConfigureBinhost)
+    ]
+    assert stage3_mirror(installation) == "https://mirrors.ustc.edu.cn/gentoo"
+    assert [operation.sync_uri for operation in configured] == [endpoint]
+
+    unreadable = (
+        f"!!! [gentoo] Error fetching binhost package info from '{endpoint}'\n"
+        "!!! HTTP Error 404: Not Found\n"
+    )
+    reason = f"binary host index unreadable: [gentoo] Error fetching binhost package info from '{endpoint}'"
+    recorder = Recorder()
+    attempts: list[tuple[str, ...]] = []
+
+    def answer(argv: Sequence[str]) -> CommandOutput:
+        if argv[0] != "emerge":
+            return CommandOutput("", 0)
+        attempts.append(tuple(argv))
+        if "--getbinpkg=n" in argv:
+            return CommandOutput("[ebuild  N    ] app-editors/nano-8\n", 0)
+        return CommandOutput(unreadable, 1)
+
+    recorder.answering = answer
+    portage.VerifyPackages(
+        requests=(
+            portage.PackageRequest(
+                atom="app-editors/nano",
+                requesters=("the `editor` group",),
+            ),
+        )
+    ).apply(recorder)
+
+    assert recorder.degradations == {portage.BINARY_PACKAGES: reason}
+    assert [("--usepkg=n" in attempt, "--getbinpkg=n" in attempt) for attempt in attempts] == [
+        (False, False),
+        (False, False),
+        (True, True),
+    ]
 
 
 def test_a_binary_host_that_cannot_be_read_degrades_the_resolve_to_source() -> None:


### PR DESCRIPTION
"Every binhost failure degrades to compiling from source with a visible warning, and `install.jsonl` records the reason" is a rule this repository states and nothing followed end to end. The plan's own tests covered the branch; what a run does with it — the emerges that follow, the warning, the journal — was untested.

The new test drives a run whose binary host answers with nothing readable and asserts what the machine is left with: the degradation is journalled once with its reason, every later emerge carries `--usepkg=n --getbinpkg=n`, and the run reaches its last operation and finishes. The commands before and after the degradation are asserted as a sequence, so a fallback that starts too early or too late is a failure rather than a detail.

Written by an agent, reviewed here. Its fixture is the input to those tests and is listed as one nobody schedules: what it describes is a host that cannot answer, and the cluster has no way to arrange one — a fixture that would silently install from a working binhost proves the opposite of what it is named for. The control is red on its assertion: removing the degrade call from the index read leaves the run without the journal entry.
