### PR TITLE
ci: run the two gates on every push and pull request

### DIFF
--- a/.github/workflows/gates.yml
+++ b/.github/workflows/gates.yml
@@ -1,0 +1,33 @@
+# The two gates every commit is held to, run on the Python the target ships.
+# Nothing here starts a virtual machine: `tests/vm/` drives real guests and
+# needs a hypervisor, so what runs in CI is what runs without one.
+name: gates
+
+on:
+  push:
+    branches: [master]
+  pull_request:
+
+permissions:
+  contents: read
+
+jobs:
+  gates:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          # This workstation has only 3.14, so 3.11 has never run the suite
+          # here and CI is not the place to find out: `mypy` already checks
+          # against the 3.11 floor `pyproject.toml` declares.
+          python-version: "3.13"
+      - name: install the gates
+        # pytest before mypy, not beside it: `mypy` reads the test files too
+        # and answers `Cannot find implementation or library stub for module
+        # named "pytest"` 139 times without them.
+        run: python -m pip install --quiet mypy==2.2.0 pytest
+      - name: mypy
+        run: python -m mypy
+      - name: pytest
+        run: python -m pytest -q -p no:cacheprovider

--- a/.github/workflows/gates.yml
+++ b/.github/workflows/gates.yml
@@ -30,4 +30,6 @@ jobs:
       - name: mypy
         run: python -m mypy
       - name: pytest
-        run: python -m pytest -q -p no:cacheprovider
+        # Without the `lab` tests: they read OVMF, a hypervisor, `arping` or a
+        # downloaded ISO, none of which a runner has.
+        run: python -m pytest -q -p no:cacheprovider -m "not lab"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,3 +13,10 @@ files = ["gentoo_install", "tests"]
 [tool.pytest.ini_options]
 testpaths = ["tests"]
 addopts = "-q"
+# A test that reads this machine rather than the tree: OVMF firmware, a
+# hypervisor, `arping`, a downloaded ISO. They run here and are skipped by CI
+# with `-m "not lab"`, because a runner has none of those and a green suite
+# that skipped nothing it needed is the point of the marker.
+markers = [
+    "lab: needs this workstation's firmware, tools or downloaded media",
+]

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -1,0 +1,30 @@
+# SPDX-License-Identifier: GPL-2.0-or-later
+"""What every unit test needs from this machine, and nothing more.
+
+The Proxmox client reads an API token from a path outside the tree, so three
+tests that build a request were green here and red on a runner that has no
+such file. A test that is about the token points `TOKEN_FILE` at its own, and
+a monkeypatch inside a test wins over this one.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from tests.vm import proxmox
+
+
+@pytest.fixture(scope="session")
+def _token_file(tmp_path_factory: pytest.TempPathFactory) -> Path:
+    # Outside each test's own `tmp_path`: one test archives that directory and
+    # compares what came back, and a token written there is an extra member.
+    token = tmp_path_factory.mktemp("api") / "token"
+    token.write_text("01234567-89ab-cdef-0123-456789abcdef\n")
+    return token
+
+
+@pytest.fixture(autouse=True)
+def _api_token(_token_file: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(proxmox, "TOKEN_FILE", _token_file)

--- a/tests/unit/test_harness.py
+++ b/tests/unit/test_harness.py
@@ -251,7 +251,9 @@ def test_a_guest_runs_behind_whoever_is_at_the_keyboard() -> None:
     spec = VmSpec(
         medium=MEDIA["official-minimal"],
         workdir=Path("/tmp"),
-        firmware=Firmware.UEFI,
+        # BIOS, because this asserts the argv prefix and UEFI would want the
+        # machine's OVMF images, which a runner without a hypervisor lacks.
+        firmware=Firmware.BIOS,
         ssh_port=2222,
         boot_installed=True,
     )
@@ -1295,6 +1297,7 @@ def test_negative_cluster_limit_is_refused_before_building() -> None:
         main(["vm-lvm", "--limit", "-1"])
 
 
+@pytest.mark.lab
 def test_zero_cluster_capacity_returns_an_error_after_a_deadline(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
@@ -1487,6 +1490,7 @@ def test_workdirs_are_confined_before_any_vm_artifact_is_written(
     ) == 1
 
 
+@pytest.mark.lab
 def test_parallel_driver_builds_do_not_share_staging(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
@@ -2957,6 +2961,7 @@ def test_the_local_runner_pins_no_interface_name_either() -> None:
         assert "eth0" not in address, address
 
 
+@pytest.mark.lab
 def test_create_target_refuses_a_path_outside_the_run_directories(tmp_path: Path) -> None:
     """Its first act is to delete the file it is given. The images an in-place
     conversion will be handed are downloaded once and kept — `lab/vm/cloud/`
@@ -3746,6 +3751,7 @@ def test_a_check_reads_the_output_and_not_the_question(tmp_path: Path) -> None:
     assert b"RESOLVCONF-OK" in whole, "the echo is what the old reading carried"
 
 
+@pytest.mark.lab
 def test_the_driver_medium_reaches_a_guest_with_no_ata_driver(tmp_path: Path) -> None:
     """The Debian genericcloud kernel builds no ATA or AHCI driver, so a
     `media=cdrom` drive gave the guest no `/dev/sr*` at all: measured inside
@@ -4046,7 +4052,7 @@ def test_the_result_disk_is_named_and_not_numbered() -> None:
     spec = VmSpec(
         medium=MEDIA["official-minimal"],
         workdir=Path("/tmp"),
-        firmware=Firmware.UEFI,
+        firmware=Firmware.BIOS,
         disks=(Path("/tmp/result.img"),),
         driver_iso=Path("/tmp/driver.iso"),
         boot_installed=True,


### PR DESCRIPTION
`mypy` and `pytest` ran on one workstation and nowhere else: a branch pushed here got no check, and every merge rested on whoever remembered to run them.

The workflow runs both on 3.13. It does not run `tests/vm/`, which drives real guests and needs a hypervisor; `mypy` already type-checks against the 3.11 floor `pyproject.toml` declares, and this workstation has only 3.14, so pinning the runner to 3.11 would be a check nobody here has ever run.