### PR TITLE
cli: --missing-commands answers for the arming when a mode is given

### DIFF
--- a/gentoo_install/cli.py
+++ b/gentoo_install/cli.py
@@ -277,6 +277,16 @@ def _arm_memory_environment(
         source=str(Path(__file__).resolve().parent.parent),
         keys=tuple(config.system.authorized_keys),
     )
+    if arguments.missing_commands:
+        # The arming's own commands, not an ordinary install's: `--ram` reads
+        # the ISO with `xorriso`, which no install needs and which the guest
+        # therefore never had. Asked without the mode, this answers for a
+        # different run than the one about to happen.
+        wanted = set(preflight.ALWAYS)
+        for operation in operations:
+            wanted |= operation.required_host_commands()
+        print("\n".join(sorted(report.absent(frozenset(wanted), probe))))
+        return EXIT_OK
     if arguments.dry_run:
         print(render(operations), end="")
         print(summarise(operations))

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -1655,3 +1655,35 @@ def test_the_boot_target_carries_the_machine_this_is_running_on(
     probe = RealProbe(runner=Runner(log=lambda line: None), work=Path("/tmp"))
 
     assert cli._boot_target(probe).architecture == "aarch64"
+
+
+def test_missing_commands_with_a_memory_mode_answers_for_the_arming(
+    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str], tmp_path: Path
+) -> None:
+    """`--ram` reads the ISO with `xorriso`, which no ordinary install needs.
+    Asked without the mode, `--missing-commands` answers for a different run
+    than the one about to happen, and the third `--ram` attempt fetched a
+    gigabyte and stopped at `command: xorriso is not installed`."""
+    from gentoo_install import cli
+
+    fixture = Path("tests/fixtures/vm-ram.toml").resolve()
+    import shutil as _shutil
+
+    monkeypatch.setattr(_shutil, "which", lambda name, path=None: None)
+    monkeypatch.setattr(RealProbe, "boot_method", lambda self: BootMethod.BIOS_GRUB)
+
+    code = cli.main(
+        [
+            "--config",
+            str(fixture),
+            "--ram",
+            "--missing-commands",
+            "--work",
+            str(tmp_path),
+        ]
+    )
+
+    said = capsys.readouterr().out.split()
+    assert code == cli.EXIT_OK, said
+    assert "xorriso" in said, said
+    assert "curl" in said, said

--- a/tests/vm/convert.py
+++ b/tests/vm/convert.py
@@ -219,11 +219,14 @@ def reach_root(console: SerialConsole, chosen: CloudImage) -> None:
     console.run("df -h / && lsblk || true", timeout=120.0)
 
 
-def install_tools(console: SerialConsole, chosen: CloudImage, config: str) -> None:
+def install_tools(
+    console: SerialConsole, chosen: CloudImage, config: str, mode: str = ""
+) -> None:
     """Install what the launcher says is missing, the way an operator would."""
     console.run(FIND_DRIVER, timeout=180.0)
     said = console.expect_output(
-        f"sh /mnt/driver/install.sh --config {config} --missing-commands || true",
+        f"sh /mnt/driver/install.sh --config {config}{f' --{mode}' if mode else ''} "
+        "--missing-commands || true",
         timeout=300.0,
     ).decode("utf-8", "replace")
     # One bare command name per line, which is what `--missing-commands`

--- a/tests/vm/ram.py
+++ b/tests/vm/ram.py
@@ -161,7 +161,7 @@ def main(argv: list[str] | None = None) -> int:
         # before its ATAPI devices are enumerated, and `sh` exits 2 for a
         # script it cannot open, which reads as the installer refusing.
         wait_for_driver(console)
-        install_tools(console, chosen, arguments.config)
+        install_tools(console, chosen, arguments.config, arguments.mode)
         # After the tools, not before them: the cloud images ship no
         # `efibootmgr`, so a first reading taken without one answered
         # `NO-BOOTORDER` and the second answered `BootOrder: 0003,0000,0004`.


### PR DESCRIPTION
PR 581 made the memory-environment operations declare what they run. The next `--ram` attempt still fetched a gigabyte and stopped at

    command: xorriso is not installed

because `--missing-commands` answers from the configuration alone when no mode is given, and the harness asked without one. The declarations were being collected from a plan nobody built.

With `--ram` or `--lowram`, `--missing-commands` now builds the arming plan and answers from it. The harness passes the mode it is about to use, so what it installs is what the next command needs rather than what an ordinary install of the same configuration would.

The control is red on its assertion.
