### PR TITLE
netboot: a UEFI GRUB entry names the path the esp holds

### DIFF
--- a/gentoo_install/plan/netboot.py
+++ b/gentoo_install/plan/netboot.py
@@ -814,7 +814,16 @@ def _write_custom(
     # a directory. Written the first way on a machine of the second kind, the
     # `search` matches nothing, `root` is left alone, and the entry stops in
     # GRUB with the kernel not found.
-    at = f"{target.grub_prefix}/{PLACE}"
+    # Where the kernel actually is, as the filesystem holding it names it. A
+    # UEFI GRUB reads it off the esp, so the path is relative to the esp and
+    # `grub_prefix` — which describes `/boot` on the root filesystem — would
+    # send `search` after a directory that exists nowhere: the entry then
+    # stopped in GRUB with `you need to load the kernel first.`
+    at = (
+        f"/{PLACE}"
+        if target.method is BootMethod.UEFI_GRUB
+        else f"{target.grub_prefix}/{PLACE}"
+    )
     entry = (
         f"{CUSTOM_BEGIN}\n"
         f"menuentry '{ENTRY_LABEL}' {{\n"

--- a/tests/unit/test_plan_netboot.py
+++ b/tests/unit/test_plan_netboot.py
@@ -1215,3 +1215,37 @@ def test_the_payload_copy_restores_no_ownership_either() -> None:
     line = " ".join(piped[0])
     assert "--no-same-owner" in line, line
     assert "--no-same-permissions" in line, line
+
+
+def test_a_uefi_grub_entry_names_the_path_the_esp_holds() -> None:
+    """The kernel is on the esp and GRUB's `search --file` finds whichever
+    filesystem holds that path. `/boot/gentoo-install-ram/kernel` is on none
+    of them, and the armed machine stopped in GRUB with `you need to load the
+    kernel first.`"""
+    recorder = _answering()
+    netboot.WriteMemoryEntry(
+        mode=MemoryMode.RAM,
+        target=replace(_target(BootMethod.UEFI_GRUB), boot_on_the_root_filesystem=True),
+        launch=_launch(),
+    ).apply(recorder)
+
+    written = _custom(recorder)
+    for line in ("search", "linux", "initrd"):
+        named = next(one for one in written.splitlines() if one.strip().startswith(line))
+        assert f"/{netboot.PLACE}/" in named, named
+        assert "/boot/" not in named, named
+
+
+def test_a_bios_grub_entry_still_names_the_path_boot_holds() -> None:
+    """The other half: a BIOS GRUB reads the kernel from `/boot`, and on a
+    machine whose `/boot` is a directory the path carries it."""
+    recorder = _answering()
+    netboot.WriteMemoryEntry(
+        mode=MemoryMode.RAM,
+        target=replace(_target(BootMethod.BIOS_GRUB), boot_on_the_root_filesystem=True),
+        launch=_launch(),
+    ).apply(recorder)
+
+    written = _custom(recorder)
+    named = next(one for one in written.splitlines() if one.strip().startswith("linux"))
+    assert f"/boot/{netboot.PLACE}/" in named, named


### PR DESCRIPTION
The sixth `--lowram` run armed the machine, kept the default entry, rebooted — and stopped in GRUB. Its console, once the escape codes are stripped:

    you need to load the kernel first.

The entry's paths came from `grub_prefix`, which describes where `/boot` is: `/boot` when it is a directory on the root filesystem, empty when it is its own partition. That is right for a BIOS GRUB, which reads the kernel from `/boot`, and wrong for a UEFI one, which reads it from the esp — so `search --file /boot/gentoo-install-ram/kernel` looked for a path that exists on no filesystem, `root` was left alone, and `linux` had nothing to load.

For a UEFI GRUB the path is relative to the esp: `/gentoo-install-ram/kernel`, which exists there and nowhere else, so `search` finds the right filesystem for the same reason it did before.

This is the same defect as PR 528 seen from the other side, and the same test shape holds both halves now. The control is red on its assertion.
