### PR TITLE
installed: read greetd and the input method off the machine

### DIFF
--- a/tests/fixtures/vm-greetd.toml
+++ b/tests/fixtures/vm-greetd.toml
@@ -1,0 +1,94 @@
+# Xfce is lighter than Plasma, so this fixture reaches greetd and IBus coverage
+# sooner without involving GNOME.
+config_version = 1
+
+[system]
+hostname = "greetdbox"
+timezone = "UTC"
+locales = ["en_US.UTF-8"]
+locale = "en_US.UTF-8"
+init = "systemd"
+networking = "networkmanager-wpa"
+sshd = true
+root_password_hash = "$6$gentooinst$IR3GrdJ862XljQYDqocr4tKniIRDIT.jQNFzIrHE3U75H6B6YSWZoSYoVd5edSHpqaYBdiNfXHCoIPRVgb9lT/"
+
+[portage]
+profile = "default/linux/amd64/23.0/desktop/systemd"
+makeopts = "-j4"
+
+[portage.mirrors]
+region = "global"
+
+[portage.binhost]
+official = true
+community = "off"
+
+[kernel]
+source = "dist-bin"
+
+[bootloader]
+kind = "grub"
+firmware = "uefi"
+kernel_params = ["console=ttyS0,115200"]
+
+[disk]
+root = "mnt-root"
+
+[[disk.devices]]
+kind = "existing"
+id = "disk"
+selector = "/dev/disk/by-id/virtio-target0"
+wipe = true
+
+[[disk.devices]]
+kind = "table"
+id = "table"
+disk = "disk"
+table = "gpt"
+
+[[disk.devices]]
+kind = "partition"
+id = "esp"
+table = "table"
+index = 1
+role = "esp"
+size = "512MiB"
+
+[[disk.devices]]
+kind = "partition"
+id = "rootpart"
+table = "table"
+index = 2
+role = "data"
+
+[[disk.devices]]
+kind = "filesystem"
+id = "espfs"
+device = "esp"
+type = "vfat"
+label = "ESP"
+
+[[disk.devices]]
+kind = "filesystem"
+id = "rootfs"
+device = "rootpart"
+type = "ext4"
+label = "gentoo"
+
+[[disk.devices]]
+kind = "mountpoint"
+id = "mnt-root"
+source = "rootfs"
+path = "/"
+
+[[disk.devices]]
+kind = "mountpoint"
+id = "mnt-esp"
+source = "espfs"
+path = "/efi"
+options = ["umask=0077"]
+
+[packages]
+desktop = "xfce"
+display_manager = "greetd"
+applications = ["ibus-pinyin", "pipewire"]

