### PR TITLE
plan: define the proxy endpoint once

### DIFF
--- a/gentoo_install/plan/system.py
+++ b/gentoo_install/plan/system.py
@@ -39,7 +39,7 @@ from ..model.device import (
 from .bootloader import serial_console
 from .mounts import resolve_mounts
 from .operations import CommandOutput, Context, Operation, Stage
-from .portage import Emerge, PortageConfigKind, WritePortageConfig
+from .portage import Emerge, PortageConfigKind, WritePortageConfig, _proxy_endpoint
 
 #: Console fonts `sys-apps/kbd` installs, by the cell size they draw.
 CONSOLE_FONTS: Final[dict[ConsoleFontSize, str]] = {
@@ -1208,11 +1208,6 @@ def build(config: InstallConfig) -> list[Operation]:
         ]
     operations += _zfs_services(config)
     return operations
-
-
-def _proxy_endpoint(proxy: ProxyConfig) -> str:
-    """The proxy URL without user information, for process environments."""
-    return proxy.redacted_url
 
 
 def _zfs_services(config: InstallConfig) -> list[Operation]:

--- a/tests/unit/test_layers.py
+++ b/tests/unit/test_layers.py
@@ -402,3 +402,21 @@ def test_every_operation_still_has_to_say_what_it_does() -> None:
     ]
     assert not silent, silent
     assert len(found) > 60, len(found)
+
+
+def test_the_proxy_endpoint_is_defined_once() -> None:
+    """It was written twice, byte for byte, in `plan/portage.py` and
+    `plan/system.py`, while `system.py` already imported from `portage.py`. A
+    second copy of a one-line rule is where the two answers diverge."""
+    import ast
+    from pathlib import Path
+
+    root = Path(__file__).resolve().parents[2] / "gentoo_install" / "plan"
+    defined = [
+        path.name
+        for path in sorted(root.glob("*.py"))
+        for node in ast.walk(ast.parse(path.read_text()))
+        if isinstance(node, ast.FunctionDef) and node.name == "_proxy_endpoint"
+    ]
+
+    assert defined == ["portage.py"], defined


### PR DESCRIPTION
`_proxy_endpoint` was defined identically in `plan/portage.py:1548` and `plan/system.py:1213`, docstring included, while `system.py:42` already imported three names from `portage.py`. The test walks the plan modules' ASTs and requires exactly one definition, so the next copy fails here.