### PR TITLE
cluster: read the installed system's login in its own locale

### DIFF
--- a/tests/unit/test_cluster.py
+++ b/tests/unit/test_cluster.py
@@ -1312,7 +1312,11 @@ def test_the_boot_check_does_not_spend_an_agetty_attempt_on_the_prompt() -> None
     import inspect
 
     source = inspect.getsource(cluster.boot_and_check)
-    waited = [line for line in source.splitlines() if "observe(r\"login:\"" in line]
+    waited = [
+        line
+        for line in source.splitlines()
+        if "observe(" in line and "LOGIN_PROMPTS" in line
+    ]
     assert waited, source
     assert not any("solicit" in line for line in waited), waited
     # And the miss is not a verdict on its own: nothing returns straight out of
@@ -1739,11 +1743,41 @@ class _LoginWithItsOwnLimit:
 
     ISSUE = b"\r\nThis is plain\r\n\r\nplain login: "
 
-    def __init__(self, gives_up: int) -> None:
+    #: The three lines `login` writes, per locale, as codepoints: shadow's own
+    #: `po/zh_TW.po` and `po/zh_CN.po` for the two Chinese ones.
+    WORDING: dict[str, tuple[str, str, str, str]] = {
+        "C": (
+            "Password: ",
+            "Login incorrect",
+            "Maximum number of tries exceeded (3)",
+            "login: ",
+        ),
+        "zh_TW": (
+            "\u5bc6\u78bc\uff1a",
+            "\u767b\u5165\u932f\u8aa4",
+            "\u5df2\u78b0\u5230\u6700\u5927\u5617\u8a66\u6b21\u6578 (3)",
+            "\u4f7f\u7528\u8005\uff1a",
+        ),
+        "zh_CN": (
+            "\u5bc6\u7801\uff1a",
+            "\u767b\u5f55\u9519\u8bef",
+            "\u5df2\u7ecf\u8d85\u8fc7\u6700\u5927\u5c1d\u8bd5\u6b21\u6570 (3)",
+            "\u7528\u6237\u540d\uff1a",
+        ),
+    }
+
+    def __init__(self, gives_up: int, locale: str = "C") -> None:
         #: How many times `login` spends its three tries before the password
         #: is finally taken.
         self.gives_up = gives_up
+        self.password_prompt, self.refusal, self.gave_up, self.name_prompt = (
+            one.encode() for one in self.WORDING[locale]
+        )
         self.tries = 0
+        #: How many waits gave up. A prompt the guest printed in its own
+        #: locale costs the whole re-prompt patience when the harness knows
+        #: only the English one.
+        self.timeouts = 0
         self.sent: list[str] = []
         self.held = b"plain login: "
         self.console = _Screen(b"plain login: ")
@@ -1751,24 +1785,29 @@ class _LoginWithItsOwnLimit:
     def respond(self, line: str) -> None:
         self.sent.append(line)
         if line == "root":
-            self.held += b"root\r\nPassword: "
+            self.held += b"root\r\n" + self.password_prompt
             return
         if self.gives_up == 0:
             self.held += b"\r\nplain ~ # "
             return
         self.tries += 1
         if self.tries < 3:
-            self.held += b"\r\n\r\nLogin incorrect\r\n" + self.ISSUE
+            # `login` asks again itself, in its own locale; agetty and its
+            # English issue only come back after `login` has given up.
+            self.held += (
+                b"\r\n\r\n" + self.refusal + b"\r\nplain " + self.name_prompt
+            )
             return
         self.tries = 0
         self.gives_up -= 1
-        self.held += b"\r\nMaximum number of tries exceeded (3)\r\n" + self.ISSUE
+        self.held += b"\r\n" + self.gave_up + b"\r\n" + self.ISSUE
 
     def observe(
         self, pattern: str, timeout: float = 0.0, *, solicit: bool = False
     ) -> bytes:
         found = re.search(pattern.encode(), self.held)
         if not found:
+            self.timeouts += 1
             raise ConsoleTimeout(f"never matched {pattern!r}")
         said, self.held = self.held[: found.end()], self.held[found.end() :]
         return said
@@ -1802,6 +1841,24 @@ def test_a_login_that_never_takes_the_password_still_ends(
         cast(cluster.Reconnecting, console), "install"
     )
     assert console.sent.count("install") <= cluster.LOGIN_TRIES * 3, console.sent
