### PR TITLE
netboot: fetch Alpine from the region the operator chose

### DIFF
--- a/gentoo_install/cli.py
+++ b/gentoo_install/cli.py
@@ -276,6 +276,7 @@ def _arm_memory_environment(
         # wrote that configuration.
         source=str(Path(__file__).resolve().parent.parent),
         keys=tuple(config.system.authorized_keys),
+        region=config.portage.mirrors.region,
     )
     if arguments.missing_commands:
         # The arming's own commands, not an ordinary install's: `--ram` reads

--- a/gentoo_install/plan/netboot.py
+++ b/gentoo_install/plan/netboot.py
@@ -17,7 +17,7 @@ from pathlib import PurePosixPath
 from typing import Final
 
 from ..errors import DownloadFailed, PreflightFailed
-from ..model.config import BootMethod, MemoryLaunch, MemoryMode
+from ..model.config import BootMethod, MemoryLaunch, MemoryMode, MirrorRegion
 from .operations import CommandOutput, Context, Operation, Stage
 
 #: Where the CJK ISO's releases are listed. The published asset name carries
@@ -55,18 +55,23 @@ CJK_ASSET = re.compile(r'href="([^"?/]+\.(?:iso|iso\.sha256))"')
 #: it the way the kernel does: `x86_64` and `aarch64` both answer, checked on
 #: 2026-08-18, and the netboot flavour is present in each with the same
 #: fields.
+
+#: Where each mirror region fetches Alpine from. The China entry is the host
+#: `tests/vm/media.py` already installs Alpine packages from, so it is
+#: measured rather than chosen.
+ALPINE_MIRRORS: Final[dict[MirrorRegion, str]] = {
+    MirrorRegion.CN: "https://mirrors.ustc.edu.cn/alpine",
+    MirrorRegion.GLOBAL: "https://dl-cdn.alpinelinux.org/alpine",
+}
 ALPINE_RELEASES: Final[str] = (
-    "https://dl-cdn.alpinelinux.org/alpine/latest-stable/releases/{}/"
-    "latest-releases.yaml"
+    "{base}/latest-stable/releases/{architecture}/latest-releases.yaml"
 )
 ALPINE_NETBOOT_FLAVOUR: Final[str] = "alpine-netboot"
 
 #: Alpine's own repository, which its netboot init installs the packages from.
 #: `alpine_repo=auto` searches for a `.boot_repository` file and finds none on
 #: a machine that booted from a local kernel.
-ALPINE_REPOSITORY: Final[str] = (
-    "https://dl-cdn.alpinelinux.org/alpine/latest-stable/main"
-)
+ALPINE_REPOSITORY: Final[str] = "{base}/latest-stable/main"
 
 #: Where the kernel modules come from. `modloop=` is not read by
 #: `initramfs-init` at all: the reader is `/etc/init.d/modloop` in the booted
