### PR TITLE
cluster: an address lease has to outlive the run holding it

### DIFF
--- a/tests/unit/test_cluster.py
+++ b/tests/unit/test_cluster.py
@@ -2566,3 +2566,44 @@ def test_a_grant_still_buys_time_when_the_ceiling_has_run_out() -> None:
 
     assert len(deadlines) == 2, deadlines
     assert deadlines[1] - started >= cluster.RECONNECT_GRANT - 1.0, deadlines
+
+
+def test_an_address_lease_outlives_the_run_that_holds_it() -> None:
+    """The lease was six hours against an eight-hour ceiling, and `vm-desktop`
+    ran 6.3. A guest that outlives its lease keeps its address while another
+    campaign reserves it, and the second guest's initramfs answers `dracut
+    Warning: Duplicate address detected for 10.31.0.151 for interface eth0` —
+    which is how `zbm-unlock` lost 65 minutes to `no ssh daemon on port
+    2222`."""
+    from tests.vm import cluster
+
+    assert cluster.LEASE_SECONDS > cluster.RUN_CEILING, (
+        cluster.LEASE_SECONDS,
+        cluster.RUN_CEILING,
+    )
+    # And by enough for the boots either side of the install and the checks
+    # between them, rather than by a second.
+    assert cluster.LEASE_SECONDS - cluster.RUN_CEILING >= cluster.LEASE_MARGIN
+
+
+def test_a_lease_older_than_any_run_is_taken_over(tmp_path: Path) -> None:
+    """The other half: a schedule that was killed never released what it took,
+    and sixteen rounds once left a hundred leases behind. A lease nothing can
+    still be holding has to be reusable, or the pool empties."""
+    import os
+    import time as clock
+
+    from tests.vm import cluster
+
+    pool = cluster.AddressPool(tmp_path, lambda address: False)
+    first = pool.reserve("10.31.0.150")
+    assert first == "10.31.0.150"
+
+    # A second reservation steps over the live lease.
+    assert pool.reserve("10.31.0.150") == "10.31.0.151"
+
+    # Aged past any possible run, the first is handed out again.
+    lease = tmp_path / "addresses" / first
+    stale = clock.time() - cluster.LEASE_SECONDS - 1.0
+    os.utime(lease, (stale, stale))
+    assert pool.reserve("10.31.0.150") == first

--- a/tests/vm/cluster.py
+++ b/tests/vm/cluster.py
@@ -1438,10 +1438,17 @@ class Running:
     created: bool = False
 
 
-#: How long an address lease is honoured. Longer than the longest run, so a
-#: guest still installing never loses its address, and short enough that a
-#: killed schedule frees what it took before the next campaign.
-LEASE_SECONDS: Final[float] = 6 * 60 * 60.0
+#: What a guest needs beyond its install: the boots either side of it and the
+#: installed-state checks between them.
+LEASE_MARGIN: Final[float] = 60 * 60.0
+
+#: How long an address lease is honoured. Derived from the ceiling rather than
+#: written beside it: at six hours against an eight-hour ceiling a guest could
+#: outlive its own lease, another campaign then reserved the same address, and
+#: the second guest's initramfs answered `dracut Warning: Duplicate address
+#: detected for 10.31.0.151 for interface eth0` and never brought up dropbear.
+#: `vm-desktop` really did run 6.3 hours the day this was found.
+LEASE_SECONDS: Final[float] = RUN_CEILING + LEASE_MARGIN
 
 
 class AddressPool:


### PR DESCRIPTION
`zbm-unlock` failed at 65.0 minutes with `remote unlock failed: no ssh daemon on port 2222`, and this time the console says why:

    dracut Warning: Duplicate address detected for 10.31.0.151 for interface eth0.
    Error: ipv4: Address already assigned.

The address pool is host-wide and locked, so two campaigns cannot reserve the same address — unless a lease expires while its guest is still alive. `LEASE_SECONDS` was six hours and `RUN_CEILING` is eight, and its own comment claimed it was "longer than the longest run"; `vm-desktop` ran 6.3 hours that day. The lease is derived from the ceiling now, plus an hour for the boots either side of the install.

Controls: the old constant fails the comparison, and treating every lease as live stops a killed schedule's leases from ever being reused — the failure the expiry exists to prevent.