### PR TITLE
cluster: answer a command without the serial line's carriage returns

### DIFF
--- a/tests/unit/test_cluster.py
+++ b/tests/unit/test_cluster.py
@@ -16,7 +16,7 @@ from gentoo_install.model.config import MirrorRegion, Sync
 from tests.vm import cluster
 
 FIXTURES = Path(__file__).resolve().parents[1] / "fixtures"
-from tests.vm.console import ConsoleTimeout, SerialConsole
+from tests.vm.console import ConsoleTimeout, SerialConsole, command_done
 from tests.vm.proxmox import Api, Node, ProxmoxNotFound, VMID_FIRST, VMID_LAST
 
 
@@ -2178,3 +2178,37 @@ def test_a_refusal_with_no_echo_still_grows_the_settle(
     assert cluster._log_in(cast(cluster.Reconnecting, console), "install") == ""
     assert console.sent.count("install") == 2, console.sent
     assert console.settled >= cluster.PASSWORD_ECHO_BACKOFF, console.settled
+
+
+def test_a_command_answer_carries_no_carriage_returns() -> None:
+    """A serial line ends every line `\\r\\n`, so a check anchored with `$`
+    matches nothing: `btrfs-luks` was failed at 130.3 minutes for an
+    `inputmethod` check whose three lines were on its console, and `vm-greetd`
+    at 59.2 for a service that was enabled and active."""
+    import re
+
+    token = 7
+
+    class Echoing:
+        def __init__(self) -> None:
+            self.sent: list[str] = []
+
+        def send(self, line: str) -> None:
+            self.sent.append(line)
+
+        def expect(self, pattern: str, timeout: float, idle: float = 0.0) -> bytes:
+            if "BEGIN" in pattern:
+                return b"MARK_7_BEGIN\r\n"
+            return (
+                b"/usr/bin/fcitx5\r\nXMODIFIERS=@im=fcitx\r\n"
+                + command_done(token).encode()
+            )
+
+        def close(self) -> None:
+            return None
+
+    link = cluster.Reconnecting(lambda: cast(Any, Echoing()))
+    said = link.expect_output("command -v fcitx5; cat /etc/environment")
+
+    assert b"\r" not in said, said
+    assert re.search(rb"(?m)^XMODIFIERS=@im=fcitx$", said), said

--- a/tests/vm/cluster.py
+++ b/tests/vm/cluster.py
@@ -2380,7 +2380,11 @@ class Reconnecting:
             with _naming(command):
                 self.console.expect(command_begin(token), _remaining(deadline))
                 said = self.console.expect(command_done(token), _remaining(deadline))
-            return said.split(command_done(token).encode())[0]
+            # Without the carriage returns: a serial line ends every one of
+            # them `\r\n`, so a pattern anchored with `$` matches nothing at
+            # all. `btrfs-luks` was failed at 130.3 minutes for an
+            # `inputmethod` check whose three lines were on the console.
+            return said.split(command_done(token).encode())[0].replace(b"\r", b"")
 
         return self._with_reconnect(
             timeout, collect_once, retry_timeout=_marker_lost


### PR DESCRIPTION
`btrfs-luks` was FAILed at 130.3 minutes with `inputmethod: the installed system does not say '(?ms)(?=.*^/usr/bin/fcitx5$)…'` and its console holds exactly those three lines — with `\r\n` endings, which `$` cannot match. `vm-greetd` was FAILed the same way at 59.2 minutes for `^enabled$\n^active$`.

The carriage returns are transport, not content, so `expect_output` drops them. The two fixtures go back into the next round.