### PR TITLE
ram: read the boot order with the same tools both times

### DIFF
--- a/tests/unit/test_harness.py
+++ b/tests/unit/test_harness.py
@@ -3594,3 +3594,20 @@ def test_a_long_command_does_not_fill_the_whole_verdict() -> None:
     assert "never matched 'MARK_9_DONE'" in said, said
     assert said.startswith("never matched"), said
     assert len(probe) > cluster.OUTCOME_BYTES, "the case this exists for"
+
+
+def test_the_boot_order_is_read_with_the_same_tools_both_times() -> None:
+    """The cloud images ship no `efibootmgr`, and `install_tools` puts one on
+    the guest. A first reading taken before that answered `NO-BOOTORDER` and
+    the second `BootOrder: 0003,0000,0004`, so the run reported the default
+    entry as moved by a machine that had not moved it."""
+    import inspect
+
+    from tests.vm import ram
+
+    source = inspect.getsource(ram.main)
+    installed = source.index("install_tools(")
+    first = source.index("before = read_the_default_entry(")
+
+    assert installed < first, "the tools go on before the first reading"
+    assert source.index("arm(console") > first, "and the reading before the arming"

--- a/tests/vm/ram.py
+++ b/tests/vm/ram.py
@@ -144,12 +144,16 @@ def main(argv: list[str] | None = None) -> int:
         console = SerialConsole.connect(vm.serial_socket, vm.serial_log)
         reach_root(console, chosen)
         print(f"[{time.monotonic() - started:5.1f}s] root shell on serial", flush=True)
-        before = read_the_default_entry(console)
         # Before anything asks the CD for a file: the guest's shell answers
         # before its ATAPI devices are enumerated, and `sh` exits 2 for a
         # script it cannot open, which reads as the installer refusing.
         wait_for_driver(console)
         install_tools(console, chosen, arguments.config)
+        # After the tools, not before them: the cloud images ship no
+        # `efibootmgr`, so a first reading taken without one answered
+        # `NO-BOOTORDER` and the second answered `BootOrder: 0003,0000,0004`.
+        # Nothing about the machine had changed; the instrument had.
+        before = read_the_default_entry(console)
         arm(console, arguments.config, arguments.mode)
         code = console.expect_command(
             "cat /tmp/gentoo-install-results/arm.rc", timeout=60.0


### PR DESCRIPTION
The fifth `--lowram` run armed the machine — `arming exited 0` at 25.3 seconds, which nothing had ever reached — and the harness then failed it:

    FAIL the default boot entry changed, which this mode promises not to do:
    b'NO-BOOTORDER' then b'next_entry=gentoo-install memory environment
                           BootOrder: 0003,0000,0004'

The machine did not change its boot order. `read_the_default_entry` runs `efibootmgr`, the cloud images do not ship one, and `install_tools` installs it between the two readings. The first was taken without the instrument and the second with it.

`BootOrder: 0003,0000,0004` is also the answer that proves the mode kept its promise: three firmware-created entries and nothing of ours, with the one-shot expressed as `next_entry` in `grubenv` exactly as intended.

The reading moves after the tools and before the arming. The control is red on its assertion.
