### PR TITLE
portage: record a binary host that answers no index

### DIFF
--- a/gentoo_install/plan/portage.py
+++ b/gentoo_install/plan/portage.py
@@ -885,6 +885,12 @@ class Emerge(Operation):
             self._from_source(context)
             return
         if not isinstance(result, CommandOutput) or result.returncode == 0:
+            # A host that answers no index does not fail the emerge: Portage
+            # says so, compiles everything and exits 0. Recorded here or
+            # nowhere, and recorded once, because it says so on every emerge.
+            unreadable = _unreadable_index(str(result))
+            if unreadable is not None and not context.degraded(BINARY_PACKAGES):
+                context.degrade(BINARY_PACKAGES, unreadable)
             return
         if (killed := _binhost_killed_emerge(result)) and not context.degraded(
             BINARY_PACKAGES
@@ -963,6 +969,23 @@ class Emerge(Operation):
 #: Portage's own binary package extension, which is what proves a fetch was a
 #: binary one when the path is the only line naming it.
 GPKG_SUFFIX: Final[str] = ".gpkg.tar"
+
+
+#: What Portage prints when a binary host's index cannot be read. It then
+#: compiles everything and exits 0, so nothing else in this file sees it: a
+#: run against a host whose index answered 404 compiled all 69 of its packages
+#: in 84 minutes and recorded no reason at all.
+_INDEX_UNREADABLE: Final[re.Pattern[str]] = re.compile(
+    r"!!! \[(?P<host>[^\]]+)\] Error fetching binhost package info from '(?P<url>[^']+)'"
+)
+
+
+def _unreadable_index(said: str) -> str | None:
+    """The reason to record when a host's index could not be read."""
+    found = _INDEX_UNREADABLE.search(said)
+    if found is None:
+        return None
+    return f"{found.group('host')} answered no package index at {found.group('url')}"
 
 
 def _binhost_killed_emerge(result: CommandOutput) -> str | None:

--- a/tests/unit/test_plan_portage.py
+++ b/tests/unit/test_plan_portage.py
@@ -2394,3 +2394,47 @@ def test_an_emerge_the_machine_needs_still_ends_the_run() -> None:
 
     with _pytest.raises(CommandFailed):
         operation.apply(recorder)
+
+
+#: What Portage printed on every emerge of the run that measured a dead host,
+#: taken from that guest's own log rather than written from memory.
+INDEX_REFUSED = (
+    "|  40450K .......... .......... 84% 93.1T 0s\n"
+    "!!! [gentoo] Error fetching binhost package info from "
+    "'https://mirror.xtom.com.hk/gentoo/releases/amd64/binpackages/23.0/x86-64'\n"
+    "[ebuild  N     ] net-misc/openssh-10.4_p1-r1\n"
+)
+
+
+def test_a_host_that_answers_no_index_is_recorded_rather_than_passed_over() -> None:
+    """`vm-binhost-fallback` compiled all 69 of its packages in 84.4 minutes
+    and its journal held no `degraded` entry at all: Portage says the index
+    could not be read, compiles everything and exits 0, so nothing that only
+    reads a failure ever saw it. The README promises a visible warning for
+    every binhost failure, and this one produced none."""
+    recorder = Recorder()
+    recorder.answering = lambda argv: (
+        CommandOutput(INDEX_REFUSED, 0) if argv[0] == "emerge" else CommandOutput("", 0)
+    )
+
+    portage.Emerge(packages=("net-misc/openssh",), summary="install ssh").apply(recorder)
+
+    assert recorder.degraded(portage.BINARY_PACKAGES)
+    reason = recorder.degradations[portage.BINARY_PACKAGES]
+    assert "mirror.xtom.com.hk" in reason, reason
+
+    # The emerge itself succeeded, so it is not retried and not re-run from
+    # source: Portage has already built everything it was asked for.
+    emerges = [argv for argv in recorder.in_target if argv[0] == "emerge"]
+    assert len(emerges) == 1, emerges
+
+
+def test_a_healthy_binhost_records_nothing() -> None:
+    """The marker is what Portage prints when the index cannot be read, so a
+    run that never sees it must not be recorded as having given anything up."""
+    recorder = Recorder()
+    recorder.answering = lambda argv: CommandOutput("[binary   ] net-misc/openssh-10.4_p1-r1", 0)
+
+    portage.Emerge(packages=("net-misc/openssh",), summary="install ssh").apply(recorder)
+
+    assert not recorder.degraded(portage.BINARY_PACKAGES)


### PR DESCRIPTION
`vm-binhost-fallback` reached the host it names for the first time (#655) and passed at 84.4 minutes. Its own journal says what really happened: 69 packages, **every one compiled**, and **no `degraded` entry at all**. The guest's log shows why — on every emerge Portage printed

    !!! [gentoo] Error fetching binhost package info from 'https://mirror.xtom.com.hk/gentoo/releases/amd64/binpackages/23.0/x86-64'

then compiled everything and exited 0. Nothing in `Emerge.apply` reads a *successful* emerge, so the installer never noticed, while the README promises a visible warning for every binhost failure and `install.jsonl` is supposed to carry the reason for every degradation to source.

The marker is now read on the success path and recorded once. The sample in the test is that guest's own line. Controls: removing the recording turns the new test red, and widening the pattern to match anything turns the healthy-host test red.