### PR TITLE
cluster: boot a silent UEFI guest once more before failing it

### DIFF
--- a/tests/unit/test_cluster.py
+++ b/tests/unit/test_cluster.py
@@ -2409,3 +2409,80 @@ def test_the_image_path_is_read_rather_than_the_fixture_named() -> None:
     # And a fixture that is not writing an image at all is never refused.
     ordinary = load(Path(__file__).resolve().parents[1] / "fixtures" / "vm-btrfs.toml")
     assert cluster._image_lands_in_memory(ordinary) == ""
+
+
+def test_a_uefi_guest_whose_console_said_nothing_is_booted_once_more(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """`vm-xfs` ended at 2.2 minutes with `the console delivered 0 bytes while
+    the editor was asked for over 120s`, having passed the same fixture in the
+    round before: the log holds `starting serial terminal on interface
+    serial0` and nothing after it. The BIOS path has had a second boot since
+    the beginning; the UEFI path had none."""
+    from tests.vm import cluster
+    from tests.vm.proxmox import GrubNotReadable
+
+    events: list[str] = []
+    attempts = {"n": 0}
+
+    def editor(link: object, extra: str) -> None:
+        attempts["n"] += 1
+        events.append(f"edit:{attempts['n']}")
+        if attempts["n"] == 1:
+            raise GrubNotReadable(
+                "the console delivered 0 bytes while the editor was asked for over 120s: b''"
+            )
+
+    class Guest:
+        def reset(self) -> None:
+            events.append("reset")
+
+    class Link:
+        def reopen(self, *, solicit_prompt: bool = True) -> None:
+            events.append(f"reopen:{solicit_prompt}")
+
+    monkeypatch.setattr(cluster, "append_to_cmdline", editor)
+    # Caught rather than allowed to escape: a retry that was removed would end
+    # this test on the exception instead of on the list it is about.
+    try:
+        cluster._edit_uefi_cmdline(cast(Any, Guest()), cast(Any, Link()))
+    except GrubNotReadable as escaped:
+        events.append(f"raised:{escaped}")
+    assert events == ["edit:1", "reset", "reopen:False", "edit:2"], events
+
+
+def test_a_uefi_guest_whose_grub_was_readable_is_not_booted_twice(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The retry is for silence. A GRUB that drew something and still could
+    not be edited is a different failure and must not cost a second boot."""
+    from tests.vm import cluster
+    from tests.vm.proxmox import GrubNotReadable
+
+    events: list[str] = []
+
+    def editor(link: object, extra: str) -> None:
+        events.append("edit")
+        raise GrubNotReadable("GRUB never opened its editor: b'\\x1b[2JBoot LiveCD'")
+
+    class Guest:
+        def reset(self) -> None:
+            events.append("reset")
+
+    class Link:
+        def reopen(self, *, solicit_prompt: bool = True) -> None:
+            events.append("reopen")
+
+    monkeypatch.setattr(cluster, "append_to_cmdline", editor)
+    with pytest.raises(GrubNotReadable, match="never opened"):
+        cluster._edit_uefi_cmdline(cast(Any, Guest()), cast(Any, Link()))
+    assert events == ["edit"], events
+
+
+def test_the_silent_console_sentence_is_the_one_the_editor_writes() -> None:
+    """Two spellings of the same sentence is a retry that never fires."""
+    import inspect
+
+    from tests.vm import cluster, proxmox
+
+    assert cluster.SILENT_EDITOR in inspect.getsource(proxmox._editor_screen)

--- a/tests/vm/cluster.py
+++ b/tests/vm/cluster.py
@@ -1654,7 +1654,7 @@ def install_one(
         # after it, and the firmware is finished before it gets there.
         guest.reset()
         if job.uefi:
-            append_to_cmdline(link, EXTRA_CMDLINE)
+            _edit_uefi_cmdline(guest, link)
         else:
             _edit_bios_cmdline(guest, link)
         reach_prompt(link)
@@ -3237,6 +3237,35 @@ def _abandon_jobs(scheduled: Mapping[str, Job]) -> None:
             job.execution.guest.destroy()
         except ProxmoxError as error:
             print(f"  {name} outlived the schedule: {error}", file=sys.stderr)
+
+
+def _edit_uefi_cmdline(guest: Guest, link: "Reconnecting") -> None:
+    """Add the serial parameters to the medium's entry, once more if the
+    console said nothing at all.
+
+    A silent console is not a stubborn GRUB. `vm-xfs` ended at 2.2 minutes
+    with `the console delivered 0 bytes while the editor was asked for over
+    120s`, having passed the same fixture in the round before: the termproxy
+    attached, the log holds `starting serial terminal on interface serial0`
+    and then nothing. The BIOS path has had a second boot since the beginning
+    and this one had none.
+    """
+    try:
+        append_to_cmdline(link, EXTRA_CMDLINE)
+        return
+    except GrubNotReadable as error:
+        if SILENT_EDITOR not in str(error):
+            raise
+        print(f"the console said nothing to the editor, booting once more: {error}", flush=True)
+    guest.reset()
+    link.reopen(solicit_prompt=False)
+    append_to_cmdline(link, EXTRA_CMDLINE)
+
+
+#: What `_editor_screen` says when the console delivered nothing rather than
+#: the wrong thing. Matched rather than re-derived, so the two sentences
+#: cannot drift apart into a retry that never fires.
+SILENT_EDITOR: Final[str] = "the console delivered"
 
 
 def _edit_bios_cmdline(guest: Guest, link: "Reconnecting") -> None:


### PR DESCRIPTION
`vm-xfs` ended at 2.2 minutes with `the console delivered 0 bytes while the editor was asked for over 120s: b''`, having passed the same fixture in the round before. Its log is two lines: the revision and `starting serial terminal on interface serial0`. That is a transport that never spoke, not a GRUB that refused to be edited — and `_edit_bios_cmdline` has had a reset-and-retry for exactly this since it was written, while the UEFI path had none.

The retry fires only on the silent sentence, so a GRUB that drew something and still could not be edited fails as before and costs no second boot. `SILENT_EDITOR` is matched against `_editor_screen`'s own wording by a test, so the two cannot drift into a retry that never fires.

Three controls, each red on an assertion: no retry, retry on every failure, and a reworded sentence.