### PR TITLE
netboot: carry what a cloud image's GRUB needs into the entry

### DIFF
--- a/gentoo_install/plan/netboot.py
+++ b/gentoo_install/plan/netboot.py
@@ -966,7 +966,15 @@ def _write_custom(
     entry = (
         f"{CUSTOM_BEGIN}\n"
         f"{chooses}"
-        f"menuentry '{ENTRY_LABEL}' {{\n"
+        # `--unrestricted`, `insmod` and `btrfs_relative_path` are what
+        # `bin456789/reinstall` carries for the same job: a GRUB password on a
+        # cloud image otherwise asks for one, `all_video` is missing from
+        # Fedora's EFI GRUB, and a `/boot` inside a btrfs subvolume resolves
+        # every path against the subvolume without the third.
+        f"menuentry '{ENTRY_LABEL}' --unrestricted {{\n"
+        "    insmod all_video\n"
+        "    insmod lvm\n"
+        "    set btrfs_relative_path=n\n"
         f"    search --no-floppy --set=root --file {at}/kernel\n"
         f"    if [ -f {at}/kernel -a -f {at}/initramfs ]; then\n"
         f"        linux {at}/kernel {cmdline}\n"

--- a/tests/unit/test_plan_netboot.py
+++ b/tests/unit/test_plan_netboot.py
@@ -807,6 +807,29 @@ def _custom(recorder: Recorder) -> str:
     return recorder.files[PurePosixPath("/boot/grub/custom.cfg")]
 
 
+def test_the_entry_carries_what_a_cloud_image_grub_needs() -> None:
+    """Taken from `bin456789/reinstall`, which arms the same kind of machine:
+    an image with a GRUB password refuses an entry that is not
+    `--unrestricted`, Fedora's EFI GRUB has no `all_video` loaded, an LVM
+    `/boot` needs its module, and a `/boot` inside a btrfs subvolume resolves
+    every path against the subvolume unless `btrfs_relative_path` is off."""
+    recorder = _answering()
+    netboot.WriteMemoryEntry(
+        mode=MemoryMode.RAM, target=_target(BootMethod.BIOS_GRUB), launch=_launch()
+    ).apply(recorder)
+
+    custom = _custom(recorder)
+    lines = [one.strip() for one in custom.splitlines()]
+    assert f"menuentry '{netboot.ENTRY_LABEL}' --unrestricted {{" in lines, custom
+    for wanted in ("insmod all_video", "insmod lvm", "set btrfs_relative_path=n"):
+        assert wanted in lines, (wanted, custom)
+    # Before the search, which is the first thing that reads a path.
+    for wanted in ("insmod all_video", "set btrfs_relative_path=n"):
+        assert lines.index(wanted) < next(
+            n for n, one in enumerate(lines) if one.startswith("search ")
+        ), (wanted, custom)
+
+
 def test_bypass_chooses_the_entry_in_the_file_grub_reads_last() -> None:
     """Measured on 2026-08-19: `--bypass` wrote `saved_entry=gentoo-install
     memory environment` into `grubenv` and the machine rebooted into


### PR DESCRIPTION
Read out of `bin456789/reinstall`, which arms the same class of machine from inside a running system and has met more of them than this installer has:

- `menuentry … --unrestricted`, because an image with a GRUB password otherwise asks for one at the entry we just armed, and nobody is at that console.
- `insmod all_video`, which Fedora's EFI GRUB does not load by itself.
- `insmod lvm`, for a `/boot` on LVM.
- `set btrfs_relative_path=n`, because a `/boot` inside a btrfs subvolume resolves every path against the subvolume and `search --file` then finds nothing.

The same script also regenerates `grub.cfg` first, because some images ship one with no `41_custom` block at all and `custom.cfg` is never read; that gap is a separate change with its own refusal.
