### PR TITLE
tui: move the Mirrors screen into tui/mirror.py

### DIFF
--- a/gentoo_install/tui/context.py
+++ b/gentoo_install/tui/context.py
@@ -9,16 +9,19 @@ direction is one way: this module knows nothing about a screen.
 
 from __future__ import annotations
 
-from dataclasses import dataclass
+from dataclasses import dataclass, replace
 from enum import Enum
-from typing import Callable, Generic, Sequence, TypedDict, TypeVar
+from typing import Callable, Final, Generic, Sequence, TypedDict, TypeVar
 
 from ..errors import ConfigError, GentooInstallError
 from ..i18n import Catalog, truncate
-from ..model import manual, qr
+from ..model import manual, mirrors, qr
 from ..model.config import (
+    BinhostChannel,
     Firmware,
     InstallConfig,
+    Overlay,
+    PortageConfig,
 )
 from ..model.device import (
     Existing,
@@ -409,3 +412,27 @@ def pick(
     if not answer.chosen:
         return None
     return apply(config, answer.unwrap())
+
+
+DONE: Final[str] = "done"
+TABLE: Final[str] = "table"
+DROP: Final[str] = "drop"
+
+
+def with_gentoo_zh(config: InstallConfig) -> PortageConfig:
+    """The overlay, cloned from the site already chosen for it.
+
+    Read from `model/mirrors.py` and not written here: a literal beside that
+    table is a second address to update, and the overlay has moved once
+    already. A site the operator has not picked yet answers as upstream.
+    """
+    if any(overlay.name == "gentoo-zh" for overlay in config.portage.overlays):
+        return config.portage
+    where = mirrors.gentoozh(config.portage.mirrors.gentoo_zh).git
+    added = (*config.portage.overlays, Overlay(name="gentoo-zh", sync_uri=where))
+    binhost = config.portage.binhost
+    if binhost.community is BinhostChannel.OFF:
+        # On with the overlay: the host serves what that overlay builds, and
+        # `compat.py` is what keeps the two from being set apart.
+        binhost = replace(binhost, community=BinhostChannel.STABLE)
+    return replace(config.portage, overlays=added, binhost=binhost)

--- a/gentoo_install/tui/mirror.py
+++ b/gentoo_install/tui/mirror.py
@@ -1,0 +1,429 @@
+# SPDX-License-Identifier: GPL-2.0-or-later
+"""The Mirrors screen: where every archive, overlay and binary host comes from.
+
+One screen, one editable table, and the rows that build it. Nothing here is
+reached from another screen, so `settings.py` is its only caller.
+"""
+
+from __future__ import annotations
+
+from dataclasses import replace
+from typing import Final
+
+from ..i18n import Catalog
+from ..model import compat, mirrors
+from ..plan.portage import community_binhost
+from ..model.config import (
+    Binhost,
+    BinhostChannel,
+    GentooZhMirror,
+    InstallConfig,
+    MirrorConfig,
+    MirrorRegion,
+    Overlay,
+    PortageConfig,
+    Sync,
+)
+from .context import (
+    Context,
+    DONE,
+    FieldDescriptor,
+    current_menu,
+    footer,
+    pick,
+    with_gentoo_zh,
+)
+from .widgets import Answer, Item, Menu, Outcome, Screen
+
+_REGION: Final[str] = "region"
+_SITE: Final[str] = "site"
+_MEASURE: Final[str] = "measure"
+_DISTFILES: Final[str] = "distfiles"
+_SYNC: Final[str] = "sync"
+_BINHOST: Final[str] = "binhost"
+_ZH_BINHOST: Final[str] = "zh-binhost"
+_ZH_SITE: Final[str] = "zh-site"
+_ZH_DISTFILES: Final[str] = "zh-distfiles"
+
+
+#: How the tree is kept up to date, and what each costs.
+SYNC_METHODS: tuple[tuple[Sync, str], ...] = (
+    (Sync.GIT, "carries the history a signed sync checks"),
+    (Sync.RSYNC, "what emerge --sync has always done"),
+    (Sync.WEBRSYNC, "no git, and no history"),
+)
+
+#: The gentoo-zh binary package channels.
+GENTOOZH_CHANNELS: tuple[tuple[BinhostChannel, str], ...] = (
+    (BinhostChannel.OFF, "not used"),
+    (BinhostChannel.STABLE, "stable ::gentoo, ~amd64 for the overlay"),
+    (BinhostChannel.UNSTABLE, "~amd64 throughout, so fewer packages match a binary host"),
+)
+
+#: Only x86-64 and x86-64-v3 carry a useful number of official binary packages;
+#: the other subarchitectures are nearly empty.
+BINHOSTS: tuple[tuple[tuple[bool, str], str], ...] = (
+    ((False, "x86-64"), "hours rather than minutes"),
+    ((True, "x86-64"), "works on every amd64 machine"),
+    ((True, "x86-64-v3"), "this CPU runs it, and the packages are built for it"),
+)
+
+#: The overlays with no mirror of their own, so they are on or off and nothing
+#: else. guru publishes from one place only.
+PLAIN_OVERLAYS: tuple[tuple[str, str], ...] = (
+    ("gig", "https://github.com/gentoo-zh/gig-overlay.git"),
+    ("guru", "https://anongit.gentoo.org/git/repo/proj/guru.git"),
+)
+
+
+def _unreachable_here(site: mirrors.Site, context: Context) -> str:
+    """Why this machine cannot fetch from a site, or empty.
+
+    An IPv6-only machine reaches four of the mirrors on this list not at all:
+    they publish no AAAA record, and one publishes an AAAA and does not answer
+    on it. Saying so here is the difference between choosing another and
+    finding out when the stage3 does not arrive.
+    """
+    # Both facts positive: this machine has IPv6 and has no IPv4. A machine
+    # whose interface is still coming up reports neither, and refusing on that
+    # would hide half the list from an operator who is about to configure it.
+    if site.ipv6 or context.ipv4 or not context.ipv6:
+        return ""
+    return context.translate("this machine has no IPv4 and the mirror has no IPv6")
+
+
+def mirror_screen(screen: Screen, config: InstallConfig, context: Context) -> Answer[InstallConfig]:
+    """Where every repository comes from, and which of them are used at all.
+
+    One screen because they are one decision: an overlay selected with no
+    mirror behind it, or a mirror chosen for an overlay that is not selected,
+    are both states the operator can reach by editing two rows apart.
+    """
+    translate = context.translate
+    current = config
+    cursor = 0
+    while True:
+        menu: Menu[str] = Menu(
+            title=translate("Mirrors"),
+            preamble=(translate("These sources provide the Gentoo tree, distfiles, overlays, and binary packages."),),
+            items=_mirror_fields(current, translate),
+            footer=footer(translate),
+            cursor=cursor,
+        )
+        answer = menu.run(screen)
+        cursor = menu.cursor
+        if not answer.chosen:
+            return Answer(answer.outcome)
+        field = answer.unwrap()
+        if field == DONE:
+            return Answer(Outcome.CHOSE, _with_a_site(current))
+        changed = _edit_mirror(screen, context, current, field)
+        if changed is not None:
+            current = changed
+
+
+def _default_site(region: MirrorRegion, translate: Catalog) -> str:
+    """What `_with_a_site` would adopt, drawn before it does."""
+    offered = mirrors.gentoo_sites(region)
+    return translate(offered[0].name) if offered else translate("none")
+
+
+def _with_a_site(config: InstallConfig) -> InstallConfig:
+    """The region's first mirror, for an operator who opened this screen and
+    changed nothing.
+
+    The row is required so that nobody installs from a mirror they never
+    looked at, and opening the screen is looking at it. Leaving it unset
+    instead made the row say `required` after it had been answered, which is
+    the interface calling the operator wrong.
+    """
+    chosen = config.portage.mirrors
+    if chosen.site:
+        return config
+    offered = mirrors.gentoo_sites(chosen.region)
+    if not offered:
+        return config
+    return replace(
+        config, portage=replace(config.portage, mirrors=replace(chosen, site=offered[0].key))
+    )
+
+
+def _mirror_fields(config: InstallConfig, translate: Catalog) -> list[Item[str]]:
+    portage = config.portage
+    chosen = portage.mirrors
+    region = chosen.region
+    site = chosen.site or mirrors.gentoo_sites(region)[0].key
+    used = {overlay.name for overlay in portage.overlays}
+    zh = mirrors.gentoozh(chosen.gentoo_zh)
+    rows = [field.row(config, translate) for field in _MIRROR_FIELDS]
+    rows += [
+        # One row, not one per method: showing a git address under a webrsync
+        # choice is the interface contradicting itself.
+        Item(
+            label=translate("Gentoo repository"),
+            value="",
+            detail=_tree_source(portage, region, site, translate),
+        ),
+        next(field.row(config, translate) for field in _ALL_MIRROR_FIELDS if field.key == _BINHOST),
+        next(field.row(config, translate) for field in _ALL_MIRROR_FIELDS if field.key == _ZH_SITE),
+    ]
+    if "gentoo-zh" in used:
+        rows += [field.row(config, translate) for field in _ZH_MIRROR_FIELDS]
+    rows += [
+        field.row(config, translate) for field in _OVERLAY_FIELDS
+    ]
+    rows.append(Item(label=translate("Done"), value=DONE))
+    return rows
+
+
+def _site_name(region: MirrorRegion, site: str, translate: Catalog) -> str:
+    """The chosen site's name, or `not set` when the region does not carry it.
+
+    The two are set together everywhere, and a bare `next` over a list that
+    does not hold it raised `StopIteration` out of the menu instead.
+    """
+    named = next((one.name for one in mirrors.gentoo_sites(region) if one.key == site), "")
+    return translate(named) if named else translate("not set")
+
+
+def _tree_source(
+    portage: PortageConfig, region: MirrorRegion, site: str, translate: Catalog
+) -> str:
+    """Where the chosen sync method will actually read the tree from."""
+    if portage.sync is Sync.GIT:
+        return mirrors.gentoo_sync_uri(region, site)
+    if portage.sync is Sync.RSYNC:
+        return mirrors.gentoo_rsync_uri(region, site)
+    return translate("a snapshot from GENTOO_MIRRORS")
+
+
+def _edit_mirror(
+    screen: Screen, context: Context, config: InstallConfig, field: str
+) -> InstallConfig | None:
+    """The one screen behind a field, or None when nothing changed."""
+    if not field:
+        # A row that only reports where a service will come from, derived from
+        # the two choices above it.
+        return None
+    descriptor = next((one for one in _ALL_MIRROR_FIELDS if one.key == field), None)
+    return descriptor.edit(screen, context, config) if descriptor else None
+
+
+def _mirror_region_row(config: InstallConfig, translate: Catalog) -> Item[str]:
+    return Item(label=translate("Region"), value=_REGION, detail=config.portage.mirrors.region.value)
+
+
+def _mirror_site_row(config: InstallConfig, translate: Catalog) -> Item[str]:
+    chosen = config.portage.mirrors
+    site = chosen.site or mirrors.gentoo_sites(chosen.region)[0].key
+    detail = _site_name(chosen.region, site, translate) if chosen.site else (
+        f"{_default_site(chosen.region, translate)} ({translate('default')})"
+    )
+    return Item(label=translate("Gentoo mirror"), value=_SITE, detail=detail)
+
+
+def _mirror_measure_row(config: InstallConfig, translate: Catalog) -> Item[str]:
+    return Item(
+        label=translate("Measure them"), value=_MEASURE,
+        detail=translate("yes") if config.portage.mirrors.speed_test else translate("no"),
+    )
+
+
+def _mirror_sync_row(config: InstallConfig, translate: Catalog) -> Item[str]:
+    return Item(label=translate("Repository sync"), value=_SYNC, detail=config.portage.sync.value)
+
+
+def _edit_mirror_region(screen: Screen, context: Context, config: InstallConfig) -> InstallConfig | None:
+    current = config.portage.mirrors
+    picked = Menu(title=context.translate("Region"), items=[Item(label=one.value, value=one) for one in MirrorRegion], footer=footer(context.translate), current=current.region).run(screen)
+    if not picked.chosen:
+        return None
+    return replace(config, portage=replace(config.portage, mirrors=replace(current, region=picked.unwrap(), site="")))
+
+
+def _edit_mirror_site(screen: Screen, context: Context, config: InstallConfig) -> InstallConfig | None:
+    current = config.portage.mirrors
+    offered = mirrors.gentoo_sites(current.region)
+    chosen = Menu(title=context.translate("Gentoo mirror"), items=[Item(label=context.translate(one.name), value=one.key, detail=f"{context.translate(one.area)}  {one.distfiles}", disabled_because=_unreachable_here(one, context)) for one in offered], footer=footer(context.translate), current=current.site).run(screen)
+    return replace(config, portage=replace(config.portage, mirrors=replace(current, site=chosen.unwrap()))) if chosen.chosen else None
+
+
+def _toggle_mirror_distfiles(screen: Screen, context: Context, config: InstallConfig) -> InstallConfig:
+    current = config.portage.mirrors
+    return replace(config, portage=replace(config.portage, mirrors=replace(current, gentoo_distfiles=not current.gentoo_distfiles)))
+
+
+def _toggle_mirror_measure(screen: Screen, context: Context, config: InstallConfig) -> InstallConfig:
+    current = config.portage.mirrors
+    return replace(config, portage=replace(config.portage, mirrors=replace(current, speed_test=not current.speed_test)))
+
+
+def _edit_mirror_sync(screen: Screen, context: Context, config: InstallConfig) -> InstallConfig | None:
+    return pick(screen, context, config, "Repository sync", list(SYNC_METHODS), config.portage.sync, lambda chosen, value: replace(chosen, portage=replace(chosen.portage, sync=value)))
+
+
+def _mirror_distfiles_row(config: InstallConfig, translate: Catalog) -> Item[str]:
+    return Item(
+        label=translate("Gentoo distfiles"),
+        value=_DISTFILES,
+        detail=translate("in use") if config.portage.mirrors.gentoo_distfiles else translate("not used"),
+    )
+
+
+def _mirror_zh_distfiles_row(config: InstallConfig, translate: Catalog) -> Item[str]:
+    chosen = config.portage.mirrors
+    return Item(label=translate("gentoo-zh distfiles"), value=_ZH_DISTFILES, detail=mirrors.gentoozh_distfiles(chosen.gentoo_zh)[0] if chosen.gentoo_zh_distfiles else translate("not used"))
+
+
+def _mirror_zh_binhost_row(config: InstallConfig, translate: Catalog) -> Item[str]:
+    return Item(label=translate("gentoo-zh binary packages"), value=_ZH_BINHOST, detail=community_binhost(config.portage) if config.portage.binhost.community is not BinhostChannel.OFF else translate("not used"))
+
+
+def _mirror_overlay_row(config: InstallConfig, translate: Catalog, name: str) -> Item[str]:
+    return Item(label=name, value=name, detail=translate("in use") if name in {one.name for one in config.portage.overlays} else translate("not used"))
+
+
+def _edit_mirror_overlay(
+    screen: Screen, context: Context, config: InstallConfig, name: str
+) -> InstallConfig:
+    return _toggle_overlay(config, name)
+
+
+def _overlay_descriptor(name: str) -> FieldDescriptor[InstallConfig]:
+    def row(config: InstallConfig, translate: Catalog) -> Item[str]:
+        return _mirror_overlay_row(config, translate, name)
+
+    def edit(screen: Screen, context: Context, config: InstallConfig) -> InstallConfig:
+        return _edit_mirror_overlay(screen, context, config, name)
+
+    return FieldDescriptor(name, row, edit)
+
+
+_MIRROR_FIELDS: tuple[FieldDescriptor[InstallConfig], ...] = (
+    FieldDescriptor(_REGION, _mirror_region_row, _edit_mirror_region),
+    FieldDescriptor(_SITE, _mirror_site_row, _edit_mirror_site),
+    FieldDescriptor(_DISTFILES, _mirror_distfiles_row, lambda s, c, x: _toggle_mirror_distfiles(s, c, x)),
+    FieldDescriptor(_MEASURE, _mirror_measure_row, lambda s, c, x: _toggle_mirror_measure(s, c, x)),
+    FieldDescriptor(_SYNC, _mirror_sync_row, _edit_mirror_sync),
+)
+_ZH_MIRROR_FIELDS: tuple[FieldDescriptor[InstallConfig], ...] = (
+    FieldDescriptor(_ZH_DISTFILES, _mirror_zh_distfiles_row, lambda s, c, x: replace(x, portage=replace(x.portage, mirrors=replace(x.portage.mirrors, gentoo_zh_distfiles=not x.portage.mirrors.gentoo_zh_distfiles)))),
+)
+_OVERLAY_FIELDS = tuple(
+    _overlay_descriptor(name)
+    for name, _ in PLAIN_OVERLAYS
+)
+_ALL_MIRROR_FIELDS = _MIRROR_FIELDS + (
+    FieldDescriptor(_BINHOST, lambda config, translate: Item(label=translate("Gentoo binary packages"), value=_BINHOST, detail=mirrors.gentoo_binhost(config.portage.mirrors.region, config.portage.mirrors.site, config.portage.binhost.subarch) if config.portage.binhost.official else translate("not used")), lambda s, c, x: _edit_binhost(s, c, x)),
+    FieldDescriptor(_ZH_BINHOST, _mirror_zh_binhost_row, lambda s, c, x: pick(s, c, x, "gentoo-zh binary packages", list(GENTOOZH_CHANNELS), x.portage.binhost.community, lambda chosen, value: replace(chosen, portage=replace(chosen.portage, binhost=replace(chosen.portage.binhost, community=value))))),
+    FieldDescriptor(_ZH_SITE, lambda config, translate: Item(label=translate("gentoo-zh"), value=_ZH_SITE, detail=translate(mirrors.gentoozh(config.portage.mirrors.gentoo_zh).name) if "gentoo-zh" in {one.name for one in config.portage.overlays} else translate("not used")), lambda s, c, x: _edit_gentoozh(s, c, x)),
+    *_ZH_MIRROR_FIELDS,
+    *_OVERLAY_FIELDS,
+)
+
+
+def _edit_binhost(
+    screen: Screen, context: Context, config: InstallConfig
+) -> InstallConfig | None:
+    """Off, or which subarchitecture. `ld.so` lists what this CPU would search,
+    so a machine that cannot run v3 is told rather than left to meet an illegal
+    instruction in the first binary package."""
+    translate = context.translate
+    items: list[Item[tuple[bool, str]]] = [
+        Item(
+            label=subarch if official else translate("not used"),
+            value=(official, subarch),
+            detail=translate(reason) if subarch != "x86-64-v3" or context.supports_v3 else "",
+            disabled_because=(
+                translate("this CPU cannot run it")
+                if subarch.endswith("v3") and not context.supports_v3
+                else ""
+            ),
+        )
+        for (official, subarch), reason in BINHOSTS
+    ]
+    menu: Menu[tuple[bool, str]] = Menu(
+        title=translate("Gentoo binary packages"),
+        preamble=(translate("Binary packages reduce compilation; source builds remain the fallback."),),
+        items=items,
+        footer=footer(translate),
+        current=(config.portage.binhost.official, config.portage.binhost.subarch),
+    )
+    answer = menu.run(screen)
+    if not answer.chosen:
+        return None
+    official, subarch = answer.unwrap()
+    portage = config.portage
+    return replace(
+        config,
+        portage=replace(
+            portage, binhost=replace(portage.binhost, official=official, subarch=subarch)
+        ),
+    )
+
+
+def _edit_gentoozh(
+    screen: Screen, context: Context, config: InstallConfig
+) -> InstallConfig | None:
+    """Whether gentoo-zh is used and where from, which is one question: a
+    mirror chosen for an overlay nobody selected changes nothing."""
+    translate = context.translate
+    items: list[Item[GentooZhMirror | None]] = [Item(label=translate("not used"), value=None)]
+    items += [
+        Item(
+            label=translate(one.name),
+            value=GentooZhMirror(one.key),
+            # The git address, not the distfiles one: this choice writes
+            # `sync-uri`, and upstream serves the two from different hosts.
+            detail=f"{translate(one.area)}  {one.git}",
+        )
+        for one in mirrors.GENTOOZH_SITES
+    ]
+    used = any(one.name == "gentoo-zh" for one in config.portage.overlays)
+    answer = current_menu(
+        screen,
+        context,
+        translate("gentoo-zh"),
+        items,
+        config.portage.mirrors.gentoo_zh if used else None,
+    )
+    if not answer.chosen:
+        return None
+    picked = answer.unwrap()
+    portage = config.portage
+    if picked is None:
+        # What required the overlay goes with it: leaving the community binhost
+        # on refuses the install from a row the operator is not looking at.
+        kept = tuple(one for one in portage.overlays if one.name != "gentoo-zh")
+        return replace(
+            config,
+            portage=replace(
+                portage,
+                overlays=kept,
+                binhost=replace(portage.binhost, community=BinhostChannel.OFF),
+            ),
+        )
+    # The overlay is cloned from the chosen site, not from upstream: a mirror
+    # picked here and ignored by the sync is the choice doing nothing.
+    added = with_gentoo_zh(config)
+    overlays = tuple(
+        replace(one, sync_uri=mirrors.gentoozh(picked).git) if one.name == "gentoo-zh" else one
+        for one in added.overlays
+    )
+    return replace(
+        config,
+        portage=replace(
+            added, overlays=overlays, mirrors=replace(portage.mirrors, gentoo_zh=picked)
+        ),
+    )
+
+
+def _toggle_overlay(config: InstallConfig, name: str) -> InstallConfig:
+    """Flipped where it stands. A yes/no screen over a row that already reads
+    `in use` or `not used` asks what the row has answered."""
+    portage = config.portage
+    kept = tuple(one for one in portage.overlays if one.name != name)
+    if len(kept) == len(portage.overlays):
+        uri = next(where for offered, where in PLAIN_OVERLAYS if offered == name)
+        kept = (*kept, Overlay(name=name, sync_uri=uri))
+    return replace(config, portage=replace(portage, overlays=kept))

--- a/gentoo_install/tui/screens.py
+++ b/gentoo_install/tui/screens.py
@@ -90,6 +90,9 @@ from ..plan import system as plan_system
 from .context import (
     Answers,
     Context,
+    DONE,
+    DROP,
+    TABLE,
     FieldDescriptor,
     Step,
     ValueKind,
@@ -101,6 +104,7 @@ from .context import (
     pick,
     say,
     show_address,
+    with_gentoo_zh,
 )
 from .widgets import (
     Accepts,
@@ -472,29 +476,10 @@ def _zfs_bootloader(
         return replace(
             config,
             bootloader=replace(config.bootloader, kind=kind),
-            portage=_with_gentoo_zh(config),
+            portage=with_gentoo_zh(config),
         )
 
     return answer.map(apply)
-
-
-def _with_gentoo_zh(config: InstallConfig) -> PortageConfig:
-    """The overlay, cloned from the site already chosen for it.
-
-    Read from `model/mirrors.py` and not written here: a literal beside that
-    table is a second address to update, and the overlay has moved once
-    already. A site the operator has not picked yet answers as upstream.
-    """
-    if any(overlay.name == "gentoo-zh" for overlay in config.portage.overlays):
-        return config.portage
-    where = mirrors.gentoozh(config.portage.mirrors.gentoo_zh).git
-    added = (*config.portage.overlays, Overlay(name="gentoo-zh", sync_uri=where))
-    binhost = config.portage.binhost
-    if binhost.community is BinhostChannel.OFF:
-        # On with the overlay: the host serves what that overlay builds, and
-        # `compat.py` is what keeps the two from being set apart.
-        binhost = replace(binhost, community=BinhostChannel.STABLE)
-    return replace(config.portage, overlays=added, binhost=binhost)
 
 
 def erase_screen(screen: Screen, config: InstallConfig, context: Context) -> Answer[InstallConfig]:
@@ -794,403 +779,6 @@ USER_NAME: Final[re.Pattern[str]] = re.compile(r"^[a-z_][a-z0-9_-]{0,31}$")
 #: One row of the mirror screen. The Gentoo rows come first and the overlay
 #: rows after, because a row of one repository between two rows of the other
 #: reads as though it belonged to it.
-_REGION: Final[str] = "region"
-_SITE: Final[str] = "site"
-_MEASURE: Final[str] = "measure"
-_DISTFILES: Final[str] = "distfiles"
-_SYNC: Final[str] = "sync"
-_BINHOST: Final[str] = "binhost"
-_ZH_BINHOST: Final[str] = "zh-binhost"
-_ZH_SITE: Final[str] = "zh-site"
-_ZH_DISTFILES: Final[str] = "zh-distfiles"
-_DONE: Final[str] = "done"
-_TABLE: Final[str] = "table"
-_DROP: Final[str] = "drop"
-
-
-#: How the tree is kept up to date, and what each costs.
-SYNC_METHODS: tuple[tuple[Sync, str], ...] = (
-    (Sync.GIT, "carries the history a signed sync checks"),
-    (Sync.RSYNC, "what emerge --sync has always done"),
-    (Sync.WEBRSYNC, "no git, and no history"),
-)
-
-#: The gentoo-zh binary package channels.
-GENTOOZH_CHANNELS: tuple[tuple[BinhostChannel, str], ...] = (
-    (BinhostChannel.OFF, "not used"),
-    (BinhostChannel.STABLE, "stable ::gentoo, ~amd64 for the overlay"),
-    (BinhostChannel.UNSTABLE, "~amd64 throughout, so fewer packages match a binary host"),
-)
-
-#: Only x86-64 and x86-64-v3 carry a useful number of official binary packages;
-#: the other subarchitectures are nearly empty.
-BINHOSTS: tuple[tuple[tuple[bool, str], str], ...] = (
-    ((False, "x86-64"), "hours rather than minutes"),
-    ((True, "x86-64"), "works on every amd64 machine"),
-    ((True, "x86-64-v3"), "this CPU runs it, and the packages are built for it"),
-)
-
-#: The overlays with no mirror of their own, so they are on or off and nothing
-#: else. guru publishes from one place only.
-PLAIN_OVERLAYS: tuple[tuple[str, str], ...] = (
-    ("gig", "https://github.com/gentoo-zh/gig-overlay.git"),
-    ("guru", "https://anongit.gentoo.org/git/repo/proj/guru.git"),
-)
-
-
-def _unreachable_here(site: mirrors.Site, context: Context) -> str:
-    """Why this machine cannot fetch from a site, or empty.
-
-    An IPv6-only machine reaches four of the mirrors on this list not at all:
-    they publish no AAAA record, and one publishes an AAAA and does not answer
-    on it. Saying so here is the difference between choosing another and
-    finding out when the stage3 does not arrive.
-    """
-    # Both facts positive: this machine has IPv6 and has no IPv4. A machine
-    # whose interface is still coming up reports neither, and refusing on that
-    # would hide half the list from an operator who is about to configure it.
-    if site.ipv6 or context.ipv4 or not context.ipv6:
-        return ""
-    return context.translate("this machine has no IPv4 and the mirror has no IPv6")
-
-
-def mirror_screen(screen: Screen, config: InstallConfig, context: Context) -> Answer[InstallConfig]:
-    """Where every repository comes from, and which of them are used at all.
-
-    One screen because they are one decision: an overlay selected with no
-    mirror behind it, or a mirror chosen for an overlay that is not selected,
-    are both states the operator can reach by editing two rows apart.
-    """
-    translate = context.translate
-    current = config
-    cursor = 0
-    while True:
-        menu: Menu[str] = Menu(
-            title=translate("Mirrors"),
-            preamble=(translate("These sources provide the Gentoo tree, distfiles, overlays, and binary packages."),),
-            items=_mirror_fields(current, translate),
-            footer=footer(translate),
-            cursor=cursor,
-        )
-        answer = menu.run(screen)
-        cursor = menu.cursor
-        if not answer.chosen:
-            return Answer(answer.outcome)
-        field = answer.unwrap()
-        if field == _DONE:
-            return Answer(Outcome.CHOSE, _with_a_site(current))
-        changed = _edit_mirror(screen, context, current, field)
-        if changed is not None:
-            current = changed
-
-
-def _default_site(region: MirrorRegion, translate: Catalog) -> str:
-    """What `_with_a_site` would adopt, drawn before it does."""
-    offered = mirrors.gentoo_sites(region)
-    return translate(offered[0].name) if offered else translate("none")
-
-
-def _with_a_site(config: InstallConfig) -> InstallConfig:
-    """The region's first mirror, for an operator who opened this screen and
-    changed nothing.
-
-    The row is required so that nobody installs from a mirror they never
-    looked at, and opening the screen is looking at it. Leaving it unset
-    instead made the row say `required` after it had been answered, which is
-    the interface calling the operator wrong.
-    """
-    chosen = config.portage.mirrors
-    if chosen.site:
-        return config
-    offered = mirrors.gentoo_sites(chosen.region)
-    if not offered:
-        return config
-    return replace(
-        config, portage=replace(config.portage, mirrors=replace(chosen, site=offered[0].key))
-    )
-
-
-def _mirror_fields(config: InstallConfig, translate: Catalog) -> list[Item[str]]:
-    portage = config.portage
-    chosen = portage.mirrors
-    region = chosen.region
-    site = chosen.site or mirrors.gentoo_sites(region)[0].key
-    used = {overlay.name for overlay in portage.overlays}
-    zh = mirrors.gentoozh(chosen.gentoo_zh)
-    rows = [field.row(config, translate) for field in _MIRROR_FIELDS]
-    rows += [
-        # One row, not one per method: showing a git address under a webrsync
-        # choice is the interface contradicting itself.
-        Item(
-            label=translate("Gentoo repository"),
-            value="",
-            detail=_tree_source(portage, region, site, translate),
-        ),
-        next(field.row(config, translate) for field in _ALL_MIRROR_FIELDS if field.key == _BINHOST),
-        next(field.row(config, translate) for field in _ALL_MIRROR_FIELDS if field.key == _ZH_SITE),
-    ]
-    if "gentoo-zh" in used:
-        rows += [field.row(config, translate) for field in _ZH_MIRROR_FIELDS]
-    rows += [
-        field.row(config, translate) for field in _OVERLAY_FIELDS
-    ]
-    rows.append(Item(label=translate("Done"), value=_DONE))
-    return rows
-
-
-def _site_name(region: MirrorRegion, site: str, translate: Catalog) -> str:
-    """The chosen site's name, or `not set` when the region does not carry it.
-
-    The two are set together everywhere, and a bare `next` over a list that
-    does not hold it raised `StopIteration` out of the menu instead.
-    """
-    named = next((one.name for one in mirrors.gentoo_sites(region) if one.key == site), "")
-    return translate(named) if named else translate("not set")
-
-
-def _tree_source(
-    portage: PortageConfig, region: MirrorRegion, site: str, translate: Catalog
-) -> str:
-    """Where the chosen sync method will actually read the tree from."""
-    if portage.sync is Sync.GIT:
-        return mirrors.gentoo_sync_uri(region, site)
-    if portage.sync is Sync.RSYNC:
-        return mirrors.gentoo_rsync_uri(region, site)
-    return translate("a snapshot from GENTOO_MIRRORS")
-
-
-def _edit_mirror(
-    screen: Screen, context: Context, config: InstallConfig, field: str
-) -> InstallConfig | None:
-    """The one screen behind a field, or None when nothing changed."""
-    if not field:
-        # A row that only reports where a service will come from, derived from
-        # the two choices above it.
-        return None
-    descriptor = next((one for one in _ALL_MIRROR_FIELDS if one.key == field), None)
-    return descriptor.edit(screen, context, config) if descriptor else None
-
-
-def _mirror_region_row(config: InstallConfig, translate: Catalog) -> Item[str]:
-    return Item(label=translate("Region"), value=_REGION, detail=config.portage.mirrors.region.value)
-
-
-def _mirror_site_row(config: InstallConfig, translate: Catalog) -> Item[str]:
-    chosen = config.portage.mirrors
-    site = chosen.site or mirrors.gentoo_sites(chosen.region)[0].key
-    detail = _site_name(chosen.region, site, translate) if chosen.site else (
-        f"{_default_site(chosen.region, translate)} ({translate('default')})"
-    )
-    return Item(label=translate("Gentoo mirror"), value=_SITE, detail=detail)
-
-
-def _mirror_measure_row(config: InstallConfig, translate: Catalog) -> Item[str]:
-    return Item(
-        label=translate("Measure them"), value=_MEASURE,
-        detail=translate("yes") if config.portage.mirrors.speed_test else translate("no"),
-    )
-
-
-def _mirror_sync_row(config: InstallConfig, translate: Catalog) -> Item[str]:
-    return Item(label=translate("Repository sync"), value=_SYNC, detail=config.portage.sync.value)
-
-
-def _edit_mirror_region(screen: Screen, context: Context, config: InstallConfig) -> InstallConfig | None:
-    current = config.portage.mirrors
-    picked = Menu(title=context.translate("Region"), items=[Item(label=one.value, value=one) for one in MirrorRegion], footer=footer(context.translate), current=current.region).run(screen)
-    if not picked.chosen:
-        return None
-    return replace(config, portage=replace(config.portage, mirrors=replace(current, region=picked.unwrap(), site="")))
-
-
-def _edit_mirror_site(screen: Screen, context: Context, config: InstallConfig) -> InstallConfig | None:
-    current = config.portage.mirrors
-    offered = mirrors.gentoo_sites(current.region)
-    chosen = Menu(title=context.translate("Gentoo mirror"), items=[Item(label=context.translate(one.name), value=one.key, detail=f"{context.translate(one.area)}  {one.distfiles}", disabled_because=_unreachable_here(one, context)) for one in offered], footer=footer(context.translate), current=current.site).run(screen)
-    return replace(config, portage=replace(config.portage, mirrors=replace(current, site=chosen.unwrap()))) if chosen.chosen else None
-
-
-def _toggle_mirror_distfiles(screen: Screen, context: Context, config: InstallConfig) -> InstallConfig:
-    current = config.portage.mirrors
-    return replace(config, portage=replace(config.portage, mirrors=replace(current, gentoo_distfiles=not current.gentoo_distfiles)))
-
-
-def _toggle_mirror_measure(screen: Screen, context: Context, config: InstallConfig) -> InstallConfig:
-    current = config.portage.mirrors
-    return replace(config, portage=replace(config.portage, mirrors=replace(current, speed_test=not current.speed_test)))
-
-
-def _edit_mirror_sync(screen: Screen, context: Context, config: InstallConfig) -> InstallConfig | None:
-    return pick(screen, context, config, "Repository sync", list(SYNC_METHODS), config.portage.sync, lambda chosen, value: replace(chosen, portage=replace(chosen.portage, sync=value)))
-
-
-def _mirror_distfiles_row(config: InstallConfig, translate: Catalog) -> Item[str]:
-    return Item(
-        label=translate("Gentoo distfiles"),
-        value=_DISTFILES,
-        detail=translate("in use") if config.portage.mirrors.gentoo_distfiles else translate("not used"),
-    )
-
-
-def _mirror_zh_distfiles_row(config: InstallConfig, translate: Catalog) -> Item[str]:
-    chosen = config.portage.mirrors
-    return Item(label=translate("gentoo-zh distfiles"), value=_ZH_DISTFILES, detail=mirrors.gentoozh_distfiles(chosen.gentoo_zh)[0] if chosen.gentoo_zh_distfiles else translate("not used"))
-
-
-def _mirror_zh_binhost_row(config: InstallConfig, translate: Catalog) -> Item[str]:
-    return Item(label=translate("gentoo-zh binary packages"), value=_ZH_BINHOST, detail=community_binhost(config.portage) if config.portage.binhost.community is not BinhostChannel.OFF else translate("not used"))
-
-
-def _mirror_overlay_row(config: InstallConfig, translate: Catalog, name: str) -> Item[str]:
-    return Item(label=name, value=name, detail=translate("in use") if name in {one.name for one in config.portage.overlays} else translate("not used"))
-
-
-def _edit_mirror_overlay(
-    screen: Screen, context: Context, config: InstallConfig, name: str
-) -> InstallConfig:
-    return _toggle_overlay(config, name)
-
-
-def _overlay_descriptor(name: str) -> FieldDescriptor[InstallConfig]:
-    def row(config: InstallConfig, translate: Catalog) -> Item[str]:
-        return _mirror_overlay_row(config, translate, name)
-
-    def edit(screen: Screen, context: Context, config: InstallConfig) -> InstallConfig:
-        return _edit_mirror_overlay(screen, context, config, name)
-
-    return FieldDescriptor(name, row, edit)
-
-
-_MIRROR_FIELDS: tuple[FieldDescriptor[InstallConfig], ...] = (
-    FieldDescriptor(_REGION, _mirror_region_row, _edit_mirror_region),
-    FieldDescriptor(_SITE, _mirror_site_row, _edit_mirror_site),
-    FieldDescriptor(_DISTFILES, _mirror_distfiles_row, lambda s, c, x: _toggle_mirror_distfiles(s, c, x)),
-    FieldDescriptor(_MEASURE, _mirror_measure_row, lambda s, c, x: _toggle_mirror_measure(s, c, x)),
-    FieldDescriptor(_SYNC, _mirror_sync_row, _edit_mirror_sync),
-)
-_ZH_MIRROR_FIELDS: tuple[FieldDescriptor[InstallConfig], ...] = (
-    FieldDescriptor(_ZH_DISTFILES, _mirror_zh_distfiles_row, lambda s, c, x: replace(x, portage=replace(x.portage, mirrors=replace(x.portage.mirrors, gentoo_zh_distfiles=not x.portage.mirrors.gentoo_zh_distfiles)))),
-)
-_OVERLAY_FIELDS = tuple(
-    _overlay_descriptor(name)
-    for name, _ in PLAIN_OVERLAYS
-)
-_ALL_MIRROR_FIELDS = _MIRROR_FIELDS + (
-    FieldDescriptor(_BINHOST, lambda config, translate: Item(label=translate("Gentoo binary packages"), value=_BINHOST, detail=mirrors.gentoo_binhost(config.portage.mirrors.region, config.portage.mirrors.site, config.portage.binhost.subarch) if config.portage.binhost.official else translate("not used")), lambda s, c, x: _edit_binhost(s, c, x)),
-    FieldDescriptor(_ZH_BINHOST, _mirror_zh_binhost_row, lambda s, c, x: pick(s, c, x, "gentoo-zh binary packages", list(GENTOOZH_CHANNELS), x.portage.binhost.community, lambda chosen, value: replace(chosen, portage=replace(chosen.portage, binhost=replace(chosen.portage.binhost, community=value))))),
-    FieldDescriptor(_ZH_SITE, lambda config, translate: Item(label=translate("gentoo-zh"), value=_ZH_SITE, detail=translate(mirrors.gentoozh(config.portage.mirrors.gentoo_zh).name) if "gentoo-zh" in {one.name for one in config.portage.overlays} else translate("not used")), lambda s, c, x: _edit_gentoozh(s, c, x)),
-    *_ZH_MIRROR_FIELDS,
-    *_OVERLAY_FIELDS,
-)
-
-
-def _edit_binhost(
-    screen: Screen, context: Context, config: InstallConfig
-) -> InstallConfig | None:
-    """Off, or which subarchitecture. `ld.so` lists what this CPU would search,
-    so a machine that cannot run v3 is told rather than left to meet an illegal
-    instruction in the first binary package."""
-    translate = context.translate
-    items: list[Item[tuple[bool, str]]] = [
-        Item(
-            label=subarch if official else translate("not used"),
-            value=(official, subarch),
-            detail=translate(reason) if subarch != "x86-64-v3" or context.supports_v3 else "",
-            disabled_because=(
-                translate("this CPU cannot run it")
-                if subarch.endswith("v3") and not context.supports_v3
-                else ""
-            ),
-        )
-        for (official, subarch), reason in BINHOSTS
-    ]
-    menu: Menu[tuple[bool, str]] = Menu(
-        title=translate("Gentoo binary packages"),
-        preamble=(translate("Binary packages reduce compilation; source builds remain the fallback."),),
-        items=items,
-        footer=footer(translate),
-        current=(config.portage.binhost.official, config.portage.binhost.subarch),
-    )
-    answer = menu.run(screen)
-    if not answer.chosen:
-        return None
-    official, subarch = answer.unwrap()
-    portage = config.portage
-    return replace(
-        config,
-        portage=replace(
-            portage, binhost=replace(portage.binhost, official=official, subarch=subarch)
-        ),
-    )
-
-
-def _edit_gentoozh(
-    screen: Screen, context: Context, config: InstallConfig
-) -> InstallConfig | None:
-    """Whether gentoo-zh is used and where from, which is one question: a
-    mirror chosen for an overlay nobody selected changes nothing."""
-    translate = context.translate
-    items: list[Item[GentooZhMirror | None]] = [Item(label=translate("not used"), value=None)]
-    items += [
-        Item(
-            label=translate(one.name),
-            value=GentooZhMirror(one.key),
-            # The git address, not the distfiles one: this choice writes
-            # `sync-uri`, and upstream serves the two from different hosts.
-            detail=f"{translate(one.area)}  {one.git}",
-        )
-        for one in mirrors.GENTOOZH_SITES
-    ]
-    used = any(one.name == "gentoo-zh" for one in config.portage.overlays)
-    answer = current_menu(
-        screen,
-        context,
-        translate("gentoo-zh"),
-        items,
-        config.portage.mirrors.gentoo_zh if used else None,
-    )
-    if not answer.chosen:
-        return None
-    picked = answer.unwrap()
-    portage = config.portage
-    if picked is None:
-        # What required the overlay goes with it: leaving the community binhost
-        # on refuses the install from a row the operator is not looking at.
-        kept = tuple(one for one in portage.overlays if one.name != "gentoo-zh")
-        return replace(
-            config,
-            portage=replace(
-                portage,
-                overlays=kept,
-                binhost=replace(portage.binhost, community=BinhostChannel.OFF),
-            ),
-        )
-    # The overlay is cloned from the chosen site, not from upstream: a mirror
-    # picked here and ignored by the sync is the choice doing nothing.
-    added = _with_gentoo_zh(config)
-    overlays = tuple(
-        replace(one, sync_uri=mirrors.gentoozh(picked).git) if one.name == "gentoo-zh" else one
-        for one in added.overlays
-    )
-    return replace(
-        config,
-        portage=replace(
-            added, overlays=overlays, mirrors=replace(portage.mirrors, gentoo_zh=picked)
-        ),
-    )
-
-
-def _toggle_overlay(config: InstallConfig, name: str) -> InstallConfig:
-    """Flipped where it stands. A yes/no screen over a row that already reads
-    `in use` or `not used` asks what the row has answered."""
-    portage = config.portage
-    kept = tuple(one for one in portage.overlays if one.name != name)
-    if len(kept) == len(portage.overlays):
-        uri = next(where for offered, where in PLAIN_OVERLAYS if offered == name)
-        kept = (*kept, Overlay(name=name, sync_uri=uri))
-    return replace(config, portage=replace(portage, overlays=kept))
-
-
 def _common_violations(candidates: Sequence[InstallConfig]) -> set[compat.Rule]:
     """Rules every candidate breaks, which no choice on this screen can fix.
 
@@ -1449,7 +1037,7 @@ def kernel_screen(screen: Screen, config: InstallConfig, context: Context) -> An
         changed = replace(changed, system=replace(changed.system, console_cjk=True))
         # The package is in gentoo-zh and in no other repository, so choosing
         # it is consenting to that overlay rather than having it added quietly.
-        return Answer(Outcome.CHOSE, replace(changed, portage=_with_gentoo_zh(changed)))
+        return Answer(Outcome.CHOSE, replace(changed, portage=with_gentoo_zh(changed)))
     if config.system.console_cjk:
         # Turned off with the kernel that carried it, and said out loud: the
         # rule would otherwise refuse the install with a message about the
@@ -3652,20 +3240,20 @@ def _edit_disk(screen: Screen, context: Context, position: int) -> None:
     disk = context.layout.disks[position]
     while True:
         items: list[Item[str]] = [
-            Item(label=translate("Partition table"), value=_TABLE, detail=disk.table.value),
+            Item(label=translate("Partition table"), value=TABLE, detail=disk.table.value),
             *(
-                [Item(label=translate("Take this disk off the table"), value=_DROP)]
+                [Item(label=translate("Take this disk off the table"), value=DROP)]
                 if position > 0
                 else []
             ),
-            Item(label=translate("Done"), value=_DONE),
+            Item(label=translate("Done"), value=DONE),
         ]
         answer = Menu(
             title=context.shown_as(disk.selector), items=items, footer=footer(translate)
         ).run(screen)
-        if not answer.chosen or answer.unwrap() == _DONE:
+        if not answer.chosen or answer.unwrap() == DONE:
             return
-        if answer.unwrap() == _DROP:
+        if answer.unwrap() == DROP:
             context.layout.disks.pop(position)
             return
         picked = current_menu(
@@ -3772,7 +3360,7 @@ def _edit_array(screen: Screen, context: Context) -> None:
             items=items,
             footer=footer(translate),
         ).run(screen)
-        if not answer.chosen or answer.unwrap() == _DONE:
+        if not answer.chosen or answer.unwrap() == DONE:
             return
         _edit_array_field(screen, context, answer.unwrap(), members)
 
@@ -3897,8 +3485,8 @@ _ARRAY_FIELDS: tuple[FieldDescriptor[tuple[manual.Array, int]], ...] = (
         lambda array, translate: translate("on") if array.passphrase_file else translate("off"),
     ),
     FieldDescriptor(
-        _DONE,
-        lambda _, translate: Item(label=translate("Done"), value=_DONE),
+        DONE,
+        lambda _, translate: Item(label=translate("Done"), value=DONE),
         lambda _, __, value: value,
     ),
 )
@@ -3995,7 +3583,7 @@ def _edit_slice(
         if not answer.chosen:
             return current
         field = answer.unwrap()
-        if field == _DONE:
+        if field == DONE:
             return entry
         if field == _DELETE:
             return None
@@ -4080,7 +3668,7 @@ def _slice_field_items(
             if entry.status is manual.SliceStatus.CREATE
             else []
         ),
-        Item(label=translate("Done"), value=_DONE),
+        Item(label=translate("Done"), value=DONE),
     ]
 
 
@@ -4530,7 +4118,7 @@ def with_language(config: InstallConfig, tag: str) -> InstallConfig:
     return replace(
         seeded,
         kernel=replace(seeded.kernel, source=KernelSource.CJK_BIN),
-        portage=_with_gentoo_zh(seeded),
+        portage=with_gentoo_zh(seeded),
     )
 
 

--- a/gentoo_install/tui/settings.py
+++ b/gentoo_install/tui/settings.py
@@ -42,6 +42,7 @@ from ..model.device import (
 )
 from ..plan import automatic as automatic_values
 from . import screens
+from .mirror import mirror_screen
 from .context import Context, Step, ValueKind, ValueSource, footer
 from ..i18n import width
 from .widgets import Answer, Item, Menu, Outcome, Screen, Style
@@ -871,7 +872,7 @@ SETTINGS: Final[tuple[Setting, ...]] = (
         rows=LANGUAGE,
     ),
     Setting("timezone", "Timezone", lambda c, x: c.system.timezone, screens.timezone_screen),
-    Setting("mirror", "Mirrors", _mirror, screens.mirror_screen, required=True, detected=True),
+    Setting("mirror", "Mirrors", _mirror, mirror_screen, required=True, detected=True),
     # Above the row that opens the rest of the install: the licence question
     # is otherwise two levels down under Compiler, and the operator meets it
     # as a refusal — `net-im/wemeet` masked, the install over — rather than as

--- a/tests/unit/test_automatic.py
+++ b/tests/unit/test_automatic.py
@@ -25,6 +25,7 @@ from gentoo_install.model.config import (
 )
 from gentoo_install.plan import automatic, bootloader as plan_bootloader, kernel as plan_kernel
 from gentoo_install.tui import context as tui_context
+from gentoo_install.tui import mirror
 from gentoo_install.tui import screens
 from gentoo_install.tui.overview import overview_screen
 from gentoo_install.tui.widgets import Answer, Outcome
@@ -887,7 +888,7 @@ def test_opening_the_mirror_screen_and_changing_nothing_answers_it() -> None:
     before = config(ext4_on_gpt())
     assert settings._mirror(before, at) == settings.UNSET
     # Down to Done and enter, touching nothing.
-    after = screens.mirror_screen(
+    after = mirror.mirror_screen(
         FakeScreen(keys=["KEY_DOWN"] * 12 + ["\n"], lines=30, columns=110), before, at
     ).unwrap()
     at.visited.add("mirror")
@@ -903,7 +904,7 @@ def test_the_mirror_screen_shows_the_site_it_would_adopt() -> None:
     from tests.unit.test_tui_app import context
 
     drawn = FakeScreen(keys=["q"], lines=30, columns=110)
-    screens.mirror_screen(drawn, config(ext4_on_gpt()), context())
+    mirror.mirror_screen(drawn, config(ext4_on_gpt()), context())
     line = next(one for one in drawn.last.splitlines() if "Gentoo mirror" in one)
     assert "not set" not in line
     assert "(default)" in line

--- a/tests/unit/test_compat.py
+++ b/tests/unit/test_compat.py
@@ -763,7 +763,7 @@ def test_a_mirror_with_no_ipv6_is_refused_on_an_ipv6_only_machine() -> None:
     from gentoo_install.i18n import Catalog
     from gentoo_install.model import mirrors
     from gentoo_install.tui.context import Context
-    from gentoo_install.tui.screens import _unreachable_here
+    from gentoo_install.tui.mirror import _unreachable_here
 
     def machine(ipv4: bool) -> Context:
         return Context(
@@ -1021,7 +1021,7 @@ def test_the_subarch_table_holds_what_the_menu_offers() -> None:
     validates it read the same set, or the menu offers what validation
     refuses."""
     from gentoo_install.model.compat import BINHOST_SUBARCHS
-    from gentoo_install.tui.screens import BINHOSTS
+    from gentoo_install.tui.mirror import BINHOSTS
 
     offered = {subarch for (_, subarch), _ in BINHOSTS}
     assert offered <= BINHOST_SUBARCHS, offered - BINHOST_SUBARCHS

--- a/tests/unit/test_i18n.py
+++ b/tests/unit/test_i18n.py
@@ -106,16 +106,14 @@ def in_a_table() -> set[str]:
     """
     from gentoo_install.model.mirrors import GENTOO_SITES, GENTOOZH_SITES
     from gentoo_install.plan.system import LOGGERS
+    from gentoo_install.tui.mirror import BINHOSTS, GENTOOZH_CHANNELS, SYNC_METHODS
     from gentoo_install.tui.screens import (
-        BINHOSTS,
         RAM_SHARES,
         DISPLAY_MANAGERS,
-        GENTOOZH_CHANNELS,
         GRAPHICS,
         INSTALL_MODES,
         KERNELS,
         LICENSES,
-        SYNC_METHODS,
     )
 
     tables = (

--- a/tests/unit/test_layers.py
+++ b/tests/unit/test_layers.py
@@ -432,7 +432,11 @@ def test_the_tui_context_knows_nothing_about_a_screen() -> None:
     tui = PACKAGE / "tui"
     imported = _imports(ast.parse((tui / "context.py").read_text()))
 
-    forbidden = {name for name in imported if name.split(".")[-1] in {"screens", "settings"}}
+    forbidden = {
+        name
+        for name in imported
+        if name.split(".")[-1] in {"screens", "settings", "mirror", "overview", "app"}
+    }
     assert not forbidden, forbidden
 
     # And the names it owns are not defined a second time next door, which is
@@ -441,13 +445,14 @@ def test_the_tui_context_knows_nothing_about_a_screen() -> None:
         "Context",
         "FieldDescriptor",
         "answers",
+        "DONE",
         "current_menu",
         "footer",
         "pick",
         "say",
         "show_address",
     }
-    for neighbour in ("screens.py", "settings.py", "overview.py", "app.py"):
+    for neighbour in ("screens.py", "settings.py", "overview.py", "app.py", "mirror.py"):
         tree = ast.parse((tui / neighbour).read_text())
         defined = {
             node.name

--- a/tests/unit/test_tui_app.py
+++ b/tests/unit/test_tui_app.py
@@ -31,6 +31,7 @@ from gentoo_install.model.validate import validate
 from gentoo_install.model import compat
 from gentoo_install.tui import app, widgets, screens, settings
 from gentoo_install.tui import context as tui_context
+from gentoo_install.tui import mirror
 from gentoo_install.tui.app import run
 from gentoo_install.tui.overview import overview_screen
 from gentoo_install.tui.widgets import Outcome
@@ -145,14 +146,14 @@ def test_a_group_is_a_list_and_never_a_wizard() -> None:
 
 def test_field_editors_have_one_descriptor_for_each_editable_row() -> None:
     at = context()
-    mirror_expected = {screens._REGION, screens._SITE, screens._DISTFILES,
-                       screens._MEASURE, screens._SYNC, screens._BINHOST,
-                       screens._ZH_SITE, screens._ZH_DISTFILES,
-                       screens._ZH_BINHOST, "gig", "guru"}
-    mirror_rows = {item.value for item in screens._mirror_fields(config(), at.translate)
-                   if item.value not in ("", screens._DONE)}
+    mirror_expected = {mirror._REGION, mirror._SITE, mirror._DISTFILES,
+                       mirror._MEASURE, mirror._SYNC, mirror._BINHOST,
+                       mirror._ZH_SITE, mirror._ZH_DISTFILES,
+                       mirror._ZH_BINHOST, "gig", "guru"}
+    mirror_rows = {item.value for item in mirror._mirror_fields(config(), at.translate)
+                   if item.value not in ("", tui_context.DONE)}
     assert mirror_rows <= mirror_expected
-    assert {field.key for field in screens._ALL_MIRROR_FIELDS} == mirror_expected
+    assert {field.key for field in mirror._ALL_MIRROR_FIELDS} == mirror_expected
 
     array_expected = {screens._NAME, screens._LEVEL, screens._METADATA,
                       screens._FILESYSTEM, screens._MOUNTPOINT, screens._LABEL,
@@ -160,9 +161,9 @@ def test_field_editors_have_one_descriptor_for_each_editable_row() -> None:
     array_rows = {
         field.row((at.layout.array, 0), at.translate).value
         for field in screens._ARRAY_FIELDS
-        if field.key != screens._DONE
+        if field.key != tui_context.DONE
     }
-    assert {field.key for field in screens._ARRAY_FIELDS} - {screens._DONE} == array_expected
+    assert {field.key for field in screens._ARRAY_FIELDS} - {tui_context.DONE} == array_expected
     assert array_rows == array_expected
 
 
@@ -665,14 +666,14 @@ def test_v3_is_recommended_only_when_this_cpu_runs_it() -> None:
             binhost=replace(config().portage.binhost, subarch="x86-64-v3"),
         ),
     )
-    answer = screens._edit_binhost(FakeScreen(keys=["\n"]), modern, current)
+    answer = mirror._edit_binhost(FakeScreen(keys=["\n"]), modern, current)
     assert answer is not None
     assert answer.portage.binhost.subarch == "x86-64-v3"
 
     old = context()
     old.supports_v3 = False
     plain = FakeScreen(keys=["\n"])
-    refused = screens._edit_binhost(plain, old, config())
+    refused = mirror._edit_binhost(plain, old, config())
     assert refused is not None
     assert refused.portage.binhost.official is True
     assert refused.portage.binhost.subarch == "x86-64"
@@ -689,7 +690,7 @@ def test_binhost_reopens_on_its_configured_subarchitecture() -> None:
             binhost=replace(config().portage.binhost, official=True, subarch="x86-64"),
         ),
     )
-    answer = screens._edit_binhost(FakeScreen(keys=["\n"]), at, chosen)
+    answer = mirror._edit_binhost(FakeScreen(keys=["\n"]), at, chosen)
     assert answer is not None
     assert answer.portage.binhost.subarch == "x86-64"
 
@@ -800,7 +801,7 @@ def test_the_mirror_row_shows_every_service_and_lets_each_be_chosen() -> None:
     from its name, so each is drawn with where it will come from."""
     at = context()
     screen = FakeScreen(keys=["q"], lines=40, columns=120)
-    screens.mirror_screen(screen, config(), at)
+    mirror.mirror_screen(screen, config(), at)
     drawn = screen.last
     for label in (
         "Region", "Gentoo mirror", "Gentoo distfiles", "Repository sync",
@@ -834,15 +835,15 @@ def test_mirror_subselectors_reopen_on_the_values_their_rows_show() -> None:
     )
 
     sync = FakeScreen(keys=["q"])
-    screens._edit_mirror(sync, at, held, screens._SYNC)
+    mirror._edit_mirror(sync, at, held, mirror._SYNC)
     assert "webrsync" in sync.highlighted[0]
 
     community = FakeScreen(keys=["q"])
-    screens._edit_mirror(community, at, held, screens._ZH_BINHOST)
+    mirror._edit_mirror(community, at, held, mirror._ZH_BINHOST)
     assert "unstable" in community.highlighted[0]
 
     overlay = FakeScreen(keys=["q"])
-    screens._edit_mirror(overlay, at, held, screens._ZH_SITE)
+    mirror._edit_mirror(overlay, at, held, mirror._ZH_SITE)
     expected = at.translate(mirrors.gentoozh(GentooZhMirror.NJU).name)
     assert expected in overlay.highlighted[0]
 
@@ -851,10 +852,10 @@ def test_choosing_a_gentoozh_mirror_is_what_adds_the_overlay() -> None:
     """A mirror chosen for an overlay nobody selected changes nothing, so the
     two are one row."""
     at = context()
-    zh = next(index for index, item in enumerate(screens._mirror_fields(config(), at.translate))
-              if item.value == screens._ZH_SITE)
+    zh = next(index for index, item in enumerate(mirror._mirror_fields(config(), at.translate))
+              if item.value == mirror._ZH_SITE)
     keys = [*down(zh), "\n", "KEY_DOWN", "KEY_DOWN", "\n", *down(20), "\n"]
-    answer = screens.mirror_screen(FakeScreen(keys=keys, lines=40), config(), at)
+    answer = mirror.mirror_screen(FakeScreen(keys=keys, lines=40), config(), at)
     changed = answer.unwrap().portage
     assert [one.name for one in changed.overlays] == ["gentoo-zh"]
     assert changed.mirrors.gentoo_zh is not MirrorConfig().gentoo_zh
@@ -1215,7 +1216,7 @@ def test_the_tree_row_names_the_address_the_chosen_method_uses() -> None:
         (Sync.WEBRSYNC, "GENTOO_MIRRORS"),
     ):
         chosen = replace(config(), portage=replace(config().portage, sync=method))
-        rows = screens._mirror_fields(chosen, at.translate)
+        rows = mirror._mirror_fields(chosen, at.translate)
         detail = next(one.detail for one in rows if one.label == "Gentoo repository")
         assert expected in detail, method
 
@@ -1381,18 +1382,18 @@ def test_a_plain_switch_flips_where_it_stands() -> None:
     at = context()
     start = config()
     blank = FakeScreen(keys=[], lines=20, columns=100)
-    measured = screens._edit_mirror(blank, at, start, screens._MEASURE)
+    measured = mirror._edit_mirror(blank, at, start, mirror._MEASURE)
     assert measured is not None
     assert measured.portage.mirrors.speed_test is not start.portage.mirrors.speed_test
 
-    files = screens._edit_mirror(blank, at, start, screens._DISTFILES)
+    files = mirror._edit_mirror(blank, at, start, mirror._DISTFILES)
     assert files is not None
     assert files.portage.mirrors.gentoo_distfiles is not start.portage.mirrors.gentoo_distfiles
 
-    added = screens._edit_mirror(blank, at, start, "guru")
+    added = mirror._edit_mirror(blank, at, start, "guru")
     assert added is not None
     assert "guru" in {one.name for one in added.portage.overlays}
-    removed = screens._edit_mirror(blank, at, added, "guru")
+    removed = mirror._edit_mirror(blank, at, added, "guru")
     assert removed is not None
     assert "guru" not in {one.name for one in removed.portage.overlays}
 
@@ -1758,7 +1759,7 @@ def test_the_overlay_address_is_held_in_one_place() -> None:
                 mirrors=replace(config().portage.mirrors, gentoo_zh=site),
             ),
         )
-        added = screens._with_gentoo_zh(chosen).overlays[-1]
+        added = tui_context.with_gentoo_zh(chosen).overlays[-1]
         assert added.name == "gentoo-zh"
         assert added.sync_uri == mirrors.gentoozh(site).git
 
@@ -2094,7 +2095,7 @@ def test_selecting_gentoo_zh_turns_its_binary_host_on() -> None:
     from gentoo_install.model.config import BinhostChannel
 
     assert config().portage.binhost.community is BinhostChannel.OFF
-    added = screens._with_gentoo_zh(config())
+    added = tui_context.with_gentoo_zh(config())
     assert any(one.name == "gentoo-zh" for one in added.overlays)
     assert added.binhost.community is BinhostChannel.STABLE
 
@@ -2106,7 +2107,7 @@ def test_selecting_gentoo_zh_turns_its_binary_host_on() -> None:
             binhost=replace(config().portage.binhost, community=BinhostChannel.UNSTABLE),
         ),
     )
