### PR TITLE
vm: give an image install a disk to write its image onto

### DIFF
--- a/tests/fixtures/vm-image.toml
+++ b/tests/fixtures/vm-image.toml
@@ -1,5 +1,9 @@
-# A UEFI GRUB install into a sparse image. The cluster attaches this file as a
-# second disk and boots it, so the loop path is not the machine's boot target.
+# A UEFI GRUB install into a sparse image on a mounted disk. `/var/tmp` was
+# the path once, and on the live medium that is tmpfs: the image and portage's
+# build directory shared the guest's RAM and both runners ran out of it.
+# `tests/vm/run.py` makes a filesystem on the spare target disk and mounts it
+# at `/mnt/scratch` before the install, which is what an operator with a
+# second disk does by hand.
 config_version = 1
 
 [system]
@@ -28,7 +32,7 @@ kernel_params = ["console=ttyS0,115200"]
 
 [disk]
 mode = "image"
-image = "/var/tmp/target.raw"
+image = "/mnt/scratch/target.raw"
 size = "20GiB"
 wipe = true
 root = "mnt-root"
@@ -36,7 +40,7 @@ root = "mnt-root"
 [[disk.devices]]
 kind = "existing"
 id = "disk"
-selector = "/var/tmp/target.raw"
+selector = "/mnt/scratch/target.raw"
 wipe = true
 
 [[disk.devices]]

--- a/tests/golden/vm-image.txt
+++ b/tests/golden/vm-image.txt
@@ -1,5 +1,5 @@
 [partition]
-  create a 20GiB sparse image at /var/tmp/target.raw and attach it as a loop device
+  create a 20GiB sparse image at /mnt/scratch/target.raw and attach it as a loop device
   release anything a previous run of this configuration left mounted or open
   wipe existing signatures from disk
   create a gpt partition table on disk as table
@@ -70,4 +70,4 @@
   point /etc/resolv.conf at systemd-resolved rather than the install medium's
   delete the downloaded stage3 from /var/cache/gentoo-install
   unmount everything under the target
-  detach the loop device for image /var/tmp/target.raw
+  detach the loop device for image /mnt/scratch/target.raw

