### PR TITLE
cluster: a refusal grows the settle even with nothing echoed

### DIFF
--- a/tests/unit/test_cluster.py
+++ b/tests/unit/test_cluster.py
@@ -1867,3 +1867,46 @@ def test_a_line_that_is_not_a_prompt_is_not_taken_for_one() -> None:
         b"Load keymap",
     ):
         assert not re.search(cluster.ROOT_PROMPT.encode(), other), other
+
+
+class _RefusesUntilTheSettleGrows:
+    """`login` on a guest that loses the race without echoing anything.
+
+    `ext3` was refused three times with nothing on the console between
+    `Password:` and `Login incorrect`: part of the password reached `login`
+    and the rest did not, so there was no echo for the harness to notice and
+    the settle it retried with was the settle that had just failed.
+    """
+
+    def __init__(self, needs: float) -> None:
+        self.needs = needs
+        self.settled = 0.0
+        self.sent: list[str] = []
+        self.answers: list[bytes] = []
+        self.console = _Screen(b"plain login: ")
+
+    def slept(self, seconds: float) -> None:
+        self.settled += seconds
+
+    def respond(self, line: str) -> None:
+        self.sent.append(line)
+        if line == "root":
+            self.answers.append(b"Password: ")
+        elif self.settled >= self.needs:
+            self.answers.append(b"plain ~ # ")
+        else:
+            self.answers.append(b"Login incorrect\r\nlogin: ")
+
+    def observe(self, pattern: str, timeout: float = 0.0) -> bytes:
+        return self.answers.pop(0) if self.answers else b""
+
+
+def test_a_refusal_with_no_echo_still_grows_the_settle(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    console = _RefusesUntilTheSettleGrows(needs=cluster.PASSWORD_ECHO_BACKOFF)
+    monkeypatch.setattr("time.sleep", console.slept)
+
+    assert cluster._log_in(cast(cluster.Reconnecting, console), "install") == ""
+    assert console.sent.count("install") == 2, console.sent
+    assert console.settled >= cluster.PASSWORD_ECHO_BACKOFF, console.settled

--- a/tests/vm/cluster.py
+++ b/tests/vm/cluster.py
@@ -2627,6 +2627,12 @@ def _log_in(link: Reconnecting, password: str) -> str:
             settle += PASSWORD_ECHO_BACKOFF
             continue
         refusals += 1
+        # The settle grows on a plain refusal as well, not only on one whose
+        # echo the console showed: `ext3` was refused three times with nothing
+        # echoed at all, which is the same race losing quietly — some of the
+        # password reached `login` and the rest did not. Repeating the settle
+        # that produced a refusal can only produce another.
+        settle += PASSWORD_ECHO_BACKOFF
         # `Login incorrect` matches before the prompt that follows it, so the
         # re-prompt stays in the buffer. `_name_the_user` then reads that one,
         # calls it a login prompt, and offers the name a second time — and the


### PR DESCRIPTION
`ext3` installed in 68.5 minutes and was then refused three times by its own login. From the guest's console:

    plain login: root
    Password:
    Login incorrect
    plain login: root
    Password:
    Login incorrect
    plain login: root
    Password:
    Maximum number of tries exceeded (3)

The same fixture, the same password and the same hash passed one round earlier, so the credentials are right and `login` read something else.

The harness already grows the settle before the password when it sees the password echoed back — that is the visible half of this race. This is the quiet half: part of the password reaches `login` and the rest does not, nothing is echoed, and the retry uses the settle that had just failed. Three attempts, one outcome.

A refusal grows it too now, so the three attempts are `0s`, `2s`, `4s` rather than the same guess three times. A genuinely wrong password still ends the run after three.

The control is red on its assertion.
