### PR TITLE
netboot: the payload copy restores no ownership either

### DIFF
--- a/gentoo_install/plan/netboot.py
+++ b/gentoo_install/plan/netboot.py
@@ -498,7 +498,11 @@ class AppendConfiguration(Operation):
                 "sh",
                 "-c",
                 f"cd {self.source} && tar --create --exclude=__pycache__ "
-                f"gentoo_install bootstrap.sh | tar --extract --directory {inside}",
+                f"gentoo_install bootstrap.sh | tar --extract --no-same-owner "
+                # The esp is vfat and has no owners: without this the copy ends
+                # `Cannot change ownership to uid 1000` for every file the tree
+                # carries and the arming stops with the payload half written.
+                f"--no-same-permissions --directory {inside}",
             ]
         )
         context.write(inside / "start.sh", _start(), mode=0o755)

--- a/tests/unit/test_plan_netboot.py
+++ b/tests/unit/test_plan_netboot.py
@@ -1178,3 +1178,22 @@ def test_the_kernel_is_unpacked_without_the_ownership_it_was_stored_with() -> No
     for argv in unpacked:
         assert "--no-same-owner" in argv, argv
         assert "--no-same-permissions" in argv, argv
+
+
+def test_the_payload_copy_restores_no_ownership_either() -> None:
+    """The tree goes onto the esp beside the kernel, and vfat has no owners:
+    the copy ended `tar: gentoo_install/cli.py: Cannot change ownership to uid
+    1000, gid 1000: Operation not permitted` with the payload half written."""
+    recorder = _answering()
+    netboot.AppendConfiguration(
+        target=_target(),
+        launch=_launch(),
+        configuration="x",
+        source="/mnt/driver",
+    ).apply(recorder)
+
+    piped = [one for one in recorder.commands if any("tar --create" in a for a in one)]
+    assert len(piped) == 1, recorder.commands
+    line = " ".join(piped[0])
+    assert "--no-same-owner" in line, line
+    assert "--no-same-permissions" in line, line


### PR DESCRIPTION
One step past PR 570, the same wall:

    sh -c 'cd /mnt/driver && tar --create --exclude=__pycache__ gentoo_install bootstrap.sh
           | tar --extract --directory /boot/efi/gentoo-install-ram/payload/gentoo-install'
    tar: gentoo_install/cli.py: Cannot change ownership to uid 1000, gid 1000: Operation not permitted

The installer's own tree goes onto the esp beside the kernel — 1.4 MiB, and it is what makes the memory environment run the revision that wrote the configuration. vfat has no owners, GNU tar restores them as root, and the arming stopped with the payload half written.

Same two flags, for the same reason, on the extracting half of the pipe. The control is red on its assertion.