### PR TITLE
netboot: declare the commands the arming runs

### DIFF
--- a/gentoo_install/plan/netboot.py
+++ b/gentoo_install/plan/netboot.py
@@ -343,6 +343,9 @@ class FetchMemoryImage(Operation):
     mode: MemoryMode
     target: BootTarget
 
+    def required_host_commands(self) -> frozenset[str]:
+        return frozenset({"curl", "sha256sum", "mkdir", "rm"})
+
     def describe_parts(self) -> tuple[str, tuple[str, ...]]:
         return "fetch the {} image and verify its checksum", (self.mode.value,)
 
@@ -378,6 +381,13 @@ class PlaceMemoryKernel(Operation):
     stage: Stage = Stage.BOOTLOADER
     mode: MemoryMode
     target: BootTarget
+
+    def required_host_commands(self) -> frozenset[str]:
+        # `xorriso` reads the ISO and `tar` the netboot archive; a machine
+        # without the one its mode needs refused at the unpack rather than in
+        # preflight, an image and several minutes later.
+        reader = "xorriso" if self.mode is MemoryMode.RAM else "tar"
+        return frozenset({reader, "mkdir", "blkid" if self.mode is MemoryMode.RAM else "ls"})
 
     def describe_parts(self) -> tuple[str, tuple[str, ...]]:
         return "unpack the {} kernel and initramfs into {}", (

--- a/tests/unit/test_plan_netboot.py
+++ b/tests/unit/test_plan_netboot.py
@@ -1326,3 +1326,20 @@ def test_a_checksum_file_with_no_hash_at_all_is_still_refused() -> None:
 
     with pytest.raises(_DownloadFailed, match="not a SHA-256"):
         netboot._first_word("# SHA256 HASH\nnot-a-hash  file.iso\n", ISO)
+
+
+def test_the_arming_declares_the_commands_it_runs() -> None:
+    """`--ram` reads the ISO with `xorriso` and the first run to get past the
+    checksum answered `command: xorriso is not installed` — after fetching a
+    gigabyte. `--missing-commands` reads these, so preflight names it first."""
+    ram = netboot.build(launch=_launch(MemoryMode.RAM), target=_target())
+    lowram = netboot.build(launch=_launch(MemoryMode.LOWRAM), target=_target())
+
+    def wanted(operations: list[Operation]) -> set[str]:
+        return {one for op in operations for one in op.required_host_commands()}
+
+    assert "xorriso" in wanted(ram), sorted(wanted(ram))
+    assert "xorriso" not in wanted(lowram), sorted(wanted(lowram))
+    assert "tar" in wanted(lowram), sorted(wanted(lowram))
+    for both in ("curl", "sha256sum"):
+        assert both in wanted(ram) and both in wanted(lowram), both


### PR DESCRIPTION
The first `--ram` run to get past the checksum fetched a gigabyte and then stopped:

    command: xorriso is not installed

Preflight builds the list of commands a run needs from the operations it is about to apply, and none of the memory-environment operations declared any. So the one command that reads the ISO was discovered by running it.

`FetchMemoryImage` declares what it fetches and verifies with; `PlaceMemoryKernel` declares the reader its own mode uses — `xorriso` for the ISO, `tar` for the netboot archive. `--missing-commands` reads the same list, so the harness installs them and an operator is told before anything is downloaded rather than after.

The control is red on its assertion.
