### PR TITLE
netboot: let --bypass choose the entry where GRUB reads it last

### DIFF
--- a/gentoo_install/plan/netboot.py
+++ b/gentoo_install/plan/netboot.py
@@ -714,6 +714,8 @@ class WriteMemoryEntry(Operation):
     target: BootTarget
     launch: MemoryLaunch
     region: MirrorRegion = MirrorRegion.GLOBAL
+    #: `--bypass`, which the entry itself has to carry on a GRUB machine.
+    bypass: bool = False
 
     def describe_parts(self) -> tuple[str, tuple[str, ...]]:
         return "write a {} entry for the {} environment", (
@@ -741,7 +743,7 @@ class WriteMemoryEntry(Operation):
             return
         # Both GRUBs read their own `custom.cfg`, and a UEFI one is reached
         # by `--bootnext` into GRUB rather than into the entry directly.
-        _write_custom(context, self.target, cmdline, place)
+        _write_custom(context, self.target, cmdline, place, bypass=self.bypass)
 
     def _cmdline(self, context: Context, place: PurePosixPath) -> tuple[str, ...]:
         if self.mode is MemoryMode.RAM:
@@ -898,7 +900,13 @@ def build(
             )
         )
     operations.append(
-        WriteMemoryEntry(mode=launch.mode, target=target, launch=launch, region=region)
+        WriteMemoryEntry(
+            mode=launch.mode,
+            target=target,
+            launch=launch,
+            region=region,
+            bypass=bypass,
+        )
     )
     if launch.mode is MemoryMode.LOWRAM:
         operations.append(DiscardTheArchive())
@@ -916,7 +924,12 @@ def disarm(*, target: BootTarget) -> list[Operation]:
 
 
 def _write_custom(
-    context: Context, target: BootTarget, cmdline: str, place: PurePosixPath
+    context: Context,
+    target: BootTarget,
+    cmdline: str,
+    place: PurePosixPath,
+    *,
+    bypass: bool = False,
 ) -> None:
     """A GRUB entry between markers, so arming twice replaces rather than adds."""
     if target.grub_directory is None:
