### PR TITLE
cluster: fail a fixture that was supposed to degrade and did not

### DIFF
--- a/tests/unit/test_harness.py
+++ b/tests/unit/test_harness.py
@@ -4306,3 +4306,42 @@ def test_every_fixture_that_keeps_its_site_pins_one() -> None:
         path = fixtures / f"{name}.toml"
         assert path.is_file(), name
         assert load(path).portage.mirrors.site, name
+
+
+def test_a_fixture_that_must_degrade_is_failed_when_it_did_not() -> None:
+    """`vm-binhost-fallback` was green because the install finished, which it
+    does whether or not the host it names ever failed: 42 minutes of binary
+    packages downloaded from a working mirror, and the verdict read as proof
+    that the degradation path works. The journal records what a run gave up
+    on, so the fixture's own premise is now part of its verdict."""
+    import json
+
+    from gentoo_install.plan.portage import BINARY_PACKAGES
+    from tests.vm import cluster
+
+    degraded = json.dumps({"event": "degraded", "what": BINARY_PACKAGES, "reason": "404"})
+    other = json.dumps({"event": "degraded", "what": "something else", "reason": "-"})
+
+    assert cluster._degradation_missing("vm-btrfs", {}) == "", "no promise, no requirement"
+    assert cluster._degradation_missing(
+        "vm-binhost-fallback", {"install.jsonl": degraded.encode()}
+    ) == ""
+
+    for held in ({}, {"install.jsonl": b""}, {"install.jsonl": other.encode()}):
+        refused = cluster._degradation_missing("vm-binhost-fallback", held)
+        assert refused, held
+        assert BINARY_PACKAGES in refused, refused
+
+    # A partial last line is what a run killed mid-write leaves behind, and it
+    # must not hide the entry above it.
+    partial = degraded.encode() + b'\n{"event": "degr'
+    assert cluster._degradation_missing("vm-binhost-fallback", {"install.jsonl": partial}) == ""
+
+
+def test_every_fixture_that_must_degrade_keeps_the_site_that_makes_it() -> None:
+    """A fixture required to degrade is required to reach the host that fails
+    it, so `--site` must not move it: the two tables have to agree or the
+    requirement is one no run can meet."""
+    from tests.vm import cluster
+
+    assert set(cluster.MUST_DEGRADE) <= cluster.KEEPS_ITS_SITE, cluster.MUST_DEGRADE

--- a/tests/vm/cluster.py
+++ b/tests/vm/cluster.py
@@ -38,6 +38,7 @@ from enum import Enum
 from pathlib import Path
 from collections import Counter
 from collections.abc import Callable, Mapping
+from types import MappingProxyType
 from contextlib import contextmanager
 from typing import Final, Iterator, Protocol, TypeVar, cast, Sequence
 
@@ -61,7 +62,7 @@ from gentoo_install.model.config import MirrorRegion, Sync
 from gentoo_install.model import mirrors
 from gentoo_install.exec.config import load
 from gentoo_install.model.serialise import to_toml
-from gentoo_install.plan.portage import KEY_SERVER
+from gentoo_install.plan.portage import BINARY_PACKAGES, KEY_SERVER
 
 from .console import (
     DISK_PASSPHRASE,
@@ -1716,6 +1717,17 @@ def install_one(
                 phase=phase,
                 revision=revision,
             )
+        missing = _degradation_missing(job.name, files) if code == b"0" else ""
+        if missing:
+            return Outcome(
+                job.name,
+                Verdict.FAIL,
+                time.monotonic() - started,
+                missing,
+                log,
+                phase=phase,
+                revision=revision,
+            )
         if code != b"0":
             outcome = Outcome(
                 job.name,
@@ -2179,6 +2191,33 @@ EXPECTED_TO_FAIL: Final[frozenset[str]] = frozenset({"vm-proxy-dead"})
 #: compiles from source. Rewritten to a working site it installed from a
 #: binhost in 42 minutes and proved nothing.
 KEEPS_ITS_SITE: Final[frozenset[str]] = frozenset({"vm-binhost-fallback"})
+
+#: Fixtures whose whole point is that the install gives something up and
+#: carries on, mapped to what `install.jsonl` must record it giving up. Without
+#: this the fixture is green when the install merely finished, which it does
+#: whether or not the host it names ever failed.
+MUST_DEGRADE: Final[Mapping[str, str]] = MappingProxyType(
+    {"vm-binhost-fallback": BINARY_PACKAGES}
+)
+
+
+def _degradation_missing(name: str, files: Mapping[str, bytes]) -> str:
+    """Empty when the journal records what this fixture had to give up."""
+    wanted = MUST_DEGRADE.get(name)
+    if wanted is None:
+        return ""
+    journal = files.get("install.jsonl")
+    if journal is None:
+        return f"{name} has to degrade {wanted!r} and the guest handed back no journal"
+    for line in journal.splitlines():
+        try:
+            entry = json.loads(line)
+        except json.JSONDecodeError:
+            # A run killed mid-write leaves a partial last line.
+            continue
+        if entry.get("event") == "degraded" and entry.get("what") == wanted:
+            return ""
+    return f"{name} finished without degrading {wanted!r}, which is what it exists to measure"
 
 #: Nodes that take no guests until `--allow-node` names them. Empty because
 #: `infra-node3`, which 66 of the 70 recorded console-proxy drops named, took


### PR DESCRIPTION
Fixing the site rewrite (#655) lets `vm-binhost-fallback` reach the host whose binary package index answers 404, but its verdict still only asked whether the install finished — which it does either way. The fixture could not fail for the reason it exists.

`MUST_DEGRADE` maps such a fixture to what `install.jsonl` must record it giving up, and the run is failed when the journal holds no matching `degraded` event. A second test requires `MUST_DEGRADE` to be a subset of `KEEPS_ITS_SITE`, since a fixture required to degrade must be allowed to reach the host that fails it; the tables cannot drift apart into a requirement no run can meet.

The reader skips a line that does not parse, because a run killed mid-write leaves a partial last one, and a test holds that too.