### PR TITLE
netboot: make the efivarfs mount point and report a failure

### DIFF
--- a/gentoo_install/plan/netboot.py
+++ b/gentoo_install/plan/netboot.py
@@ -571,9 +571,11 @@ class AppendConfiguration(Operation):
 ALPINE_PYTHON: Final[str] = "python3"
 
 #: Where the kernel exposes the firmware variables a UEFI boot entry is
-#: written into. Named here so a test can point the script at a directory of
-#: its own rather than at this machine's.
+#: written into, and where the mounted filesystems are listed. Named here so a
+#: test can point the script at files of its own rather than at this machine's.
+FIRMWARE: Final[str] = "/sys/firmware/efi"
 EFIVARS: Final[str] = "/sys/firmware/efi/efivars"
+MOUNTS: Final[str] = "/proc/mounts"
 
 
 def _ready_the_environment() -> str:
@@ -588,8 +590,14 @@ def _ready_the_environment() -> str:
         # Alpine's netboot init mounts no efivarfs, so the preflight refused
         # the first `--lowram` install with `the firmware variables are not
         # readable` on a machine that boots through them.
-        f"    if [ -d {EFIVARS} ]; then\n"
-        f"        mount -t efivarfs efivarfs {EFIVARS} 2>/dev/null || true\n"
+        f"    if [ -d {FIRMWARE} ] && ! grep -q ' efivarfs ' {MOUNTS}; then\n"
+        # `mkdir` as well: the refusal came back on a machine where the mount
+        # point itself was absent, and the failure is printed rather than
+        # swallowed because the preflight's own message is the only other
+        # evidence there is.
+        f"        mkdir -p {EFIVARS}\n"
+        f"        mount -t efivarfs efivarfs {EFIVARS} || "
+        "printf 'the firmware variables did not mount\\n'\n"
         "    fi\n"
         "    if ! command -v python3 >/dev/null 2>&1 && command -v apk >/dev/null 2>&1; "
         "then\n"

--- a/tests/unit/test_plan_netboot.py
+++ b/tests/unit/test_plan_netboot.py
@@ -1425,11 +1425,15 @@ def test_the_first_screen_mounts_the_firmware_variables(
     install was refused by the preflight with `the firmware variables are not
     readable` on a machine whose own boot entry lives in them. A machine with
     no such directory is not sent to `mount` at all."""
-    efivars = tmp_path / "efivars"
-    efivars.mkdir()
-    monkeypatch.setattr(netboot, "EFIVARS", str(efivars))
+    firmware = tmp_path / "firmware"
+    firmware.mkdir()
+    listed = tmp_path / "mounts"
+    listed.write_text("proc /proc proc rw 0 0\n", encoding="utf-8")
+    monkeypatch.setattr(netboot, "FIRMWARE", str(firmware))
+    monkeypatch.setattr(netboot, "EFIVARS", str(firmware / "efivars"))
+    monkeypatch.setattr(netboot, "MOUNTS", str(listed))
     where = _payload_at(tmp_path, monkeypatch)
-    tools = _only_these_tools(tmp_path, "sh", "chmod", "python3")
+    tools = _only_these_tools(tmp_path, "sh", "chmod", "python3", "mkdir", "grep")
     mounts = tmp_path / "mount-bin"
     mounts.mkdir()
     (mounts / "mount").write_text(
@@ -1439,9 +1443,23 @@ def test_the_first_screen_mounts_the_firmware_variables(
 
     said = _first_screen_with_path(where, "install", f"{mounts}:{tools}")
 
-    assert f"MOUNT -t efivarfs efivarfs {efivars}" in said, said
+    assert f"MOUNT -t efivarfs efivarfs {firmware / 'efivars'}" in said, said
+    # The mount point is made rather than assumed: the refusal came back on a
+    # machine that had the firmware directory and not the one under it.
+    assert (firmware / "efivars").is_dir()
 
-    monkeypatch.setattr(netboot, "EFIVARS", str(tmp_path / "no-firmware-here"))
+    # Already mounted: nothing is attempted, so the console does not carry a
+    # failure that means nothing.
+    listed.write_text(
+        f"efivarfs {firmware / 'efivars'} efivarfs rw 0 0\n", encoding="utf-8"
+    )
+    again = _first_screen_with_path(where, "install", f"{mounts}:{tools}")
+
+    assert "MOUNT" not in again, again
+
+    # And a machine with no firmware directory at all is not sent to `mount`.
+    listed.write_text("proc /proc proc rw 0 0\n", encoding="utf-8")
+    monkeypatch.setattr(netboot, "FIRMWARE", str(tmp_path / "no-firmware-here"))
     elsewhere = tmp_path / "bios"
     elsewhere.mkdir()
     absent = _payload_at(elsewhere, monkeypatch)


### PR DESCRIPTION
The mount was guarded on `/sys/firmware/efi/efivars` existing and sent its error to `/dev/null`, so on a guest that has `/sys/firmware/efi` and no directory under it the preflight refused again with `the firmware variables are not readable` and the console said nothing else.

It now guards on the firmware directory, makes the mount point, skips the attempt when `/proc/mounts` already lists `efivarfs`, and prints the failure when there is one.
