### PR TITLE
probe: scan for a new node where mdev manages the devices

### DIFF
--- a/gentoo_install/exec/probe.py
+++ b/gentoo_install/exec/probe.py
@@ -53,6 +53,11 @@ EFI_WIDTH: Final[Path] = EFI_MARKER / "fw_platform_size"
 EFI_VARIABLES: Final[Path] = EFI_MARKER / "efivars"
 
 
+#: udev's own socket. Present exactly while udevd is running, so its absence
+#: is what tells a machine managed by mdev apart from one managed by udev.
+UDEV_CONTROL: Final[Path] = Path("/run/udev/control")
+
+
 #: Where a BIOS GRUB keeps its configuration. Both spellings, because Fedora
 #: and openSUSE use `grub2` and Debian and Arch use `grub`.
 GRUB_DIRECTORIES: Final[tuple[Path, ...]] = (
@@ -644,12 +649,18 @@ class Probe:
 
         `partprobe` returns before udev has finished creating the nodes, so the
         first operation that wants a new partition would otherwise find nothing.
+        Where mdev is the device manager instead, `udevadm settle` answers at
+        once with no daemon behind it and the node is created by a scan: the
+        `--lowram` environment had `vdc1` and `vdc2` in `/proc/partitions` and
+        neither of them in `/dev`.
         """
         deadline = time.monotonic() + seconds
         while time.monotonic() < deadline:
             if Path(path).exists():
                 return path
             self.runner.run(["udevadm", "settle"], check=False)
+            if not UDEV_CONTROL.exists():
+                self.runner.run(["mdev", "-s"], check=False)
             time.sleep(0.5)
         raise DeviceNotFound(f"{path} did not appear within {seconds:.0f}s")
 

--- a/tests/unit/test_probe.py
+++ b/tests/unit/test_probe.py
@@ -6,6 +6,7 @@ from typing import Sequence
 import json
 import pytest
 
+from gentoo_install.errors import DeviceNotFound
 from gentoo_install.exec import probe
 from gentoo_install.exec.probe import Probe
 from gentoo_install.exec.runner import Result, Runner
@@ -726,3 +727,51 @@ def test_a_machine_with_no_such_variable_answers_unread(
     `disabled`: a refusal built on it would be one nobody can act on."""
     monkeypatch.setattr(probe, "SECURE_BOOT", tmp_path / "absent")
     assert probe.secure_boot() is None
+
+
+class Asking(Runner):
+    """A runner that records what was asked and answers nothing."""
+
+    def __init__(self) -> None:
+        super().__init__(log=lambda line: None)
+        self.asked: list[tuple[str, ...]] = []
+
+    def run(self, argv: Sequence[str], **rest: object) -> Result:
+        self.asked.append(tuple(argv))
+        return Result(argv=tuple(argv), returncode=0, stdout="", stderr="", seconds=0.0)
+
+
+def test_a_node_is_scanned_for_where_mdev_is_the_device_manager(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Alpine's netboot root runs mdev, so `udevadm settle` returns at once
+    with no daemon behind it. The `--lowram` install stopped at `/dev/vdc2 did
+    not appear within 15s` on a machine whose `/proc/partitions` held `vdc1`
+    and `vdc2` and whose `/dev` held neither."""
+    monkeypatch.setattr(probe, "UDEV_CONTROL", tmp_path / "no-udev-here")
+    asking = Asking()
+    reader = Probe(runner=asking, work=tmp_path)
+
+    with pytest.raises(DeviceNotFound):
+        reader.wait_for(str(tmp_path / "vdc2"), seconds=0.6)
+
+    assert ("mdev", "-s") in asking.asked, asking.asked
+    assert ("udevadm", "settle") in asking.asked, asking.asked
+
+
+def test_a_machine_running_udev_is_not_sent_to_mdev(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The other direction: `mdev -s` on a udev machine rebuilds `/dev` from
+    mdev's own rules while udevd is writing it."""
+    control = tmp_path / "udev-control"
+    control.write_text("")
+    monkeypatch.setattr(probe, "UDEV_CONTROL", control)
+    asking = Asking()
+    reader = Probe(runner=asking, work=tmp_path)
+
+    with pytest.raises(DeviceNotFound):
+        reader.wait_for(str(tmp_path / "vdc2"), seconds=0.6)
+
+    assert ("mdev", "-s") not in asking.asked, asking.asked
+    assert ("udevadm", "settle") in asking.asked, asking.asked


### PR DESCRIPTION
The `--lowram` environment runs mdev, so `udevadm settle` returns immediately with no daemon behind it and a node for a partition that did not exist before is never created. The guest's own answer: `/proc/partitions` held `253 33 524288 vdc1` and `253 34 24640495 vdc2` while `ls -l /dev/vd*` held `vda`, `vdb` and `vdc` and nothing else.

The wait now scans with `mdev -s` when `/run/udev/control` is absent, which is the only state in which udevd is not the manager.
