### PR TITLE
tui: offer every license from the main menu

### DIFF
--- a/gentoo_install/data/locale/ja.toml
+++ b/gentoo_install/data/locale/ja.toml
@@ -153,6 +153,8 @@
 
 # Licenses and compilation
 "Licenses to accept" = "受け入れるライセンス"
+"Accept every license" = "すべてのライセンスを受け入れる"
+"every license, including proprietary ones" = "プロプライエタリを含むすべてのライセンス"
 "Licenses" = "ライセンス"
 "free software and free documentation only" = "自由ソフトウェアと自由文書のみ"
 "also firmware and other redistributable binaries" = "ファームウェアなど再配布可能なバイナリも含む"

--- a/gentoo_install/data/locale/ko.toml
+++ b/gentoo_install/data/locale/ko.toml
@@ -153,6 +153,8 @@
 
 # Licenses and compilation
 "Licenses to accept" = "허용할 라이선스"
+"Accept every license" = "모든 라이선스 수용"
+"every license, including proprietary ones" = "독점 소프트웨어를 포함한 모든 라이선스"
 "Licenses" = "라이선스"
 "free software and free documentation only" = "자유 소프트웨어와 자유 문서만"
 "also firmware and other redistributable binaries" = "펌웨어 등 재배포 가능한 바이너리도 포함"

--- a/gentoo_install/data/locale/zh-CN.toml
+++ b/gentoo_install/data/locale/zh-CN.toml
@@ -153,6 +153,8 @@
 
 # 许可与编译
 "Licenses to accept" = "接受哪些许可"
+"Accept every license" = "接受全部许可"
+"every license, including proprietary ones" = "全部许可，包含专有软件"
 "Licenses" = "许可"
 "free software and free documentation only" = "仅自由软件与自由文档"
 "also firmware and other redistributable binaries" = "另含固件等可再分发二进制文件"

--- a/gentoo_install/data/locale/zh-TW.toml
+++ b/gentoo_install/data/locale/zh-TW.toml
@@ -153,6 +153,8 @@
 
 # 授權與編譯
 "Licenses to accept" = "接受哪些授權"
+"Accept every license" = "接受全部授權"
+"every license, including proprietary ones" = "全部授權，包含專有軟體"
 "Licenses" = "授權"
 "free software and free documentation only" = "僅自由軟體與自由文件"
 "also firmware and other redistributable binaries" = "另含韌體等可再散布二進位檔"

--- a/gentoo_install/tui/screens.py
+++ b/gentoo_install/tui/screens.py
@@ -4923,6 +4923,54 @@ LICENSES: tuple[tuple[str, str], ...] = (
 )
 
 
+#: What the profile accepts when nothing widens it, and what the button below
+#: puts back.
+DEFAULT_LICENSES: Final[tuple[str, ...]] = ("@FREE",)
+
+
+def accept_every_license_screen(
+    screen: Screen, config: InstallConfig, context: Context
+) -> Answer[InstallConfig]:
+    """`ACCEPT_LICENSE="*"` from the main menu, or the profile's own default.
+
+    The Licenses row is two levels down under Compiler, and an operator
+    installing WeChat or an NVIDIA driver meets the question as a refusal
+    instead: `net-im/wemeet` masked, the install over. Two answers rather than
+    a toggle, because every other row keeps its value when it is opened and
+    accepted again.
+    """
+    translate = context.translate
+    every = ("*",)
+    items = [
+        Item(
+            label="*",
+            value=" ".join(every),
+            detail=translate("every license, including proprietary ones"),
+        ),
+        Item(
+            label=" ".join(DEFAULT_LICENSES),
+            value=" ".join(DEFAULT_LICENSES),
+            detail=translate("free software and free documentation only"),
+        ),
+    ]
+    menu: Menu[str] = Menu(
+        title=translate("Accept every license"),
+        items=items,
+        current=" ".join(config.portage.accept_license),
+        footer=footer(translate),
+    )
+    answer = menu.run(screen)
+    if not answer.chosen:
+        return Answer(answer.outcome)
+    return Answer(
+        Outcome.CHOSE,
+        replace(
+            config,
+            portage=replace(config.portage, accept_license=tuple(answer.unwrap().split())),
+        ),
+    )
+
+
 def license_screen(screen: Screen, config: InstallConfig, context: Context) -> Answer[InstallConfig]:
     """`ACCEPT_LICENSE`. The default refuses anything that is not free, and a
     machine that needs firmware will not install until this is widened."""