--- a/tests/golden/vm-greetd.txt
+++ b/tests/golden/vm-greetd.txt
@@ -1,0 +1,90 @@
+[partition]
+  release anything a previous run of this configuration left mounted or open
+  wipe existing signatures from disk
+  create a gpt partition table on disk as table
+  create partition 1 on disk as esp: esp, 512MiB
+  create partition 2 on disk as rootpart: data, the rest of the disk
+  reread the partition table of disk and wait for its nodes
+
+[format]
+  make a vfat filesystem on esp as espfs labelled ESP
+  make a ext4 filesystem on rootpart as rootfs labelled gentoo
+
+[mount]
+  mount rootpart at /
+  mount esp at /efi with umask=0077
+
+[stage3]
+  download the newest desktop-systemd stage3 from https://distfiles.gentoo.org directly, verify it against BB572E0E2D182910 and unpack it into the target
+
+[chroot]
+  mount transient proc, sys, dev and run filesystems into the target
+  seed the target's resolv.conf from the install medium
+
+[portage]
+  write /etc/portage/make.conf with MAKEOPTS, USE, INPUT_DEVICES, ACCEPT_LICENSE, L10N, FEATURES; 2 mirrors in the configured order, 5 appended
+  configure Portage, wget, curl, git and gpg for direct connection
+  create the three autounmask files emerge writes its decisions into
+  run getuto so Portage has a keyring to verify binary packages against
+  add verified binary package host gentoo at https://distfiles.gentoo.org/releases/amd64/binpackages/23.0/x86-64
+  fetch the first ebuild repository snapshot with emerge-webrsync
+  select profile default/linux/amd64/23.0/desktop/systemd
+  install git, which every later repository sync needs: emerge dev-vcs/git
+  point repository gentoo at https://github.com/gentoo-mirror/gentoo.git, commit signatures verified
+  sync repository gentoo
+  set sys-kernel/installkernel to dracut
+  accept the linux-firmware licence
+  ask for dev-libs/libdbusmenu gtk3 for the xfce group
+  ask for media-video/pipewire sound-server for the pipewire group
+  resolve net-misc/openssh net-misc/networkmanager net-wireless/wpa_supplicant sys-process/cronie sys-kernel/installkernel sys-kernel/dracut sys-kernel/linux-firmware sys-fs/dosfstools sys-fs/e2fsprogs sys-kernel/gentoo-kernel-bin sys-boot/grub sys-boot/efibootmgr xfce-base/xfce4-meta x11-base/xorg-server gui-libs/greetd gui-apps/tuigreet app-i18n/ibus-libpinyin media-video/pipewire media-video/wireplumber app-i18n/ibus together before installing the requested packages
+
+[system]
+  generate and verify locales en_US.UTF-8
+  set the system locale to en_US.UTF-8
+  set the timezone to UTC
+  set the console keymap to us and its font to default8x16
+  set the hostname to greetdbox
+  give the target its own machine id
+  write /etc/fstab with entries for /, /efi
+  treat the hardware clock as UTC
+  set the root password
+  install sshd: emerge net-misc/openssh
+  ssh password login: off, root: off
+  enable sshd at boot
+  generate the ssh host keys
+  install the network tools: emerge net-misc/networkmanager net-wireless/wpa_supplicant
+  leave the interfaces to NetworkManager (networkmanager-wpa)
+  enable NetworkManager at boot
+  install cron: emerge sys-process/cronie
+  enable cronie at boot
+
+[kernel]
+  install the hook that puts a kernel in /boot: emerge sys-kernel/installkernel
+  install the initramfs builder and firmware: emerge sys-kernel/dracut sys-kernel/linux-firmware
+  install the storage tools: emerge sys-fs/dosfstools sys-fs/e2fsprogs
+  install the kernel: emerge sys-kernel/gentoo-kernel-bin
+  rebuild the initramfs from sys-kernel/gentoo-kernel-bin with the modules written above
+  check the installkernel payload names existing kernel files
+
+[bootloader]
+  install the bootloader: emerge sys-boot/grub sys-boot/efibootmgr
+  write /etc/default/grub with cmdline console=ttyS0,115200, its menu on ttyS0
+  install GRUB for uefi on the esp at /efi
+
+[packages]
+  install the xfce group: emerge xfce-base/xfce4-meta x11-base/xorg-server
+  install the greetd group: emerge gui-libs/greetd gui-apps/tuigreet
+  verify gui-libs/greetd installed /etc/greetd/config.toml
+  verify gui-apps/tuigreet installed /usr/bin/tuigreet with --time, --remember, --remember-session, --sessions, --xsessions
+  verify session directories for xfce-base/xfce4-meta
+  set the greetd default session command in /etc/greetd/config.toml
+  enable greetd at boot
+  install the ibus-pinyin group: emerge app-i18n/ibus-libpinyin
+  install the pipewire group: emerge media-video/pipewire media-video/wireplumber
+  enable pipewire.socket, pipewire-pulse.socket, wireplumber.service for every user
+  install the ibus group: emerge app-i18n/ibus
+  set XMODIFIERS, GTK_IM_MODULE, QT_IM_MODULE in /etc/environment for ibus
+
+[finish]
+  delete the downloaded stage3 from /var/cache/gentoo-install
+  unmount everything under the target

