### PR TITLE
netboot: make the memory environment able to install

### DIFF
--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -48,7 +48,9 @@ install_command() {
 	suse | opensuse | opensuse-leap | opensuse-tumbleweed) printf 'zypper --non-interactive install' ;;
 	fedora | rhel | centos) printf 'dnf install -y' ;;
 	gentoo) printf 'emerge --noreplace' ;;
-	alpine) printf 'apk add' ;;
+	# `--update-cache`: a netboot root has a repository file from
+	# `alpine_repo=` and no index beside it, and `apk add` alone selects nothing.
+	alpine) printf 'apk add --update-cache' ;;
 	*) return 1 ;;
 	esac
 }
@@ -139,6 +141,20 @@ python_binary() {
 	return 1
 }
 
+install_missing=no
+# Consumed here rather than passed on: the installer's own parser rejects it,
+# and the memory environment's first screen is where the operator consented.
+count=$#
+while [ "$count" -gt 0 ]; do
+	argument=$1
+	shift
+	count=$((count - 1))
+	case "$argument" in
+	--install-missing) install_missing=yes ;;
+	*) set -- "$@" "$argument" ;;
+	esac
+done
+
 family=$(distribution)
 say "live system: $family"
 
@@ -203,12 +219,27 @@ if [ -n "$missing" ]; then
 	if [ -n "$unavailable" ]; then
 		say "this system has no package for:$unavailable"
 	fi
-	if [ -n "$packages" ] && manager=$(install_command "$family"); then
-		say "run: $manager$packages"
-	else
+	if [ -z "$packages" ] || ! manager=$(install_command "$family"); then
 		say "install what provides them, then run this again"
+		exit 1
 	fi
-	exit 1
+	say "run: $manager$packages"
+	if [ "$install_missing" != yes ]; then
+		exit 1
+	fi
+	# shellcheck disable=SC2086
+	if ! $manager$packages; then
+		say "that command failed, so nothing was installed"
+		exit 1
+	fi
+	if ! missing=$(PYTHONPATH=$HERE "$python" -m gentoo_install --missing-commands "$@" 2>&1); then
+		say "the installer could not list what is missing: $missing"
+		exit 1
+	fi
+	if [ -n "$missing" ]; then
+		say "still missing:$(printf ' %s' $missing)"
+		exit 1
+	fi
 fi
 
 # Last, so the diagnostics above still run for an ordinary user: what needs

--- a/gentoo_install/plan/netboot.py
+++ b/gentoo_install/plan/netboot.py
@@ -615,7 +615,8 @@ def _start() -> str:
         + _bring_python()
         # `sh`, not `exec sh`: this is sourced, so exec removes the login shell.
         # After consent, `--no-shell` prevents a later prompt from stopping the run.
-        + f"    sh ./bootstrap.sh --no-shell --config {PAYLOAD}/config.toml ;;\n"
+        + "    sh ./bootstrap.sh --no-shell --install-missing "
+        + f"--config {PAYLOAD}/config.toml ;;\n"
         + "*) printf 'nothing was changed\\n' ;;\n"
         "esac\n"
     )

--- a/gentoo_install/plan/netboot.py
+++ b/gentoo_install/plan/netboot.py
@@ -570,9 +570,14 @@ class AppendConfiguration(Operation):
 #: Alpine's package for the interpreter the installer runs on.
 ALPINE_PYTHON: Final[str] = "python3"
 
+#: Where the kernel exposes the firmware variables a UEFI boot entry is
+#: written into. Named here so a test can point the script at a directory of
+#: its own rather than at this machine's.
+EFIVARS: Final[str] = "/sys/firmware/efi/efivars"
 
-def _bring_python() -> str:
-    """Put an interpreter in the memory environment that has none.
+
+def _ready_the_environment() -> str:
+    """Make the memory environment able to run the installer at all.
 
     Alpine's netboot root ships busybox and `apk` and no Python, so the first
     `--lowram` install ended at `this installer needs python 3.11 or newer`.
