### PR TITLE
netboot: discard the archive after the entry has read its name

### DIFF
--- a/gentoo_install/plan/netboot.py
+++ b/gentoo_install/plan/netboot.py
@@ -429,10 +429,7 @@ class PlaceMemoryKernel(Operation):
                     member,
                 ]
             )
-        # The archive is transport and nothing reads it again: `modloop=` names
-        # a URL, not this file, and 373 MB on the root filesystem of a machine
-        # about to reboot into memory is 373 MB nobody asked for.
-        context.run(["rm", "--force", str(archive)])
+
 
 
 #: Where the payload lands inside the initramfs, and where the hook puts it
@@ -576,6 +573,27 @@ def _handover() -> str:
         f'printf \'\\n[ -f {PAYLOAD}/start.sh ] && . {PAYLOAD}/start.sh\\n\' '
         f'>> "$NEWROOT{AUTOSTART}"\n'
     )
+
+
+@dataclass(frozen=True, kw_only=True)
+class DiscardTheArchive(Operation):
+    """Delete the netboot archive once everything that reads it has.
+
+    Transport, not payload: the two files are out and `modloop=` names a URL
+    rather than this file. It is 373 MB on the root filesystem of a machine
+    about to reboot into memory. After the entry, not before it: the entry
+    composes that URL from this file's name, and deleting it first ended a run
+    with `/gentoo-install-ram holds 0 files ending .tar.gz`.
+    """
+
+    stage: Stage = Stage.BOOTLOADER
+
+    def describe_parts(self) -> tuple[str, tuple[str, ...]]:
+        return "delete the downloaded archive, now that its two files are out", ()
+
+    def apply(self, context: Context) -> None:
+        archive = _only_image(context, STAGING, ".tar.gz")
+        context.run(["rm", "--force", str(archive)])
 
 
 @dataclass(frozen=True, kw_only=True)
@@ -765,10 +783,10 @@ def build(
                 keys=keys,
             )
         )
-    operations += [
-        WriteMemoryEntry(mode=launch.mode, target=target, launch=launch),
-        arming,
-    ]
+    operations.append(WriteMemoryEntry(mode=launch.mode, target=target, launch=launch))
+    if launch.mode is MemoryMode.LOWRAM:
+        operations.append(DiscardTheArchive())
+    operations.append(arming)
     return operations
 
 

--- a/tests/unit/test_plan_netboot.py
+++ b/tests/unit/test_plan_netboot.py
@@ -1142,15 +1142,33 @@ def test_the_kernel_still_lands_where_the_firmware_reads() -> None:
         assert argv[argv.index("--directory") + 1] == f"{ESP}/{netboot.PLACE}", argv
 
 
-def test_the_lowram_archive_is_deleted_once_its_two_files_are_out() -> None:
-    """`modloop=` names a URL rather than this file, so nothing reads it
-    again, and it is 373 MB on the root filesystem of a machine that is about
-    to reboot into memory."""
-    recorder = _answering(MemoryMode.LOWRAM)
-    netboot.PlaceMemoryKernel(mode=MemoryMode.LOWRAM, target=_target()).apply(recorder)
+def test_the_lowram_archive_is_deleted_after_the_entry_has_read_its_name() -> None:
+    """`modloop=` names a URL rather than this file, so nothing reads it again
+    once the entry is written, and it is 373 MB on the root filesystem of a
+    machine about to reboot into memory. Deleting it any earlier ended a run
+    with `/gentoo-install-ram holds 0 files ending .tar.gz`: the entry composes
+    that URL from this file's name."""
+    operations = netboot.build(
+        launch=_launch(MemoryMode.LOWRAM), target=_target(), configuration="x"
+    )
+    kinds = [type(one).__name__ for one in operations]
 
+    assert "DiscardTheArchive" in kinds, kinds
+    assert kinds.index("WriteMemoryEntry") < kinds.index("DiscardTheArchive"), kinds
+
+    recorder = _answering(MemoryMode.LOWRAM)
+    netboot.DiscardTheArchive().apply(recorder)
     removed = [one for one in _run(recorder, "rm") if any(".tar.gz" in a for a in one)]
     assert len(removed) == 1, recorder.commands
+
+
+def test_the_ram_iso_is_never_discarded() -> None:
+    """`iso-scan/filename` names it, so the machine reads it at boot."""
+    operations = netboot.build(
+        launch=_launch(MemoryMode.RAM), target=_target(), configuration="x"
+    )
+
+    assert "DiscardTheArchive" not in [type(one).__name__ for one in operations]
 
 
 def test_the_ram_image_stays_where_iso_scan_will_look_for_it() -> None:


### PR DESCRIPTION
PR 569 deleted the netboot archive as soon as the kernel and initramfs were out of it. The next run got further and stopped at

    download: /gentoo-install-ram holds 0 files ending .tar.gz and this needs one

because the command line is written after that, and PR 542 composes the `modloop=` URL from the archive's own name — the version and the architecture of the kernel that will be running.

The deletion is its own operation now, after the entry. It applies to `--lowram` alone: the `--ram` ISO is what `iso-scan/filename` names, so the machine reads it at boot.

The control is red on its assertion: with the discard moved back before the entry, the ordering test fails.