--- a/tests/unit/test_harness.py
+++ b/tests/unit/test_harness.py
@@ -152,6 +152,7 @@ NOT_IN_THE_CAMPAIGN: Final[frozenset[str]] = frozenset(
         # cannot answer, and the cluster has no way to arrange one. The rule
         # itself is held in `test_exec.py`, through the runner and the journal.
         "vm-binhost-fallback.toml",
+        "vm-greetd.toml",
         # The dd runner generates its sources, streams each one from the driver
         # CD, and reads the target back; neither target can boot as a system.
         "vm-dd-raw.toml",
@@ -443,8 +444,8 @@ def test_the_installed_checks_read_the_files_the_plan_writes() -> None:
 
     installation = load(Path("tests/fixtures/vm-desktop.toml"))
     asked = next(one.command for one in checks(installation) if one.name == "inputmethod")
-    missing = [str(one) for one in ENVIRONMENT_FILE.values() if str(one) not in asked]
-    assert not missing, (missing, asked)
+    expected = str(ENVIRONMENT_FILE[installation.system.init])
+    assert expected in asked
     # And nothing the plan stopped writing: a path left behind reads as
     # coverage while the check answers with nothing.
     named = {
@@ -452,7 +453,134 @@ def test_the_installed_checks_read_the_files_the_plan_writes() -> None:
         for word in asked.replace(";", " ").split()
         if word.startswith("/etc/") and "fcitx5" not in word
     }
-    assert named == {str(one) for one in ENVIRONMENT_FILE.values()}, named
+    assert named == {expected}, named
+
+
+def test_every_input_framework_has_a_binary_to_ask_for() -> None:
+    """The check asks `command -v <binary>`, and the map from framework to
+    binary is a second table beside the catalog's own `input_framework`. A
+    framework with no entry raises `KeyError` while the checks are derived,
+    which ends the run before the machine is asked anything."""
+    from gentoo_install.data import load_catalog
+    from tests.vm.installed import INPUT_METHOD_BINARIES
+
+    frameworks = {
+        group.input_framework
+        for group in load_catalog().values()
+        if group.input_method and group.input_framework
+    }
+    assert frameworks, "the catalog names no input framework at all"
+    assert frameworks <= set(INPUT_METHOD_BINARIES), frameworks - set(
+        INPUT_METHOD_BINARIES
+    )
+
+
+def test_an_openrc_machine_is_asked_about_greetd_the_way_openrc_answers() -> None:
+    """`systemctl` is not on that machine, so the systemd wording would answer
+    nothing and the check would read as a failed greeter. No fixture installs
+    greetd under OpenRC yet, so the configuration is built here."""
+    from dataclasses import replace
+
+    from gentoo_install.exec.config import load
+    from gentoo_install.model.config import InitSystem
+    from tests.vm.installed import checks
+
+    installation = load(Path("tests/fixtures/vm-greetd.toml"))
+    under_openrc = replace(
+        installation,
+        system=replace(installation.system, init=InitSystem.OPENRC),
+    )
+
+    asked = next(
+        one for one in checks(under_openrc) if one.name == "greetd service"
+    )
+
+    assert "systemctl" not in asked.command, asked.command
+    assert "rc-update" in asked.command, asked.command
+    # A running greeter, not just an enabled one: the pid comes from the
+    # machine and cannot be echoed by the command that asks for it.
+    assert "pgrep" in asked.command, asked.command
+    assert re.search(asked.pattern, "display-manager | default\n1234\n")
+    assert not re.search(asked.pattern, "display-manager | default\n")
+
+
+def test_greetd_service_check_reads_systemd_state() -> None:
+    from gentoo_install.exec.config import load
+    from tests.vm.installed import InstalledCheck, checks
+
+    installation = load(Path("tests/fixtures/vm-greetd.toml"))
+    actual = [one for one in checks(installation) if one.name == "greetd service"]
+    assert actual == [
+        InstalledCheck(
+            "greetd service",
+            "systemctl is-enabled greetd.service; systemctl is-active greetd.service",
+            r"(?m)^enabled$\n^active$",
+        )
+    ]
+    assert re.search(actual[0].pattern, "enabled\nactive\n")
+    assert not re.search(actual[0].pattern, "enabled\ninactive\n")
+
+
+def test_greetd_config_check_requires_tuigreet_session_directories() -> None:
+    from gentoo_install.exec.config import load
+    from tests.vm.installed import InstalledCheck, checks
+
+    installation = load(Path("tests/fixtures/vm-greetd.toml"))
+    actual = [one for one in checks(installation) if one.name == "greetd config"]
+    assert actual == [
+        InstalledCheck(
+            "greetd config",
+            "cat /etc/greetd/config.toml",
+            r"(?ms)\A(?!.*\bagreety\b)"
+            r"(?=.*^command = \"tuigreet .*--sessions /usr/share/wayland-sessions"
+            r" --xsessions /usr/share/xsessions\"$)",
+        )
+    ]
+    configured = (
+        "[default_session]\n"
+        'command = "tuigreet --sessions /usr/share/wayland-sessions'
+        ' --xsessions /usr/share/xsessions"\n'
+    )
+    assert re.search(actual[0].pattern, configured)
+    assert not re.search(actual[0].pattern, f"# agreety\n{configured}")
+    assert not re.search(actual[0].pattern, 'command = "tuigreet"\n')
+
+
+def test_ibus_check_reads_its_binary_and_session_environment() -> None:
+    from gentoo_install.exec.config import load
+    from tests.vm.installed import InstalledCheck, checks
+
+    installation = load(Path("tests/fixtures/vm-greetd.toml"))
+    actual = [one for one in checks(installation) if one.name == "inputmethod"]
+    assert actual == [
+        InstalledCheck(
+            "inputmethod",
+            "command -v ibus-daemon; cat /etc/environment",
+            r"(?ms)(?=.*^/usr/bin/ibus\-daemon$)(?=.*^XMODIFIERS=@im=ibus$)"
+            r"(?=.*^GTK_IM_MODULE=ibus$)(?=.*^QT_IM_MODULE=ibus$)",
+        )
+    ]
+    configured = (
+        "/usr/bin/ibus-daemon\n"
+        "XMODIFIERS=@im=ibus\n"
+        "GTK_IM_MODULE=ibus\n"
+        "QT_IM_MODULE=ibus\n"
+    )
+    assert re.search(actual[0].pattern, configured)
+    assert not re.search(actual[0].pattern, configured.replace("QT_IM_MODULE=ibus\n", ""))
+
+
+def test_greetd_checks_are_not_requested_without_greetd() -> None:
+    from dataclasses import replace
+
+    from gentoo_install.exec.config import load
+    from tests.vm.installed import checks
+
+    selected = load(Path("tests/fixtures/vm-greetd.toml"))
+    installation = replace(
+        selected, packages=replace(selected.packages, display_manager="lightdm")
+    )
+    assert [one for one in checks(installation) if one.name.startswith("greetd")] == []
 
 
 def test_a_guest_waits_until_the_machine_has_room_for_it() -> None:
@@ -2286,26 +2414,21 @@ def test_a_proxy_somewhere_else_is_not_checked_against_this_workstation() -> Non
     )
 
 
