### PR TITLE
ram: close a run with what that run measured

### DIFF
--- a/tests/unit/test_harness.py
+++ b/tests/unit/test_harness.py
@@ -3877,3 +3877,18 @@ def test_the_mirror_check_cannot_match_its_own_command() -> None:
         command.group(0)
     )
     assert 'rb"MIRROR_BYTES=[1-9][0-9]*"' in source, "and the check wants a count"
+
+
+def test_a_run_of_one_half_does_not_claim_the_other() -> None:
+    """`--part install` ended with `proved a broken one-shot returns twice`
+    and nothing in that run had armed a broken entry. A closing line is a
+    claim, and a claim about a guest that was never started is the shape of
+    failure this suite exists to catch."""
+    from tests.vm import ram
+
+    assert set(ram.RAN) == {"install", "fallback", "both"}
+    assert "one-shot" not in ram.RAN["install"], ram.RAN["install"]
+    assert "installed Gentoo" not in ram.RAN["fallback"], ram.RAN["fallback"]
+    # And the whole run still says both, because it did both.
+    assert "installed Gentoo" in ram.RAN["both"]
+    assert "one-shot" in ram.RAN["both"]

--- a/tests/vm/ram.py
+++ b/tests/vm/ram.py
@@ -418,6 +418,22 @@ def run_fallback(
             root.unlink(missing_ok=True)
 
 
+#: What the closing line says, per half. A run of one half claimed both: a
+#: `--part install` run ended with `proved a broken one-shot returns twice`
+#: and nothing had armed a broken one.
+RAN: Final[dict[str, str]] = {
+    "install": "memory mode installed Gentoo from the environment it delivered",
+    "fallback": "memory mode proved a broken one-shot returns to its own system twice",
+    "both": (
+        "memory mode installed Gentoo and proved a broken one-shot returns twice"
+    ),
+}
+
+
+def _what_ran(part: str) -> str:
+    return RAN[part]
+
+
 def main(argv: list[str] | None = None) -> int:
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("--image", choices=sorted(IMAGES), default="debian")
@@ -476,10 +492,7 @@ def main(argv: list[str] | None = None) -> int:
     ) as error:
         print(f"FAIL {error}", file=sys.stderr, flush=True)
         return 1
-    print(
-        "memory mode installed Gentoo and proved a broken one-shot returns twice",
-        flush=True,
-    )
+    print(_what_ran(arguments.part), flush=True)
     return 0
 
 


### PR DESCRIPTION
The `--ram` install run that finished tonight ended with `memory mode installed Gentoo and proved a broken one-shot returns twice`, and it had run only the install half: nothing in that run had armed a broken entry. The closing line now comes from a table keyed by the half that ran.
