### PR TITLE
vm: give the result disk a name of its own

### DIFF
--- a/tests/unit/test_harness.py
+++ b/tests/unit/test_harness.py
@@ -4015,3 +4015,32 @@ def test_a_run_of_one_half_does_not_claim_the_other() -> None:
     # And the whole run still says both, because it did both.
     assert "installed Gentoo" in ram.RAN["both"]
     assert "one-shot" in ram.RAN["both"]
+
+
+def test_the_result_disk_is_named_and_not_numbered() -> None:
+    """An install that had finished ended with
+
+        tar: /dev/vda: Cannot write: Operation not permitted
+
+    because the driver CD is a virtio disk too and took `/dev/vda`, leaving
+    the results written at a read-only device. The targets already carry a
+    serial for the same reason; the result disk now does as well."""
+    from tests.vm.qemu import Firmware, Vm, VmSpec
+    from tests.vm.media import MEDIA
+    from tests.vm.results import RESULT_DEVICE, RESULT_SERIAL, collect_command
+
+    spec = VmSpec(
+        medium=MEDIA["official-minimal"],
+        workdir=Path("/tmp"),
+        firmware=Firmware.UEFI,
+        disks=(Path("/tmp/result.img"),),
+        driver_iso=Path("/tmp/driver.iso"),
+        boot_installed=True,
+    )
+    argv = Vm(spec)._argv()
+
+    named = [one for one in argv if one.startswith("virtio-blk-pci,drive=disk0")]
+    assert named == [f"virtio-blk-pci,drive=disk0,serial={RESULT_SERIAL}0"], argv
+    # And the command writes to the name, not to whichever disk came first.
+    assert "/dev/vda" not in collect_command("/run/vm-result")
+    assert RESULT_DEVICE in collect_command("/run/vm-result")

--- a/tests/vm/qemu.py
+++ b/tests/vm/qemu.py
@@ -13,6 +13,7 @@ from types import TracebackType
 from typing import Final, Self
 
 from .media import Medium
+from .results import RESULT_SERIAL
 
 OVMF_CODE = Path("/usr/share/edk2-ovmf/OVMF_CODE_4M.qcow2")
 OVMF_VARS = Path("/usr/share/edk2-ovmf/OVMF_VARS.fd")
@@ -137,9 +138,14 @@ class Vm:
                 "virtio-blk-pci,drive=driver",
             ]
         for index, disk in enumerate(self.spec.disks):
+            # A serial, for the same reason the targets have one: the driver CD
+            # is a virtio disk too, so it takes `/dev/vda` and the results were
+            # written to a read-only device — `tar: /dev/vda: Cannot write:
+            # Operation not permitted` after an install that had finished.
             argv += [
                 "-drive", f"file={disk},format=raw,if=none,id=disk{index}",
-                "-device", f"virtio-blk-pci,drive=disk{index}",
+                "-device",
+                f"virtio-blk-pci,drive=disk{index},serial={RESULT_SERIAL}{index}",
             ]
         for index, target in enumerate(self.spec.targets):
             # A stable serial gives the configuration a selector that survives

--- a/tests/vm/results.py
+++ b/tests/vm/results.py
@@ -13,6 +13,7 @@ import binascii
 import io
 import tarfile
 from pathlib import Path
+from typing import Final
 
 DEFAULT_SIZE_MIB = 64
 RESULT_BUFFER_BYTES = 64 * 1024 * 1024
@@ -29,7 +30,14 @@ def create_disk(path: Path, size_mib: int = DEFAULT_SIZE_MIB) -> Path:
     return path
 
 
-def collect_command(directory: str, device: str = "/dev/vda") -> str:
+#: The serial QEMU gives the result disk, and the name udev builds from it.
+#: Named rather than numbered: the driver CD is a virtio disk as well, so
+#: `/dev/vda` is whichever of them the kernel enumerated first.
+RESULT_SERIAL: Final[str] = "result"
+RESULT_DEVICE: Final[str] = f"/dev/disk/by-id/virtio-{RESULT_SERIAL}0"
+
+
+def collect_command(directory: str, device: str = RESULT_DEVICE) -> str:
     return f"tar cf {device} -C {directory} ."
 
 


### PR DESCRIPTION
A local `official-minimal` run installed 56 operations and then ended at

    tar: /dev/vda: Cannot write: Operation not permitted
    ResultError: result.img holds an empty tar archive

`collect_command` writes the results to `/dev/vda`, and the driver CD has been a `virtio-blk-pci` device since it had to leave q35's legacy IDE, so `/dev/vda` is the read-only driver and the results disk is `/dev/vdb`. The install's own log has `blkid … /dev/vdc2`, which is the target, one further along.

The result disk now carries the serial the targets already have, and the collection writes to `/dev/disk/by-id/virtio-result0`.
