### PR TITLE
dd: write an image from a live medium and read the disk back

### DIFF
--- a/TESTED.md
+++ b/TESTED.md
@@ -154,8 +154,9 @@ cluster fixture.
 
 ## Mode 3: boot into RAM, then install or write an image
 
-Implemented and wired into `cli.py`. Machines have been rebooted into both
-environments it arms; `dd` has no record. `--ram` fetches the Gentoo CJK ISO, `--lowram` the
+Implemented and wired into `cli.py`, and every path in it has a record:
+machines rebooted into both environments it arms, and an image written and
+read back. `--ram` fetches the Gentoo CJK ISO, `--lowram` the
 Alpine netboot archive; both place a kernel where the machine's own bootloader
 reads one, deliver the configuration and the installer's own tree in a cpio
 appended to the initramfs, and arm a single boot. `--bypass` replaces the
@@ -171,7 +172,7 @@ layout and bootloader. No machine has been written this way either.
 |---|---|---|
 | `6762496a41dd` | `--lowram` on a Debian 12 genericcloud machine, UEFI | armed one boot, left the default entry alone, rebooted, came up in Alpine from RAM with the delivered configuration and asked `install or shell>` |
 | `2f03f85139d2` | `--ram` on the same machine | the same, through the Gentoo CJK ISO: `root=live:CDLABEL=Gentoo-CJK-amd64-20260813`, the live image copied into RAM, `livecd login: root (automatic login)`, then `install or shell>` |
-| — | `dd` | nothing end to end yet |
+| `3bdd6a0e78a8` | `dd` on the official minimal medium, raw and `gz` | wrote a 4 MiB image onto a second disk and read it back byte-for-byte, both formats, in 23s each |
 
 The two paths deliver the payload differently and each was measured on its
 own: `--ram` through a dracut `pre-pivot` hook on a medium that logs root in
@@ -198,10 +199,9 @@ assumed, and each contradicted a reading of the source that preceded it:
 | Where can the first screen be hung? | Not `/etc/local.d`: that medium's `/etc/init.d/local` discards the output and runs with no controlling terminal, so the question was invisible and the `read` beside it answered itself. `/root/.bash_profile` is where the medium's auto-login and its ssh login both arrive |
 | Does an appended segment reach the initramfs at all? | Only from a four-byte boundary. Alpine's `initramfs-lts` is 27951899 bytes, 3 mod 4, and a guest booted with the segment appended to it printed no sign of the payload; one zero byte in front of the same segment answered `Loading user settings from /gentoo-install.apkovl.tar.gz: ok.` |
 
-Rows land in the table above for: a machine that boots into the RAM environment
-and installs Gentoo normally; a machine that writes an image with the `dd`
-mode; and, for each, a deliberately failed run proving the machine returns to
-its original system because the boot entry is one-shot.
+What has no record yet: a machine that goes on to install Gentoo from inside
+the environment it came up in, and a deliberately failed arming proving the
+machine returns to its own system because the entry is one-shot.
 
 ## Not covered by any record
 

--- a/tests/fixtures/vm-dd-gz.toml
+++ b/tests/fixtures/vm-dd-gz.toml
@@ -1,0 +1,7 @@
+config_version = 1
+
+[disk]
+mode = "dd"
+source = "/mnt/driver/fixtures/dd-source.raw.gz"
+source_format = "gz"
+destination = "/dev/disk/by-id/virtio-target0"

--- a/tests/fixtures/vm-dd-raw.toml
+++ b/tests/fixtures/vm-dd-raw.toml
@@ -1,0 +1,7 @@
+config_version = 1
+
+[disk]
+mode = "dd"
+source = "/mnt/driver/fixtures/dd-source.raw"
+source_format = "raw"
+destination = "/dev/disk/by-id/virtio-target0"

--- a/tests/golden/vm-dd-gz.txt
+++ b/tests/golden/vm-dd-gz.txt
@@ -1,0 +1,2 @@
+[partition]
+  stream the gz image /mnt/driver/fixtures/dd-source.raw.gz onto /dev/disk/by-id/virtio-target0

--- a/tests/golden/vm-dd-raw.txt
+++ b/tests/golden/vm-dd-raw.txt
@@ -1,0 +1,2 @@
+[partition]
+  stream the raw image /mnt/driver/fixtures/dd-source.raw onto /dev/disk/by-id/virtio-target0

