### PR TITLE
cluster: keep a long command from filling the whole verdict

### DIFF
--- a/tests/unit/test_harness.py
+++ b/tests/unit/test_harness.py
@@ -3572,3 +3572,25 @@ def test_a_package_manager_that_installed_nothing_stops_the_run() -> None:
     console.absent = ("efibootmgr", "dosfstools")
     with _pytest.raises(MediaError, match="efibootmgr"):
         install_tools(cast(Any, console), IMAGES["debian"], "fixtures/vm-ram.toml")
+
+
+def test_a_long_command_does_not_fill_the_whole_verdict() -> None:
+    """`vm-zram` ended a round with a mirror probe naming eight URLs, and the
+    command alone filled all 300 bytes a verdict is cut to: what the guest was
+    doing was written down and why it stopped was not."""
+    from tests.vm import cluster
+    from tests.vm.console import ConsoleTimeout
+
+    probe = "for one in " + " ".join(
+        f"https://mirror{n}.example.edu.cn/gentoo/releases/amd64/autobuilds/"
+        "latest-stage3-amd64-systemd.txt"
+        for n in range(8)
+    )
+    with pytest.raises(ConsoleTimeout) as raised:
+        with cluster._naming(probe):
+            raise ConsoleTimeout("never matched 'MARK_9_DONE', 121s of 120s elapsed")
+
+    said = str(raised.value)[: cluster.OUTCOME_BYTES]
+    assert "never matched 'MARK_9_DONE'" in said, said
+    assert said.startswith("never matched"), said
+    assert len(probe) > cluster.OUTCOME_BYTES, "the case this exists for"

--- a/tests/vm/cluster.py
+++ b/tests/vm/cluster.py
@@ -2163,19 +2163,32 @@ KNOWN_BAD_NODES: Final[frozenset[str]] = frozenset()
 REOPEN_CEILING: Final[int] = 24
 
 
+#: How much of a command a verdict carries. `vm-zram` ended a round with a
+#: mirror probe naming eight URLs, and the command alone filled all 300 bytes
+#: of the verdict: the reason it failed was never written down.
+COMMAND_IN_A_VERDICT: Final[int] = 80
+
+
+def _shortened(command: str) -> str:
+    if len(command) <= COMMAND_IN_A_VERDICT:
+        return command
+    return f"{command[:COMMAND_IN_A_VERDICT]}… ({len(command)} chars)"
+
+
 @contextmanager
 def _naming(command: str) -> Iterator[None]:
     """Put the command into a marker's timeout, which otherwise names a token.
 
     `vm-convert` ended a 156-minute run with `never matched 'MARK_63_DONE'`,
-    and reading which of sixty-three commands that was took the source.
+    and reading which of sixty-three commands that was took the source. Enough
+    of it to recognise it, and no more: the reason has to fit as well.
     """
     try:
         yield
     except ConsoleIdle as error:
-        raise ConsoleIdle(f"{command!r}: {error}") from error
+        raise ConsoleIdle(f"{error} while running {_shortened(command)!r}") from error
     except ConsoleTimeout as error:
-        raise ConsoleTimeout(f"{command!r}: {error}") from error
+        raise ConsoleTimeout(f"{error} while running {_shortened(command)!r}") from error
 
 
 class Reconnecting:


### PR DESCRIPTION
run75's first failure, in full:

    ERROR vm-zram 3.9m 'for one in https://mirrors.tuna.tsinghua.edu.cn/gentoo/releases/amd64/autobuilds/latest-stage3-amd64-systemd.txt https://mirror.nju.edu.cn/… htt

Three hundred bytes of mirror URLs and not one word about what went wrong. The command goes in front of the reason, and a probe that names eight mirrors is longer than a verdict.

Same lesson as PR 549 at a different call site: the reason first, and enough of the command to recognise it. Eighty characters names any command in this harness, and the length is kept so a truncated one still reads as truncated.

The control is red on its assertion: with the old order, the reason is outside the first three hundred bytes.