@@ -580,6 +585,12 @@ def _bring_python() -> str:
     leaves no index beside it.
     """
     return (
+        # Alpine's netboot init mounts no efivarfs, so the preflight refused
+        # the first `--lowram` install with `the firmware variables are not
+        # readable` on a machine that boots through them.
+        f"    if [ -d {EFIVARS} ]; then\n"
+        f"        mount -t efivarfs efivarfs {EFIVARS} 2>/dev/null || true\n"
+        "    fi\n"
         "    if ! command -v python3 >/dev/null 2>&1 && command -v apk >/dev/null 2>&1; "
         "then\n"
         "        printf 'installing python3 into the memory environment\\n'\n"
@@ -612,7 +623,7 @@ def _start() -> str:
         "read answer\n"
         'case "$answer" in\n'
         "install)\n"
-        + _bring_python()
+        + _ready_the_environment()
         # `sh`, not `exec sh`: this is sourced, so exec removes the login shell.
         # After consent, `--no-shell` prevents a later prompt from stopping the run.
         + "    sh ./bootstrap.sh --no-shell --install-missing "

--- a/gentoo_install/plan/netboot.py
+++ b/gentoo_install/plan/netboot.py
@@ -567,6 +567,28 @@ class AppendConfiguration(Operation):
         context.run(["rm", "--recursive", "--force", str(staging)])
 
 
+#: Alpine's package for the interpreter the installer runs on.
+ALPINE_PYTHON: Final[str] = "python3"
+
+
+def _bring_python() -> str:
+    """Put an interpreter in the memory environment that has none.
+
+    Alpine's netboot root ships busybox and `apk` and no Python, so the first
+    `--lowram` install ended at `this installer needs python 3.11 or newer`.
+    `--update-cache` because `alpine_repo=` writes the repository file and
+    leaves no index beside it.
+    """
+    return (
+        "    if ! command -v python3 >/dev/null 2>&1 && command -v apk >/dev/null 2>&1; "
+        "then\n"
+        "        printf 'installing python3 into the memory environment\\n'\n"
+        f"        apk add --update-cache --quiet {ALPINE_PYTHON} || "
+        "printf 'python3 could not be installed\\n'\n"
+        "    fi\n"
+    )
+
+
 def _start() -> str:
     """What the operator's login shell runs. It asks before it erases anything.
 
@@ -589,11 +611,12 @@ def _start() -> str:
         "printf 'install or shell> '\n"
         "read answer\n"
         'case "$answer" in\n'
-        # `sh`, not `exec sh`: this is sourced, and `exec` would replace the
-        # operator's login shell with the installer and leave them with no
-        # shell when it ends.
-        f"install) sh ./bootstrap.sh --config {PAYLOAD}/config.toml ;;\n"
-        "*) printf 'nothing was changed\\n' ;;\n"
+        "install)\n"
+        + _bring_python()
+        # `sh`, not `exec sh`: this is sourced, so exec removes the login shell.
+        # After consent, `--no-shell` prevents a later prompt from stopping the run.
+        + f"    sh ./bootstrap.sh --no-shell --config {PAYLOAD}/config.toml ;;\n"
+        + "*) printf 'nothing was changed\\n' ;;\n"
         "esac\n"
     )
 

