### PR TITLE
netboot: the lowram payload is an apkovl, not a dracut hook

### DIFF
--- a/gentoo_install/plan/netboot.py
+++ b/gentoo_install/plan/netboot.py
@@ -432,20 +432,18 @@ class PlaceMemoryKernel(Operation):
 
 
 
-#: Where the payload lands inside the initramfs, and where the hook puts it
-#: in the live system. One name, because the hook that copies it and the
-#: installer that reads it are written apart.
+#: Where the payload lands inside both live systems.
 PAYLOAD: Final[str] = "/gentoo-install"
 
-#: Where the first screen is hung, which is the login shell rather than a
-#: boot service. OpenRC's `local` runs `local.d/*.start` with
-#: `> /dev/null 2>&1` unless `rc_verbose` is set — read from that medium's own
-#: `/etc/init.d/local` — and it runs during boot with no controlling
-#: terminal, so a question printed there is invisible and the `read` beside it
-#: answers itself. `/root/.bash_profile` runs for the medium's console
-#: auto-login and for an ssh login, which is where the operator is; root's
-#: shell there is `/bin/bash` and the file already exists.
-AUTOSTART: Final[str] = "/root/.bash_profile"
+#: The archive `initramfs-init` unpacks after it has built Alpine's sysroot.
+APKOVL: Final[str] = "gentoo-install.apkovl.tar.gz"
+
+#: The login profile that sources the first screen in each environment. CJK
+#: root uses bash; Alpine root uses ash and reads `.profile`.
+AUTOSTART: Final[dict[MemoryMode, str]] = {
+    MemoryMode.RAM: "/root/.bash_profile",
+    MemoryMode.LOWRAM: "/root/.profile",
+}
 
 
 @dataclass(frozen=True, kw_only=True)
@@ -453,11 +451,9 @@ class AppendConfiguration(Operation):
     """Put the configuration and the keys inside the initramfs.
 
     A newc cpio appended to the compressed initramfs is unpacked by the kernel
-    and its hooks are run by dracut, which was measured on 2026-08-18 by
-    booting one: a `cmdline` hook in the appended segment printed its marker at
-    3.5 seconds. So a 1.5 KiB segment delivers everything rather than the whole
-    55 MiB image being repacked. `lsinitrd` does not list the appended segment,
-    so it cannot be used to check this.
+    without repacking its 55 MiB base image. `--ram` uses the appended dracut
+    hook; `--lowram` puts an apkovl in that cpio's root, because Alpine's
+    `initramfs-init` unpacks it into the live sysroot without running dracut.
     """
 
     stage: Stage = Stage.BOOTLOADER
@@ -480,15 +476,23 @@ class AppendConfiguration(Operation):
 
     def apply(self, context: Context) -> None:
         staging = self.target.place / "payload"
-        inside = PurePosixPath(str(staging) + PAYLOAD)
+        payload_staging = (
+            staging
+            if self.launch.mode is MemoryMode.RAM
+            else staging / "apkovl"
+        )
+        inside = payload_staging / PAYLOAD.lstrip("/")
         context.run(["mkdir", "--parents", str(inside)])
         context.write(inside / "config.toml", self.configuration)
         if self.keys:
-            context.write(
-                inside / "authorized_keys",
-                "".join(f"{one}\n" for one in self.keys),
-                mode=0o600,
-            )
+            key_text = "".join(f"{one}\n" for one in self.keys)
+            context.write(inside / "authorized_keys", key_text, mode=0o600)
+            if self.launch.mode is MemoryMode.LOWRAM:
+                context.write(
+                    payload_staging / "root/.ssh/authorized_keys",
+                    key_text,
+                    mode=0o600,
+                )
         # `bootstrap.sh` runs the tree beside it, so both go in together.
         context.run(
             [
@@ -503,11 +507,30 @@ class AppendConfiguration(Operation):
             ]
         )
         context.write(inside / "start.sh", _start(), mode=0o755)
-        hooks = staging / "usr/lib/dracut/hooks/pre-pivot"
-        context.run(["mkdir", "--parents", str(hooks)])
-        context.write(hooks / "99-gentoo-install.sh", _handover(), mode=0o755)
+        if self.launch.mode is MemoryMode.RAM:
+            hooks = staging / "usr/lib/dracut/hooks/pre-pivot"
+            context.run(["mkdir", "--parents", str(hooks)])
+            context.write(
+                hooks / "99-gentoo-install.sh",
+                _handover(self.launch.mode),
+                mode=0o755,
+            )
+        else:
+            context.write(
+                payload_staging / AUTOSTART[self.launch.mode].lstrip("/"),
+                _source_start(),
+            )
+            apkovl = staging / APKOVL
+            context.run(
+                [
+                    "sh",
+                    "-c",
+                    f"cd {payload_staging} && tar --create --gzip --file {apkovl} .",
+                ]
+            )
+            context.run(["rm", "--recursive", "--force", str(payload_staging)])
         # `find | cpio` from inside the staging directory, or every path in the
