### PR TITLE
docs: record two cluster rounds in TESTED.md

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,26 @@
+# Code of conduct
+
+## The standard
+
+Be accurate and be civil. Those are the whole of it.
+
+- Bring evidence: a revision, a log, a command someone else can run. A bug
+  report without one is a guess, and a review comment without one is an
+  opinion.
+- Say what you mean plainly. Neither deference nor contempt makes a patch
+  correct.
+- Assume the other person read the same file you did and reached a different
+  conclusion. Ask which line, not which motive.
+
+## Not welcome
+
+Harassment, personal attacks, and material that targets someone for who they
+are rather than for what they wrote. Deliberately wasting a reviewer's time —
+patches nobody ran, reports nobody reproduced, arguments nobody can check —
+is the same failure in a slower form.
+
+## Enforcement
+
+Reports go to <zakk@gentoozh.org>. The maintainer reads them and decides:
+a correction, a rejected patch, or a ban. There is no committee and no appeal
+process; there is one person and a public history of what was decided.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,37 @@
+# Security
+
+## What this program does
+
+`gentoo-install` partitions disks, writes filesystems, installs a bootloader
+and configures the system that boots afterwards. Every one of those is
+destructive on the wrong machine, and the program is normally run as root from
+a live medium.
+
+## Reporting
+
+Report a vulnerability privately to <zakk@gentoozh.org>. Do not open a public
+issue for one. A report that names the revision, the configuration and the
+command line is one that can be reproduced; one that names a machine's
+passphrase is one that has to be discarded, so redact secrets first.
+
+There is no bounty and no service-level agreement. The project is maintained
+by one person: a reply comes when there is one to give.
+
+## Where the risk is
+
+- **The configuration is executable.** A TOML file selects disks, mirrors,
+  overlays and packages. Treat one you did not write as you would a shell
+  script from the same source.
+- **Passphrases are staged in a file.** A LUKS or ZFS passphrase is written
+  under `/run/gentoo-install/keys/` with mode `0600` for the command that
+  reads it, and `/run` is a tmpfs, so it does not survive the reboot into the
+  installed system. The installer does not delete it before then. `--paste`
+  replaces `password_hash` and `root_password_hash` and drops the proxy
+  username and password, so a published configuration carries neither.
+- **What is verified.** The stage3 is checked against its DIGESTS and its
+  OpenPGP signature; the repository snapshot is verified by `emerge-webrsync`;
+  binary packages are refused unless their host's key is imported and locally
+  signed, and a failure there degrades to compiling from source rather than
+  installing something unverified.
+- **What is not.** Overlays are cloned over HTTPS and are not signed by this
+  program. A mirror the operator names is trusted to serve what it claims.

--- a/TESTED.md
+++ b/TESTED.md
@@ -42,6 +42,8 @@ The ordinary path: partition, format, unpack a stage3, configure, boot.
 | `e2986684da66` | `ext3`, `vm-unlock`, `vm-zfs-mirror`, `vm-raidz` — `ext3` and `vm-unlock` are the two the login work fixed: `login` prints `Maximum number of tries exceeded` instead of a third refusal, and it prints all three in the installed system's own locale |
 | `7fcc7edcec6b` | `openrc-sdboot`, `mbr-edit` — `mbr-edit`'s first record at all: it installed in 46.6 minutes in an earlier round and lost the login every time |
 | `18f150282cb1` | `vm-lvm`, `static-ip`, `ext2` — three of three |
+| `3692e4b29743` | `vm-zfs`, `vm-f2fs`, `vm-luks`, `vm-lvm`, `vm-mdraid`, `vm-unlock`, `vm-xfs`, `vm-zram` — eight of ten; `ext3` was refused by its own login again, which `2849e42a151a` addresses |
+| `2849e42a151a` | `ext3` — the first record of `ext3` since the harness waits for the name's echo before the password prompt, the race that had left `Password:` in the buffer and typed the password into the name field |
 
 Every row from `08015b221d73` onward ran `--region cn --site nju --sync
 webrsync --distfiles http://10.31.0.2/gentoo`, so what they establish about

--- a/tests/unit/test_project_docs.py
+++ b/tests/unit/test_project_docs.py
@@ -1,0 +1,43 @@
+# SPDX-License-Identifier: GPL-2.0-or-later
+"""The documents a contributor reads before the code: SECURITY and the code of
+conduct. What they claim about the program is checked against the program."""
+
+from __future__ import annotations
+
+from dataclasses import fields
+from pathlib import Path
+
+import pytest
+
+from gentoo_install.model.config import ProxyConfig
+from gentoo_install.model.serialise import SECRET
+
+ROOT = Path(__file__).resolve().parents[2]
+
+#: The address every report goes to. One address, so a document that names a
+#: different one sends a vulnerability report nobody reads.
+CONTACT = "zakk@gentoozh.org"
+
+DOCUMENTS = ("SECURITY.md", "CODE_OF_CONDUCT.md")
+
+
+@pytest.mark.parametrize("name", DOCUMENTS)
+def test_a_report_has_somewhere_to_go(name: str) -> None:
+    said = (ROOT / name).read_text(encoding="utf-8")
+    assert CONTACT in said, f"{name} names no address to report to"
+
+
+def test_security_names_what_publishing_actually_removes() -> None:
+    """`SECURITY.md` tells an operator which values `--paste` takes out. The
+    list is `serialise.SECRET` plus the two proxy credentials, and a field
+    added to one and not the other leaves the document promising a protection
+    that is not there."""
+    said = (ROOT / "SECURITY.md").read_text(encoding="utf-8")
+    paragraph = next(part for part in said.split("\n- ") if "--paste" in part)
+
+    for name in SECRET:
+        assert f"`{name}`" in paragraph, name
+    dropped = {"username", "password"}
+    assert dropped <= {field.name for field in fields(ProxyConfig)}, "the model moved"
+    for name in dropped:
+        assert name in paragraph, name


### PR DESCRIPTION
`3692e4b29743` took eight of ten and lost `ext3` at the installed system's login. `2849e42a151a` is the first round in which `ext3` reached that login and passed, which is what the name-echo wait was for.