### PR TITLE
probe: read whether a udev daemon runs, not whether one is installed

### DIFF
--- a/gentoo_install/exec/probe.py
+++ b/gentoo_install/exec/probe.py
@@ -53,9 +53,31 @@ EFI_WIDTH: Final[Path] = EFI_MARKER / "fw_platform_size"
 EFI_VARIABLES: Final[Path] = EFI_MARKER / "efivars"
 
 
-#: udev's own socket. Present exactly while udevd is running, so its absence
-#: is what tells a machine managed by mdev apart from one managed by udev.
-UDEV_CONTROL: Final[Path] = Path("/run/udev/control")
+#: What a udev daemon calls itself. `/run/udev/control` was the first test and
+#: it was wrong: the Alpine netboot root has that socket from the `eudev`
+#: package `--install-missing` brings in for `udevadm`, and no daemon behind
+#: it, so the scan below never ran and the install stopped anyway.
+UDEV_NAMES: Final[tuple[str, ...]] = ("udevd", "systemd-udevd")
+
+PROC: Final[Path] = Path("/proc")
+
+
+def _udev_is_running() -> bool:
+    """Whether a udev daemon is on this machine, read from `/proc`."""
+    try:
+        entries = list(PROC.iterdir())
+    except OSError:
+        return True
+    for entry in entries:
+        if not entry.name.isdigit():
+            continue
+        try:
+            name = (entry / "comm").read_text().strip()
+        except OSError:
+            continue
+        if name in UDEV_NAMES:
+            return True
+    return False
 
 
 #: Where a BIOS GRUB keeps its configuration. Both spellings, because Fedora
@@ -659,7 +681,7 @@ class Probe:
             if Path(path).exists():
                 return path
             self.runner.run(["udevadm", "settle"], check=False)
-            if not UDEV_CONTROL.exists():
+            if not _udev_is_running():
                 self.runner.run(["mdev", "-s"], check=False)
             time.sleep(0.5)
         raise DeviceNotFound(f"{path} did not appear within {seconds:.0f}s")

--- a/tests/unit/test_probe.py
+++ b/tests/unit/test_probe.py
@@ -729,6 +729,18 @@ def test_a_machine_with_no_such_variable_answers_unread(
     assert probe.secure_boot() is None
 
 
+def _fake_proc(tmp_path: Path, *names: str) -> Path:
+    """A `/proc` holding one process per name, and one entry that is not one."""
+    proc = tmp_path / "proc"
+    proc.mkdir(exist_ok=True)
+    (proc / "self").mkdir(exist_ok=True)
+    for number, name in enumerate(names, start=100):
+        entry = proc / str(number)
+        entry.mkdir(exist_ok=True)
+        (entry / "comm").write_text(f"{name}\n")
+    return proc
+
+
 class Asking(Runner):
     """A runner that records what was asked and answers nothing."""
 
@@ -748,7 +760,7 @@ def test_a_node_is_scanned_for_where_mdev_is_the_device_manager(
     with no daemon behind it. The `--lowram` install stopped at `/dev/vdc2 did
     not appear within 15s` on a machine whose `/proc/partitions` held `vdc1`
     and `vdc2` and whose `/dev` held neither."""
-    monkeypatch.setattr(probe, "UDEV_CONTROL", tmp_path / "no-udev-here")
+    monkeypatch.setattr(probe, "PROC", _fake_proc(tmp_path, "busybox"))
     asking = Asking()
     reader = Probe(runner=asking, work=tmp_path)
 
@@ -764,9 +776,7 @@ def test_a_machine_running_udev_is_not_sent_to_mdev(
 ) -> None:
     """The other direction: `mdev -s` on a udev machine rebuilds `/dev` from
     mdev's own rules while udevd is writing it."""
-    control = tmp_path / "udev-control"
-    control.write_text("")
-    monkeypatch.setattr(probe, "UDEV_CONTROL", control)
+    monkeypatch.setattr(probe, "PROC", _fake_proc(tmp_path, "udevd"))
     asking = Asking()
     reader = Probe(runner=asking, work=tmp_path)
 


### PR DESCRIPTION
`#603` guarded the scan on `/run/udev/control`, and the next `--lowram` run stopped at exactly the same place with no `mdev -s` in its log: the Alpine netboot root has that socket because `--install-missing` installs `eudev` for `udevadm`, and no daemon has ever run behind it.

The guard now reads `/proc/*/comm` for `udevd` or `systemd-udevd`, which is the process, not the package.