-        # archive carries the staging prefix and lands nowhere the hook looks.
+        # archive carries the staging prefix and lands nowhere the initramfs reads.
         context.run(
             [
                 "sh",
@@ -522,7 +545,7 @@ class AppendConfiguration(Operation):
 def _start() -> str:
     """What the operator's login shell runs. It asks before it erases anything.
 
-    Sourced by `.bash_profile` rather than executed by a boot service, so it
+    Sourced by a login profile rather than executed by a boot service, so it
     must not `exit`: that would end the login shell it is running in and drop
     the operator straight back to a prompt they cannot use. `return` ends a
     sourced file and nothing else.
@@ -550,8 +573,13 @@ def _start() -> str:
     )
 
 
-def _handover() -> str:
-    """What runs in the initramfs to hand the payload to the live system.
+def _source_start() -> str:
+    """The profile line that presents the delivered installer."""
+    return f"[ -f {PAYLOAD}/start.sh ] && . {PAYLOAD}/start.sh\n"
+
+
+def _handover(mode: MemoryMode) -> str:
+    """What dracut runs to hand the payload to the CJK live system.
 
     `pre-pivot`, because `$NEWROOT` is mounted by then and writable: with
     `rd.live.ram=1` the squashfs is read-only but `dmsquash-live-root` puts an
@@ -570,8 +598,7 @@ def _handover() -> str:
         # Appended, not written: the file exists on the medium and sources
         # `.bashrc`, and replacing it would take the prompt and the aliases
         # with it.
-        f'printf \'\\n[ -f {PAYLOAD}/start.sh ] && . {PAYLOAD}/start.sh\\n\' '
-        f'>> "$NEWROOT{AUTOSTART}"\n'
+        f'printf \'\\n{_source_start()}\' >> "$NEWROOT{AUTOSTART[mode]}"\n'
     )
 
 
@@ -661,6 +688,7 @@ class WriteMemoryEntry(Operation):
         words = [
             f"alpine_repo={ALPINE_REPOSITORY}",
             f"modloop={_alpine_modloop(_only_image(context, STAGING, '.tar.gz'))}",
+            f"apkovl=/{APKOVL}",
             "ip=dhcp",
             *_inherited_consoles(context),
         ]

--- a/tests/unit/test_plan_netboot.py
+++ b/tests/unit/test_plan_netboot.py
@@ -333,6 +333,7 @@ def test_the_lowram_cmdline_names_the_repository_alpine_fetches_modloop_from() -
     entry = recorder.files[PurePosixPath(f"{ESP}/loader/entries/{netboot.PLACE}.conf")]
     assert f"alpine_repo={netboot.ALPINE_REPOSITORY}" in entry, entry
     assert "modloop=" in entry and "ip=dhcp" in entry, entry
+    assert f"apkovl=/{netboot.APKOVL}" in entry, entry
 
 
 def _modloop(entry: str) -> str:
@@ -568,10 +569,15 @@ def _relabelled(
     return answer
 
 
-def _appended(recorder: Recorder, keys: tuple[str, ...] = ()) -> None:
+def _appended(
+    recorder: Recorder,
+    *,
+    mode: MemoryMode = MemoryMode.RAM,
+    keys: tuple[str, ...] = (),
+) -> None:
     netboot.AppendConfiguration(
         target=_target(),
-        launch=_launch(),
+        launch=_launch(mode),
         configuration='[disk]\nmode = "partition"\n',
         source="/opt/gentoo-install",
         keys=keys,
@@ -595,6 +601,44 @@ def test_the_payload_is_appended_to_the_initramfs_rather_than_repacked() -> None
     # payload and a machine with no way to mount its root.
     assert ">>" in appended[0][-1] and ">> " in appended[0][-1], appended
     assert f"{netboot.PLACE}/initramfs" in appended[0][-1], appended
+
+
+def test_the_lowram_payload_is_an_apkovl_at_the_initramfs_root() -> None:
+    """Alpine unpacks `apkovl=` into its sysroot and never runs dracut hooks."""
+    recorder = _answering(MemoryMode.LOWRAM)
+    _appended(
+        recorder,
+        mode=MemoryMode.LOWRAM,
+        keys=("ssh-ed25519 AAAA zakk@box",),
+    )
+
+    staging = PurePosixPath(f"{ESP}/{netboot.PLACE}/payload")
+    payload = staging / "apkovl"
+    inside = payload / netboot.PAYLOAD.lstrip("/")
+    assert recorder.files[inside / "config.toml"] == '[disk]\nmode = "partition"\n'
+    assert recorder.files[inside / "start.sh"] == netboot._start()
+    assert recorder.files[payload / "root/.profile"] == netboot._source_start()
+    assert recorder.files[payload / "root/.ssh/authorized_keys"].endswith("zakk@box\n")
+    assert recorder.modes[payload / "root/.ssh/authorized_keys"] == 0o600
+    assert not any("dracut" in str(path) for path in recorder.files), recorder.files
+
+    packed = next(
+        one
+        for one in recorder.commands
+        if one[0] == "sh" and "tar --create --gzip" in one[-1]
+    )
+    assert (
+        packed[-1]
+        == f"cd {payload} && tar --create --gzip --file {staging / netboot.APKOVL} ."
+    ), packed
+    removed = ("rm", "--recursive", "--force", str(payload))
+    cpio = next(
+        one
+        for one in recorder.commands
+        if one[0] == "sh" and "cpio --create" in one[-1]
+    )
+    assert recorder.commands.index(removed) < recorder.commands.index(cpio), recorder.commands
+    assert cpio[-1].startswith(f"cd {staging} && find . |"), cpio
 
 
 def test_the_archive_is_made_from_inside_the_staging_directory() -> None:
@@ -1042,7 +1086,7 @@ def _sourced(where: Path, answer: str) -> str:
     import subprocess
 
     return subprocess.run(
-        ["bash", "-c", f". {where}/start.sh; echo LOGIN-SHELL-ALIVE"],
+        ["sh", "-c", f". {where}/start.sh; echo LOGIN-SHELL-ALIVE"],
         input=f"{answer}\n",
         capture_output=True,
         text=True,
@@ -1078,15 +1122,18 @@ def test_any_other_answer_changes_nothing(
         assert "LOGIN-SHELL-ALIVE" in said, (answer, said)
 
 
-def test_the_first_screen_is_hung_on_the_login_shell_not_a_boot_service() -> None:
-    """OpenRC's `local` runs `local.d/*.start` with `> /dev/null 2>&1` unless
-    `rc_verbose` is set — read from the CJK medium's own `/etc/init.d/local` —
-    and it runs during boot with no controlling terminal. A question printed
-    there is invisible and the `read` beside it answers itself."""
-    assert netboot.AUTOSTART == "/root/.bash_profile", netboot.AUTOSTART
-    assert "local.d" not in netboot._handover(), netboot._handover()
-    # Appended: the file exists on the medium and sources `.bashrc`.
-    assert f'>> "$NEWROOT{netboot.AUTOSTART}"' in netboot._handover()
+def test_the_first_screen_is_hung_on_each_environment_login_profile() -> None:
+    """CJK root runs bash; Alpine root runs ash and reads `.profile`."""
+    assert netboot.AUTOSTART == {
+        MemoryMode.RAM: "/root/.bash_profile",
+        MemoryMode.LOWRAM: "/root/.profile",
+    }
+    assert "local.d" not in netboot._handover(MemoryMode.RAM)
+    # Appended: the file exists on the CJK medium and sources `.bashrc`.
+    assert (
+        f'>> "$NEWROOT{netboot.AUTOSTART[MemoryMode.RAM]}"'
+        in netboot._handover(MemoryMode.RAM)
+    )
 
 
 def test_a_missing_payload_does_not_end_the_operators_session(


### PR DESCRIPTION
The seventh `--lowram` run armed a machine, kept its default entry, rebooted, and came up:

    Alpine Init 3.14.0-r0
    '/lib/modloop-lts' saved … Mounting modloop … Verifying modloop
    Welcome to Alpine Linux 3.24
    localhost login:

and failed on the check after that alone — `never matched 'install or shell>'`. The payload reaches the live system through a dracut `pre-pivot` hook, which was measured on the CJK medium; Alpine's initramfs is `initramfs-init` and runs no dracut hooks, so the configuration and the installer's tree never left the initramfs.

Alpine's own mechanism is `apkovl=`. Its init takes three forms — a URL, `device[:fstype]:relpath`, and otherwise the value as a path inside the initramfs (`initramfs-init.in:468-482,916-928`) — and the third is what this needs, since the appended cpio is already unpacked at the initramfs root. `unpack_apkovl` extracts a `.gz` with `tar -C "$sysroot" -zxvf` (`:47-56`), so the archive is laid out as the booted filesystem.

`--ram` keeps the dracut hook unchanged. The first screen is hung on `/root/.profile` there and `/root/.bash_profile` on the CJK medium — Alpine's root shell is ash — from one table read by both paths.

Written by an agent against the design section, reviewed here. Both gates run in this tree and two controls of my own, each red on an assertion: a wrong `apkovl=` path, and the two profiles collapsed into one.
