### PR TITLE
cluster: refuse an image fixture the medium would hold in RAM

### DIFF
--- a/tests/unit/test_cluster.py
+++ b/tests/unit/test_cluster.py
@@ -2368,3 +2368,44 @@ def test_a_verdict_with_no_log_does_not_print_a_path_that_is_not_one(
 
     printed = inspect.getsource(cluster.main)
     assert 'f" ({one.log})" if one.log is not None else ""' in printed, printed
+
+
+def test_an_image_fixture_that_writes_into_the_medium_is_refused_before_it_runs() -> None:
+    """`vm-image` asked for a 20 GiB sparse file under `/var/tmp`, which on
+    the minimal ISO is tmpfs in the guest's own RAM. The stage3 going into it
+    filled memory: `EXT4-fs (loop1p2): failed to convert unwritten extents to
+    written extents -- potential data loss! (error -5)`, then `No space left
+    on device`, and no room left to write an exit code — so the verdict was
+    `the installer exited b''` after two minutes."""
+    import pytest as _pytest
+
+    from tests.vm import cluster
+
+    with _pytest.raises(SystemExit, match="tmpfs on the medium"):
+        cluster.fixtures(["vm-image"])
+
+    # And a fixture that installs onto a disk is dispatched as it always was.
+    assert [one.name for one in cluster.fixtures(["vm-btrfs"])] == ["vm-btrfs"]
+
+
+def test_the_image_path_is_read_rather_than_the_fixture_named() -> None:
+    """Named, the rule protects one fixture; read, it protects the next one
+    somebody writes."""
+    from dataclasses import replace as _replace
+
+    from gentoo_install.exec.config import load
+    from tests.vm import cluster
+
+    config = load(Path(__file__).resolve().parents[1] / "fixtures" / "vm-image.toml")
+    assert cluster._image_lands_in_memory(config) == "/var/tmp/target.raw"
+
+    onto_a_disk = _replace(config, disk=_replace(config.disk, image="/mnt/scratch/target.raw"))
+    assert cluster._image_lands_in_memory(onto_a_disk) == ""
+
+    # A path that only starts with the same letters is not inside it.
+    beside = _replace(config, disk=_replace(config.disk, image="/var/tmpish/target.raw"))
+    assert cluster._image_lands_in_memory(beside) == ""
+
+    # And a fixture that is not writing an image at all is never refused.
+    ordinary = load(Path(__file__).resolve().parents[1] / "fixtures" / "vm-btrfs.toml")
+    assert cluster._image_lands_in_memory(ordinary) == ""

--- a/tests/vm/cluster.py
+++ b/tests/vm/cluster.py
@@ -1733,7 +1733,12 @@ def install_one(
                 job.name,
                 Verdict.FAIL,
                 time.monotonic() - started,
-                f"the installer exited {code!r}",
+                (
+                    f"the installer exited {code!r}"
+                    if code
+                    else "the installer wrote no exit code, so it died before its "
+                    "last line: read the log"
+                ),
                 log,
                 phase=phase,
                 revision=revision,
@@ -3347,6 +3352,26 @@ def _compiles(config: InstallConfig) -> bool:
 USER_MODE_NETWORK: Final[str] = "10.0.2.0/24"
 
 
+#: Where a fixture's install image would land, against what the medium can
+#: hold. A cluster guest boots the minimal ISO, whose only writable paths are
+#: tmpfs in its own RAM: `vm-image` asked for a 20 GiB sparse file under
+#: `/var/tmp`, and the stage3 going into it filled memory. The guest answered
+#: `EXT4-fs (loop1p2): failed to convert unwritten extents ... error -5` and
+#: `No space left on device`, then had no room left to write its exit code.
+LIVE_MEDIUM_TMPFS: Final[tuple[str, ...]] = ("/var/tmp", "/tmp", "/run")
+
+
+def _image_lands_in_memory(config: InstallConfig) -> str:
+    """The path an image fixture would write to, when the medium holds it in
+    RAM. Empty for a fixture that writes somewhere a cluster guest has."""
+    if config.disk.mode is not DiskMode.IMAGE:
+        return ""
+    image = config.disk.image
+    if any(image == one or image.startswith(f"{one}/") for one in LIVE_MEDIUM_TMPFS):
+        return image
+    return ""
+
+
 def _needs_user_mode_networking(config: InstallConfig) -> str:
     """The address that only the local hypervisor provides, or empty."""
     if not config.proxy.host:
@@ -3366,6 +3391,13 @@ def fixtures(names: list[str]) -> list[Job]:
         if not path.is_file():
             raise SystemExit(f"no fixture named {name} at {path}")
         config: InstallConfig = load(path)
+        in_memory = _image_lands_in_memory(config)
+        if in_memory:
+            raise SystemExit(
+                f"{name} writes its image to {in_memory}, which is tmpfs on the "
+                "medium a cluster guest boots: run it with tests/vm/run.py, where "
+                "the workstation's own disk holds it"
+            )
         local_only = _needs_user_mode_networking(config)
         if local_only:
             raise SystemExit(


### PR DESCRIPTION
`vm-image` failed in 2.0 minutes with `the installer exited b''`. The guest's log says why: it created its 20 GiB sparse image under `/var/tmp`, which on the minimal ISO is tmpfs in the guest's own RAM. Unpacking the stage3 into it filled memory — `EXT4-fs (loop1p2): failed to convert unwritten extents to written extents -- potential data loss! (error -5)`, then `No space left on device` — and there was no room left to write `install.rc`, which is why the exit code came back empty.

The refusal reads the fixture's image path against the medium's tmpfs mounts rather than naming the fixture, so it covers the next one somebody writes; the control that replaces the path-boundary match with a prefix match turns it red on `/var/tmpish`.

The empty exit code now says what it means instead of printing `b''`.