### PR TITLE
ram: log in on the console the netboot medium asks a login for

### DIFF
--- a/tests/unit/test_harness.py
+++ b/tests/unit/test_harness.py
@@ -3611,3 +3611,19 @@ def test_the_boot_order_is_read_with_the_same_tools_both_times() -> None:
 
     assert installed < first, "the tools go on before the first reading"
     assert source.index("arm(console") > first, "and the reading before the arming"
+
+
+def test_the_lowram_check_logs_in_where_the_medium_asks_for_one() -> None:
+    """Alpine's netboot console asks for a login and the CJK medium logs root
+    in by itself. The first screen is in root's profile either way, so the
+    ninth `--lowram` run reached `Loading user settings from
+    /gentoo-install.apkovl.tar.gz: ok.` and then `(none) login:` and waited
+    five minutes at a prompt nobody answered."""
+    import inspect
+
+    from tests.vm import ram
+
+    source = inspect.getsource(ram.came_up)
+    assert 'console.send("root")' in source, source
+    assert source.index('mode == "lowram"') < source.index('console.send("root")')
+    assert source.index("PAYLOAD_SPEAKS") > source.index('console.send("root")')

--- a/tests/vm/ram.py
+++ b/tests/vm/ram.py
@@ -53,6 +53,9 @@ ALPINE_SPEAKS: Final[str] = r"Welcome to Alpine Linux|localhost login:"
 #: configuration arrived, not merely that a live medium booted.
 PAYLOAD_SPEAKS: Final[str] = r"install or shell>"
 
+#: How long the login prompt is given after the medium's banner.
+LOGIN_PATIENCE: Final[float] = 300.0
+
 #: How long that screen is given after the medium speaks. The payload is
 #: copied by a `pre-pivot` hook and started by the medium's own `local`
 #: service, so it follows the login prompt rather than racing it.
@@ -96,6 +99,16 @@ def came_up(console: SerialConsole, mode: str) -> str:
         console.expect(speaks, timeout=MEMORY_BOOT_PATIENCE)
     except (ConsoleTimeout, ConsoleClosed) as error:
         return f"the memory environment never spoke: {error}"[:600]
+    if mode == "lowram":
+        # Alpine's netboot console asks for a login and the CJK medium logs
+        # root in by itself. The first screen is in root's profile either way,
+        # so this console has to log in for the same reason the operator's ssh
+        # session does. Root has no password in a netboot Alpine.
+        try:
+            console.expect(r"login:", timeout=LOGIN_PATIENCE)
+            console.send("root")
+        except (ConsoleTimeout, ConsoleClosed) as error:
+            return f"the environment asked for no login: {error}"[:600]
     try:
         console.expect(PAYLOAD_SPEAKS, timeout=PAYLOAD_PATIENCE)
     except (ConsoleTimeout, ConsoleClosed) as error:


### PR DESCRIPTION
The ninth `--lowram` run, with the padding from PR 582:

    Loading user settings from /gentoo-install.apkovl.tar.gz: ok.
    Welcome to Alpine Linux 3.24
    Kernel 6.18.35-0-lts on x86_64 (/dev/ttyS0)
    (none) login:

The payload arrived. The first screen is sourced from root's profile, which runs when root logs in — the CJK medium logs root in by itself and Alpine's netboot console asks. So the run sat five minutes at a prompt nobody answered.

This is the harness catching up with the two media, not a change to either. On a real machine the operator arrives over ssh, which is a login shell and runs the same profile; on this console the check logs in as root, which a netboot Alpine takes with no password.

The control is red on its assertion.
