### PR TITLE
probe: one reader for both of the json trees it walks

### DIFF
--- a/gentoo_install/exec/probe.py
+++ b/gentoo_install/exec/probe.py
@@ -219,37 +219,19 @@ def _fstab_we_do_not_manage(esp: str | None, boot: str | None) -> tuple[str, ...
     return tuple(carried)
 
 
-def _mount_entries(document: object) -> tuple[Mapping[str, object], ...]:
+def _entries(document: object, key: str) -> tuple[Mapping[str, object], ...]:
+    """Every node under `key`, parents before their children.
+
+    `findmnt --json` nests a mount's submounts and `lsblk --json` nests a
+    disk's partitions, both under `children`, so one reader answers for both:
+    they differed only in the key and in one blank line.
+    """
     if not isinstance(document, Mapping):
         return ()
-    roots = document.get("filesystems")
+    roots = document.get(key)
     if not isinstance(roots, list):
         return ()
     found: list[Mapping[str, object]] = []
-
-    def visit(value: object) -> None:
-        if not isinstance(value, Mapping):
-            return
-        found.append(value)
-        children = value.get("children")
-        if isinstance(children, list):
-            for child in children:
-                visit(child)
-
-    for root in roots:
-        visit(root)
-    return tuple(found)
-
-
-def _block_entries(document: object) -> tuple[Mapping[str, object], ...]:
-    if not isinstance(document, Mapping):
-        return ()
-    roots = document.get("blockdevices")
-    if not isinstance(roots, list):
-        return ()
-
-    found: list[Mapping[str, object]] = []
-
 
     def visit(value: object) -> None:
         if not isinstance(value, Mapping):
@@ -953,7 +935,7 @@ class Probe:
         mounts: tuple[Mapping[str, object], ...] = ()
         if mounts_result.returncode == 0:
             try:
-                mounts = _mount_entries(json.loads(mounts_result.stdout))
+                mounts = _entries(json.loads(mounts_result.stdout), "filesystems")
             except json.JSONDecodeError:
                 mounts = ()
         root = next((entry for entry in mounts if _entry_text(entry, "target") == "/"), None)
@@ -974,7 +956,7 @@ class Probe:
         blocks: tuple[Mapping[str, object], ...] = ()
         if blocks_result.returncode == 0:
             try:
-                blocks = _block_entries(json.loads(blocks_result.stdout))
+                blocks = _entries(json.loads(blocks_result.stdout), "blockdevices")
             except json.JSONDecodeError:
                 blocks = ()
         root_uuid: str | None = None

--- a/tests/unit/test_exec.py
+++ b/tests/unit/test_exec.py
@@ -2586,3 +2586,37 @@ def test_preflight_asks_for_every_command_the_plan_will_run() -> None:
         # reason at the head of the table: the operation degrades to
         # `blockdev --rereadpt` without it.
         assert planned - configured - {"partprobe"} == set(), (name, planned - configured)
+
+
+def test_one_reader_flattens_both_of_the_json_trees_the_probe_reads() -> None:
+    """`findmnt --json` nests submounts and `lsblk --json` nests partitions,
+    both under `children`. Two copies of the same walker differed only in the
+    key they start from, so a fix to one would have been a fix to half."""
+    from gentoo_install.exec.probe import _entries
+
+    mounts = {
+        "filesystems": [
+            {"target": "/", "children": [{"target": "/efi"}, {"target": "/home"}]},
+            {"target": "/proc"},
+        ]
+    }
+    blocks = {
+        "blockdevices": [
+            {"name": "vda", "children": [{"name": "vda1"}, {"name": "vda2"}]},
+        ]
+    }
+
+    assert [one["target"] for one in _entries(mounts, "filesystems")] == [
+        "/",
+        "/efi",
+        "/home",
+        "/proc",
+    ]
+    assert [one["name"] for one in _entries(blocks, "blockdevices")] == ["vda", "vda1", "vda2"]
+
+    # The key is what selects the tree, and anything else answers empty rather
+    # than reaching into the wrong one.
+    assert _entries(mounts, "blockdevices") == ()
+    assert _entries(blocks, "filesystems") == ()
+    assert _entries("not a document", "filesystems") == ()
+    assert _entries({"filesystems": "not a list"}, "filesystems") == ()


### PR DESCRIPTION
An AST scan with names and constants erased finds two functions in `gentoo_install/` sharing a shape: `_mount_entries` and `_block_entries`. They walk `findmnt --json` and `lsblk --json`, which both nest under `children`, and differed only in the key they start from and in one stray blank line.

`_entries(document, key)` replaces both. The test walks a nested tree of each kind, requires parents before children, and requires the wrong key to answer empty rather than reaching into the other tree; stopping the descent turns it red.

The same scan over `tests/vm/` finds no duplication beyond three one-line `__exit__` methods, so `cluster.py` is long but not repetitive — length alone is not a reason to split it.