--- a/tests/unit/test_harness.py
+++ b/tests/unit/test_harness.py
@@ -152,6 +152,10 @@ NOT_IN_THE_CAMPAIGN: Final[frozenset[str]] = frozenset(
         # cannot answer, and the cluster has no way to arrange one. The rule
         # itself is held in `test_exec.py`, through the runner and the journal.
         "vm-binhost-fallback.toml",
+        # The dd runner generates its sources, streams each one from the driver
+        # CD, and reads the target back; neither target can boot as a system.
+        "vm-dd-raw.toml",
+        "vm-dd-gz.toml",
     }
 )
 
@@ -535,13 +539,17 @@ def test_every_fixture_sets_the_password_the_harness_logs_in_with() -> None:
     import subprocess
     from pathlib import Path
 
+    from gentoo_install.model.config import DiskMode
     from gentoo_install.exec.config import load
     from tests.vm.run import INSTALLED_PASSWORD
 
     # `openssl passwd`, not `crypt`: the module left the standard library in
     # 3.13 and openssl is a tool the installer already requires.
     for fixture in sorted(Path("tests/fixtures").glob("*.toml")):
-        hashed = load(fixture).system.root_password_hash
+        installation = load(fixture)
+        if installation.disk.mode is DiskMode.DD:
+            continue
+        hashed = installation.system.root_password_hash
         assert hashed, f"{fixture.name} sets no root password"
         salt = hashed.split("$")[2]
         said = subprocess.run(
@@ -583,11 +591,15 @@ def test_every_fixture_has_a_boot_check_that_can_fail() -> None:
     cannot fail, which is how the empty ones went unnoticed."""
     from pathlib import Path
 
+    from gentoo_install.model.config import DiskMode
     from gentoo_install.exec.config import load
     from tests.vm.cluster import _asked_for
 
     for fixture in sorted(Path("tests/fixtures").glob("*.toml")):
-        checks = _asked_for(load(fixture))
+        installation = load(fixture)
+        if installation.disk.mode is DiskMode.DD:
+            continue
+        checks = _asked_for(installation)
         empty = [one for one, _, value in checks if not value]
         assert not empty, f"{fixture.name}: {empty}"
         assert len(checks) >= 4, f"{fixture.name}: {checks}"
@@ -595,6 +607,7 @@ def test_every_fixture_has_a_boot_check_that_can_fail() -> None:
 
 def test_local_and_cluster_use_the_same_installed_contract() -> None:
     """Both transport adapters must derive checks from one specification."""
+    from gentoo_install.model.config import DiskMode
     from tests.vm.cluster import _asked_for
     from tests.vm.installed import checks
     from tests.vm.run import _from_config
@@ -602,9 +615,110 @@ def test_local_and_cluster_use_the_same_installed_contract() -> None:
 
     for path in sorted(Path("tests/fixtures").glob("*.toml")):
         installation = load(path)
+        if installation.disk.mode is DiskMode.DD:
+            continue
         expected = [(one.name, one.pattern) for one in checks(installation)]
         assert _from_config(path) == expected
         assert [(name, pattern) for name, _, pattern in _asked_for(installation)] == expected
+
+
+def test_dd_runner_selects_raw_and_gzip_sources() -> None:
+    """The end-to-end runner must stream every reader format it says it checks."""
+    from gentoo_install.exec.config import load
+    from gentoo_install.model.config import DiskMode, ImageFormat
+    from tests.vm import dd
+
+    expected = {
+        "vm-dd-raw.toml": (ImageFormat.RAW, f"/mnt/driver/fixtures/{dd.RAW_SOURCE_NAME}"),
+        "vm-dd-gz.toml": (ImageFormat.GZIP, f"/mnt/driver/fixtures/{dd.GZIP_SOURCE_NAME}"),
+    }
+    assert {Path(selected.fixture).name for selected in dd.INPUTS} == set(expected)
+    for selected in dd.INPUTS:
+        name = Path(selected.fixture).name
+        source_format, source = expected[name]
+        installation = load(Path("tests") / selected.fixture)
+        assert installation.disk.mode is DiskMode.DD
+        assert installation.disk.source_format is source_format
+        assert installation.disk.source == source
+        assert installation.disk.destination == "/dev/disk/by-id/virtio-target0"
+
+
+def test_dd_runner_builds_a_unique_raw_source_and_its_gzip_stream(tmp_path: Path) -> None:
+    """A stale blank disk must not be indistinguishable from this run's source."""
+    import gzip
+
+    from tests.vm import dd
+
+    sources = dd.build_sources(tmp_path)
+    raw = sources.raw.read_bytes()
+
+    assert len(raw) == dd.SOURCE_BYTES
+    assert raw.startswith(sources.marker)
+    assert raw != b"\0" * dd.SOURCE_BYTES
+    with gzip.open(sources.gzip, "rb") as compressed:
+        assert compressed.read() == raw
+    staged = dd.stage_sources(tmp_path / "driver", sources)
+    assert (staged / dd.RAW_SOURCE_NAME).read_bytes() == raw
+    with gzip.open(staged / dd.GZIP_SOURCE_NAME, "rb") as compressed:
+        assert compressed.read() == raw
+
+
+def test_dd_runner_reads_the_marker_bounded_installer_status() -> None:
+    """A status check must not match the shell echo of its own command."""
+    from typing import Any, cast
+
+    from tests.vm import dd
+
+    class Output:
+        def __init__(self, status: bytes) -> None:
+            self.status = status
+            self.commands: list[str] = []
+
+        def expect_output(self, command: str, timeout: float) -> bytes:
+            self.commands.append(command)
+            return self.status
+
+    successful = Output(b"0\n")
+    dd.require_install_success(cast(Any, successful), "raw")
+    assert successful.commands == [f"cat {dd.INSTALL_RESULT}"]
+
+    with pytest.raises(RuntimeError, match="gz installer exited"):
+        dd.require_install_success(cast(Any, Output(b"1\n")), "gz")
+
+
+def test_dd_runner_rejects_a_target_byte_mismatch(monkeypatch: pytest.MonkeyPatch) -> None:
+    """The target comparison fails instead of trusting the dd process status."""
+    import subprocess
+
+    from tests.vm import dd
+
+    calls: list[list[str]] = []
+
+    def identical(command: list[str], **_: object) -> subprocess.CompletedProcess[str]:
+        calls.append(command)
+        return subprocess.CompletedProcess(command, 0, stdout="Images are identical.\n", stderr="")
+
+    monkeypatch.setattr("tests.vm.dd.subprocess.run", identical)
+    dd.target_matches(Path("source.raw"), Path("target.qcow2"), "raw")
+    assert calls == [
+        [
+            "qemu-img",
+            "compare",
+            "-f",
+            "raw",
+            "-F",
+            "qcow2",
+            "source.raw",
+            "target.qcow2",
+        ]
+    ]
+
+    def different(command: list[str], **_: object) -> subprocess.CompletedProcess[str]:
+        return subprocess.CompletedProcess(command, 1, stdout="byte 512 differs\n", stderr="")
+
+    monkeypatch.setattr("tests.vm.dd.subprocess.run", different)
+    with pytest.raises(RuntimeError, match="byte 512 differs"):
+        dd.target_matches(Path("source.raw"), Path("target.qcow2"), "raw")
 
 
 def test_a_single_runner_check_cannot_be_added_without_breaking_parity(

--- a/tests/unit/test_readme.py
+++ b/tests/unit/test_readme.py
@@ -231,14 +231,15 @@ def test_the_record_file_holds_what_the_readmes_stopped_carrying() -> None:
     # absent section reads as an oversight, an empty one as a fact.
     for heading in ("## Mode 1", "## Mode 2", "## Mode 3"):
         assert heading in record, heading
-    # Mode 3 has one record and two paths without one. Both halves are
-    # asserted: a section carrying only the record reads as a finished mode,
-    # and one carrying only the gap reads as a plan.
-    assert "nothing end to end yet" in record, "what has no record says so"
+    # Every path in mode 3 has a record, and what is still missing is named
+    # where the rows are: a section carrying only records reads as a finished
+    # mode, and one carrying only gaps reads as a plan.
+    assert "install or shell>" in record, "the record says what came up"
+    assert "read it back byte-for-byte" in record, "and what was written"
     assert (
-        "`dd` has no record" in " ".join(record.split())
+        "a machine that goes on to install Gentoo from inside the environment"
+        in " ".join(record.split())
     ), "the boundary of mode 3 is stated where its rows are"
-    assert "install or shell>" in record, "and the record says what came up"
 
     # And every README points at it rather than repeating it.
     for name in READMES:

--- a/tests/vm/dd.py
+++ b/tests/vm/dd.py
@@ -1,0 +1,182 @@
+# SPDX-License-Identifier: GPL-2.0-or-later
+"""Write generated raw and gzip images from a live medium, then compare bytes.
+
+    python3 -m tests.vm.dd
+"""
+
+from __future__ import annotations
+
+import argparse
+import gzip
+import hashlib
+import shutil
+import subprocess
+import sys
+import time
+import uuid
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Final
+
+from .console import ConsoleClosed, ConsoleTimeout, SerialConsole
+from .driver import REPOSITORY, build as build_driver, wait_for_driver
+from .media import MEDIA
+from .qemu import Firmware, Vm, VmSpec
+from .run import power_off, reach_shell, run_installer
+from .workdir import confined
+
+WORKROOT: Final[Path] = Path.home() / "code/gentoo-install/lab/vm/dd"
+SOURCE_BYTES: Final[int] = 4 * 1024 * 1024
+SOURCE_BLOCK_BYTES: Final[int] = 64 * 1024
+RAW_SOURCE_NAME: Final[str] = "dd-source.raw"
+GZIP_SOURCE_NAME: Final[str] = "dd-source.raw.gz"
+INSTALL_RESULT: Final[str] = "/run/vm-result/install.rc"
+
+
+@dataclass(frozen=True)
+class SourceImages:
+    """The generated source bytes and their compressed representation."""
+
+    raw: Path
+    gzip: Path
+    marker: bytes
+
+
+@dataclass(frozen=True)
+class Input:
+    """One reader format and the fixture that selects it."""
+
+    name: str
+    fixture: str
+
+
+INPUTS: Final[tuple[Input, ...]] = (
+    Input(name="raw", fixture="fixtures/vm-dd-raw.toml"),
+    Input(name="gz", fixture="fixtures/vm-dd-gz.toml"),
+)
+
+
+def _source_block(marker: bytes, index: int) -> bytes:
+    """One non-zero block derived from this run's marker."""
+    digest = hashlib.sha256(marker + index.to_bytes(4, "big")).digest()
+    repeats, remainder = divmod(SOURCE_BLOCK_BYTES, len(digest))
+    return digest * repeats + digest[:remainder]
+
+
+def build_sources(workdir: Path) -> SourceImages:
+    """Build a small image whose unique marker makes a stale target impossible."""
+    raw = workdir / RAW_SOURCE_NAME
+    compressed = workdir / GZIP_SOURCE_NAME
+    marker = f"GENTOO-INSTALL-DD-{uuid.uuid4().hex}\n".encode()
+    with raw.open("wb") as output:
+        for index in range(SOURCE_BYTES // SOURCE_BLOCK_BYTES):
+            block = _source_block(marker, index)
+            if index == 0:
+                block = marker + block[len(marker) :]
+            output.write(block)
+    with raw.open("rb") as source, gzip.open(compressed, "wb") as output:
+        shutil.copyfileobj(source, output)
+    return SourceImages(raw=raw, gzip=compressed, marker=marker)
+
+
+def stage_sources(workdir: Path, sources: SourceImages) -> Path:
+    """Add the generated images beside the fixtures the driver CD receives."""
+    fixtures = workdir / "fixtures"
+    shutil.copytree(REPOSITORY / "tests" / "fixtures", fixtures)
+    shutil.copy2(sources.raw, fixtures / RAW_SOURCE_NAME)
+    shutil.copy2(sources.gzip, fixtures / GZIP_SOURCE_NAME)
+    return fixtures
+
+
+def create_target(path: Path) -> Path:
+    """Create a target whose virtual size exactly equals the source image."""
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.unlink(missing_ok=True)
+    result = subprocess.run(
+        ["qemu-img", "create", "-f", "qcow2", str(path), str(SOURCE_BYTES)],
+        capture_output=True,
+        text=True,
+    )
+    if result.returncode != 0:
+        raise RuntimeError(f"qemu-img could not create {path}: {result.stderr.strip()}")
+    return path
+
+
+def target_matches(source: Path, target: Path, name: str) -> None:
+    """Read a qcow2 target through QEMU and reject any byte mismatch."""
+    result = subprocess.run(
+        ["qemu-img", "compare", "-f", "raw", "-F", "qcow2", str(source), str(target)],
+        capture_output=True,
+        text=True,
+    )
+    if result.returncode != 0:
+        detail = "\n".join(part for part in (result.stdout, result.stderr) if part).strip()
+        raise RuntimeError(f"{name} target differs from its source: {detail or 'qemu-img compare failed'}")
+
+
+def require_install_success(console: SerialConsole, name: str) -> None:
+    """Read the installer status between console markers, never from its echo."""
+    status = console.expect_output(f"cat {INSTALL_RESULT}", timeout=60.0).strip()
+    if status != b"0":
+        raise RuntimeError(f"{name} installer exited {status!r}")
+
+
+def run_input(
+    selected: Input, sources: SourceImages, driver: Path, workdir: Path, *, keep: bool
+) -> None:
+    """Run one reader against a fresh target and compare it after power-off."""
+    target = create_target(workdir / "target.qcow2")
+    matched = False
+    try:
+        medium = MEDIA["official-minimal"]
+        spec = VmSpec(
+            medium=medium,
+            workdir=workdir,
+            firmware=Firmware.UEFI,
+            driver_iso=driver,
+            targets=(target,),
+        )
+        started = time.monotonic()
+        with Vm(spec) as vm:
+            with SerialConsole.connect(vm.serial_socket, vm.serial_log) as console:
+                reach_shell(console, medium, ())
+                wait_for_driver(console)
+                run_installer(console, selected.fixture)
+                require_install_success(console, selected.name)
+                power_off(console, vm)
+        target_matches(sources.raw, target, selected.name)
+        matched = True
+        print(
+            f"[{time.monotonic() - started:5.1f}s] {selected.name} target byte-for-byte "
+            "matches its source",
+            flush=True,
+        )
+    finally:
+        if matched and not keep:
+            target.unlink(missing_ok=True)
+
+
+def main(argv: list[str] | None = None) -> int:
+    """Run both streamed source formats on the official minimal live medium."""
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--keep", action="store_true", help="keep verified target disks")
+    arguments = parser.parse_args(argv)
+
+    workdir = confined(WORKROOT / str(time.time_ns()))
+    workdir.mkdir(parents=True)
+    print(f"work directory: {workdir}", flush=True)
+    try:
+        sources = build_sources(workdir)
+        fixtures = stage_sources(workdir, sources)
+        driver = build_driver(workdir / "driver.iso", fixtures=fixtures)
+        for selected in INPUTS:
+            run_input(selected, sources, driver, workdir / selected.name, keep=arguments.keep)
+    except (ConsoleClosed, ConsoleTimeout, OSError, RuntimeError, subprocess.SubprocessError) as error:
+        print(f"FAIL {error}", file=sys.stderr, flush=True)
+        return 1
+    print("dd mode wrote and read back raw and gz sources byte-for-byte", flush=True)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
`dd` was the last path in mode 3 with no record. It has one now, and the check is the bytes rather than an exit code.

The runner builds a 4 MiB source whose every block is derived from a marker generated for that run, so a target that was never written, or written by an earlier run, cannot match. It stages that source and its gzip beside the fixtures on the driver CD, boots the official minimal medium — a live medium, which is the condition the mode requires — attaches a target of exactly the source's size, runs the installer, and compares the disk afterwards with `qemu-img compare`.

Run here, both formats:

    [partition] stream the raw image /mnt/driver/fixtures/dd-source.raw onto /dev/disk/by-id/virtio-target0
    4194304 bytes (4.2 MB, 4.0 MiB) copied, 0.00367821 s, 1.1 GB/s
    raw target byte-for-byte matches its source
    gz  target byte-for-byte matches its source

And the control for the comparison itself: the same source against a freshly created empty target answers `Content mismatch at offset 0!`.

Written by an agent, which was told not to run a guest; that half was done here. Both gates pass in this tree.

`TESTED.md` now says every path in mode 3 has a record, and names what still has none: a machine that goes on to install Gentoo from inside the environment it came up in, and a deliberately failed arming proving the machine returns to its own system.
