### PR TITLE
packages: the proprietary chat groups accept their own licences

### DIFF
--- a/gentoo_install/data/packages/dingtalk.toml
+++ b/gentoo_install/data/packages/dingtalk.toml
@@ -1,2 +1,4 @@
 packages = ["net-im/dingtalk"]
 repositories = ["gentoo-zh"]
+# `LICENSE="all-rights-reserved"`.
+accept_license = ["all-rights-reserved"]

--- a/gentoo_install/data/packages/tencent-qq.toml
+++ b/gentoo_install/data/packages/tencent-qq.toml
@@ -1,2 +1,4 @@
 packages = ["net-im/tencent-qq"]
 repositories = ["gentoo-zh"]
+# `LICENSE="Tencent-QQ"`.
+accept_license = ["Tencent-QQ"]

--- a/gentoo_install/data/packages/wechat.toml
+++ b/gentoo_install/data/packages/wechat.toml
@@ -2,3 +2,6 @@
 # `wechat` package needs a system the sandbox already provides.
 packages = ["net-im/wechat-universal-bwrap"]
 repositories = ["gentoo-zh"]
+# `LICENSE="all-rights-reserved GPL-2"` in the ebuild, so the default @FREE
+# hides it and the install stops at the group check with the package masked.
+accept_license = ["all-rights-reserved"]

--- a/gentoo_install/data/packages/wemeet.toml
+++ b/gentoo_install/data/packages/wemeet.toml
@@ -1,2 +1,4 @@
 packages = ["net-im/wemeet"]
 repositories = ["gentoo-zh"]
+# `LICENSE="wemeet_license"`, which is in no licence group at all.
+accept_license = ["wemeet_license"]

--- a/tests/unit/test_plan.py
+++ b/tests/unit/test_plan.py
@@ -658,6 +658,31 @@ def test_only_nvidia_widens_accept_license() -> None:
     assert catalog["nvidia"].accept_license == ("@BINARY-REDISTRIBUTABLE",)
 
 
+def test_every_group_whose_package_is_proprietary_accepts_its_licence() -> None:
+    """A real install stopped at
+
+        ConfigError: the `wechat` group asks for
+        `net-im/wechat-universal-bwrap`, which the target's configuration
+        masks; the `wemeet` group asks for `net-im/wemeet`, which the
+        target's configuration masks
+
+    The refusal was right and the catalog was wrong: both are proprietary and
+    neither said so, so `ACCEPT_LICENSE` stayed at the profile's default and
+    `portageq best_visible` answered nothing. Each licence below is the
+    `LICENSE=` line of that package's ebuild in `gentoo-zh`, read on
+    2026-08-19; `flclash` is `GPL-3` and needs nothing."""
+    catalog = load_catalog()
+    wanted = {
+        "wechat": ("all-rights-reserved",),
+        "wemeet": ("wemeet_license",),
+        "dingtalk": ("all-rights-reserved",),
+        "tencent-qq": ("Tencent-QQ",),
+    }
+    for name, licences in wanted.items():
+        assert catalog[name].accept_license == licences, name
+    assert catalog["flclash"].accept_license == ()
+
+
 def test_the_older_amd_group_does_not_suppress_r300() -> None:
     """mesa enables r300 and r600 under the `radeon` umbrella only when
     neither is named explicitly, so `radeon r600` leaves an r300 card on


### PR DESCRIPTION
An install on a real machine stopped at the group check:

    ConfigError: the `wechat` group asks for `net-im/wechat-universal-bwrap`, which the target's configuration masks; the `wemeet` group asks for `net-im/wemeet`, which the target's configuration masks

The refusal was right and the catalog was wrong. `net-im/wechat-universal-bwrap` is `LICENSE="all-rights-reserved GPL-2"`, `net-im/wemeet` is `LICENSE="wemeet_license"`, and neither group said so, so `ACCEPT_LICENSE` stayed at the profile's `@FREE` and `portageq best_visible` answered nothing. `net-im/dingtalk` and `net-im/tencent-qq` have the same gap and are fixed with them; `net-proxy/flclash-bin` is `GPL-3` and needs nothing.

Each licence is the `LICENSE=` line of that package's ebuild in `gentoo-zh`, read today.