+
+
+def test_a_login_speaking_the_installed_locale_is_read_the_same_way() -> None:
+    """shadow's `login` is translated, so a fixture installing a Chinese
+    locale is refused in Chinese. `vm-unlock` was failed at 64.0 minutes with
+    the refusal and the name prompt both on its console in `zh_TW`."""
+    for locale in ("zh_TW", "zh_CN"):
+        console = _LoginWithItsOwnLimit(gives_up=1, locale=locale)
+
+        assert cluster._log_in(cast(cluster.Reconnecting, console), "install") == "", (
+            locale,
+            console.sent,
+        )
+        assert console.sent.count("install") == 4, (locale, console.sent)
+        # `login` asks for the name again in its own locale, so a harness that
+        # knows only agetty's English one waits out its re-prompt patience on
+        # every refusal before typing anything.
+        assert console.timeouts == 0, (locale, console.timeouts)
 
 
 def test_a_refusal_holding_none_of_the_password_still_ends_the_login() -> None:

--- a/tests/vm/cluster.py
+++ b/tests/vm/cluster.py
@@ -2507,10 +2507,12 @@ def _name_the_user(link: Reconnecting) -> bool:
             time.sleep(AGETTY_FLUSHES_AFTER)
         link.respond("root")
         try:
-            said = link.observe(rf"{PASSWORD_PROMPT}|login:", timeout=60.0)
+            said = link.observe(
+                rf"{PASSWORD_PROMPT}|{'|'.join(LOGIN_PROMPTS)}", timeout=60.0
+            )
         except ConsoleTimeout:
             continue
-        if b"login:" not in said:
+        if not any(one.encode() in said for one in LOGIN_PROMPTS):
             return True
     return False
 
@@ -2575,15 +2577,47 @@ def _seen_since(link: Reconnecting, said: bytes) -> str:
 #: check did not see, and the fragment then went to `login` as the password.
 ECHO_FRAGMENT: Final[int] = 2
 
-#: What `login` writes when it will not take a password.
-REFUSED: Final[bytes] = b"Login incorrect"
+#: What `login` writes when it will not take a password, in each locale a
+#: fixture installs. shadow's `login` is translated, so `vm-unlock` was refused
+#: in Chinese and the harness spent its whole budget waiting for the English
+#: wording. Taken from shadow's own `po/zh_TW.po` and `po/zh_CN.po`; codepoints
+#: rather than literals, because no CJK belongs under `tests/`.
+REFUSALS: Final[tuple[bytes, ...]] = (
+    b"Login incorrect",
+    "\u767b\u5165\u932f\u8aa4".encode(),
+    "\u767b\u5f55\u9519\u8bef".encode(),
+)
+
+#: What `login` prints instead of a refusal when its own three tries are gone.
+#: `ext3` was failed twice for a `Login incorrect` that was never coming: the
+#: harness waited its whole 120 seconds while agetty reprinted the prompt
+#: beside it, ready for another name.
+GAVE_UPS: Final[tuple[bytes, ...]] = (
+    b"Maximum number of tries exceeded",
+    "\u5df2\u78b0\u5230\u6700\u5927\u5617\u8a66\u6b21\u6578".encode(),
+    "\u5df2\u7ecf\u8d85\u8fc7\u6700\u5927\u5c1d\u8bd5\u6b21\u6570".encode(),
+)
+
+#: The name prompt, which `login` translates and agetty does not: a guest
+#: shows agetty's English one first and `login`'s own after a refusal.
+LOGIN_PROMPTS: Final[tuple[str, ...]] = (
+    "login:",
+    "\u4f7f\u7528\u8005\uff1a",
+    "\u7528\u6237\u540d\uff1a",
+)
 
 
-#: What `login` prints instead of a refusal when its own three tries are
-#: gone. `ext3` was failed twice for a `Login incorrect` that was never
-#: coming: the harness waited its whole 120 seconds while agetty reprinted the
-#: prompt beside it, ready for another name.
-GAVE_UP: Final[bytes] = b"Maximum number of tries exceeded"
+def _any_of(words: tuple[bytes, ...]) -> str:
+    """One pattern matching any of these, for a console wait."""
+    return "|".join(re.escape(one.decode()) for one in words)
+
+
+def _held(said: bytes, words: tuple[bytes, ...]) -> bytes:
+    """Whichever of these the console holds, or empty."""
+    for one in words:
+        if one in said:
+            return one
+    return b""
 
 
 def _echoed_back(said: bytes, password: str) -> bool:
