### PR TITLE
cluster: read the guest's CPU beside its byte counters

### DIFF
--- a/tests/unit/test_cluster.py
+++ b/tests/unit/test_cluster.py
@@ -207,7 +207,7 @@ def test_non_double_memory_reservation_is_admitted_in_exact_bytes(
 
     execution = cluster.Running(
         Guest(),
-        cluster.Watchdog(tmp_path / "odd-sized.log", lambda: 0),
+        cluster.Watchdog(tmp_path / "odd-sized.log", lambda: (0, 0.0)),
         job.reservation_bytes,
     )
     dispatched = job.dispatch(
@@ -254,7 +254,7 @@ def _timed_wait(
     monkeypatch: pytest.MonkeyPatch,
     tmp_path: Path,
     clock: list[float],
-    counters: Callable[[], int | None],
+    counters: Callable[[], tuple[int, float] | None],
     output_at: float | None = None,
 ) -> tuple[cluster.Reconnecting, cluster.Watchdog]:
     monkeypatch.setattr(time, "monotonic", lambda: clock[0])
@@ -270,9 +270,9 @@ def test_install_wait_continues_when_silent_guest_moves_bytes(
     clock = [0.0]
     traffic = [0]
 
-    def counters() -> int:
+    def counters() -> tuple[int, float]:
         traffic[0] += cluster.QUIET_BYTES * 2
-        return traffic[0]
+        return traffic[0], 0.0
 
     link, watch = _timed_wait(monkeypatch, tmp_path, clock, counters, output_at=3.0)
     link.wait_for("install", timeout=5.0, idle=2.0, watch=watch)
@@ -285,7 +285,7 @@ def test_install_wait_names_silent_console_and_flat_counters(
     monkeypatch: pytest.MonkeyPatch, tmp_path: Path
 ) -> None:
     clock = [0.0]
-    link, watch = _timed_wait(monkeypatch, tmp_path, clock, lambda: 0)
+    link, watch = _timed_wait(monkeypatch, tmp_path, clock, lambda: (0, 0.0))
     watch.log.write_bytes(b"output before the idle window\n")
 
     with pytest.raises(ConsoleTimeout) as raised:
@@ -304,9 +304,9 @@ def test_run_ceiling_ends_silent_guest_that_keeps_moving_bytes(
     clock = [0.0]
     readings = [0]
 
-    def counters() -> int:
+    def counters() -> tuple[int, float]:
         readings[0] += 1
-        return readings[0] * cluster.QUIET_BYTES * 2
+        return readings[0] * cluster.QUIET_BYTES * 2, 0.0
 
     link, watch = _timed_wait(monkeypatch, tmp_path, clock, counters)
     with pytest.raises(ConsoleTimeout, match="never matched"):
@@ -492,7 +492,7 @@ def test_the_network_is_measured_once_more_after_the_install(
     job = cluster.Job("network", FIXTURES / "mbr-edit.toml")
     held = cluster.Running(
         guest=cast(Any, guest),
-        watch=cluster.Watchdog(log, lambda: 0),
+        watch=cluster.Watchdog(log, lambda: (0, 0.0)),
         reservation_bytes=0,
         created=True,
     )
@@ -769,7 +769,8 @@ def _held(log: Path, moved: bool, stuck: bool, busy: bool = False) -> object:
     is working while its console has gone."""
     counters = iter(range(0, 10**9, cluster.QUIET_BYTES * 2))
     watch = cluster.Watchdog(
-        log=log, counters=(lambda: next(counters)) if busy else (lambda: 0)
+        log=log,
+        counters=(lambda: (next(counters), 0.0)) if busy else (lambda: (0, 0.0)),
     )
     # One pass so the watchdog has seen the log: the first call always reports
     # growth, from nothing to whatever is there.
@@ -1580,10 +1581,10 @@ def test_a_dropped_console_does_not_end_a_guest_that_is_still_working(
     opened: list[Console] = []
     sampled: list[int] = []
 
-    def counters() -> int | None:
+    def counters() -> tuple[int, float] | None:
         # A guest whose disk keeps growing while its console says nothing.
         sampled.append(len(sampled))
-        return cluster.QUIET_BYTES * 2 * (len(sampled) + 1)
+        return cluster.QUIET_BYTES * 2 * (len(sampled) + 1), 0.0
 
     log = tmp_path / "serial.log"
     log.write_bytes(b"")
@@ -1629,7 +1630,7 @@ def test_a_dropped_console_still_ends_a_guest_that_moves_nothing(tmp_path: Path)
         opened.append(Console())
         return opened[-1]
 
-    still = cluster.Watchdog(log=log, counters=lambda: 0)
+    still = cluster.Watchdog(log=log, counters=lambda: (0, 0.0))
     link = cluster.Reconnecting(open_console, tries=2)
     with pytest.raises(ConsoleClosed):
         link.wait_for("emerge --ask=n @world", timeout=0.0, idle=1.0, watch=still)

--- a/tests/unit/test_harness.py
+++ b/tests/unit/test_harness.py
@@ -820,7 +820,7 @@ def test_a_guest_that_could_not_be_removed_keeps_its_slot(
         job = cluster.Job(name, Path(f"tests/fixtures/{name}.toml"))
         execution = cluster.Running(
             Guest(),
-            cluster.Watchdog(Path(f"/nonexistent/{name}.log"), lambda: 0),
+            cluster.Watchdog(Path(f"/nonexistent/{name}.log"), lambda: (0, 0.0)),
             job.reservation_bytes,
         )
         return job.dispatch(
@@ -990,7 +990,9 @@ def test_unknown_telemetry_does_not_make_a_quiet_guest_stuck(tmp_path: Path) -> 
 
     log = tmp_path / "quiet.log"
     log.write_bytes(b"")
-    answers: list[int | None] = [None] * WATCH_STRIKES + [10] * (WATCH_STRIKES + 1)
+    answers: list[tuple[int, float] | None] = [None] * WATCH_STRIKES + [
+        (10, 0.0)
+    ] * (WATCH_STRIKES + 1)
     watch = Watchdog(log, lambda: answers.pop(0))
     unknown = [watch.moved() for _ in range(WATCH_STRIKES)]
     assert unknown == [True] * WATCH_STRIKES
@@ -2015,7 +2017,7 @@ def test_an_idle_verdict_names_the_counters_before_the_console_tail() -> None:
         "was " + "b'0.1/src/shared/data-fd-util.c [294/2044] compiling'" * 6
     )
     link = cluster.Reconnecting(lambda: _PatternConsole(idle, sent))
-    watch = cluster.Watchdog(log=Path("/nonexistent"), counters=lambda: 0)
+    watch = cluster.Watchdog(log=Path("/nonexistent"), counters=lambda: (0, 0.0))
 
     with pytest.raises(ConsoleTimeout) as raised:
         link.wait_for("sh install.sh", timeout=10.0, idle=1200.0, watch=watch)

--- a/tests/unit/test_proxmox.py
+++ b/tests/unit/test_proxmox.py
@@ -667,7 +667,7 @@ def test_the_watchdog_counts_quiet_looks_not_elapsed_time(tmp_path: Path) -> Non
 
     log = tmp_path / "run.log"
     log.write_bytes(b"booting\n")
-    watch = Watchdog(log=log, counters=lambda: 0)
+    watch = Watchdog(log=log, counters=lambda: (0, 0.0))
     # Read into locals: mypy narrows a property and never widens it again,
     # because it cannot see `moved()` changing what `stuck` answers.
     first = (watch.moved(), watch.stuck)
@@ -694,13 +694,33 @@ def test_a_silent_guest_that_is_still_downloading_is_left_alone(tmp_path: Path) 
     log.write_bytes(b"downloading\n")
     moving = [0]
 
-    def counters() -> int:
+    def counters() -> tuple[int, float]:
         moving[0] += QUIET_BYTES * 2
-        return moving[0]
+        return moving[0], 0.0
 
     watch = Watchdog(log=log, counters=counters)
     looks = [watch.moved() for _ in range(WATCH_STRIKES + 2)]
     assert looks == [True] * (WATCH_STRIKES + 2)
+    assert not watch.stuck
+
+
+def test_a_guest_compiling_in_memory_is_not_read_as_stuck(tmp_path: Path) -> None:
+    """`vm-binhost-fallback` was ended at 48.8 minutes with
+
+        the console was silent for 1200s and counters were flat
+        (16883546473 -> 16883554254 bytes)
+
+    while it was building grub. A build whose directory is in RAM writes no
+    disk and answers no network, so the bytes are the wrong question on their
+    own; the guest's share of a core answers it."""
+    from tests.vm.cluster import BUSY_CPU, WATCH_STRIKES, Watchdog
+
+    log = tmp_path / "compiling.log"
+    log.write_bytes(b"")
+    watch = Watchdog(log=log, counters=lambda: (5_000_000, BUSY_CPU))
+    looks = [watch.moved() for _ in range(WATCH_STRIKES + 2)]
+
+    assert looks == [True] * (WATCH_STRIKES + 2), looks
     assert not watch.stuck
 
 
@@ -710,7 +730,7 @@ def test_a_guest_moving_nothing_at_all_is_stuck(tmp_path: Path) -> None:
 
     log = tmp_path / "dead.log"
     log.write_bytes(b"")
-    watch = Watchdog(log=log, counters=lambda: 5_000_000)
+    watch = Watchdog(log=log, counters=lambda: (5_000_000, 0.0))
     quiet = [watch.moved() for _ in range(WATCH_STRIKES + 1)]
     assert quiet[1:] == [False] * WATCH_STRIKES
     assert watch.stuck
@@ -732,7 +752,7 @@ def test_a_stuck_guest_is_stopped_and_not_deleted_by_the_sweep(tmp_path: Path) -
 
     log = tmp_path / "quiet.log"
     log.write_bytes(b"")
-    watch = Watchdog(log=log, counters=lambda: 0, strikes=WATCH_STRIKES - 1)
+    watch = Watchdog(log=log, counters=lambda: (0, 0.0), strikes=WATCH_STRIKES - 1)
     inflight = {
         "vm-zfs": Running(
             guest=Quiet(),
@@ -2225,7 +2245,7 @@ def test_a_reserved_guest_is_not_created_twice_and_is_still_cleaned_up(
     job = Job(name="reserved", fixture=tmp_path / "reserved.toml", iso="minimal.iso")
     execution = Running(
         guest,
-        Watchdog(log=log, counters=lambda: 0),
+        Watchdog(log=log, counters=lambda: (0, 0.0)),
         job.reservation_bytes,
         created=True,
     )

--- a/tests/vm/cluster.py
+++ b/tests/vm/cluster.py
@@ -428,6 +428,11 @@ class Job:
 #: slowest this network has served one is 40 KiB/s, which is 24 MiB.
 QUIET_BYTES: Final[int] = 1024 * 1024
 
+#: The share of a core a working guest holds. A hung one reads 0.00 and a
+#: guest at a prompt is near it; `vm-binhost-fallback` was compiling grub at
+#: this and above while its counters moved 7781 bytes in twenty minutes.
+BUSY_CPU: Final[float] = 0.10
+
 
 #: What a guest still moving bytes buys back after its console dropped. The
 #: transport outage is not the guest's silence: `vm-gnome` was compiling git
@@ -448,12 +453,13 @@ class Watchdog:
     """
 
     log: Path
-    counters: Callable[[], int | None]
+    counters: Callable[[], tuple[int, float] | None]
     strikes: int = 0
     _seen: int = field(default=0, init=False)
     _moved: int = field(default=0, init=False)
     _counter_before: int = field(default=0, init=False)
     _counter_after: int = field(default=0, init=False)
+    _cpu: float = field(default=0.0, init=False)
     #: Consecutive samples the hypervisor would not answer.
     _blind: int = field(default=0, init=False)
     #: Whether the last sample saw nothing new in the log.
@@ -492,10 +498,14 @@ class Watchdog:
             self._blind += 1
             return self._blind < BLIND_SAMPLES
         self._blind = 0
+        moved, self._cpu = traffic
         self._counter_before = self._moved
-        self._counter_after = traffic
-        working = traffic - self._moved >= QUIET_BYTES
-        self._moved = max(self._moved, traffic)
+        self._counter_after = moved
+        # Either signal is enough. A compile whose build directory is in RAM
+        # writes nothing and answers no network, and `vm-binhost-fallback` was
+        # ended for that at 48.8 minutes with grub half built.
+        working = moved - self._moved >= QUIET_BYTES or self._cpu >= BUSY_CPU
+        self._moved = max(self._moved, moved)
         if talking or working:
             self.strikes = 0
             return True
@@ -514,7 +524,8 @@ class Watchdog:
                 )
             return (
                 "counters were flat "
-                f"({self._counter_before} -> {self._counter_after} bytes)"
+                f"({self._counter_before} -> {self._counter_after} bytes, "
+                f"cpu {self._cpu:.2f})"
             )
 
     @property

--- a/tests/vm/proxmox.py
+++ b/tests/vm/proxmox.py
@@ -583,8 +583,8 @@ class Guest:
         assert last is not None
         raise last
 
-    def transferred(self) -> int | None:
-        """Bytes this guest has received and written since it started.
+    def transferred(self) -> tuple[int, float] | None:
+        """Bytes this guest has received and written, and its CPU share.
 
         What the watchdog reads when the console is silent: an install
         downloading a stage3 prints nothing for minutes, and ending it for
@@ -596,7 +596,12 @@ class Guest:
             # One unanswered request is not evidence about the guest, and a
             # watchdog that raises here stops the whole schedule.
             return None
-        return int(status.get("netin", 0)) + int(status.get("diskwrite", 0))
+        moved = int(status.get("netin", 0)) + int(status.get("diskwrite", 0))
+        # The share of a core the guest is using, from the same reading. A
+        # compile whose build directory is in RAM moves no bytes at all:
+        # `vm-binhost-fallback` was ended for 7781 bytes in twenty minutes
+        # while it was building grub.
+        return moved, float(status.get("cpu", 0.0))
 
     def running(self) -> bool:
         status = self.api.call("GET", f"/nodes/{self.node}/qemu/{self.vmid}/status/current")


### PR DESCRIPTION
The watchdog read `netin + diskwrite` and the console, and both are silent for a guest compiling with its build directory in RAM. `vm-binhost-fallback` was ERRORed at 48.8 minutes with `counters were flat (16883546473 -> 16883554254 bytes)` and grub half built.

The same status reading already carries `cpu`, so the guest's share of a core is read beside the bytes and either one keeps it alive.
