### PR TITLE
tui: move what every screen shares into tui/context.py

### DIFF
--- a/gentoo_install/cli.py
+++ b/gentoo_install/cli.py
@@ -37,6 +37,7 @@ from .exec.runner import Runner
 from .model.device import StorageFacts, StorageLayout, ZfsPool
 from .model.size import Size
 from .tui import app, screens
+from .tui import context as tui_context
 from .tui.curses_screen import CursesScreen, too_small
 from .i18n import Catalog, tag_for
 from .model import mirrors, qr, templates
@@ -889,7 +890,7 @@ def _from_menu(arguments: argparse.Namespace) -> InstallConfig | None:
         raise errors.PreflightFailed(f"the menu needs {', '.join(sorted(lacking))}")
     running_system, conversion_refused = _conversion_offer(probe)
     image_write_refused = _image_write_offer(probe)
-    context = screens.Context(
+    context = tui_context.Context(
         translate=Catalog(tag_for(override=arguments.lang)),
         ipv4=has_ipv4,
         ipv6=has_ipv6,

--- a/gentoo_install/tui/app.py
+++ b/gentoo_install/tui/app.py
@@ -20,8 +20,8 @@ from ..model.config import DiskMode, InstallConfig
 from ..errors import GentooInstallError
 from ..plan.build import build
 from .overview import overview_screen
-from .screens import Context
-from .screens import _say as say
+from .context import Context
+from .context import say
 from .settings import SETTINGS, UNSET, Setting, settings_for, shown_value, style_of, unanswered
 from .widgets import Item, Menu, Outcome, Screen, Style, TextField
 

--- a/gentoo_install/tui/context.py
+++ b/gentoo_install/tui/context.py
@@ -1,0 +1,356 @@
+# SPDX-License-Identifier: GPL-2.0-or-later
+"""What every screen needs and no screen owns.
+
+`settings.py`, `overview.py` and `app.py` all reach for `Context`, the footer
+and the one-line acknowledgement, and each import of them from `screens.py`
+made a screen module the place a caller went for a shared type. The import
+direction is one way: this module knows nothing about a screen.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from enum import Enum
+from typing import Callable, Sequence, TypedDict
+
+from ..errors import ConfigError, GentooInstallError
+from ..i18n import Catalog, truncate
+from ..model import manual, qr
+from ..model.config import (
+    Firmware,
+    InstallConfig,
+)
+from ..model.device import (
+    Existing,
+    Filesystem,
+    FilesystemType,
+    Luks,
+    Mountpoint,
+    Partition,
+    PartitionTable,
+    Swap,
+    ZfsPool,
+)
+from ..model.size import ZERO, Size
+from ..model.templates import Choice, Layout
+from ..plan.packages import Catalog as Groups
+from .widgets import Answer, Item, Menu, Screen
+
+#: A screen takes what has been decided and returns it changed.
+Step = Callable[[Screen, InstallConfig, "Context"], Answer[InstallConfig]]
+
+
+class ValueKind(Enum):
+    """A configuration value whose source must survive a later choice."""
+
+    USE_FLAG = "use flag"
+    VIDEO_CARD = "video card"
+    NETWORKING = "networking"
+    DISPLAY_MANAGER = "display manager"
+
+
+class ValueSource(Enum):
+    """Whether the operator or a TUI choice supplied a value."""
+
+    OPERATOR = "operator"
+    DERIVED = "derived"
+
+
+@dataclass(frozen=True)
+class ValueProvenance:
+    """The source of one value in the current TUI session."""
+
+    kind: ValueKind
+    value: str
+    source: ValueSource
+
+
+def _cannot_load(name: str) -> InstallConfig:
+    raise ConfigError(f"this installer was built with no way to read {name}")
+
+
+class Context:
+    """What the screens need besides the configuration itself."""
+
+    columns: int
+    visited: set[str]
+
+    def __init__(
+        self,
+        translate: Catalog,
+        disks: Sequence[tuple[str, str]],
+        groups: Groups,
+        hash_password: Callable[[str], str],
+        stage_passphrase: Callable[[str], str] = lambda text: "",
+        timezones: Sequence[str] = (),
+        firmware: Firmware = Firmware.UEFI,
+        cores: int = 1,
+        memory: Size = ZERO,
+        cpu_flags: Sequence[str] = (),
+        supports_v3: bool = False,
+        inspect_disk: Callable[[str], tuple[tuple[tuple[str, str, str], ...], str]] = (
+            lambda disk: ((), "")
+        ),
+        #: Every spelling of one device, for the erase confirmation. The
+        #: default answers with the selector alone: only the machine knows
+        #: which kernel name it resolves to today.
+        names_for: Callable[[str], tuple[str, ...]] = lambda selector: (selector,),
+        fetch_text: Callable[[str], str] = lambda url: "",
+        kernel_versions: Callable[[str], tuple[tuple[str, bool], ...]] = lambda atom: (),
+        keymaps: Callable[[], tuple[tuple[str, str], ...]] = lambda: (),
+        timezone_here: str = "",
+        zfs_kernel_max: str = "",
+        save_config: Callable[[InstallConfig, str], str] = lambda config, name: "",
+        publish_config: Callable[[InstallConfig], str] = lambda config: "",
+        #: Configuration files sitting where the installer was started, and how
+        #: to read one. An operator who saved their answers and rebooted should
+        #: not have to retype them or remember the `--config` flag.
+        configs_here: Sequence[str] = (),
+        load_config: Callable[[str], InstallConfig] | None = None,
+        zfs_unavailable: str = "",
+        #: Whether this machine has a routable address of each family. A
+        #: mirror with no AAAA record cannot be reached from an IPv6-only
+        #: machine, and the menu says so rather than letting the operator find
+        #: out when the stage3 does not arrive. Both true by default: a
+        #: machine that cannot be read refuses nothing.
+        ipv4: bool = True,
+        ipv6: bool = True,
+        profile_paths: Sequence[str] = (),
+        #: What the running system is, in one line, and why it cannot be
+        #: converted in place. The description is shown so the operator can see
+        #: which machine was read; the refusal is empty when a conversion is
+        #: possible. Both come from `exec/probe.py` and `plan/convert.py`,
+        #: because this layer reads no machine. A machine that could not be
+        #: read refuses the conversion rather than offering one blind.
+        running_system: str = "",
+        conversion_refused: str = "the running system was not read",
+        image_write_refused: str = "the memory environment was not read",
+    ) -> None:
+        self.translate = translate
+        self.running_system = running_system
+        self.conversion_refused = conversion_refused
+        self.image_write_refused = image_write_refused
+        self.ipv4 = ipv4
+        self.ipv6 = ipv6
+        self.profile_paths = tuple(profile_paths)
+        #: Selector and a human description, from `exec/probe.py`.
+        self.disks = disks
+        self.groups = groups
+        #: Injected rather than imported: the model layer does no I/O, and
+        #: hashing runs `openssl` on the installing system.
+        self.hash_password = hash_password
+        #: Writes a passphrase into the run's work directory and returns its
+        #: path. Injected because the model layer does no I/O.
+        self.stage_passphrase = stage_passphrase
+        #: Reads a short document over the network, for a key someone pasted
+        #: somewhere. Injected because this layer opens no connection.
+        self.fetch_text = fetch_text
+        #: Versions of a kernel package this machine can see, newest first,
+        #: each with whether it is stable on amd64. Empty on a medium with no
+        #: repository, which is when the version is typed instead.
+        self.kernel_versions = kernel_versions
+        #: Writes the configuration under the given name and returns the path.
+        #: Injected because this layer opens no file.
+        self.save_config = save_config
+        #: Sends the configuration to the pastebin and returns the address.
+        #: Injected because this layer opens no connection.
+        self.publish_config = publish_config
+        self.configs_here = tuple(configs_here)
+        #: Defaulted to a refusal rather than to a blank configuration: a
+        #: double that silently answers with defaults would let the screen
+        #: report a load that never happened.
+        self.load_config: Callable[[str], InstallConfig] = load_config or _cannot_load
+        #: Why this live system cannot make a pool, or empty when it can. Every
+        #: row that would produce one is drawn with this as its reason, because
+        #: the medium the installer runs from is often not a Gentoo one.
+        self.zfs_unavailable = zfs_unavailable
+        #: Every console keymap the machine ships, as (family, name). Empty on
+        #: a medium with no keymap tree, which is when the name is typed.
+        self.keymaps = keymaps
+        #: The highest kernel `sys-fs/zfs` builds a module for, read from its
+        #: ebuild. Empty when no repository is visible, which offers every version.
+        self.zfs_kernel_max = zfs_kernel_max
+        #: The zone the installing system is on, from its `/etc/localtime`. A
+        #: live medium sets that from the firmware clock and its own default,
+        #: so it is the one guess about where the machine is that costs nothing.
+        self.timezone_here = timezone_here
+        #: Every zone the machine knows, from `exec/probe.py`.
+        self.timezones = tuple(timezones)
+        #: How this machine booted. The install defaults to the same, because
+        #: installing for the other is almost always a mistake.
+        self.firmware = firmware
+        #: Kept so a disk screen can rebuild the graph when one answer changes,
+        #: rather than editing a graph it did not build.
+        self.choice = Choice(disk=disks[0][0] if disks else "", firmware=firmware)
+        #: Selectors whose destruction the operator confirmed by typing the
+        #: name. A set rather than one flag: a layout can destroy content on
+        #: more than one device, and a single flag confirmed for the first
+        #: disk authorised a second one the prompt never named.
+        self.confirmed: set[str] = set()
+        self.provenance: set[ValueProvenance] = set()
+        #: The hand-written partition table, when the layout is manual.
+        self.layout = manual.Layout()
+        #: Whether the disk comes from that table rather than a template.
+        self.manual = False
+        #: What the chosen disk holds now, and how big it is. Both come from
+        #: `exec/probe.py` and are shown before anything is erased.
+        self.existing: tuple[tuple[str, str, str], ...] = ()
+        self.disk_size = ""
+        #: The catalog's tag, so the language screen can preselect it.
+        self.tag = translate.tag
+        #: This machine's core count and instruction set, for the rows that
+        #: recommend a value rather than asking for one blind.
+        self.cores = cores
+        self.memory = memory
+        self.cpu_flags = tuple(cpu_flags)
+        #: Whether `ld.so` says this CPU runs x86-64-v3 binaries.
+        self.supports_v3 = supports_v3
+        self._inspect = inspect_disk
+        #: Every spelling of one device, for the erase confirmation.
+        self.names_for = names_for
+        self._inspected: dict[str, tuple[tuple[tuple[str, str, str], ...], str]] = {}
+        if self.choice.disk:
+            self.inspect_disk(self.choice.disk)
+
+    def hydrate_disk(self, config: InstallConfig) -> None:
+        """Align the editable disk choice with a loaded configuration graph."""
+        disks = config.disk.graph.of_type(Existing)
+        if not disks:
+            return
+        disk = disks[0].selector
+        table = next(
+            (one.table for one in config.disk.graph.of_type(PartitionTable) if one.disk in config.disk.graph.nodes),
+            None,
+        )
+        root = config.disk.graph[config.disk.root]
+        root_device = root.source if isinstance(root, Mountpoint) else None
+        root_fs = FilesystemType.EXT4
+        for filesystem in config.disk.graph.of_type(Filesystem):
+            if root_device == filesystem.id or (
+                root_device is not None and filesystem.id in config.disk.graph.ancestors_of(root_device)
+            ):
+                root_fs = filesystem.kind
+                break
+        layout = Layout.WHOLE_DISK
+        if config.disk.graph.of_type(ZfsPool):
+            layout = Layout.WHOLE_DISK_ZFS
+        elif root_fs is FilesystemType.BTRFS:
+            layout = Layout.WHOLE_DISK_BTRFS
+        swap = next(
+            (
+                partition.size
+                for one in config.disk.graph.of_type(Swap)
+                if isinstance((partition := config.disk.graph[one.device]), Partition)
+            ),
+            None,
+        )
+        encrypted = next(
+            (one.passphrase_file for one in config.disk.graph.of_type(Luks)),
+            next((one.passphrase_file for one in config.disk.graph.of_type(ZfsPool)), ""),
+        )
+        self.choice = Choice(
+            disk=disk,
+            layout=layout,
+            firmware=self.firmware,
+            table=table,
+            filesystem=root_fs,
+            swap=swap,
+            passphrase_file=encrypted,
+        )
+        self.manual = False
+        self.layout = manual.Layout()
+        self.confirmed.clear()
+        self.inspect_disk(disk)
+
+    def shown_as(self, selector: str) -> str:
+        """What to call a device on screen.
+
+        The configuration keeps the `/dev/disk/by-id/` selector, because a
+        kernel name is assigned at probe time and one saved today installs
+        somewhere else after the next reboot. Nobody reads sixty characters of
+        it: the screen says `/dev/sda`, which is what `lsblk` says too.
+        """
+        paths = [
+            one
+            for one in self.names_for(selector)
+            if one.startswith("/dev/") and one != selector
+        ]
+        return min(paths, key=len) if paths else selector.rsplit("/", 1)[-1]
+
+    def inspect_disk(self, disk: str) -> None:
+        self.existing, self.disk_size = self.contents(disk)
+
+    def contents(self, disk: str) -> tuple[tuple[tuple[str, str, str], ...], str]:
+        """What that disk holds and how big it is, asked once per disk.
+
+        Cached because the partition screen redraws after every edit and a
+        manual table may span several disks; `lsblk` per disk per keystroke is
+        a visible pause on a machine with a dozen of them.
+        """
+        known = self._inspected.get(disk)
+        if known is None:
+            known = self._inspect(disk)
+            self._inspected[disk] = known
+        return known
+
+
+class Answers(TypedDict):
+    no: str
+    yes: str
+
+
+def answers(translate: Catalog) -> Answers:
+    """The yes and no a `Confirm` shows. Every one of them reads them from the
+    catalog, so a translated interface does not answer in English."""
+    return {"no": translate("No"), "yes": translate("Yes")}
+
+
+def footer(translate: Catalog, enter: str = "Continue") -> str:
+    """What each key does here. `enter` names the action of this screen: the
+    overview said `Continue` on the screen where enter starts the install."""
+    return "  ".join(
+        (
+            f"[enter] {translate(enter)}",
+            f"[backspace] {translate('Back')}",
+            f"[q] {translate('Cancel')}",
+        )
+    )
+
+
+
+def say(screen: Screen, context: Context, message: str) -> Answer[None]:
+    """One line the operator has to acknowledge, so a rejected entry is not
+    silently redrawn as an empty field."""
+    answer = Menu(
+        title=message,
+        items=[Item(label=context.translate("Continue"), value=0)],
+        footer=footer(context.translate),
+    ).run(screen)
+    return Answer(answer.outcome)
+
+
+
+def show_address(screen: Screen, context: Context, url: str) -> None:
+    """The address as a code and as text, on the screen the operator is on.
+
+    The machine showing this has no browser and no way to copy a line off its
+    console. Drawn here rather than after curses exits, because the operator
+    asked for it from the overview and is going back to the overview.
+    """
+    lines, columns = screen.size()
+    drawn = []
+    try:
+        drawn = qr.halved(qr.encode(url))
+    except GentooInstallError:
+        # Too long for the versions the encoder covers. The address still is
+        # the answer, and it is printed either way.
+        drawn = []
+    if drawn and (len(drawn[0]) > columns or len(drawn) + 4 > lines):
+        drawn = []
+    screen.clear()
+    screen.write(0, 0, truncate(url, columns))
+    for index, line in enumerate(drawn):
+        screen.write(index + 2, 0, line)
+    screen.write(min(len(drawn) + 3, lines - 1), 0, context.translate("Continue"))
+    screen.show()
+    screen.key()

--- a/gentoo_install/tui/overview.py
+++ b/gentoo_install/tui/overview.py
@@ -12,7 +12,7 @@ from ..plan import automatic as automatic_values
 from ..plan.build import build as plan_build
 from ..plan.operations import Operation
 from ..plan.render import counts
-from .screens import Context, _say, answers, footer, show_address
+from .context import Context, answers, footer, say, show_address
 from .settings import SETTINGS, UNSET
 from .widgets import Answer, Confirm, Item, Menu, Outcome, Screen
 
@@ -47,7 +47,7 @@ def overview_screen(
     try:
         operations = plan_build(config, context.groups)
     except GentooInstallError as error:
-        _say(screen, context, str(error).splitlines()[-1].strip())
+        say(screen, context, str(error).splitlines()[-1].strip())
         return Answer(Outcome.CANCELLED)
     items: list[Item[int]] = []
     for group in SETTINGS:
@@ -115,7 +115,7 @@ def overview_screen(
         try:
             show_address(screen, context, context.publish_config(config))
         except GentooInstallError as error:
-            _say(screen, context, str(error))
+            say(screen, context, str(error))
     confirmed = Confirm(
         **answers(translate),
         title=translate("Install"),

--- a/gentoo_install/tui/screens.py
+++ b/gentoo_install/tui/screens.py
@@ -87,6 +87,18 @@ from ..plan.packages import FONT_CONFIGURATION_DISABLED, FONT_CONFIGURATION_ENAB
 from ..plan.packages import INPUT_CONFIGURATION_DISABLED, INPUT_CONFIGURATION_ENABLED
 from ..plan.packages import driver_conflict, framework_conflict
 from ..plan import system as plan_system
+from .context import (
+    Answers,
+    Context,
+    Step,
+    ValueKind,
+    ValueProvenance,
+    ValueSource,
+    answers,
+    footer,
+    say,
+    show_address,
+)
 from .widgets import (
     Accepts,
     band,
@@ -103,283 +115,6 @@ from .widgets import (
     Screen,
     TextField,
 )
-
-#: A screen takes what has been decided and returns it changed.
-Step = Callable[[Screen, InstallConfig, "Context"], Answer[InstallConfig]]
-
-
-class ValueKind(Enum):
-    """A configuration value whose source must survive a later choice."""
-
-    USE_FLAG = "use flag"
-    VIDEO_CARD = "video card"
-    NETWORKING = "networking"
-    DISPLAY_MANAGER = "display manager"
-
-
-class ValueSource(Enum):
-    """Whether the operator or a TUI choice supplied a value."""
-
-    OPERATOR = "operator"
-    DERIVED = "derived"
-
-
-@dataclass(frozen=True)
-class ValueProvenance:
-    """The source of one value in the current TUI session."""
-
-    kind: ValueKind
-    value: str
-    source: ValueSource
-
-
-class Context:
-    """What the screens need besides the configuration itself."""
-
-    columns: int
-    visited: set[str]
-
-    def __init__(
-        self,
-        translate: Catalog,
-        disks: Sequence[tuple[str, str]],
-        groups: Groups,
-        hash_password: Callable[[str], str],
-        stage_passphrase: Callable[[str], str] = lambda text: "",
-        timezones: Sequence[str] = (),
-        firmware: Firmware = Firmware.UEFI,
-        cores: int = 1,
-        memory: Size = ZERO,
-        cpu_flags: Sequence[str] = (),
-        supports_v3: bool = False,
-        inspect_disk: Callable[[str], tuple[tuple[tuple[str, str, str], ...], str]] = (
-            lambda disk: ((), "")
-        ),
-        #: Every spelling of one device, for the erase confirmation. The
-        #: default answers with the selector alone: only the machine knows
-        #: which kernel name it resolves to today.
-        names_for: Callable[[str], tuple[str, ...]] = lambda selector: (selector,),
-        fetch_text: Callable[[str], str] = lambda url: "",
-        kernel_versions: Callable[[str], tuple[tuple[str, bool], ...]] = lambda atom: (),
-        keymaps: Callable[[], tuple[tuple[str, str], ...]] = lambda: (),
-        timezone_here: str = "",
-        zfs_kernel_max: str = "",
-        save_config: Callable[[InstallConfig, str], str] = lambda config, name: "",
-        publish_config: Callable[[InstallConfig], str] = lambda config: "",
-        #: Configuration files sitting where the installer was started, and how
-        #: to read one. An operator who saved their answers and rebooted should
-        #: not have to retype them or remember the `--config` flag.
-        configs_here: Sequence[str] = (),
-        load_config: Callable[[str], InstallConfig] | None = None,
-        zfs_unavailable: str = "",
-        #: Whether this machine has a routable address of each family. A
-        #: mirror with no AAAA record cannot be reached from an IPv6-only
-        #: machine, and the menu says so rather than letting the operator find
-        #: out when the stage3 does not arrive. Both true by default: a
-        #: machine that cannot be read refuses nothing.
-        ipv4: bool = True,
-        ipv6: bool = True,
-        profile_paths: Sequence[str] = (),
-        #: What the running system is, in one line, and why it cannot be
-        #: converted in place. The description is shown so the operator can see
-        #: which machine was read; the refusal is empty when a conversion is
-        #: possible. Both come from `exec/probe.py` and `plan/convert.py`,
-        #: because this layer reads no machine. A machine that could not be
-        #: read refuses the conversion rather than offering one blind.
-        running_system: str = "",
-        conversion_refused: str = "the running system was not read",
-        image_write_refused: str = "the memory environment was not read",
-    ) -> None:
-        self.translate = translate
-        self.running_system = running_system
-        self.conversion_refused = conversion_refused
-        self.image_write_refused = image_write_refused
-        self.ipv4 = ipv4
-        self.ipv6 = ipv6
-        self.profile_paths = tuple(profile_paths)
-        #: Selector and a human description, from `exec/probe.py`.
-        self.disks = disks
-        self.groups = groups
-        #: Injected rather than imported: the model layer does no I/O, and
-        #: hashing runs `openssl` on the installing system.
-        self.hash_password = hash_password
-        #: Writes a passphrase into the run's work directory and returns its
-        #: path. Injected because the model layer does no I/O.
-        self.stage_passphrase = stage_passphrase
-        #: Reads a short document over the network, for a key someone pasted
-        #: somewhere. Injected because this layer opens no connection.
-        self.fetch_text = fetch_text
-        #: Versions of a kernel package this machine can see, newest first,
-        #: each with whether it is stable on amd64. Empty on a medium with no
-        #: repository, which is when the version is typed instead.
-        self.kernel_versions = kernel_versions
-        #: Writes the configuration under the given name and returns the path.
-        #: Injected because this layer opens no file.
-        self.save_config = save_config
-        #: Sends the configuration to the pastebin and returns the address.
-        #: Injected because this layer opens no connection.
-        self.publish_config = publish_config
-        self.configs_here = tuple(configs_here)
-        #: Defaulted to a refusal rather than to a blank configuration: a
-        #: double that silently answers with defaults would let the screen
-        #: report a load that never happened.
-        self.load_config: Callable[[str], InstallConfig] = load_config or _cannot_load
-        #: Why this live system cannot make a pool, or empty when it can. Every
-        #: row that would produce one is drawn with this as its reason, because
-        #: the medium the installer runs from is often not a Gentoo one.
-        self.zfs_unavailable = zfs_unavailable
-        #: Every console keymap the machine ships, as (family, name). Empty on
-        #: a medium with no keymap tree, which is when the name is typed.
-        self.keymaps = keymaps
-        #: The highest kernel `sys-fs/zfs` builds a module for, read from its
-        #: ebuild. Empty when no repository is visible, which offers every version.
-        self.zfs_kernel_max = zfs_kernel_max
-        #: The zone the installing system is on, from its `/etc/localtime`. A
-        #: live medium sets that from the firmware clock and its own default,
-        #: so it is the one guess about where the machine is that costs nothing.
-        self.timezone_here = timezone_here
-        #: Every zone the machine knows, from `exec/probe.py`.
-        self.timezones = tuple(timezones)
-        #: How this machine booted. The install defaults to the same, because
-        #: installing for the other is almost always a mistake.
-        self.firmware = firmware
-        #: Kept so a disk screen can rebuild the graph when one answer changes,
-        #: rather than editing a graph it did not build.
-        self.choice = Choice(disk=disks[0][0] if disks else "", firmware=firmware)
-        #: Selectors whose destruction the operator confirmed by typing the
-        #: name. A set rather than one flag: a layout can destroy content on
-        #: more than one device, and a single flag confirmed for the first
-        #: disk authorised a second one the prompt never named.
-        self.confirmed: set[str] = set()
-        self.provenance: set[ValueProvenance] = set()
-        #: The hand-written partition table, when the layout is manual.
-        self.layout = manual.Layout()
-        #: Whether the disk comes from that table rather than a template.
-        self.manual = False
-        #: What the chosen disk holds now, and how big it is. Both come from
-        #: `exec/probe.py` and are shown before anything is erased.
-        self.existing: tuple[tuple[str, str, str], ...] = ()
-        self.disk_size = ""
-        #: The catalog's tag, so the language screen can preselect it.
-        self.tag = translate.tag
-        #: This machine's core count and instruction set, for the rows that
-        #: recommend a value rather than asking for one blind.
-        self.cores = cores
-        self.memory = memory
-        self.cpu_flags = tuple(cpu_flags)
-        #: Whether `ld.so` says this CPU runs x86-64-v3 binaries.
-        self.supports_v3 = supports_v3
-        self._inspect = inspect_disk
-        #: Every spelling of one device, for the erase confirmation.
-        self.names_for = names_for
-        self._inspected: dict[str, tuple[tuple[tuple[str, str, str], ...], str]] = {}
-        if self.choice.disk:
-            self.inspect_disk(self.choice.disk)
-
-    def hydrate_disk(self, config: InstallConfig) -> None:
-        """Align the editable disk choice with a loaded configuration graph."""
-        disks = config.disk.graph.of_type(Existing)
-        if not disks:
-            return
-        disk = disks[0].selector
-        table = next(
-            (one.table for one in config.disk.graph.of_type(PartitionTable) if one.disk in config.disk.graph.nodes),
-            None,
-        )
-        root = config.disk.graph[config.disk.root]
-        root_device = root.source if isinstance(root, Mountpoint) else None
-        root_fs = FilesystemType.EXT4
-        for filesystem in config.disk.graph.of_type(Filesystem):
-            if root_device == filesystem.id or (
-                root_device is not None and filesystem.id in config.disk.graph.ancestors_of(root_device)
-            ):
-                root_fs = filesystem.kind
-                break
-        layout = Layout.WHOLE_DISK
-        if config.disk.graph.of_type(ZfsPool):
-            layout = Layout.WHOLE_DISK_ZFS
-        elif root_fs is FilesystemType.BTRFS:
-            layout = Layout.WHOLE_DISK_BTRFS
-        swap = next(
-            (
-                partition.size
-                for one in config.disk.graph.of_type(Swap)
-                if isinstance((partition := config.disk.graph[one.device]), Partition)
-            ),
-            None,
-        )
-        encrypted = next(
-            (one.passphrase_file for one in config.disk.graph.of_type(Luks)),
-            next((one.passphrase_file for one in config.disk.graph.of_type(ZfsPool)), ""),
-        )
-        self.choice = Choice(
-            disk=disk,
-            layout=layout,
-            firmware=self.firmware,
-            table=table,
-            filesystem=root_fs,
-            swap=swap,
-            passphrase_file=encrypted,
-        )
-        self.manual = False
-        self.layout = manual.Layout()
-        self.confirmed.clear()
-        self.inspect_disk(disk)
-
-    def shown_as(self, selector: str) -> str:
-        """What to call a device on screen.
-
-        The configuration keeps the `/dev/disk/by-id/` selector, because a
-        kernel name is assigned at probe time and one saved today installs
-        somewhere else after the next reboot. Nobody reads sixty characters of
-        it: the screen says `/dev/sda`, which is what `lsblk` says too.
-        """
-        paths = [
-            one
-            for one in self.names_for(selector)
-            if one.startswith("/dev/") and one != selector
-        ]
-        return min(paths, key=len) if paths else selector.rsplit("/", 1)[-1]
-
-    def inspect_disk(self, disk: str) -> None:
-        self.existing, self.disk_size = self.contents(disk)
-
-    def contents(self, disk: str) -> tuple[tuple[tuple[str, str, str], ...], str]:
-        """What that disk holds and how big it is, asked once per disk.
-
-        Cached because the partition screen redraws after every edit and a
-        manual table may span several disks; `lsblk` per disk per keystroke is
-        a visible pause on a machine with a dozen of them.
-        """
-        known = self._inspected.get(disk)
-        if known is None:
-            known = self._inspect(disk)
-            self._inspected[disk] = known
-        return known
-
-
-class Answers(TypedDict):
-    no: str
-    yes: str
-
-
-def answers(translate: Catalog) -> Answers:
-    """The yes and no a `Confirm` shows. Every one of them reads them from the
-    catalog, so a translated interface does not answer in English."""
-    return {"no": translate("No"), "yes": translate("Yes")}
-
-
-def footer(translate: Catalog, enter: str = "Continue") -> str:
-    """What each key does here. `enter` names the action of this screen: the
-    overview said `Continue` on the screen where enter starts the install."""
-    return "  ".join(
-        (
-            f"[enter] {translate(enter)}",
-            f"[backspace] {translate('Back')}",
-            f"[q] {translate('Cancel')}",
-        )
-    )
-
 
 def _rebuild(config: InstallConfig, context: Context) -> InstallConfig:
     """The disk graph, from whichever description the operator is editing.
@@ -813,7 +548,7 @@ def _confirm_one(
             return None
         # Said rather than swallowed: a trailing space read as a refusal, and
         # the row went back to unset with nothing explaining why.
-        _say(screen, context, translate("That is not the name of this disk."))
+        say(screen, context, translate("That is not the name of this disk."))
 
 
 def system_screen(screen: Screen, config: InstallConfig, context: Context) -> Answer[InstallConfig]:
@@ -1671,7 +1406,7 @@ def logger_screen(screen: Screen, config: InstallConfig, context: Context) -> An
     """
     translate = context.translate
     if config.system.init is InitSystem.SYSTEMD:
-        _say(screen, context, translate("systemd logs to journald; no other logger is needed."))
+        say(screen, context, translate("systemd logs to journald; no other logger is needed."))
         return Answer(Outcome.BACK)
     menu: Menu[Logger] = Menu(
         title=translate("System logger"),
@@ -1770,7 +1505,7 @@ def kernel_screen(screen: Screen, config: InstallConfig, context: Context) -> An
         # Turned off with the kernel that carried it, and said out loud: the
         # rule would otherwise refuse the install with a message about the
         # kernel, from a row that has no way to clear this.
-        _say(screen, context, translate("This kernel has no cjktty: console CJK is off."))
+        say(screen, context, translate("This kernel has no cjktty: console CJK is off."))
         changed = replace(changed, system=replace(changed.system, console_cjk=False))
     return Answer(Outcome.CHOSE, changed)
 
@@ -2229,7 +1964,7 @@ def graphics_screen(
         if not clash:
             return settle(screen, context, config, chosen)
         ticked = set(answer.unwrap())
-        _say(screen, context, translate(clash))
+        say(screen, context, translate(clash))
 
 
 def display_manager_screen(
@@ -2883,7 +2618,7 @@ def packages_screen(
         if not clash:
             return settle(screen, context, config, edited)
         chosen_already = set(chosen)
-        _say(screen, context, clash)
+        say(screen, context, clash)
 
 
 #: `zpool create` refuses anything shorter, and LUKS with a short passphrase is
@@ -3082,7 +2817,7 @@ def encryption_screen(screen: Screen, config: InstallConfig, context: Context) -
         # `_rebuild` builds from `context.layout` here and reads none of
         # `context.choice`, so staging a passphrase left the row reading `on`
         # over a graph with no container in it at all.
-        _say(screen, context, translate("Encryption is a field of each partition, under Partitions."))
+        say(screen, context, translate("Encryption is a field of each partition, under Partitions."))
         return Answer(Outcome.BACK)
     edited = _edit_passphrase(
         screen,
@@ -3147,7 +2882,7 @@ def _ask_passphrase(screen: Screen, context: Context) -> Answer[str]:
         if len(typed) < PASSPHRASE_MINIMUM:
             # Checked here, not at preflight: zfs refuses a short passphrase
             # only once the disks have been partitioned.
-            _say(screen, context, translate("The passphrase is too short."))
+            say(screen, context, translate("The passphrase is too short."))
             continue
         again = TextField(
             title=translate("Passphrase again"),
@@ -3158,7 +2893,7 @@ def _ask_passphrase(screen: Screen, context: Context) -> Answer[str]:
         if not again.chosen:
             return Answer(again.outcome)
         if again.unwrap() != typed:
-            _say(screen, context, translate("The two do not match."))
+            say(screen, context, translate("The two do not match."))
             continue
         return Answer(Outcome.CHOSE, context.stage_passphrase(typed))
 
@@ -3196,17 +2931,6 @@ def _ask_password(screen: Screen, context: Context, title: str) -> Answer[str]:
         ],
         footer=footer(translate),
     ).run_validated(screen, validated)
-
-
-def _say(screen: Screen, context: Context, message: str) -> Answer[None]:
-    """One line the operator has to acknowledge, so a rejected entry is not
-    silently redrawn as an empty field."""
-    answer = Menu(
-        title=message,
-        items=[Item(label=context.translate("Continue"), value=0)],
-        footer=footer(context.translate),
-    ).run(screen)
-    return Answer(answer.outcome)
 
 
 def swap_screen(screen: Screen, config: InstallConfig, context: Context) -> Answer[InstallConfig]:
@@ -3277,7 +3001,7 @@ def zram_screen(screen: Screen, config: InstallConfig, context: Context) -> Answ
     if len(items) == 1:
         # Only `off` is left, which is not a question. This machine reported no
         # memory, so there is no share of it to offer.
-        _say(screen, context, translate("this machine reports no memory to share"))
+        say(screen, context, translate("this machine reports no memory to share"))
         return Answer(Outcome.BACK)
     menu: Menu[Size | None] = Menu(
         title=translate("zram"),
@@ -3329,7 +3053,7 @@ def build_in_ram_screen(
                 )
             )
     if len(items) == 1:
-        _say(screen, context, translate("this machine has too little memory to build in it"))
+        say(screen, context, translate("this machine has too little memory to build in it"))
         return Answer(Outcome.BACK)
     menu: Menu[Size | None] = Menu(
         title=translate("Build in RAM"),
@@ -3422,7 +3146,7 @@ def sshd_screen(screen: Screen, config: InstallConfig, context: Context) -> Answ
         return Answer(answer.outcome)
     running, password = answer.unwrap()
     if running and config.system.firewall is Firewall.NONE:
-        acknowledged = _say(
+        acknowledged = say(
             screen,
             context,
             translate(
@@ -3440,10 +3164,6 @@ def sshd_screen(screen: Screen, config: InstallConfig, context: Context) -> Answ
             system=replace(config.system, sshd=running, sshd_password_login=password),
         ),
     )
-
-
-def _cannot_load(name: str) -> InstallConfig:
-    raise ConfigError(f"this installer was built with no way to read {name}")
 
 
 def saved_config_screen(
@@ -3481,33 +3201,7 @@ def saved_config_screen(
         except GentooInstallError as error:
             # Back to the list rather than out of the installer: the file being
             # unreadable says nothing about the other one beside it.
-            _say(screen, context, str(error).splitlines()[-1].strip())
-
-
-def show_address(screen: Screen, context: Context, url: str) -> None:
-    """The address as a code and as text, on the screen the operator is on.
-
-    The machine showing this has no browser and no way to copy a line off its
-    console. Drawn here rather than after curses exits, because the operator
-    asked for it from the overview and is going back to the overview.
-    """
-    lines, columns = screen.size()
-    drawn = []
-    try:
-        drawn = qr.halved(qr.encode(url))
-    except GentooInstallError:
-        # Too long for the versions the encoder covers. The address still is
-        # the answer, and it is printed either way.
-        drawn = []
-    if drawn and (len(drawn[0]) > columns or len(drawn) + 4 > lines):
-        drawn = []
-    screen.clear()
-    screen.write(0, 0, truncate(url, columns))
-    for index, line in enumerate(drawn):
-        screen.write(index + 2, 0, line)
-    screen.write(min(len(drawn) + 3, lines - 1), 0, context.translate("Continue"))
-    screen.show()
-    screen.key()
+            say(screen, context, str(error).splitlines()[-1].strip())
 
 
 def _profile_screen(screen: Screen, config: InstallConfig, context: Context) -> Answer[InstallConfig]:
@@ -3757,7 +3451,7 @@ def firewall_screen(
         return Answer(answer.outcome)
     chosen = answer.unwrap()
     if chosen is not Firewall.NONE:
-        acknowledged = _say(
+        acknowledged = say(
             screen,
             context,
             translate(
@@ -4637,7 +4331,7 @@ def extra_packages_screen(
             return Answer(typed.outcome)
         good, bad = atoms.split(typed.unwrap())
         if bad:
-            informed = _say(screen, context, f"{translate('Not a package name')}: {' '.join(bad)}")
+            informed = say(screen, context, f"{translate('Not a package name')}: {' '.join(bad)}")
             if not informed.chosen:
                 return Answer(informed.outcome)
             continue
@@ -4699,7 +4393,7 @@ def _typed_beside_automatic(
             return Answer(entered.outcome)
         good, bad = accepts(entered.unwrap())
         if bad:
-            informed = _say(screen, context, f"{rejected}: {' '.join(bad)}")
+            informed = say(screen, context, f"{rejected}: {' '.join(bad)}")
             if not informed.chosen:
                 return Answer(informed.outcome)
             continue
@@ -5309,14 +5003,14 @@ def _read_a_key(screen: Screen, context: Context, url: str) -> str:
     try:
         body = context.fetch_text(url)
     except GentooInstallError as error:
-        _say(screen, context, str(error))
+        say(screen, context, str(error))
         return ""
     # A paste holding several keys is the normal case for one person's file,
     # and taking the first line silently would drop the rest.
     for line in body.splitlines():
         if line.strip() and not line.lstrip().startswith("#"):
             return _checked_key(screen, context, line)
-    _say(screen, context, translate("that address returned no key"))
+    say(screen, context, translate("that address returned no key"))
     return ""
 
 
@@ -5334,7 +5028,7 @@ def _checked_key(screen: Screen, context: Context, line: str) -> str:
     try:
         return sshkey.check(line.strip())
     except GentooInstallError as error:
-        _say(screen, context, str(error))
+        say(screen, context, str(error))
         return ""
 
 
@@ -5357,7 +5051,7 @@ def remote_unlock_screen(
     )
     blocking = compat.violations(candidate)
     if blocking and not unlock.enabled:
-        _say(screen, context, context.translate(blocking[0].reason))
+        say(screen, context, context.translate(blocking[0].reason))
         return Answer(Outcome.BACK)
     asked = Confirm(
         **answers(translate),

--- a/gentoo_install/tui/settings.py
+++ b/gentoo_install/tui/settings.py
@@ -42,7 +42,7 @@ from ..model.device import (
 )
 from ..plan import automatic as automatic_values
 from . import screens
-from .screens import Context, Step, footer
+from .context import Context, Step, ValueKind, ValueSource, footer
 from ..i18n import width
 from .widgets import Answer, Item, Menu, Outcome, Screen, Style
 
@@ -579,9 +579,9 @@ def _input_devices(config: InstallConfig, context: Context) -> str:
 def _display_manager(config: InstallConfig, context: Context) -> str:
     chosen = config.packages.display_manager
     if chosen and any(
-        one.kind is screens.ValueKind.DISPLAY_MANAGER
+        one.kind is ValueKind.DISPLAY_MANAGER
         and one.value == chosen
-        and one.source is screens.ValueSource.DERIVED
+        and one.source is ValueSource.DERIVED
         for one in context.provenance
     ):
         return f"{chosen} ({context.translate('proposed')})"

--- a/tests/unit/test_automatic.py
+++ b/tests/unit/test_automatic.py
@@ -24,6 +24,7 @@ from gentoo_install.model.config import (
     SystemConfig,
 )
 from gentoo_install.plan import automatic, bootloader as plan_bootloader, kernel as plan_kernel
+from gentoo_install.tui import context as tui_context
 from gentoo_install.tui import screens
 from gentoo_install.tui.overview import overview_screen
 from gentoo_install.tui.widgets import Answer, Outcome
@@ -497,7 +498,7 @@ def test_the_blocked_row_lists_as_many_names_as_the_terminal_fits() -> None:
 
 
 def _account(
-    keys: list[str], at: screens.Context, start: InstallConfig | None = None
+    keys: list[str], at: tui_context.Context, start: InstallConfig | None = None
 ) -> Answer[InstallConfig]:
     from tests.unit.fake_screen import FakeScreen
 

--- a/tests/unit/test_compat.py
+++ b/tests/unit/test_compat.py
@@ -762,7 +762,8 @@ def test_a_mirror_with_no_ipv6_is_refused_on_an_ipv6_only_machine() -> None:
     from gentoo_install.data import load_catalog
     from gentoo_install.i18n import Catalog
     from gentoo_install.model import mirrors
-    from gentoo_install.tui.screens import Context, _unreachable_here
+    from gentoo_install.tui.context import Context
+    from gentoo_install.tui.screens import _unreachable_here
 
     def machine(ipv4: bool) -> Context:
         return Context(

--- a/tests/unit/test_every_row.py
+++ b/tests/unit/test_every_row.py
@@ -19,7 +19,7 @@ import pytest
 
 from gentoo_install.model.config import InstallConfig
 from gentoo_install.tui import app, settings
-from gentoo_install.tui.screens import Context
+from gentoo_install.tui.context import Context
 from gentoo_install.tui.settings import UNSET, Setting
 from gentoo_install.tui.widgets import Answer, Outcome
 

--- a/tests/unit/test_layers.py
+++ b/tests/unit/test_layers.py
@@ -420,3 +420,29 @@ def test_the_proxy_endpoint_is_defined_once() -> None:
     ]
 
     assert defined == ["portage.py"], defined
+
+
+def test_the_tui_context_knows_nothing_about_a_screen() -> None:
+    """`Context`, the footer and the one-line acknowledgement moved out of
+    `screens.py` because `settings.py`, `overview.py`, `app.py` and `cli.py`
+    all reached into a screen module for them. The move is only worth its
+    churn while the direction stays one way: an import of `screens` or
+    `settings` from here is the cycle that put them together in the first
+    place."""
+    tui = PACKAGE / "tui"
+    imported = _imports(ast.parse((tui / "context.py").read_text()))
+
+    forbidden = {name for name in imported if name.split(".")[-1] in {"screens", "settings"}}
+    assert not forbidden, forbidden
+
+    # And the names it owns are not defined a second time next door, which is
+    # how a moved definition comes back as a copy.
+    owned = {"Context", "footer", "answers", "say", "show_address"}
+    for neighbour in ("screens.py", "settings.py", "overview.py", "app.py"):
+        tree = ast.parse((tui / neighbour).read_text())
+        defined = {
+            node.name
+            for node in tree.body
+            if isinstance(node, (ast.FunctionDef, ast.ClassDef)) and node.name in owned
+        }
+        assert not defined, f"{neighbour} defines {defined} again"

--- a/tests/unit/test_plan_system.py
+++ b/tests/unit/test_plan_system.py
@@ -337,6 +337,7 @@ def test_declining_sudo_in_the_menu_keeps_the_account_out_of_wheel() -> None:
     """`_groups_of` strips `wheel` for a plain account and then re-adds every
     name in `user.groups`, so a second copy of the list in the menu handed the
     account the group `/etc/sudoers.d/10-wheel` grants ALL to."""
+    from gentoo_install.tui import context as tui_context
     from gentoo_install.tui import screens
 
     from .fake_screen import FakeScreen
@@ -344,7 +345,7 @@ def test_declining_sudo_in_the_menu_keeps_the_account_out_of_wheel() -> None:
     from gentoo_install.data import load_catalog
     from gentoo_install.i18n import Catalog
 
-    at = screens.Context(
+    at = tui_context.Context(
         translate=Catalog("en"),
         disks=[("/dev/disk/by-id/virtio-target0", "20 GiB")],
         groups=load_catalog(),

--- a/tests/unit/test_tui_app.py
+++ b/tests/unit/test_tui_app.py
@@ -30,6 +30,7 @@ from gentoo_install.model.device import (
 from gentoo_install.model.validate import validate
 from gentoo_install.model import compat
 from gentoo_install.tui import app, widgets, screens, settings
+from gentoo_install.tui import context as tui_context
 from gentoo_install.tui.app import run
 from gentoo_install.tui.overview import overview_screen
 from gentoo_install.tui.widgets import Outcome
@@ -63,9 +64,9 @@ def staged(text: str) -> str:
     return "/run/keys/tui"
 
 
-def context() -> screens.Context:
+def context() -> tui_context.Context:
     STAGED.clear()
-    return app.MainMenuContext(screens.Context(
+    return app.MainMenuContext(tui_context.Context(
         translate=Catalog("en"),
         disks=DISKS,
         groups=load_catalog(),
@@ -2598,7 +2599,7 @@ def test_cancelled_manual_layout_restores_the_opening_table(
 
     before = deepcopy(at.layout)
 
-    def mutate(_: object, context: screens.Context, __: object) -> None:
+    def mutate(_: object, context: tui_context.Context, __: object) -> None:
         context.layout.disks[0].slices[0] = replace(
             context.layout.disks[0].slices[0], mountpoint="/changed"
         )
@@ -3122,7 +3123,7 @@ def test_the_conversion_is_not_offered_when_the_machine_refuses_it() -> None:
     """The refusal is asked before the operator answers twenty screens, and it
     is shown rather than hidden: a menu that quietly lacks an option teaches
     nothing about the machine it is running on."""
-    refusing = app.MainMenuContext(screens.Context(
+    refusing = app.MainMenuContext(tui_context.Context(
         translate=Catalog("en"),
         disks=DISKS,
         groups=load_catalog(),
@@ -3138,7 +3139,7 @@ def test_the_conversion_is_not_offered_when_the_machine_refuses_it() -> None:
 
     # Negative control: a machine that can be converted is offered it, and told
     # what was read, so the operator can see it looked at the right system.
-    offering = app.MainMenuContext(screens.Context(
+    offering = app.MainMenuContext(tui_context.Context(
         translate=Catalog("en"),
         disks=DISKS,
         groups=load_catalog(),
@@ -3154,7 +3155,7 @@ def test_the_conversion_is_not_offered_when_the_machine_refuses_it() -> None:
 
     # And a context nobody filled in refuses, rather than offering a conversion
     # of a machine that was never read.
-    blank = screens.Context(
+    blank = tui_context.Context(
         translate=Catalog("en"),
         disks=DISKS,
         groups=load_catalog(),
@@ -3172,7 +3173,7 @@ def test_choosing_the_conversion_drops_the_device_graph() -> None:
     from gentoo_install.model.validate import validate
     from gentoo_install.plan import convert
 
-    offering = app.MainMenuContext(screens.Context(
+    offering = app.MainMenuContext(tui_context.Context(
         translate=Catalog("en"),
         disks=DISKS,
         groups=load_catalog(),
@@ -3210,7 +3211,7 @@ def test_choosing_the_conversion_drops_the_device_graph() -> None:
 
 def test_dd_mode_is_offered_only_from_a_live_or_memory_environment() -> None:
     unsafe = app.MainMenuContext(
-        screens.Context(
+        tui_context.Context(
             translate=Catalog("en"),
             disks=DISKS,
             groups=load_catalog(),
@@ -3223,7 +3224,7 @@ def test_dd_mode_is_offered_only_from_a_live_or_memory_environment() -> None:
     assert "write a prepared image" not in "\n".join(hidden.frames[0])
 
     safe = app.MainMenuContext(
-        screens.Context(
+        tui_context.Context(
             translate=Catalog("en"),
             disks=DISKS,
             groups=load_catalog(),

--- a/tests/unit/test_tui_partitions.py
+++ b/tests/unit/test_tui_partitions.py
@@ -37,6 +37,7 @@ from gentoo_install.model.device import (
 from gentoo_install.model.size import Size
 from gentoo_install.model.validate import validate
 from gentoo_install.model.templates import Layout
+from gentoo_install.tui import context as tui_context
 from gentoo_install.tui import screens
 from gentoo_install.tui.widgets import Outcome
 
@@ -57,7 +58,7 @@ def one_disk(
     )
 
 
-def to_row(at: screens.Context, label: str) -> list[str]:
+def to_row(at: tui_context.Context, label: str) -> list[str]:
     """The keys that reach the partition-screen row with that label.
 
     Counted rather than written out: the screen grew a line per disk, and every
@@ -67,7 +68,7 @@ def to_row(at: screens.Context, label: str) -> list[str]:
     return ["KEY_DOWN"] * labels.index(label) + ["\n"]
 
 
-def opened() -> screens.Context:
+def opened() -> tui_context.Context:
     at = context()
     at.manual = True
     return at
@@ -988,7 +989,7 @@ def test_the_raid_purpose_is_offered_beside_the_pool_member() -> None:
     assert "raid" in keys and "zfs" in keys
 
 
-def without_zfs() -> screens.Context:
+def without_zfs() -> tui_context.Context:
     at = opened()
     at.zfs_unavailable = "this live system has no zpool"
     return at
@@ -1079,6 +1080,7 @@ def test_the_layout_row_opens_on_what_is_already_set() -> None:
     opened on whichever row was listed first, so an operator who pressed enter
     twice changed a setting they were looking at."""
     from gentoo_install.model.device import Filesystem, FilesystemType
+    from gentoo_install.tui import context as tui_context
     from gentoo_install.tui import screens
 
     at = context()
@@ -1095,6 +1097,7 @@ def test_raid_and_the_pool_topology_are_visible_before_they_are_reachable() -> N
     """Both rows appeared only once a partition happened to carry the right
     purpose, so neither feature could be found by anyone who did not already
     know it was there. Drawn always, with the reason when they cannot open."""
+    from gentoo_install.tui import context as tui_context
     from gentoo_install.tui import screens
 
     at = context()
@@ -1158,6 +1161,7 @@ def test_who_lays_the_disk_out_is_asked_before_what_goes_on_it() -> None:
     side, as if `manual` were a fifth filesystem. It is the other question,
     and a list that mixes them offers the automatic path as a default nobody
     was shown an alternative to."""
+    from gentoo_install.tui import context as tui_context
     from gentoo_install.tui import screens
 
     at = context()


### PR DESCRIPTION
`settings.py`, `overview.py`, `app.py` and `cli.py` each imported `Context`, `footer` or the one-line acknowledgement from a screen module, so a shared type lived in the file that happened to define it first. They now come from `tui/context.py`, which imports neither `screens` nor `settings`.

`test_the_tui_context_knows_nothing_about_a_screen` holds the direction and refuses a name defined a second time next door, which is how a moved definition comes back as a copy.

`_say` becomes `say`; `overview.py` and `app.py` already imported it across modules and `app.py` aliased it to that name.