### PR TITLE
tui: offer every timezone a language default picks

### DIFF
--- a/gentoo_install/tui/screens.py
+++ b/gentoo_install/tui/screens.py
@@ -2916,11 +2916,15 @@ LOCALES: tuple[tuple[str, str], ...] = (
 )
 
 #: The zones this installer is aimed at, with UTC for a server.
+#: What the screen offers when the machine's own `/usr/share/zoneinfo` cannot
+#: be read. Every zone `LANGUAGE_DEFAULTS` picks is here: a `ko` interface
+#: pre-filled `Asia/Seoul` and this list could not show it.
 TIMEZONES: tuple[str, ...] = (
     "Asia/Shanghai",
     "Asia/Taipei",
     "Asia/Hong_Kong",
     "Asia/Tokyo",
+    "Asia/Seoul",
     "Europe/London",
     "America/New_York",
     "UTC",

--- a/tests/unit/test_tui_app.py
+++ b/tests/unit/test_tui_app.py
@@ -3312,3 +3312,19 @@ def test_the_licence_button_sits_above_the_row_that_opens_the_install() -> None:
     names = [one.key for one in SETTINGS]
     assert "every_license" in names, names
     assert names.index("every_license") < names.index("mode"), names
+
+
+def test_every_language_default_names_a_zone_the_screen_can_show() -> None:
+    """The interface language pre-fills a timezone, and the timezone screen
+    falls back to its own list when the machine's `/usr/share/zoneinfo` cannot
+    be read. `ko` picked `Asia/Seoul`, which that list did not hold, so the
+    row showed a value the screen could not offer."""
+    from gentoo_install.tui.screens import LANGUAGE_DEFAULTS, TIMEZONES
+
+    missing = sorted(
+        default.timezone
+        for default in LANGUAGE_DEFAULTS.values()
+        if default.timezone not in TIMEZONES
+    )
+
+    assert not missing, missing


### PR DESCRIPTION
`LANGUAGE_DEFAULTS` gives `ko` the zone `Asia/Seoul`, and `TIMEZONES` — what the screen offers when the machine's own `/usr/share/zoneinfo` cannot be read — did not hold it. The row then shows a value its own screen cannot offer.

The test walks the language defaults and requires every zone to be in the fallback list, so the next language added fails here.