### PR TITLE
docs: ask an install report for the evidence it needs

### DIFF
--- a/.github/ISSUE_TEMPLATE/an-install-failed.yml
+++ b/.github/ISSUE_TEMPLATE/an-install-failed.yml
@@ -1,0 +1,59 @@
+name: An install failed
+description: A run that stopped, or produced a system that does not boot.
+labels: [install]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        A report that names the revision, the medium and the configuration can
+        be reproduced. One that names a machine's passphrase has to be
+        discarded, so redact secrets before pasting. Do not report a
+        vulnerability here — `SECURITY.md` has the private address.
+  - type: input
+    id: revision
+    attributes:
+      label: Installer revision
+      description: The first line of `install.log`, or the commit you cloned.
+      placeholder: ce95e7df72cd
+    validations:
+      required: true
+  - type: input
+    id: medium
+    attributes:
+      label: Install medium
+      description: Which image was booted, with its build date.
+      placeholder: install-amd64-minimal-20260816T170110Z
+    validations:
+      required: true
+  - type: textarea
+    id: what-happened
+    attributes:
+      label: What the machine said
+      description: >
+        The last operation printed and the error under it. `install.log` and
+        `install.jsonl` are in `/var/log/gentoo-install` on the installed
+        system, and under `--work` while a run is going. A paste address from
+        the overview's publish action is better than a screenshot.
+      render: text
+    validations:
+      required: true
+  - type: textarea
+    id: configuration
+    attributes:
+      label: Configuration
+      description: >
+        The TOML the run was given, with `password_hash`, `root_password_hash`
+        and any proxy credentials removed. Publishing from the menu removes
+        them for you.
+      render: toml
+    validations:
+      required: true
+  - type: textarea
+    id: disks
+    attributes:
+      label: What the disks looked like before
+      description: >
+        `lsblk -o NAME,SIZE,FSTYPE,PARTTYPENAME,MOUNTPOINTS` from the live
+        medium, when the failure touched partitioning, filesystems or the
+        bootloader.
+      render: text

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,5 @@
+blank_issues_enabled: true
+contact_links:
+  - name: A vulnerability
+    url: https://github.com/Zakkaus/gentoo-install/blob/master/SECURITY.md
+    about: Report it privately to the address in SECURITY.md, not as an issue.

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,12 @@
+<!--
+The body carries the reason, not an inventory of the diff: what was wrong,
+what the change makes true, and the evidence. At most three paragraphs. CI
+attests that the gates pass, so a green suite earns no mention; a test that
+forced a change does.
+
+A change touching partitioning, filesystems, chroot, bootloader or binhost
+trust needs a `tests/vm/run.py` or cluster run behind it. Say which run and
+what it answered, or say that the path is unverified.
+
+`CONTRIBUTING.md` has the rest.
+-->

--- a/tests/unit/test_project_docs.py
+++ b/tests/unit/test_project_docs.py
@@ -41,3 +41,29 @@ def test_security_names_what_publishing_actually_removes() -> None:
     assert dropped <= {field.name for field in fields(ProxyConfig)}, "the model moved"
     for name in dropped:
         assert name in paragraph, name
+
+
+def test_the_issue_form_asks_for_files_that_exist() -> None:
+    """The form names where a run's record is. A path or a filename that has
+    moved sends every reporter to an empty directory, and the report that
+    comes back cannot be reproduced."""
+    from gentoo_install.exec.report import LOG_DIRECTORY, RunFile
+
+    form = (ROOT / ".github" / "ISSUE_TEMPLATE" / "an-install-failed.yml").read_text(
+        encoding="utf-8"
+    )
+    assert str(LOG_DIRECTORY) in form, LOG_DIRECTORY
+    for held in RunFile:
+        assert held.value in form, held.value
+
+    # And what it promises the publish action removes.
+    for name in SECRET:
+        assert name in form, name
+
+
+def test_the_issue_form_sends_a_vulnerability_somewhere_else() -> None:
+    """An installer that runs as root gets reports that should not be public
+    until they are fixed. The link is the only thing standing between a
+    reporter and the issue tracker."""
+    config = (ROOT / ".github" / "ISSUE_TEMPLATE" / "config.yml").read_text(encoding="utf-8")
+    assert "SECURITY.md" in config, config


### PR DESCRIPTION
An install report is reproducible when it names the installer revision, the medium, what the machine printed and the configuration with its secrets removed; the form asks for exactly those, and for `lsblk` when the failure touched partitioning. A vulnerability is pointed at the private address in `SECURITY.md` rather than the tracker.

The test holds the form to the code: the paths and filenames it tells a reporter to look in come from `report.LOG_DIRECTORY` and `report.RunFile`, and the field names it promises the publish action removes come from `serialise.SECRET`. Renaming either turns it red.