### PR TITLE
netboot: keep Alpine's boot services when the apkovl arrives

### DIFF
--- a/gentoo_install/plan/netboot.py
+++ b/gentoo_install/plan/netboot.py
@@ -453,6 +453,10 @@ PAYLOAD: Final[str] = "/gentoo-install"
 #: The archive `initramfs-init` unpacks after it has built Alpine's sysroot.
 APKOVL: Final[str] = "gentoo-install.apkovl.tar.gz"
 
+#: The marker that keeps Alpine's default boot services on a machine that
+#: brings its own apkovl. `initramfs-init` removes it after reading it.
+DEFAULT_SERVICES: Final[str] = "/etc/.default_boot_services"
+
 #: The login profile that sources the first screen in each environment. CJK
 #: root uses bash; Alpine root uses ash and reads `.profile`.
 AUTOSTART: Final[dict[MemoryMode, str]] = {
@@ -535,6 +539,10 @@ class AppendConfiguration(Operation):
                 payload_staging / AUTOSTART[self.launch.mode].lstrip("/"),
                 _source_start(),
             )
+            # `initramfs-init` adds `modloop`, `mdev`, `hwdrivers` and the rest
+            # only when there is no apkovl or this file is in it, so ours came
+            # up with no `/lib/modules` at all (`initramfs-init.in:950`).
+            context.write(payload_staging / DEFAULT_SERVICES.lstrip("/"), "")
             apkovl = staging / APKOVL
             context.run(
                 [

--- a/tests/unit/test_plan_netboot.py
+++ b/tests/unit/test_plan_netboot.py
@@ -704,6 +704,24 @@ def test_the_lowram_payload_is_an_apkovl_at_the_initramfs_root() -> None:
     assert cpio[-1].startswith(f"cd {staging} && find . |"), cpio
 
 
+def test_the_apkovl_keeps_alpines_own_boot_services() -> None:
+    """`initramfs-init` adds `modloop`, `mdev`, `hwdrivers`, `sshd` and the
+    rest only when no apkovl was loaded or this marker is inside the one that
+    was (`initramfs-init.in:950`). Without it the guest came up with no
+    `/lib/modules` at all, and `mount -t efivarfs` answered `No such device`,
+    which the preflight reported as unreadable firmware variables."""
+    recorder = _answering(MemoryMode.LOWRAM)
+    _appended(recorder, mode=MemoryMode.LOWRAM)
+
+    payload = PurePosixPath(f"{ESP}/{netboot.PLACE}/payload/apkovl")
+    marker = payload / netboot.DEFAULT_SERVICES.lstrip("/")
+    assert marker in recorder.files, sorted(recorder.files)
+    assert recorder.files[marker] == ""
+    # Inside the apkovl, not beside it: the initramfs reads it out of the
+    # unpacked sysroot.
+    assert str(marker).startswith(f"{payload}/"), marker
+
+
 def test_the_archive_is_made_from_inside_the_staging_directory() -> None:
     """`find` from anywhere else writes the staging prefix into every path, so
     the payload unpacks to a directory the hook does not look in."""


### PR DESCRIPTION
`initramfs-init.in:950` adds `modloop`, `devfs`, `mdev`, `hwdrivers`, `modules`, `syslog` and `sshd` to the runlevels only when no apkovl was loaded, or when `/etc/.default_boot_services` is inside the one that was. Ours carried no such file, so the `--lowram` guest booted with `modprobe: can't change directory to '/lib/modules'`, `mount -t efivarfs` answered `No such device`, and the preflight refused the install for unreadable firmware variables.

The marker is written into the apkovl; `initramfs-init` removes it after reading it.