--- a/gentoo_install/tui/settings.py
+++ b/gentoo_install/tui/settings.py
@@ -848,6 +848,11 @@ NETWORK: Final[tuple[Setting, ...]] = (
     Setting("firewall", "Firewall", _firewall, screens.firewall_screen),
 )
 
+def _every_license(config: InstallConfig, context: Context) -> str:
+    every = tuple(config.portage.accept_license) == ("*",)
+    return context.translate("yes" if every else "no")
+
+
 INSTALL_MODE: Final[Setting] = Setting(
     "mode", "Install mode", _mode, screens.install_mode_screen, required=True, detected=True
 )
@@ -867,6 +872,16 @@ SETTINGS: Final[tuple[Setting, ...]] = (
     ),
     Setting("timezone", "Timezone", lambda c, x: c.system.timezone, screens.timezone_screen),
     Setting("mirror", "Mirrors", _mirror, screens.mirror_screen, required=True, detected=True),
+    # Above the row that opens the rest of the install: the licence question
+    # is otherwise two levels down under Compiler, and the operator meets it
+    # as a refusal — `net-im/wemeet` masked, the install over — rather than as
+    # a menu.
+    Setting(
+        "every_license",
+        "Accept every license",
+        _every_license,
+        screens.accept_every_license_screen,
+    ),
     # Before the Disk row, because it decides whether that row applies at all.
     INSTALL_MODE,
     Setting(

--- a/tests/unit/test_tui_app.py
+++ b/tests/unit/test_tui_app.py
@@ -3265,3 +3265,50 @@ def test_a_cpu_that_cannot_run_v3_cannot_be_made_to_choose_it() -> None:
     assert answer is not None
     assert answer.portage.binhost.subarch == "x86-64", answer.portage.binhost
     assert "this CPU cannot run it" in screen.last
+
+
+def test_the_licence_button_offers_every_licence_and_the_default() -> None:
+    """A machine that needs `net-im/wemeet` or an NVIDIA driver meets the
+    licence question as a refusal — the group masked, the install over — and
+    the Licenses row is two levels down under Compiler. This row is at the
+    top level and offers two answers, so opening it and accepting keeps what
+    it held, which every other row does as well."""
+    import pathlib
+    from typing import Any, cast
+
+    from gentoo_install.exec.config import load
+
+    here = pathlib.Path(__file__).resolve().parents[1]
+    config = load(here / "fixtures" / "vm-desktop.toml")
+    assert tuple(config.portage.accept_license) != ("*",)
+
+    # The menu opens on the value the configuration holds, which is the
+    # second row here, so `*` is one press up.
+    screen = FakeScreen(keys=["KEY_UP", "\n"])
+    widened = screens.accept_every_license_screen(cast(Any, screen), config, context())
+
+    assert widened.chosen
+    assert widened.unwrap().portage.accept_license == ("*",)
+
+    # And the second row is the profile's own, so the answer is reversible
+    # from the same place it was given.
+    back = screens.accept_every_license_screen(
+        cast(Any, FakeScreen(keys=["KEY_DOWN", "\n"])), widened.unwrap(), context()
+    )
+    kept = screens.accept_every_license_screen(
+        cast(Any, FakeScreen(keys=["\n"])), widened.unwrap(), context()
+    )
+    assert kept.unwrap().portage.accept_license == ("*",)
+
+    assert back.unwrap().portage.accept_license == screens.DEFAULT_LICENSES
+
+
+def test_the_licence_button_sits_above_the_row_that_opens_the_install() -> None:
+    """Above the install-mode row, where it is read before anything else is
+    chosen, and not two levels down where the refusal finds the operator
+    first."""
+    from gentoo_install.tui.settings import SETTINGS
+
+    names = [one.key for one in SETTINGS]
+    assert "every_license" in names, names
+    assert names.index("every_license") < names.index("mode"), names


### PR DESCRIPTION
`ACCEPT_LICENSE` was reachable only through Compiler → Licenses, two levels down, and the operator who needs it meets the question as a refusal instead: `net-im/wemeet` masked, `emerge` stopped, the install over.

The new row sits above `Install mode`, at the top level, and offers two answers: `*` and the profile's own `@FREE`. Two answers rather than a toggle, because every other row keeps its value when it is opened and accepted again, and `test_no_row_loses_its_value_when_it_is_opened_again` holds that.

Both new strings are in all four catalogs.