--- a/tests/unit/test_cluster.py
+++ b/tests/unit/test_cluster.py
@@ -2370,45 +2370,38 @@ def test_a_verdict_with_no_log_does_not_print_a_path_that_is_not_one(
     assert 'f" ({one.log})" if one.log is not None else ""' in printed, printed
 
 
-def test_an_image_fixture_that_writes_into_the_medium_is_refused_before_it_runs() -> None:
-    """`vm-image` asked for a 20 GiB sparse file under `/var/tmp`, which on
-    the minimal ISO is tmpfs in the guest's own RAM. The stage3 going into it
-    filled memory: `EXT4-fs (loop1p2): failed to convert unwritten extents to
-    written extents -- potential data loss! (error -5)`, then `No space left
-    on device`, and no room left to write an exit code — so the verdict was
-    `the installer exited b''` after two minutes."""
+def test_an_image_fixture_is_refused_where_nothing_mounts_a_disk_for_it() -> None:
+    """`vm-image` asked for a 20 GiB sparse file on a path that is tmpfs on
+    the minimal ISO. The stage3 going into it filled the guest's memory:
+    `EXT4-fs (loop1p2): failed to convert unwritten extents to written extents
+    -- potential data loss! (error -5)`, then `No space left on device`, and
+    no room left to write an exit code — so the verdict was `the installer
+    exited b\'\'` after two minutes. `tests/vm/run.py` makes a filesystem on
+    the spare target disk and mounts it; this runner does not."""
     import pytest as _pytest
 
     from tests.vm import cluster
 
-    with _pytest.raises(SystemExit, match="tmpfs on the medium"):
+    with _pytest.raises(SystemExit, match="only tests/vm/run.py mounts a disk"):
         cluster.fixtures(["vm-image"])
 
     # And a fixture that installs onto a disk is dispatched as it always was.
     assert [one.name for one in cluster.fixtures(["vm-btrfs"])] == ["vm-btrfs"]
 
 
-def test_the_image_path_is_read_rather_than_the_fixture_named() -> None:
-    """Named, the rule protects one fixture; read, it protects the next one
-    somebody writes."""
-    from dataclasses import replace as _replace
-
+def test_the_refusal_reads_the_mode_rather_than_the_fixture_name() -> None:
+    """Named, the rule protects one fixture; read from the configuration, it
+    protects the next one somebody writes — including one whose image path
+    looks perfectly reasonable, because the path is not what is missing."""
     from gentoo_install.exec.config import load
     from tests.vm import cluster
 
-    config = load(Path(__file__).resolve().parents[1] / "fixtures" / "vm-image.toml")
-    assert cluster._image_lands_in_memory(config) == "/var/tmp/target.raw"
+    image = load(Path(__file__).resolve().parents[1] / "fixtures" / "vm-image.toml")
+    assert cluster._needs_a_scratch_filesystem(image) == image.disk.image
+    assert image.disk.image.startswith("/mnt/"), "the path is fine; the mount is what is absent"
 
-    onto_a_disk = _replace(config, disk=_replace(config.disk, image="/mnt/scratch/target.raw"))
-    assert cluster._image_lands_in_memory(onto_a_disk) == ""
-
-    # A path that only starts with the same letters is not inside it.
-    beside = _replace(config, disk=_replace(config.disk, image="/var/tmpish/target.raw"))
-    assert cluster._image_lands_in_memory(beside) == ""
-
-    # And a fixture that is not writing an image at all is never refused.
     ordinary = load(Path(__file__).resolve().parents[1] / "fixtures" / "vm-btrfs.toml")
-    assert cluster._image_lands_in_memory(ordinary) == ""
+    assert cluster._needs_a_scratch_filesystem(ordinary) == ""
 
 
 def test_a_uefi_guest_whose_console_said_nothing_is_booted_once_more(

--- a/tests/unit/test_harness.py
+++ b/tests/unit/test_harness.py
@@ -4345,3 +4345,49 @@ def test_every_fixture_that_must_degrade_keeps_the_site_that_makes_it() -> None:
     from tests.vm import cluster
 
     assert set(cluster.MUST_DEGRADE) <= cluster.KEEPS_ITS_SITE, cluster.MUST_DEGRADE
+
+
+def test_an_image_install_is_given_a_disk_to_write_its_image_onto() -> None:
+    """Nothing mounted anything at the image's path, so it landed on the live
+    medium's tmpfs and both runners ran out of the guest's memory. The spare
+    target disk was already attached — `_target_paths` asks for one even when
+    the configuration has no `existing` node — and nothing used it."""
+    from gentoo_install.exec.config import load
+    from tests.vm import run as runner
+
+    said: list[str] = []
+
+    class Console:
+        def run(self, command: str, timeout: float = 0.0) -> None:
+            said.append(command)
+
+    image = load(Path(__file__).resolve().parents[1] / "fixtures" / "vm-image.toml")
+    runner.mount_scratch_for_image(cast(Any, Console()), image)
+
+    where = str(Path(image.disk.image).parent)
+    assert said == [
+        f"mkfs.ext4 -F -L scratch {runner.SCRATCH_DISK}",
+        f"mkdir -p {where}",
+        f"mount {runner.SCRATCH_DISK} {where}",
+    ], said
+
+    # A configuration that installs onto a disk is left alone: formatting the
+    # target it is about to partition would destroy the install.
+    said.clear()
+    ordinary = load(Path(__file__).resolve().parents[1] / "fixtures" / "vm-btrfs.toml")
+    runner.mount_scratch_for_image(cast(Any, Console()), ordinary)
+    assert said == [], said
+
+
+def test_the_image_fixture_writes_where_the_runner_mounts() -> None:
+    """Two places name the path and they have to agree: the fixture writes the
+    image and the runner mounts the disk under it."""
+    import inspect
+
+    from gentoo_install.exec.config import load
+    from tests.vm import run as runner
+
+    image = load(Path(__file__).resolve().parents[1] / "fixtures" / "vm-image.toml")
+    mounted = inspect.getsource(runner.mount_scratch_for_image)
+    assert "PurePosixPath(installation.disk.image).parent" in mounted, mounted
+    assert image.disk.image.startswith("/mnt/"), image.disk.image

--- a/tests/vm/cluster.py
+++ b/tests/vm/cluster.py
@@ -3383,24 +3383,14 @@ def _compiles(config: InstallConfig) -> bool:
 USER_MODE_NETWORK: Final[str] = "10.0.2.0/24"
 
 
-#: Where a fixture's install image would land, against what the medium can
-#: hold. A cluster guest boots the minimal ISO, whose only writable paths are
-#: tmpfs in its own RAM: `vm-image` asked for a 20 GiB sparse file under
-#: `/var/tmp`, and the stage3 going into it filled memory. The guest answered
-#: `EXT4-fs (loop1p2): failed to convert unwritten extents ... error -5` and
-#: `No space left on device`, then had no room left to write its exit code.
-LIVE_MEDIUM_TMPFS: Final[tuple[str, ...]] = ("/var/tmp", "/tmp", "/run")
-
-
-def _image_lands_in_memory(config: InstallConfig) -> str:
-    """The path an image fixture would write to, when the medium holds it in
-    RAM. Empty for a fixture that writes somewhere a cluster guest has."""
-    if config.disk.mode is not DiskMode.IMAGE:
-        return ""
-    image = config.disk.image
-    if any(image == one or image.startswith(f"{one}/") for one in LIVE_MEDIUM_TMPFS):
-        return image
-    return ""
+#: An image-mode install needs a filesystem to write its image onto, and on a
+#: live medium every writable path is RAM. `tests/vm/run.py` makes one on the
+#: spare target disk and mounts it; this runner does not, and `vm-image` died
+#: at 2.0 minutes with `EXT4-fs … error -5` and `No space left on device`,
+#: having filled the guest's own memory.
+def _needs_a_scratch_filesystem(config: InstallConfig) -> str:
+    """The image path this runner cannot provide a disk for, or empty."""
+    return config.disk.image if config.disk.mode is DiskMode.IMAGE else ""
 
 
 def _needs_user_mode_networking(config: InstallConfig) -> str:
@@ -3422,12 +3412,12 @@ def fixtures(names: list[str]) -> list[Job]:
         if not path.is_file():
             raise SystemExit(f"no fixture named {name} at {path}")
         config: InstallConfig = load(path)
-        in_memory = _image_lands_in_memory(config)
-        if in_memory:
+        needs_scratch = _needs_a_scratch_filesystem(config)
+        if needs_scratch:
             raise SystemExit(
-                f"{name} writes its image to {in_memory}, which is tmpfs on the "
-                "medium a cluster guest boots: run it with tests/vm/run.py, where "
-                "the workstation's own disk holds it"
+                f"{name} writes its image to {needs_scratch}, and only "
+                "tests/vm/run.py mounts a disk there: on this runner the path "
+                "is the medium's own tmpfs and the guest fills its memory"
             )
         local_only = _needs_user_mode_networking(config)
         if local_only:

--- a/tests/vm/run.py
+++ b/tests/vm/run.py
@@ -21,11 +21,17 @@ import sys
 import time
 from collections.abc import Sequence
 from dataclasses import replace
-from pathlib import Path
+from pathlib import Path, PurePosixPath
 from typing import Final
 from urllib.parse import urlsplit
 
-from gentoo_install.model.config import Bootloader, Firmware as BootFirmware, InitSystem, InstallConfig
+from gentoo_install.model.config import (
+    Bootloader,
+    DiskMode,
+    Firmware as BootFirmware,
+    InitSystem,
+    InstallConfig,
+)
 from gentoo_install.model.device import (
     Existing,
     Filesystem,
@@ -480,6 +486,29 @@ def stage_passphrases(console: SerialConsole, installation: InstallConfig) -> No
         console.run(command)
 
 
+#: The disk an image-mode install writes onto. `_target_paths` already asks
+#: for one, because a configuration with no `existing` node still gets a
+#: single target; nothing mounted it, so the image landed on the medium's own
+#: tmpfs and both runners ran out of memory: the cluster at 2.0 minutes with
+#: `No space left on device`, this one at `linux-firmware` unpacking.
+SCRATCH_DISK: Final[str] = "/dev/disk/by-id/virtio-target0"
+
+
+def mount_scratch_for_image(console: SerialConsole, installation: InstallConfig) -> None:
+    """Give an image-mode install a filesystem to write its image onto.
+
+    An operator writing an image has a disk to put it on; on a live medium
+    every writable path is RAM, so the harness provides the disk the fixture
+    assumes.
+    """
+    if installation.disk.mode is not DiskMode.IMAGE:
+        return
+    where = PurePosixPath(installation.disk.image).parent
+    console.run(f"mkfs.ext4 -F -L scratch {SCRATCH_DISK}", timeout=300.0)
+    console.run(f"mkdir -p {where}")
+    console.run(f"mount {SCRATCH_DISK} {where}")
+
+
 def interrupt_and_resume(console: SerialConsole, config: str) -> None:
     """Kill a run partway, then finish it with `--resume`.
 
@@ -794,6 +823,7 @@ def _perform(args: argparse.Namespace, medium: Medium, workdir: Path) -> int:
             elif args.install:
                 installation = load(REPOSITORY / "tests" / args.install)
                 config = install_remote_config(console, key, ssh_port, installation, args.install)
+                mount_scratch_for_image(console, installation)
                 stage_passphrases(console, load(REPOSITORY / "tests" / args.install))
                 run_installer(console, config, "--dry-run" if args.dry_run else "")
             else:


### PR DESCRIPTION
`vm-image` wrote its 20 GiB sparse file to `/var/tmp`, which is tmpfs on the live medium. Both runners ran out of the guest's RAM — the cluster at 2.0 minutes with `EXT4-fs … error -5` and `No space left on device`, and this workstation further along, unpacking `linux-firmware`.

`_target_paths` already asks for one target disk even when the configuration has no `existing` node, so the disk was attached and unused. `tests/vm/run.py` now makes a filesystem on it and mounts it under the image path before the install, which is what an operator with a second disk does by hand; the fixture writes to `/mnt/scratch/target.raw`.

The cluster mounts nothing, so it still refuses an image fixture — the refusal reads the mode rather than the path now, because the path is no longer what is wrong.