### PR TITLE
cluster: send a marked command again when a console session took it

### DIFF
--- a/tests/unit/test_cluster.py
+++ b/tests/unit/test_cluster.py
@@ -406,7 +406,9 @@ class _AnsweringLink:
         self.ran.append(command)
         return self.answer
 
-    def run(self, command: str, timeout: float = 0.0) -> None:
+    def run(
+        self, command: str, timeout: float = 0.0, *, repeatable: bool = True
+    ) -> None:
         self.ran.append(command)
 
 
@@ -453,6 +455,7 @@ def test_the_network_is_measured_once_more_after_the_install(
 ) -> None:
     """The post-install probe has to precede collection of the guest results."""
     events: list[str] = []
+    repeatability: dict[str, bool] = {}
 
     class Guest:
         vmid = 9301
@@ -469,8 +472,11 @@ def test_the_network_is_measured_once_more_after_the_install(
     class Link:
         console = object()
 
-        def run(self, command: str, timeout: float = 0.0) -> None:
+        def run(
+            self, command: str, timeout: float = 0.0, *, repeatable: bool = True
+        ) -> None:
             events.append(command)
+            repeatability[command] = repeatable
 
         def wait_for(
             self, command: str, timeout: float, idle: float, watch: cluster.Watchdog
@@ -483,7 +489,7 @@ def test_the_network_is_measured_once_more_after_the_install(
 
     guest = Guest()
     log = tmp_path / "network.log"
-    job = cluster.Job("network", FIXTURES / "ext4-bios.toml")
+    job = cluster.Job("network", FIXTURES / "mbr-edit.toml")
     held = cluster.Running(
         guest=cast(Any, guest),
         watch=cluster.Watchdog(log, lambda: 0),
@@ -506,6 +512,8 @@ def test_the_network_is_measured_once_more_after_the_install(
     assert outcome.verdict is cluster.Verdict.FAIL
     assert len(probes) == 2
     assert probes[0] < installed < probes[1] < events.index("collect")
+    partition = next(one for one in events if one.startswith("parted --script"))
+    assert not repeatability[partition]
 
 
 def test_the_keeper_puts_the_address_back_and_counts_it() -> None:
@@ -1396,6 +1404,126 @@ def test_a_timed_out_marker_names_the_command_it_was_waiting_on() -> None:
     cluster.Reconnecting(
         lambda: cast(Any, Answering(ConsoleTimeout("unused"))), tries=1
     ).run("true")
+
+
+
+class _MarkerConsole:
+    def __init__(self, tail: bytes, completes: bool) -> None:
+        self.tail = tail
+        self.completes = completes
+        self.sent: list[str] = []
+        self.echoed = bytearray()
+        self.patterns: list[str] = []
+
+    def send(self, line: str) -> None:
+        self.sent.append(line)
+        self.echoed.extend(line.encode() + b"\r\n")
+
+    def send_raw(self, keys: str) -> None:
+        self.echoed.extend(keys.encode())
+
+    def snapshot(self, seconds: float) -> bytes:
+        return bytes(self.echoed)
+
+    @property
+    def closed(self) -> bool:
+        return False
+
+    def expect(self, pattern: str, timeout: float, idle: float = 0.0) -> bytes:
+        self.patterns.append(pattern)
+        if self.completes:
+            matched = re.search(r"MARK_(\d+)_DONE", pattern)
+            assert matched is not None
+            self.echoed.extend(f"MARK_{matched.group(1)}_DONE\n".encode())
+            return bytes(self.echoed)
+        raise ConsoleTimeout(
+            f"never matched {pattern!r}; last output was {bytes(self.echoed) + self.tail!r}"
+        )
+
+    def close(self) -> None:
+        return None
+
+
+def _marked_token(line: str) -> str:
+    matched = re.search(r"MARK_%s_BEGIN\\n' (\d+)", line)
+    assert matched is not None
+    return matched.group(1)
+
+
+def test_a_lost_marker_is_resent_with_a_fresh_token(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    clock = [0.0]
+    monkeypatch.setattr(time, "monotonic", lambda: clock[0])
+
+    class ExpiringMarkerConsole(_MarkerConsole):
+        def expect(self, pattern: str, timeout: float, idle: float = 0.0) -> bytes:
+            if self.tail:
+                clock[0] = 2.0
+            return super().expect(pattern, timeout, idle)
+
+    opened: list[_MarkerConsole] = []
+
+    def open_console() -> _MarkerConsole:
+        console = ExpiringMarkerConsole(
+            cluster._SERIAL_TERMINAL_STARTED.encode() if not opened else b"",
+            completes=bool(opened),
+        )
+        opened.append(console)
+        return console
+
+    failure: ConsoleTimeout | None = None
+    try:
+        cluster.Reconnecting(open_console, tries=2).run("true", timeout=1.0)
+    except ConsoleTimeout as error:
+        failure = error
+
+    assert failure is None, failure
+    assert [_marked_token(one.sent[-1]) for one in opened] == ["1", "2"]
+    assert opened[0].echoed.startswith(opened[0].sent[0].encode())
+    assert opened[1].sent[0] == ""
+    assert opened[1].echoed.endswith(b"MARK_2_DONE\n")
+
+
+def test_a_lost_marker_retry_is_bounded_and_keeps_the_console_tail() -> None:
+    opened: list[_MarkerConsole] = []
+
+    def open_console() -> _MarkerConsole:
+        console = _MarkerConsole(cluster._SERIAL_TERMINAL_STARTED.encode(), completes=False)
+        opened.append(console)
+        return console
+
+    failure: ConsoleTimeout | None = None
+    try:
+        cluster.Reconnecting(open_console, tries=3).run("true")
+    except ConsoleTimeout as error:
+        failure = error
+
+    assert failure is not None
+    assert len(opened) == 3, opened
+    assert cluster._SERIAL_TERMINAL_STARTED in str(failure)
+    assert [_marked_token(one.sent[-1]) for one in opened] == ["1", "2", "3"]
+
+
+def test_a_nonrepeatable_marker_loss_is_not_resent() -> None:
+    opened: list[_MarkerConsole] = []
+
+    def open_console() -> _MarkerConsole:
+        console = _MarkerConsole(cluster._SERIAL_TERMINAL_STARTED.encode(), completes=False)
+        opened.append(console)
+        return console
+
+    failure: ConsoleTimeout | None = None
+    try:
+        cluster.Reconnecting(open_console, tries=3).run(
+            "parted --script /dev/vda mklabel gpt", repeatable=False
+        )
+    except ConsoleTimeout as error:
+        failure = error
+
+    assert failure is not None
+    assert len(opened) == 1, opened
+    assert len(opened[0].sent) == 1
 
 
 def test_a_capacity_read_that_did_not_answer_does_not_end_the_schedule() -> None:

--- a/tests/unit/test_harness.py
+++ b/tests/unit/test_harness.py
@@ -2501,7 +2501,9 @@ def test_nothing_is_carried_when_it_was_not_asked_for() -> None:
     sent: list[str] = []
 
     class Link:
-        def run(self, command: str, timeout: float = 120.0) -> None:
+        def run(
+            self, command: str, timeout: float = 120.0, *, repeatable: bool = True
+        ) -> None:
             sent.append(command)
 
         def expect_output(self, command: str, timeout: float = 180.0) -> bytes:

--- a/tests/vm/cluster.py
+++ b/tests/vm/cluster.py
@@ -1058,7 +1058,7 @@ def wait_for_network(
             link.run(use_our_resolvers(), timeout=120.0)
             if vmid:
                 for command in keep_the_address(address or static_address(vmid)):
-                    link.run(command, timeout=120.0)
+                    link.run(command, timeout=120.0, repeatable=False)
             _note_the_probe(link, "network-up")
             return
         # Every pass, not once: the fallback asks a DHCP server that answers
@@ -1669,7 +1669,9 @@ def install_one(
         if seeded:
             selector = _first_selector(load(job.installed_config or job.fixture))
             link.run(
-                f"parted --script {selector} {' '.join(seeded)}", timeout=180.0
+                f"parted --script {selector} {' '.join(seeded)}",
+                timeout=180.0,
+                repeatable=False,
             )
         _note_the_probe(link, "pre-install")
         phase = Phase.INSTALL
@@ -2133,6 +2135,15 @@ RECONNECT_TRIES: Final[int] = 4
 #: `root@livecd ~ # ` on a guest that had rebooted into `xfsbox`.
 _ANY_ROOT_PROMPT: Final[str] = r"root@[A-Za-z0-9._-]+ ~ # "
 
+#: What Proxmox prints when a console session starts. Seen in the middle of a
+#: marked command in run78, whose `MARK_25_DONE` never arrived.
+_SERIAL_TERMINAL_STARTED: Final[str] = "starting serial terminal on interface serial0"
+
+
+def _marker_lost(error: ConsoleTimeout) -> bool:
+    """Whether a console session started under the command that timed out."""
+    return _SERIAL_TERMINAL_STARTED in str(error)
+
 
 _Result = TypeVar("_Result")
 
@@ -2200,9 +2211,8 @@ class Reconnecting:
     running in what the log had already captured. The guest is fine; only the
     connection to it is gone.
 
-    `run` re-sends its command after a reconnect, because the shell never
-    received it. `wait_for` does not: the command is already running in the
-    guest, and sending it again would start a second install.
+    `run` resends repeatable commands; `wait_for` does not, because it could
+    start a second install.
     """
 
     def __init__(self, open_console: Callable[[], Line], tries: int = RECONNECT_TRIES) -> None:
@@ -2265,14 +2275,26 @@ class Reconnecting:
             solicit_on_reconnect=solicit,
         )
 
-    def run(self, command: str, timeout: float = 120.0) -> None:
+    def run(self, command: str, timeout: float = 120.0, *, repeatable: bool = True) -> None:
+        """Send a marked command and wait for its marker.
+
+        `repeatable` is false for a command that must not run twice: `parted`
+        would write a second partition beside the first, and re-sending it
+        after a console session started under it is worse than ending the run.
+        """
+
         def run_once(deadline: float) -> None:
             token = next(self._marks)
             self.console.send(marked_command(command, token))
             with _naming(command):
                 self.console.expect(command_done(token), _remaining(deadline))
 
-        self._with_reconnect(timeout, run_once)
+        self._with_reconnect(
+            timeout,
+            run_once,
+            retry_closed=repeatable,
+            retry_timeout=_marker_lost if repeatable else None,
+        )
 
     def wait_for(
         self,
@@ -2343,13 +2365,17 @@ class Reconnecting:
                 said = self.console.expect(command_done(token), _remaining(deadline))
             return said.split(command_done(token).encode())[0]
 
-        return self._with_reconnect(timeout, collect_once)
+        return self._with_reconnect(
+            timeout, collect_once, retry_timeout=_marker_lost
+        )
 
     def _with_reconnect(
         self,
         timeout: float,
         operation: Callable[[float], _Result],
         *,
+        retry_closed: bool = True,
+        retry_timeout: Callable[[ConsoleTimeout], bool] | None = None,
         solicit_on_reconnect: bool = True,
         watch: Watchdog | None = None,
     ) -> _Result:
@@ -2368,6 +2394,8 @@ class Reconnecting:
             try:
                 return operation(deadline)
             except ConsoleClosed:
+                if not retry_closed:
+                    raise
                 attempt += 1
                 if attempt >= self._tries or _remaining(deadline) <= 0.0:
                     # `moved()` is asked once, and only here: it takes a sample
@@ -2382,6 +2410,14 @@ class Reconnecting:
                         f"{RECONNECT_GRANT / 60:.0f}m more",
                         flush=True,
                     )
+                self.reopen(solicit_prompt=solicit_on_reconnect)
+            except ConsoleTimeout as error:
+                if retry_timeout is None or not retry_timeout(error):
+                    raise
+                attempt += 1
+                if attempt >= self._tries:
+                    raise
+                deadline = time.monotonic() + timeout
                 self.reopen(solicit_prompt=solicit_on_reconnect)
 
     def send(self, line: str) -> None:


### PR DESCRIPTION
`vm-sdboot` was ERRORed in run78 at 69.4 minutes after an install that had completed and a machine that had booted: the results copy printed `MARK_25_BEGIN`, Proxmox printed `starting serial terminal on interface serial0` in the middle of it, and the matching `MARK_25_DONE` never arrived. `_with_reconnect` retried only on `ConsoleClosed`, so the timeout ended the run.

A marked command whose timeout carries that banner is now sent again with a fresh token, bounded by the same try count. Two commands are excluded by name: `parted --script` would write a second partition beside the first, and the address commands answer `File exists`.
