### PR TITLE
netboot: pad the initramfs before appending the payload

### DIFF
--- a/gentoo_install/plan/netboot.py
+++ b/gentoo_install/plan/netboot.py
@@ -541,12 +541,27 @@ class AppendConfiguration(Operation):
             context.run(["rm", "--recursive", "--force", str(payload_staging)])
         # `find | cpio` from inside the staging directory, or every path in the
         # archive carries the staging prefix and lands nowhere the initramfs reads.
+        image = self.target.place / "initramfs"
+        # Padded to a four-byte boundary first, because the kernel reads
+        # concatenated initramfs segments only from one. Measured on this
+        # workstation on 2026-08-18: Alpine's `initramfs-lts` is 27951899
+        # bytes, 3 mod 4, and a guest booted with the segment appended to it
+        # reached `localhost login:` with no `Loading user settings from` line
+        # at all; one zero byte in front of the same segment answered
+        # `Loading user settings from /gentoo-install.apkovl.tar.gz: ok.`
         context.run(
             [
                 "sh",
                 "-c",
-                f"cd {staging} && find . | cpio --create --format=newc "
-                f">> {self.target.place / 'initramfs'}",
+                f'pad=$(( (4 - $(stat --format=%s {image}) % 4) % 4 )); '
+                f'[ "$pad" -eq 0 ] || dd if=/dev/zero bs=1 count="$pad" >> {image}',
+            ]
+        )
+        context.run(
+            [
+                "sh",
+                "-c",
+                f"cd {staging} && find . | cpio --create --format=newc >> {image}",
             ]
         )
         context.run(["rm", "--recursive", "--force", str(staging)])

--- a/tests/unit/test_plan_netboot.py
+++ b/tests/unit/test_plan_netboot.py
@@ -1343,3 +1343,28 @@ def test_the_arming_declares_the_commands_it_runs() -> None:
     assert "tar" in wanted(lowram), sorted(wanted(lowram))
     for both in ("curl", "sha256sum"):
         assert both in wanted(ram) and both in wanted(lowram), both
+
+
+def test_the_initramfs_is_padded_before_the_segment_is_appended() -> None:
+    """The kernel reads a concatenated initramfs segment only from a four-byte
+    boundary. Measured on this workstation: Alpine's `initramfs-lts` is
+    27951899 bytes, 3 mod 4, and a guest booted with the segment appended to
+    it reached `localhost login:` with no `Loading user settings from` line;
+    one zero byte in front of the same segment answered `Loading user settings
+    from /gentoo-install.apkovl.tar.gz: ok.`"""
+    recorder = _answering(MemoryMode.LOWRAM)
+    netboot.AppendConfiguration(
+        target=_target(),
+        launch=_launch(MemoryMode.LOWRAM),
+        configuration="x",
+        source="/mnt/driver",
+    ).apply(recorder)
+
+    shell = [one[-1] for one in recorder.commands if one[0] == "sh"]
+    padding = [one for one in shell if "dd if=/dev/zero" in one]
+    appending = [one for one in shell if "cpio --create" in one]
+
+    assert len(padding) == 1, shell
+    assert len(appending) == 1, shell
+    assert shell.index(padding[0]) < shell.index(appending[0]), shell
+    assert "% 4" in padding[0], padding[0]


### PR DESCRIPTION
The eighth `--lowram` run carried `apkovl=/gentoo-install.apkovl.tar.gz` on the kernel command line, booted the memory environment, and printed no `Loading user settings from` line — Alpine's init had looked for that file and not found it.

Reproduced on this workstation rather than reasoned about, with Alpine's own `vmlinuz-lts` and `initramfs-lts` and the same appended segment:

    initramfs-lts   27951899 bytes   3 mod 4
    combined.igz    → Welcome to Alpine Linux 3.24 / localhost login:      (no apkovl line)
    padded.igz      → Loading user settings from /gentoo-install.apkovl.tar.gz: ok.

One zero byte. The kernel reads concatenated initramfs segments only from a four-byte boundary, and everything after an unaligned one is ignored in silence. The appended segment itself was never in question: `tail -c 1024 combined.igz | cpio -t` lists it.

This also explains why the mechanism was measured working in the first place: the CJK medium's `gentoo.igz` happens to be aligned, so the same code has been right there and wrong on Alpine since the day it was written.

The control is red on its assertion.
