### PR TITLE
cluster: answer the system initramfs after a ZFSBootMenu unlock

### DIFF
--- a/tests/unit/test_proxmox.py
+++ b/tests/unit/test_proxmox.py
@@ -4125,12 +4125,129 @@ def test_a_remote_unlock_that_worked_carries_on_to_the_login(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     """The check must not turn every remote unlock into a failure: a console
-    that never says the initramfs gave up carries on as it always did."""
+    that answers with a login prompt carries on as it always did, and the
+    layouts whose initramfs really was unlocked over ssh see exactly that."""
+    from gentoo_install.exec.config import load
     from tests.vm import cluster
-    from tests.vm.console import ConsoleTimeout
+
+    class Guest:
+        def stop(self) -> None:
+            return None
+
+        def boot_from_disk(self) -> None:
+            return None
+
+        def start(self) -> None:
+            return None
+
+        def reset(self) -> None:
+            return None
 
     class Link:
-        def observe(self, pattern: str, timeout: float = 0.0, **ignored: object) -> bytes:
-            raise ConsoleTimeout("the boot said nothing of the sort")
+        def __init__(self) -> None:
+            self.asked: list[str] = []
 
-    assert cluster._initramfs_gave_up(cast(Any, Link())) == ""
+        def reopen(self, *, solicit_prompt: bool = True) -> None:
+            return None
+
+        def observe(self, pattern: str, timeout: float = 0.0, **ignored: object) -> bytes:
+            self.asked.append(pattern)
+            return b"\r\nunlockbox login: "
+
+        def respond(self, line: str) -> None:
+            return None
+
+        def run(self, command: str, **ignored: object) -> None:
+            return None
+
+        def expect_output(self, command: str, timeout: float = 0.0) -> bytes:
+            return b""
+
+    monkeypatch.setattr(cluster, "remote_unlock", lambda *unused, **ignored: None)
+    monkeypatch.setattr(cluster, "_log_in", lambda *unused: "")
+    monkeypatch.setattr(cluster, "_asked_for", lambda installation: ())
+
+    link = Link()
+    refused = cluster.boot_and_check(
+        cast(Any, Guest()),
+        cast(Any, link),
+        Path("unused"),
+        load(Path("tests/fixtures/zbm-unlock.toml")),
+        remote_key=Path("unused.key"),
+    )
+
+    assert refused == "", refused
+    # And the wait it did covers every prompt the machine might show, so a
+    # console that asks again is answered rather than waited out.
+    # `re.escape` puts a backslash before the space, so the pattern is matched
+    # by what it is built from rather than by its literal text.
+    assert any("emergency" in one for one in link.asked), link.asked
+    assert any("passphrase" in one for one in link.asked), link.asked
+
+
+def test_a_zfsbootmenu_machine_is_answered_when_its_own_initramfs_asks(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """ZFSBootMenu carries the ssh daemon in its own image, so `zfs load-key`
+    over that session unlocks the pool ZBM reads and nothing else: the system
+    initramfs it boots asks again on the console. The harness took the ssh
+    session as the end of the passphrase and never answered."""
+    from gentoo_install.exec.config import load
+    from tests.vm import cluster
+    from tests.vm.console import DISK_PASSPHRASE
+
+    class Guest:
+        def stop(self) -> None:
+            return None
+
+        def boot_from_disk(self) -> None:
+            return None
+
+        def start(self) -> None:
+            return None
+
+        def reset(self) -> None:
+            return None
+
+    class Link:
+        """Asks for a passphrase once, then shows a login prompt."""
+
+        def __init__(self) -> None:
+            self.answered: list[str] = []
+            self.looks = 0
+
+        def reopen(self, *, solicit_prompt: bool = True) -> None:
+            return None
+
+        def observe(self, pattern: str, timeout: float = 0.0, **ignored: object) -> bytes:
+            self.looks += 1
+            if self.looks == 1:
+                return b"Encrypted ZFS password for zpcala/ROOT/gentoo/root "
+            return b"\r\nzbmunlockbox login: "
+
+        def respond(self, line: str) -> None:
+            self.answered.append(line)
+
+        def run(self, command: str, **ignored: object) -> None:
+            return None
+
+        def expect_output(self, command: str, timeout: float = 0.0) -> bytes:
+            return b""
+
+    monkeypatch.setattr(cluster, "remote_unlock", lambda *unused, **ignored: None)
+    monkeypatch.setattr(cluster, "_log_in", lambda *unused: "")
+    monkeypatch.setattr(cluster, "_asked_for", lambda installation: ())
+    monkeypatch.setattr(cluster, "PASSWORD_ECHO_OFF_AFTER", 0.0)
+    monkeypatch.setattr(cluster, "PASSWORD_ECHO_BACKOFF", 0.0)
+
+    link = Link()
+    refused = cluster.boot_and_check(
+        cast(Any, Guest()),
+        cast(Any, link),
+        Path("unused"),
+        load(Path("tests/fixtures/zbm-unlock.toml")),
+        remote_key=Path("unused.key"),
+    )
+
+    assert refused == "", refused
+    assert link.answered == [DISK_PASSPHRASE], link.answered

--- a/tests/vm/cluster.py
+++ b/tests/vm/cluster.py
@@ -2737,28 +2737,6 @@ INITRAMFS_GAVE_UP: Final[tuple[str, ...]] = (
     "Key load error",
 )
 
-#: How long the console is read for one of those before the boot is believed.
-#: The unlock returns as soon as ssh closes and the mount follows it.
-INITRAMFS_PATIENCE: Final[float] = 90.0
-
-
-def _initramfs_gave_up(link: "Reconnecting") -> str:
-    """Empty unless the console says the root was never mounted.
-
-    Read after a remote unlock reports success: the ssh session only proves
-    the passphrase was delivered, and a wrong one is delivered just as well.
-    """
-    try:
-        said = link.observe(_any_of(tuple(one.encode() for one in INITRAMFS_GAVE_UP)),
-                            timeout=INITRAMFS_PATIENCE)
-    except (ConsoleTimeout, ConsoleClosed):
-        return ""
-    return (
-        "the initramfs did not mount the root after the remote unlock; "
-        f"the console held {said[-INITRAMFS_SCREEN_BYTES:]!r}"
-    )[:VERDICT_BYTES]
-
-
 #: Enough of the screen to carry the refusal and the prompt above it.
 INITRAMFS_SCREEN_BYTES: Final[int] = 600
 
@@ -2928,16 +2906,29 @@ def _unlock(
     )
     if not encrypted:
         return UnlockResult(InstalledBootState.WAIT_LOGIN)
-    if remotely_unlocked:
-        return UnlockResult(InstalledBootState.LOGIN_READY)
-    if installation.bootloader.firmware is BootFirmware.BIOS:
+    # A remote unlock is not the end of the passphrase for every layout.
+    # ZFSBootMenu carries the ssh daemon in its own image, so `zfs load-key`
+    # over that session unlocks the pool ZBM is reading and nothing else: the
+    # system initramfs it boots asks again on the console. `zbm-unlock` was
+    # marked unlocked, its `dracut-pre-mount` answered `Key load error:
+    # Incorrect key provided for 'zpcala'` three times, and the harness typed
+    # a login name at emergency mode for 93 minutes. The loop below answers
+    # whichever prompt actually appears, so a machine that needs nothing more
+    # reads its login prompt on the first look and returns just as it did.
+    if not remotely_unlocked and installation.bootloader.firmware is BootFirmware.BIOS:
         time.sleep(GRUB_PROMPT_SECONDS)
         guest.send_keys([*keys_for(DISK_PASSPHRASE), "ret"])
     settle = PASSWORD_ECHO_OFF_AFTER
     for _ in range(UNLOCK_TRIES):
         try:
             said = link.observe(
-                rf"{PASSPHRASE_PROMPT}|{'|'.join(LOGIN_PROMPTS)}",
+                "|".join(
+                    (
+                        PASSPHRASE_PROMPT,
+                        *LOGIN_PROMPTS,
+                        *(re.escape(one) for one in INITRAMFS_GAVE_UP),
+                    )
+                ),
                 timeout=BOOT_PATIENCE,
             )
         except (ConsoleTimeout, ConsoleClosed) as error:
@@ -2947,6 +2938,14 @@ def _unlock(
             )
         if any(one.encode() in said for one in LOGIN_PROMPTS):
             return UnlockResult(InstalledBootState.LOGIN_READY)
+        if any(one.encode() in said for one in INITRAMFS_GAVE_UP):
+            return UnlockResult(
+                InstalledBootState.WAIT_LOGIN,
+                (
+                    "the initramfs did not mount the root; the console held "
+                    f"{said[-INITRAMFS_SCREEN_BYTES:]!r}"
+                )[:VERDICT_BYTES],
+            )
         # The same race the installed system's login lost: the prompt turns
         # the echo off with `TCSAFLUSH`, which discards whatever was typed
         # before it. `zbm-unlock` answered twice and ZFSBootMenu said `Key
@@ -3050,9 +3049,6 @@ def boot_and_check(
             return f"remote unlock failed: {error}; the console held {held}"[:VERDICT_BYTES]
         remotely_unlocked = True
         print("installed root unlocked by remote SSH session", flush=True)
-        stopped = _initramfs_gave_up(link)
-        if stopped:
-            return stopped
     unlocked = _unlock(guest, link, installation, remotely_unlocked)
     if unlocked.refused:
         return unlocked.refused


### PR DESCRIPTION
`zbm-unlock` failed at 93.0 minutes. Reading the guest's own log settles what happened at each layer: `remote_unlock` ran `zfs load-key -a` over ssh **and verified `keystatus` is `available`**, so that half worked; ZFSBootMenu then booted `zpcala/ROOT/gentoo/root`; and the *system* initramfs asked for the passphrase again on the console, where nobody answered — `dracut-pre-mount: Key load error: Incorrect key provided for 'zpcala'` three times, `Failed to mount /sysroot`, emergency mode.

The fixture's own comment says why this layout is different: ZFSBootMenu carries the ssh daemon in its image, not the system initramfs. So a successful remote unlock is the end of the passphrase for `vm-unlock` (dracut-crypt-ssh, same initramfs) and not for this one.

The short-circuit is gone: the unlock loop now waits for whichever prompt appears — passphrase, login, or the initramfs giving up — and answers it. A machine that needed nothing more reads its login prompt on the first look and returns as before. Controls: restoring the short-circuit reproduces the original verdict verbatim, and dropping the emergency-mode branch turns the wrong-passphrase test red.