### PR TITLE
netboot: load efivarfs before mounting it

### DIFF
--- a/gentoo_install/plan/netboot.py
+++ b/gentoo_install/plan/netboot.py
@@ -591,10 +591,11 @@ def _ready_the_environment() -> str:
         # the first `--lowram` install with `the firmware variables are not
         # readable` on a machine that boots through them.
         f"    if [ -d {FIRMWARE} ] && ! grep -q ' efivarfs ' {MOUNTS}; then\n"
-        # `mkdir` as well: the refusal came back on a machine where the mount
-        # point itself was absent, and the failure is printed rather than
-        # swallowed because the preflight's own message is the only other
-        # evidence there is.
+        # Alpine's `linux-lts` ships `efivarfs.ko.gz`, so the type is a module
+        # and the mount answered `No such device` without this.
+        "        modprobe efivarfs 2>/dev/null || true\n"
+        # The mount point is absent on that guest as well, and the failure is
+        # printed because the preflight's refusal is the only other evidence.
         f"        mkdir -p {EFIVARS}\n"
         f"        mount -t efivarfs efivarfs {EFIVARS} || "
         "printf 'the firmware variables did not mount\\n'\n"

--- a/tests/unit/test_plan_netboot.py
+++ b/tests/unit/test_plan_netboot.py
@@ -1436,13 +1436,18 @@ def test_the_first_screen_mounts_the_firmware_variables(
     tools = _only_these_tools(tmp_path, "sh", "chmod", "python3", "mkdir", "grep")
     mounts = tmp_path / "mount-bin"
     mounts.mkdir()
-    (mounts / "mount").write_text(
-        "#!/bin/sh\nprintf 'MOUNT %s\\n' \"$*\"\n", encoding="utf-8"
-    )
-    (mounts / "mount").chmod(0o755)
+    for name in ("mount", "modprobe"):
+        (mounts / name).write_text(
+            f"#!/bin/sh\nprintf '{name.upper()} %s\\n' \"$*\"\n", encoding="utf-8"
+        )
+        (mounts / name).chmod(0o755)
 
     said = _first_screen_with_path(where, "install", f"{mounts}:{tools}")
 
+    # The module first: Alpine's `linux-lts` ships `efivarfs.ko.gz`, so a
+    # mount without it answers `No such device` and the preflight refuses.
+    assert "MODPROBE efivarfs" in said, said
+    assert said.index("MODPROBE") < said.index("MOUNT"), said
     assert f"MOUNT -t efivarfs efivarfs {firmware / 'efivars'}" in said, said
     # The mount point is made rather than assumed: the refusal came back on a
     # machine that had the firmware directory and not the one under it.


### PR DESCRIPTION
The guest answered `mount: mounting efivarfs on /sys/firmware/efi/efivars failed: No such device`, and `pkgs.alpinelinux.org` lists `kernel/fs/efivarfs/efivarfs.ko.gz` in `linux-lts`, so the filesystem type is a module the netboot root has not loaded.
