### PR TITLE
cli: answer --missing-commands before the arming's refusals

### DIFF
--- a/gentoo_install/cli.py
+++ b/gentoo_install/cli.py
@@ -362,7 +362,12 @@ def main(argv: Sequence[str] | None = None) -> int:
         if launch is not None:
             if arguments.config is not None and _needs_network(arguments):
                 _check_the_clock()
-            _validate_memory_launch(config, launch, _probe_for(arguments))
+            # The refusals come after the question about commands, because
+            # one of them is `--ram cannot arm a one-shot boot entry on this
+            # machine`, which is what a machine without `efibootmgr` answers —
+            # and `efibootmgr` is one of the commands being asked about.
+            if not arguments.missing_commands:
+                _validate_memory_launch(config, launch, _probe_for(arguments))
             return _arm_memory_environment(config, launch, arguments)
         if arguments.missing_commands:
             print(

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -1687,3 +1687,28 @@ def test_missing_commands_with_a_memory_mode_answers_for_the_arming(
     assert code == cli.EXIT_OK, said
     assert "xorriso" in said, said
     assert "curl" in said, said
+
+
+def test_missing_commands_is_answered_before_the_arming_refusals(
+    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str], tmp_path: Path
+) -> None:
+    """`--ram cannot arm a one-shot boot entry on this machine` is what a
+    machine without `efibootmgr` answers, and `efibootmgr` is one of the
+    commands being asked about: the guest was refused instead of told, so it
+    installed nothing and the arming failed on the same machine minutes
+    later."""
+    import shutil as _shutil
+
+    from gentoo_install import cli
+
+    fixture = Path("tests/fixtures/vm-ram.toml").resolve()
+    monkeypatch.setattr(_shutil, "which", lambda name, path=None: None)
+    monkeypatch.setattr(RealProbe, "boot_method", lambda self: BootMethod.NONE)
+
+    code = cli.main(
+        ["--config", str(fixture), "--ram", "--missing-commands", "--work", str(tmp_path)]
+    )
+    said = capsys.readouterr().out.split()
+
+    assert code == cli.EXIT_OK, said
+    assert "xorriso" in said, said


### PR DESCRIPTION
PR 585 made `--missing-commands` answer for the arming when a mode is given, and the next `--ram` attempt still stopped at `command: xorriso is not installed`. The guest's own console says why:

    sh /mnt/driver/install.sh --config fixtures/vm-ram.toml --ram --missing-commands
    nothing was written to the selected disk
    preflight: --ram cannot arm a one-shot boot entry on this machine

The refusal ran first. It is the answer a machine gives when `boot_method()` finds no `efibootmgr` — one of the commands the question was about. So the run refused to say what was missing because something was missing, the harness installed nothing, and the arming failed on the same machine minutes later.

A question about commands is answered before the refusals that depend on them. Every other refusal still runs for a real arming.

The control is red on its assertion.