-def test_the_input_method_check_names_something_the_file_can_hold() -> None:
-    """`DefaultIM=` was asserted against `/etc/environment` for three weeks. It
-    lives in the user's `fcitx5/profile`, so the check could only ever fail,
-    and `vm-desktop` was the first fixture to reach it."""
+def test_input_method_check_accepts_its_planned_environment() -> None:
+    from gentoo_install.data import load_catalog
     from gentoo_install.exec.config import load
-    from gentoo_install.plan.packages import INPUT_ENVIRONMENT
+    from gentoo_install.plan.packages import input_environment
     from tests.vm.installed import checks
 
     installation = load(Path("tests/fixtures/vm-desktop.toml"))
     named = [one for one in checks(installation) if one.name == "inputmethod"]
     assert named, "a configuration with an input method has no check for it"
 
-    written = {
-        line
-        for (framework, _), lines in INPUT_ENVIRONMENT.items()
-        for line in lines
-    }
+    environment = "\n".join(input_environment(installation, load_catalog()))
     for check in named:
-        wanted = check.pattern.replace("\\", "")
-        assert any(wanted in line for line in written), wanted
+        binary = check.command.removeprefix("command -v ").split(";", maxsplit=1)[0]
+        output = f"/usr/bin/{binary}\n{environment}\n"
+        assert re.search(check.pattern, output), (check, output)
 
 
 def test_no_input_method_asks_for_no_environment() -> None:

--- a/tests/vm/installed.py
+++ b/tests/vm/installed.py
@@ -6,6 +6,7 @@ from __future__ import annotations
 import re
 from dataclasses import dataclass
 from pathlib import PurePosixPath
