### PR TITLE
preflight: ask for every command the plan will run

### DIFF
--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -64,15 +64,21 @@ package_for() {
 	sgdisk:alpine) printf 'sgdisk' ;;
 	sgdisk:*) printf 'gptfdisk' ;;
 	partprobe:* | parted:*) printf 'parted' ;;
-	install:* | sleep:*) printf 'coreutils' ;;
+	install:* | sleep:* | mkdir:*) printf 'coreutils' ;;
 	mkfs.vfat:* | mkfs.fat:*) printf 'dosfstools' ;;
 	mkfs.btrfs:* | btrfs:*) printf 'btrfs-progs' ;;
 	cryptsetup:*) printf 'cryptsetup' ;;
 	mdadm:*) printf 'mdadm' ;;
+	# Read from each distribution on 2026-08-19: Alpine and Arch ship
+	# `device-mapper`, Gentoo puts `dmsetup` in lvm2, and Debian names the
+	# package after the command, which the fallback already covers.
+	dmsetup:gentoo) printf 'sys-fs/lvm2' ;;
+	dmsetup:alpine | dmsetup:arch | dmsetup:fedora | dmsetup:rhel | dmsetup:centos \
+		| dmsetup:suse | dmsetup:opensuse*) printf 'device-mapper' ;;
 	# The multicall name and the three binaries the operations invoke: all of
 	# them come from lvm2, and the three reached the fallback and were printed
 	# as package names no distribution has.
-	lvm:* | pvcreate:* | vgcreate:* | lvcreate:*) printf 'lvm2' ;;
+	lvm:* | pvcreate:* | vgcreate:* | lvcreate:* | vgchange:*) printf 'lvm2' ;;
 	gpg:*) printf 'gnupg' ;;
 	gpg-agent:gentoo | gpg-agent:arch) printf 'gnupg' ;;
 	gpg-agent:alpine | gpg-agent:debian | gpg-agent:ubuntu) printf 'gpg-agent' ;;

--- a/gentoo_install/exec/preflight.py
+++ b/gentoo_install/exec/preflight.py
@@ -48,6 +48,10 @@ STAGE3_COMMANDS: Final[tuple[str, ...]] = ("tar", "xz", "gpg", "gpg-agent")
 #: Commands every install needs, whatever the layout is.
 ALWAYS: Final[tuple[str, ...]] = (
     "tar", "gpg", "mount", "umount", "findmnt", "lsblk", "blkid", "chroot", "udevadm", "swapon",
+    # Reached through a context method rather than an operation's own list, so
+    # the plan runs them on every configuration: `install` mounts the chroot's
+    # filesystems, `mkdir` makes every mount point, `sleep` spaces a retry.
+    "install", "mkdir", "sleep",
 )
 
 #: Commands reached through context methods or helper subprocesses.
@@ -72,13 +76,17 @@ BY_FEATURE: Final[dict[str, tuple[str, ...]]] = {
     # `partprobe` is absent here on purpose: it comes from parted, and
     # `RereadPartitionTable` falls back to `blockdev --rereadpt` without it.
     "gpt": ("sgdisk", "blockdev", "wipefs"),
-    "mbr": ("parted", "partprobe", "wipefs"),
-    "luks": ("cryptsetup",),
+    # `blockdev` as well: the reread falls back to it, and an MBR layout
+    # reaches the same operation a GPT one does.
+    "mbr": ("parted", "partprobe", "wipefs", "blockdev"),
+    # `dmsetup` as well: `OpenLuks` lists the mapper's own devices before it
+    # opens one, and a medium without it stops with the disks partitioned.
+    "luks": ("cryptsetup", "dmsetup"),
     "mdraid": ("mdadm",),
     # The binaries the operations invoke, not the multicall name: a medium
     # carrying lvm without its symlinks passes on `lvm` and dies at `pvcreate`
     # with the disks already partitioned.
-    "lvm": ("pvcreate", "vgcreate", "lvcreate"),
+    "lvm": ("pvcreate", "vgcreate", "lvcreate", "vgchange"),
     "swap": ("mkswap", "swapoff"),
     # `hostid`, not `zgenhostid`: the host reads its own id and the target
     # writes it, so the tool that writes runs inside the chroot.

--- a/tests/unit/test_exec.py
+++ b/tests/unit/test_exec.py
@@ -2556,3 +2556,33 @@ def test_an_existing_file_is_narrowed_before_the_secret_reaches_it(
     assert seen == [0o600], [oct(one) for one in seen]
     assert stat.S_IMODE(where.stat().st_mode) == 0o600
     assert where.read_text() == "secret"
+
+
+def test_preflight_asks_for_every_command_the_plan_will_run() -> None:
+    """Two tables for one rule set: `BY_FEATURE` in `preflight.py` and the
+    `host_commands` each operation declares. They had already drifted —
+    `OpenLuks` lists `dmsetup` and the `luks` row did not, so a medium without
+    it passed preflight and stopped with the disks already partitioned."""
+    from gentoo_install.data import load_catalog
+    from gentoo_install.exec import preflight as check
+    from gentoo_install.plan.build import build
+
+    catalog = load_catalog()
+    fixtures = Path(__file__).resolve().parents[1] / "fixtures"
+    for name in (
+        "vm-luks",
+        "btrfs-luks",
+        "vm-lvm",
+        "vm-mdraid",
+        "vm-zfs",
+        "vm-xfs",
+        "vm-zram",
+        "ext2",
+    ):
+        config = load(fixtures / f"{name}.toml")
+        planned = check.required_commands(config, build(config, catalog))
+        configured = check.required_commands(config)
+        # `partprobe` is the one deliberate omission, and it carries its
+        # reason at the head of the table: the operation degrades to
+        # `blockdev --rereadpt` without it.
+        assert planned - configured - {"partprobe"} == set(), (name, planned - configured)

--- a/tests/unit/test_harness.py
+++ b/tests/unit/test_harness.py
@@ -405,6 +405,10 @@ def test_bootstrap_names_a_package_for_every_command_preflight_wants() -> None:
         ("umount", "debian"),
         ("mount", "ubuntu"),
         ("umount", "ubuntu"),
+        # Debian's package is called `dmsetup`; Alpine, Arch and the rpm
+        # families call it `device-mapper` and Gentoo puts it in lvm2.
+        ("dmsetup", "debian"),
+        ("dmsetup", "ubuntu"),
     }
     wrong: list[str] = []
     for command in sorted(wanted):


### PR DESCRIPTION
`BY_FEATURE` and the `host_commands` each operation declares are two tables for one rule set, and they had drifted in four places. Each gap is the same failure: preflight passes, the install starts, and the missing command is reached with the disks already partitioned.

- `OpenLuks` declares `dmsetup` and the `luks` row did not.
- `RereadPartitionTable` falls back to `blockdev`, which only the `gpt` row named; an MBR layout reaches the same operation.
- `ActivateVolumeGroup` runs `vgchange`, which the `lvm` row did not name.
- `install`, `mkdir` and `sleep` are reached through context methods on every configuration.

The new test builds the plan for eight fixtures and requires the configuration-only answer to cover everything the plan will run, so the next operation that runs a command the table does not name fails here rather than on a machine. `bootstrap.sh` gains the packages for `dmsetup` and `vgchange`, read from each distribution today: Alpine and Arch ship `device-mapper`, Gentoo puts it in `sys-fs/lvm2`, Debian names the package after the command.
