### PR TITLE
docs: say why the upstream key-file recipe does not apply here

### DIFF
--- a/tests/unit/test_plan_boot.py
+++ b/tests/unit/test_plan_boot.py
@@ -756,6 +756,15 @@ def test_no_pool_is_pointed_at_a_key_file_zfsbootmenu_cannot_open() -> None:
     the remote path. `keylocation` stays `prompt` and the second prompt in the
     target initramfs is the accepted cost, which is what
     `calamares-settings-gig` already accepts.
+
+    ZFSBootMenu's own remote-access wiki page recommends the key file, and it
+    is right for the setup it describes: there the image is built by
+    `zbm-builder.sh`, which bind-mounts the builder's own directory into the
+    container and can put the key inside the image as well. This installer
+    takes ZFSBootMenu from `sys-boot/zfsbootmenu`, whose image carries no such
+    file, so the same `keylocation` leaves ZBM reading a path that exists only
+    in the target. Anyone holding that page and reaching for this again should
+    read run65's console first.
     """
     from gentoo_install.model.config import Bootloader
 


### PR DESCRIPTION
The guard that refuses `keylocation=file://` already carries run65's console — `0 / 1 key(s) successfully loaded / Key load error: Failed to open key material file` — but not why ZFSBootMenu's own wiki recommends exactly that.

It is right for the setup that page describes: there the image comes from `zbm-builder.sh`, which bind-mounts the builder's directory into the container and can put the key inside the image. This installer takes ZFSBootMenu from `sys-boot/zfsbootmenu`, whose image carries no such file, so the same setting leaves ZBM reading a path that exists only in the target and the pool becomes unlockable by nobody.

I reached for it again this morning with that page in hand; the guard is what stopped it. The paragraph is so the next reader stops sooner.