### PR TITLE
docs: record four passes from two rounds

### DIFF
--- a/TESTED.md
+++ b/TESTED.md
@@ -46,6 +46,8 @@ The ordinary path: partition, format, unpack a stage3, configure, boot.
 | `2849e42a151a` | `ext3` — the first record of `ext3` since the harness waits for the name's echo before the password prompt, the race that had left `Password:` in the buffer and typed the password into the name field |
 | `02141f7a9902` | `vm-xfs`, `vm-luks`, `vm-sdboot`, `vm-greetd`, `vm-zfs-encrypted` — five of the round's six. `vm-greetd` is the first record of greetd and tuigreet, and the first of ibus-pinyin under a display manager; the check before it refused every machine for a word its own configuration file carries in a comment. The sixth, `vm-binhost-fallback`, also passed and is not counted: `--site` had moved it off the host whose index answers 404 |
 | `ce95e7df72cd` | `static-ip`, `vm-btrfs`, `vm-mdraid`, `vm-zram`, `vm-f2fs` |
+| `74ba411eaea9` | `vm-lvm`, `vm-unlock` |
+| `cc84e970ddba` | `vm-cjk-kernel`, `vm-binpkg` |
 
 Every row from `08015b221d73` onward ran `--region cn --site nju --sync
 webrsync --distfiles http://10.31.0.2/gentoo`, so what they establish about


### PR DESCRIPTION
`vm-lvm` and `vm-unlock` at `74ba411eaea9`, `vm-cjk-kernel` and `vm-binpkg` at `cc84e970ddba`. Each revision comes from the guest's own first log line rather than from which worktree I think was pinned.