### PR TITLE
cluster: leave the site alone where the site is the test

### DIFF
--- a/tests/unit/test_harness.py
+++ b/tests/unit/test_harness.py
@@ -4267,3 +4267,42 @@ def test_a_lowram_install_failure_carries_the_installers_own_log() -> None:
     # And it reads between the markers, because several of these commands name
     # their own answer.
     assert "expect_output" in asked and "expect_command" not in asked, asked
+
+
+def test_a_fixture_whose_site_is_the_test_keeps_it() -> None:
+    """`vm-binhost-fallback` names `xtom-hk`, whose binary package index
+    answers 404, and it is green only when Portage drops that host and
+    compiles from source. `--site nju` rewrote it to a working mirror, so the
+    guest installed 42 minutes of binary packages and the verdict said the
+    degradation path works."""
+    from gentoo_install.exec.config import load
+    from gentoo_install.model.config import MirrorRegion, Sync
+    from tests.vm import cluster
+
+    fixtures = Path(__file__).resolve().parents[1] / "fixtures"
+    kept = cluster.Job(name="vm-binhost-fallback", fixture=fixtures / "vm-binhost-fallback.toml")
+    moved = cluster.Job(name="vm-btrfs", fixture=fixtures / "vm-btrfs.toml")
+    pinned = load(kept.fixture).portage.mirrors.site
+    assert pinned and pinned != "nju", "the fixture pins a site of its own"
+
+    import tempfile
+
+    with tempfile.TemporaryDirectory() as where:
+        written = cluster.rewrite_fixtures(
+            [kept, moved], Path(where) / "fixtures", MirrorRegion.CN, Sync.WEBRSYNC, site="nju"
+        )
+        assert load(written / kept.fixture.name).portage.mirrors.site == pinned
+        assert load(written / moved.fixture.name).portage.mirrors.site == "nju"
+
+
+def test_every_fixture_that_keeps_its_site_pins_one() -> None:
+    """A name in the table whose fixture does not pin a site keeps nothing and
+    reads as protection that is not there."""
+    from gentoo_install.exec.config import load
+    from tests.vm import cluster
+
+    fixtures = Path(__file__).resolve().parents[1] / "fixtures"
+    for name in cluster.KEEPS_ITS_SITE:
+        path = fixtures / f"{name}.toml"
+        assert path.is_file(), name
+        assert load(path).portage.mirrors.site, name

--- a/tests/vm/cluster.py
+++ b/tests/vm/cluster.py
@@ -1159,7 +1159,7 @@ def rewrite_fixtures(
                 mirrors=replace(
                     config.portage.mirrors,
                     region=region,
-                    site=site,
+                    site=config.portage.mirrors.site if job.name in KEEPS_ITS_SITE else site,
                     gentoo_zh=chosen,
                     # A replaced list, when one is given: a cache on the
                     # guests' own segment is an address with no name to
@@ -2172,6 +2172,13 @@ def _remaining(deadline: float) -> float:
 #: fixture that could never be green, and it was counted as unverified for
 #: weeks. `campaign.py` knew this and the cluster did not.
 EXPECTED_TO_FAIL: Final[frozenset[str]] = frozenset({"vm-proxy-dead"})
+
+#: Fixtures whose mirror site is the thing under test, so `--site` must not
+#: move it. `vm-binhost-fallback` names `xtom-hk`, whose binary package index
+#: answers 404, and the run is green only if Portage drops that host and
+#: compiles from source. Rewritten to a working site it installed from a
+#: binhost in 42 minutes and proved nothing.
+KEEPS_ITS_SITE: Final[frozenset[str]] = frozenset({"vm-binhost-fallback"})
 
 #: Nodes that take no guests until `--allow-node` names them. Empty because
 #: `infra-node3`, which 66 of the 70 recorded console-proxy drops named, took


### PR DESCRIPTION
`vm-binhost-fallback` pins `xtom-hk`, whose binary package index answers 404, and is green only when Portage drops that host and compiles from source. `rewrite_fixtures` moved every fixture's site to whatever `--site` named, so the campaign's own parameter removed the failure the fixture exists to cause: the guest downloaded binary packages for 42 minutes, passed, and the verdict said the degradation path works.

`KEEPS_ITS_SITE` names the fixtures whose site is under test. One test rewrites two fixtures and requires the pinned one to keep `xtom-hk` while the other moves to `nju`; a second requires every name in the table to belong to a fixture that actually pins a site, so an entry that protects nothing fails.