### PR TITLE
cli: refuse a resume whose journal is another run's

### DIFF
--- a/gentoo_install/cli.py
+++ b/gentoo_install/cli.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 
 import argparse
 import curses
+import hashlib
 import locale
 import os
 import shutil
@@ -21,10 +22,11 @@ from pathlib import Path
 from typing import Callable, Final, Sequence
 
 from . import errors
-from .errors import GentooInstallError
+from .errors import GentooInstallError, ResumeRefused
 from .data import load_catalog
 from .exec import fetch, preflight, report
 from .exec.apply import Machine, already_degraded, apply, completed
+from .exec import probe as probe_module
 from .exec.probe import (
     GRUB_DIRECTORIES,
     BootMethod,
@@ -34,6 +36,7 @@ from .exec.probe import (
     secure_boot,
 )
 from .exec.runner import Runner
+from .log import Journal
 from .model.device import StorageFacts, StorageLayout, ZfsPool
 from .model.size import Size
 from .tui import app, screens
@@ -425,6 +428,11 @@ def main(argv: Sequence[str] | None = None) -> int:
         _print_machine_state(state)
         print(f"device: {error}", file=sys.stderr)
         return EXIT_PREFLIGHT
+    except errors.ResumeRefused as error:
+        # Before the machine state is printed: nothing of this run has touched
+        # the disks, and the state to report is the earlier run's.
+        print(f"resume: {error}", file=sys.stderr)
+        return EXIT_CONFIG
     except errors.ConfigError as error:
         _print_machine_state(state)
         print(f"configuration: {error}", file=sys.stderr)
@@ -521,6 +529,10 @@ def install(
             work=work,
             mountpoint=target,
         )
+        identity = _run_identity(config)
+        if arguments.resume:
+            _refuse_a_different_run(journal, identity, record)
+        journal.started(configuration=identity[0], session=identity[1])
         finished = completed(journal) if arguments.resume else frozenset()
         if arguments.resume:
             # Replayed before anything runs. The operation that recorded an
@@ -877,6 +889,38 @@ def _image_write_offer(probe: Probe) -> str:
         return ""
     return "writing an image over the running root would overwrite the installer"
 
+
+
+def _run_identity(config: InstallConfig) -> tuple[str, str]:
+    """What this run is: the configuration it was given and the live session."""
+    written = to_toml(config).encode("utf-8")
+    return hashlib.sha256(written).hexdigest(), probe_module.session_id()
+
+
+def _refuse_a_different_run(
+    journal: Journal, identity: tuple[str, str], record: Callable[[str], None]
+) -> None:
+    """A resume carries on from operations recorded by position and text, so a
+    journal from another configuration would skip the wrong ones and one from
+    another boot would skip operations whose result the reboot discarded.
+
+    A journal with no identity is from a run that predates this and is resumed
+    the way it always was, with a line saying so.
+    """
+    held = journal.identity()
+    if held is None:
+        record("resuming: the journal records no identity, so it is not checked")
+        return
+    if held[0] != identity[0]:
+        raise ResumeRefused(
+            "this journal was written for a different configuration; "
+            "start a new run or pass the configuration the first one used"
+        )
+    if held[1] and identity[1] and held[1] != identity[1]:
+        raise ResumeRefused(
+            "this journal was written before the machine rebooted, and a "
+            "resumed run needs the state the first one left in memory"
+        )
 
 def _from_menu(arguments: argparse.Namespace) -> InstallConfig | None:
     """Walk the screens and return what the operator built, or None."""

--- a/gentoo_install/errors.py
+++ b/gentoo_install/errors.py
@@ -91,6 +91,10 @@ class ArchiveDigestMismatch(IntegrityError):
     """
 
 
+class ResumeRefused(GentooInstallError):
+    """A `--resume` whose journal was written by a different run."""
+
+
 class ConversionUnsupported(GentooInstallError):
     """The running layout is one the conversion cannot rebuild.
 

--- a/gentoo_install/exec/probe.py
+++ b/gentoo_install/exec/probe.py
@@ -60,6 +60,19 @@ UDEV_NAMES: Final[tuple[str, ...]] = ("udevd", "systemd-udevd")
 
 PROC: Final[Path] = Path("/proc")
 
+#: What makes one live session different from the next. A resumed install must
+#: run on the machine the first one left half-configured, and a reboot both
+#: changes this and empties the tmpfs the run's state lives in.
+BOOT_ID: Final[Path] = PROC / "sys" / "kernel" / "random" / "boot_id"
+
+
+def session_id() -> str:
+    """The machine's boot id, or empty where the kernel does not publish one."""
+    try:
+        return BOOT_ID.read_text().strip()
+    except OSError:
+        return ""
+
 
 def _udev_is_running() -> bool:
     """Whether a udev daemon is on this machine, read from `/proc`."""

--- a/gentoo_install/log.py
+++ b/gentoo_install/log.py
@@ -51,6 +51,26 @@ class Journal:
         for atom, source in merged(output):
             self.write("package", atom=atom, source=source.value)
 
+    def started(self, *, configuration: str, session: str) -> None:
+        """What this run is, so a later `--resume` can refuse a different one.
+
+        `configuration` is a digest of the file the run was given and
+        `session` is the machine's boot id: a resume that skips operations by
+        their position and description would otherwise skip them on a plan
+        that no longer says the same thing.
+        """
+        self.write("started", configuration=configuration, session=session)
+
+    def identity(self) -> tuple[str, str] | None:
+        """What the first run recorded, or None for a journal without one."""
+        for entry in self.replay():
+            if entry.get("event") == "started":
+                configuration = entry.get("configuration")
+                session = entry.get("session")
+                if isinstance(configuration, str) and isinstance(session, str):
+                    return configuration, session
+        return None
+
     def degraded(self, what: str, reason: str) -> None:
         """A path the install had to give up on, and why. Always recorded: a
         binary host that fell back to compiling is the difference between a

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -1712,3 +1712,73 @@ def test_missing_commands_is_answered_before_the_arming_refusals(
 
     assert code == cli.EXIT_OK, said
     assert "xorriso" in said, said
+
+
+def test_a_resume_refuses_a_journal_from_another_run(tmp_path: Path) -> None:
+    """The README documents `--resume` for the same live session, installer
+    and configuration because nothing checked any of it: a resume replays
+    operations by position and description, so a journal from a different
+    configuration skips the wrong ones and one from before a reboot skips
+    operations whose result the reboot discarded."""
+    import json
+
+    import pytest as _pytest
+
+    from gentoo_install import cli
+    from gentoo_install.errors import ResumeRefused
+    from gentoo_install.log import Journal
+
+    said: list[str] = []
+    path = tmp_path / "install.jsonl"
+
+    def journal_of(configuration: str, session: str) -> Journal:
+        path.write_text(
+            json.dumps(
+                {"event": "started", "configuration": configuration, "session": session}
+            )
+            + "\n"
+        )
+        return Journal(path=path)
+
+    same = ("digest-of-the-file", "the-boot-id")
+
+    # The ordinary resume: same configuration, same session.
+    cli._refuse_a_different_run(journal_of(*same), same, said.append)
+    assert said == []
+
+    with _pytest.raises(ResumeRefused, match="different configuration"):
+        cli._refuse_a_different_run(journal_of("another-digest", same[1]), same, said.append)
+
+    with _pytest.raises(ResumeRefused, match="rebooted"):
+        cli._refuse_a_different_run(journal_of(same[0], "another-boot-id"), same, said.append)
+
+    # A machine whose kernel publishes no boot id: the configuration still has
+    # to match, and the session cannot be compared either way.
+    cli._refuse_a_different_run(journal_of(same[0], ""), (same[0], ""), said.append)
+
+    # A journal from a run that predates this carries on as it always did, and
+    # says so rather than refusing.
+    path.write_text(json.dumps({"event": "operation", "position": 0}) + "\n")
+    cli._refuse_a_different_run(Journal(path=path), same, said.append)
+    assert said and "records no identity" in said[-1], said
+
+
+def test_the_identity_of_a_run_is_the_configuration_it_was_given() -> None:
+    """Two configurations that differ anywhere have to differ here, or a
+    resume accepts a journal written for the other one."""
+    from dataclasses import replace as _replace
+
+    from gentoo_install import cli
+
+    from .layouts import config
+
+    first = config()
+    digest, session = cli._run_identity(first)
+    assert len(digest) == 64, digest
+    assert cli._run_identity(first)[0] == digest, "the same file answers the same"
+
+    other = _replace(first, system=_replace(first.system, hostname="somewhere-else"))
+    assert cli._run_identity(other)[0] != digest
+
+    # The session is the machine's, not the configuration's.
+    assert session == cli._run_identity(other)[1]

--- a/tests/unit/test_log.py
+++ b/tests/unit/test_log.py
@@ -51,3 +51,33 @@ def test_a_chrooted_runner_writes_to_the_same_journal(tmp_path: Path) -> None:
     journal = Journal(path=tmp_path / "install.jsonl")
     runner = Runner(log=lambda line: None, journal=journal)
     assert runner.in_target(Path("/mnt/gentoo")).journal is journal
+
+
+def test_a_journal_carries_what_the_run_was(tmp_path: Path) -> None:
+    """`--resume` skips operations by position and description, so a journal
+    from another configuration would skip the wrong ones and one from before a
+    reboot would skip operations whose result the reboot discarded. The
+    journal had no way to say which run wrote it."""
+    from gentoo_install.log import Journal
+
+    journal = Journal(path=tmp_path / "install.jsonl")
+    assert journal.identity() is None, "a journal that recorded nothing claims nothing"
+
+    journal.started(configuration="abc123", session="a-boot-id")
+    journal.operation(stage="partition", described="do something", seconds=1.0)
+    assert journal.identity() == ("abc123", "a-boot-id")
+
+    # Read back from the file, not from memory: a resumed run is a new process.
+    assert Journal(path=tmp_path / "install.jsonl").identity() == ("abc123", "a-boot-id")
+
+
+def test_an_identity_entry_missing_a_field_is_not_an_identity(tmp_path: Path) -> None:
+    """A line written by a future version, or a partial one from a run killed
+    mid-write, must not read as an identity that happens to match."""
+    import json
+
+    from gentoo_install.log import Journal
+
+    path = tmp_path / "install.jsonl"
+    path.write_text(json.dumps({"event": "started", "configuration": "abc123"}) + "\n")
+    assert Journal(path=path).identity() is None


### PR DESCRIPTION
`--resume` replays a journal and skips what it records as finished, matched by position and description. Nothing recorded which run wrote that journal, so a different configuration skipped the wrong operations and a journal from before a reboot skipped operations whose result the reboot discarded — which is why the README documents `--resume` only for the same live session and configuration.

The journal now opens with a `started` entry carrying a sha256 of `to_toml(config)` and `/proc/sys/kernel/random/boot_id`. A resume compares both and raises `ResumeRefused` (`EXIT_CONFIG`) on either mismatch; where the kernel publishes no boot id only the configuration is compared. A journal with no identity — written before this change — resumes as it always did and says so, so the change cannot strand a run already in progress.

Four paths have tests, and the controls: removing the configuration comparison stops the refusal, and accepting a partial `started` entry makes a half-written line read as an identity.