### PR TITLE
tested: run81 finished three of three

### DIFF
--- a/TESTED.md
+++ b/TESTED.md
@@ -41,7 +41,7 @@ The ordinary path: partition, format, unpack a stage3, configure, boot.
 | `77edc8352186` | `vm-luks`, `vm-zram`, `vm-zfs`, `zfs-zbm`, `vm-desktop` — five of ten; `ext3` and `vm-unlock` failed at the installed system's login, `vm-sdboot` lost a marker to a console session and `vm-gnome` was ended mid-compile |
 | `e2986684da66` | `ext3`, `vm-unlock`, `vm-zfs-mirror`, `vm-raidz` — `ext3` and `vm-unlock` are the two the login work fixed: `login` prints `Maximum number of tries exceeded` instead of a third refusal, and it prints all three in the installed system's own locale |
 | `7fcc7edcec6b` | `openrc-sdboot`, `mbr-edit` — `mbr-edit`'s first record at all: it installed in 46.6 minutes in an earlier round and lost the login every time |
-| `18f150282cb1` | `vm-lvm`, `static-ip` |
+| `18f150282cb1` | `vm-lvm`, `static-ip`, `ext2` — three of three |
 
 Every row from `08015b221d73` onward ran `--region cn --site nju --sync
 webrsync --distfiles http://10.31.0.2/gentoo`, so what they establish about


### PR DESCRIPTION
`ext2` closed run81 at 49.5 minutes.