### PR TITLE
vm: put the installer's own log in a memory-install failure

### DIFF
--- a/tests/unit/test_harness.py
+++ b/tests/unit/test_harness.py
@@ -4246,3 +4246,24 @@ def test_the_firmware_and_its_variable_store_are_the_same_build() -> None:
     # And qemu is told the format each one is actually in.
     assert PFLASH_FORMAT[OVMF_CODE.suffix] == "qcow2"
     assert PFLASH_FORMAT[OVMF_VARS.suffix] == PFLASH_FORMAT[OVMF_CODE.suffix]
+
+
+def test_a_lowram_install_failure_carries_the_installers_own_log() -> None:
+    """`FAIL the memory environment did not install: … espfs labelled ESP` came
+    with `/proc/partitions` holding `vdc1` and `vdc2`, `/dev` holding neither,
+    and no way to tell whether `wait_for` had fallen back to `mdev -s` or what
+    stood between the node appearing and the formatter finding nothing. The
+    installer writes every command it runs to its own log, and the diagnostic
+    read everything except that."""
+    import inspect
+
+    from gentoo_install.cli import WORK
+    from gentoo_install.exec.report import RunFile
+    from tests.vm import ram
+
+    asked = inspect.getsource(ram._what_the_disk_holds)
+    assert f"{WORK}/{RunFile.LOG.value}" in asked, asked
+
+    # And it reads between the markers, because several of these commands name
+    # their own answer.
+    assert "expect_output" in asked and "expect_command" not in asked, asked

--- a/tests/vm/ram.py
+++ b/tests/vm/ram.py
@@ -227,6 +227,12 @@ def _what_the_disk_holds(console: SerialConsole) -> str:
         "ls -l /dev/vd*",
         "for one in /proc/[0-9]*/comm; do cat \"$one\"; done | sort -u | tr '\\n' ' '",
         "command -v mdev; echo mdev=$?",
+        # The installer's own log, which names every command it ran: whether
+        # `wait_for` fell back to `mdev -s`, and what stood between the node
+        # appearing and the formatter finding nothing, are in it and in no
+        # file either runner keeps.
+        "tail -25 /run/gentoo-install/install.log",
+        "stat -c '%n %F' /dev/vdc /dev/vdc1 /dev/vdc2 2>&1",
         "dmesg | tail -20",
     ):
         try:


### PR DESCRIPTION
A `--lowram` install stopped at `make a vfat filesystem on espfs labelled ESP`. The diagnostic showed `/proc/partitions` holding `vdc1` and `vdc2`, `ls -l /dev/vd*` holding neither, and `mkfs.vfat` had been reached at all — which it cannot be unless `wait_for` saw the node. Nothing said whether the fallback to `mdev -s` ran, or what stood between the node appearing and the formatter finding nothing, because the installer's own log lives on the guest and neither runner keeps it.

The failure now carries `tail -25 /run/gentoo-install/install.log` and `stat` of the three nodes. The test takes the path from `cli.WORK` and `report.RunFile` rather than repeating it, and requires the reader to stay on `expect_output`, since several of these commands name their own answer.