### PR TITLE
docs: take UEFI conversion out of the not-verified list

### DIFF
--- a/TESTED.md
+++ b/TESTED.md
@@ -155,8 +155,9 @@ written.
 
 ### Not verified
 
-UEFI conversion, a btrfs subvolume root end to end, and the `vm-convert`
-cluster fixture.
+A btrfs subvolume root end to end, and the `vm-convert` cluster fixture. UEFI
+conversion moved out of this list when `639c5cd4069f` booted through its own
+firmware entry.
 
 ## Mode 3: boot into RAM, then install or write an image
 


### PR DESCRIPTION
The record table for mode 2 has carried `639c5cd4069f` — a UEFI machine converted and booted through its own `Boot0001* Gentoo` entry — while the section three rows below still listed UEFI conversion as unverified.