### PR TITLE
vm: give the 4M firmware its own variable store

### DIFF
--- a/tests/unit/test_harness.py
+++ b/tests/unit/test_harness.py
@@ -4225,3 +4225,24 @@ def test_no_installed_check_is_ever_read_with_its_own_echo() -> None:
         }
         assert "expect_command" not in asked, f"{module}.{function} reads the echo: {asked}"
         assert "expect_output" in asked, f"{module}.{function} asks nothing: {asked}"
+
+
+def test_the_firmware_and_its_variable_store_are_the_same_build() -> None:
+    """A 4 MB `OVMF_CODE` handed the 2 MB `OVMF_VARS.fd` keeps its variables
+    in memory and writes none of them back. A Fedora conversion wrote
+    `Boot0002 Gentoo` first in `BootOrder`, powered off, and the store on disk
+    was byte-identical to the template it was copied from, so the next boot
+    scanned the ESP and started `\\EFI\\fedora\\shimx64.efi` instead."""
+    from tests.vm.qemu import OVMF_CODE, OVMF_VARS, PFLASH_FORMAT
+
+    def build(path: Path) -> str:
+        # `OVMF_CODE_4M.qcow2` and `OVMF_VARS_4M.qcow2` against `OVMF_CODE.fd`
+        # and `OVMF_VARS.fd`: whatever follows the role is the build.
+        parts = path.stem.split("_")
+        return "_".join(parts[2:])
+
+    assert build(OVMF_CODE) == build(OVMF_VARS), (OVMF_CODE.name, OVMF_VARS.name)
+
+    # And qemu is told the format each one is actually in.
+    assert PFLASH_FORMAT[OVMF_CODE.suffix] == "qcow2"
+    assert PFLASH_FORMAT[OVMF_VARS.suffix] == PFLASH_FORMAT[OVMF_CODE.suffix]

--- a/tests/vm/qemu.py
+++ b/tests/vm/qemu.py
@@ -16,7 +16,14 @@ from .media import Medium
 from .results import RESULT_SERIAL
 
 OVMF_CODE = Path("/usr/share/edk2-ovmf/OVMF_CODE_4M.qcow2")
-OVMF_VARS = Path("/usr/share/edk2-ovmf/OVMF_VARS.fd")
+#: The variable store of the same build as the code. `OVMF_VARS.fd` is the
+#: 2 MB build's, and a 4 MB firmware handed it keeps its variables in memory:
+#: a Fedora conversion wrote `Boot0002 Gentoo` first in `BootOrder`, powered
+#: off, and came back to a store byte-identical to the template.
+OVMF_VARS = Path("/usr/share/edk2-ovmf/OVMF_VARS_4M.qcow2")
+
+#: How qemu is told to read each of them, from the name rather than beside it.
+PFLASH_FORMAT = {".fd": "raw", ".qcow2": "qcow2"}
 
 
 class Firmware(Enum):
@@ -196,12 +203,14 @@ class Vm:
         # NVRAM must be writable and per-run, so boot entries do not leak between
         # tests. Booting the installed system keeps the file the install wrote,
         # which is where its boot entry lives.
-        variables = self.spec.workdir / "OVMF_VARS.fd"
+        variables = self.spec.workdir / OVMF_VARS.name
         if not (self.spec.boot_installed and variables.is_file()):
             shutil.copy(OVMF_VARS, variables)
         return [
-            "-drive", f"if=pflash,format=qcow2,readonly=on,file={OVMF_CODE}",
-            "-drive", f"if=pflash,format=raw,file={variables}",
+            "-drive",
+            f"if=pflash,format={PFLASH_FORMAT[OVMF_CODE.suffix]},readonly=on,file={OVMF_CODE}",
+            "-drive",
+            f"if=pflash,format={PFLASH_FORMAT[OVMF_VARS.suffix]},file={variables}",
         ]
 
     def wait(self, timeout: float) -> int:
@@ -215,7 +224,9 @@ class Vm:
         `kill()` is SIGKILL, so a pflash write stays in the host page cache and
         is lost: a Fedora conversion wrote a `Gentoo` entry, `efibootmgr -v` in
         that guest answered `BootOrder: 0002,0001,...` with Gentoo first, and
-        the next VM booted a firmware whose `OVMF_VARS.fd` held neither name.
+        the next VM booted a firmware whose variable store held neither name.
+        The store being the wrong build was the other half of that; both had
+        to be right before an entry survived a power cycle.
         """
         if self._process is not None and self._process.poll() is None:
             try:


### PR DESCRIPTION
`OVMF_CODE_4M.qcow2` was paired with `OVMF_VARS.fd`, which belongs to the 2 MB build. A 4 MB firmware handed that store keeps its variables in memory and writes none of them back, so no boot entry a guest created survived its power cycle.

Measured before: a Fedora conversion exited zero, `efibootmgr -v` inside it put `Gentoo … \\EFI\\Gentoo\\grubx64.efi` first in `BootOrder`, and `cmp` then found the store byte-identical to the template. The machine booted `Boot0001 "Fedora"` and stopped at `file '/vmlinuz-6.11.4-301.fc41.x86_64' not found`.

Measured after, same image and same command: `[727.4s] the converted machine booted and holds what the conversion asked for` — the first Fedora conversion on record to boot.