+from typing import Final
 
 from gentoo_install.data import load_catalog
 from gentoo_install.model import compat
@@ -18,6 +19,7 @@ from gentoo_install.model.config import (
 )
 from gentoo_install.model.device import Filesystem, Luks, Mountpoint, Subvolume, ZfsDataset, ZfsPool
 from gentoo_install.plan.system import _network_service as network_service
+from gentoo_install.plan.packages import ENVIRONMENT_FILE, input_environment
 
 from .console import DISK_PASSPHRASE
 
@@ -52,6 +54,12 @@ CPU_FLAGS_COMMAND: str = (
     "command -v cpuid2cpuflags >/dev/null 2>&1 && "
     "printf 'CPUFLAGS-TOOL %s\\n' \"$(cpuid2cpuflags)\" || true"
 )
+
+
+INPUT_METHOD_BINARIES: Final[dict[str, str]] = {
+    "fcitx": "fcitx5",
+    "ibus": "ibus-daemon",
+}
 
 
 def checks(installation: InstallConfig) -> tuple[InstalledCheck, ...]:
@@ -101,6 +109,32 @@ def checks(installation: InstallConfig) -> tuple[InstalledCheck, ...]:
                 )
                 for resolver in installation.system.dns
             )
+    if installation.packages.display_manager == "greetd":
+        if installation.system.init is InitSystem.SYSTEMD:
+            result.append(
+                InstalledCheck(
+                    "greetd service",
+                    "systemctl is-enabled greetd.service; systemctl is-active greetd.service",
+                    r"(?m)^enabled$\n^active$",
+                )
+            )
+        else:
+            result.append(
+                InstalledCheck(
+                    "greetd service",
+                    "rc-update show default; pgrep -x greetd",
+                    r"(?ms)(?=.*^display-manager\s+\|\s+default$)(?=.*^[1-9][0-9]*$)",
+                )
+            )
+        result.append(
+            InstalledCheck(
+                "greetd config",
+                "cat /etc/greetd/config.toml",
+                r"(?ms)\A(?!.*\bagreety\b)"
+                r"(?=.*^command = \"tuigreet .*--sessions /usr/share/wayland-sessions"
+                r" --xsessions /usr/share/xsessions\"$)",
+            )
+        )
     groups = load_catalog()
     frameworks = {
         groups[name].input_framework
@@ -108,15 +142,17 @@ def checks(installation: InstallConfig) -> tuple[InstalledCheck, ...]:
         if name in groups and groups[name].input_method
     }
     for framework in sorted(one for one in frameworks if one):
-        # What the environment file actually carries. `DefaultIM=` was asserted
-        # here for three weeks and lives in the user's `fcitx5/profile`, so the
-        # check could only ever fail; `vm-desktop` was the first fixture to
-        # reach it and it did have a working input method.
+        binary = INPUT_METHOD_BINARIES[framework]
+        environment = ENVIRONMENT_FILE[installation.system.init]
+        wanted = (f"/usr/bin/{binary}", *input_environment(installation, groups))
+        pattern = "(?ms)" + "".join(
+            rf"(?=.*^{re.escape(line)}$)" for line in wanted
+        )
         result.append(
             InstalledCheck(
                 "inputmethod",
-                "cat /etc/environment /etc/env.d/90input-method 2>/dev/null",
-                re.escape(f"XMODIFIERS=@im={framework}"),
+                f"command -v {binary}; cat {environment}",
+                pattern,
             )
         )
     if (


### PR DESCRIPTION
`TESTED.md` lists greetd sessions and ibus outside GNOME as covered by nothing. Both are implemented — `greetd.toml` replaces the ebuild's `agreety` config with tuigreet pointed at the session directories — and nothing had ever installed them.

`vm-greetd.toml` installs Xfce with greetd and ibus-pinyin, and the installed-state checks ask the machine: `systemctl is-enabled`/`is-active` for the greeter, the config file with a negative lookahead on `agreety`, and `command -v ibus-daemon` beside the environment file the session reads. The input-method check was reading `XMODIFIERS` alone; it now reads the binary and every line the plan writes, derived from the planner's own table rather than a second copy.

The fixture is not in the campaign yet: it needs a cluster round before `TESTED.md` can say anything.
