### PR TITLE
netcheck: the mirror check matched its own command

### DIFF
--- a/tests/unit/test_harness.py
+++ b/tests/unit/test_harness.py
@@ -3627,3 +3627,21 @@ def test_the_lowram_check_logs_in_where_the_medium_asks_for_one() -> None:
     assert 'console.send("root")' in source, source
     assert source.index('mode == "lowram"') < source.index('console.send("root")')
     assert source.index("PAYLOAD_SPEAKS") > source.index('console.send("root")')
+
+
+def test_the_mirror_check_cannot_match_its_own_command() -> None:
+    """It asked for `print('BYTES', …)` and looked for `BYTES` in a reply that
+    begins with the shell's echo of that line, so a machine that fetched
+    nothing passed. The count is what the machine produces."""
+    import inspect
+    import re as _re
+
+    from tests.vm import netcheck
+
+    source = inspect.getsource(netcheck)
+    command = _re.search(r"print\('MIRROR_BYTES=%d'[^\n]*", source)
+    assert command is not None, source
+    assert not _re.search(rb"MIRROR_BYTES=[1-9][0-9]*", command.group(0).encode()), (
+        command.group(0)
+    )
+    assert 'rb"MIRROR_BYTES=[1-9][0-9]*"' in source, "and the check wants a count"

--- a/tests/vm/netcheck.py
+++ b/tests/vm/netcheck.py
@@ -22,6 +22,7 @@ own before it touches a disk:
 from __future__ import annotations
 
 import argparse
+import re
 import sys
 import time
 from dataclasses import dataclass
@@ -120,12 +121,15 @@ def _check(console: SerialConsole, families: str, driver: str) -> Result:
     if b"RC=0" not in said:
         found.startup = f"the launcher did not answer: {said[-200:]!r}"
 
+    # The count, not a bare marker: the command carries `MIRROR_BYTES` in its
+    # own text and a shell echoes what it was given, so a check for the word
+    # alone passed on a machine that fetched nothing.
     said = console.expect_command(
         f"cd {driver} && python3 -c \"from gentoo_install.exec import fetch; "
-        f"print('BYTES', len(fetch._read('{POINTER}')))\" 2>&1",
+        f"print('MIRROR_BYTES=%d' % len(fetch._read('{POINTER}')))\" 2>&1",
         timeout=300.0,
     )
-    if b"BYTES" not in said:
+    if not re.search(rb"MIRROR_BYTES=[1-9][0-9]*", said):
         found.mirror = f"the pointer file was not fetched: {said[-300:]!r}"
     return found
 


### PR DESCRIPTION
Three checks of this shape were found by running things today, so an agent was sent to read every console check in `tests/vm/` for the same thing. Of thirteen candidates it flagged one as affected, and reading the source confirms it:

    print('BYTES', len(fetch._read(POINTER)))
    …
    if b"BYTES" not in said:

`expect_command` answers with everything up to the marker, and a shell echoes the line it was given, so `BYTES` is in the reply before the command runs. The mirror check has always passed.

It matches the count now — `MIRROR_BYTES=<n>` with a non-zero first digit — which the echo cannot contain because the command carries a `%d` there.

The other twelve are safe, each for a reason worth having checked: `run.py` writes every installed-state check to a file first, and `convert.py` and `cluster.py` read between the markers since PR 552. Two neighbours in this same file were already immune — `FAMILIES (True, False)` names the values and `RC=0` is compared against `echo RC=$?`.

The control is red on its assertion.
