### PR TITLE
tui: delete twenty imports with no user left

### DIFF
--- a/gentoo_install/exec/apply.py
+++ b/gentoo_install/exec/apply.py
@@ -36,7 +36,7 @@ from ..plan.operations import CommandOutput, Operation
 from . import fetch, packages
 from .preflight import SecretStore
 from .probe import Probe
-from .runner import Runner, TargetEscape, open_in_target, under, write_file
+from .runner import Runner, TargetEscape, open_in_target, under
 
 
 @dataclass

--- a/gentoo_install/exec/fetch.py
+++ b/gentoo_install/exec/fetch.py
@@ -37,7 +37,6 @@ from ..errors import (
     UploadFailed,
 )
 from ..model import paste
-from ..model.device import DeviceId
 from ..model.validate import KernelCeiling
 from ..model.config import ProxyConfig
 from .probe import RELEASE_KEY

--- a/gentoo_install/exec/probe.py
+++ b/gentoo_install/exec/probe.py
@@ -16,7 +16,6 @@ import re
 import shutil
 import time
 from dataclasses import dataclass, field
-from enum import Enum
 from pathlib import Path
 from typing import ClassVar, Final, Iterable, Mapping
 

--- a/gentoo_install/model/parse.py
+++ b/gentoo_install/model/parse.py
@@ -8,9 +8,8 @@ is missing. That keeps a configuration file checkable on any machine.
 
 from __future__ import annotations
 
-import tomllib
 from enum import Enum
-from pathlib import Path, PurePosixPath
+from pathlib import PurePosixPath
 from typing import Any, Mapping, Sequence, TypeVar
 
 from ..errors import ConfigError

--- a/gentoo_install/model/validate.py
+++ b/gentoo_install/model/validate.py
@@ -17,7 +17,6 @@ from typing import Collection, Final, Mapping
 
 from ..errors import CommandFailed, ValidationFailed
 from . import compat
-from .compat import Trait
 from .config import (
     Bootloader,
     DiskMode,

--- a/gentoo_install/plan/kernel.py
+++ b/gentoo_install/plan/kernel.py
@@ -13,7 +13,7 @@ from pathlib import PurePosixPath
 from typing import Final
 
 from ..model.config import Bootloader, InitSystem, InstallConfig, KernelSource
-from ..errors import ConfigError, InvalidLayout, NothingToBoot, ValidationFailed
+from ..errors import ConfigError, NothingToBoot, ValidationFailed
 from ..model import compat
 from ..model.compat import CJK_KERNELS, KERNEL_PACKAGES
 from ..model.validate import zfs_kernel_version_problem

--- a/gentoo_install/tui/app.py
+++ b/gentoo_install/tui/app.py
@@ -22,7 +22,7 @@ from ..plan.build import build
 from .overview import overview_screen
 from .context import Context
 from .context import say
-from .settings import SETTINGS, UNSET, Setting, settings_for, shown_value, style_of, unanswered
+from .settings import SETTINGS, Setting, settings_for, shown_value, style_of, unanswered
 from .widgets import Item, Menu, Outcome, Screen, Style, TextField
 
 

--- a/gentoo_install/tui/mirror.py
+++ b/gentoo_install/tui/mirror.py
@@ -11,7 +11,7 @@ from dataclasses import replace
 from typing import Final
 
 from ..i18n import Catalog
-from ..model import compat, mirrors
+from ..model import mirrors
 from ..plan.portage import community_binhost
 from ..model.config import (
     Binhost,

--- a/gentoo_install/tui/screens.py
+++ b/gentoo_install/tui/screens.py
@@ -14,10 +14,9 @@ from copy import deepcopy
 from dataclasses import dataclass, replace
 from enum import Enum
 from itertools import takewhile
-from pathlib import PurePosixPath
-from typing import Callable, Final, Generic, Sequence, TypeVar, TypedDict
+from typing import Callable, Final, Sequence
 
-from ..i18n import Catalog, truncate
+from ..i18n import Catalog
 from ..exec import fetch
 from ..model import compat
 from ..model.config import (
@@ -70,15 +69,11 @@ from ..model.device import (
 )
 from ..plan import automatic as automatic_values
 from ..plan.convert import REPLACED_DIRECTORIES, SWAP_CONFIRMATION
-from ..plan import kernel as plan_kernel
 from ..plan.fonts import CJK_SANS_PREFERENCE, CjkFontconfigLocale, FontCategory
 from ..model.compat import KERNEL_PACKAGES
-from ..plan.portage import community_binhost
-from ..plan.operations import Operation
-from ..plan.render import counts
-from ..model.size import ZERO, Size
+from ..model.size import Size
 from ..errors import ConfigError, DeviceNotFound, GentooInstallError, ValidationFailed
-from ..model import atoms, manual, mirrors, paste, qr, sshkey
+from ..model import atoms, manual, paste, sshkey
 from ..model.templates import Choice, Layout, build
 from ..model.validate import validate
 from ..plan.packages import Catalog as Groups

--- a/tests/unit/test_layers.py
+++ b/tests/unit/test_layers.py
@@ -460,3 +460,33 @@ def test_the_tui_context_knows_nothing_about_a_screen() -> None:
             if isinstance(node, (ast.FunctionDef, ast.ClassDef)) and node.name in owned
         }
         assert not defined, f"{neighbour} defines {defined} again"
+
+
+def test_no_module_imports_a_name_it_never_uses() -> None:
+    """Twenty dead imports were in the tree at once, twelve of them left in
+    `tui/screens.py` by two moves that took their users away. `mypy` does not
+    see them and no lint gate is configured, so an import that survives its
+    last caller reads as a dependency the module still has."""
+    dead: list[str] = []
+    for path in sorted(PACKAGE.rglob("*.py")):
+        source = path.read_text()
+        tree = ast.parse(source)
+        lines = source.splitlines()
+        imported: dict[str, int] = {}
+        for node in ast.walk(tree):
+            if isinstance(node, (ast.Import, ast.ImportFrom)):
+                # `from __future__ import annotations` has no user by design.
+                if isinstance(node, ast.ImportFrom) and node.module == "__future__":
+                    continue
+                for alias in node.names:
+                    imported[alias.asname or alias.name.split(".")[0]] = node.lineno
+        # The import statements themselves are not uses of what they bind.
+        elsewhere = "\n".join(
+            line for number, line in enumerate(lines, 1) if number not in set(imported.values())
+        )
+        dead += [
+            f"{path.relative_to(PACKAGE.parent)}:{line} {name}"
+            for name, line in sorted(imported.items())
+            if not re.search(rf"\b{re.escape(name)}\b", elsewhere)
+        ]
+    assert not dead, dead


### PR DESCRIPTION
Twelve were left in `screens.py` by the two moves that took their callers into `tui/context.py` and `tui/mirror.py`; eight predate them (`write_file`, `DeviceId`, `Enum`, `Path`, `tomllib`, `Trait`, `InvalidLayout`, `UNSET`).

`mypy` does not report an unused import and no lint gate is configured, so the rule is a test that reads every module's imports and asks whether the name appears anywhere else in the file. It is red on the twenty before this commit removes them.