### PR TITLE
tui: move the disk screens into tui/partitions.py

### DIFF
--- a/gentoo_install/tui/context.py
+++ b/gentoo_install/tui/context.py
@@ -14,6 +14,7 @@ from enum import Enum
 from typing import Callable, Final, Generic, Sequence, TypedDict, TypeVar
 
 from ..errors import ConfigError, GentooInstallError
+from ..exec.preflight import ZFS_PASSPHRASE_MINIMUM
 from ..i18n import Catalog, truncate
 from ..model import manual, mirrors, qr
 from ..model.config import (
@@ -436,3 +437,10 @@ def with_gentoo_zh(config: InstallConfig) -> PortageConfig:
         # `compat.py` is what keeps the two from being set apart.
         binhost = replace(binhost, community=BinhostChannel.STABLE)
     return replace(config.portage, overlays=added, binhost=binhost)
+
+
+#: What the preflight refuses, read from there rather than written again: the
+#: two carried the same 8 and the same reason, and raising one would have left
+#: the menu accepting a passphrase the install stops on once the disk is
+#: already partitioned.
+PASSPHRASE_MINIMUM: Final[int] = ZFS_PASSPHRASE_MINIMUM

--- a/gentoo_install/tui/partitions.py
+++ b/gentoo_install/tui/partitions.py
@@ -1,0 +1,1045 @@
+# SPDX-License-Identifier: GPL-2.0-or-later
+"""The disk screens: what a layout is made of, and how it is edited by hand.
+
+Fifty-one definitions reachable from `partitions_screen` and from nothing
+else. `screens.py` reaches four of them — the screen itself, `_from_layout`,
+`_zfs_bootloader` and `_edit_passphrase` — and this module reaches nothing in
+`screens.py`, which is what makes the boundary one way. The closure was
+computed rather than guessed: an earlier attempt cut by subject matter and
+found edges running both ways.
+"""
+
+from __future__ import annotations
+
+from copy import deepcopy
+from dataclasses import dataclass, replace
+from enum import Enum
+from typing import Callable, Final, Sequence
+
+from ..i18n import Catalog
+from ..model import manual
+from ..model.config import (
+    Bootloader,
+    DiskConfig,
+    Firmware,
+    InstallConfig,
+    PortageConfig,
+)
+from ..model.device import (
+    DeviceGraph,
+    DeviceId,
+    Existing,
+    Filesystem,
+    FilesystemType,
+    Luks,
+    Mountpoint,
+    Partition,
+    PartitionRole,
+    PartitionTable,
+    RaidLevel,
+    RaidMetadata,
+    Swap,
+    TableType,
+    ZfsPool,
+    ZfsTopology,
+)
+from ..model.size import Size
+from ..model.templates import Choice, Layout, build
+from ..model.validate import validate
+from ..errors import GentooInstallError, ValidationFailed
+from .context import (
+    Context,
+    answers,
+    DONE,
+    DROP,
+    FieldDescriptor,
+    PASSPHRASE_MINIMUM,
+    TABLE,
+    current_menu,
+    footer,
+    pick,
+    say,
+    with_gentoo_zh,
+)
+from .widgets import (
+    Accepts,
+    Answer,
+    Confirm,
+    Field,
+    Form,
+    FormRejected,
+    Item,
+    Menu,
+    MultipleChoiceMenu,
+    Outcome,
+    Screen,
+    TextField,
+)
+
+def _known(kind: str) -> FilesystemType | None:
+    """The type blkid reported, when the model has a member for it. ntfs and
+    exfat are mounted and never created, so they have no member and no row."""
+    return next((one for one in FilesystemType if one.value == kind), None)
+
+
+def _zfs_bootloader(
+    screen: Screen, config: InstallConfig, context: Context
+) -> Answer[InstallConfig]:
+    """A ZFS root cannot use GRUB, so this asks which of the two that remain.
+
+    ZFSBootMenu lives in the gentoo-zh overlay and in no other repository, so
+    choosing it is also consenting to that overlay. Adding it silently is what
+    this replaces.
+    """
+    translate = context.translate
+    answer = Menu(
+        title=translate("A ZFS root cannot boot from GRUB. Which bootloader?"),
+        preamble=(translate("The bootloader determines how the ZFS root is found at startup."),),
+        items=[
+            Item(
+                label="ZFSBootMenu",
+                value=Bootloader.ZFSBOOTMENU,
+                detail=translate("adds the gentoo-zh overlay, the only one that has it"),
+            ),
+            Item(
+                label="systemd-boot",
+                value=Bootloader.SYSTEMD_BOOT,
+                detail=translate("no overlay, and the esp has to hold the kernel"),
+            ),
+        ],
+        footer=footer(translate),
+        current=config.bootloader.kind,
+    ).run(screen)
+
+    def apply(kind: Bootloader) -> InstallConfig:
+        if kind is Bootloader.SYSTEMD_BOOT:
+            return replace(config, bootloader=replace(config.bootloader, kind=kind))
+        return replace(
+            config,
+            bootloader=replace(config.bootloader, kind=kind),
+            portage=with_gentoo_zh(config),
+        )
+
+    return answer.map(apply)
+
+
+def _edit_passphrase(
+    screen: Screen, context: Context, staged_path: str, title: str
+) -> Answer[str]:
+    """Enable, disable, or replace one staged encryption passphrase."""
+    translate = context.translate
+    enabled = Confirm(
+        **answers(translate),
+        title=title,
+        footer=footer(translate),
+        current=bool(staged_path),
+    ).run(screen)
+    if not enabled.chosen:
+        return Answer(enabled.outcome)
+    if not enabled.unwrap():
+        return Answer(Outcome.CHOSE, "")
+    return _ask_passphrase(screen, context)
+
+
+def _ask_passphrase(screen: Screen, context: Context) -> Answer[str]:
+    """The passphrase typed twice, staged in a file whose path is returned.
+
+    The configuration holds the path and never the passphrase, because it is
+    copied into the target and the install log is what people paste into bug
+    reports.
+    """
+    translate = context.translate
+    hint = translate("At least {count} characters.").format(count=PASSPHRASE_MINIMUM)
+    while True:
+        first = TextField(
+            title=translate("Passphrase"),
+            masked=True,
+            detail=hint,
+            footer=footer(translate),
+        ).run(screen)
+        if not first.chosen:
+            return Answer(first.outcome)
+        typed = first.unwrap()
+        if len(typed) < PASSPHRASE_MINIMUM:
+            # Checked here, not at preflight: zfs refuses a short passphrase
+            # only once the disks have been partitioned.
+            say(screen, context, translate("The passphrase is too short."))
+            continue
+        again = TextField(
+            title=translate("Passphrase again"),
+            masked=True,
+            detail=hint,
+            footer=footer(translate),
+        ).run(screen)
+        if not again.chosen:
+            return Answer(again.outcome)
+        if again.unwrap() != typed:
+            say(screen, context, translate("The two do not match."))
+            continue
+        return Answer(Outcome.CHOSE, context.stage_passphrase(typed))
+
+
+class _RowKind(Enum):
+    """What one line of the partition screen stands for."""
+
+    DISK = "disk"
+    SLICE = "slice"
+    ADD_PARTITION = "add-partition"
+    ADD_DISK = "add-disk"
+    TOPOLOGY = "topology"
+    POOL_ENCRYPTION = "pool-encryption"
+    ARRAY = "array"
+    DONE = "done"
+
+
+@dataclass(frozen=True)
+
+
+class _Row:
+    """A line of the partition screen, and what it points at.
+
+    `disk` is a position in `Layout.disks` and `entry` a position in that
+    disk's rows; both are -1 on a line that points at neither.
+    """
+
+    kind: _RowKind
+    disk: int = -1
+    entry: int = -1
+
+
+def partitions_screen(
+    screen: Screen, config: InstallConfig, context: Context
+) -> Answer[InstallConfig]:
+    """Every disk being partitioned, and under each one its table, row by row.
+
+    Every change rebuilds the graph and runs the validator, so a table that
+    cannot be installed says why here rather than at the first `mkfs`.
+    """
+    translate = context.translate
+    if not context.layout.holds(context.choice.disk) or not context.layout.slices:
+        # Seeded from what is on the disk when there is anything, and from the
+        # template that was chosen when there is not: opening this row after
+        # picking zfs used to show an ext4 root and discard the choice.
+        context.layout = _seed(context)
+    saved_layout = deepcopy(context.layout)
+    saved_manual = context.manual
+    cursor = 0
+    while True:
+        items = _partition_rows(context)
+        menu: Menu[_Row] = Menu(
+            title=_partitions_title(context),
+            preamble=(translate("This editor controls which partitions are kept, formatted, mounted, or erased."),),
+            items=items,
+            cursor=cursor,
+            footer=f"{_layout_problem(context, config)}  {footer(translate)}".strip(),
+        )
+        answer = menu.run(screen)
+        cursor = menu.cursor
+        if not answer.chosen:
+            added = [
+                deepcopy(disk)
+                for disk in context.layout.disks
+                if not saved_layout.holds(disk.selector)
+            ]
+            context.layout = saved_layout
+            context.layout.disks.extend(added)
+            context.manual = saved_manual
+            return Answer(answer.outcome)
+        row = answer.unwrap()
+        if row.kind is _RowKind.DONE:
+            # Marked here rather than by whoever opened this screen: the row can
+            # be reached from the menu as well as from the layout row, and a
+            # flag set before the editor answers describes a table that may
+            # never have been produced.
+            context.manual = True
+            built = _from_layout(config, context)
+            if context.layout.disks and _pool_members(context):
+                # The same question the template path asks: a ZFS root cannot
+                # boot from GRUB, and ZFSBootMenu needs the overlay adding.
+                # Without this every bootloader row was greyed and the table
+                # had no way out.
+                picked = _zfs_bootloader(screen, built, context)
+                if not picked.chosen:
+                    if picked.outcome is Outcome.CANCELLED:
+                        return Answer(picked.outcome)
+                    # Back to the editor rather than out of it: the table the
+                    # operator drew is still there, and a ZFS root with GRUB
+                    # is what committing this would have written.
+                    continue
+                built = picked.unwrap()
+            return Answer(Outcome.CHOSE, built)
+        _act_on(screen, context, row)
+
+
+def _partitions_title(context: Context) -> str:
+    translate = context.translate
+    if context.layout.writes_the_table():
+        return translate("A new partition table")
+    return translate("Partitions")
+
+
+def _partition_rows(context: Context) -> list[Item[_Row]]:
+    """One line per disk, its rows indented under it, then what can be added."""
+    translate = context.translate
+    items: list[Item[_Row]] = []
+    for position, disk in enumerate(context.layout.disks):
+        items.append(
+            Item(
+                label=context.shown_as(disk.selector),
+                value=_Row(_RowKind.DISK, position),
+                detail=f"{disk.table.value}  {_capacity(context, disk)}",
+            )
+        )
+        for index, entry in enumerate(sorted(disk.slices, key=lambda one: one.index)):
+            # Two spaces rather than a box-drawing character: the console this
+            # runs on may have neither a CJK font nor a line-drawing set.
+            items.append(
+                Item(label=f"  {entry.describe()}", value=_Row(_RowKind.SLICE, position, index))
+            )
+        items.append(
+            Item(
+                label=f"  {translate('Add a partition')}",
+                value=_Row(_RowKind.ADD_PARTITION, position),
+            )
+        )
+    if _unused_disks(context):
+        items.append(Item(label=translate("Add a disk"), value=_Row(_RowKind.ADD_DISK)))
+    # Both rows are drawn whether or not they can be opened. Hidden until a
+    # partition happened to carry the right purpose, the two features were
+    # unreachable to anyone who did not already know they existed.
+    pool = len(_pool_members(context))
+    items.append(
+        Item(
+            label=translate("Pool topology"),
+            value=_Row(_RowKind.TOPOLOGY),
+            detail=context.layout.topology.value if pool > 1 else "",
+            disabled_because=(
+                "" if pool > 1 else translate("give two partitions the zfs pool member purpose")
+            ),
+        )
+    )
+    if pool:
+        items.append(
+            Item(
+                label=f"ZFS {translate('Encryption')}",
+                value=_Row(_RowKind.POOL_ENCRYPTION),
+                detail=translate("on") if context.layout.passphrase_file else translate("off"),
+            )
+        )
+    array = len(_array_members(context))
+    items.append(
+        Item(
+            label=translate("RAID array"),
+            value=_Row(_RowKind.ARRAY),
+            detail=_array_summary(context) if array else "",
+            disabled_because=(
+                "" if array else translate("give a partition the raid array member purpose")
+            ),
+        )
+    )
+    items.append(Item(label=translate("Done"), value=_Row(_RowKind.DONE)))
+    return items
+
+
+def _array_summary(context: Context) -> str:
+    array = context.layout.array
+    where = array.mountpoint or "-"
+    return f"{array.name}, {array.level.value}, {array.filesystem.value}, {where}"
+
+
+def _act_on(screen: Screen, context: Context, row: _Row) -> None:
+    """Everything the screen does but leave, so the loop above stays readable."""
+    if row.kind is _RowKind.TOPOLOGY:
+        picked = _pool_topology(screen, context, len(_pool_members(context)))
+        if picked is not None:
+            context.layout.topology = picked
+        return
+    if row.kind is _RowKind.POOL_ENCRYPTION:
+        _edit_pool_encryption(screen, context)
+        return
+    if row.kind is _RowKind.ARRAY:
+        _edit_array(screen, context)
+        return
+    if row.kind is _RowKind.ADD_DISK:
+        added = _pick_another_disk(screen, context)
+        if added is not None:
+            held, _ = context.contents(added)
+            context.layout.disks.append(_seeded_disk(added, held))
+        return
+    disk = context.layout.disks[row.disk]
+    if row.kind is _RowKind.DISK:
+        _edit_disk(screen, context, row.disk)
+        return
+    if row.kind is _RowKind.ADD_PARTITION:
+        fresh = _edit_slice(screen, context, disk, None)
+        if fresh is not None:
+            disk.slices.append(fresh)
+        return
+    rows = sorted(disk.slices, key=lambda one: one.index)
+    edited = _edit_slice(screen, context, disk, rows[row.entry])
+    disk.slices.remove(rows[row.entry])
+    if edited is not None:
+        disk.slices.append(edited)
+
+
+def _array_members(context: Context) -> list[manual.Slice]:
+    return [one for one in context.layout.slices if one.role is PartitionRole.RAID]
+
+
+def _pool_members(context: Context) -> list[manual.Slice]:
+    return [one for one in context.layout.slices if one.role is PartitionRole.ZFS]
+
+
+def _unused_disks(context: Context) -> list[tuple[str, str]]:
+    """Disks this machine has that the table does not already cover."""
+    return [one for one in context.disks if not context.layout.holds(one[0])]
+
+
+def _pick_another_disk(screen: Screen, context: Context) -> str | None:
+    translate = context.translate
+    answer = Menu(
+        title=translate("Add a disk"),
+        items=[
+            Item(label=name, value=name, detail=detail) for name, detail in _unused_disks(context)
+        ],
+        footer=footer(translate),
+    ).run(screen)
+    return answer.unwrap() if answer.chosen else None
+
+
+def _edit_disk(screen: Screen, context: Context, position: int) -> None:
+    """What the disk itself carries: its table type, and whether it stays.
+
+    The first disk cannot be dropped here; it is the one the disk row chose,
+    and a table with no disk at all has nothing to install onto.
+    """
+    translate = context.translate
+    disk = context.layout.disks[position]
+    while True:
+        items: list[Item[str]] = [
+            Item(label=translate("Partition table"), value=TABLE, detail=disk.table.value),
+            *(
+                [Item(label=translate("Take this disk off the table"), value=DROP)]
+                if position > 0
+                else []
+            ),
+            Item(label=translate("Done"), value=DONE),
+        ]
+        answer = Menu(
+            title=context.shown_as(disk.selector), items=items, footer=footer(translate)
+        ).run(screen)
+        if not answer.chosen or answer.unwrap() == DONE:
+            return
+        if answer.unwrap() == DROP:
+            context.layout.disks.pop(position)
+            return
+        picked = current_menu(
+            screen,
+            context,
+            translate("Partition table"),
+            [Item(label=one.value, value=one) for one in TableType],
+            disk.table,
+        )
+        if picked.chosen:
+            disk.table = picked.unwrap()
+
+
+def _template_filesystem(choice: Choice) -> FilesystemType | None:
+    """What the root of the chosen template carries. None for ZFS, whose root
+    is a dataset on a pool and not a filesystem on a partition."""
+    return None if choice.layout is Layout.WHOLE_DISK_ZFS else choice.filesystem
+
+
+def _capacity(context: Context, disk: manual.Disk) -> str:
+    """The disk's size and what its table has already claimed, because a size
+    is guesswork without them."""
+    translate = context.translate
+    total = context.contents(disk.selector)[1]
+    if not total:
+        return ""
+    fresh = [one for one in disk.slices if one.status is manual.SliceStatus.CREATE]
+    claimed = sum(entry.size.bytes for entry in fresh if entry.size is not None)
+    rest = any(entry.size is None for entry in fresh)
+    used = Size(claimed)
+    return translate("{total} total, {used} claimed{rest}").format(
+        total=total, used=used, rest=translate(", rest to one partition") if rest else ""
+    )
+
+
+def _seed(context: Context) -> manual.Layout:
+    """The table the editor opens on.
+
+    Every partition already on the disk, kept: an operator who opens this over
+    a machine with data on it should see that data, not a proposal that erases
+    it. An empty disk has nothing to list, so it gets the template's proposal.
+    """
+    if not context.existing:
+        return manual.suggest(
+            context.choice.disk, context.choice.firmware, _template_filesystem(context.choice)
+        )
+    return manual.Layout(
+        disks=[
+            _seeded_disk(
+                context.choice.disk,
+                context.existing,
+                context.choice.table or TableType.GPT,
+            )
+        ]
+    )
+
+
+def _seeded_disk(
+    selector: str, held: Sequence[tuple[str, str, str]], table: TableType = TableType.GPT
+) -> manual.Disk:
+    """A disk with what the machine says is already on it, kept.
+
+    Every disk, not only the first: a second one was appended empty, so a disk
+    with partitions was drawn as blank and the rows added beside them rewrote
+    its table.
+    """
+    disk = manual.Disk(selector=selector, table=table)
+    for index, (where, _, kind) in enumerate(held, start=1):
+        disk.slices.append(
+            manual.Slice(
+                index=index,
+                role=PartitionRole.DATA,
+                size=None,
+                filesystem=_known(kind),
+                status=manual.SliceStatus.KEEP,
+                selector=where,
+            )
+        )
+    return disk
+
+
+_LEVEL: Final[str] = "level"
+
+
+_METADATA: Final[str] = "metadata"
+
+
+_NAME: Final[str] = "name"
+
+
+_FILESYSTEM: Final[str] = "filesystem"
+
+
+_MOUNTPOINT: Final[str] = "mountpoint"
+
+
+_LABEL: Final[str] = "label"
+
+
+_ENCRYPTION: Final[str] = "encryption"
+
+
+def _edit_array(screen: Screen, context: Context) -> None:
+    """The array the member rows are assembled into, as a list of fields.
+
+    The same shape as a partition's field list, because it answers the same
+    kind of questions: what it is called, what goes on it and where.
+    """
+    translate = context.translate
+    members = len(_array_members(context))
+    while True:
+        array = context.layout.array
+        items = [field.row((array, members), translate) for field in _ARRAY_FIELDS]
+        answer = Menu(
+            title=f"{translate('RAID array')}  {members} {translate('members')}",
+            items=items,
+            footer=footer(translate),
+        ).run(screen)
+        if not answer.chosen or answer.unwrap() == DONE:
+            return
+        _edit_array_field(screen, context, answer.unwrap(), members)
+
+
+def _edit_array_field(screen: Screen, context: Context, field: str, members: int) -> None:
+    descriptor = next((one for one in _ARRAY_FIELDS if one.key == field), None)
+    if descriptor is not None:
+        descriptor.edit(screen, context, (context.layout.array, members))
+    return
+
+
+def _edit_array_field_legacy(screen: Screen, context: Context, field: str, members: int) -> None:
+    translate = context.translate
+    array = context.layout.array
+    if field == _LEVEL:
+        picked = current_menu(
+            screen,
+            context,
+            translate("RAID level"),
+            [
+                Item(
+                    label=one.value,
+                    value=one,
+                    disabled_because=""
+                    if members >= one.minimum
+                    else translate("needs at least {count}").format(count=one.minimum),
+                )
+                for one in RaidLevel
+            ],
+            array.level,
+        )
+        if picked.chosen:
+            array.level = picked.unwrap()
+        return
+    if field == _METADATA:
+        chosen = current_menu(
+            screen,
+            context,
+            translate("Superblock"),
+            [
+                Item(
+                    label=one.value,
+                    value=one,
+                    detail=""
+                    if one.superblock_at_start
+                    else translate("at the end, so firmware reads the member"),
+                )
+                for one in RaidMetadata
+            ],
+            array.metadata,
+        )
+        if chosen.chosen:
+            array.metadata = chosen.unwrap()
+        return
+    if field == _FILESYSTEM:
+        kind = current_menu(
+            screen,
+            context,
+            translate("Filesystem"),
+            [Item(label=one.value, value=one) for one in FilesystemType],
+            array.filesystem,
+        )
+        if kind.chosen:
+            array.filesystem = kind.unwrap()
+        return
+    if field == _ENCRYPTION:
+        edited = _edit_passphrase(
+            screen,
+            context,
+            array.passphrase_file,
+            translate("Encrypt this array?"),
+        )
+        if edited.chosen:
+            array.passphrase_file = edited.unwrap()
+        return
+    titles = {_NAME: "Name", _MOUNTPOINT: "Mount point", _LABEL: "Label"}
+    values = {_NAME: array.name, _MOUNTPOINT: array.mountpoint, _LABEL: array.label}
+    typed = TextField(
+        title=translate(titles[field]), value=values[field], footer=footer(translate)
+    ).run(screen)
+    if not typed.chosen:
+        return
+    text = typed.unwrap().strip()
+    if field == _NAME:
+        array.name = text or array.name
+    elif field == _MOUNTPOINT:
+        array.mountpoint = text
+    else:
+        array.label = text
+
+
+def _array_descriptor(
+    key: str, label: str, detail: Callable[[manual.Array, Catalog], str]
+) -> FieldDescriptor[tuple[manual.Array, int]]:
+    def row(value: tuple[manual.Array, int], translate: Catalog) -> Item[str]:
+        shown = translate(label)
+        if key == _NAME:
+            shown = translate("Name")
+        return Item(label=shown, value=key, detail=detail(value[0], translate))
+
+    def edit(screen: Screen, context: Context, value: tuple[manual.Array, int]) -> tuple[manual.Array, int]:
+        _edit_array_field_legacy(screen, context, key, value[1])
+        return value
+
+    return FieldDescriptor(
+        key,
+        row,
+        edit,
+    )
+
+
+_ARRAY_FIELDS: tuple[FieldDescriptor[tuple[manual.Array, int]], ...] = (
+    _array_descriptor(_NAME, "Name", lambda array, _: array.name),
+    _array_descriptor(_LEVEL, "RAID level", lambda array, _: array.level.value),
+    _array_descriptor(_METADATA, "Superblock", lambda array, _: array.metadata.value),
+    _array_descriptor(_FILESYSTEM, "Filesystem", lambda array, _: array.filesystem.value),
+    _array_descriptor(_MOUNTPOINT, "Mount point", lambda array, _: array.mountpoint or "-"),
+    _array_descriptor(_LABEL, "Label", lambda array, _: array.label or "-"),
+    _array_descriptor(
+        _ENCRYPTION,
+        "Encryption",
+        lambda array, translate: translate("on") if array.passphrase_file else translate("off"),
+    ),
+    FieldDescriptor(
+        DONE,
+        lambda _, translate: Item(label=translate("Done"), value=DONE),
+        lambda _, __, value: value,
+    ),
+)
+
+
+def _pool_topology(
+    screen: Screen, context: Context, members: int
+) -> ZfsTopology | None:
+    """How the pool members are joined, with the ones this many cannot make
+    drawn with the count they need rather than left out."""
+    translate = context.translate
+    items = [
+        Item(
+            label=one.value,
+            value=one,
+            detail=translate("no redundancy") if one is ZfsTopology.STRIPE else "",
+            disabled_because=""
+            if members >= one.minimum
+            else translate("needs at least {count}").format(count=one.minimum),
+        )
+        for one in ZfsTopology
+    ]
+    answer = current_menu(
+        screen,
+        context,
+        translate("Pool topology"),
+        items,
+        context.layout.topology,
+    )
+    return answer.unwrap() if answer.chosen else None
+
+
+def _edit_pool_encryption(screen: Screen, context: Context) -> Answer[str]:
+    edited = _edit_passphrase(
+        screen,
+        context,
+        context.layout.passphrase_file,
+        context.translate("Encrypt the pool?"),
+    )
+    if edited.chosen:
+        context.layout.passphrase_file = edited.unwrap()
+    return edited
+
+
+def _layout_problem(context: Context, config: InstallConfig) -> str:
+    """What the validator says about the table as it stands."""
+    try:
+        graph, root = manual.build(context.layout)
+    except GentooInstallError as error:
+        return str(error)
+    if not root:
+        return context.translate("no partition is mounted at /")
+    try:
+        validate(replace(config, disk=DiskConfig(graph=graph, root=root)))
+    except ValidationFailed as error:
+        return str(error).splitlines()[-1].strip()
+    return ""
+
+
+def _from_layout(config: InstallConfig, context: Context) -> InstallConfig:
+    graph, root = manual.build(context.layout)
+    return replace(config, disk=DiskConfig(graph=graph, root=root))
+#: One row of the slice editor. Every field is visible with its value, so no
+#: answer is hidden behind a screen the operator has to reach to discover.
+
+
+_SIZE: Final[str] = "size"
+
+
+_PURPOSE: Final[str] = "purpose"
+
+
+_DELETE: Final[str] = "delete"
+
+
+_STATUS: Final[str] = "status"
+
+
+def _edit_slice(
+    screen: Screen, context: Context, disk: manual.Disk, current: manual.Slice | None
+) -> manual.Slice | None:
+    """One partition as a list of fields, or None to delete it."""
+    translate = context.translate
+    entry = current or manual.Slice(
+        index=disk.next_index(),
+        role=PartitionRole.DATA,
+        size=None,
+        filesystem=FilesystemType.EXT4,
+        mountpoint="",
+    )
+    cursor = 0
+    while True:
+        purpose = manual.purpose_of(entry)
+        menu: Menu[str] = Menu(
+            title=f"{translate('Partition')} {entry.index}",
+            items=_slice_fields(entry, purpose, translate),
+            footer=footer(translate),
+            cursor=cursor,
+        )
+        answer = menu.run(screen)
+        cursor = menu.cursor
+        if not answer.chosen:
+            return current
+        field = answer.unwrap()
+        if field == DONE:
+            return entry
+        if field == _DELETE:
+            return None
+        changed = _edit_field(screen, context, entry, purpose, field)
+        if changed is not None:
+            entry = changed
+
+
+def _slice_fields(
+    entry: manual.Slice, purpose: manual.Purpose, translate: Catalog
+) -> list[Item[str]]:
+    return [
+        descriptor.row((entry, purpose), translate)
+        for descriptor in _SLICE_FIELDS
+        if descriptor.key in {item.value for item in _slice_field_items(entry, purpose, translate)}
+    ]
+
+
+def _slice_field_items(
+    entry: manual.Slice, purpose: manual.Purpose, translate: Catalog
+) -> list[Item[str]]:
+    """Every field with its value, and why one that does not apply cannot be
+    opened."""
+    no_filesystem = translate("this purpose fixes the filesystem")
+    purpose_labels = {
+        "root": translate("root"),
+        "esp": translate("esp"),
+        "boot": translate("boot"),
+        "home": translate("home"),
+        "var": translate("var"),
+        "swap": translate("swap"),
+        "zfs pool member": translate("zfs pool member"),
+        "raid array member": translate("raid array member"),
+        "bios-boot": translate("bios-boot"),
+        "other": translate("other"),
+    }
+    return [
+        Item(label=translate("Size"), value=_SIZE, detail=_size_of(entry, translate)),
+        Item(label=translate("Purpose"), value=_PURPOSE, detail=purpose_labels[purpose.label]),
+        Item(
+            label=translate("Filesystem"),
+            value=_FILESYSTEM,
+            detail=entry.filesystem.value if entry.filesystem else "-",
+            disabled_because="" if purpose.chooses_filesystem else no_filesystem,
+        ),
+        Item(
+            label=translate("Mount point"),
+            value=_MOUNTPOINT,
+            detail=entry.mountpoint or "-",
+            disabled_because=(
+                "" if purpose.asks_mountpoint else translate("this purpose fixes the mount point")
+            ),
+        ),
+        Item(label=translate("Label"), value=_LABEL, detail=entry.label or "-"),
+        *(
+            [
+                Item(
+                    label=translate("Encryption"),
+                    value=_ENCRYPTION,
+                    detail=translate("on") if entry.passphrase_file else translate("off"),
+                    # Firmware reads the esp itself and cannot open a container,
+                    # so an encrypted esp never boots.
+                    disabled_because=(
+                        translate("firmware cannot open a container to read the esp")
+                        if purpose.role is PartitionRole.ESP
+                        else ""
+                    ),
+                )
+            ]
+            if purpose.role is not PartitionRole.ZFS
+            else []
+        ),
+        Item(
+            label=translate("What happens to it"),
+            value=_STATUS,
+            detail=translate(entry.status.value),
+        ),
+        # Only a row this table invented: one already on the disk is removed by
+        # answering `delete`, which is an edit to the table and not to the list.
+        *(
+            [Item(label=translate("Take this row off the table"), value=_DELETE)]
+            if entry.status is manual.SliceStatus.CREATE
+            else []
+        ),
+        Item(label=translate("Done"), value=DONE),
+    ]
+
+
+def _size_of(entry: manual.Slice, translate: Catalog) -> str:
+    return str(entry.size) if entry.size is not None else translate("the remaining space")
+
+
+def _edit_field(
+    screen: Screen,
+    context: Context,
+    entry: manual.Slice,
+    purpose: manual.Purpose,
+    field: str,
+) -> manual.Slice | None:
+    descriptor = next((one for one in _SLICE_FIELDS if one.key == field), None)
+    if descriptor is None:
+        return None
+    changed = descriptor.edit(screen, context, (entry, purpose))
+    return changed[0] if changed is not None else None
+
+
+def _edit_field_legacy(
+    screen: Screen,
+    context: Context,
+    entry: manual.Slice,
+    purpose: manual.Purpose,
+    field: str,
+) -> manual.Slice | None:
+    """The one screen behind a field, or None when the operator went back."""
+    translate = context.translate
+    if field == _STATUS:
+        offered = (
+            [manual.SliceStatus.CREATE]
+            if entry.status is manual.SliceStatus.CREATE
+            else [
+                manual.SliceStatus.KEEP,
+                manual.SliceStatus.FORMAT,
+                manual.SliceStatus.DELETE,
+            ]
+        )
+        chosen_status = current_menu(
+            screen,
+            context,
+            translate("What happens to it"),
+            [
+                Item(label=translate(one.value), value=one, detail=translate(manual.STATUS_REASONS[one]))
+                for one in offered
+            ],
+            entry.status,
+        )
+        if not chosen_status.chosen:
+            return None
+        return replace(entry, status=chosen_status.unwrap())
+    if field == _SIZE:
+        typed = TextField(
+            title=translate("Size"),
+            value="" if entry.size is None else str(entry.size),
+            placeholder=translate("512MiB, 20GiB, or empty for the remaining space"),
+            footer=footer(translate),
+        ).run(screen)
+        if not typed.chosen:
+            return None
+        text = typed.unwrap().strip()
+        return replace(entry, size=Size.parse(text) if text else None)
+    if field == _PURPOSE:
+        picked = current_menu(
+            screen,
+            context,
+            translate("What is this partition for?"),
+            [
+                Item(
+                    label=one.label,
+                    value=one,
+                    disabled_because=(
+                        context.zfs_unavailable if one.role is PartitionRole.ZFS else ""
+                    ),
+                )
+                for one in manual.PURPOSES
+            ],
+            purpose,
+        )
+        if not picked.chosen:
+            return None
+        return _apply_purpose(entry, picked.unwrap())
+    if field == _FILESYSTEM:
+        # zfs is listed here as well as under the purpose, because that is
+        # where anyone choosing a filesystem looks for it. It is a pool, so
+        # picking it changes what the partition is rather than how it is
+        # formatted.
+        items: list[Item[FilesystemType | None]] = [
+            Item(label=one.value, value=one) for one in FilesystemType
+        ]
+        items.append(
+            Item(
+                label="zfs",
+                value=None,
+                detail=translate("a pool member, not a filesystem"),
+                disabled_because=context.zfs_unavailable,
+            )
+        )
+        answered = current_menu(
+            screen,
+            context,
+            translate("Filesystem"),
+            items,
+            entry.filesystem,
+        )
+        if not answered.chosen:
+            return None
+        kind = answered.unwrap()
+        if kind is None:
+            return _apply_purpose(entry, manual.purpose_for("zfs"))
+        return replace(entry, filesystem=kind)
+    if field == _MOUNTPOINT:
+        where = TextField(
+            title=translate("Mount point"),
+            value=entry.mountpoint,
+            placeholder=translate("/srv, or empty to leave it unmounted"),
+            footer=footer(translate),
+        ).run(screen)
+        if not where.chosen:
+            return None
+        return replace(entry, mountpoint=where.unwrap().strip())
+    if field == _LABEL:
+        named = TextField(
+            title=translate("Label"),
+            value=entry.label,
+            placeholder=translate("gentoo"),
+            footer=footer(translate),
+        ).run(screen)
+        if not named.chosen:
+            return None
+        return replace(entry, label=named.unwrap().strip())
+    return _edit_slice_encryption(screen, context, entry, purpose)
+
+
+def _slice_descriptor(key: str) -> FieldDescriptor[tuple[manual.Slice, manual.Purpose]]:
+    def row(value: tuple[manual.Slice, manual.Purpose], translate: Catalog) -> Item[str]:
+        return next(item for item in _slice_field_items(*value, translate) if item.value == key)
+
+    def edit(
+        screen: Screen, context: Context, value: tuple[manual.Slice, manual.Purpose]
+    ) -> tuple[manual.Slice, manual.Purpose] | None:
+        changed = _edit_field_legacy(screen, context, value[0], value[1], key)
+        return (changed, value[1]) if changed is not None else None
+
+    return FieldDescriptor(key, row, edit)
+
+
+_SLICE_FIELDS: tuple[FieldDescriptor[tuple[manual.Slice, manual.Purpose]], ...] = tuple(
+    _slice_descriptor(key)
+    for key in (_SIZE, _PURPOSE, _FILESYSTEM, _MOUNTPOINT, _LABEL, _ENCRYPTION, _STATUS, _DELETE)
+)
+
+
+def _apply_purpose(entry: manual.Slice, purpose: manual.Purpose) -> manual.Slice:
+    """Everything the purpose decides, in one place: picking `swap` has to drop
+    the filesystem and the mount point it had as `root`."""
+    return replace(
+        entry,
+        role=purpose.role,
+        filesystem=entry.filesystem if purpose.chooses_filesystem else purpose.filesystem,
+        mountpoint=entry.mountpoint if purpose.asks_mountpoint else purpose.mountpoint,
+        passphrase_file=("" if purpose.role is PartitionRole.ZFS else entry.passphrase_file),
+    )
+
+
+def _edit_slice_encryption(
+    screen: Screen, context: Context, entry: manual.Slice, purpose: manual.Purpose
+) -> manual.Slice | None:
+    translate = context.translate
+    return _edit_passphrase(
+        screen,
+        context,
+        entry.passphrase_file,
+        translate("Encrypt this partition?"),
+    ).map(lambda staged_path: replace(entry, passphrase_file=staged_path)).value

--- a/gentoo_install/tui/screens.py
+++ b/gentoo_install/tui/screens.py
@@ -10,15 +10,12 @@ validator never disagree about why something cannot be chosen.
 from __future__ import annotations
 
 import re
-from copy import deepcopy
 from dataclasses import dataclass, replace
-from enum import Enum
 from itertools import takewhile
 from typing import Callable, Final, Sequence
 
 from ..i18n import Catalog
 from ..exec import fetch
-from ..exec.preflight import ZFS_PASSPHRASE_MINIMUM
 from ..model import compat
 from ..model.config import (
     SystemConfig,
@@ -73,20 +70,26 @@ from ..plan.convert import REPLACED_DIRECTORIES, SWAP_CONFIRMATION
 from ..plan.fonts import CJK_SANS_PREFERENCE, CjkFontconfigLocale, FontCategory
 from ..model.compat import KERNEL_PACKAGES
 from ..model.size import Size
-from ..errors import ConfigError, DeviceNotFound, GentooInstallError, ValidationFailed
+from ..errors import ConfigError, DeviceNotFound, GentooInstallError
 from ..model import atoms, manual, paste, sshkey
-from ..model.templates import Choice, Layout, build
-from ..model.validate import validate
+from ..model.templates import Layout, build
 from ..plan.packages import Catalog as Groups
 from ..plan.packages import FRAMEWORK_GROUPS
 from ..plan.packages import FONT_CONFIGURATION_DISABLED, FONT_CONFIGURATION_ENABLED
 from ..plan.packages import INPUT_CONFIGURATION_DISABLED, INPUT_CONFIGURATION_ENABLED
 from ..plan.packages import driver_conflict, framework_conflict
 from ..plan import system as plan_system
+from .partitions import (
+    _edit_passphrase,
+    _from_layout,
+    _zfs_bootloader,
+    partitions_screen,
+)
 from .context import (
     Answers,
     Context,
     DONE,
+    PASSPHRASE_MINIMUM,
     DROP,
     TABLE,
     FieldDescriptor,
@@ -431,51 +434,8 @@ def _template_screen(
     return Answer(Outcome.CHOSE, changed)
 
 
-def _known(kind: str) -> FilesystemType | None:
-    """The type blkid reported, when the model has a member for it. ntfs and
-    exfat are mounted and never created, so they have no member and no row."""
-    return next((one for one in FilesystemType if one.value == kind), None)
 
 
-def _zfs_bootloader(
-    screen: Screen, config: InstallConfig, context: Context
-) -> Answer[InstallConfig]:
-    """A ZFS root cannot use GRUB, so this asks which of the two that remain.
-
-    ZFSBootMenu lives in the gentoo-zh overlay and in no other repository, so
-    choosing it is also consenting to that overlay. Adding it silently is what
-    this replaces.
-    """
-    translate = context.translate
-    answer = Menu(
-        title=translate("A ZFS root cannot boot from GRUB. Which bootloader?"),
-        preamble=(translate("The bootloader determines how the ZFS root is found at startup."),),
-        items=[
-            Item(
-                label="ZFSBootMenu",
-                value=Bootloader.ZFSBOOTMENU,
-                detail=translate("adds the gentoo-zh overlay, the only one that has it"),
-            ),
-            Item(
-                label="systemd-boot",
-                value=Bootloader.SYSTEMD_BOOT,
-                detail=translate("no overlay, and the esp has to hold the kernel"),
-            ),
-        ],
-        footer=footer(translate),
-        current=config.bootloader.kind,
-    ).run(screen)
-
-    def apply(kind: Bootloader) -> InstallConfig:
-        if kind is Bootloader.SYSTEMD_BOOT:
-            return replace(config, bootloader=replace(config.bootloader, kind=kind))
-        return replace(
-            config,
-            bootloader=replace(config.bootloader, kind=kind),
-            portage=with_gentoo_zh(config),
-        )
-
-    return answer.map(apply)
 
 
 def erase_screen(screen: Screen, config: InstallConfig, context: Context) -> Answer[InstallConfig]:
@@ -2154,11 +2114,6 @@ def packages_screen(
         say(screen, context, clash)
 
 
-#: What the preflight refuses, read from there rather than written again: the
-#: two carried the same 8 and the same reason, and raising one would have left
-#: the menu accepting a passphrase the install stops on once the disk is
-#: already partitioned.
-PASSPHRASE_MINIMUM: Final[int] = ZFS_PASSPHRASE_MINIMUM
 
 #: Taken from profiles.desc for amd64 23.0. A systemd profile is the same path
 #: plus /systemd, which `_profile_for` relies on.
@@ -2377,60 +2332,8 @@ def encryption_screen(screen: Screen, config: InstallConfig, context: Context) -
     return edited.map(rebuilt)
 
 
-def _edit_passphrase(
-    screen: Screen, context: Context, staged_path: str, title: str
-) -> Answer[str]:
-    """Enable, disable, or replace one staged encryption passphrase."""
-    translate = context.translate
-    enabled = Confirm(
-        **answers(translate),
-        title=title,
-        footer=footer(translate),
-        current=bool(staged_path),
-    ).run(screen)
-    if not enabled.chosen:
-        return Answer(enabled.outcome)
-    if not enabled.unwrap():
-        return Answer(Outcome.CHOSE, "")
-    return _ask_passphrase(screen, context)
 
 
-def _ask_passphrase(screen: Screen, context: Context) -> Answer[str]:
-    """The passphrase typed twice, staged in a file whose path is returned.
-
-    The configuration holds the path and never the passphrase, because it is
-    copied into the target and the install log is what people paste into bug
-    reports.
-    """
-    translate = context.translate
-    hint = translate("At least {count} characters.").format(count=PASSPHRASE_MINIMUM)
-    while True:
-        first = TextField(
-            title=translate("Passphrase"),
-            masked=True,
-            detail=hint,
-            footer=footer(translate),
-        ).run(screen)
-        if not first.chosen:
-            return Answer(first.outcome)
-        typed = first.unwrap()
-        if len(typed) < PASSPHRASE_MINIMUM:
-            # Checked here, not at preflight: zfs refuses a short passphrase
-            # only once the disks have been partitioned.
-            say(screen, context, translate("The passphrase is too short."))
-            continue
-        again = TextField(
-            title=translate("Passphrase again"),
-            masked=True,
-            detail=hint,
-            footer=footer(translate),
-        ).run(screen)
-        if not again.chosen:
-            return Answer(again.outcome)
-        if again.unwrap() != typed:
-            say(screen, context, translate("The two do not match."))
-            continue
-        return Answer(Outcome.CHOSE, context.stage_passphrase(typed))
 
 
 def _ask_password(screen: Screen, context: Context, title: str) -> Answer[str]:
@@ -3002,848 +2905,76 @@ def firewall_screen(
     )
 
 
-class _RowKind(Enum):
-    """What one line of the partition screen stands for."""
-
-    DISK = "disk"
-    SLICE = "slice"
-    ADD_PARTITION = "add-partition"
-    ADD_DISK = "add-disk"
-    TOPOLOGY = "topology"
-    POOL_ENCRYPTION = "pool-encryption"
-    ARRAY = "array"
-    DONE = "done"
-
-
-@dataclass(frozen=True)
-class _Row:
-    """A line of the partition screen, and what it points at.
-
-    `disk` is a position in `Layout.disks` and `entry` a position in that
-    disk's rows; both are -1 on a line that points at neither.
-    """
-
-    kind: _RowKind
-    disk: int = -1
-    entry: int = -1
-
-
-def partitions_screen(
-    screen: Screen, config: InstallConfig, context: Context
-) -> Answer[InstallConfig]:
-    """Every disk being partitioned, and under each one its table, row by row.
-
-    Every change rebuilds the graph and runs the validator, so a table that
-    cannot be installed says why here rather than at the first `mkfs`.
-    """
-    translate = context.translate
-    if not context.layout.holds(context.choice.disk) or not context.layout.slices:
-        # Seeded from what is on the disk when there is anything, and from the
-        # template that was chosen when there is not: opening this row after
-        # picking zfs used to show an ext4 root and discard the choice.
-        context.layout = _seed(context)
-    saved_layout = deepcopy(context.layout)
-    saved_manual = context.manual
-    cursor = 0
-    while True:
-        items = _partition_rows(context)
-        menu: Menu[_Row] = Menu(
-            title=_partitions_title(context),
-            preamble=(translate("This editor controls which partitions are kept, formatted, mounted, or erased."),),
-            items=items,
-            cursor=cursor,
-            footer=f"{_layout_problem(context, config)}  {footer(translate)}".strip(),
-        )
-        answer = menu.run(screen)
-        cursor = menu.cursor
-        if not answer.chosen:
-            added = [
-                deepcopy(disk)
-                for disk in context.layout.disks
-                if not saved_layout.holds(disk.selector)
-            ]
-            context.layout = saved_layout
-            context.layout.disks.extend(added)
-            context.manual = saved_manual
-            return Answer(answer.outcome)
-        row = answer.unwrap()
-        if row.kind is _RowKind.DONE:
-            # Marked here rather than by whoever opened this screen: the row can
-            # be reached from the menu as well as from the layout row, and a
-            # flag set before the editor answers describes a table that may
-            # never have been produced.
-            context.manual = True
-            built = _from_layout(config, context)
-            if context.layout.disks and _pool_members(context):
-                # The same question the template path asks: a ZFS root cannot
-                # boot from GRUB, and ZFSBootMenu needs the overlay adding.
-                # Without this every bootloader row was greyed and the table
-                # had no way out.
-                picked = _zfs_bootloader(screen, built, context)
-                if not picked.chosen:
-                    if picked.outcome is Outcome.CANCELLED:
-                        return Answer(picked.outcome)
-                    # Back to the editor rather than out of it: the table the
-                    # operator drew is still there, and a ZFS root with GRUB
-                    # is what committing this would have written.
-                    continue
-                built = picked.unwrap()
-            return Answer(Outcome.CHOSE, built)
-        _act_on(screen, context, row)
-
-
-def _partitions_title(context: Context) -> str:
-    translate = context.translate
-    if context.layout.writes_the_table():
-        return translate("A new partition table")
-    return translate("Partitions")
-
-
-def _partition_rows(context: Context) -> list[Item[_Row]]:
-    """One line per disk, its rows indented under it, then what can be added."""
-    translate = context.translate
-    items: list[Item[_Row]] = []
-    for position, disk in enumerate(context.layout.disks):
-        items.append(
-            Item(
-                label=context.shown_as(disk.selector),
-                value=_Row(_RowKind.DISK, position),
-                detail=f"{disk.table.value}  {_capacity(context, disk)}",
-            )
-        )
-        for index, entry in enumerate(sorted(disk.slices, key=lambda one: one.index)):
-            # Two spaces rather than a box-drawing character: the console this
-            # runs on may have neither a CJK font nor a line-drawing set.
-            items.append(
-                Item(label=f"  {entry.describe()}", value=_Row(_RowKind.SLICE, position, index))
-            )
-        items.append(
-            Item(
-                label=f"  {translate('Add a partition')}",
-                value=_Row(_RowKind.ADD_PARTITION, position),
-            )
-        )
-    if _unused_disks(context):
-        items.append(Item(label=translate("Add a disk"), value=_Row(_RowKind.ADD_DISK)))
-    # Both rows are drawn whether or not they can be opened. Hidden until a
-    # partition happened to carry the right purpose, the two features were
-    # unreachable to anyone who did not already know they existed.
-    pool = len(_pool_members(context))
-    items.append(
-        Item(
-            label=translate("Pool topology"),
-            value=_Row(_RowKind.TOPOLOGY),
-            detail=context.layout.topology.value if pool > 1 else "",
-            disabled_because=(
-                "" if pool > 1 else translate("give two partitions the zfs pool member purpose")
-            ),
-        )
-    )
-    if pool:
-        items.append(
-            Item(
-                label=f"ZFS {translate('Encryption')}",
-                value=_Row(_RowKind.POOL_ENCRYPTION),
-                detail=translate("on") if context.layout.passphrase_file else translate("off"),
-            )
-        )
-    array = len(_array_members(context))
-    items.append(
-        Item(
-            label=translate("RAID array"),
-            value=_Row(_RowKind.ARRAY),
-            detail=_array_summary(context) if array else "",
-            disabled_because=(
-                "" if array else translate("give a partition the raid array member purpose")
-            ),
-        )
-    )
-    items.append(Item(label=translate("Done"), value=_Row(_RowKind.DONE)))
-    return items
-
-
-def _array_summary(context: Context) -> str:
-    array = context.layout.array
-    where = array.mountpoint or "-"
-    return f"{array.name}, {array.level.value}, {array.filesystem.value}, {where}"
-
-
-def _act_on(screen: Screen, context: Context, row: _Row) -> None:
-    """Everything the screen does but leave, so the loop above stays readable."""
-    if row.kind is _RowKind.TOPOLOGY:
-        picked = _pool_topology(screen, context, len(_pool_members(context)))
-        if picked is not None:
-            context.layout.topology = picked
-        return
-    if row.kind is _RowKind.POOL_ENCRYPTION:
-        _edit_pool_encryption(screen, context)
-        return
-    if row.kind is _RowKind.ARRAY:
-        _edit_array(screen, context)
-        return
-    if row.kind is _RowKind.ADD_DISK:
-        added = _pick_another_disk(screen, context)
-        if added is not None:
-            held, _ = context.contents(added)
-            context.layout.disks.append(_seeded_disk(added, held))
-        return
-    disk = context.layout.disks[row.disk]
-    if row.kind is _RowKind.DISK:
-        _edit_disk(screen, context, row.disk)
-        return
-    if row.kind is _RowKind.ADD_PARTITION:
-        fresh = _edit_slice(screen, context, disk, None)
-        if fresh is not None:
-            disk.slices.append(fresh)
-        return
-    rows = sorted(disk.slices, key=lambda one: one.index)
-    edited = _edit_slice(screen, context, disk, rows[row.entry])
-    disk.slices.remove(rows[row.entry])
-    if edited is not None:
-        disk.slices.append(edited)
-
-
-def _array_members(context: Context) -> list[manual.Slice]:
-    return [one for one in context.layout.slices if one.role is PartitionRole.RAID]
-
-
-def _pool_members(context: Context) -> list[manual.Slice]:
-    return [one for one in context.layout.slices if one.role is PartitionRole.ZFS]
-
-
-def _unused_disks(context: Context) -> list[tuple[str, str]]:
-    """Disks this machine has that the table does not already cover."""
-    return [one for one in context.disks if not context.layout.holds(one[0])]
-
-
-def _pick_another_disk(screen: Screen, context: Context) -> str | None:
-    translate = context.translate
-    answer = Menu(
-        title=translate("Add a disk"),
-        items=[
-            Item(label=name, value=name, detail=detail) for name, detail in _unused_disks(context)
-        ],
-        footer=footer(translate),
-    ).run(screen)
-    return answer.unwrap() if answer.chosen else None
-
-
-def _edit_disk(screen: Screen, context: Context, position: int) -> None:
-    """What the disk itself carries: its table type, and whether it stays.
-
-    The first disk cannot be dropped here; it is the one the disk row chose,
-    and a table with no disk at all has nothing to install onto.
-    """
-    translate = context.translate
-    disk = context.layout.disks[position]
-    while True:
-        items: list[Item[str]] = [
-            Item(label=translate("Partition table"), value=TABLE, detail=disk.table.value),
-            *(
-                [Item(label=translate("Take this disk off the table"), value=DROP)]
-                if position > 0
-                else []
-            ),
-            Item(label=translate("Done"), value=DONE),
-        ]
-        answer = Menu(
-            title=context.shown_as(disk.selector), items=items, footer=footer(translate)
-        ).run(screen)
-        if not answer.chosen or answer.unwrap() == DONE:
-            return
-        if answer.unwrap() == DROP:
-            context.layout.disks.pop(position)
-            return
-        picked = current_menu(
-            screen,
-            context,
-            translate("Partition table"),
-            [Item(label=one.value, value=one) for one in TableType],
-            disk.table,
-        )
-        if picked.chosen:
-            disk.table = picked.unwrap()
-
-
-def _template_filesystem(choice: Choice) -> FilesystemType | None:
-    """What the root of the chosen template carries. None for ZFS, whose root
-    is a dataset on a pool and not a filesystem on a partition."""
-    return None if choice.layout is Layout.WHOLE_DISK_ZFS else choice.filesystem
-
-
-def _capacity(context: Context, disk: manual.Disk) -> str:
-    """The disk's size and what its table has already claimed, because a size
-    is guesswork without them."""
-    translate = context.translate
-    total = context.contents(disk.selector)[1]
-    if not total:
-        return ""
-    fresh = [one for one in disk.slices if one.status is manual.SliceStatus.CREATE]
-    claimed = sum(entry.size.bytes for entry in fresh if entry.size is not None)
-    rest = any(entry.size is None for entry in fresh)
-    used = Size(claimed)
-    return translate("{total} total, {used} claimed{rest}").format(
-        total=total, used=used, rest=translate(", rest to one partition") if rest else ""
-    )
-
-
-def _seed(context: Context) -> manual.Layout:
-    """The table the editor opens on.
-
-    Every partition already on the disk, kept: an operator who opens this over
-    a machine with data on it should see that data, not a proposal that erases
-    it. An empty disk has nothing to list, so it gets the template's proposal.
-    """
-    if not context.existing:
-        return manual.suggest(
-            context.choice.disk, context.choice.firmware, _template_filesystem(context.choice)
-        )
-    return manual.Layout(
-        disks=[
-            _seeded_disk(
-                context.choice.disk,
-                context.existing,
-                context.choice.table or TableType.GPT,
-            )
-        ]
-    )
-
-
-def _seeded_disk(
-    selector: str, held: Sequence[tuple[str, str, str]], table: TableType = TableType.GPT
-) -> manual.Disk:
-    """A disk with what the machine says is already on it, kept.
-
-    Every disk, not only the first: a second one was appended empty, so a disk
-    with partitions was drawn as blank and the rows added beside them rewrote
-    its table.
-    """
-    disk = manual.Disk(selector=selector, table=table)
-    for index, (where, _, kind) in enumerate(held, start=1):
-        disk.slices.append(
-            manual.Slice(
-                index=index,
-                role=PartitionRole.DATA,
-                size=None,
-                filesystem=_known(kind),
-                status=manual.SliceStatus.KEEP,
-                selector=where,
-            )
-        )
-    return disk
-
-
-_LEVEL: Final[str] = "level"
-_METADATA: Final[str] = "metadata"
-_NAME: Final[str] = "name"
-_FILESYSTEM: Final[str] = "filesystem"
-_MOUNTPOINT: Final[str] = "mountpoint"
-_LABEL: Final[str] = "label"
-_ENCRYPTION: Final[str] = "encryption"
-
-
-def _edit_array(screen: Screen, context: Context) -> None:
-    """The array the member rows are assembled into, as a list of fields.
-
-    The same shape as a partition's field list, because it answers the same
-    kind of questions: what it is called, what goes on it and where.
-    """
-    translate = context.translate
-    members = len(_array_members(context))
-    while True:
-        array = context.layout.array
-        items = [field.row((array, members), translate) for field in _ARRAY_FIELDS]
-        answer = Menu(
-            title=f"{translate('RAID array')}  {members} {translate('members')}",
-            items=items,
-            footer=footer(translate),
-        ).run(screen)
-        if not answer.chosen or answer.unwrap() == DONE:
-            return
-        _edit_array_field(screen, context, answer.unwrap(), members)
-
-
-def _edit_array_field(screen: Screen, context: Context, field: str, members: int) -> None:
-    descriptor = next((one for one in _ARRAY_FIELDS if one.key == field), None)
-    if descriptor is not None:
-        descriptor.edit(screen, context, (context.layout.array, members))
-    return
-
-
-def _edit_array_field_legacy(screen: Screen, context: Context, field: str, members: int) -> None:
-    translate = context.translate
-    array = context.layout.array
-    if field == _LEVEL:
-        picked = current_menu(
-            screen,
-            context,
-            translate("RAID level"),
-            [
-                Item(
-                    label=one.value,
-                    value=one,
-                    disabled_because=""
-                    if members >= one.minimum
-                    else translate("needs at least {count}").format(count=one.minimum),
-                )
-                for one in RaidLevel
-            ],
-            array.level,
-        )
-        if picked.chosen:
-            array.level = picked.unwrap()
-        return
-    if field == _METADATA:
-        chosen = current_menu(
-            screen,
-            context,
-            translate("Superblock"),
-            [
-                Item(
-                    label=one.value,
-                    value=one,
-                    detail=""
-                    if one.superblock_at_start
-                    else translate("at the end, so firmware reads the member"),
-                )
-                for one in RaidMetadata
-            ],
-            array.metadata,
-        )
-        if chosen.chosen:
-            array.metadata = chosen.unwrap()
-        return
-    if field == _FILESYSTEM:
-        kind = current_menu(
-            screen,
-            context,
-            translate("Filesystem"),
-            [Item(label=one.value, value=one) for one in FilesystemType],
-            array.filesystem,
-        )
-        if kind.chosen:
-            array.filesystem = kind.unwrap()
-        return
-    if field == _ENCRYPTION:
-        edited = _edit_passphrase(
-            screen,
-            context,
-            array.passphrase_file,
-            translate("Encrypt this array?"),
-        )
-        if edited.chosen:
-            array.passphrase_file = edited.unwrap()
-        return
-    titles = {_NAME: "Name", _MOUNTPOINT: "Mount point", _LABEL: "Label"}
-    values = {_NAME: array.name, _MOUNTPOINT: array.mountpoint, _LABEL: array.label}
-    typed = TextField(
-        title=translate(titles[field]), value=values[field], footer=footer(translate)
-    ).run(screen)
-    if not typed.chosen:
-        return
-    text = typed.unwrap().strip()
-    if field == _NAME:
-        array.name = text or array.name
-    elif field == _MOUNTPOINT:
-        array.mountpoint = text
-    else:
-        array.label = text
-
-
-def _array_descriptor(
-    key: str, label: str, detail: Callable[[manual.Array, Catalog], str]
-) -> FieldDescriptor[tuple[manual.Array, int]]:
-    def row(value: tuple[manual.Array, int], translate: Catalog) -> Item[str]:
-        shown = translate(label)
-        if key == _NAME:
-            shown = translate("Name")
-        return Item(label=shown, value=key, detail=detail(value[0], translate))
-
-    def edit(screen: Screen, context: Context, value: tuple[manual.Array, int]) -> tuple[manual.Array, int]:
-        _edit_array_field_legacy(screen, context, key, value[1])
-        return value
-
-    return FieldDescriptor(
-        key,
-        row,
-        edit,
-    )
-
-
-_ARRAY_FIELDS: tuple[FieldDescriptor[tuple[manual.Array, int]], ...] = (
-    _array_descriptor(_NAME, "Name", lambda array, _: array.name),
-    _array_descriptor(_LEVEL, "RAID level", lambda array, _: array.level.value),
-    _array_descriptor(_METADATA, "Superblock", lambda array, _: array.metadata.value),
-    _array_descriptor(_FILESYSTEM, "Filesystem", lambda array, _: array.filesystem.value),
-    _array_descriptor(_MOUNTPOINT, "Mount point", lambda array, _: array.mountpoint or "-"),
-    _array_descriptor(_LABEL, "Label", lambda array, _: array.label or "-"),
-    _array_descriptor(
-        _ENCRYPTION,
-        "Encryption",
-        lambda array, translate: translate("on") if array.passphrase_file else translate("off"),
-    ),
-    FieldDescriptor(
-        DONE,
-        lambda _, translate: Item(label=translate("Done"), value=DONE),
-        lambda _, __, value: value,
-    ),
-)
-def _pool_topology(
-    screen: Screen, context: Context, members: int
-) -> ZfsTopology | None:
-    """How the pool members are joined, with the ones this many cannot make
-    drawn with the count they need rather than left out."""
-    translate = context.translate
-    items = [
-        Item(
-            label=one.value,
-            value=one,
-            detail=translate("no redundancy") if one is ZfsTopology.STRIPE else "",
-            disabled_because=""
-            if members >= one.minimum
-            else translate("needs at least {count}").format(count=one.minimum),
-        )
-        for one in ZfsTopology
-    ]
-    answer = current_menu(
-        screen,
-        context,
-        translate("Pool topology"),
-        items,
-        context.layout.topology,
-    )
-    return answer.unwrap() if answer.chosen else None
-
-
-def _edit_pool_encryption(screen: Screen, context: Context) -> Answer[str]:
-    edited = _edit_passphrase(
-        screen,
-        context,
-        context.layout.passphrase_file,
-        context.translate("Encrypt the pool?"),
-    )
-    if edited.chosen:
-        context.layout.passphrase_file = edited.unwrap()
-    return edited
-
-
-def _layout_problem(context: Context, config: InstallConfig) -> str:
-    """What the validator says about the table as it stands."""
-    try:
-        graph, root = manual.build(context.layout)
-    except GentooInstallError as error:
-        return str(error)
-    if not root:
-        return context.translate("no partition is mounted at /")
-    try:
-        validate(replace(config, disk=DiskConfig(graph=graph, root=root)))
-    except ValidationFailed as error:
-        return str(error).splitlines()[-1].strip()
-    return ""
-
-
-def _from_layout(config: InstallConfig, context: Context) -> InstallConfig:
-    graph, root = manual.build(context.layout)
-    return replace(config, disk=DiskConfig(graph=graph, root=root))
-
-
-#: One row of the slice editor. Every field is visible with its value, so no
-#: answer is hidden behind a screen the operator has to reach to discover.
-_SIZE: Final[str] = "size"
-_PURPOSE: Final[str] = "purpose"
-_DELETE: Final[str] = "delete"
-_STATUS: Final[str] = "status"
-
-
-def _edit_slice(
-    screen: Screen, context: Context, disk: manual.Disk, current: manual.Slice | None
-) -> manual.Slice | None:
-    """One partition as a list of fields, or None to delete it."""
-    translate = context.translate
-    entry = current or manual.Slice(
-        index=disk.next_index(),
-        role=PartitionRole.DATA,
-        size=None,
-        filesystem=FilesystemType.EXT4,
-        mountpoint="",
-    )
-    cursor = 0
-    while True:
-        purpose = manual.purpose_of(entry)
-        menu: Menu[str] = Menu(
-            title=f"{translate('Partition')} {entry.index}",
-            items=_slice_fields(entry, purpose, translate),
-            footer=footer(translate),
-            cursor=cursor,
-        )
-        answer = menu.run(screen)
-        cursor = menu.cursor
-        if not answer.chosen:
-            return current
-        field = answer.unwrap()
-        if field == DONE:
-            return entry
-        if field == _DELETE:
-            return None
-        changed = _edit_field(screen, context, entry, purpose, field)
-        if changed is not None:
-            entry = changed
-
-
-def _slice_fields(
-    entry: manual.Slice, purpose: manual.Purpose, translate: Catalog
-) -> list[Item[str]]:
-    return [
-        descriptor.row((entry, purpose), translate)
-        for descriptor in _SLICE_FIELDS
-        if descriptor.key in {item.value for item in _slice_field_items(entry, purpose, translate)}
-    ]
-
-
-def _slice_field_items(
-    entry: manual.Slice, purpose: manual.Purpose, translate: Catalog
-) -> list[Item[str]]:
-    """Every field with its value, and why one that does not apply cannot be
-    opened."""
-    no_filesystem = translate("this purpose fixes the filesystem")
-    purpose_labels = {
-        "root": translate("root"),
-        "esp": translate("esp"),
-        "boot": translate("boot"),
-        "home": translate("home"),
-        "var": translate("var"),
-        "swap": translate("swap"),
-        "zfs pool member": translate("zfs pool member"),
-        "raid array member": translate("raid array member"),
-        "bios-boot": translate("bios-boot"),
-        "other": translate("other"),
-    }
-    return [
-        Item(label=translate("Size"), value=_SIZE, detail=_size_of(entry, translate)),
-        Item(label=translate("Purpose"), value=_PURPOSE, detail=purpose_labels[purpose.label]),
-        Item(
-            label=translate("Filesystem"),
-            value=_FILESYSTEM,
-            detail=entry.filesystem.value if entry.filesystem else "-",
-            disabled_because="" if purpose.chooses_filesystem else no_filesystem,
-        ),
-        Item(
-            label=translate("Mount point"),
-            value=_MOUNTPOINT,
-            detail=entry.mountpoint or "-",
-            disabled_because=(
-                "" if purpose.asks_mountpoint else translate("this purpose fixes the mount point")
-            ),
-        ),
-        Item(label=translate("Label"), value=_LABEL, detail=entry.label or "-"),
-        *(
-            [
-                Item(
-                    label=translate("Encryption"),
-                    value=_ENCRYPTION,
-                    detail=translate("on") if entry.passphrase_file else translate("off"),
-                    # Firmware reads the esp itself and cannot open a container,
-                    # so an encrypted esp never boots.
-                    disabled_because=(
-                        translate("firmware cannot open a container to read the esp")
-                        if purpose.role is PartitionRole.ESP
-                        else ""
-                    ),
-                )
-            ]
-            if purpose.role is not PartitionRole.ZFS
-            else []
-        ),
-        Item(
-            label=translate("What happens to it"),
-            value=_STATUS,
-            detail=translate(entry.status.value),
-        ),
-        # Only a row this table invented: one already on the disk is removed by
-        # answering `delete`, which is an edit to the table and not to the list.
-        *(
-            [Item(label=translate("Take this row off the table"), value=_DELETE)]
-            if entry.status is manual.SliceStatus.CREATE
-            else []
-        ),
-        Item(label=translate("Done"), value=DONE),
-    ]
-
-
-def _size_of(entry: manual.Slice, translate: Catalog) -> str:
-    return str(entry.size) if entry.size is not None else translate("the remaining space")
-
-
-def _edit_field(
-    screen: Screen,
-    context: Context,
-    entry: manual.Slice,
-    purpose: manual.Purpose,
-    field: str,
-) -> manual.Slice | None:
-    descriptor = next((one for one in _SLICE_FIELDS if one.key == field), None)
-    if descriptor is None:
-        return None
-    changed = descriptor.edit(screen, context, (entry, purpose))
-    return changed[0] if changed is not None else None
-
-
-def _edit_field_legacy(
-    screen: Screen,
-    context: Context,
-    entry: manual.Slice,
-    purpose: manual.Purpose,
-    field: str,
-) -> manual.Slice | None:
-    """The one screen behind a field, or None when the operator went back."""
-    translate = context.translate
-    if field == _STATUS:
-        offered = (
-            [manual.SliceStatus.CREATE]
-            if entry.status is manual.SliceStatus.CREATE
-            else [
-                manual.SliceStatus.KEEP,
-                manual.SliceStatus.FORMAT,
-                manual.SliceStatus.DELETE,
-            ]
-        )
-        chosen_status = current_menu(
-            screen,
-            context,
-            translate("What happens to it"),
-            [
-                Item(label=translate(one.value), value=one, detail=translate(manual.STATUS_REASONS[one]))
-                for one in offered
-            ],
-            entry.status,
-        )
-        if not chosen_status.chosen:
-            return None
-        return replace(entry, status=chosen_status.unwrap())
-    if field == _SIZE:
-        typed = TextField(
-            title=translate("Size"),
-            value="" if entry.size is None else str(entry.size),
-            placeholder=translate("512MiB, 20GiB, or empty for the remaining space"),
-            footer=footer(translate),
-        ).run(screen)
-        if not typed.chosen:
-            return None
-        text = typed.unwrap().strip()
-        return replace(entry, size=Size.parse(text) if text else None)
-    if field == _PURPOSE:
-        picked = current_menu(
-            screen,
-            context,
-            translate("What is this partition for?"),
-            [
-                Item(
-                    label=one.label,
-                    value=one,
-                    disabled_because=(
-                        context.zfs_unavailable if one.role is PartitionRole.ZFS else ""
-                    ),
-                )
-                for one in manual.PURPOSES
-            ],
-            purpose,
-        )
-        if not picked.chosen:
-            return None
-        return _apply_purpose(entry, picked.unwrap())
-    if field == _FILESYSTEM:
-        # zfs is listed here as well as under the purpose, because that is
-        # where anyone choosing a filesystem looks for it. It is a pool, so
-        # picking it changes what the partition is rather than how it is
-        # formatted.
-        items: list[Item[FilesystemType | None]] = [
-            Item(label=one.value, value=one) for one in FilesystemType
-        ]
-        items.append(
-            Item(
-                label="zfs",
-                value=None,
-                detail=translate("a pool member, not a filesystem"),
-                disabled_because=context.zfs_unavailable,
-            )
-        )
-        answered = current_menu(
-            screen,
-            context,
-            translate("Filesystem"),
-            items,
-            entry.filesystem,
-        )
-        if not answered.chosen:
-            return None
-        kind = answered.unwrap()
-        if kind is None:
-            return _apply_purpose(entry, manual.purpose_for("zfs"))
-        return replace(entry, filesystem=kind)
-    if field == _MOUNTPOINT:
-        where = TextField(
-            title=translate("Mount point"),
-            value=entry.mountpoint,
-            placeholder=translate("/srv, or empty to leave it unmounted"),
-            footer=footer(translate),
-        ).run(screen)
-        if not where.chosen:
-            return None
-        return replace(entry, mountpoint=where.unwrap().strip())
-    if field == _LABEL:
-        named = TextField(
-            title=translate("Label"),
-            value=entry.label,
-            placeholder=translate("gentoo"),
-            footer=footer(translate),
-        ).run(screen)
-        if not named.chosen:
-            return None
-        return replace(entry, label=named.unwrap().strip())
-    return _edit_slice_encryption(screen, context, entry, purpose)
-
-
-def _slice_descriptor(key: str) -> FieldDescriptor[tuple[manual.Slice, manual.Purpose]]:
-    def row(value: tuple[manual.Slice, manual.Purpose], translate: Catalog) -> Item[str]:
-        return next(item for item in _slice_field_items(*value, translate) if item.value == key)
-
-    def edit(
-        screen: Screen, context: Context, value: tuple[manual.Slice, manual.Purpose]
-    ) -> tuple[manual.Slice, manual.Purpose] | None:
-        changed = _edit_field_legacy(screen, context, value[0], value[1], key)
-        return (changed, value[1]) if changed is not None else None
-
-    return FieldDescriptor(key, row, edit)
-
-
-_SLICE_FIELDS: tuple[FieldDescriptor[tuple[manual.Slice, manual.Purpose]], ...] = tuple(
-    _slice_descriptor(key)
-    for key in (_SIZE, _PURPOSE, _FILESYSTEM, _MOUNTPOINT, _LABEL, _ENCRYPTION, _STATUS, _DELETE)
-)
-
-
-def _apply_purpose(entry: manual.Slice, purpose: manual.Purpose) -> manual.Slice:
-    """Everything the purpose decides, in one place: picking `swap` has to drop
-    the filesystem and the mount point it had as `root`."""
-    return replace(
-        entry,
-        role=purpose.role,
-        filesystem=entry.filesystem if purpose.chooses_filesystem else purpose.filesystem,
-        mountpoint=entry.mountpoint if purpose.asks_mountpoint else purpose.mountpoint,
-        passphrase_file=("" if purpose.role is PartitionRole.ZFS else entry.passphrase_file),
-    )
-
-
-def _edit_slice_encryption(
-    screen: Screen, context: Context, entry: manual.Slice, purpose: manual.Purpose
-) -> manual.Slice | None:
-    translate = context.translate
-    return _edit_passphrase(
-        screen,
-        context,
-        entry.passphrase_file,
-        translate("Encrypt this partition?"),
-    ).map(lambda staged_path: replace(entry, passphrase_file=staged_path)).value
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
 
 
 def extra_packages_screen(

--- a/gentoo_install/tui/settings.py
+++ b/gentoo_install/tui/settings.py
@@ -43,6 +43,7 @@ from ..model.device import (
 from ..plan import automatic as automatic_values
 from . import screens
 from .mirror import mirror_screen
+from .partitions import partitions_screen
 from .context import Context, Step, ValueKind, ValueSource, footer
 from ..i18n import width
 from .widgets import Answer, Item, Menu, Outcome, Screen, Style
@@ -732,7 +733,7 @@ DISK: Final[tuple[Setting, ...]] = (
     ),
     Setting("layout", "Layout", _layout, screens.layout_screen),
     Setting(
-        "partitions", "Partitions", _partitions, screens.partitions_screen,
+        "partitions", "Partitions", _partitions, partitions_screen,
         unavailable=_template_writes_the_table,
     ),
     Setting("encryption", "Encryption", _encryption, screens.encryption_screen),

--- a/tests/unit/test_layers.py
+++ b/tests/unit/test_layers.py
@@ -498,7 +498,7 @@ def test_the_passphrase_minimum_is_one_number() -> None:
     constants carried the same 8 and the same reason, and raising one would
     have left the menu accepting what the install then stops on."""
     from gentoo_install.exec.preflight import ZFS_PASSPHRASE_MINIMUM
-    from gentoo_install.tui.screens import PASSPHRASE_MINIMUM
+    from gentoo_install.tui.context import PASSPHRASE_MINIMUM
 
     assert PASSPHRASE_MINIMUM is ZFS_PASSPHRASE_MINIMUM
 
@@ -515,3 +515,34 @@ def test_the_passphrase_minimum_is_one_number() -> None:
         and isinstance(node.value, ast.Constant)
     }
     assert written == {"gentoo_install/exec/preflight.py"}, written
+
+
+def test_the_disk_screens_reach_nothing_in_the_screen_module() -> None:
+    """`tui/partitions.py` is the closure of `partitions_screen`: everything
+    it reaches and nothing else. `screens.py` reaches four of those names and
+    this module reaches none of its, which is what makes the split one way. An
+    earlier attempt cut the same subject by hand and found edges running both
+    ways, so the boundary was computed instead."""
+    tui = PACKAGE / "tui"
+    imported = _imports(ast.parse((tui / "partitions.py").read_text()))
+    forbidden = {name for name in imported if name.split(".")[-1] in {"screens", "settings"}}
+    assert not forbidden, forbidden
+
+    # And the four names that cross the other way, by name: a fifth would mean
+    # the closure moved and the boundary was not recomputed.
+    source = (tui / "screens.py").read_text()
+    crossing = {
+        name
+        for name in ("partitions_screen", "_from_layout", "_zfs_bootloader", "_edit_passphrase")
+        if re.search(rf"\b{name}\b", source)
+    }
+    assert crossing == {
+        "partitions_screen",
+        "_from_layout",
+        "_zfs_bootloader",
+        "_edit_passphrase",
+    }, crossing
+
+    # Whatever `screens.py` uses from there, it imports from there.
+    for name in crossing:
+        assert re.search(rf"from \.partitions import \([^)]*\b{name}\b", source, re.S), name

--- a/tests/unit/test_tui_app.py
+++ b/tests/unit/test_tui_app.py
@@ -31,6 +31,7 @@ from gentoo_install.model.validate import validate
 from gentoo_install.model import compat
 from gentoo_install.tui import app, widgets, screens, settings
 from gentoo_install.tui import context as tui_context
+from gentoo_install.tui import partitions
 from gentoo_install.tui import mirror
 from gentoo_install.tui.app import run
 from gentoo_install.tui.overview import overview_screen
@@ -155,15 +156,15 @@ def test_field_editors_have_one_descriptor_for_each_editable_row() -> None:
     assert mirror_rows <= mirror_expected
     assert {field.key for field in mirror._ALL_MIRROR_FIELDS} == mirror_expected
 
-    array_expected = {screens._NAME, screens._LEVEL, screens._METADATA,
-                      screens._FILESYSTEM, screens._MOUNTPOINT, screens._LABEL,
-                      screens._ENCRYPTION}
+    array_expected = {partitions._NAME, partitions._LEVEL, partitions._METADATA,
+                      partitions._FILESYSTEM, partitions._MOUNTPOINT, partitions._LABEL,
+                      partitions._ENCRYPTION}
     array_rows = {
         field.row((at.layout.array, 0), at.translate).value
-        for field in screens._ARRAY_FIELDS
+        for field in partitions._ARRAY_FIELDS
         if field.key != tui_context.DONE
     }
-    assert {field.key for field in screens._ARRAY_FIELDS} - {tui_context.DONE} == array_expected
+    assert {field.key for field in partitions._ARRAY_FIELDS} - {tui_context.DONE} == array_expected
     assert array_rows == array_expected
 
 
@@ -432,11 +433,11 @@ def test_the_passphrase_field_says_the_length_before_it_is_typed() -> None:
     screen = FakeScreen(keys=keys)
     screens.encryption_screen(screen, config(), at)
     drawn = "\n".join("\n".join(frame) for frame in screen.frames)
-    assert str(screens.PASSPHRASE_MINIMUM) in drawn, drawn
+    assert str(tui_context.PASSPHRASE_MINIMUM) in drawn, drawn
     typed = [frame for frame in screen.frames if any("Passphrase" in one for one in frame)]
     assert typed, "no passphrase field was drawn"
     for frame in typed:
-        assert any(str(screens.PASSPHRASE_MINIMUM) in one for one in frame), frame
+        assert any(str(tui_context.PASSPHRASE_MINIMUM) in one for one in frame), frame
 
 
 def test_every_catalog_translates_the_passphrase_hint() -> None:
@@ -500,8 +501,8 @@ def test_reopening_array_encryption_preserves_its_passphrase_on_child_exit(
     at = context()
     at.layout.array.passphrase_file = "/run/keys/old"
 
-    screens._edit_array_field(
-        FakeScreen(keys=["\n", leave]), at, screens._ENCRYPTION, members=2
+    partitions._edit_array_field(
+        FakeScreen(keys=["\n", leave]), at, partitions._ENCRYPTION, members=2
     )
 
     assert at.layout.array.passphrase_file == "/run/keys/old"
@@ -513,10 +514,10 @@ def test_array_encryption_replaces_its_staged_passphrase_after_success() -> None
     at.layout.array.passphrase_file = "/run/keys/old"
     typed = list("replacement")
 
-    screens._edit_array_field(
+    partitions._edit_array_field(
         FakeScreen(keys=["\n", *typed, "\n", *typed, "\n"]),
         at,
-        screens._ENCRYPTION,
+        partitions._ENCRYPTION,
         members=2,
     )
 
@@ -534,7 +535,7 @@ def test_reopening_pool_encryption_preserves_its_passphrase_on_child_exit(
     at = context()
     at.layout.passphrase_file = "/run/keys/old"
 
-    answer = screens._edit_pool_encryption(FakeScreen(keys=["\n", leave]), at)
+    answer = partitions._edit_pool_encryption(FakeScreen(keys=["\n", leave]), at)
 
     assert answer.outcome is outcome
     assert at.layout.passphrase_file == "/run/keys/old"
@@ -546,7 +547,7 @@ def test_pool_encryption_replaces_its_staged_passphrase_after_success() -> None:
     at.layout.passphrase_file = "/run/keys/old"
     typed = list("replacement")
 
-    answer = screens._edit_pool_encryption(
+    answer = partitions._edit_pool_encryption(
         FakeScreen(keys=["\n", *typed, "\n", *typed, "\n"]), at
     )
 
@@ -572,7 +573,7 @@ def test_reopening_partition_encryption_preserves_its_passphrase_on_child_exit(
     at = context()
     entry = encrypted_partition()
 
-    changed = screens._edit_slice_encryption(
+    changed = partitions._edit_slice_encryption(
         FakeScreen(keys=["\n", leave]), at, entry, manual.purpose_of(entry)
     )
 
@@ -586,7 +587,7 @@ def test_partition_encryption_replaces_its_staged_passphrase_after_success() -> 
     entry = encrypted_partition()
     typed = list("replacement")
 
-    changed = screens._edit_slice_encryption(
+    changed = partitions._edit_slice_encryption(
         FakeScreen(keys=["\n", *typed, "\n", *typed, "\n"]),
         at,
         entry,
@@ -1285,7 +1286,7 @@ def test_the_table_lists_what_is_on_the_disk_and_keeps_it_by_default() -> None:
         ("/dev/vda3", "500 GiB", "ntfs"),
     )
     screen = FakeScreen(keys=["q"], lines=30, columns=110)
-    screens.partitions_screen(screen, config(), at)
+    partitions.partitions_screen(screen, config(), at)
     rows = at.layout.slices
     assert [one.selector for one in rows] == ["/dev/vda1", "/dev/vda2", "/dev/vda3"]
     assert all(one.status is manual.SliceStatus.KEEP for one in rows)
@@ -1302,7 +1303,7 @@ def test_an_empty_disk_opens_on_the_template_proposal() -> None:
     at.layout = manual.Layout()
     at.existing = ()
     screen = FakeScreen(keys=["q"], lines=20, columns=100)
-    screens.partitions_screen(screen, config(), at)
+    partitions.partitions_screen(screen, config(), at)
     assert at.layout.slices
     assert all(one.status is manual.SliceStatus.CREATE for one in at.layout.slices)
 
@@ -1315,17 +1316,17 @@ def test_manual_storage_subselectors_reopen_on_the_values_their_rows_show() -> N
     at.layout.topology = ZfsTopology.RAIDZ2
 
     cases = (
-        (screens._LEVEL, "raid6"),
-        (screens._METADATA, "1.2"),
-        (screens._FILESYSTEM, "xfs"),
+        (partitions._LEVEL, "raid6"),
+        (partitions._METADATA, "1.2"),
+        (partitions._FILESYSTEM, "xfs"),
     )
     for field, shown in cases:
         reopened = FakeScreen(keys=["q"])
-        screens._edit_array_field(reopened, at, field, members=4)
+        partitions._edit_array_field(reopened, at, field, members=4)
         assert shown in reopened.highlighted[0], field
 
     topology = FakeScreen(keys=["q"])
-    screens._pool_topology(topology, at, members=4)
+    partitions._pool_topology(topology, at, members=4)
     assert "raidz2" in topology.highlighted[0]
 
 
@@ -1447,7 +1448,11 @@ def test_what_still_asks_before_it_changes() -> None:
     data, opens a second question, or starts the install asks first."""
     import inspect
 
-    source = inspect.getsource(screens) + inspect.getsource(overview_screen)
+    # Every module that draws a screen, not one of them: the disk screens moved
+    # to `tui/partitions.py` and four of these nine titles went with them.
+    source = "".join(
+        inspect.getsource(one) for one in (screens, partitions, mirror)
+    ) + inspect.getsource(overview_screen)
     asked = {
         "This erases every partition on the disk.",
         "Encrypt the root filesystem?",
@@ -1628,9 +1633,9 @@ def test_opening_the_partitions_row_directly_marks_the_layout_manual() -> None:
     at = context()
     at.manual = False
     at.layout = manual.suggest(at.choice.disk, at.firmware)
-    done = [item.label for item in screens._partition_rows(at)].index("Done")
+    done = [item.label for item in partitions._partition_rows(at)].index("Done")
     screen = FakeScreen(keys=[*down(done), "\n"], lines=30, columns=100)
-    screens.partitions_screen(screen, config(), at)
+    partitions.partitions_screen(screen, config(), at)
     assert at.manual
 
 
@@ -2605,8 +2610,8 @@ def test_cancelled_manual_layout_restores_the_opening_table(
             context.layout.disks[0].slices[0], mountpoint="/changed"
         )
 
-    monkeypatch.setattr(screens, "_act_on", mutate)
-    screens.partitions_screen(FakeScreen(keys=["\n", "q"], lines=30), config(), at)
+    monkeypatch.setattr(partitions, "_act_on", mutate)
+    partitions.partitions_screen(FakeScreen(keys=["\n", "q"], lines=30), config(), at)
     assert at.layout == before
 
 
@@ -2646,7 +2651,7 @@ def test_the_zfs_bootloader_prompt_returns_only_installable_answers() -> None:
     at = context()
     start = config(zfs_root())
     for keys in (["\n"], ["KEY_DOWN", "\n"]):
-        answered = screens._zfs_bootloader(
+        answered = partitions._zfs_bootloader(
             FakeScreen(keys=keys, lines=24, columns=100), start, at
         )
         validate(answered.unwrap())

--- a/tests/unit/test_tui_partitions.py
+++ b/tests/unit/test_tui_partitions.py
@@ -38,6 +38,7 @@ from gentoo_install.model.size import Size
 from gentoo_install.model.validate import validate
 from gentoo_install.model.templates import Layout
 from gentoo_install.tui import context as tui_context
+from gentoo_install.tui import partitions
 from gentoo_install.tui import screens
 from gentoo_install.tui.widgets import Outcome
 
@@ -64,7 +65,7 @@ def to_row(at: tui_context.Context, label: str) -> list[str]:
     Counted rather than written out: the screen grew a line per disk, and every
     test that had counted its own KEY_DOWNs then landed a row short.
     """
-    labels = [item.label for item in screens._partition_rows(at)]
+    labels = [item.label for item in partitions._partition_rows(at)]
     return ["KEY_DOWN"] * labels.index(label) + ["\n"]
 
 
@@ -132,7 +133,7 @@ def test_a_table_with_no_root_says_so_rather_than_installing() -> None:
         manual.Slice(index=1, role=PartitionRole.ESP, size=Size.parse("1GiB"),
                      filesystem=FilesystemType.VFAT, mountpoint="/efi"),
     ])
-    assert "mounted at /" in screens._layout_problem(at, config())
+    assert "mounted at /" in partitions._layout_problem(at, config())
 
 
 def test_a_root_too_small_is_reported_in_the_table() -> None:
@@ -144,7 +145,7 @@ def test_a_root_too_small_is_reported_in_the_table() -> None:
         manual.Slice(index=2, role=PartitionRole.DATA, size=Size.parse("4GiB"),
                      filesystem=FilesystemType.EXT4, mountpoint="/"),
     ])
-    assert "under the" in screens._layout_problem(at, config())
+    assert "under the" in partitions._layout_problem(at, config())
 
 
 def test_a_swap_partition_needs_no_filesystem() -> None:
@@ -161,7 +162,7 @@ def test_the_editor_lists_the_table_and_leaves_on_done() -> None:
     at = opened()
     at.layout = manual.suggest(at.choice.disk, Firmware.UEFI)
     screen = FakeScreen(keys=to_row(at, "Done"), lines=30, columns=90)
-    answer = screens.partitions_screen(screen, config(), at)
+    answer = partitions.partitions_screen(screen, config(), at)
     assert answer.outcome is Outcome.CHOSE
     drawn = "\n".join("\n".join(frame) for frame in screen.frames)
     assert "/efi" in drawn and "rest" in drawn
@@ -181,7 +182,7 @@ def test_choosing_a_purpose_settles_the_mount_point_and_the_filesystem() -> None
     rooted = manual.Slice(index=1, role=PartitionRole.DATA, size=None,
                           filesystem=FilesystemType.EXT4, mountpoint="/")
     swap = next(one for one in manual.PURPOSES if one.key == "swap")
-    changed = screens._apply_purpose(rooted, swap)
+    changed = partitions._apply_purpose(rooted, swap)
     assert changed.role is PartitionRole.SWAP
     assert changed.mountpoint == "" and changed.filesystem is None
 
@@ -306,7 +307,7 @@ def test_every_field_of_a_partition_is_visible_with_its_value() -> None:
     at = opened()
     at.layout = manual.suggest("/dev/vda", Firmware.UEFI)
     entry = at.layout.slices[1]
-    fields = screens._slice_fields(entry, manual.purpose_of(entry), at.translate)
+    fields = partitions._slice_fields(entry, manual.purpose_of(entry), at.translate)
     shown = {item.label: item.detail for item in fields}
     assert shown["Purpose"] == "root"
     assert shown["Filesystem"] == "ext4"
@@ -316,19 +317,19 @@ def test_every_field_of_a_partition_is_visible_with_its_value() -> None:
 
 def test_a_zfs_member_has_no_partition_encryption_field() -> None:
     entry = manual.Slice(index=2, role=PartitionRole.ZFS, size=None, mountpoint="/")
-    fields = screens._slice_fields(entry, manual.purpose_of(entry), opened().translate)
+    fields = partitions._slice_fields(entry, manual.purpose_of(entry), opened().translate)
     assert "Encryption" not in {item.label for item in fields}
 
 
 def test_exactly_one_pool_encryption_row_is_shown_only_when_a_pool_exists() -> None:
     at = opened()
-    assert not [item for item in screens._partition_rows(at) if item.label == "ZFS Encryption"]
+    assert not [item for item in partitions._partition_rows(at) if item.label == "ZFS Encryption"]
 
     at.layout = one_disk(
         slices=[manual.Slice(index=1, role=PartitionRole.ZFS, size=None, mountpoint="/")]
     )
     at.layout.passphrase_file = "/run/keys/pool"
-    rows = [item for item in screens._partition_rows(at) if item.label == "ZFS Encryption"]
+    rows = [item for item in partitions._partition_rows(at) if item.label == "ZFS Encryption"]
 
     assert len(rows) == 1
     assert rows[0].detail == "on"
@@ -344,14 +345,14 @@ def test_changing_an_encrypted_partition_to_zfs_drops_its_luks_path() -> None:
         passphrase_file="/run/keys/partition",
     )
 
-    changed = screens._apply_purpose(entry, manual.purpose_for("zfs"))
+    changed = partitions._apply_purpose(entry, manual.purpose_for("zfs"))
 
     assert changed.passphrase_file == ""
 
 
 def test_a_field_that_does_not_apply_says_why() -> None:
     swap = manual.Slice(index=2, role=PartitionRole.SWAP, size=Size.parse("4GiB"))
-    fields = screens._slice_fields(swap, manual.purpose_of(swap), opened().translate)
+    fields = partitions._slice_fields(swap, manual.purpose_of(swap), opened().translate)
     filesystem = next(item for item in fields if item.label == "Filesystem")
     assert filesystem.disabled_because
 
@@ -363,7 +364,7 @@ def test_zfs_is_offered_where_a_filesystem_is_chosen() -> None:
     entry = manual.Slice(index=2, role=PartitionRole.DATA, size=None,
                          filesystem=FilesystemType.EXT4, mountpoint="/")
     screen = FakeScreen(keys=[*["KEY_DOWN"] * len(FilesystemType), "\n"], lines=30)
-    changed = screens._edit_field(screen, at, entry, manual.purpose_of(entry), screens._FILESYSTEM)
+    changed = partitions._edit_field(screen, at, entry, manual.purpose_of(entry), partitions._FILESYSTEM)
     assert changed is not None
     assert changed.role is PartitionRole.ZFS
     assert changed.filesystem is None
@@ -376,7 +377,7 @@ def test_opening_the_table_after_choosing_zfs_keeps_zfs() -> None:
     operator had just chosen without saying so."""
     at = opened()
     at.choice = replace(at.choice, layout=Layout.WHOLE_DISK_ZFS, disk="/dev/vdb")
-    screens.partitions_screen(FakeScreen(keys=["q"]), config(), at)
+    partitions.partitions_screen(FakeScreen(keys=["q"]), config(), at)
     root = next(one for one in at.layout.slices if one.mountpoint == "/")
     assert root.role is PartitionRole.ZFS and root.filesystem is None
 
@@ -384,7 +385,7 @@ def test_opening_the_table_after_choosing_zfs_keeps_zfs() -> None:
 def test_opening_the_table_after_choosing_xfs_keeps_xfs() -> None:
     at = opened()
     at.choice = replace(at.choice, filesystem=FilesystemType.XFS, disk="/dev/vdb")
-    screens.partitions_screen(FakeScreen(keys=["q"]), config(), at)
+    partitions.partitions_screen(FakeScreen(keys=["q"]), config(), at)
     root = next(one for one in at.layout.slices if one.mountpoint == "/")
     assert root.filesystem is FilesystemType.XFS
 
@@ -647,7 +648,7 @@ def test_the_table_opens_on_what_is_already_on_the_disk() -> None:
     at.manual = True
     at.layout = manual.Layout()
     screen = FakeScreen(keys=["q"], lines=24, columns=100)
-    screens.partitions_screen(screen, config(), at)
+    partitions.partitions_screen(screen, config(), at)
 
     assert [one.selector for one in at.layout.slices] == ["/dev/vda1", "/dev/vda2"]
     assert all(one.status is manual.SliceStatus.KEEP for one in at.layout.slices)
@@ -699,14 +700,14 @@ def test_the_pool_topology_row_appears_once_there_is_something_to_join() -> None
 
     at.layout = one_disk(slices(1), disk=at.choice.disk)
     single = FakeScreen(keys=["q"], lines=24, columns=110)
-    screens.partitions_screen(single, config(), at)
+    partitions.partitions_screen(single, config(), at)
     drawn = "\n".join(single.frames[0])
     assert "Pool topology" in drawn
     assert "zfs pool member purpose" in drawn
 
     at.layout = one_disk(slices(2), disk=at.choice.disk)
     pair = FakeScreen(keys=["q"], lines=24, columns=110)
-    screens.partitions_screen(pair, config(), at)
+    partitions.partitions_screen(pair, config(), at)
     opened = "\n".join(pair.frames[0])
     assert "Pool topology" in opened
     assert "zfs pool member purpose" not in opened
@@ -719,7 +720,7 @@ def test_a_topology_this_many_devices_cannot_make_says_how_many_it_needs() -> No
 
     at = context()
     screen = FakeScreen(keys=["q"], lines=20, columns=100)
-    screens._pool_topology(screen, at, 2)
+    partitions._pool_topology(screen, at, 2)
     drawn = "\n".join(screen.frames[0])
     for one in ZfsTopology:
         assert one.value in drawn, one
@@ -728,7 +729,7 @@ def test_a_topology_this_many_devices_cannot_make_says_how_many_it_needs() -> No
 
     # Enough devices, and no row carries a count.
     roomy = FakeScreen(keys=["q"], lines=20, columns=100)
-    screens._pool_topology(roomy, at, 4)
+    partitions._pool_topology(roomy, at, 4)
     assert "needs at least" not in "\n".join(roomy.frames[0])
 
 
@@ -860,7 +861,7 @@ def test_the_screen_lists_every_disk_with_its_rows_under_it() -> None:
     at.layout = two_disks()
     at.choice = replace(at.choice, disk="/dev/vda")
     screen = FakeScreen(keys=["q"], lines=30, columns=100)
-    screens.partitions_screen(screen, config(), at)
+    partitions.partitions_screen(screen, config(), at)
     drawn = "\n".join(screen.frames[0])
     assert "vda" in drawn and "vdb" in drawn
     assert drawn.index("vda") < drawn.index("/efi") < drawn.index("vdb")
@@ -870,7 +871,7 @@ def test_a_second_disk_can_be_added_from_the_table() -> None:
     at = opened()
     at.layout = manual.suggest(at.choice.disk, Firmware.UEFI)
     keys = [*to_row(at, "Add a disk"), "\n"]
-    screens.partitions_screen(FakeScreen(keys=[*keys, "q"], lines=30, columns=100), config(), at)
+    partitions.partitions_screen(FakeScreen(keys=[*keys, "q"], lines=30, columns=100), config(), at)
     assert [one.selector for one in at.layout.disks] == [one[0] for one in at.disks]
 
 
@@ -879,8 +880,8 @@ def test_a_disk_already_in_the_table_is_not_offered_again() -> None:
     at.layout = manual.Layout(
         disks=[manual.Disk(selector=one[0]) for one in at.disks]
     )
-    assert not screens._unused_disks(at)
-    labels = [item.label for item in screens._partition_rows(at)]
+    assert not partitions._unused_disks(at)
+    labels = [item.label for item in partitions._partition_rows(at)]
     assert "Add a disk" not in labels
 
 
@@ -890,11 +891,11 @@ def test_the_first_disk_cannot_be_taken_off_the_table() -> None:
     at = opened()
     at.layout = two_disks()
     first = FakeScreen(keys=["q"], lines=24, columns=90)
-    screens._edit_disk(first, at, 0)
+    partitions._edit_disk(first, at, 0)
     assert "Take this disk off the table" not in "\n".join(first.frames[0])
 
     second = FakeScreen(keys=["KEY_DOWN", "\n"], lines=24, columns=90)
-    screens._edit_disk(second, at, 1)
+    partitions._edit_disk(second, at, 1)
     assert [one.selector for one in at.layout.disks] == ["/dev/vda"]
 
 
@@ -963,11 +964,11 @@ def test_the_array_row_says_what_to_set_before_it_can_be_opened() -> None:
     at = opened()
     at.choice = replace(at.choice, disk="/dev/vda")
     at.layout = manual.suggest("/dev/vda", Firmware.UEFI)
-    shut = next(one for one in screens._partition_rows(at) if one.label == "RAID array")
+    shut = next(one for one in partitions._partition_rows(at) if one.label == "RAID array")
     assert "raid array member purpose" in shut.disabled_because
 
     at.layout = mirrored()
-    open_now = next(one for one in screens._partition_rows(at) if one.label == "RAID array")
+    open_now = next(one for one in partitions._partition_rows(at) if one.label == "RAID array")
     assert open_now.disabled_because == ""
     assert open_now.detail
 
@@ -978,7 +979,7 @@ def test_a_level_the_members_cannot_make_is_shown_with_what_it_needs() -> None:
     at = opened()
     at.layout = mirrored()
     screen = FakeScreen(keys=["KEY_DOWN", "\n", "q", "q"], lines=24, columns=90)
-    screens._edit_array(screen, at)
+    partitions._edit_array(screen, at)
     drawn = "\n".join("\n".join(frame) for frame in screen.frames)
     assert "raid5 - needs at least 3" in drawn
     assert "raid6 - needs at least 4" in drawn
@@ -1011,7 +1012,7 @@ def test_a_medium_with_no_zfs_offers_no_pool_member_purpose() -> None:
     entry = manual.Slice(index=1, role=PartitionRole.DATA, size=None,
                          filesystem=FilesystemType.EXT4, mountpoint="/")
     screen = FakeScreen(keys=["q"], lines=24, columns=100)
-    screens._edit_field(screen, at, entry, manual.purpose_of(entry), screens._PURPOSE)
+    partitions._edit_field(screen, at, entry, manual.purpose_of(entry), partitions._PURPOSE)
     drawn = "\n".join(screen.frames[0])
     assert "zfs pool member - this live system has no zpool" in drawn
 
@@ -1023,7 +1024,7 @@ def test_a_medium_with_no_zfs_offers_no_zfs_in_the_filesystem_menu() -> None:
     entry = manual.Slice(index=1, role=PartitionRole.DATA, size=None,
                          filesystem=FilesystemType.EXT4, mountpoint="/")
     screen = FakeScreen(keys=["q"], lines=24, columns=100)
-    screens._edit_field(screen, at, entry, manual.purpose_of(entry), screens._FILESYSTEM)
+    partitions._edit_field(screen, at, entry, manual.purpose_of(entry), partitions._FILESYSTEM)
     drawn = "\n".join(screen.frames[0])
     assert "this live system has no zpool" in drawn
 
@@ -1032,15 +1033,15 @@ def test_a_medium_with_zfs_offers_all_three() -> None:
     at = opened()
     for screen, call in (
         (FakeScreen(keys=["q"], lines=24, columns=100), "layout"),
-        (FakeScreen(keys=["q"], lines=24, columns=100), screens._PURPOSE),
-        (FakeScreen(keys=["q"], lines=24, columns=100), screens._FILESYSTEM),
+        (FakeScreen(keys=["q"], lines=24, columns=100), partitions._PURPOSE),
+        (FakeScreen(keys=["q"], lines=24, columns=100), partitions._FILESYSTEM),
     ):
         if call == "layout":
             screens.layout_screen(screen, config(), at)
         else:
             entry = manual.Slice(index=1, role=PartitionRole.DATA, size=None,
                                  filesystem=FilesystemType.EXT4, mountpoint="/")
-            screens._edit_field(screen, at, entry, manual.purpose_of(entry), call)
+            partitions._edit_field(screen, at, entry, manual.purpose_of(entry), call)
         assert "live system" not in "\n".join(screen.frames[0])
 
 
@@ -1066,10 +1067,10 @@ def test_a_hand_built_zfs_root_is_asked_which_bootloader() -> None:
             )
         ]
     )
-    done = [item.label for item in screens._partition_rows(at)].index("Done")
+    done = [item.label for item in partitions._partition_rows(at)].index("Done")
     keys = ["KEY_DOWN"] * done + ["\n", "\n"]
     screen = FakeScreen(keys=keys, lines=30, columns=110)
-    answer = screens.partitions_screen(screen, config(), at)
+    answer = partitions.partitions_screen(screen, config(), at)
     assert answer.chosen
     assert answer.unwrap().bootloader.kind is Bootloader.ZFSBOOTMENU
     assert [one.name for one in answer.unwrap().portage.overlays] == ["gentoo-zh"]
@@ -1103,7 +1104,7 @@ def test_raid_and_the_pool_topology_are_visible_before_they_are_reachable() -> N
     at = context()
     at.manual = True
     drawn = FakeScreen(keys=["q"], lines=30, columns=118)
-    screens.partitions_screen(drawn, config(), at)
+    partitions.partitions_screen(drawn, config(), at)
     assert "RAID array" in drawn.last
     assert "raid array member purpose" in drawn.last
     assert "Pool topology" in drawn.last


### PR DESCRIPTION
The design note said to find the true one-way boundary before cutting this, and an attempt that grouped by subject matter found edges running both ways. So the boundary was computed: build the reference graph over `screens.py`'s top-level definitions, take the closure of `partitions_screen`, and ask which of those names anything outside it uses.

The answer is exact — 51 definitions, 865 lines, and four names crossing outward: `partitions_screen`, `_from_layout`, `_zfs_bootloader`, `_edit_passphrase`. Nothing crosses inward, because a closure needs nothing beyond itself. `screens.py` is 3817 lines, down from 4683.

`PASSPHRASE_MINIMUM` went to `tui/context.py` instead: it is a rule both modules want, and leaving it in either would have made the other import backwards.

The test holds the direction and names the four crossings, so a fifth means the closure moved and nobody recomputed it. Controls: an import of `screens` from the new module, and a crossing name used without being imported from there.