### PR TITLE
cluster: read the console after a remote unlock reports success

### DIFF
--- a/tests/unit/test_proxmox.py
+++ b/tests/unit/test_proxmox.py
@@ -4043,3 +4043,94 @@ def test_a_failed_installed_check_answers_with_what_the_machine_said(
 
     assert "does not say" in refused, refused
     assert "agreety" in refused, "the answer, not only the pattern"
+
+
+def test_a_remote_unlock_that_delivered_a_wrong_passphrase_is_not_a_login_failure(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """`zbm-unlock` failed at 93.0 minutes with `the installed system asked
+    for a name and kept asking`. Its console says otherwise: the passphrase
+    reached dropbear, `dracut-pre-mount` answered `Key load error: Incorrect
+    key provided for 'zpcala'` three times, `/sysroot` never mounted and the
+    guest sat in emergency mode. The ssh session proves delivery, not that the
+    key was right."""
+    from gentoo_install.exec.config import load
+    from tests.vm import cluster
+    from tests.vm.console import ConsoleTimeout
+
+    class Guest:
+        def stop(self) -> None:
+            return None
+
+        def boot_from_disk(self) -> None:
+            return None
+
+        def start(self) -> None:
+            return None
+
+        def reset(self) -> None:
+            return None
+
+    held = (
+        b"[   60.242509] dracut-pre-mount[622]: Key load error: "
+        b"Incorrect key provided for 'zpcala'.\r\n"
+        b"[FAILED] Failed to mount /sysroot.\r\n"
+        b"Entering emergency mode. Exit the shell to continue.\r\n"
+    )
+
+    class Link:
+        """A console holding that screen and nothing else.
+
+        It answers the rest of the login protocol too, so removing the check
+        under test fails an assertion rather than an attribute lookup.
+        """
+
+        def reopen(self, *, solicit_prompt: bool = True) -> None:
+            return None
+
+        def observe(self, pattern: str, timeout: float = 0.0, **ignored: object) -> bytes:
+            import re as _re
+
+            if _re.search(pattern.encode(), held):
+                return held
+            raise ConsoleTimeout("nothing like that on the screen")
+
+        def respond(self, line: str) -> None:
+            return None
+
+        def run(self, command: str, **ignored: object) -> None:
+            return None
+
+        def expect_output(self, command: str, timeout: float = 0.0) -> bytes:
+            return b""
+
+    monkeypatch.setattr(cluster, "remote_unlock", lambda *unused, **ignored: None)
+    installation = load(Path("tests/fixtures/zbm-unlock.toml"))
+    assert installation.kernel.remote_unlock.enabled, "the fixture under test"
+
+    refused = cluster.boot_and_check(
+        cast(Any, Guest()),
+        cast(Any, Link()),
+        Path("unused"),
+        installation,
+        remote_key=Path("unused.key"),
+    )
+
+    assert "did not mount the root" in refused, refused
+    assert "Key load error" in refused, "the screen, not only the conclusion"
+    assert "asked for a name" not in refused, refused
+
+
+def test_a_remote_unlock_that_worked_carries_on_to_the_login(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The check must not turn every remote unlock into a failure: a console
+    that never says the initramfs gave up carries on as it always did."""
+    from tests.vm import cluster
+    from tests.vm.console import ConsoleTimeout
+
+    class Link:
+        def observe(self, pattern: str, timeout: float = 0.0, **ignored: object) -> bytes:
+            raise ConsoleTimeout("the boot said nothing of the sort")
+
+    assert cluster._initramfs_gave_up(cast(Any, Link())) == ""

--- a/tests/vm/cluster.py
+++ b/tests/vm/cluster.py
@@ -2720,6 +2720,44 @@ LOGIN_PROMPTS: Final[tuple[str, ...]] = (
 )
 
 
+#: What the initramfs says when it could not mount the root it was asked for.
+#: The passphrase reaching dropbear is not the passphrase being right: a
+#: `zbm-unlock` run handed one over ssh, `dracut-pre-mount` answered `Key load
+#: error: Incorrect key provided for 'zpcala'` three times, and the guest sat
+#: in emergency mode while the harness typed a login name at it for 93
+#: minutes and blamed the login.
+INITRAMFS_GAVE_UP: Final[tuple[str, ...]] = (
+    "Entering emergency mode",
+    "Failed to mount /sysroot",
+    "Key load error",
+)
+
+#: How long the console is read for one of those before the boot is believed.
+#: The unlock returns as soon as ssh closes and the mount follows it.
+INITRAMFS_PATIENCE: Final[float] = 90.0
+
+
+def _initramfs_gave_up(link: "Reconnecting") -> str:
+    """Empty unless the console says the root was never mounted.
+
+    Read after a remote unlock reports success: the ssh session only proves
+    the passphrase was delivered, and a wrong one is delivered just as well.
+    """
+    try:
+        said = link.observe(_any_of(tuple(one.encode() for one in INITRAMFS_GAVE_UP)),
+                            timeout=INITRAMFS_PATIENCE)
+    except (ConsoleTimeout, ConsoleClosed):
+        return ""
+    return (
+        "the initramfs did not mount the root after the remote unlock; "
+        f"the console held {said[-INITRAMFS_SCREEN_BYTES:]!r}"
+    )[:VERDICT_BYTES]
+
+
+#: Enough of the screen to carry the refusal and the prompt above it.
+INITRAMFS_SCREEN_BYTES: Final[int] = 600
+
+
 def _any_of(words: tuple[bytes, ...]) -> str:
     """One pattern matching any of these, for a console wait."""
     return "|".join(re.escape(one.decode()) for one in words)
@@ -3007,6 +3045,9 @@ def boot_and_check(
             return f"remote unlock failed: {error}; the console held {held}"[:VERDICT_BYTES]
         remotely_unlocked = True
         print("installed root unlocked by remote SSH session", flush=True)
+        stopped = _initramfs_gave_up(link)
+        if stopped:
+            return stopped
     unlocked = _unlock(guest, link, installation, remotely_unlocked)
     if unlocked.refused:
         return unlocked.refused


### PR DESCRIPTION
`zbm-unlock` failed at 93.0 minutes with `the installed system asked for a name and kept asking`. Its console says something else entirely: the passphrase reached dropbear, `dracut-pre-mount[622]: Key load error: Incorrect key provided for 'zpcala'` three times, `[FAILED] Failed to mount /sysroot`, `Entering emergency mode`. The harness then typed a login name at the emergency prompt and blamed the login.

A successful ssh handshake proves the passphrase was delivered, not that it was right. The console is now read for `Entering emergency mode`, `Failed to mount /sysroot` or `Key load error` before the boot is believed, and the verdict carries that screen.

The control removes the check and reproduces the old verdict verbatim; the fake console answers the rest of the login protocol so it fails on an assertion rather than an attribute lookup. This does not fix the wrong passphrase itself — that is the next question, and the next round's verdict will now name it.