### PR TITLE
docs: record a SOCKS5 proxy install and boot

### DIFF
--- a/TESTED.md
+++ b/TESTED.md
@@ -63,6 +63,7 @@ a way to pass firmware arguments is available to a non-root API token.
 | `15d45598637a` | `zfs-zbm`, `vm-proxy`, `vm-proxy-http` | the proxy fixtures reach a proxy on the host through QEMU's user-mode network, which a bridged cluster guest does not have |
 | `4d8512a496d` | `vm-proxy` (SOCKS5, password), `vm-proxy-http` | 57 operations, 93 packages from a binary host, 14 compiled |
 | `7b08c47f383a` | `vm-bios` | BIOS serial console; 53 operations, 55 packages from a binary host, 20 compiled, then the disk it wrote booted, logged in on the console and passed every installed-state check |
+| `90516741321b` | `vm-proxy` | the SOCKS5 proxy runs on the host, which a bridged cluster guest cannot reach; 57 operations, 69 packages from a binary host, 46 compiled, then the disk it wrote booted and passed every installed-state check |
 
 ### Historical records
 


### PR DESCRIPTION
`vm-proxy` at `90516741321b`: every fetch through a SOCKS5 proxy that demands a password, 57 operations, then the disk it wrote booted and passed every installed-state check. The proxy runs on the host through QEMU's user-mode network, so this stays a QEMU record.