--- a/tests/unit/test_bootstrap.py
+++ b/tests/unit/test_bootstrap.py
@@ -351,3 +351,62 @@ def test_arch_is_told_what_it_cannot_supply_instead_of_a_failing_command(
         assert command in said.split("this system has no package for:")[1].splitlines()[0]
     installs = [line for line in said.splitlines() if line.startswith("run: pacman")]
     assert not any("zfs-utils" in line for line in installs), installs
+
+
+def test_install_missing_runs_the_command_it_prints_and_checks_again(
+    tmp_path: Path,
+) -> None:
+    """The memory environment has no second screen to ask at: the operator
+    typed `install` once, and Alpine's netboot root arrives without `sgdisk`,
+    `blkid` or an interpreter. Without the flag the launcher still only prints
+    the command, because a live system is somebody else's machine."""
+    helpers = tmp_path / "helpers"
+    helpers.mkdir()
+    (helpers / "python3").symlink_to(PYTHON)
+    installed = tmp_path / "installed"
+    # An `apk` that reports what it was asked for and, from then on, makes the
+    # installer answer that nothing is missing.
+    (helpers / "apk").write_text(
+        # A redirection, not `touch`: the PATH this case hands the launcher
+        # holds python and this script and nothing else.
+        f"#!/bin/sh\nprintf 'APK %s\\n' \"$*\"\n: > {installed}\n", encoding="utf-8"
+    )
+    (helpers / "apk").chmod(0o755)
+    # The preflight's own answer, so the case does not depend on which tools
+    # this workstation happens to have.
+    module = tmp_path / "fake"
+    (module / "gentoo_install").mkdir(parents=True)
+    (module / "gentoo_install" / "__init__.py").write_text("", encoding="utf-8")
+    (module / "gentoo_install" / "__main__.py").write_text(
+        "import os, sys\n"
+        f"print('' if os.path.exists({str(installed)!r}) else 'sgdisk blkid')\n",
+        encoding="utf-8",
+    )
+    where = tmp_path / "os-release"
+    where.write_text("ID=alpine\n")
+
+    def launch(*arguments: str) -> subprocess.CompletedProcess[str]:
+        return subprocess.run(
+            [SHELL, str(LAUNCHER), *arguments],
+            cwd=str(module),
+            env={
+                "OS_RELEASE": str(where),
+                "PATH": str(helpers),
+                "PYTHONPATH": str(module),
+            },
+            capture_output=True,
+            text=True,
+        )
+
+    printed = launch("--config", "x.toml")
+    assert printed.returncode == 1, output(printed)
+    assert "run: apk add --update-cache sgdisk blkid" in output(printed), output(printed)
+    assert "APK" not in output(printed), output(printed)
+    assert not installed.exists()
+
+    ran = launch("--install-missing", "--config", "x.toml")
+    said = output(ran)
+    assert "APK add --update-cache sgdisk blkid" in said, said
+    assert installed.exists()
+    # The flag is consumed here: the installer's own parser has no such option.
+    assert "--install-missing" not in said.replace("run: ", ""), said

--- a/tests/unit/test_plan_netboot.py
+++ b/tests/unit/test_plan_netboot.py
@@ -690,7 +690,7 @@ def test_the_live_system_asks_before_it_erases_anything() -> None:
         PurePosixPath(f"{ESP}/{netboot.PLACE}/payload{netboot.PAYLOAD}/start.sh")
     ]
     assert "read answer" in start, start
-    assert "install)" in start and "bootstrap.sh --config" in start, start
+    assert "install)" in start and "bootstrap.sh --no-shell --config" in start, start
     # No timeout anywhere: `read -t` and `sleep` are both ways to answer for
     # the operator, and the answer they would give erases a disk.
     assert "read -t" not in start and "sleep" not in start, start
@@ -1368,3 +1368,72 @@ def test_the_initramfs_is_padded_before_the_segment_is_appended() -> None:
     assert len(appending) == 1, shell
     assert shell.index(padding[0]) < shell.index(appending[0]), shell
     assert "% 4" in padding[0], padding[0]
