### PR TITLE
vm: refuse a greetd command, not the word agreety

### DIFF
--- a/tests/unit/test_automatic.py
+++ b/tests/unit/test_automatic.py
@@ -1444,3 +1444,57 @@ def test_a_group_somebody_typed_is_not_reported_as_automatic() -> None:
     )
     shown = {one.value for one in automatic.user_groups(installation, load_catalog())}
     assert "pipewire" not in shown, shown
+
+
+#: `/etc/greetd/config.toml` as `gui-libs/greetd-0.10.3-r1` installs it: the
+#: upstream file with the ebuild's `correct_user_config_toml` patch applied,
+#: read from the tarball and the patch rather than remembered.
+EBUILD_GREETD_CONFIG = '''[terminal]
+# The VT to run the greeter on. Can be "next", "current" or a number
+# designating the VT.
+vt = 7
+
+# The default session, also known as the greeter.
+[default_session]
+
+# `agreety` is the bundled agetty/login-lookalike. You can replace `/bin/sh`
+# with whatever you want started, such as `sway`.
+command = "agreety --cmd /bin/sh"
+
+# The user to run the command as. The privileges this user must have depends
+# on the greeter. A graphical greeter may for example require the user to be
+# in the `video` group.
+user = "greetd"
+'''
+
+
+def test_the_greetd_check_passes_the_file_the_installer_leaves_behind() -> None:
+    """The check refused `vm-greetd` after 49 minutes for holding the word
+    `agreety`, which the ebuild's file carries in a comment two lines above
+    the command and which `UpdateGreetdConfig` does not touch: it rewrites the
+    command line and nothing else. The check could not pass on any machine."""
+    import re
+
+    from gentoo_install.exec.config import load
+    from gentoo_install.plan.packages import _replace_greetd_command
+    from tests.vm.installed import checks
+
+    assert "agreety" in EBUILD_GREETD_CONFIG, "the comment this is about"
+
+    group = load_catalog()["greetd"]
+    declared = {str(one.path): one.content for one in group.files}
+    import tomllib
+
+    command = tomllib.loads(declared["/etc/greetd/config.toml"])["default_session"]["command"]
+    left_behind = _replace_greetd_command(EBUILD_GREETD_CONFIG, command)
+
+    pattern = next(
+        check.pattern
+        for check in checks(load(Path("tests/fixtures/vm-greetd.toml")))
+        if check.name == "greetd config"
+    )
+    assert re.search(pattern, left_behind) is not None, left_behind
+
+    # And it still refuses the file before the installer touched it, which is
+    # the machine where tuigreet was installed and never reached.
+    assert re.search(pattern, EBUILD_GREETD_CONFIG) is None

--- a/tests/unit/test_harness.py
+++ b/tests/unit/test_harness.py
@@ -537,7 +537,7 @@ def test_greetd_config_check_requires_tuigreet_session_directories() -> None:
         InstalledCheck(
             "greetd config",
             "cat /etc/greetd/config.toml",
-            r"(?ms)\A(?!.*\bagreety\b)"
+            r"(?ms)\A(?!.*^\s*command\s*=\s*\"agreety)"
             r"(?=.*^command = \"tuigreet .*--sessions /usr/share/wayland-sessions"
             r" --xsessions /usr/share/xsessions\"$)",
         )
@@ -548,7 +548,10 @@ def test_greetd_config_check_requires_tuigreet_session_directories() -> None:
         ' --xsessions /usr/share/xsessions"\n'
     )
     assert re.search(actual[0].pattern, configured)
-    assert not re.search(actual[0].pattern, f"# agreety\n{configured}")
+    # The comment the ebuild's file carries above the command, which this test
+    # used to require a failure for and which no machine is without.
+    assert re.search(actual[0].pattern, f"# `agreety` is the bundled\n{configured}")
+    assert not re.search(actual[0].pattern, f'command = "agreety --cmd /bin/sh"\n{configured}')
     assert not re.search(actual[0].pattern, 'command = "tuigreet"\n')
 
 

--- a/tests/unit/test_proxmox.py
+++ b/tests/unit/test_proxmox.py
@@ -3991,3 +3991,55 @@ def test_the_installed_checks_come_from_one_table() -> None:
     assert not hasattr(cluster, "INSIDE")
     named = {check.name for check in checks(load(_Path("tests/fixtures/vm-xfs.toml")))}
     assert {"os-release", "fstab"} <= named, named