-    assert screens._with_gentoo_zh(picked).binhost.community is BinhostChannel.UNSTABLE
+    assert tui_context.with_gentoo_zh(picked).binhost.community is BinhostChannel.UNSTABLE
 
 
 def test_a_grouped_row_uses_the_width_the_terminal_actually_has() -> None:
@@ -2854,9 +2855,15 @@ def test_a_reopened_selector_starts_on_what_is_already_set() -> None:
             "A ZFS root cannot boot from GRUB. Which bootloader?",
         }
     )
-    tree = ast.parse(Path("gentoo_install/tui/screens.py").read_text())
+    # Every module under `tui/`, not one of them: the Mirrors rows moved to
+    # `tui/mirror.py` and a scan of `screens.py` alone stopped seeing two of
+    # the selectors this is about.
+    trees = [
+        ast.parse(one.read_text())
+        for one in sorted(Path("gentoo_install/tui").glob("*.py"))
+    ]
     seen: dict[str, bool] = {}
-    for node in ast.walk(tree):
+    for node in [one for tree in trees for one in ast.walk(tree)]:
         if not (isinstance(node, ast.Call) and isinstance(node.func, ast.Name)):
             continue
         if node.func.id != "Menu":
@@ -3261,7 +3268,7 @@ def test_a_cpu_that_cannot_run_v3_cannot_be_made_to_choose_it() -> None:
     old = context()
     old.supports_v3 = False
     screen = FakeScreen(keys=["KEY_DOWN", "KEY_DOWN", "KEY_DOWN", "\n"])
-    answer = screens._edit_binhost(screen, old, config())
+    answer = mirror._edit_binhost(screen, old, config())
 
     assert answer is not None
     assert answer.portage.binhost.subarch == "x86-64", answer.portage.binhost


### PR DESCRIPTION
Forty-six definitions, and an AST scan found that nothing outside them used any except three row sentinels and `_with_gentoo_zh`; those four moved to `tui/context.py` and the rest became `tui/mirror.py`. `settings.py` is its only caller and `screens.py` imports none of it, so `screens.py` is 4684 lines rather than 5457.

The move exposed a check that only scanned `screens.py`: `test_a_reopened_selector_starts_on_what_is_already_set` walks the AST for selectors that must carry `current`, and two of the five live in the new module. It now walks every module under `tui/`; renaming `Gentoo mirror` turns it red.