+
+
+def _only_these_tools(tmp_path: Path, *names: str) -> Path:
+    """A PATH holding these commands and nothing else, so `command -v` is real."""
+    import shutil
+
+    tools = tmp_path / "tools"
+    tools.mkdir(exist_ok=True)
+    for name in names:
+        found = shutil.which(name)
+        assert found, name
+        target = tools / name
+        if not target.exists():
+            target.symlink_to(found)
+    return tools
+
+
+def _fake_apk(tmp_path: Path) -> Path:
+    """An `apk` that reports its arguments and leaves a `python3` behind."""
+    fake = tmp_path / "apk-bin"
+    fake.mkdir(exist_ok=True)
+    apk = fake / "apk"
+    apk.write_text(
+        "#!/bin/sh\n"
+        "printf 'APK %s\\n' \"$*\"\n"
+        f"printf '#!/bin/sh\\nexit 0\\n' > {fake}/python3\n"
+        f"chmod 755 {fake}/python3\n",
+        encoding="utf-8",
+    )
+    apk.chmod(0o755)
+    return fake
+
+
+def _first_screen_with_path(where: Path, answer: str, path: str) -> str:
+    import subprocess
+
+    return subprocess.run(
+        ["sh", "-c", f". {where}/start.sh; echo LOGIN-SHELL-ALIVE"],
+        input=f"{answer}\n",
+        capture_output=True,
+        text=True,
+        check=False,
+        env={"PATH": path},
+    ).stdout
+
+
+def test_the_first_screen_installs_an_interpreter_where_there_is_none(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Alpine's netboot root has `apk` and no Python, so the first `--lowram`
+    install answered `install` and stopped at `this installer needs python
+    3.11 or newer; found: none`. The environment installs one itself, and a
+    machine that already has one is not sent to a package manager."""
+    where = _payload_at(tmp_path, monkeypatch)
+    tools = _only_these_tools(tmp_path, "sh", "chmod")
+    fake = _fake_apk(tmp_path)
+
+    said = _first_screen_with_path(where, "install", f"{fake}:{tools}")
+
+    assert "APK add --update-cache --quiet python3" in said, said
+    assert "BOOTSTRAP" in said, said
+
+    # The other direction: an environment that has an interpreter installs
+    # nothing, so a `--ram` medium is not sent to a package manager it lacks.
+    already = _only_these_tools(tmp_path, "sh", "chmod", "python3")
+    again = _first_screen_with_path(where, "install", f"{fake}:{already}")
+
+    assert "APK" not in again, again
+    assert "BOOTSTRAP" in again, again

--- a/tests/unit/test_plan_netboot.py
+++ b/tests/unit/test_plan_netboot.py
@@ -1418,6 +1418,38 @@ def _first_screen_with_path(where: Path, answer: str, path: str) -> str:
     ).stdout
 
 
+def test_the_first_screen_mounts_the_firmware_variables(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Alpine's netboot init mounts no efivarfs, so the first `--lowram`
+    install was refused by the preflight with `the firmware variables are not
+    readable` on a machine whose own boot entry lives in them. A machine with
+    no such directory is not sent to `mount` at all."""
+    efivars = tmp_path / "efivars"
+    efivars.mkdir()
+    monkeypatch.setattr(netboot, "EFIVARS", str(efivars))
+    where = _payload_at(tmp_path, monkeypatch)
+    tools = _only_these_tools(tmp_path, "sh", "chmod", "python3")
+    mounts = tmp_path / "mount-bin"
+    mounts.mkdir()
+    (mounts / "mount").write_text(
+        "#!/bin/sh\nprintf 'MOUNT %s\\n' \"$*\"\n", encoding="utf-8"
+    )
+    (mounts / "mount").chmod(0o755)
+
+    said = _first_screen_with_path(where, "install", f"{mounts}:{tools}")
+
+    assert f"MOUNT -t efivarfs efivarfs {efivars}" in said, said
+
+    monkeypatch.setattr(netboot, "EFIVARS", str(tmp_path / "no-firmware-here"))
+    elsewhere = tmp_path / "bios"
+    elsewhere.mkdir()
+    absent = _payload_at(elsewhere, monkeypatch)
+    on_bios = _first_screen_with_path(absent, "install", f"{mounts}:{tools}")
+
+    assert "MOUNT" not in on_bios, on_bios
+
+
 def test_the_first_screen_installs_an_interpreter_where_there_is_none(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:

--- a/tests/unit/test_plan_netboot.py
+++ b/tests/unit/test_plan_netboot.py
@@ -690,7 +690,11 @@ def test_the_live_system_asks_before_it_erases_anything() -> None:
         PurePosixPath(f"{ESP}/{netboot.PLACE}/payload{netboot.PAYLOAD}/start.sh")
     ]
     assert "read answer" in start, start
-    assert "install)" in start and "bootstrap.sh --no-shell --config" in start, start
+    assert "install)" in start, start
+    # `--no-shell` so no later question stops an unattended run, and
+    # `--install-missing` because the consent that covers erasing the disk
+    # covers installing the tools that erase it.
+    assert "bootstrap.sh --no-shell --install-missing --config" in start, start
     # No timeout anywhere: `read -t` and `sleep` are both ways to answer for
     # the operator, and the answer they would give erases a disk.
     assert "read -t" not in start and "sleep" not in start, start


### PR DESCRIPTION
The first `--lowram` install that answered `install` at the delivered screen stopped three times in a row, each on something the environment lacks rather than on the installer: no interpreter, then `missing commands: blkid findmnt gpg gpg-agent lsblk mkfs.ext4 mount sgdisk swapon tar udevadm umount wipefs xz`, then `the firmware variables are not readable`.

The first screen now installs `python3` with `apk`, mounts `efivarfs` where the directory exists, and calls `bootstrap.sh --install-missing`. That flag runs the command the launcher already prints and asks the preflight again; without it nothing changes, because a live medium is somebody else's machine and the operator decides there.
