### PR TITLE
docs: record the round that measured the silent-console retry

### DIFF
--- a/TESTED.md
+++ b/TESTED.md
@@ -48,6 +48,7 @@ The ordinary path: partition, format, unpack a stage3, configure, boot.
 | `ce95e7df72cd` | `static-ip`, `vm-btrfs`, `vm-mdraid`, `vm-zram`, `vm-f2fs` |
 | `74ba411eaea9` | `vm-lvm`, `vm-unlock` |
 | `cc84e970ddba` | `vm-cjk-kernel`, `vm-binpkg`, `zfs-zbm`, `vm-gnome`, `ext3` |
+| `8dbfc12f35e0` | `ext4-bios`, `vm-xfs`, `vm-lvm`, `vm-f2fs`, `vm-btrfs` — `vm-xfs` is the first record since a UEFI guest whose console delivered nothing gets a second boot, which is what ended its previous round at 2.2 minutes |
 
 Every row from `08015b221d73` onward ran `--region cn --site nju --sync
 webrsync --distfiles http://10.31.0.2/gentoo`, so what they establish about


### PR DESCRIPTION
`ext4-bios`, `vm-xfs`, `vm-lvm`, `vm-f2fs` and `vm-btrfs` at `8dbfc12f35e0`. `vm-xfs` is the one that matters: its previous round ended at 2.2 minutes with `the console delivered 0 bytes while the editor was asked for over 120s`, and with the second boot it installed in 33.6.