### PR TITLE
docs: say what the round's sixth fixture lost its address to

### DIFF
--- a/TESTED.md
+++ b/TESTED.md
@@ -48,7 +48,7 @@ The ordinary path: partition, format, unpack a stage3, configure, boot.
 | `ce95e7df72cd` | `static-ip`, `vm-btrfs`, `vm-mdraid`, `vm-zram`, `vm-f2fs` |
 | `74ba411eaea9` | `vm-lvm`, `vm-unlock` |
 | `cc84e970ddba` | `vm-cjk-kernel`, `vm-binpkg`, `zfs-zbm`, `vm-gnome`, `ext3` |
-| `8dbfc12f35e0` | `ext4-bios`, `vm-xfs`, `vm-lvm`, `vm-f2fs`, `vm-btrfs` — `vm-xfs` is the first record since a UEFI guest whose console delivered nothing gets a second boot, which is what ended its previous round at 2.2 minutes |
+| `8dbfc12f35e0` | `ext4-bios`, `vm-xfs`, `vm-lvm`, `vm-f2fs`, `vm-btrfs` — five of six. `vm-xfs` is the first record since a UEFI guest whose console delivered nothing gets a second boot, which is what ended its previous round at 2.2 minutes; `zbm-unlock` lost its initramfs address to a lease that expired under a live guest, which `52b373dca9a2` addresses |
 
 Every row from `08015b221d73` onward ran `--region cn --site nju --sync
 webrsync --distfiles http://10.31.0.2/gentoo`, so what they establish about

--- a/tests/unit/test_readme.py
+++ b/tests/unit/test_readme.py
@@ -419,8 +419,10 @@ def test_every_fixture_a_record_used_is_named_in_it() -> None:
     recorded = set(re.findall(r"`([a-z0-9][a-z0-9-]+)`", (ROOT / "TESTED.md").read_text()))
     fixtures = {one.stem for one in (ROOT / "tests" / "fixtures").glob("*.toml")}
 
-    # The dd and memory-environment rows name theirs now; these are the ones
-    # with no record at all, and each is a path nothing has measured.
-    without_a_record = {"vm-image", "vm-source-kernel", "zbm-unlock"}
+    # Named anywhere in the file, which includes a row that records why a
+    # fixture failed: this rule is about a record a reader can trace back to a
+    # configuration, not about a fixture having passed. These two appear
+    # nowhere at all.
+    without_a_record = {"vm-image", "vm-source-kernel"}
     assert without_a_record <= fixtures, without_a_record
     assert fixtures - recorded == without_a_record, sorted(fixtures - recorded)


### PR DESCRIPTION
The row said five fixtures and left the sixth unexplained. `zbm-unlock`'s initramfs answered `Duplicate address detected for 10.31.0.151` because its lease had expired under a live guest, which `52b373dca9a2` fixes.

Naming it there shrinks the set of fixtures no record mentions, so the rule that guards that set now says what it means: named anywhere a reader can trace back to a configuration, not passed. `vm-image` and `vm-source-kernel` are the two that appear nowhere.