### PR TITLE
cluster: wait longer for room this harness is holding

### DIFF
--- a/tests/unit/test_cluster.py
+++ b/tests/unit/test_cluster.py
@@ -2607,3 +2607,33 @@ def test_a_lease_older_than_any_run_is_taken_over(tmp_path: Path) -> None:
     stale = clock.time() - cluster.LEASE_SECONDS - 1.0
     os.utime(lease, (stale, stale))
     assert pool.reserve("10.31.0.150") == first
+
+
+def test_a_round_waits_longer_when_our_own_guests_hold_the_room() -> None:
+    """`vm-image` was failed with `the cluster had no capacity for 121s` while
+    ten guests of this harness were still installing. That room is provably
+    coming back; room held by somebody else's machines is not, and a cluster
+    that cannot answer at all is not either."""
+    from tests.vm import cluster
+    from tests.vm.proxmox import ProxmoxError
+
+    class Busy:
+        def ours(self) -> list[tuple[str, int]]:
+            return [("infra-node4", 9300), ("infra-node1", 9303)]
+
+    class Empty:
+        def ours(self) -> list[tuple[str, int]]:
+            return []
+
+    class Silent:
+        def ours(self) -> list[tuple[str, int]]:
+            raise ProxmoxError("GET /cluster/resources did not answer")
+
+    assert cluster._capacity_patience(cast(Any, Busy())) == cluster.CAPACITY_PATIENCE_SHARED
+    assert cluster._capacity_patience(cast(Any, Empty())) == cluster.CAPACITY_PATIENCE
+    assert cluster._capacity_patience(cast(Any, Silent())) == cluster.CAPACITY_PATIENCE
+
+    # And the longer wait is bounded, so a guest nothing collects cannot hold
+    # a round for ever.
+    assert cluster.CAPACITY_PATIENCE_SHARED > cluster.CAPACITY_PATIENCE
+    assert cluster.CAPACITY_PATIENCE_SHARED <= cluster.RUN_CEILING

--- a/tests/vm/cluster.py
+++ b/tests/vm/cluster.py
@@ -236,6 +236,23 @@ BOOT_PATIENCE: Final[float] = 600.0
 #: A cluster with no room must produce a result rather than poll for ever.
 CAPACITY_PATIENCE: Final[float] = 120.0
 
+#: How long to wait instead when the room is held by this harness's own
+#: guests. That room is provably coming back — every one of them ends — and a
+#: single-fixture round dispatched beside a full campaign was failed at 121
+#: seconds with ten of ours still installing. Bounded rather than endless: a
+#: guest nothing ever collects would otherwise hold a round for ever.
+CAPACITY_PATIENCE_SHARED: Final[float] = 60 * 60.0
+
+
+def _capacity_patience(api: Api) -> float:
+    """How long a round waits for room, by who is holding it."""
+    try:
+        return CAPACITY_PATIENCE_SHARED if api.ours() else CAPACITY_PATIENCE
+    except ProxmoxError:
+        # The cluster could not say. The shorter bound is the safe answer: it
+        # produces a verdict rather than waiting on an unknown.
+        return CAPACITY_PATIENCE
+
 #: A conflict refreshes cluster allocation before another create. The bound
 #: prevents a busy VMID range from holding the scheduler indefinitely.
 RESERVATION_TRIES: Final[int] = 4
@@ -1976,14 +1993,15 @@ def run(
                 if capacity_since is None:
                     capacity_since = now
                 waited = now - capacity_since
-                if waited >= CAPACITY_PATIENCE:
+                patience = _capacity_patience(api)
+                if waited >= patience:
                     for job in waiting:
                         scheduled[job.name] = job.capacity_failed(waited, revision).collect(
                             collected
                         )
                         collected += 1
                     continue
-                time.sleep(min(POLL_WHILE_QUEUED, CAPACITY_PATIENCE - waited))
+                time.sleep(min(POLL_WHILE_QUEUED, patience - waited))
                 continue
             capacity_since = None
             while waiting and slots:


### PR DESCRIPTION
`vm-image` was answered `the cluster had no capacity for 121s` while ten guests of this harness were still installing on the same cluster. The two-minute bound is right for a cluster whose room belongs to somebody else — it may never come back — and wrong for room our own campaigns are holding, which every one of them releases.

`_capacity_patience` asks `Api.ours()` and answers an hour when the answer is non-empty, two minutes otherwise, and two minutes when the cluster cannot say at all. The longer bound is still a bound, and a test holds it under `RUN_CEILING`.

Controls: collapsing the two cases fails the busy one, and waiting the long time on an unreadable cluster fails the silent one.