+
+
+def test_a_failed_installed_check_answers_with_what_the_machine_said(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """`greetd config: the installed system does not say '(?ms)...'` was the
+    whole of a 49-minute verdict. The same sentence covers a file never
+    written, a file written and still naming `agreety`, and no file at all,
+    and the round after it could only guess which."""
+    from gentoo_install.exec.config import load
+    from tests.vm import cluster
+
+    class Guest:
+        def stop(self) -> None:
+            return None
+
+        def boot_from_disk(self) -> None:
+            return None
+
+        def start(self) -> None:
+            return None
+
+        def reset(self) -> None:
+            return None
+
+    held = b"[default_session]\r\ncommand = \"agreety --cmd /bin/sh\"\r\nuser = \"greetd\"\r\n"
+
+    class Link:
+        def reopen(self, *, solicit_prompt: bool = True) -> None:
+            return None
+
+        def observe(self, *unused: object, **ignored: object) -> bytes:
+            return b""
+
+        def expect_output(self, command: str, timeout: float = 0.0) -> bytes:
+            return held
+
+    def unlocked(*unused: object) -> cluster.UnlockResult:
+        return cluster.UnlockResult(cluster.InstalledBootState.LOGIN_READY, "")
+
+    monkeypatch.setattr(cluster, "_unlock", unlocked)
+    monkeypatch.setattr(cluster, "_log_in", lambda *unused: "")
+
+    refused = cluster.boot_and_check(
+        cast(Any, Guest()),
+        cast(Any, Link()),
+        Path("unused"),
+        load(Path("tests/fixtures/vm-greetd.toml")),
+    )
+
+    assert "does not say" in refused, refused
+    assert "agreety" in refused, "the answer, not only the pattern"

--- a/tests/vm/cluster.py
+++ b/tests/vm/cluster.py
@@ -2600,6 +2600,11 @@ PASSWORD_ECHO_CATCHES: Final[int] = 3
 #: because it reads as the whole screen.
 VERDICT_BYTES: Final[int] = 3600
 
+#: How much of a failed check's answer the verdict carries. The tail rather
+#: than the head: a `cat` of a configuration file ends with the lines the
+#: pattern was looking for.
+ANSWER_BYTES: Final[int] = 1200
+
 #: How long the prompt that follows a refusal is waited for before the next
 #: attempt. `login` writes it at once, so this only has to outlast a loaded
 #: node rather than anything the guest is doing.
@@ -2986,7 +2991,14 @@ def boot_and_check(
     for name, command, wanted in _asked_for(installation):
         said = link.expect_output(command, timeout=120.0)
         if said != wanted.encode() and re.search(wanted.encode(), said) is None:
-            return f"{name}: the installed system does not say {wanted!r}"
+            # With the answer, not only the pattern: `greetd config: the
+            # installed system does not say '(?ms)...'` is the same verdict
+            # whether the file was never written, was written and still names
+            # `agreety`, or does not exist at all.
+            return (
+                f"{name}: the installed system does not say {wanted!r}; "
+                f"it said {said[-ANSWER_BYTES:]!r}"
+            )[:VERDICT_BYTES]
     return ""
 
 

--- a/tests/vm/installed.py
+++ b/tests/vm/installed.py
@@ -130,7 +130,12 @@ def checks(installation: InstallConfig) -> tuple[InstalledCheck, ...]:
             InstalledCheck(
                 "greetd config",
                 "cat /etc/greetd/config.toml",
-                r"(?ms)\A(?!.*\bagreety\b)"
+                # The refusal is a `command` line running agreety, not the
+                # word: greetd 0.10.3 ships the comment "`agreety` is the
+                # bundled agetty/login-lookalike" two lines above the command,
+                # and the ebuild's patch leaves it there, so a check for the
+                # word alone could never pass.
+                r"(?ms)\A(?!.*^\s*command\s*=\s*\"agreety)"
                 r"(?=.*^command = \"tuigreet .*--sessions /usr/share/wayland-sessions"
                 r" --xsessions /usr/share/xsessions\"$)",
             )


### PR DESCRIPTION
The greetd config check refused any machine at all: `gui-libs/greetd` installs upstream's `config.toml`, whose comment two lines above the command reads `# \`agreety\` is the bundled agetty/login-lookalike`, and the ebuild's `correct_user_config_toml` patch changes only `vt` and `user`. `UpdateGreetdConfig` rewrites the command line and leaves the comment, so `(?!.*\bagreety\b)` could not pass. `vm-greetd` spent 49.1 minutes reaching it.

The new test runs that exact file through `_replace_greetd_command` and requires the check to pass on the result and still refuse the file before it.

The second commit puts what the machine said into the verdict; the round that produced this could not tell a file never written from one written and still wrong.