@@ -76,8 +81,7 @@ ALPINE_REPOSITORY: Final[str] = (
 #: composes an aarch64 URL and the modloop is the one built beside the kernel
 #: that will be running.
 ALPINE_MODLOOP: Final[str] = (
-    "https://dl-cdn.alpinelinux.org/alpine/latest-stable/releases/"
-    "{architecture}/netboot-{version}/modloop-lts"
+    "{base}/latest-stable/releases/{architecture}/netboot-{version}/modloop-lts"
 )
 
 #: What Alpine names a netboot archive. `netboot/` beside it holds whatever
@@ -342,6 +346,7 @@ class FetchMemoryImage(Operation):
     stage: Stage = Stage.STAGE3
     mode: MemoryMode
     target: BootTarget
+    region: MirrorRegion = MirrorRegion.GLOBAL
 
     def required_host_commands(self) -> frozenset[str]:
         return frozenset({"curl", "sha256sum", "mkdir", "rm"})
@@ -355,7 +360,7 @@ class FetchMemoryImage(Operation):
         name, url, checksum = (
             _cjk_release(context, self.target.architecture)
             if self.mode is MemoryMode.RAM
-            else _alpine_release(context, self.target.architecture)
+            else _alpine_release(context, self.target.architecture, self.region)
         )
         image = place / name
         context.run(["curl", "--fail", "--location", "--output", str(image), url])
@@ -700,6 +705,7 @@ class WriteMemoryEntry(Operation):
     mode: MemoryMode
     target: BootTarget
     launch: MemoryLaunch
+    region: MirrorRegion = MirrorRegion.GLOBAL
 
     def describe_parts(self) -> tuple[str, tuple[str, ...]]:
         return "write a {} entry for the {} environment", (
@@ -754,9 +760,11 @@ class WriteMemoryEntry(Operation):
                 # this and a key login does not.
                 words.append(f"passwd={self.launch.root_password}")
             return tuple(words)
+        base = ALPINE_MIRRORS[self.region]
+        archive = _only_image(context, STAGING, ".tar.gz")
         words = [
-            f"alpine_repo={ALPINE_REPOSITORY}",
-            f"modloop={_alpine_modloop(_only_image(context, STAGING, '.tar.gz'))}",
+            f"alpine_repo={ALPINE_REPOSITORY.format(base=base)}",
+            f"modloop={_alpine_modloop(archive, self.region)}",
             f"apkovl=/{APKOVL}",
             "ip=dhcp",
             *_inherited_consoles(context),
@@ -848,6 +856,7 @@ def build(
     configuration: str = "",
     source: str = "",
     keys: tuple[str, ...] = (),
+    region: MirrorRegion = MirrorRegion.GLOBAL,
 ) -> list[Operation]:
     """Every operation that arms one boot into the memory environment.
 
@@ -865,7 +874,7 @@ def build(
         # After the refusals and before the fetch: a machine this refuses is
         # one whose earlier arming is not this run's to take back.
         ClearPreviousArming(target=target),
-        FetchMemoryImage(mode=launch.mode, target=target),
+        FetchMemoryImage(mode=launch.mode, target=target, region=region),
         PlaceMemoryKernel(mode=launch.mode, target=target),
     ]
     if configuration:
@@ -880,7 +889,9 @@ def build(
                 keys=keys,
             )
         )
-    operations.append(WriteMemoryEntry(mode=launch.mode, target=target, launch=launch))
+    operations.append(
+        WriteMemoryEntry(mode=launch.mode, target=target, launch=launch, region=region)
+    )
     if launch.mode is MemoryMode.LOWRAM:
         operations.append(DiscardTheArchive())
     operations.append(arming)
@@ -979,7 +990,9 @@ def _inherited_consoles(context: Context) -> tuple[str, ...]:
 
 
 
-def _alpine_modloop(archive: PurePosixPath) -> str:
+def _alpine_modloop(
+    archive: PurePosixPath, region: MirrorRegion = MirrorRegion.GLOBAL
+) -> str:
     """The modloop belonging to the netboot archive this run downloaded."""
     named = ALPINE_ARCHIVE.match(archive.name)
     if named is None:
@@ -987,7 +1000,7 @@ def _alpine_modloop(archive: PurePosixPath) -> str:
             f"{archive.name} is not named as an Alpine netboot archive, so the "
             "modloop its kernel needs cannot be composed from it"
         )
-    return ALPINE_MODLOOP.format(**named.groupdict())
+    return ALPINE_MODLOOP.format(base=ALPINE_MIRRORS[region], **named.groupdict())
 
 
 def _volume_label(context: Context, image: PurePosixPath) -> str:
@@ -1083,14 +1096,16 @@ def _cjk_from_mirror(context: Context, named: str) -> tuple[str, str, str] | Non
     return iso, f"{inside}{iso}", _first_word(digest, iso)
 
 
-def _alpine_release(context: Context, machine: str) -> tuple[str, str, str]:
+def _alpine_release(
+    context: Context, machine: str, region: MirrorRegion = MirrorRegion.GLOBAL
+) -> tuple[str, str, str]:
     """The newest Alpine netboot bundle: its name, its URL and its SHA-256.
 
     `latest-releases.yaml` is read as records separated by `-` at the start of
     a line rather than with a YAML parser, because no YAML parser is in the
     standard library and this file's shape is two levels deep.
     """
-    index = ALPINE_RELEASES.format(machine)
+    index = ALPINE_RELEASES.format(base=ALPINE_MIRRORS[region], architecture=machine)
     said = context.run(["curl", "--fail", "--location", index])
     for record in said.split("\n-\n"):
         fields = dict(_yaml_pairs(record))

--- a/tests/unit/test_plan_netboot.py
+++ b/tests/unit/test_plan_netboot.py
@@ -12,7 +12,7 @@ from typing import Final, Sequence
 import pytest
 
 from gentoo_install.errors import DownloadFailed, PreflightFailed
-from gentoo_install.model.config import BootMethod, MemoryLaunch, MemoryMode
+from gentoo_install.model.config import BootMethod, MemoryLaunch, MemoryMode, MirrorRegion
 from gentoo_install.plan import netboot
 from gentoo_install.plan.operations import CommandOutput, Operation, Stage
 
@@ -244,6 +244,66 @@ def test_the_alpine_bundle_is_read_out_of_the_published_index() -> None:
     assert fetched[0][-1].endswith("alpine-netboot-3.24.1-x86_64.tar.gz"), fetched
 
 
+@pytest.mark.parametrize(
+    ("region", "base"),
+    (
+        (MirrorRegion.CN, "https://mirrors.ustc.edu.cn/alpine"),
+        (MirrorRegion.GLOBAL, "https://dl-cdn.alpinelinux.org/alpine"),
+    ),
+)
+def test_lowram_takes_every_alpine_url_from_the_configured_region(
+    region: MirrorRegion, base: str
+) -> None:
+    """`dl-cdn.alpinelinux.org` is where this installer's own operators cannot
+    reach, and the configuration already carries the region every other mirror
+    follows. Three URLs read it: the release index, the archive beside it and
+    the `alpine_repo=` and `modloop=` the entry carries."""
+    assert set(netboot.ALPINE_MIRRORS) == set(MirrorRegion)
+
+    recorder = _answering(
+        MemoryMode.LOWRAM,
+        digest="9a7769ea8fa1737b1b49d82f1bdd53d0a17338d6d3b7cfc6f2c3ec5158596d8b",
+    )
+    operations = netboot.build(
+        launch=_launch(MemoryMode.LOWRAM), target=_target(), region=region
+    )
+    fetch = next(one for one in operations if isinstance(one, netboot.FetchMemoryImage))
+    entry = next(one for one in operations if isinstance(one, netboot.WriteMemoryEntry))
+    assert fetch.region is region
+    assert entry.region is region
+
+    fetch.apply(recorder)
+    entry.apply(recorder)
+
+    requested = _run(recorder, "curl")
+    assert requested[0][-1] == (
+        f"{base}/latest-stable/releases/{MACHINE}/latest-releases.yaml"
+    ), requested
+    downloaded = next(one for one in requested if "--output" in one)
+    assert downloaded[-1] == (
+        f"{base}/latest-stable/releases/{MACHINE}/{ALPINE_ARCHIVE}"
+    ), downloaded
+    written = recorder.files[PurePosixPath(f"{ESP}/loader/entries/{netboot.PLACE}.conf")]
+    assert f"alpine_repo={base}/latest-stable/main" in written, written
+    assert (
+        f"modloop={base}/latest-stable/releases/{MACHINE}/netboot-3.24.1/modloop-lts"
+        in written
+    ), written
+
+
+def test_the_arming_hands_the_plan_the_region_the_operator_chose() -> None:
+    """The plan cannot read a configuration: `cli.py` holds the model and the
+    region reaches `build()` from there, or every machine fetches Alpine from
+    the global mirror whatever its Mirrors screen said."""
+    import inspect
+
+    from gentoo_install import cli
+
+    source = inspect.getsource(cli._arm_memory_environment)
+    called = source.split("netboot.build(")[1].split("\n    )")[0]
+    assert "region=config.portage.mirrors.region" in called, called
+
+
 def test_the_ram_cmdline_adds_dodhcp_and_finds_the_iso_by_its_own_scanner() -> None:
     """The ISO ships `nodhcp`, so a copied line comes up with no network and
     cannot fetch a stage3. GRUB's `loopback` is visible only inside GRUB, so
@@ -331,7 +391,10 @@ def test_the_lowram_cmdline_names_the_repository_alpine_fetches_modloop_from() -
     ).apply(recorder)
 
     entry = recorder.files[PurePosixPath(f"{ESP}/loader/entries/{netboot.PLACE}.conf")]
-    assert f"alpine_repo={netboot.ALPINE_REPOSITORY}" in entry, entry
+    assert (
+        f"alpine_repo={netboot.ALPINE_REPOSITORY.format(base=netboot.ALPINE_MIRRORS[MirrorRegion.GLOBAL])}"
+        in entry
+    ), entry
     assert "modloop=" in entry and "ip=dhcp" in entry, entry
     assert f"apkovl=/{netboot.APKOVL}" in entry, entry
 
@@ -903,9 +966,9 @@ def test_the_alpine_index_is_asked_for_this_machine() -> None:
     the kernel does; `x86_64` and `aarch64` both answer with a netboot flavour
     and a sha256, checked on 2026-08-18."""
     for machine in ("x86_64", "aarch64"):
-        assert netboot.ALPINE_RELEASES.format(machine).endswith(
-            f"releases/{machine}/latest-releases.yaml"
-        ), machine
+        assert netboot.ALPINE_RELEASES.format(
+            base=netboot.ALPINE_MIRRORS[MirrorRegion.GLOBAL], architecture=machine
+        ).endswith(f"releases/{machine}/latest-releases.yaml"), machine
 
 
 def test_the_iso_is_chosen_by_the_name_the_release_publishes() -> None:
@@ -945,10 +1008,11 @@ def test_no_address_carries_an_architecture_of_its_own() -> None:
     """The one place a machine's name is written is the table. A copy inside
     an address is what has to be found and changed the day arm is tested, and
     the one that is missed sends that machine to another machine's image."""
-    assert "{}" in netboot.ALPINE_RELEASES, netboot.ALPINE_RELEASES
+    assert "{architecture}" in netboot.ALPINE_RELEASES, netboot.ALPINE_RELEASES
     for address in (
         netboot.ALPINE_RELEASES,
         netboot.ALPINE_REPOSITORY,
+        netboot.ALPINE_MODLOOP,
         netboot.CJK_RELEASES,
     ):
         for named in ("x86_64", "amd64", "aarch64", "arm64", "i686", "x86"):
@@ -1200,7 +1264,7 @@ def test_the_lowram_archive_is_deleted_after_the_entry_has_read_its_name() -> No
     with `/gentoo-install-ram holds 0 files ending .tar.gz`: the entry composes
     that URL from this file's name."""
     operations = netboot.build(
-        launch=_launch(MemoryMode.LOWRAM), target=_target(), configuration="x"
+        launch=_launch(MemoryMode.LOWRAM), target=_target(), configuration="x = 1\n"
     )
     kinds = [type(one).__name__ for one in operations]
 
@@ -1216,7 +1280,7 @@ def test_the_lowram_archive_is_deleted_after_the_entry_has_read_its_name() -> No
 def test_the_ram_iso_is_never_discarded() -> None:
     """`iso-scan/filename` names it, so the machine reads it at boot."""
     operations = netboot.build(
-        launch=_launch(MemoryMode.RAM), target=_target(), configuration="x"
+        launch=_launch(MemoryMode.RAM), target=_target(), configuration="x = 1\n"
     )
 
     assert "DiscardTheArchive" not in [type(one).__name__ for one in operations]


### PR DESCRIPTION
The release index, the netboot archive, `alpine_repo=` and `modloop=` all named `dl-cdn.alpinelinux.org`, and the Mirrors screen's region reached none of them. They now come from one table keyed by `MirrorRegion`, whose China entry is the host `tests/vm/media.py` already installs Alpine packages from.

The region is handed to `build()` by `cli.py`, which holds the model; the plan parses no configuration of its own.
