### PR TITLE
cluster: let a working guest spend every grant it is given

### DIFF
--- a/tests/unit/test_cluster.py
+++ b/tests/unit/test_cluster.py
@@ -1604,6 +1604,10 @@ def test_a_dropped_console_does_not_end_a_guest_that_is_still_working(
     # It reconnected, and it stopped: a run that never gives up holds a node
     # for the rest of the schedule.
     assert 1 < len(opened) <= cluster.REOPEN_CEILING, len(opened)
+    # The reopen ceiling is what a grant spends, so a ceiling below the grants
+    # ends a working guest before its last one: `vm-gnome` spent all four of
+    # its grants compiling and was ERRORed at 156.5 minutes.
+    assert cluster.REOPEN_CEILING >= cluster.RECONNECT_GRANTS * 2
 
 
 def test_a_dropped_console_still_ends_a_guest_that_moves_nothing(tmp_path: Path) -> None:

--- a/tests/vm/cluster.py
+++ b/tests/vm/cluster.py
@@ -439,7 +439,10 @@ BUSY_CPU: Final[float] = 0.10
 #: when one `Connection reset by peer` ended 167 minutes of work.
 RECONNECT_GRANT: Final[float] = 900.0
 #: At most this many, so a console that never comes back still ends the run.
-RECONNECT_GRANTS: Final[int] = 4
+#: Sixteen rather than four: every grant is given only to a guest whose own
+#: counters or CPU say it is working, and `vm-gnome` spent all four of them
+#: still compiling and was ERRORed at 156.5 minutes with the console mid-line.
+RECONNECT_GRANTS: Final[int] = 16
 
 
 @dataclass
@@ -2181,8 +2184,11 @@ KNOWN_BAD_NODES: Final[frozenset[str]] = frozenset()
 #: How many times one guest's console may be reopened before the node itself
 #: is called the problem. A healthy run reconnects a handful of times over an
 #: hour; a node whose proxy is refusing grants and closes a session every time,
-#: which raises nothing and burns the whole run ceiling.
-REOPEN_CEILING: Final[int] = 24
+#: which raises nothing and burns the whole run ceiling. Derived from the
+#: grants, because a ceiling below what the grants can spend ends a working
+#: guest before its last grant: `vm-gnome` was ERRORed mid-compile at 156.5
+#: minutes.
+REOPEN_CEILING: Final[int] = RECONNECT_GRANTS * RECONNECT_TRIES
 
 
 #: How much of a command a verdict carries. `vm-zram` ended a round with a


### PR DESCRIPTION
`vm-gnome` was ERRORed in run78 at 156.5 minutes with `never matched 'MARK_23_DONE|root@…'` and its console mid-line inside a cmake build: the guest was working the whole time, and every one of its four grants had been approved by the watchdog.

The grants go to sixteen, and the reopen ceiling is derived from them rather than fixed at 24, because a ceiling below what the grants can spend ends the guest before its last grant. Nothing loosens the condition itself: each grant still needs the guest's own counters or CPU to say it is working.
