### PR TITLE
docs: name the fixture each mode 3 record ran

### DIFF
--- a/TESTED.md
+++ b/TESTED.md
@@ -206,7 +206,7 @@ layout and bootloader. One disk has been written this way and read back.
 |---|---|---|
 | `6762496a41dd` | `--lowram` on a Debian 12 genericcloud machine, UEFI | armed one boot, left the default entry alone, rebooted, came up in Alpine from RAM with the delivered configuration and asked `install or shell>` |
 | `2f03f85139d2` | `--ram` on the same machine | the same, through the Gentoo CJK ISO: `root=live:CDLABEL=Gentoo-CJK-amd64-20260813`, the live image copied into RAM, `livecd login: root (automatic login)`, then `install or shell>` |
-| `3bdd6a0e78a8` | `dd` on the official minimal medium, raw and `gz` | wrote a 4 MiB image onto a second disk and read it back byte-for-byte, both formats, in 23s each |
+| `3bdd6a0e78a8` | `dd` on the official minimal medium: `vm-dd-raw` and `vm-dd-gz` | wrote a 4 MiB image onto a second disk and read it back byte-for-byte, both formats, in 23s each |
 | `7fcc7edcec6b` | `--lowram` on a Debian 12 genericcloud machine, UEFI, answering `install` | installed Gentoo from inside the memory environment, powered the machine off, booted the disk it had written and passed the shared installed-state checks: `the installed system booted, mounted its layout and has no failed unit` |
 | `7fcc7edcec6b` | `--lowram` on a second machine, its armed entry's initramfs removed | the delivered screen never appeared, and the cloud system's own marker and `/etc/os-release` `ID` were read back on the two boots that followed |
 | `6502c213269e` | the same, with the guarded entry | GRUB read the machine's own menu on the failed boot itself and booted Debian from it: `the failed one-shot returned to the cloud system` at 237.3s, `the second reboot still reached the cloud system` at 246.0s |
@@ -214,6 +214,9 @@ layout and bootloader. One disk has been written this way and read back.
 | `f5b6d5e142fd` | `--ram` on a Debian 12 genericcloud machine, UEFI, answering `install` | installed Gentoo from inside the Gentoo CJK ISO environment and passed the same installed-state checks: `logged into the installed system (console)` at 532.8s, `the installed system booted, mounted its layout and has no failed unit` |
 | `e430b3fadbfe` | the same, once the firmware kept its variables | installed from the Gentoo CJK ISO environment again and booted the disk it wrote: `logged into the installed system (console)` at 531.8s, `memory install booted its disk and passed the shared installed-state checks` at 534.5s |
 | `3e085f078c9f` | `--lowram` on a Debian 12 genericcloud machine, UEFI, answering `install` | installed from the Alpine netboot environment and booted the disk it wrote: `logged into the installed system (console)` at 457.6s, `memory install booted its disk and passed the shared installed-state checks` at 460.1s. The run before it stopped at `make a vfat filesystem on espfs labelled ESP` with `vdc1` and `vdc2` in `/proc/partitions` and neither in `/dev`, so this path is not reliable yet |
+
+Every row above installed `vm-ram`, the fixture `tests/vm/ram.py` hands the
+environment unless `--config` names another.
 
 Both environments install, and they needed different work to get there: the
 CJK ISO answered `live system: gentoo` with `python3.14`, `mount`, `tar` and

--- a/tests/unit/test_readme.py
+++ b/tests/unit/test_readme.py
@@ -403,3 +403,24 @@ def test_the_readme_names_everything_publishing_removes() -> None:
     # `only` was the word that made it wrong; it must not come back beside the
     # two hashes it used to qualify.
     assert "replaces only" not in said, said
+
+
+def test_every_fixture_a_record_used_is_named_in_it() -> None:
+    """A row that says `dd`, raw and gz` does not say which configuration ran,
+    and a reader cannot check the claim against the tree. Six of the forty
+    fixtures were used by a record that never named them.
+
+    Only the fixtures a record exists for: one that has never run is absent
+    from `TESTED.md` on purpose, and this must not turn into a rule that every
+    fixture has a record.
+    """
+    import re
+
+    recorded = set(re.findall(r"`([a-z0-9][a-z0-9-]+)`", (ROOT / "TESTED.md").read_text()))
+    fixtures = {one.stem for one in (ROOT / "tests" / "fixtures").glob("*.toml")}
+
+    # The dd and memory-environment rows name theirs now; these are the ones
+    # with no record at all, and each is a path nothing has measured.
+    without_a_record = {"vm-image", "vm-source-kernel", "zbm-unlock"}
+    assert without_a_record <= fixtures, without_a_record
+    assert fixtures - recorded == without_a_record, sorted(fixtures - recorded)


### PR DESCRIPTION
`dd` on the official minimal medium, raw and `gz`` does not say which configuration produced the row, so a reader cannot check it against the tree. The `dd` row names `vm-dd-raw` and `vm-dd-gz`, and the memory-environment rows name `vm-ram`, which is what `tests/vm/ram.py` hands the environment unless `--config` says otherwise.

The test keeps the set of fixtures no record names down to the three nothing has measured — `vm-image`, `vm-source-kernel`, `zbm-unlock` — and is written so it cannot become a rule that every fixture must have a record. Reverting the `dd` row turns it red.