### PR TITLE
netboot: read the hash past the comment the release puts above it

### DIFF
--- a/gentoo_install/plan/netboot.py
+++ b/gentoo_install/plan/netboot.py
@@ -1018,9 +1018,17 @@ def _yaml_pairs(record: str) -> list[tuple[str, str]]:
 
 
 def _first_word(digest: str, name: str) -> str:
-    """A `.sha256` file is `<hex>  <name>`, and taking the whole line compares
-    a hash against a hash and a filename."""
-    fields = digest.split()
-    if not fields or len(fields[0]) != 64:
-        raise DownloadFailed(f"the checksum published beside {name} is not a SHA-256")
-    return fields[0]
+    """The hash out of a `.sha256` file, which is `<hex>  <name>` per line.
+
+    Not the first word of the file: the CJK release publishes `# SHA256 HASH`
+    above the hash, and the first `--ram` run to reach the download refused
+    with `the checksum published beside … is not a SHA-256` because it had
+    read that comment. The line naming this file is taken when there is one,
+    since a file listing several is answered by the wrong hash otherwise.
+    """
+    lines = [line.split() for line in digest.splitlines()]
+    named = [one for one in lines if len(one) >= 2 and one[1].lstrip("*") == name]
+    for fields in named or lines:
+        if fields and len(fields[0]) == 64:
+            return fields[0]
+    raise DownloadFailed(f"the checksum published beside {name} is not a SHA-256")

--- a/tests/unit/test_plan_netboot.py
+++ b/tests/unit/test_plan_netboot.py
@@ -1249,3 +1249,33 @@ def test_a_bios_grub_entry_still_names_the_path_boot_holds() -> None:
     written = _custom(recorder)
     named = next(one for one in written.splitlines() if one.strip().startswith("linux"))
     assert f"/boot/{netboot.PLACE}/" in named, named
+
+
+def test_the_hash_is_read_past_the_comment_the_release_puts_above_it() -> None:
+    """The CJK release publishes `# SHA256 HASH` on the first line, and the
+    first `--ram` run to reach the download refused with `the checksum
+    published beside … is not a SHA-256` having read that comment. Fetched
+    from the mirror on 2026-08-18."""
+    published = (
+        "# SHA256 HASH\n"
+        "7d0e58aa3680fe777cfa1b80e6f8a55df8af913e01ea17dd4f69f04591b68013  "
+        f"{ISO}\n"
+    )
+
+    assert netboot._first_word(published, ISO).startswith("7d0e58aa"), published
+
+
+def test_a_checksum_file_listing_several_names_the_one_asked_for() -> None:
+    """Answering with the first hash in the file gives the wrong one."""
+    other = "b" * 64
+    wanted = "a" * 64
+    published = f"{other}  something-else.iso\n{wanted}  {ISO}\n"
+
+    assert netboot._first_word(published, ISO) == wanted, published
+
+
+def test_a_checksum_file_with_no_hash_at_all_is_still_refused() -> None:
+    from gentoo_install.errors import DownloadFailed as _DownloadFailed
+
+    with pytest.raises(_DownloadFailed, match="not a SHA-256"):
+        netboot._first_word("# SHA256 HASH\nnot-a-hash  file.iso\n", ISO)


### PR DESCRIPTION
The first `--ram` run to get as far as the download stopped there:

    download: the checksum published beside install-amd64-cjk-minimal-20260813T073053Z.iso is not a SHA-256

It is one. Fetched from the mirror:

    # SHA256 HASH
    7d0e58aa3680fe777cfa1b80e6f8a55df8af913e01ea17dd4f69f04591b68013  install-amd64-cjk-minimal-20260813T073053Z.iso

The reader took the first word of the file, which is `#`. It now takes the hash from the line that names the file it asked for, falling back to the first line that carries a 64-character hex word, so a file listing several is not answered with the wrong one either. A file with no hash at all is still refused.

Three tests, two of them red as controls with the old reading.
