### PR TITLE
cluster: read the name's echo before waiting for a password prompt

### DIFF
--- a/tests/unit/test_cluster.py
+++ b/tests/unit/test_cluster.py
@@ -1167,6 +1167,9 @@ def test_the_prompt_after_a_refusal_is_read_before_the_name_is_offered_again(
             self.sent.append(line)
             if self.wants == "name":
                 self.wants = "password"
+                # Echoed, because agetty echoes a name: the harness reads its
+                # own name back to know the prompt after it is a fresh one.
+                self.pending.append(line.encode() + b"\r\n")
                 self.pending.append(b"Password: ")
                 return
             if line != "install":
@@ -2259,3 +2262,69 @@ def test_the_passphrase_prompt_gets_a_growing_settle(
 class _Keyboard:
     def send_keys(self, keys: list[str]) -> None:
         return None
+
+
+def test_a_stale_password_prompt_does_not_take_the_password(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """`ext3` was failed at 33.6 minutes with
+
+        Maximum number of tries exceeded install\r\r\nPassword:
+
+    on its console: `login` had given up, agetty printed a fresh name prompt
+    and swallowed the name typed into its flush window, and the `Password:`
+    the attempt before had left in the buffer read as an answer — so the
+    password went into the name field. The name's own echo tells them apart."""
+    monkeypatch.setattr(time, "sleep", lambda seconds: None)
+
+    class Agetty:
+        """A guest at a name prompt, with one prompt left over from before.
+
+        The first name lands in agetty's flush window and is discarded, which
+        is the state the harness cannot see and the echo reports.
+        """
+
+        console = _Screen(b"")
+
+        def __init__(self) -> None:
+            self.sent: list[str] = []
+            self.pending: list[bytes] = [b"Password: "]
+            self.wants = "name"
+            self.flushed = False
+            self.names: list[str] = []
+
+        def respond(self, line: str) -> None:
+            self.sent.append(line)
+            if self.wants == "name":
+                if not self.flushed:
+                    self.flushed = True
+                    return
+                self.names.append(line)
+                self.pending.append(line.encode() + b"\r\n")
+                self.pending.append(b"Password: ")
+                self.wants = "password"
+                return
+            self.wants = "name"
+            if self.names[-1:] == [cluster.NAME] and line == "install":
+                self.pending.append(b"\r\nplain ~ # ")
+                return
+            self.pending.append(b"\r\nLogin incorrect\r\nplain login: ")
+
+        def observe(self, pattern: str, timeout: float = 0.0, *, solicit: bool = False) -> bytes:
+            import re as _re
+
+            while self.pending:
+                said = self.pending.pop(0)
+                if _re.search(pattern.encode(), said):
+                    return said
+            raise ConsoleTimeout(f"never matched {pattern!r}")
+
+    console = Agetty()
+
+    assert cluster._log_in(cast(cluster.Reconnecting, console), "install") == "", (
+        console.sent
+    )
+    # The password reached the password field and nothing else did: the name
+    # was offered twice because the first one was flushed.
+    assert console.names == [cluster.NAME], console.names
+    assert console.sent == [cluster.NAME, cluster.NAME, "install"], console.sent

--- a/tests/unit/test_harness.py
+++ b/tests/unit/test_harness.py
@@ -2706,7 +2706,17 @@ def test_a_name_typed_the_moment_the_prompt_appears_is_offered_again(
     from tests.vm import cluster
 
     monkeypatch.setattr(cluster, "AGETTY_FLUSHES_AFTER", 0.0)
-    said = [b"\r\nopenrcsdbox login: ", b"\r\nopenrcsdbox login: ", b"Password: "]
+    # The name's echo before each answer, because agetty echoes what is typed
+    # at a login prompt and the harness reads its own name back to know that
+    # the prompt after it is a fresh one.
+    said = [
+        b"root\r\n",
+        b"\r\nopenrcsdbox login: ",
+        b"root\r\n",
+        b"\r\nopenrcsdbox login: ",
+        b"root\r\n",
+        b"Password: ",
+    ]
     offered: list[str] = []
 
     class Prompting:

--- a/tests/vm/cluster.py
+++ b/tests/vm/cluster.py
@@ -2538,6 +2538,11 @@ AGETTY_FLUSHES_AFTER: Final[float] = 2.0
 LOGIN_TRIES: Final[int] = 4
 
 
+#: Who the installed system is logged in as. Its echo is what tells a fresh
+#: password prompt from one the attempt before left in the buffer.
+NAME: Final[str] = "root"
+
+
 def _name_the_user(link: Reconnecting) -> bool:
     """Give the login prompt a name, and say whether it took one.
 
@@ -2557,8 +2562,13 @@ def _name_the_user(link: Reconnecting) -> bool:
             # It came back, so that name did not take. This is the wait agetty
             # needs, and it belongs where the console has proved it.
             time.sleep(AGETTY_FLUSHES_AFTER)
-        link.respond("root")
+        link.respond(NAME)
         try:
+            # The echo of the name first: the prompt that follows it is the
+            # one this name produced. `ext3` was failed for a `Password:` left
+            # in the buffer by the attempt before, which read as an answer and
+            # sent the password into the next login prompt's name field.
+            link.observe(rf"{NAME}", timeout=60.0)
             said = link.observe(
                 rf"{PASSWORD_PROMPT}|{'|'.join(LOGIN_PROMPTS)}", timeout=60.0
             )


### PR DESCRIPTION
`ext3` was FAILed at 33.6 minutes in run85 and its console ends

    Maximum number of tries exceeded install\r\r\nPassword:

`login` had spent its three tries and exited, agetty printed a fresh name prompt and swallowed the name typed into its flush window, and the `Password:` the previous attempt had left in the buffer matched the wait that follows the name — so `_name_the_user` reported a password prompt that had already been answered and the password went into the name field.

The name's own echo is what separates the two: agetty echoes at a login prompt, so reading the name back first discards whatever the last attempt left behind. Both fakes in the suite were answering without echoing, which is the shape `CLAUDE.md` names — a double of a shell echoes first — and they now do.