@@ -2595,7 +2629,7 @@ def _echoed_back(said: bytes, password: str) -> bool:
     the prompt that follows it carry letters of their own: `Login incorrect`
     holds `in`, and so does `install`.
     """
-    echo = said.partition(REFUSED)[0]
+    echo = said.partition(_held(said, REFUSALS))[0]
     return any(
         password[at : at + width].encode() in echo
         for width in range(len(password), ECHO_FRAGMENT - 1, -1)
@@ -2622,25 +2656,29 @@ def _log_in(link: Reconnecting, password: str) -> str:
         link.respond(password)
         try:
             said = link.observe(
-                rf"#|\$|Login incorrect|{GAVE_UP.decode()}", timeout=120.0
+                rf"#|\$|{_any_of(REFUSALS)}|{_any_of(GAVE_UPS)}", timeout=120.0
             )
         except ConsoleTimeout as error:
             return (
                 f"root could not log into the installed system: {error}; "
                 f"the console held {_seen_since(link, b'')}"
             )[:VERDICT_BYTES]
-        if GAVE_UP in said:
+        if _held(said, GAVE_UPS):
             # `login` has spent its own three tries and exited; agetty starts
             # another one, so the name goes in again rather than the run
             # waiting for a refusal that cannot arrive.
             refusals += 1
             settle += PASSWORD_ECHO_BACKOFF
             try:
-                link.observe(r"login:", timeout=REPROMPT_PATIENCE, solicit=True)
+                link.observe(
+                    rf"{'|'.join(LOGIN_PROMPTS)}",
+                    timeout=REPROMPT_PATIENCE,
+                    solicit=True,
+                )
             except ConsoleTimeout:
                 pass
             continue
-        if REFUSED not in said:
+        if not _held(said, REFUSALS):
             return ""
         if _echoed_back(said, password) and echoed < PASSWORD_ECHO_CATCHES:
             echoed += 1
@@ -2659,7 +2697,7 @@ def _log_in(link: Reconnecting, password: str) -> str:
         # second one lands in the password field. `vm-lvm` failed at 55.6
         # minutes with `root` echoed under `Password:` for exactly that.
         try:
-            link.observe(r"login:", timeout=REPROMPT_PATIENCE)
+            link.observe(rf"{'|'.join(LOGIN_PROMPTS)}", timeout=REPROMPT_PATIENCE)
         except ConsoleTimeout:
             pass
     return (
@@ -2742,7 +2780,7 @@ def _unlock(
     for _ in range(UNLOCK_TRIES):
         try:
             said = link.observe(
-                rf"{PASSPHRASE_PROMPT}|login:",
+                rf"{PASSPHRASE_PROMPT}|{'|'.join(LOGIN_PROMPTS)}",
                 timeout=BOOT_PATIENCE,
             )
         except (ConsoleTimeout, ConsoleClosed) as error:
@@ -2750,7 +2788,7 @@ def _unlock(
                 InstalledBootState.WAIT_LOGIN,
                 f"the encrypted disk asked for nothing and booted nowhere: {error}"[:200],
             )
-        if b"login:" in said:
+        if any(one.encode() in said for one in LOGIN_PROMPTS):
             return UnlockResult(InstalledBootState.LOGIN_READY)
         try:
             link.respond(DISK_PASSPHRASE)
@@ -2859,7 +2897,7 @@ def boot_and_check(
             # agetty as one of its attempts, and `vm-lvm` came back with
             # `Maximum number of tries exceeded (5)` after two reconnects where
             # the same fixture passed with one and no solicit.
-            link.observe(r"login:", timeout=BOOT_PATIENCE)
+            link.observe(rf"{'|'.join(LOGIN_PROMPTS)}", timeout=BOOT_PATIENCE)
         except (ConsoleTimeout, ConsoleClosed) as error:
             # Not fatal: agetty prints `login:` once, so a console reopened past
             # it never sees the prompt again, while `_name_the_user` types a


### PR DESCRIPTION
shadow's `login` is translated, so a fixture that selects `zh_TW.UTF-8` is refused in Chinese. The wait knew only `Login incorrect`, so `vm-unlock` spent its whole 120 seconds beside a console that had already answered, and was failed at 64.0 minutes for an install that had completed.

The refusal, the three-tries line and the name prompt now carry the wording shadow's own `po/zh_TW.po` and `po/zh_CN.po` give them, written as codepoints so no CJK enters `tests/`.