@@ -944,8 +957,15 @@ def _write_custom(
     # found.` and `Press any key to continue...`: a machine armed from far away
     # then waits at a menu nobody is at. `$prefix` carries its own device, so
     # rereading the machine's own configuration works whatever `search` set.
+    # `grub-set-default` writes `saved_entry`, which a machine whose
+    # configuration says `GRUB_DEFAULT=0` never reads: a `--bypass` guest
+    # rebooted straight into `Booting \'Debian GNU/Linux\'` with our entry
+    # selected in `grubenv`. `custom.cfg` is sourced at the end of `grub.cfg`,
+    # after its own `set default`, so this assignment is the one that stands.
+    chooses = f"set default='{ENTRY_LABEL}'\n" if bypass else ""
     entry = (
         f"{CUSTOM_BEGIN}\n"
+        f"{chooses}"
         f"menuentry '{ENTRY_LABEL}' {{\n"
         f"    search --no-floppy --set=root --file {at}/kernel\n"
         f"    if [ -f {at}/kernel -a -f {at}/initramfs ]; then\n"

--- a/tests/unit/test_harness.py
+++ b/tests/unit/test_harness.py
@@ -4073,3 +4073,23 @@ def test_the_bypass_runner_asks_for_two_boots_and_names_the_flag() -> None:
     assert 'for boot in ("first", "second")' in source, source
     assert "arm_bypass" in source, source
     assert "--bypass" in inspect.getsource(ram.arm_bypass)
+
+
+def test_the_bypass_runner_reaches_a_shell_before_it_sends_a_command() -> None:
+    """The delivered screen reads a whole line as its answer, so a marked
+    command typed there is consumed: the second `--bypass` reboot ended at
+    `never matched 'MARK_14_DONE'` with `nothing was changed` on the console."""
+    import inspect
+
+    from tests.vm import ram
+
+    source = inspect.getsource(ram.run_bypass)
+    assert "leave_the_first_screen(console)" in source, source
+    left = source.index("leave_the_first_screen(console)")
+    # Last in the loop body, so the next pass's `reboot` reaches a shell: the
+    # reboot is the first statement of the pass that follows it.
+    assert source.index("came_up(console, mode)") < left, source
+    assert source.index('console.run("reboot"') < left, source
+    assert 'for boot in ("first", "second")' in source, source
+    answered = inspect.getsource(ram.leave_the_first_screen)
+    assert 'console.send("shell")' in answered, answered

--- a/tests/unit/test_harness.py
+++ b/tests/unit/test_harness.py
@@ -4009,9 +4009,40 @@ def test_a_run_of_one_half_does_not_claim_the_other() -> None:
     failure this suite exists to catch."""
     from tests.vm import ram
 
-    assert set(ram.RAN) == {"install", "fallback", "both"}
+    assert set(ram.RAN) == {"install", "fallback", "bypass", "both"}
     assert "one-shot" not in ram.RAN["install"], ram.RAN["install"]
     assert "installed Gentoo" not in ram.RAN["fallback"], ram.RAN["fallback"]
     # And the whole run still says both, because it did both.
     assert "installed Gentoo" in ram.RAN["both"]
     assert "one-shot" in ram.RAN["both"]
+
+
+def test_bypass_requires_the_default_entry_to_move() -> None:
+    """The one-shot's check is `_default_changed` being false; this path's is
+    the same reading being true. `--bypass` exists for firmware that drops a
+    one-shot, and an arming that left the default alone would look like a pass
+    while the machine boots what it always did."""
+    from tests.vm import ram
+
+    before = b"saved_entry=Debian\n"
+    replaced = b"saved_entry=gentoo-install memory environment\n"
+    assert ram._default_changed(before, replaced)
+    assert not ram._default_changed(before, before)
+    # The closing line says what this half measured and not what the others do.
+    assert "default entry" in ram.RAN["bypass"], ram.RAN["bypass"]
+    assert "one-shot" not in ram.RAN["bypass"], ram.RAN["bypass"]
+
+
+def test_the_bypass_runner_asks_for_two_boots_and_names_the_flag() -> None:
+    """A single boot is what `--ram` alone already proves. The second boot is
+    the difference: a replaced default entry comes up in the environment
+    again, and that is why this path leaves an unbootable machine when the
+    environment does not come up."""
+    import inspect
+
+    from tests.vm import ram
+
+    source = inspect.getsource(ram.run_bypass)
+    assert 'for boot in ("first", "second")' in source, source
+    assert "arm_bypass" in source, source
+    assert "--bypass" in inspect.getsource(ram.arm_bypass)

--- a/tests/unit/test_plan_netboot.py
+++ b/tests/unit/test_plan_netboot.py
@@ -807,6 +807,37 @@ def _custom(recorder: Recorder) -> str:
     return recorder.files[PurePosixPath("/boot/grub/custom.cfg")]
 
 
+def test_bypass_chooses_the_entry_in_the_file_grub_reads_last() -> None:
+    """Measured on 2026-08-19: `--bypass` wrote `saved_entry=gentoo-install
+    memory environment` into `grubenv` and the machine rebooted into
+    ``Booting `Debian GNU/Linux'``. `grub-set-default` writes a variable a
+    configuration that says `GRUB_DEFAULT=0` never reads, and `custom.cfg` is
+    sourced at the end of `grub.cfg`, after its own `set default`."""
+    for method in (BootMethod.BIOS_GRUB, BootMethod.UEFI_GRUB):
+        recorder = _answering()
+        target = _target(method)
+        netboot.WriteMemoryEntry(
+            mode=MemoryMode.RAM, target=target, launch=_launch(), bypass=True
+        ).apply(recorder)
+
+        custom = _custom(recorder)
+        chooses = f"set default='{netboot.ENTRY_LABEL}'"
+        assert chooses in custom, custom
+        # Before the entry and inside the markers, so taking the arming back
+        # removes the choice with it.
+        assert custom.index(netboot.CUSTOM_BEGIN) < custom.index(chooses), custom
+        assert custom.index(chooses) < custom.index("menuentry"), custom
+
+        without = _answering()
+        netboot.WriteMemoryEntry(
+            mode=MemoryMode.RAM, target=_target(method), launch=_launch()
+        ).apply(without)
+
+        # The one-shot leaves the default alone, which is the whole of its own
+        # promise: `set default` there would arm every boot.
+        assert "set default" not in _custom(without), _custom(without)
+
+
 def test_an_entry_whose_files_are_gone_rereads_the_machines_own_menu() -> None:
     """Measured on 2026-08-19: with the initramfs removed, GRUB answered
 

--- a/tests/vm/ram.py
+++ b/tests/vm/ram.py
@@ -89,6 +89,29 @@ def arm(console: SerialConsole, config: str, mode: str) -> None:
     )
 
 
+def arm_bypass(console: SerialConsole, config: str, mode: str) -> bytes:
+    """Replace the default entry, and require it to have moved.
+
+    The one-shot's promise is the opposite of this one: `--bypass` exists for
+    firmware that drops a one-shot, and it is the only path where an
+    environment that does not come up leaves a machine that does not boot.
+    """
+    before = read_the_default_entry(console)
+    console.run("mkdir -p /tmp/gentoo-install-results", timeout=60.0)
+    console.run(
+        f"sh /mnt/driver/install.sh --config {config} --{mode} --bypass 2>&1 "
+        "| tee /tmp/gentoo-install-results/arm.txt",
+        timeout=ARM_CEILING,
+    )
+    after = read_the_default_entry(console)
+    if not _default_changed(before, after):
+        raise RuntimeError(
+            "the default boot entry did not move, which is the whole of what "
+            f"--bypass does: {before!r} then {after!r}"
+        )
+    return after
+
+
 def arm_and_confirm(console: SerialConsole, config: str, mode: str) -> bytes:
     """Arm one boot and reject a missing one-shot or a moved default entry."""
     before = read_the_default_entry(console)
@@ -424,6 +447,9 @@ def run_fallback(
 RAN: Final[dict[str, str]] = {
     "install": "memory mode installed Gentoo from the environment it delivered",
     "fallback": "memory mode proved a broken one-shot returns to its own system twice",
+    "bypass": (
+        "memory mode replaced the default entry and came up in the environment twice"
+    ),
     "both": (
         "memory mode installed Gentoo and proved a broken one-shot returns twice"
     ),
@@ -432,6 +458,64 @@ RAN: Final[dict[str, str]] = {
 
 def _what_ran(part: str) -> str:
     return RAN[part]
+
+
+def run_bypass(
+    chosen: CloudImage,
+    config: str,
+    driver: Path,
+    workdir: Path,
+    *,
+    mode: str,
+    memory: str,
+    cpus: int,
+    keep: bool,
+) -> None:
+    """Replace the default entry, and require both boots to reach the environment.
+
+    One boot is what `--ram` alone proves. The second is what separates this
+    path from it: a replaced default entry comes up in the environment again,
+    which is why this is the one path an environment that does not come up
+    leaves unbootable.
+    """
+    workdir.mkdir(parents=True, exist_ok=True)
+    root = overlay(chosen.image, workdir)
+    cidata = seed(workdir)
+    verified = False
+    started = time.monotonic()
+    try:
+        spec = VmSpec(
+            medium=MEDIA["official-minimal"],
+            workdir=workdir,
+            firmware=chosen.firmware,
+            memory=memory,
+            cpus=cpus,
+            ssh_port=free_port(),
+            driver_iso=driver,
+            targets=(root,),
+            disks=(cidata,),
+            boot_installed=True,
+        )
+        with Vm(spec) as vm:
+            console = SerialConsole.connect(vm.serial_socket, vm.serial_log)
+            reach_root(console, chosen)
+            wait_for_driver(console)
+            install_tools(console, chosen, config, mode)
+            arm_bypass(console, config, mode)
+            for boot in ("first", "second"):
+                console.run("reboot", timeout=60.0)
+                refused = came_up(console, mode)
+                if refused:
+                    raise RuntimeError(f"the {boot} boot after --bypass: {refused}")
+                print(
+                    f"[{time.monotonic() - started:5.1f}s] the {boot} boot came up "
+                    "in the memory environment",
+                    flush=True,
+                )
+        verified = True
+    finally:
+        if verified and not keep:
+            root.unlink(missing_ok=True)
 
 
 def main(argv: list[str] | None = None) -> int:
@@ -449,7 +533,7 @@ def main(argv: list[str] | None = None) -> int:
     # The two halves are an hour apart, and the fallback is the one a change to
     # the boot entry has to be measured against.
     parser.add_argument(
-        "--part", choices=("both", "install", "fallback"), default="both"
+        "--part", choices=("both", "install", "fallback", "bypass"), default="both"
     )
     arguments = parser.parse_args(argv)
     chosen: CloudImage = IMAGES[arguments.image]
@@ -465,6 +549,17 @@ def main(argv: list[str] | None = None) -> int:
                 arguments.config,
                 driver,
                 workdir / "install",
+                mode=arguments.mode,
+                memory=arguments.memory,
+                cpus=arguments.cpus,
+                keep=arguments.keep,
+            )
+        if arguments.part == "bypass":
+            run_bypass(
+                chosen,
+                arguments.config,
+                driver,
+                workdir / "bypass",
                 mode=arguments.mode,
                 memory=arguments.memory,
                 cpus=arguments.cpus,

--- a/tests/vm/ram.py
+++ b/tests/vm/ram.py
@@ -280,6 +280,18 @@ def came_up(console: SerialConsole, mode: str) -> str:
     return ""
 
 
+def leave_the_first_screen(console: SerialConsole) -> None:
+    """Answer the delivered screen so the console is at a shell again.
+
+    `run()` sends a marked command, and typed at `install or shell>` the whole
+    line is read as the answer: the screen printed `nothing was changed` and
+    the marker never came back, so the second reboot of a `--bypass` run
+    failed at `never matched 'MARK_14_DONE'`.
+    """
+    console.send("shell")
+    console.expect(r"# ", timeout=POST_INSTALL_PATIENCE)
+
+
 def run_install(
     chosen: CloudImage,
     config: str,
@@ -507,6 +519,9 @@ def run_bypass(
                 refused = came_up(console, mode)
                 if refused:
                     raise RuntimeError(f"the {boot} boot after --bypass: {refused}")
+                # The environment is at its own first screen, and the next
+                # command has to reach a shell rather than that prompt.
+                leave_the_first_screen(console)
                 print(
                     f"[{time.monotonic() - started:5.1f}s] the {boot} boot came up "
                     "in the memory environment",


### PR DESCRIPTION
`--bypass` wrote `saved_entry=gentoo-install memory environment` with `grub-set-default` and the guest rebooted into ``Booting `Debian GNU/Linux'``: that variable is read only by a configuration that says `GRUB_DEFAULT=saved`, and Debian's says `0`.

`custom.cfg` is sourced at the end of `grub.cfg`, after its own `set default`, so the entry now carries `set default='<label>'` inside the same markers the arming removes. Measured after the change: `the first boot came up in the memory environment` at 65.6s and `the second boot came up in the memory environment` at 82.2s, which is what separates a replaced default from a one-shot.

The runner's second reboot also had to answer the delivered screen first: a marked command typed at `install or shell>` is read as the answer, and the run ended at `never matched 'MARK_14_DONE'` with `nothing was changed` on the console.
