### PR TITLE
tui: ask for the passphrase length the preflight requires

### DIFF
--- a/gentoo_install/tui/screens.py
+++ b/gentoo_install/tui/screens.py
@@ -18,6 +18,7 @@ from typing import Callable, Final, Sequence
 
 from ..i18n import Catalog
 from ..exec import fetch
+from ..exec.preflight import ZFS_PASSPHRASE_MINIMUM
 from ..model import compat
 from ..model.config import (
     SystemConfig,
@@ -2153,9 +2154,11 @@ def packages_screen(
         say(screen, context, clash)
 
 
-#: `zpool create` refuses anything shorter, and LUKS with a short passphrase is
-#: not worth offering either.
-PASSPHRASE_MINIMUM: Final[int] = 8
+#: What the preflight refuses, read from there rather than written again: the
+#: two carried the same 8 and the same reason, and raising one would have left
+#: the menu accepting a passphrase the install stops on once the disk is
+#: already partitioned.
+PASSPHRASE_MINIMUM: Final[int] = ZFS_PASSPHRASE_MINIMUM
 
 #: Taken from profiles.desc for amd64 23.0. A systemd profile is the same path
 #: plus /systemd, which `_profile_for` relies on.

--- a/tests/unit/test_layers.py
+++ b/tests/unit/test_layers.py
@@ -490,3 +490,28 @@ def test_no_module_imports_a_name_it_never_uses() -> None:
             if not re.search(rf"\b{re.escape(name)}\b", elsewhere)
         ]
     assert not dead, dead
+
+
+def test_the_passphrase_minimum_is_one_number() -> None:
+    """`zpool create` refuses a short passphrase after the disk is already
+    partitioned, so the menu asks for the same length the preflight does. Two
+    constants carried the same 8 and the same reason, and raising one would
+    have left the menu accepting what the install then stops on."""
+    from gentoo_install.exec.preflight import ZFS_PASSPHRASE_MINIMUM
+    from gentoo_install.tui.screens import PASSPHRASE_MINIMUM
+
+    assert PASSPHRASE_MINIMUM is ZFS_PASSPHRASE_MINIMUM
+
+    # And nothing else in the package writes a minimum of its own. The file,
+    # not the line: a number in this assertion would break on any edit above
+    # it and say nothing about the rule.
+    written = {
+        str(path.relative_to(PACKAGE.parent))
+        for path in sorted(PACKAGE.rglob("*.py"))
+        for node in ast.parse(path.read_text()).body
+        if isinstance(node, ast.AnnAssign)
+        and isinstance(node.target, ast.Name)
+        and node.target.id.endswith("PASSPHRASE_MINIMUM")
+        and isinstance(node.value, ast.Constant)
+    }
+    assert written == {"gentoo_install/exec/preflight.py"}, written


### PR DESCRIPTION
`exec/preflight.py` and `tui/screens.py` each carried a passphrase minimum of 8, with the same reason written twice: `zpool create` refuses anything shorter, and it refuses it after the disk is already partitioned. Raising one would have left the menu accepting a passphrase the install then stops on, with the partitions already written.

The menu reads the preflight's number. The test requires exactly one file in the package to write such a constant, and names the file rather than a line so an edit above it cannot break the rule it is about.

Control: restoring the literal turns it red; and with the preflight's number moved to 12, the menu asks for 12.