### PR TITLE
tui: move the package screens into tui/packages.py

### DIFF
--- a/gentoo_install/tui/packages.py
+++ b/gentoo_install/tui/packages.py
@@ -1,0 +1,1331 @@
+# SPDX-License-Identifier: GPL-2.0-or-later
+"""The package screens: desktop, graphics, fonts, input method, and the rest.
+
+The closure of the seven screens that choose packages, which share one set of
+helpers — `Effects`, `derive_effects`, `settle` and the operator's own
+choices. Six names cross outward and none inward; the boundary was computed
+the way `tui/partitions.py`'s was, not chosen by subject.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, replace
+from typing import Callable, Final, Sequence
+
+from ..errors import ConfigError
+from ..i18n import Catalog
+from ..model import atoms
+from ..model.config import (
+    Binhost,
+    BinhostChannel,
+    InitSystem,
+    InstallConfig,
+    Networking,
+    Overlay,
+    PackagesConfig,
+    PortageConfig,
+)
+from ..plan import automatic as automatic_values
+from ..plan.fonts import CJK_SANS_PREFERENCE, CjkFontconfigLocale, FontCategory
+from ..plan.packages import Catalog as Groups
+from ..plan.packages import FRAMEWORK_GROUPS
+from ..plan.packages import FONT_CONFIGURATION_DISABLED, FONT_CONFIGURATION_ENABLED
+from ..plan.packages import INPUT_CONFIGURATION_DISABLED, INPUT_CONFIGURATION_ENABLED
+from ..plan.packages import driver_conflict, framework_conflict
+from .context import (
+    Context,
+    DONE,
+    FieldDescriptor,
+    ValueKind,
+    ValueProvenance,
+    ValueSource,
+    answers,
+    current_menu,
+    footer,
+    pick,
+    say,
+    with_gentoo_zh,
+)
+from .widgets import (
+    Accepts,
+    Answer,
+    Confirm,
+    Field,
+    Form,
+    FormRejected,
+    Item,
+    Menu,
+    MultipleChoiceMenu,
+    Outcome,
+    Screen,
+    TextField,
+)
+
+def _profile_was_chosen(config: InstallConfig, groups: Groups) -> bool:
+    """Whether the profile is something other than what the current desktop and
+    init imply, which is the only evidence the operator set it by hand."""
+    implied = desktop_profiles(groups).get(config.packages.desktop)
+    if implied is None:
+        return True
+    return config.portage.profile != _profile_for(implied, config.system.init)
+
+
+def _profile_for(profile: str, init: InitSystem) -> str:
+    """The profile has to follow the init: a systemd profile has `systemd` as a
+    path component, and the two disagreeing builds packages for the other."""
+    parts = [part for part in profile.split("/") if part != "systemd"]
+    if init is InitSystem.SYSTEMD:
+        parts.append("systemd")
+    return "/".join(parts)
+#: What a machine with no desktop is built against. Every other answer names
+#: its own profile in `data/profiles/<name>.toml`.
+
+
+BASE_PROFILE: Final[str] = "default/linux/amd64/23.0"
+
+
+def desktop_profiles(groups: Groups, profile_paths: Sequence[str] = ()) -> dict[str, str]:
+    """The desktops and the profile each is built against, read from the files
+    that declare them: a table beside `data/profiles/` meant a desktop added
+    there never reached the menu, and one added here installed nothing."""
+    release = next(
+        (path.split("/")[3] for path in profile_paths if path.startswith("default/linux/amd64/")),
+        BASE_PROFILE.split("/")[3],
+    )
+    prefix = f"default/linux/amd64/{release}"
+    found = {"": prefix}
+    for name, group in groups.items():
+        if group.profile:
+            found[name] = group.profile.replace(BASE_PROFILE, prefix, 1)
+    return found
+
+
+def desktop_screen(screen: Screen, config: InstallConfig, context: Context) -> Answer[InstallConfig]:
+    """The desktop decides the profile as well as the packages, the same way
+    the init system does."""
+    translate = context.translate
+    detail = {
+        "plasma": translate("the session only"),
+        "plasma-full": translate("with the KDE application set"),
+        "gnome": translate("the session only"),
+        "gnome-full": translate("with the GNOME application set"),
+    }
+    items = [
+        Item(
+            label=translate("no desktop") if not name else name,
+            value=name,
+            # Plasma and GNOME both bring `wayland`, and the operator reads
+            # that here rather than after choosing.
+            detail=detail.get(name, "")
+            + _adds(config, context, lambda packages, one: replace(packages, desktop=one), name),
+        )
+        for name in sorted(desktop_profiles(context.groups, context.profile_paths))
+    ]
+    menu: Menu[str] = Menu(
+        title=translate("Desktop and applications"),
+        preamble=(translate("The desktop selects its profile and proposes login and network services."),),
+        items=items,
+        current=config.packages.desktop,
+        footer=footer(translate),
+    )
+    answer = menu.run(screen)
+    if not answer.chosen:
+        return Answer(answer.outcome)
+    desktop = answer.unwrap()
+    changed = replace(config, packages=replace(config.packages, desktop=desktop))
+    if desktop != config.packages.desktop:
+        changed = _set_input_configuration(changed, context.groups, None)
+    if not _profile_was_chosen(config, context.groups):
+        # Only while the profile is still the one the last desktop implied.
+        # Overwriting it regardless threw away a profile the operator had
+        # picked on purpose, such as no-multilib.
+        changed = replace(
+            changed,
+            portage=replace(
+                config.portage,
+                profile=_profile_for(
+                    desktop_profiles(context.groups, context.profile_paths)[desktop], config.system.init
+                ),
+            ),
+        )
+    manager = config.packages.display_manager
+    was_proposed = _has_derived(context, ValueKind.DISPLAY_MANAGER, manager)
+    kept_manager = (
+        manager
+        if manager and not was_proposed and desktop != config.packages.desktop
+        else ""
+    )
+    changed = _desktop_proposes(changed, config, context, desktop)
+    login = LOGIN_SCREEN.get(desktop, "")
+    effects = derive_effects(config, changed, context, kept_manager)
+    answered = settle(
+        screen,
+        context,
+        config,
+        changed,
+        kept_display_manager=kept_manager,
+    )
+    if answered.chosen:
+        _record_derived(context, answered.unwrap(), effects)
+    return answered
+#: What each desktop's own login screen is. Proposed rather than fixed: the
+#: row stays editable, and pulling the login screen out of the desktop profile
+#: was right — leaving it empty was not, because the row is then required and
+#: red on a menu whose operator has already said which desktop they want.
+
+
+LOGIN_SCREEN: Final[dict[str, str]] = {
+    "plasma": "sddm",
+    "plasma-full": "sddm",
+    "gnome": "gdm",
+    "gnome-full": "gdm",
+    "xfce": "lightdm",
+}
+
+
+@dataclass(frozen=True)
+
+
+class Effects:
+    """Derived values changed by one TUI choice."""
+
+    use_flags: tuple[str, ...] = ()
+    video_cards: tuple[str, ...] = ()
+    user_groups: tuple[str, ...] = ()
+    profile: str = ""
+    display_manager_changed: bool = False
+    networking_changed: bool = False
+    kept_display_manager: str = ""
+    withdrawn_use: tuple[str, ...] = ()
+    withdrawn_video_cards: tuple[str, ...] = ()
+
+    @property
+    def has_changes(self) -> bool:
+        """Whether the choice has a value to confirm."""
+        return bool(
+            self.use_flags
+            or self.video_cards
+            or self.user_groups
+            or self.profile
+            or self.display_manager_changed
+            or self.networking_changed
+            or self.kept_display_manager
+        )
+
+    @property
+    def editable_row(self) -> Callable[..., Answer[InstallConfig]] | None:
+        """The row containing values that can be inspected after consent."""
+        if self.use_flags:
+            return use_flags_screen
+        if self.video_cards:
+            return video_cards_screen
+        return None
+
+
+def derive_effects(
+    before: InstallConfig,
+    after: InstallConfig,
+    context: Context,
+    kept_display_manager: str = "",
+) -> Effects:
+    """Derive every value one choice adds, replaces, or withdraws."""
+    return Effects(
+        use_flags=_new(automatic_values.use_flags, before, after, context.groups),
+        video_cards=_new(automatic_values.video_cards, before, after, context.groups),
+        user_groups=_new(automatic_values.user_groups, before, after, context.groups),
+        profile=after.portage.profile if after.portage.profile != before.portage.profile else "",
+        display_manager_changed=(
+            after.packages.display_manager != before.packages.display_manager
+        ),
+        networking_changed=after.system.networking is not before.system.networking,
+        kept_display_manager=kept_display_manager,
+        withdrawn_use=tuple(
+            one.value
+            for one in context.provenance
+            if one.kind is ValueKind.USE_FLAG and one.source is ValueSource.DERIVED
+        ),
+        withdrawn_video_cards=tuple(
+            one.value
+            for one in context.provenance
+            if one.kind is ValueKind.VIDEO_CARD and one.source is ValueSource.DERIVED
+        ),
+    )
+
+
+def apply_effects(after: InstallConfig, effects: Effects) -> InstallConfig:
+    """Pin additions while removing only values derived by the replaced choice."""
+    kept_use = tuple(one for one in after.portage.use if one not in effects.withdrawn_use)
+    kept_cards = tuple(
+        one for one in after.portage.video_cards if one not in effects.withdrawn_video_cards
+    )
+    return replace(
+        after,
+        portage=replace(
+            after.portage,
+            use=(*kept_use, *effects.use_flags),
+            video_cards=(*kept_cards, *effects.video_cards),
+        ),
+    )
+
+
+def _desktop_proposes(
+    changed: InstallConfig, before: InstallConfig, context: Context, desktop: str
+) -> InstallConfig:
+    """The login screen and the network manager a desktop implies.
+
+    Only over what the operator has not set: a login screen they picked stands,
+    and so does a network manager. The Plasma and GNOME profiles already carry
+    `USE=networkmanager`, and nothing moved `system.networking` with it, so the
+    installed desktop had the settings panel and not the service behind it.
+    """
+    if (
+        _has_derived(context, ValueKind.DISPLAY_MANAGER, before.packages.display_manager)
+    ):
+        changed = replace(
+            changed,
+            packages=replace(changed.packages, display_manager=""),
+        )
+    if not desktop:
+        return changed
+    login = LOGIN_SCREEN.get(desktop, "")
+    if login and not changed.packages.display_manager and login in context.groups:
+        changed = replace(
+            changed, packages=replace(changed.packages, display_manager=login)
+        )
+    if not _has_operator(context, ValueKind.NETWORKING, before.system.networking.value):
+        changed = replace(
+            changed,
+            system=replace(changed.system, networking=Networking.NETWORKMANAGER_WPA),
+        )
+    return changed
+
+
+def settle(
+    screen: Screen,
+    context: Context,
+    before: InstallConfig,
+    after: InstallConfig,
+    kept_display_manager: str = "",
+) -> Answer[InstallConfig]:
+    """Confirm what a choice changes outside its own row, then write it down.
+
+    Choosing a driver or a desktop moves `VIDEO_CARDS`, `USE` and the profile.
+    Deriving those silently at build time meant the operator met them for the
+    first time in the installed system, so they are listed here and, once
+    confirmed, put into the configuration as the operator's own values. Pinned
+    rather than left derived: a value in `portage.use` survives a later change
+    to the desktop, and `automatic.use_flags` stops reporting a flag that is
+    already there, so nothing appears twice.
+
+    Declining cancels the choice. The flags are not optional extras that come
+    with it; they are what makes it work.
+    """
+    effects = derive_effects(before, after, context, kept_display_manager)
+    if not effects.has_changes:
+        return Answer(Outcome.CHOSE, after)
+    translate = context.translate
+    lines = []
+    if effects.video_cards:
+        lines.append(f"VIDEO_CARDS: {' '.join(effects.video_cards)}")
+    if effects.use_flags:
+        lines.append(f"USE: {' '.join(effects.use_flags)}")
+    if effects.display_manager_changed:
+        lines.append(
+            f"{translate('Display manager')}: {after.packages.display_manager}"
+        )
+    elif effects.kept_display_manager:
+        lines.append(
+            f"{translate('Display manager')}: {effects.kept_display_manager} "
+            f"({translate('kept')})"
+        )
+    if effects.networking_changed:
+        lines.append(f"{translate('Network')}: {after.system.networking.value}")
+    if effects.user_groups:
+        # Not pinned into the account: `AddUserToGroups` derives them from the
+        # same catalog at build time, so the account is put in them whether or
+        # not one exists when the driver is chosen.
+        lines.append(f"{translate('Extra groups')}: {' '.join(effects.user_groups)}")
+    if effects.profile:
+        lines.append(f"{translate('Profile')}: {effects.profile}")
+    # A third answer only when there is something to open. The row is derived
+    # from what actually changed: with a profile and no flags it offered `Yes,
+    # and open VIDEO_CARDS`, which edits a value this choice did not touch.
+    where = effects.editable_row
+    named = translate("USE flags") if effects.use_flags else translate("VIDEO_CARDS")
+    # Yes first and preselected. Declining cancels the desktop the operator
+    # just chose, and these values are what makes it work rather than extras
+    # that come with it, so the cursor starting on `No` offered the refusal as
+    # the default answer to a question the choice itself had already implied.
+    items = [
+        Item(label=translate("Yes"), value="yes"),
+        Item(label=translate("No"), value="no"),
+    ]
+    if where is not None:
+        # The row the values land on is somewhere else in the menu, and an
+        # operator who wants to look at them now would otherwise have to leave,
+        # find it, and remember what they were checking.
+        items.append(
+            Item(
+                label=f"{translate('Yes, and open')} {named}",
+                value="open",
+                detail=translate("editable"),
+            )
+        )
+    asked: Menu[str] = Menu(
+        title=translate("This choice also sets"),
+        preamble=tuple(lines),
+        items=items,
+        footer=footer(translate),
+        current="yes",
+    )
+    answered = asked.run(screen)
+    if not answered.chosen or answered.unwrap() == "no":
+        return Answer(Outcome.BACK, before)
+    # Pinned without what the choice being replaced had derived. Adding to
+    # `portage.use` and never taking anything out meant switching from Plasma
+    # to GNOME left `qt6` and `sddm` behind and read as
+    # `wayland qt6 networkmanager sddm gnome gtk`. What the operator typed is
+    # not derivable and stays; what the last choice derived goes with it.
+    pinned = apply_effects(after, effects)
+    if answered.unwrap() == "open" and where is not None:
+        opened = where(screen, pinned, context)
+        if opened.chosen:
+            return Answer(Outcome.CHOSE, opened.unwrap())
+        if opened.outcome is Outcome.CANCELLED:
+            # Cancelling reaches the application's leave confirmation. Reading
+            # it as `keep what was pinned` committed a desktop and a profile
+            # the operator had just refused.
+            return Answer(Outcome.CANCELLED)
+    return Answer(Outcome.CHOSE, pinned)
+
+
+def _has_derived(context: Context, kind: ValueKind, value: str) -> bool:
+    """Whether this value came from the current automatic proposal."""
+    return ValueProvenance(kind, value, ValueSource.DERIVED) in context.provenance
+
+
+def _has_operator(context: Context, kind: ValueKind, value: str) -> bool:
+    """Whether the operator selected this value in its own row."""
+    return ValueProvenance(kind, value, ValueSource.OPERATOR) in context.provenance
+
+
+def _record_derived(context: Context, after: InstallConfig, effects: Effects) -> None:
+    """Replace the previous choice's derived values with the new choice's."""
+    context.provenance = {
+        one for one in context.provenance if one.source is not ValueSource.DERIVED
+    }
+    context.provenance.update(
+        ValueProvenance(ValueKind.USE_FLAG, value, ValueSource.DERIVED)
+        for value in effects.use_flags
+    )
+    context.provenance.update(
+        ValueProvenance(ValueKind.VIDEO_CARD, value, ValueSource.DERIVED)
+        for value in effects.video_cards
+    )
+    if effects.networking_changed:
+        context.provenance.add(
+            ValueProvenance(
+                ValueKind.NETWORKING,
+                after.system.networking.value,
+                ValueSource.DERIVED,
+            )
+        )
+    if effects.display_manager_changed:
+        context.provenance.add(
+            ValueProvenance(
+                ValueKind.DISPLAY_MANAGER,
+                after.packages.display_manager,
+                ValueSource.DERIVED,
+            )
+        )
+
+
+def _record_operator(context: Context, kind: ValueKind, values: Sequence[str]) -> None:
+    """Mark values edited in their own row as operator choices."""
+    kept = {
+        one
+        for one in context.provenance
+        if one.kind is not kind or one.source is not ValueSource.DERIVED
+    }
+    context.provenance = kept | {
+        ValueProvenance(kind, value, ValueSource.OPERATOR) for value in values
+    }
+
+
+def _new(
+    derive: Callable[[InstallConfig, Groups], tuple[automatic_values.Added, ...]],
+    before: InstallConfig,
+    after: InstallConfig,
+    groups: Groups,
+) -> tuple[str, ...]:
+    """What the change added, in order, without what was already there.
+
+    Only what the same function said before. Unioning `portage.use` as well
+    crossed two namespaces: `pipewire` is both a USE flag and the group its
+    ebuild asks the account to join, so pinning the flag hid the group. Each
+    `derive` already drops what the operator typed.
+    """
+    had = {one.value for one in derive(before, groups)}
+    return tuple(one.value for one in derive(after, groups) if one.value not in had)
+#: The graphics groups, in the order the menu lists them, and what each is
+#: for. Kept out of the applications list: a driver is one choice, not a set of
+#: things to tick.
+
+
+GRAPHICS: tuple[tuple[str, str], ...] = (
+    ("", "no driver package: i915, amdgpu, radeon and nouveau are in the kernel"),
+    ("intel", "i915 and xe, with the firmware they need"),
+    ("amdgpu", "GCN 1.2 and newer"),
+    ("radeon", "AMD up to Sea Islands"),
+    ("nouveau", "the in-kernel NVIDIA driver"),
+    ("nvidia", "proprietary, widens ACCEPT_LICENSE, and blacklists nouveau itself"),
+    ("virtual-machine", "virtio-gpu, QXL and VMware, with fbdev left as the fallback"),
+)
+#: The display managers. A desktop no longer names one, because which login
+#: screen to run is a decision of its own.
+
+
+DISPLAY_MANAGERS: tuple[tuple[str, str], ...] = (
+    ("", "a text console login"),
+    ("sddm", "the one Plasma expects"),
+    ("gdm", "the one GNOME expects, and it installs gnome-shell whatever you run"),
+    ("lightdm", "the one Xfce expects"),
+    ("greetd", "a console greeter"),
+)
+
+
+def graphics_screen(
+    screen: Screen, config: InstallConfig, context: Context
+) -> Answer[InstallConfig]:
+    """Which drivers, which is what VIDEO_CARDS and the firmware follow.
+
+    More than one can be ticked: a hybrid machine has more than one adapter,
+    and an AMD laptop with an NVIDIA card needs `amdgpu radeonsi nvidia`. Each
+    row says what it adds, so the line the ticks build is readable before any
+    of them is pressed.
+    """
+    translate = context.translate
+    named = tuple((name, reason) for name, reason in GRAPHICS if name)
+    items = [
+        Item(
+            label=name,
+            value=name,
+            detail=translate(reason)
+            + _adds(config, context, lambda packages, one: replace(packages, graphics=(one,)), name),
+        )
+        for name, reason in named
+    ]
+    ticked = set(config.packages.graphics)
+    while True:
+        menu: MultipleChoiceMenu[str] = MultipleChoiceMenu(
+            title=translate("Graphics"),
+            preamble=(translate("The drivers set VIDEO_CARDS and install required firmware or packages."),),
+            items=items,
+            selected={index for index, item in enumerate(items) if item.value in ticked},
+            footer=footer(translate),
+        )
+        answer = menu.run(screen)
+        if not answer.chosen:
+            return Answer(answer.outcome)
+        chosen = replace(
+            config, packages=replace(config.packages, graphics=tuple(answer.unwrap()))
+        )
+        # Checked here rather than at the Install row: the conflict is between
+        # two ticks on this screen and this is where either can be unticked.
+        clash = driver_conflict(chosen, context.groups)
+        if not clash:
+            return settle(screen, context, config, chosen)
+        ticked = set(answer.unwrap())
+        say(screen, context, translate(clash))
+
+
+def display_manager_screen(
+    screen: Screen, config: InstallConfig, context: Context
+) -> Answer[InstallConfig]:
+    # A manager with no desktop installs a login screen that has no session to
+    # start, so every entry but `none` says to pick a desktop first.
+    without = "" if config.packages.desktop else context.translate("choose a desktop first")
+    chosen = _one_group(
+        screen,
+        config,
+        context,
+        "Display manager",
+        DISPLAY_MANAGERS,
+        lambda packages, name: replace(packages, display_manager=name),
+        current=config.packages.display_manager,
+        unavailable=lambda name: without if name else "",
+        say_what_it_adds=True,
+    )
+    if not chosen.chosen:
+        return chosen
+    answered = settle(screen, context, config, chosen.unwrap())
+    if answered.chosen:
+        _record_operator(
+            context,
+            ValueKind.DISPLAY_MANAGER,
+            (answered.unwrap().packages.display_manager,),
+        )
+    return answered
+
+
+def _needs_an_overlay(
+    wanted: Sequence[str], have: set[str], translate: Catalog
+) -> str:
+    """Why a group cannot be ticked: its packages are in no repository this
+    configuration adds. Said here rather than at the Install row, because this
+    is the screen the tick is on."""
+    missing = [name for name in wanted if name not in have]
+    if not missing:
+        return ""
+    return f"{translate('needs the overlay')} {', '.join(missing)}"
+
+
+def _one_group(
+    screen: Screen,
+    config: InstallConfig,
+    context: Context,
+    title: str,
+    offered: tuple[tuple[str, str], ...],
+    apply: Callable[[PackagesConfig, str], PackagesConfig],
+    current: str,
+    unavailable: Callable[[str], str] = lambda name: "",
+    say_what_it_adds: bool = False,
+) -> Answer[InstallConfig]:
+    """A row that holds one group name, drawn from a table of them."""
+    translate = context.translate
+    answer = current_menu(
+        screen,
+        context,
+        translate(title),
+        [
+            Item(
+                label=name or translate("none"),
+                value=name,
+                detail=translate(reason) + _adds(config, context, apply, name)
+                if say_what_it_adds
+                else translate(reason),
+                disabled_because=unavailable(name),
+            )
+            for name, reason in offered
+        ],
+        current,
+    )
+    if not answer.chosen:
+        return Answer(answer.outcome)
+    return Answer(
+        Outcome.CHOSE, replace(config, packages=apply(config.packages, answer.unwrap()))
+    )
+
+
+def _adds(
+    config: InstallConfig,
+    context: Context,
+    apply: Callable[[PackagesConfig, str], PackagesConfig],
+    name: str,
+) -> str:
+    """What choosing this row would put in `make.conf`, on the row itself.
+
+    `settle` asks the same question after the choice, and the panel lists the
+    values on the USE row afterwards. This is the third place, and the earliest
+    one: an operator comparing `nouveau` against `nvidia` reads what each costs
+    without having to pick one to find out.
+    """
+    would = replace(config, packages=apply(config.packages, name))
+    effects = derive_effects(config, would, context)
+    added = (*effects.video_cards, *effects.use_flags)
+    return f" (+{' '.join(added)})" if added else ""
+
+
+FRAMEWORK_LABELS: Final[tuple[tuple[str, str], ...]] = (
+    ("fcitx", "Fcitx 5"),
+    ("ibus", "IBus"),
+)
+
+
+def input_method_groups(groups: Groups) -> tuple[str, ...]:
+    """Framework and engine groups, classified by their catalog metadata."""
+    return tuple(sorted(name for name, group in groups.items() if group.input_framework))
+
+
+def input_framework_groups(groups: Groups) -> tuple[str, ...]:
+    """Framework providers from the plan layer's canonical registry."""
+    return tuple(
+        sorted(name for name in FRAMEWORK_GROUPS.values() if name in groups)
+    )
+
+
+def input_engine_groups(groups: Groups, framework: str) -> tuple[str, ...]:
+    """Selectable engines belonging to one framework."""
+    providers = set(input_framework_groups(groups))
+    return tuple(
+        sorted(
+            name
+            for name, group in groups.items()
+            if group.input_framework == framework
+            and group.input_method
+            and name not in providers
+        )
+    )
+
+
+def input_engine_sections(
+    groups: Groups, framework: str
+) -> tuple[tuple[str, tuple[str, ...]], ...]:
+    """Engine groups under the language each catalog entry declares."""
+    names = input_engine_groups(groups, framework)
+    languages = sorted({groups[name].input_language for name in names})
+    return tuple(
+        (
+            language,
+            tuple(name for name in names if groups[name].input_language == language),
+        )
+        for language in languages
+        if language
+    )
+
+
+def _selected_input_framework(config: InstallConfig, groups: Groups) -> str:
+    frameworks = set(input_framework_groups(groups))
+    selected = [
+        name for name in config.packages.applications if name in frameworks
+    ]
+    if len(selected) > 1:
+        raise ConfigError("more than one input framework is selected")
+    return selected[0] if selected else ""
+
+
+def select_input_framework(
+    config: InstallConfig, groups: Groups, framework_group: str
+) -> InstallConfig:
+    """Choose one framework and discard every earlier framework and engine."""
+    frameworks = set(input_framework_groups(groups))
+    if framework_group and framework_group not in frameworks:
+        raise ConfigError(f"{framework_group!r} is not an input framework group")
+    current = _selected_input_framework(config, groups)
+    if current == framework_group:
+        return config
+    input_groups = set(input_method_groups(groups))
+    kept = tuple(
+        name for name in config.packages.applications if name not in input_groups
+    )
+    chosen = (framework_group,) if framework_group else ()
+    return replace(
+        config,
+        packages=replace(config.packages, applications=(*kept, *chosen)),
+    )
+
+
+def select_input_engines(
+    config: InstallConfig, groups: Groups, engine_groups: Sequence[str]
+) -> InstallConfig:
+    """Select engines only when their framework is already selected."""
+    framework_group = _selected_input_framework(config, groups)
+    if engine_groups and not framework_group:
+        raise ConfigError("an input engine needs its framework selected first")
+    framework = groups[framework_group].input_framework if framework_group else ""
+    offered = set(input_engine_groups(groups, framework))
+    wrong = [name for name in engine_groups if name not in offered]
+    if wrong:
+        raise ConfigError(
+            f"the {', '.join(wrong)} engine groups do not belong to {framework}"
+        )
+    every_engine = {
+        name
+        for name in input_method_groups(groups)
+        if name not in input_framework_groups(groups)
+    }
+    kept = tuple(
+        name for name in config.packages.applications if name not in every_engine
+    )
+    return replace(
+        config,
+        packages=replace(config.packages, applications=(*kept, *engine_groups)),
+    )
+
+
+def cjk_font_groups(groups: Groups) -> tuple[str, ...]:
+    """Font groups classified by declared family metadata."""
+    return tuple(sorted(name for name, group in groups.items() if group.font_family))
+
+
+def font_sections(groups: Groups) -> tuple[tuple[str, tuple[str, ...]], ...]:
+    """Font groups in the category order that also owns generic aliases."""
+    return tuple(
+        (
+            category.heading,
+            tuple(
+                name
+                for name in cjk_font_groups(groups)
+                if groups[name].font_category == category.catalog
+            ),
+        )
+        for category in FontCategory
+        if any(
+            groups[name].font_category == category.catalog
+            for name in cjk_font_groups(groups)
+        )
+    )
+
+
+def select_cjk_fonts(
+    config: InstallConfig,
+    groups: Groups,
+    chosen: Sequence[str],
+    preferred: Sequence[str],
+) -> InstallConfig:
+    """Store each generic's preferred font before other installed fonts."""
+    offered = set(cjk_font_groups(groups))
+    wrong = [name for name in chosen if name not in offered]
+    if wrong:
+        raise ConfigError(f"the {', '.join(wrong)} groups do not provide CJK fonts")
+    missing = [name for name in preferred if name not in chosen]
+    if missing:
+        raise ConfigError("a preferred font must also be installed")
+    unsupported = [name for name in preferred if not groups[name].font_cjk]
+    if unsupported:
+        raise ConfigError("a preferred CJK font must provide CJK glyphs")
+    generics = [
+        FontCategory.selected(groups[name].font_category).generic for name in preferred
+    ]
+    if len(generics) != len(set(generics)):
+        raise ConfigError("only one font may be preferred for each generic")
+    fonts = set(cjk_font_groups(groups))
+    kept = tuple(
+        name for name in config.packages.applications if name not in fonts
+    )
+    ordered = (*preferred, *(name for name in chosen if name not in preferred))
+    return replace(
+        config,
+        packages=replace(config.packages, applications=(*kept, *ordered)),
+    )
+
+
+def preferred_font_groups(config: InstallConfig, groups: Groups) -> tuple[str, ...]:
+    """The first selected font for each generic owns its preferred mark."""
+    selected = [
+        name for name in config.packages.applications if name in cjk_font_groups(groups)
+    ]
+    found: list[str] = []
+    generics: set[str] = set()
+    for name in selected:
+        if not groups[name].font_cjk:
+            continue
+        generic = FontCategory.selected(groups[name].font_category).generic
+        if generic not in generics:
+            generics.add(generic)
+            found.append(name)
+    return tuple(found)
+
+
+def font_configuration_group(groups: Groups, decision: str) -> str:
+    names = [
+        name for name, group in groups.items() if group.font_configuration == decision
+    ]
+    if len(names) != 1:
+        raise ConfigError(
+            f"the catalog must declare exactly one {decision} font configuration group"
+        )
+    return names[0]
+
+
+def input_configuration_group(groups: Groups, decision: str) -> str:
+    names = [
+        name
+        for name, group in groups.items()
+        if group.input_configuration == decision
+    ]
+    if len(names) != 1:
+        raise ConfigError(
+            f"the catalog must declare exactly one {decision} input configuration group"
+        )
+    return names[0]
+
+
+def _set_font_configuration(
+    config: InstallConfig, groups: Groups, enabled: bool | None
+) -> InstallConfig:
+    accepted = font_configuration_group(groups, FONT_CONFIGURATION_ENABLED)
+    declined = font_configuration_group(groups, FONT_CONFIGURATION_DISABLED)
+    decisions = {accepted, declined}
+    kept = tuple(
+        name for name in config.packages.applications if name not in decisions
+    )
+    chosen = () if enabled is None else ((accepted,) if enabled else (declined,))
+    return replace(
+        config,
+        packages=replace(config.packages, applications=(*kept, *chosen)),
+    )
+
+
+def _set_input_configuration(
+    config: InstallConfig, groups: Groups, enabled: bool | None
+) -> InstallConfig:
+    accepted = input_configuration_group(groups, INPUT_CONFIGURATION_ENABLED)
+    declined = input_configuration_group(groups, INPUT_CONFIGURATION_DISABLED)
+    decisions = {accepted, declined}
+    kept = tuple(
+        name for name in config.packages.applications if name not in decisions
+    )
+    chosen = () if enabled is None else ((accepted,) if enabled else (declined,))
+    return replace(
+        config,
+        packages=replace(config.packages, applications=(*kept, *chosen)),
+    )
+
+
+def _consent_screen(
+    screen: Screen,
+    config: InstallConfig,
+    context: Context,
+    title: str,
+    summary: str,
+) -> Answer[InstallConfig]:
+    translate = context.translate
+    declined = font_configuration_group(
+        context.groups, FONT_CONFIGURATION_DISABLED
+    )
+    answer = Menu(
+        title=translate(title),
+        preamble=(summary,),
+        items=[
+            Item(label=translate("Yes"), value="yes"),
+            Item(label=translate("No"), value="no"),
+        ],
+        current=("no" if declined in config.packages.applications else "yes"),
+        footer=footer(translate),
+    ).run(screen)
+    if not answer.chosen:
+        return Answer(answer.outcome)
+    edited = _set_font_configuration(
+        config, context.groups, answer.unwrap() == "yes"
+    )
+    return Answer(Outcome.CHOSE, edited)
+
+
+def _input_consent_screen(
+    screen: Screen,
+    config: InstallConfig,
+    context: Context,
+    summary: str,
+) -> Answer[InstallConfig]:
+    translate = context.translate
+    declined = input_configuration_group(
+        context.groups, INPUT_CONFIGURATION_DISABLED
+    )
+    answer = Menu(
+        title=translate("Input method configuration"),
+        preamble=(summary,),
+        items=[
+            Item(label=translate("Yes"), value="yes"),
+            Item(label=translate("No"), value="no"),
+        ],
+        current=(
+            "no" if declined in config.packages.applications else "yes"
+        ),
+        footer=footer(translate),
+    ).run(screen)
+    if not answer.chosen:
+        return Answer(answer.outcome)
+    edited = _set_input_configuration(
+        config, context.groups, answer.unwrap() == "yes"
+    )
+    return Answer(Outcome.CHOSE, edited)
+
+
+def _input_configuration_summary(
+    config: InstallConfig, groups: Groups, framework: str, translate: Catalog
+) -> str:
+    selected = [
+        groups[name]
+        for name in config.packages.applications
+        if name in groups and groups[name].input_method
+    ]
+    engines = ", ".join(group.input_method for group in selected)
+    subject = engines or translate("the selected framework")
+    desktop = groups.get(config.packages.desktop)
+    if (
+        framework == "fcitx"
+        and engines
+        and desktop is not None
+        and desktop.input_method_launcher
+    ):
+        return translate(
+            "Write /etc/xdg/kwinrc and the Fcitx profile for: {engines}."
+        ).format(
+            engines=subject
+        )
+    sources = ", ".join(group.input_source for group in selected if group.input_source)
+    if framework == "ibus" and config.packages.desktop == "gnome" and sources:
+        return translate(
+            "Write /etc/dconf/db/local.d/00-gentoo-install-input-sources with "
+            "IBus engines: {engines}."
+        ).format(engines=sources)
+    if framework == "fcitx":
+        return translate(
+            "Write the Fcitx profile and input environment for: {engines}."
+        ).format(engines=subject)
+    return translate("Write the IBus input environment.")
+
+
+def input_method_screen(
+    screen: Screen, config: InstallConfig, context: Context
+) -> Answer[InstallConfig]:
+    translate = context.translate
+    frameworks = input_framework_groups(context.groups)
+    labels: dict[str, str] = dict(FRAMEWORK_LABELS)
+    framework_items = [Item(label=translate("none"), value="")]
+    framework_items += [
+        Item(
+            label=translate(labels.get(context.groups[name].input_framework, name)),
+            value=name,
+        )
+        for name in frameworks
+    ]
+    framework_answer = Menu(
+        title=translate("Input framework"),
+        items=framework_items,
+        current=_selected_input_framework(config, context.groups),
+        footer=footer(translate),
+    ).run(screen)
+    if not framework_answer.chosen:
+        return Answer(framework_answer.outcome)
+    with_framework = select_input_framework(
+        config, context.groups, framework_answer.unwrap()
+    )
+    framework_group = _selected_input_framework(with_framework, context.groups)
+    if not framework_group:
+        without_configuration = _set_input_configuration(
+            with_framework, context.groups, None
+        )
+        return settle(screen, context, config, without_configuration)
+    framework = context.groups[framework_group].input_framework
+    sections = input_engine_sections(context.groups, framework)
+    names = tuple(name for _, section in sections for name in section)
+    have = {overlay.name for overlay in config.portage.overlays}
+    items = [
+        Item(
+            label=translate(context.groups[name].label or name),
+            value=name,
+            heading=translate(language) if offset == 0 else "",
+            disabled_because=_needs_an_overlay(
+                context.groups[name].repositories, have, translate
+            ),
+        )
+        for language, section in sections
+        for offset, name in enumerate(section)
+    ]
+    selected = set(with_framework.packages.applications) & set(names)
+    engine_answer = MultipleChoiceMenu(
+        title=translate("Input engines"),
+        items=items,
+        selected={
+            index for index, item in enumerate(items) if item.value in selected
+        },
+        footer=footer(translate),
+    ).run(screen)
+    if not engine_answer.chosen:
+        return Answer(engine_answer.outcome)
+    edited = select_input_engines(
+        with_framework, context.groups, tuple(engine_answer.unwrap())
+    )
+    summary = _input_configuration_summary(
+        edited, context.groups, framework, translate
+    )
+    consented = _input_consent_screen(screen, edited, context, summary)
+    if not consented.chosen:
+        return Answer(consented.outcome)
+    return settle(screen, context, config, consented.unwrap())
+
+
+def cjk_fonts_screen(
+    screen: Screen, config: InstallConfig, context: Context
+) -> Answer[InstallConfig]:
+    translate = context.translate
+    sections = font_sections(context.groups)
+    names = tuple(name for _, section in sections for name in section)
+    have = {overlay.name for overlay in config.portage.overlays}
+    items = [
+        Item(
+            label=translate(context.groups[name].label or name),
+            value=name,
+            heading=translate(heading) if offset == 0 else "",
+            preference_group=(
+                FontCategory.selected(context.groups[name].font_category).generic
+                if context.groups[name].font_cjk
+                else ""
+            ),
+            disabled_because=_needs_an_overlay(
+                context.groups[name].repositories, have, translate
+            ),
+        )
+        for heading, section in sections
+        for offset, name in enumerate(section)
+    ]
+    selected = [name for name in config.packages.applications if name in names]
+    preferred = set(preferred_font_groups(config, context.groups))
+    font_menu = MultipleChoiceMenu(
+        title=translate("Fonts"),
+        items=items,
+        tri_state=True,
+        selected={
+            index for index, item in enumerate(items) if item.value in selected
+        },
+        preferred={
+            index for index, item in enumerate(items) if item.value in preferred
+        },
+        footer="  ".join(
+            (
+                f"[-] {translate('installed')}",
+                f"[x] {translate('installed and preferred')}",
+                translate("one preferred per generic"),
+                footer(translate),
+            )
+        ),
+    )
+    font_answer = font_menu.run(screen)
+    if not font_answer.chosen:
+        return Answer(font_answer.outcome)
+    chosen = tuple(font_answer.unwrap())
+    chosen_preferred = tuple(
+        items[index].value for index in sorted(font_menu.preferred)
+    )
+    edited = select_cjk_fonts(config, context.groups, chosen, chosen_preferred)
+    locale = CjkFontconfigLocale.selected(edited.system.locale)
+    if not chosen or locale is None:
+        without_configuration = _set_font_configuration(
+            edited, context.groups, None
+        )
+        return settle(screen, context, config, without_configuration)
+    preferred_sans = next(
+        (
+            name
+            for name in chosen_preferred
+            if FontCategory.selected(context.groups[name].font_category).generic
+            == "sans-serif"
+        ),
+        "",
+    )
+    leading_sans = (
+        locale.resolve(context.groups[preferred_sans].font_family)
+        if preferred_sans
+        else locale.face
+    )
+    summary = translate("Write {path}; {face} will lead sans-serif.").format(
+        path=CJK_SANS_PREFERENCE, face=leading_sans
+    )
+    consented = _consent_screen(
+        screen,
+        edited,
+        context,
+        "Font configuration",
+        summary,
+    )
+    if not consented.chosen:
+        return Answer(consented.outcome)
+    return settle(screen, context, config, consented.unwrap())
+
+
+def packages_screen(
+    screen: Screen, config: InstallConfig, context: Context
+) -> Answer[InstallConfig]:
+    translate = context.translate
+    # A desktop, a driver and a display manager each decide something else as
+    # well, so each has its own screen and none is a row to tick here.
+    elsewhere = (
+        set(desktop_profiles(context.groups, context.profile_paths))
+        | {name for name, _ in GRAPHICS}
+        | {name for name, _ in DISPLAY_MANAGERS}
+        | set(input_method_groups(context.groups))
+        | set(cjk_font_groups(context.groups))
+    )
+    names = sorted(name for name in context.groups if name not in elsewhere)
+    have = {overlay.name for overlay in config.portage.overlays}
+    items = [
+        Item(
+            label=name,
+            value=name,
+            detail=" ".join(context.groups[name].packages)
+            + _adds(
+                config,
+                context,
+                lambda packages, one: replace(
+                    packages, applications=(*packages.applications, one)
+                ),
+                name,
+            ),
+            disabled_because=_needs_an_overlay(context.groups[name].repositories, have, translate),
+        )
+        for name in names
+    ]
+    chosen_already = set(config.packages.applications)
+    while True:
+        menu: MultipleChoiceMenu[str] = MultipleChoiceMenu(
+            title=translate("Applications"),
+            preamble=(translate("These packages supplement the desktop selection."),),
+            items=items,
+            selected={index for index, item in enumerate(items) if item.value in chosen_already},
+            footer=footer(translate),
+        )
+        answer = menu.run(screen)
+        if not answer.chosen:
+            return Answer(answer.outcome)
+        chosen = answer.unwrap()
+        kept = tuple(name for name in config.packages.applications if name in elsewhere)
+        edited = replace(
+            config,
+            packages=replace(config.packages, applications=(*kept, *chosen)),
+        )
+        # Checked here rather than at the Install row: the conflict is between
+        # two ticks on this screen and this is where either can be unticked.
+        clash = framework_conflict(edited, context.groups)
+        if not clash:
+            return settle(screen, context, config, edited)
+        chosen_already = set(chosen)
+        say(screen, context, clash)
+
+
+def extra_packages_screen(
+    screen: Screen, config: InstallConfig, context: Context
+) -> Answer[InstallConfig]:
+    """Any atom the operator wants, typed in.
+
+    Only the syntax is checked here. Whether it resolves is a question for the
+    target's repositories, which `VerifyPackages` asks once the tree is synced;
+    the live medium often carries no repository at all.
+    """
+    translate = context.translate
+    while True:
+        typed = TextField(
+            title=translate("Packages to install, separated by spaces"),
+            value=" ".join(config.packages.extra),
+            footer=footer(translate),
+        ).run(screen)
+        if not typed.chosen:
+            return Answer(typed.outcome)
+        good, bad = atoms.split(typed.unwrap())
+        if bad:
+            informed = say(screen, context, f"{translate('Not a package name')}: {' '.join(bad)}")
+            if not informed.chosen:
+                return Answer(informed.outcome)
+            continue
+        return Answer(
+            Outcome.CHOSE, replace(config, packages=replace(config.packages, extra=good))
+        )
+
+
+def _typed_beside_automatic(
+    screen: Screen,
+    context: Context,
+    *,
+    title: str,
+    prompt: str,
+    typed: tuple[str, ...],
+    automatic: tuple[automatic_values.Added, ...],
+    accepts: Callable[[str], tuple[tuple[str, ...], tuple[str, ...]]],
+    rejected: str,
+) -> Answer[tuple[str, ...]]:
+    """One editable list, and under it what the installer adds by itself.
+
+    The automatic rows are drawn disabled with their reason: an operator who
+    can see that `root=` and `rd.luks.uuid=` are already handled stops adding a
+    second copy of them, and one who cannot see it finds them in the installed
+    system with nothing to attribute them to.
+    """
+    translate = context.translate
+    while True:
+        items: list[Item[str]] = [
+            Item(
+                label=prompt,
+                value="edit",
+                detail=" ".join(typed) or translate("none"),
+            )
+        ]
+        items += [
+            Item(
+                label=one.value,
+                value="",
+                disabled_because=translate("added for you"),
+                detail=(
+                    f"{translate(one.because)} ({one.source})"
+                    if one.source
+                    else translate(one.because)
+                ),
+            )
+            for one in automatic
+        ]
+        menu: Menu[str] = Menu(title=title, items=items, footer=footer(translate))
+        answer = menu.run(screen)
+        if not answer.chosen:
+            return Answer(answer.outcome)
+        entered = TextField(
+            title=prompt,
+            value=" ".join(typed),
+            footer=footer(translate),
+        ).run(screen)
+        if not entered.chosen:
+            return Answer(entered.outcome)
+        good, bad = accepts(entered.unwrap())
+        if bad:
+            informed = say(screen, context, f"{rejected}: {' '.join(bad)}")
+            if not informed.chosen:
+                return Answer(informed.outcome)
+            continue
+        return Answer(Outcome.CHOSE, good)
+
+
+def use_flags_screen(
+    screen: Screen, config: InstallConfig, context: Context
+) -> Answer[InstallConfig]:
+    """`USE` in `make.conf`, beside what the chosen groups already ask for.
+
+    A flag typed here is appended after the profile's own, so `-foo` turns off
+    something the profile set. The groups' flags are listed rather than merged
+    into the field: an operator who deletes `wayland` from a field that was
+    pre-filled with it has silently overridden their desktop.
+    """
+    answer = _typed_beside_automatic(
+        screen,
+        context,
+        title=context.translate("USE flags"),
+        prompt=context.translate("Flags to add, separated by spaces"),
+        typed=config.portage.use,
+        automatic=automatic_values.use_flags(config, context.groups),
+        accepts=atoms.split_use_flags,
+        rejected=context.translate("Not a USE flag"),
+    )
+    if not answer.chosen:
+        return Answer(answer.outcome)
+    values = answer.unwrap()
+    _record_operator(context, ValueKind.USE_FLAG, values)
+    return Answer(
+        Outcome.CHOSE, replace(config, portage=replace(config.portage, use=values))
+    )
+
+
+def video_cards_screen(
+    screen: Screen, config: InstallConfig, context: Context
+) -> Answer[InstallConfig]:
+    """`VIDEO_CARDS` on top of what the driver choice contributes.
+
+    A hybrid machine needs more than one: an AMD laptop with an NVIDIA card
+    carries `amdgpu radeonsi nvidia`, and the driver row offers one group. The
+    values are USE_EXPAND flags, so they are checked as flags.
+    """
+    answer = _typed_beside_automatic(
+        screen,
+        context,
+        title=context.translate("VIDEO_CARDS"),
+        prompt=context.translate("Values to add, separated by spaces"),
+        typed=config.portage.video_cards,
+        automatic=automatic_values.video_cards(config, context.groups),
+        accepts=atoms.split_use_flags,
+        rejected=context.translate("Not a VIDEO_CARDS value"),
+    )
+    if not answer.chosen:
+        return Answer(answer.outcome)
+    values = answer.unwrap()
+    _record_operator(context, ValueKind.VIDEO_CARD, values)
+    return Answer(
+        Outcome.CHOSE,
+        replace(config, portage=replace(config.portage, video_cards=values)),
+    )

--- a/gentoo_install/tui/screens.py
+++ b/gentoo_install/tui/screens.py
@@ -67,18 +67,24 @@ from ..model.device import (
 )
 from ..plan import automatic as automatic_values
 from ..plan.convert import REPLACED_DIRECTORIES, SWAP_CONFIRMATION
-from ..plan.fonts import CJK_SANS_PREFERENCE, CjkFontconfigLocale, FontCategory
+from ..plan.fonts import CjkFontconfigLocale
 from ..model.compat import KERNEL_PACKAGES
 from ..model.size import Size
-from ..errors import ConfigError, DeviceNotFound, GentooInstallError
+from ..errors import DeviceNotFound, GentooInstallError
 from ..model import atoms, manual, paste, sshkey
 from ..model.templates import Layout, build
 from ..plan.packages import Catalog as Groups
-from ..plan.packages import FRAMEWORK_GROUPS
 from ..plan.packages import FONT_CONFIGURATION_DISABLED, FONT_CONFIGURATION_ENABLED
 from ..plan.packages import INPUT_CONFIGURATION_DISABLED, INPUT_CONFIGURATION_ENABLED
-from ..plan.packages import driver_conflict, framework_conflict
 from ..plan import system as plan_system
+from .packages import (
+    _profile_for,
+    _record_operator,
+    _set_font_configuration,
+    _typed_beside_automatic,
+    font_configuration_group,
+    input_configuration_group,
+)
 from .partitions import (
     _edit_passphrase,
     _from_layout,
@@ -596,22 +602,8 @@ def init_screen(screen: Screen, config: InstallConfig, context: Context) -> Answ
     )
 
 
-def _profile_was_chosen(config: InstallConfig, groups: Groups) -> bool:
-    """Whether the profile is something other than what the current desktop and
-    init imply, which is the only evidence the operator set it by hand."""
-    implied = desktop_profiles(groups).get(config.packages.desktop)
-    if implied is None:
-        return True
-    return config.portage.profile != _profile_for(implied, config.system.init)
 
 
-def _profile_for(profile: str, init: InitSystem) -> str:
-    """The profile has to follow the init: a systemd profile has `systemd` as a
-    path component, and the two disagreeing builds packages for the other."""
-    parts = [part for part in profile.split("/") if part != "systemd"]
-    if init is InitSystem.SYSTEMD:
-        parts.append("systemd")
-    return "/".join(parts)
 
 
 def root_password_screen(
@@ -1003,763 +995,73 @@ def kernel_screen(screen: Screen, config: InstallConfig, context: Context) -> An
     return Answer(Outcome.CHOSE, changed)
 
 
-#: What a machine with no desktop is built against. Every other answer names
-#: its own profile in `data/profiles/<name>.toml`.
-BASE_PROFILE: Final[str] = "default/linux/amd64/23.0"
-
-
-def desktop_profiles(groups: Groups, profile_paths: Sequence[str] = ()) -> dict[str, str]:
-    """The desktops and the profile each is built against, read from the files
-    that declare them: a table beside `data/profiles/` meant a desktop added
-    there never reached the menu, and one added here installed nothing."""
-    release = next(
-        (path.split("/")[3] for path in profile_paths if path.startswith("default/linux/amd64/")),
-        BASE_PROFILE.split("/")[3],
-    )
-    prefix = f"default/linux/amd64/{release}"
-    found = {"": prefix}
-    for name, group in groups.items():
-        if group.profile:
-            found[name] = group.profile.replace(BASE_PROFILE, prefix, 1)
-    return found
-
-
-def desktop_screen(screen: Screen, config: InstallConfig, context: Context) -> Answer[InstallConfig]:
-    """The desktop decides the profile as well as the packages, the same way
-    the init system does."""
-    translate = context.translate
-    detail = {
-        "plasma": translate("the session only"),
-        "plasma-full": translate("with the KDE application set"),
-        "gnome": translate("the session only"),
-        "gnome-full": translate("with the GNOME application set"),
-    }
-    items = [
-        Item(
-            label=translate("no desktop") if not name else name,
-            value=name,
-            # Plasma and GNOME both bring `wayland`, and the operator reads
-            # that here rather than after choosing.
-            detail=detail.get(name, "")
-            + _adds(config, context, lambda packages, one: replace(packages, desktop=one), name),
-        )
-        for name in sorted(desktop_profiles(context.groups, context.profile_paths))
-    ]
-    menu: Menu[str] = Menu(
-        title=translate("Desktop and applications"),
-        preamble=(translate("The desktop selects its profile and proposes login and network services."),),
-        items=items,
-        current=config.packages.desktop,
-        footer=footer(translate),
-    )
-    answer = menu.run(screen)
-    if not answer.chosen:
-        return Answer(answer.outcome)
-    desktop = answer.unwrap()
-    changed = replace(config, packages=replace(config.packages, desktop=desktop))
-    if desktop != config.packages.desktop:
-        changed = _set_input_configuration(changed, context.groups, None)
-    if not _profile_was_chosen(config, context.groups):
-        # Only while the profile is still the one the last desktop implied.
-        # Overwriting it regardless threw away a profile the operator had
-        # picked on purpose, such as no-multilib.
-        changed = replace(
-            changed,
-            portage=replace(
-                config.portage,
-                profile=_profile_for(
-                    desktop_profiles(context.groups, context.profile_paths)[desktop], config.system.init
-                ),
-            ),
-        )
-    manager = config.packages.display_manager
-    was_proposed = _has_derived(context, ValueKind.DISPLAY_MANAGER, manager)
-    kept_manager = (
-        manager
-        if manager and not was_proposed and desktop != config.packages.desktop
-        else ""
-    )
-    changed = _desktop_proposes(changed, config, context, desktop)
-    login = LOGIN_SCREEN.get(desktop, "")
-    effects = derive_effects(config, changed, context, kept_manager)
-    answered = settle(
-        screen,
-        context,
-        config,
-        changed,
-        kept_display_manager=kept_manager,
-    )
-    if answered.chosen:
-        _record_derived(context, answered.unwrap(), effects)
-    return answered
-
-
-#: What each desktop's own login screen is. Proposed rather than fixed: the
-#: row stays editable, and pulling the login screen out of the desktop profile
-#: was right — leaving it empty was not, because the row is then required and
-#: red on a menu whose operator has already said which desktop they want.
-LOGIN_SCREEN: Final[dict[str, str]] = {
-    "plasma": "sddm",
-    "plasma-full": "sddm",
-    "gnome": "gdm",
-    "gnome-full": "gdm",
-    "xfce": "lightdm",
-}
-
-
-@dataclass(frozen=True)
-class Effects:
-    """Derived values changed by one TUI choice."""
-
-    use_flags: tuple[str, ...] = ()
-    video_cards: tuple[str, ...] = ()
-    user_groups: tuple[str, ...] = ()
-    profile: str = ""
-    display_manager_changed: bool = False
-    networking_changed: bool = False
-    kept_display_manager: str = ""
-    withdrawn_use: tuple[str, ...] = ()
-    withdrawn_video_cards: tuple[str, ...] = ()
-
-    @property
-    def has_changes(self) -> bool:
-        """Whether the choice has a value to confirm."""
-        return bool(
-            self.use_flags
-            or self.video_cards
-            or self.user_groups
-            or self.profile
-            or self.display_manager_changed
-            or self.networking_changed
-            or self.kept_display_manager
-        )
-
-    @property
-    def editable_row(self) -> Callable[..., Answer[InstallConfig]] | None:
-        """The row containing values that can be inspected after consent."""
-        if self.use_flags:
-            return use_flags_screen
-        if self.video_cards:
-            return video_cards_screen
-        return None
-
-
-def derive_effects(
-    before: InstallConfig,
-    after: InstallConfig,
-    context: Context,
-    kept_display_manager: str = "",
-) -> Effects:
-    """Derive every value one choice adds, replaces, or withdraws."""
-    return Effects(
-        use_flags=_new(automatic_values.use_flags, before, after, context.groups),
-        video_cards=_new(automatic_values.video_cards, before, after, context.groups),
-        user_groups=_new(automatic_values.user_groups, before, after, context.groups),
-        profile=after.portage.profile if after.portage.profile != before.portage.profile else "",
-        display_manager_changed=(
-            after.packages.display_manager != before.packages.display_manager
-        ),
-        networking_changed=after.system.networking is not before.system.networking,
-        kept_display_manager=kept_display_manager,
-        withdrawn_use=tuple(
-            one.value
-            for one in context.provenance
-            if one.kind is ValueKind.USE_FLAG and one.source is ValueSource.DERIVED
-        ),
-        withdrawn_video_cards=tuple(
-            one.value
-            for one in context.provenance
-            if one.kind is ValueKind.VIDEO_CARD and one.source is ValueSource.DERIVED
-        ),
-    )
-
-
-def apply_effects(after: InstallConfig, effects: Effects) -> InstallConfig:
-    """Pin additions while removing only values derived by the replaced choice."""
-    kept_use = tuple(one for one in after.portage.use if one not in effects.withdrawn_use)
-    kept_cards = tuple(
-        one for one in after.portage.video_cards if one not in effects.withdrawn_video_cards
-    )
-    return replace(
-        after,
-        portage=replace(
-            after.portage,
-            use=(*kept_use, *effects.use_flags),
-            video_cards=(*kept_cards, *effects.video_cards),
-        ),
-    )
-
-
-def _desktop_proposes(
-    changed: InstallConfig, before: InstallConfig, context: Context, desktop: str
-) -> InstallConfig:
-    """The login screen and the network manager a desktop implies.
-
-    Only over what the operator has not set: a login screen they picked stands,
-    and so does a network manager. The Plasma and GNOME profiles already carry
-    `USE=networkmanager`, and nothing moved `system.networking` with it, so the
-    installed desktop had the settings panel and not the service behind it.
-    """
-    if (
-        _has_derived(context, ValueKind.DISPLAY_MANAGER, before.packages.display_manager)
-    ):
-        changed = replace(
-            changed,
-            packages=replace(changed.packages, display_manager=""),
-        )
-    if not desktop:
-        return changed
-    login = LOGIN_SCREEN.get(desktop, "")
-    if login and not changed.packages.display_manager and login in context.groups:
-        changed = replace(
-            changed, packages=replace(changed.packages, display_manager=login)
-        )
-    if not _has_operator(context, ValueKind.NETWORKING, before.system.networking.value):
-        changed = replace(
-            changed,
-            system=replace(changed.system, networking=Networking.NETWORKMANAGER_WPA),
-        )
-    return changed
-
-
-def settle(
-    screen: Screen,
-    context: Context,
-    before: InstallConfig,
-    after: InstallConfig,
-    kept_display_manager: str = "",
-) -> Answer[InstallConfig]:
-    """Confirm what a choice changes outside its own row, then write it down.
-
-    Choosing a driver or a desktop moves `VIDEO_CARDS`, `USE` and the profile.
-    Deriving those silently at build time meant the operator met them for the
-    first time in the installed system, so they are listed here and, once
-    confirmed, put into the configuration as the operator's own values. Pinned
-    rather than left derived: a value in `portage.use` survives a later change
-    to the desktop, and `automatic.use_flags` stops reporting a flag that is
-    already there, so nothing appears twice.
-
-    Declining cancels the choice. The flags are not optional extras that come
-    with it; they are what makes it work.
-    """
-    effects = derive_effects(before, after, context, kept_display_manager)
-    if not effects.has_changes:
-        return Answer(Outcome.CHOSE, after)
-    translate = context.translate
-    lines = []
-    if effects.video_cards:
-        lines.append(f"VIDEO_CARDS: {' '.join(effects.video_cards)}")
-    if effects.use_flags:
-        lines.append(f"USE: {' '.join(effects.use_flags)}")
-    if effects.display_manager_changed:
-        lines.append(
-            f"{translate('Display manager')}: {after.packages.display_manager}"
-        )
-    elif effects.kept_display_manager:
-        lines.append(
-            f"{translate('Display manager')}: {effects.kept_display_manager} "
-            f"({translate('kept')})"
-        )
-    if effects.networking_changed:
-        lines.append(f"{translate('Network')}: {after.system.networking.value}")
-    if effects.user_groups:
-        # Not pinned into the account: `AddUserToGroups` derives them from the
-        # same catalog at build time, so the account is put in them whether or
-        # not one exists when the driver is chosen.
-        lines.append(f"{translate('Extra groups')}: {' '.join(effects.user_groups)}")
-    if effects.profile:
-        lines.append(f"{translate('Profile')}: {effects.profile}")
-    # A third answer only when there is something to open. The row is derived
-    # from what actually changed: with a profile and no flags it offered `Yes,
-    # and open VIDEO_CARDS`, which edits a value this choice did not touch.
-    where = effects.editable_row
-    named = translate("USE flags") if effects.use_flags else translate("VIDEO_CARDS")
-    # Yes first and preselected. Declining cancels the desktop the operator
-    # just chose, and these values are what makes it work rather than extras
-    # that come with it, so the cursor starting on `No` offered the refusal as
-    # the default answer to a question the choice itself had already implied.
-    items = [
-        Item(label=translate("Yes"), value="yes"),
-        Item(label=translate("No"), value="no"),
-    ]
-    if where is not None:
-        # The row the values land on is somewhere else in the menu, and an
-        # operator who wants to look at them now would otherwise have to leave,
-        # find it, and remember what they were checking.
-        items.append(
-            Item(
-                label=f"{translate('Yes, and open')} {named}",
-                value="open",
-                detail=translate("editable"),
-            )
-        )
-    asked: Menu[str] = Menu(
-        title=translate("This choice also sets"),
-        preamble=tuple(lines),
-        items=items,
-        footer=footer(translate),
-        current="yes",
-    )
-    answered = asked.run(screen)
-    if not answered.chosen or answered.unwrap() == "no":
-        return Answer(Outcome.BACK, before)
-    # Pinned without what the choice being replaced had derived. Adding to
-    # `portage.use` and never taking anything out meant switching from Plasma
-    # to GNOME left `qt6` and `sddm` behind and read as
-    # `wayland qt6 networkmanager sddm gnome gtk`. What the operator typed is
-    # not derivable and stays; what the last choice derived goes with it.
-    pinned = apply_effects(after, effects)
-    if answered.unwrap() == "open" and where is not None:
-        opened = where(screen, pinned, context)
-        if opened.chosen:
-            return Answer(Outcome.CHOSE, opened.unwrap())
-        if opened.outcome is Outcome.CANCELLED:
-            # Cancelling reaches the application's leave confirmation. Reading
-            # it as `keep what was pinned` committed a desktop and a profile
-            # the operator had just refused.
-            return Answer(Outcome.CANCELLED)
-    return Answer(Outcome.CHOSE, pinned)
-
-
-def _has_derived(context: Context, kind: ValueKind, value: str) -> bool:
-    """Whether this value came from the current automatic proposal."""
-    return ValueProvenance(kind, value, ValueSource.DERIVED) in context.provenance
-
-
-def _has_operator(context: Context, kind: ValueKind, value: str) -> bool:
-    """Whether the operator selected this value in its own row."""
-    return ValueProvenance(kind, value, ValueSource.OPERATOR) in context.provenance
-
-
-def _record_derived(context: Context, after: InstallConfig, effects: Effects) -> None:
-    """Replace the previous choice's derived values with the new choice's."""
-    context.provenance = {
-        one for one in context.provenance if one.source is not ValueSource.DERIVED
-    }
-    context.provenance.update(
-        ValueProvenance(ValueKind.USE_FLAG, value, ValueSource.DERIVED)
-        for value in effects.use_flags
-    )
-    context.provenance.update(
-        ValueProvenance(ValueKind.VIDEO_CARD, value, ValueSource.DERIVED)
-        for value in effects.video_cards
-    )
-    if effects.networking_changed:
-        context.provenance.add(
-            ValueProvenance(
-                ValueKind.NETWORKING,
-                after.system.networking.value,
-                ValueSource.DERIVED,
-            )
-        )
-    if effects.display_manager_changed:
-        context.provenance.add(
-            ValueProvenance(
-                ValueKind.DISPLAY_MANAGER,
-                after.packages.display_manager,
-                ValueSource.DERIVED,
-            )
-        )
-
-
-def _record_operator(context: Context, kind: ValueKind, values: Sequence[str]) -> None:
-    """Mark values edited in their own row as operator choices."""
-    kept = {
-        one
-        for one in context.provenance
-        if one.kind is not kind or one.source is not ValueSource.DERIVED
-    }
-    context.provenance = kept | {
-        ValueProvenance(kind, value, ValueSource.OPERATOR) for value in values
-    }
-
-
-def _new(
-    derive: Callable[[InstallConfig, Groups], tuple[automatic_values.Added, ...]],
-    before: InstallConfig,
-    after: InstallConfig,
-    groups: Groups,
-) -> tuple[str, ...]:
-    """What the change added, in order, without what was already there.
-
-    Only what the same function said before. Unioning `portage.use` as well
-    crossed two namespaces: `pipewire` is both a USE flag and the group its
-    ebuild asks the account to join, so pinning the flag hid the group. Each
-    `derive` already drops what the operator typed.
-    """
-    had = {one.value for one in derive(before, groups)}
-    return tuple(one.value for one in derive(after, groups) if one.value not in had)
-
-
-#: The graphics groups, in the order the menu lists them, and what each is
-#: for. Kept out of the applications list: a driver is one choice, not a set of
-#: things to tick.
-GRAPHICS: tuple[tuple[str, str], ...] = (
-    ("", "no driver package: i915, amdgpu, radeon and nouveau are in the kernel"),
-    ("intel", "i915 and xe, with the firmware they need"),
-    ("amdgpu", "GCN 1.2 and newer"),
-    ("radeon", "AMD up to Sea Islands"),
-    ("nouveau", "the in-kernel NVIDIA driver"),
-    ("nvidia", "proprietary, widens ACCEPT_LICENSE, and blacklists nouveau itself"),
-    ("virtual-machine", "virtio-gpu, QXL and VMware, with fbdev left as the fallback"),
-)
-
-#: The display managers. A desktop no longer names one, because which login
-#: screen to run is a decision of its own.
-DISPLAY_MANAGERS: tuple[tuple[str, str], ...] = (
-    ("", "a text console login"),
-    ("sddm", "the one Plasma expects"),
-    ("gdm", "the one GNOME expects, and it installs gnome-shell whatever you run"),
-    ("lightdm", "the one Xfce expects"),
-    ("greetd", "a console greeter"),
-)
-
-
-def graphics_screen(
-    screen: Screen, config: InstallConfig, context: Context
-) -> Answer[InstallConfig]:
-    """Which drivers, which is what VIDEO_CARDS and the firmware follow.
-
-    More than one can be ticked: a hybrid machine has more than one adapter,
-    and an AMD laptop with an NVIDIA card needs `amdgpu radeonsi nvidia`. Each
-    row says what it adds, so the line the ticks build is readable before any
-    of them is pressed.
-    """
-    translate = context.translate
-    named = tuple((name, reason) for name, reason in GRAPHICS if name)
-    items = [
-        Item(
-            label=name,
-            value=name,
-            detail=translate(reason)
-            + _adds(config, context, lambda packages, one: replace(packages, graphics=(one,)), name),
-        )
-        for name, reason in named
-    ]
-    ticked = set(config.packages.graphics)
-    while True:
-        menu: MultipleChoiceMenu[str] = MultipleChoiceMenu(
-            title=translate("Graphics"),
-            preamble=(translate("The drivers set VIDEO_CARDS and install required firmware or packages."),),
-            items=items,
-            selected={index for index, item in enumerate(items) if item.value in ticked},
-            footer=footer(translate),
-        )
-        answer = menu.run(screen)
-        if not answer.chosen:
-            return Answer(answer.outcome)
-        chosen = replace(
-            config, packages=replace(config.packages, graphics=tuple(answer.unwrap()))
-        )
-        # Checked here rather than at the Install row: the conflict is between
-        # two ticks on this screen and this is where either can be unticked.
-        clash = driver_conflict(chosen, context.groups)
-        if not clash:
-            return settle(screen, context, config, chosen)
-        ticked = set(answer.unwrap())
-        say(screen, context, translate(clash))
-
-
-def display_manager_screen(
-    screen: Screen, config: InstallConfig, context: Context
-) -> Answer[InstallConfig]:
-    # A manager with no desktop installs a login screen that has no session to
-    # start, so every entry but `none` says to pick a desktop first.
-    without = "" if config.packages.desktop else context.translate("choose a desktop first")
-    chosen = _one_group(
-        screen,
-        config,
-        context,
-        "Display manager",
-        DISPLAY_MANAGERS,
-        lambda packages, name: replace(packages, display_manager=name),
-        current=config.packages.display_manager,
-        unavailable=lambda name: without if name else "",
-        say_what_it_adds=True,
-    )
-    if not chosen.chosen:
-        return chosen
-    answered = settle(screen, context, config, chosen.unwrap())
-    if answered.chosen:
-        _record_operator(
-            context,
-            ValueKind.DISPLAY_MANAGER,
-            (answered.unwrap().packages.display_manager,),
-        )
-    return answered
-
-
-def _needs_an_overlay(
-    wanted: Sequence[str], have: set[str], translate: Catalog
-) -> str:
-    """Why a group cannot be ticked: its packages are in no repository this
-    configuration adds. Said here rather than at the Install row, because this
-    is the screen the tick is on."""
-    missing = [name for name in wanted if name not in have]
-    if not missing:
-        return ""
-    return f"{translate('needs the overlay')} {', '.join(missing)}"
-
-
-def _one_group(
-    screen: Screen,
-    config: InstallConfig,
-    context: Context,
-    title: str,
-    offered: tuple[tuple[str, str], ...],
-    apply: Callable[[PackagesConfig, str], PackagesConfig],
-    current: str,
-    unavailable: Callable[[str], str] = lambda name: "",
-    say_what_it_adds: bool = False,
-) -> Answer[InstallConfig]:
-    """A row that holds one group name, drawn from a table of them."""
-    translate = context.translate
-    answer = current_menu(
-        screen,
-        context,
-        translate(title),
-        [
-            Item(
-                label=name or translate("none"),
-                value=name,
-                detail=translate(reason) + _adds(config, context, apply, name)
-                if say_what_it_adds
-                else translate(reason),
-                disabled_because=unavailable(name),
-            )
-            for name, reason in offered
-        ],
-        current,
-    )
-    if not answer.chosen:
-        return Answer(answer.outcome)
-    return Answer(
-        Outcome.CHOSE, replace(config, packages=apply(config.packages, answer.unwrap()))
-    )
-
-
-def _adds(
-    config: InstallConfig,
-    context: Context,
-    apply: Callable[[PackagesConfig, str], PackagesConfig],
-    name: str,
-) -> str:
-    """What choosing this row would put in `make.conf`, on the row itself.
-
-    `settle` asks the same question after the choice, and the panel lists the
-    values on the USE row afterwards. This is the third place, and the earliest
-    one: an operator comparing `nouveau` against `nvidia` reads what each costs
-    without having to pick one to find out.
-    """
-    would = replace(config, packages=apply(config.packages, name))
-    effects = derive_effects(config, would, context)
-    added = (*effects.video_cards, *effects.use_flags)
-    return f" (+{' '.join(added)})" if added else ""
-
-
-FRAMEWORK_LABELS: Final[tuple[tuple[str, str], ...]] = (
-    ("fcitx", "Fcitx 5"),
-    ("ibus", "IBus"),
-)
-
-
-def input_method_groups(groups: Groups) -> tuple[str, ...]:
-    """Framework and engine groups, classified by their catalog metadata."""
-    return tuple(sorted(name for name, group in groups.items() if group.input_framework))
-
-
-def input_framework_groups(groups: Groups) -> tuple[str, ...]:
-    """Framework providers from the plan layer's canonical registry."""
-    return tuple(
-        sorted(name for name in FRAMEWORK_GROUPS.values() if name in groups)
-    )
-
-
-def input_engine_groups(groups: Groups, framework: str) -> tuple[str, ...]:
-    """Selectable engines belonging to one framework."""
-    providers = set(input_framework_groups(groups))
-    return tuple(
-        sorted(
-            name
-            for name, group in groups.items()
-            if group.input_framework == framework
-            and group.input_method
-            and name not in providers
-        )
-    )
-
-
-def input_engine_sections(
-    groups: Groups, framework: str
-) -> tuple[tuple[str, tuple[str, ...]], ...]:
-    """Engine groups under the language each catalog entry declares."""
-    names = input_engine_groups(groups, framework)
-    languages = sorted({groups[name].input_language for name in names})
-    return tuple(
-        (
-            language,
-            tuple(name for name in names if groups[name].input_language == language),
-        )
-        for language in languages
-        if language
-    )
-
-
-def _selected_input_framework(config: InstallConfig, groups: Groups) -> str:
-    frameworks = set(input_framework_groups(groups))
-    selected = [
-        name for name in config.packages.applications if name in frameworks
-    ]
-    if len(selected) > 1:
-        raise ConfigError("more than one input framework is selected")
-    return selected[0] if selected else ""
-
-
-def select_input_framework(
-    config: InstallConfig, groups: Groups, framework_group: str
-) -> InstallConfig:
-    """Choose one framework and discard every earlier framework and engine."""
-    frameworks = set(input_framework_groups(groups))
-    if framework_group and framework_group not in frameworks:
-        raise ConfigError(f"{framework_group!r} is not an input framework group")
-    current = _selected_input_framework(config, groups)
-    if current == framework_group:
-        return config
-    input_groups = set(input_method_groups(groups))
-    kept = tuple(
-        name for name in config.packages.applications if name not in input_groups
-    )
-    chosen = (framework_group,) if framework_group else ()
-    return replace(
-        config,
-        packages=replace(config.packages, applications=(*kept, *chosen)),
-    )
-
-
-def select_input_engines(
-    config: InstallConfig, groups: Groups, engine_groups: Sequence[str]
-) -> InstallConfig:
-    """Select engines only when their framework is already selected."""
-    framework_group = _selected_input_framework(config, groups)
-    if engine_groups and not framework_group:
-        raise ConfigError("an input engine needs its framework selected first")
-    framework = groups[framework_group].input_framework if framework_group else ""
-    offered = set(input_engine_groups(groups, framework))
-    wrong = [name for name in engine_groups if name not in offered]
-    if wrong:
-        raise ConfigError(
-            f"the {', '.join(wrong)} engine groups do not belong to {framework}"
-        )
-    every_engine = {
-        name
-        for name in input_method_groups(groups)
-        if name not in input_framework_groups(groups)
-    }
-    kept = tuple(
-        name for name in config.packages.applications if name not in every_engine
-    )
-    return replace(
-        config,
-        packages=replace(config.packages, applications=(*kept, *engine_groups)),
-    )
-
-
-def cjk_font_groups(groups: Groups) -> tuple[str, ...]:
-    """Font groups classified by declared family metadata."""
-    return tuple(sorted(name for name, group in groups.items() if group.font_family))
-
-
-def font_sections(groups: Groups) -> tuple[tuple[str, tuple[str, ...]], ...]:
-    """Font groups in the category order that also owns generic aliases."""
-    return tuple(
-        (
-            category.heading,
-            tuple(
-                name
-                for name in cjk_font_groups(groups)
-                if groups[name].font_category == category.catalog
-            ),
-        )
-        for category in FontCategory
-        if any(
-            groups[name].font_category == category.catalog
-            for name in cjk_font_groups(groups)
-        )
-    )
-
-
-def select_cjk_fonts(
-    config: InstallConfig,
-    groups: Groups,
-    chosen: Sequence[str],
-    preferred: Sequence[str],
-) -> InstallConfig:
-    """Store each generic's preferred font before other installed fonts."""
-    offered = set(cjk_font_groups(groups))
-    wrong = [name for name in chosen if name not in offered]
-    if wrong:
-        raise ConfigError(f"the {', '.join(wrong)} groups do not provide CJK fonts")
-    missing = [name for name in preferred if name not in chosen]
-    if missing:
-        raise ConfigError("a preferred font must also be installed")
-    unsupported = [name for name in preferred if not groups[name].font_cjk]
-    if unsupported:
-        raise ConfigError("a preferred CJK font must provide CJK glyphs")
-    generics = [
-        FontCategory.selected(groups[name].font_category).generic for name in preferred
-    ]
-    if len(generics) != len(set(generics)):
-        raise ConfigError("only one font may be preferred for each generic")
-    fonts = set(cjk_font_groups(groups))
-    kept = tuple(
-        name for name in config.packages.applications if name not in fonts
-    )
-    ordered = (*preferred, *(name for name in chosen if name not in preferred))
-    return replace(
-        config,
-        packages=replace(config.packages, applications=(*kept, *ordered)),
-    )
-
-
-def preferred_font_groups(config: InstallConfig, groups: Groups) -> tuple[str, ...]:
-    """The first selected font for each generic owns its preferred mark."""
-    selected = [
-        name for name in config.packages.applications if name in cjk_font_groups(groups)
-    ]
-    found: list[str] = []
-    generics: set[str] = set()
-    for name in selected:
-        if not groups[name].font_cjk:
-            continue
-        generic = FontCategory.selected(groups[name].font_category).generic
-        if generic not in generics:
-            generics.add(generic)
-            found.append(name)
-    return tuple(found)
-
-
-def font_configuration_group(groups: Groups, decision: str) -> str:
-    names = [
-        name for name, group in groups.items() if group.font_configuration == decision
-    ]
-    if len(names) != 1:
-        raise ConfigError(
-            f"the catalog must declare exactly one {decision} font configuration group"
-        )
-    return names[0]
-
-
-def input_configuration_group(groups: Groups, decision: str) -> str:
-    names = [
-        name
-        for name, group in groups.items()
-        if group.input_configuration == decision
-    ]
-    if len(names) != 1:
-        raise ConfigError(
-            f"the catalog must declare exactly one {decision} input configuration group"
-        )
-    return names[0]
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
 
 
 def configuration_groups(groups: Groups) -> tuple[str, ...]:
@@ -1771,347 +1073,20 @@ def configuration_groups(groups: Groups) -> tuple[str, ...]:
     )
 
 
-def _set_font_configuration(
-    config: InstallConfig, groups: Groups, enabled: bool | None
-) -> InstallConfig:
-    accepted = font_configuration_group(groups, FONT_CONFIGURATION_ENABLED)
-    declined = font_configuration_group(groups, FONT_CONFIGURATION_DISABLED)
-    decisions = {accepted, declined}
-    kept = tuple(
-        name for name in config.packages.applications if name not in decisions
-    )
-    chosen = () if enabled is None else ((accepted,) if enabled else (declined,))
-    return replace(
-        config,
-        packages=replace(config.packages, applications=(*kept, *chosen)),
-    )
 
 
-def _set_input_configuration(
-    config: InstallConfig, groups: Groups, enabled: bool | None
-) -> InstallConfig:
-    accepted = input_configuration_group(groups, INPUT_CONFIGURATION_ENABLED)
-    declined = input_configuration_group(groups, INPUT_CONFIGURATION_DISABLED)
-    decisions = {accepted, declined}
-    kept = tuple(
-        name for name in config.packages.applications if name not in decisions
-    )
-    chosen = () if enabled is None else ((accepted,) if enabled else (declined,))
-    return replace(
-        config,
-        packages=replace(config.packages, applications=(*kept, *chosen)),
-    )
 
 
-def _consent_screen(
-    screen: Screen,
-    config: InstallConfig,
-    context: Context,
-    title: str,
-    summary: str,
-) -> Answer[InstallConfig]:
-    translate = context.translate
-    declined = font_configuration_group(
-        context.groups, FONT_CONFIGURATION_DISABLED
-    )
-    answer = Menu(
-        title=translate(title),
-        preamble=(summary,),
-        items=[
-            Item(label=translate("Yes"), value="yes"),
-            Item(label=translate("No"), value="no"),
-        ],
-        current=("no" if declined in config.packages.applications else "yes"),
-        footer=footer(translate),
-    ).run(screen)
-    if not answer.chosen:
-        return Answer(answer.outcome)
-    edited = _set_font_configuration(
-        config, context.groups, answer.unwrap() == "yes"
-    )
-    return Answer(Outcome.CHOSE, edited)
 
 
-def _input_consent_screen(
-    screen: Screen,
-    config: InstallConfig,
-    context: Context,
-    summary: str,
-) -> Answer[InstallConfig]:
-    translate = context.translate
-    declined = input_configuration_group(
-        context.groups, INPUT_CONFIGURATION_DISABLED
-    )
-    answer = Menu(
-        title=translate("Input method configuration"),
-        preamble=(summary,),
-        items=[
-            Item(label=translate("Yes"), value="yes"),
-            Item(label=translate("No"), value="no"),
-        ],
-        current=(
-            "no" if declined in config.packages.applications else "yes"
-        ),
-        footer=footer(translate),
-    ).run(screen)
-    if not answer.chosen:
-        return Answer(answer.outcome)
-    edited = _set_input_configuration(
-        config, context.groups, answer.unwrap() == "yes"
-    )
-    return Answer(Outcome.CHOSE, edited)
 
 
-def _input_configuration_summary(
-    config: InstallConfig, groups: Groups, framework: str, translate: Catalog
-) -> str:
-    selected = [
-        groups[name]
-        for name in config.packages.applications
-        if name in groups and groups[name].input_method
-    ]
-    engines = ", ".join(group.input_method for group in selected)
-    subject = engines or translate("the selected framework")
-    desktop = groups.get(config.packages.desktop)
-    if (
-        framework == "fcitx"
-        and engines
-        and desktop is not None
-        and desktop.input_method_launcher
-    ):
-        return translate(
-            "Write /etc/xdg/kwinrc and the Fcitx profile for: {engines}."
-        ).format(
-            engines=subject
-        )
-    sources = ", ".join(group.input_source for group in selected if group.input_source)
-    if framework == "ibus" and config.packages.desktop == "gnome" and sources:
-        return translate(
-            "Write /etc/dconf/db/local.d/00-gentoo-install-input-sources with "
-            "IBus engines: {engines}."
-        ).format(engines=sources)
-    if framework == "fcitx":
-        return translate(
-            "Write the Fcitx profile and input environment for: {engines}."
-        ).format(engines=subject)
-    return translate("Write the IBus input environment.")
 
 
-def input_method_screen(
-    screen: Screen, config: InstallConfig, context: Context
-) -> Answer[InstallConfig]:
-    translate = context.translate
-    frameworks = input_framework_groups(context.groups)
-    labels: dict[str, str] = dict(FRAMEWORK_LABELS)
-    framework_items = [Item(label=translate("none"), value="")]
-    framework_items += [
-        Item(
-            label=translate(labels.get(context.groups[name].input_framework, name)),
-            value=name,
-        )
-        for name in frameworks
-    ]
-    framework_answer = Menu(
-        title=translate("Input framework"),
-        items=framework_items,
-        current=_selected_input_framework(config, context.groups),
-        footer=footer(translate),
-    ).run(screen)
-    if not framework_answer.chosen:
-        return Answer(framework_answer.outcome)
-    with_framework = select_input_framework(
-        config, context.groups, framework_answer.unwrap()
-    )
-    framework_group = _selected_input_framework(with_framework, context.groups)
-    if not framework_group:
-        without_configuration = _set_input_configuration(
-            with_framework, context.groups, None
-        )
-        return settle(screen, context, config, without_configuration)
-    framework = context.groups[framework_group].input_framework
-    sections = input_engine_sections(context.groups, framework)
-    names = tuple(name for _, section in sections for name in section)
-    have = {overlay.name for overlay in config.portage.overlays}
-    items = [
-        Item(
-            label=translate(context.groups[name].label or name),
-            value=name,
-            heading=translate(language) if offset == 0 else "",
-            disabled_because=_needs_an_overlay(
-                context.groups[name].repositories, have, translate
-            ),
-        )
-        for language, section in sections
-        for offset, name in enumerate(section)
-    ]
-    selected = set(with_framework.packages.applications) & set(names)
-    engine_answer = MultipleChoiceMenu(
-        title=translate("Input engines"),
-        items=items,
-        selected={
-            index for index, item in enumerate(items) if item.value in selected
-        },
-        footer=footer(translate),
-    ).run(screen)
-    if not engine_answer.chosen:
-        return Answer(engine_answer.outcome)
-    edited = select_input_engines(
-        with_framework, context.groups, tuple(engine_answer.unwrap())
-    )
-    summary = _input_configuration_summary(
-        edited, context.groups, framework, translate
-    )
-    consented = _input_consent_screen(screen, edited, context, summary)
-    if not consented.chosen:
-        return Answer(consented.outcome)
-    return settle(screen, context, config, consented.unwrap())
 
 
-def cjk_fonts_screen(
-    screen: Screen, config: InstallConfig, context: Context
-) -> Answer[InstallConfig]:
-    translate = context.translate
-    sections = font_sections(context.groups)
-    names = tuple(name for _, section in sections for name in section)
-    have = {overlay.name for overlay in config.portage.overlays}
-    items = [
-        Item(
-            label=translate(context.groups[name].label or name),
-            value=name,
-            heading=translate(heading) if offset == 0 else "",
-            preference_group=(
-                FontCategory.selected(context.groups[name].font_category).generic
-                if context.groups[name].font_cjk
-                else ""
-            ),
-            disabled_because=_needs_an_overlay(
-                context.groups[name].repositories, have, translate
-            ),
-        )
-        for heading, section in sections
-        for offset, name in enumerate(section)
-    ]
-    selected = [name for name in config.packages.applications if name in names]
-    preferred = set(preferred_font_groups(config, context.groups))
-    font_menu = MultipleChoiceMenu(
-        title=translate("Fonts"),
-        items=items,
-        tri_state=True,
-        selected={
-            index for index, item in enumerate(items) if item.value in selected
-        },
-        preferred={
-            index for index, item in enumerate(items) if item.value in preferred
-        },
-        footer="  ".join(
-            (
-                f"[-] {translate('installed')}",
-                f"[x] {translate('installed and preferred')}",
-                translate("one preferred per generic"),
-                footer(translate),
-            )
-        ),
-    )
-    font_answer = font_menu.run(screen)
-    if not font_answer.chosen:
-        return Answer(font_answer.outcome)
-    chosen = tuple(font_answer.unwrap())
-    chosen_preferred = tuple(
-        items[index].value for index in sorted(font_menu.preferred)
-    )
-    edited = select_cjk_fonts(config, context.groups, chosen, chosen_preferred)
-    locale = CjkFontconfigLocale.selected(edited.system.locale)
-    if not chosen or locale is None:
-        without_configuration = _set_font_configuration(
-            edited, context.groups, None
-        )
-        return settle(screen, context, config, without_configuration)
-    preferred_sans = next(
-        (
-            name
-            for name in chosen_preferred
-            if FontCategory.selected(context.groups[name].font_category).generic
-            == "sans-serif"
-        ),
-        "",
-    )
-    leading_sans = (
-        locale.resolve(context.groups[preferred_sans].font_family)
-        if preferred_sans
-        else locale.face
-    )
-    summary = translate("Write {path}; {face} will lead sans-serif.").format(
-        path=CJK_SANS_PREFERENCE, face=leading_sans
-    )
-    consented = _consent_screen(
-        screen,
-        edited,
-        context,
-        "Font configuration",
-        summary,
-    )
-    if not consented.chosen:
-        return Answer(consented.outcome)
-    return settle(screen, context, config, consented.unwrap())
 
 
-def packages_screen(
-    screen: Screen, config: InstallConfig, context: Context
-) -> Answer[InstallConfig]:
-    translate = context.translate
-    # A desktop, a driver and a display manager each decide something else as
-    # well, so each has its own screen and none is a row to tick here.
-    elsewhere = (
-        set(desktop_profiles(context.groups, context.profile_paths))
-        | {name for name, _ in GRAPHICS}
-        | {name for name, _ in DISPLAY_MANAGERS}
-        | set(input_method_groups(context.groups))
-        | set(cjk_font_groups(context.groups))
-    )
-    names = sorted(name for name in context.groups if name not in elsewhere)
-    have = {overlay.name for overlay in config.portage.overlays}
-    items = [
-        Item(
-            label=name,
-            value=name,
-            detail=" ".join(context.groups[name].packages)
-            + _adds(
-                config,
-                context,
-                lambda packages, one: replace(
-                    packages, applications=(*packages.applications, one)
-                ),
-                name,
-            ),
-            disabled_because=_needs_an_overlay(context.groups[name].repositories, have, translate),
-        )
-        for name in names
-    ]
-    chosen_already = set(config.packages.applications)
-    while True:
-        menu: MultipleChoiceMenu[str] = MultipleChoiceMenu(
-            title=translate("Applications"),
-            preamble=(translate("These packages supplement the desktop selection."),),
-            items=items,
-            selected={index for index, item in enumerate(items) if item.value in chosen_already},
-            footer=footer(translate),
-        )
-        answer = menu.run(screen)
-        if not answer.chosen:
-            return Answer(answer.outcome)
-        chosen = answer.unwrap()
-        kept = tuple(name for name in config.packages.applications if name in elsewhere)
-        edited = replace(
-            config,
-            packages=replace(config.packages, applications=(*kept, *chosen)),
-        )
-        # Checked here rather than at the Install row: the conflict is between
-        # two ticks on this screen and this is where either can be unticked.
-        clash = framework_conflict(edited, context.groups)
-        if not clash:
-            return settle(screen, context, config, edited)
-        chosen_already = set(chosen)
-        say(screen, context, clash)
 
 
 
@@ -2977,93 +1952,8 @@ def firewall_screen(
 
 
 
-def extra_packages_screen(
-    screen: Screen, config: InstallConfig, context: Context
-) -> Answer[InstallConfig]:
-    """Any atom the operator wants, typed in.
-
-    Only the syntax is checked here. Whether it resolves is a question for the
-    target's repositories, which `VerifyPackages` asks once the tree is synced;
-    the live medium often carries no repository at all.
-    """
-    translate = context.translate
-    while True:
-        typed = TextField(
-            title=translate("Packages to install, separated by spaces"),
-            value=" ".join(config.packages.extra),
-            footer=footer(translate),
-        ).run(screen)
-        if not typed.chosen:
-            return Answer(typed.outcome)
-        good, bad = atoms.split(typed.unwrap())
-        if bad:
-            informed = say(screen, context, f"{translate('Not a package name')}: {' '.join(bad)}")
-            if not informed.chosen:
-                return Answer(informed.outcome)
-            continue
-        return Answer(
-            Outcome.CHOSE, replace(config, packages=replace(config.packages, extra=good))
-        )
 
 
-def _typed_beside_automatic(
-    screen: Screen,
-    context: Context,
-    *,
-    title: str,
-    prompt: str,
-    typed: tuple[str, ...],
-    automatic: tuple[automatic_values.Added, ...],
-    accepts: Callable[[str], tuple[tuple[str, ...], tuple[str, ...]]],
-    rejected: str,
-) -> Answer[tuple[str, ...]]:
-    """One editable list, and under it what the installer adds by itself.
-
-    The automatic rows are drawn disabled with their reason: an operator who
-    can see that `root=` and `rd.luks.uuid=` are already handled stops adding a
-    second copy of them, and one who cannot see it finds them in the installed
-    system with nothing to attribute them to.
-    """
-    translate = context.translate
-    while True:
-        items: list[Item[str]] = [
-            Item(
-                label=prompt,
-                value="edit",
-                detail=" ".join(typed) or translate("none"),
-            )
-        ]
-        items += [
-            Item(
-                label=one.value,
-                value="",
-                disabled_because=translate("added for you"),
-                detail=(
-                    f"{translate(one.because)} ({one.source})"
-                    if one.source
-                    else translate(one.because)
-                ),
-            )
-            for one in automatic
-        ]
-        menu: Menu[str] = Menu(title=title, items=items, footer=footer(translate))
-        answer = menu.run(screen)
-        if not answer.chosen:
-            return Answer(answer.outcome)
-        entered = TextField(
-            title=prompt,
-            value=" ".join(typed),
-            footer=footer(translate),
-        ).run(screen)
-        if not entered.chosen:
-            return Answer(entered.outcome)
-        good, bad = accepts(entered.unwrap())
-        if bad:
-            informed = say(screen, context, f"{rejected}: {' '.join(bad)}")
-            if not informed.chosen:
-                return Answer(informed.outcome)
-            continue
-        return Answer(Outcome.CHOSE, good)
 
 
 def kernel_cmdline_screen(
@@ -3097,62 +1987,8 @@ def kernel_cmdline_screen(
     )
 
 
-def use_flags_screen(
-    screen: Screen, config: InstallConfig, context: Context
-) -> Answer[InstallConfig]:
-    """`USE` in `make.conf`, beside what the chosen groups already ask for.
-
-    A flag typed here is appended after the profile's own, so `-foo` turns off
-    something the profile set. The groups' flags are listed rather than merged
-    into the field: an operator who deletes `wayland` from a field that was
-    pre-filled with it has silently overridden their desktop.
-    """
-    answer = _typed_beside_automatic(
-        screen,
-        context,
-        title=context.translate("USE flags"),
-        prompt=context.translate("Flags to add, separated by spaces"),
-        typed=config.portage.use,
-        automatic=automatic_values.use_flags(config, context.groups),
-        accepts=atoms.split_use_flags,
-        rejected=context.translate("Not a USE flag"),
-    )
-    if not answer.chosen:
-        return Answer(answer.outcome)
-    values = answer.unwrap()
-    _record_operator(context, ValueKind.USE_FLAG, values)
-    return Answer(
-        Outcome.CHOSE, replace(config, portage=replace(config.portage, use=values))
-    )
 
 
-def video_cards_screen(
-    screen: Screen, config: InstallConfig, context: Context
-) -> Answer[InstallConfig]:
-    """`VIDEO_CARDS` on top of what the driver choice contributes.
-
-    A hybrid machine needs more than one: an AMD laptop with an NVIDIA card
-    carries `amdgpu radeonsi nvidia`, and the driver row offers one group. The
-    values are USE_EXPAND flags, so they are checked as flags.
-    """
-    answer = _typed_beside_automatic(
-        screen,
-        context,
-        title=context.translate("VIDEO_CARDS"),
-        prompt=context.translate("Values to add, separated by spaces"),
-        typed=config.portage.video_cards,
-        automatic=automatic_values.video_cards(config, context.groups),
-        accepts=atoms.split_use_flags,
-        rejected=context.translate("Not a VIDEO_CARDS value"),
-    )
-    if not answer.chosen:
-        return Answer(answer.outcome)
-    values = answer.unwrap()
-    _record_operator(context, ValueKind.VIDEO_CARD, values)
-    return Answer(
-        Outcome.CHOSE,
-        replace(config, portage=replace(config.portage, video_cards=values)),
-    )
 
 
 def input_devices_screen(

--- a/gentoo_install/tui/settings.py
+++ b/gentoo_install/tui/settings.py
@@ -43,6 +43,20 @@ from ..model.device import (
 from ..plan import automatic as automatic_values
 from . import screens
 from .mirror import mirror_screen
+from .packages import (
+    cjk_font_groups,
+    cjk_fonts_screen,
+    desktop_screen,
+    display_manager_screen,
+    extra_packages_screen,
+    graphics_screen,
+    input_method_groups,
+    input_method_screen,
+    packages_screen,
+    preferred_font_groups,
+    use_flags_screen,
+    video_cards_screen,
+)
 from .partitions import partitions_screen
 from .context import Context, Step, ValueKind, ValueSource, footer
 from ..i18n import width
@@ -593,8 +607,8 @@ def _display_manager(config: InstallConfig, context: Context) -> str:
 def _applications(config: InstallConfig, context: Context) -> str:
     language_groups = frozenset(
         (
-            *screens.input_method_groups(context.groups),
-            *screens.cjk_font_groups(context.groups),
+            *input_method_groups(context.groups),
+            *cjk_font_groups(context.groups),
             *screens.configuration_groups(context.groups),
         )
     )
@@ -614,17 +628,17 @@ def _input_method(config: InstallConfig, context: Context) -> str:
     selected = [
         context.groups[name].label or name
         for name in config.packages.applications
-        if name in screens.input_method_groups(context.groups)
+        if name in input_method_groups(context.groups)
     ]
     return ", ".join(context.translate(name) for name in selected) or context.translate("none")
 
 
 def _cjk_fonts(config: InstallConfig, context: Context) -> str:
-    offered = screens.cjk_font_groups(context.groups)
+    offered = cjk_font_groups(context.groups)
     selected = [name for name in config.packages.applications if name in offered]
     if not selected:
         return context.translate("none")
-    preferred = set(screens.preferred_font_groups(config, context.groups))
+    preferred = set(preferred_font_groups(config, context.groups))
     shown = []
     for name in selected:
         label = context.translate(context.groups[name].label or name)
@@ -765,7 +779,7 @@ COMPILER: Final[tuple[Setting, ...]] = (
     Setting("cpu_flags", "CPU flags", _cpu_flags, screens.cpu_flags_screen),
     Setting("license", "Licenses", _license, screens.license_screen),
     Setting("keywords", "Package keywords", _keywords, screens.keywords_screen),
-    Setting("use", "USE flags", _use, screens.use_flags_screen),
+    Setting("use", "USE flags", _use, use_flags_screen),
     Setting("ram", "Build in RAM", _build_in_ram, screens.build_in_ram_screen),
 )
 
@@ -794,7 +808,7 @@ KERNEL: Final[tuple[Setting, ...]] = (
 LANGUAGE: Final[tuple[Setting, ...]] = (
     Setting("locale", "System language", lambda c, x: c.system.locale, screens.locale_screen),
     Setting("locales", "Other locales", _other_locales, screens.additional_locales_screen),
-    Setting("fonts", "Fonts", _cjk_fonts, screens.cjk_fonts_screen),
+    Setting("fonts", "Fonts", _cjk_fonts, cjk_fonts_screen),
 )
 
 
@@ -828,18 +842,18 @@ INIT: Final[tuple[Setting, ...]] = (
 DESKTOP: Final[tuple[Setting, ...]] = (
     Setting(
         "desktop", "Desktop", lambda c, x: c.packages.desktop or x.translate("none"),
-        screens.desktop_screen,
+        desktop_screen,
     ),
     Setting(
         "input_method",
         "Input method",
         _input_method,
-        screens.input_method_screen,
+        input_method_screen,
     ),
-    Setting("graphics", "Graphics", _graphics, screens.graphics_screen),
-    Setting("cards", "VIDEO_CARDS", _video_cards, screens.video_cards_screen),
+    Setting("graphics", "Graphics", _graphics, graphics_screen),
+    Setting("cards", "VIDEO_CARDS", _video_cards, video_cards_screen),
     Setting("input", "INPUT_DEVICES", _input_devices, screens.input_devices_screen),
-    Setting("dm", "Display manager", _display_manager, screens.display_manager_screen),
+    Setting("dm", "Display manager", _display_manager, display_manager_screen),
 )
 
 #: How the machine comes up on the network. The address is only read by some of
@@ -916,8 +930,8 @@ SETTINGS: Final[tuple[Setting, ...]] = (
     Setting("kernel", "Kernel", _summary(KERNEL), nested("Kernel", KERNEL), rows=KERNEL),
     Setting("bootloader", "Bootloader", _summary(BOOT), nested("Bootloader", BOOT), rows=BOOT),
     Setting("environment", "Desktop environment", _summary(DESKTOP), nested("Desktop environment", DESKTOP), rows=DESKTOP),
-    Setting("packages", "Applications", _applications, screens.packages_screen),
-    Setting("extra", "Extra packages", _extra, screens.extra_packages_screen),
+    Setting("packages", "Applications", _applications, packages_screen),
+    Setting("extra", "Extra packages", _extra, extra_packages_screen),
     Setting("networking", "Network", _summary(NETWORK), nested("Network", NETWORK), rows=NETWORK),
     Setting("ssh", "SSH", _summary(SSH), nested("SSH", SSH), rows=SSH),
     Setting(

--- a/tests/unit/test_automatic.py
+++ b/tests/unit/test_automatic.py
@@ -26,6 +26,7 @@ from gentoo_install.model.config import (
 from gentoo_install.plan import automatic, bootloader as plan_bootloader, kernel as plan_kernel
 from gentoo_install.tui import context as tui_context
 from gentoo_install.tui import mirror
+from gentoo_install.tui import packages as tui_packages
 from gentoo_install.tui import screens
 from gentoo_install.tui.overview import overview_screen
 from gentoo_install.tui.widgets import Answer, Outcome
@@ -230,7 +231,7 @@ def test_confirming_a_driver_pins_what_it_adds_into_the_configuration() -> None:
     after = replace(before, packages=replace(before.packages, graphics=("nvidia",)))
     # The confirmation opens on `Yes`: declining cancels the choice, and these
     # values are what makes it work rather than extras that come with it.
-    answer = screens.settle(FakeScreen(keys=["\n"], lines=30), at, before, after)
+    answer = tui_packages.settle(FakeScreen(keys=["\n"], lines=30), at, before, after)
     pinned = answer.unwrap()
     assert pinned.portage.video_cards == ("nvidia",)
     assert automatic.video_cards(pinned, at.groups) == ()
@@ -250,7 +251,7 @@ def test_declining_the_side_effects_cancels_the_choice() -> None:
     # choice the operator has already made.
     from tests.unit.test_tui_app import down
 
-    answer = screens.settle(FakeScreen(keys=[*down(1), "\n"], lines=30), at, before, after)
+    answer = tui_packages.settle(FakeScreen(keys=[*down(1), "\n"], lines=30), at, before, after)
     assert answer.unwrap() == before
 
 
@@ -263,7 +264,7 @@ def test_a_choice_that_changes_nothing_asks_nothing() -> None:
     at = context()
     before = config(ext4_on_gpt())
     # No keys at all: FakeScreen raises if the widget asks for one.
-    answer = screens.settle(FakeScreen(keys=[], lines=30), at, before, before)
+    answer = tui_packages.settle(FakeScreen(keys=[], lines=30), at, before, before)
     assert answer.unwrap() == before
 
 
@@ -275,7 +276,7 @@ def test_a_driver_row_says_what_it_will_add_before_it_is_chosen() -> None:
     from tests.unit.test_tui_app import context
 
     drawn = FakeScreen(keys=["q"], lines=30, columns=110)
-    screens.graphics_screen(drawn, config(ext4_on_gpt()), context())
+    tui_packages.graphics_screen(drawn, config(ext4_on_gpt()), context())
     assert "nvidia  proprietary" in drawn.last
     assert "(+nvidia)" in drawn.last
     assert "(+amdgpu radeonsi)" in drawn.last
@@ -292,7 +293,7 @@ def test_a_desktop_row_says_it_brings_wayland() -> None:
     from tests.unit.test_tui_app import context
 
     drawn = FakeScreen(keys=["q"], lines=30, columns=120)
-    screens.desktop_screen(drawn, config(ext4_on_gpt()), context())
+    tui_packages.desktop_screen(drawn, config(ext4_on_gpt()), context())
     assert "plasma  the session only (+wayland qt6 networkmanager)" in drawn.last
     assert "gnome  the session only (+wayland gnome networkmanager gtk)" in drawn.last
 
@@ -332,7 +333,7 @@ def test_the_confirmation_can_open_the_row_the_values_landed_on() -> None:
     before = config(ext4_on_gpt())
     after = replace(before, packages=replace(before.packages, desktop="plasma"))
     # Down twice to "Yes, and open", enter; then backspace out of the USE row.
-    answer = screens.settle(
+    answer = tui_packages.settle(
         FakeScreen(keys=[*down(2), "\n", "KEY_BACKSPACE"], lines=30, columns=110),
         at,
         before,
@@ -354,7 +355,7 @@ def test_cancelling_the_row_it_opened_cancels_the_choice() -> None:
 
     before = config(ext4_on_gpt())
     after = replace(before, packages=replace(before.packages, desktop="plasma"))
-    answer = screens.settle(
+    answer = tui_packages.settle(
         FakeScreen(keys=[*down(2), "\n", "q"], lines=30, columns=110),
         context(),
         before,
@@ -377,7 +378,7 @@ def test_a_profile_only_change_offers_no_row_to_open() -> None:
         before, portage=replace(before.portage, profile="default/linux/amd64/23.0/no-multilib")
     )
     screen = FakeScreen(keys=["\n"], lines=30, columns=110)
-    answer = screens.settle(screen, context(), before, after)
+    answer = tui_packages.settle(screen, context(), before, after)
     assert answer.unwrap().portage.profile.endswith("no-multilib")
     drawn = " ".join(line for frame in screen.frames for line in frame)
     assert "VIDEO_CARDS" not in drawn, drawn
@@ -398,14 +399,14 @@ def test_every_screen_that_picks_a_group_carrying_use_confirms_it() -> None:
     assert carries, "the catalog is meant to have groups that set make.conf"
     picks = {
         "desktop_screen": set(catalog),
-        "graphics_screen": {name for name, _ in screens.GRAPHICS if name},
-        "display_manager_screen": {name for name, _ in screens.DISPLAY_MANAGERS if name},
+        "graphics_screen": {name for name, _ in tui_packages.GRAPHICS if name},
+        "display_manager_screen": {name for name, _ in tui_packages.DISPLAY_MANAGERS if name},
         "packages_screen": set(catalog),
     }
     for name, chooses in picks.items():
         if not (chooses & carries):
             continue
-        source = inspect.getsource(getattr(screens, name))
+        source = inspect.getsource(getattr(tui_packages, name))
         assert "settle(" in source, f"{name} picks a group that sets make.conf and never asks"
 
 

--- a/tests/unit/test_i18n.py
+++ b/tests/unit/test_i18n.py
@@ -107,10 +107,9 @@ def in_a_table() -> set[str]:
     from gentoo_install.model.mirrors import GENTOO_SITES, GENTOOZH_SITES
     from gentoo_install.plan.system import LOGGERS
     from gentoo_install.tui.mirror import BINHOSTS, GENTOOZH_CHANNELS, SYNC_METHODS
+    from gentoo_install.tui.packages import DISPLAY_MANAGERS, GRAPHICS
     from gentoo_install.tui.screens import (
         RAM_SHARES,
-        DISPLAY_MANAGERS,
-        GRAPHICS,
         INSTALL_MODES,
         KERNELS,
         LICENSES,

--- a/tests/unit/test_layers.py
+++ b/tests/unit/test_layers.py
@@ -517,6 +517,33 @@ def test_the_passphrase_minimum_is_one_number() -> None:
     assert written == {"gentoo_install/exec/preflight.py"}, written
 
 
+def test_the_package_screens_reach_nothing_in_the_screen_module() -> None:
+    """`tui/packages.py` is the closure of the seven screens that choose
+    packages. They share one set of helpers — `Effects`, `derive_effects`,
+    `settle` — so no single screen's closure is the module; the union of the
+    seven is, with six names crossing outward and none inward."""
+    tui = PACKAGE / "tui"
+    imported = _imports(ast.parse((tui / "packages.py").read_text()))
+    forbidden = {
+        name
+        for name in imported
+        if name.split(".")[-1] in {"screens", "settings", "partitions"}
+    }
+    assert not forbidden, forbidden
+
+    source = (tui / "screens.py").read_text()
+    crossing = {
+        "_profile_for",
+        "_record_operator",
+        "_set_font_configuration",
+        "_typed_beside_automatic",
+        "font_configuration_group",
+        "input_configuration_group",
+    }
+    for name in crossing:
+        assert re.search(rf"from \.packages import \([^)]*\b{name}\b", source, re.S), name
+
+
 def test_the_disk_screens_reach_nothing_in_the_screen_module() -> None:
     """`tui/partitions.py` is the closure of `partitions_screen`: everything
     it reaches and nothing else. `screens.py` reaches four of those names and

--- a/tests/unit/test_tui_app.py
+++ b/tests/unit/test_tui_app.py
@@ -31,6 +31,7 @@ from gentoo_install.model.validate import validate
 from gentoo_install.model import compat
 from gentoo_install.tui import app, widgets, screens, settings
 from gentoo_install.tui import context as tui_context
+from gentoo_install.tui import packages as tui_packages
 from gentoo_install.tui import partitions
 from gentoo_install.tui import mirror
 from gentoo_install.tui.app import run
@@ -297,7 +298,7 @@ def test_firewall_dialog_leaving_does_not_commit(leaving: str) -> None:
 
 
 def test_invalid_extra_package_dialog_cancellation_reaches_caller() -> None:
-    answer = screens.extra_packages_screen(
+    answer = tui_packages.extra_packages_screen(
         FakeScreen(keys=[*"bad!", "\n", "q"]), config(), context()
     )
     assert answer.outcome is Outcome.CANCELLED
@@ -982,22 +983,22 @@ def test_a_chinese_system_locale_selects_no_input_method_or_font_group() -> None
     ).unwrap()
     assert chosen.system.locale == "zh_CN.UTF-8"
     language_packages = {
-        *screens.input_method_groups(context().groups),
-        *screens.cjk_font_groups(context().groups),
+        *tui_packages.input_method_groups(context().groups),
+        *tui_packages.cjk_font_groups(context().groups),
     }
     assert not language_packages.intersection(chosen.packages.applications)
 
 
 def test_an_input_engine_cannot_be_selected_without_its_framework() -> None:
     with pytest.raises(ConfigError, match="framework"):
-        screens.select_input_engines(config(), context().groups, ("pinyin",))
+        tui_packages.select_input_engines(config(), context().groups, ("pinyin",))
 
 
 def test_switching_input_framework_clears_the_previous_engines() -> None:
     groups = context().groups
-    fcitx = screens.select_input_framework(config(), groups, "fcitx5")
-    with_pinyin = screens.select_input_engines(fcitx, groups, ("pinyin",))
-    switched = screens.select_input_framework(with_pinyin, groups, "ibus")
+    fcitx = tui_packages.select_input_framework(config(), groups, "fcitx5")
+    with_pinyin = tui_packages.select_input_engines(fcitx, groups, ("pinyin",))
+    switched = tui_packages.select_input_framework(with_pinyin, groups, "ibus")
     assert "pinyin" not in switched.packages.applications
     assert "fcitx5" not in switched.packages.applications
     assert "ibus" in switched.packages.applications
@@ -1015,10 +1016,10 @@ def test_the_language_section_names_fonts_as_part_of_its_subject() -> None:
 
 
 def test_the_preferred_cjk_font_is_stored_before_the_other_fonts() -> None:
-    chosen = screens.select_cjk_fonts(
+    chosen = tui_packages.select_cjk_fonts(
         config(), context().groups, ("noto-cjk", "sarasa-mono"), ("sarasa-mono",)
     )
-    fonts = screens.cjk_font_groups(context().groups)
+    fonts = tui_packages.cjk_font_groups(context().groups)
     selected = tuple(
         name for name in chosen.packages.applications if name in fonts
     )
@@ -1027,8 +1028,8 @@ def test_the_preferred_cjk_font_is_stored_before_the_other_fonts() -> None:
 
 def test_engines_and_fonts_are_grouped_by_declared_metadata() -> None:
     groups = context().groups
-    engine_sections = dict(screens.input_engine_sections(groups, "fcitx"))
-    font_sections = dict(screens.font_sections(groups))
+    engine_sections = dict(tui_packages.input_engine_sections(groups, "fcitx"))
+    font_sections = dict(tui_packages.font_sections(groups))
 
     assert "pinyin" in engine_sections["Chinese"]
     assert "anthy" in engine_sections["Japanese"]
@@ -1047,7 +1048,7 @@ def test_engines_and_fonts_are_grouped_by_declared_metadata() -> None:
 def test_font_and_engine_rows_use_names_instead_of_slugs_and_packages() -> None:
     at = context()
     engine_screen = FakeScreen(keys=["KEY_DOWN", "\n", "q"], lines=35, columns=100)
-    screens.input_method_screen(engine_screen, config(), at)
+    tui_packages.input_method_screen(engine_screen, config(), at)
     engines = "\n".join("\n".join(frame) for frame in engine_screen.frames)
     assert "Chinese" in engines
     assert "Japanese" in engines
@@ -1055,7 +1056,7 @@ def test_font_and_engine_rows_use_names_instead_of_slugs_and_packages() -> None:
     assert "app-i18n/fcitx-rime" not in engines
 
     font_screen = FakeScreen(keys=["q"], lines=35, columns=100)
-    screens.cjk_fonts_screen(font_screen, config(), at)
+    tui_packages.cjk_fonts_screen(font_screen, config(), at)
     fonts = font_screen.last
     assert "Sans" in fonts
     assert "Kai" in fonts
@@ -1079,7 +1080,7 @@ def test_plasma_with_fcitx_and_ibus_describe_different_configuration() -> None:
             ),
         )
         at = context()
-        summary = screens._input_configuration_summary(
+        summary = tui_packages._input_configuration_summary(
             chosen, at.groups, at.groups[framework].input_framework, at.translate
         )
         return summary
@@ -1108,7 +1109,7 @@ def test_more_than_one_driver_can_be_ticked_and_not_in_the_application_list() ->
     # Rows: intel, amdgpu, radeon, nouveau, nvidia, virtual-machine. Down to
     # amdgpu and tick, down to nvidia and tick, enter, then the confirmation,
     # which opens on `Yes`.
-    answer = screens.graphics_screen(
+    answer = tui_packages.graphics_screen(
         FakeScreen(keys=[*down(1), " ", *down(3), " ", "\n", "\n"], lines=30),
         config(),
         at,
@@ -1117,8 +1118,8 @@ def test_more_than_one_driver_can_be_ticked_and_not_in_the_application_list() ->
     assert chosen.packages.graphics == ("amdgpu", "nvidia")
     assert chosen.portage.video_cards == ("amdgpu", "radeonsi", "nvidia")
     offered = FakeScreen(keys=["q"], lines=30, columns=100)
-    screens.packages_screen(offered, config(), at)
-    for name, _ in screens.GRAPHICS:
+    tui_packages.packages_screen(offered, config(), at)
+    for name, _ in tui_packages.GRAPHICS:
         if name:
             assert f"  {name} " not in offered.last, name
 
@@ -1136,7 +1137,7 @@ def test_a_desktop_no_longer_picks_the_login_screen_for_the_operator() -> None:
     chosen = replace(config(), packages=replace(config().packages, desktop="plasma"))
     # sddm carries USE=sddm, so the choice confirms before it is taken, and
     # the confirmation opens on `Yes`.
-    answer = screens.display_manager_screen(
+    answer = tui_packages.display_manager_screen(
         FakeScreen(keys=["KEY_DOWN", "\n", "\n"]), chosen, at
     )
     assert answer.unwrap().packages.display_manager == "sddm"
@@ -1146,7 +1147,7 @@ def test_a_desktop_no_longer_picks_the_login_screen_for_the_operator() -> None:
 def test_a_login_screen_is_not_offered_without_a_desktop_to_start() -> None:
     at = context()
     screen = FakeScreen(keys=["q"], lines=24, columns=100)
-    screens.display_manager_screen(screen, config(), at)
+    tui_packages.display_manager_screen(screen, config(), at)
     drawn = "\n".join(screen.frames[0])
     assert "sddm  the one Plasma expects (+sddm) - choose a desktop first" in drawn
     # `none` stays selectable: it is the answer that needs no desktop.
@@ -1408,16 +1409,16 @@ def test_effects_are_derived_once_for_preview_and_pinning() -> None:
     before = config()
     after = replace(before, packages=replace(before.packages, graphics=("nvidia",)))
 
-    effects = screens.derive_effects(before, after, at)
+    effects = tui_packages.derive_effects(before, after, at)
 
     assert effects.video_cards == ("nvidia",)
     assert effects.use_flags == ()
     assert effects.user_groups == ()
     assert effects.display_manager_changed is False
-    assert effects.editable_row is screens.video_cards_screen
+    assert effects.editable_row is tui_packages.video_cards_screen
 
     typed = replace(after, portage=replace(after.portage, use=("operator_flag",)))
-    pinned = screens.apply_effects(typed, effects)
+    pinned = tui_packages.apply_effects(typed, effects)
     assert pinned.portage.use == ("operator_flag",)
     assert pinned.portage.video_cards == ("nvidia",)
 
@@ -1436,8 +1437,8 @@ def test_effects_withdraw_only_the_previous_derived_values() -> None:
     )
     after = replace(before, packages=replace(before.packages, graphics=("amdgpu",)))
 
-    effects = screens.derive_effects(before, after, at)
-    pinned = screens.apply_effects(after, effects)
+    effects = tui_packages.derive_effects(before, after, at)
+    pinned = tui_packages.apply_effects(after, effects)
 
     assert pinned.portage.use == ("operator_flag", "wayland")
     assert pinned.portage.video_cards == ("operator_card", "amdgpu", "radeonsi")
@@ -1451,7 +1452,7 @@ def test_what_still_asks_before_it_changes() -> None:
     # Every module that draws a screen, not one of them: the disk screens moved
     # to `tui/partitions.py` and four of these nine titles went with them.
     source = "".join(
-        inspect.getsource(one) for one in (screens, partitions, mirror)
+        inspect.getsource(one) for one in (screens, partitions, mirror, tui_packages)
     ) + inspect.getsource(overview_screen)
     asked = {
         "This erases every partition on the disk.",
@@ -1650,7 +1651,7 @@ def test_a_profile_the_operator_picked_survives_choosing_a_desktop() -> None:
         # on `Yes`.
         return [*down(4), "\n", "\n"]
 
-    fresh = screens.desktop_screen(FakeScreen(keys=plasma(), lines=30), config(), at).unwrap()
+    fresh = tui_packages.desktop_screen(FakeScreen(keys=plasma(), lines=30), config(), at).unwrap()
     assert fresh.packages.desktop == "plasma"
     assert fresh.portage.profile.endswith("desktop/plasma/systemd")
 
@@ -1658,7 +1659,7 @@ def test_a_profile_the_operator_picked_survives_choosing_a_desktop() -> None:
         config(),
         portage=replace(config().portage, profile="default/linux/amd64/23.0/no-multilib/systemd"),
     )
-    kept = screens.desktop_screen(FakeScreen(keys=plasma(), lines=30), chosen, at).unwrap()
+    kept = tui_packages.desktop_screen(FakeScreen(keys=plasma(), lines=30), chosen, at).unwrap()
     assert kept.packages.desktop == "plasma"
     assert kept.portage.profile == "default/linux/amd64/23.0/no-multilib/systemd"
 
@@ -1784,11 +1785,11 @@ def test_the_desktops_offered_are_the_ones_with_a_profile_file() -> None:
 
     from gentoo_install import data
 
-    offered = screens.desktop_profiles(at.groups)
+    offered = tui_packages.desktop_profiles(at.groups)
     shipped = {path.stem for path in (Path(data.__file__).parent / "data/profiles").glob("*.toml")}
     # One row per file, plus the machine with no desktop at all.
     assert set(offered) == {"", *shipped}
-    assert offered[""] == screens.BASE_PROFILE
+    assert offered[""] == tui_packages.BASE_PROFILE
     # Every desktop the menu shows can be built: the profile comes from its file.
     for name, path in offered.items():
         assert path.startswith("default/linux/amd64/23.0"), name
@@ -2255,7 +2256,7 @@ def test_an_overlay_only_application_cannot_be_ticked_without_its_overlay() -> N
     plain = config()
     assert not plain.portage.overlays
     screen = FakeScreen(keys=["q"], lines=40, columns=110)
-    screens.packages_screen(screen, plain, at)
+    tui_packages.packages_screen(screen, plain, at)
     drawn = "\n".join(screen.frames[0])
     assert "wechat" in drawn
     assert "needs the overlay gentoo-zh" in drawn
@@ -2360,7 +2361,7 @@ def test_changing_desktop_withdraws_input_configuration_consent() -> None:
     at = context()
     groups = screens.configuration_groups(at.groups)
     wanted = replace(config(), packages=replace(config().packages, desktop="plasma", applications=(*groups,)))
-    answer = screens.desktop_screen(FakeScreen(keys=["KEY_UP", "\n", "\n"], lines=30), wanted, at)
+    answer = tui_packages.desktop_screen(FakeScreen(keys=["KEY_UP", "\n", "\n"], lines=30), wanted, at)
     applications = answer.unwrap().packages.applications
     assert groups[2] not in applications and groups[3] not in applications
 
@@ -2925,7 +2926,7 @@ def test_the_values_a_choice_brings_are_accepted_by_pressing_enter() -> None:
     # Down to plasma, enter, then enter again on the confirmation without
     # navigating: the answer that takes the choice is the one under the cursor.
     keys = [*down(4), "\n", "\n"]
-    answer = screens.desktop_screen(FakeScreen(keys=keys, lines=30), config(), at)
+    answer = tui_packages.desktop_screen(FakeScreen(keys=keys, lines=30), config(), at)
 
     assert answer.unwrap().packages.desktop == "plasma"
     assert answer.unwrap().portage.profile.endswith("desktop/plasma/systemd")
@@ -2942,7 +2943,7 @@ def test_a_desktop_proposes_its_login_screen_and_a_network_manager() -> None:
 
     at = context()
     keys = [*down(4), "\n", "\n"]  # plasma, then accept what it brings
-    answer = screens.desktop_screen(FakeScreen(keys=keys, lines=30), config(), at)
+    answer = tui_packages.desktop_screen(FakeScreen(keys=keys, lines=30), config(), at)
     chosen = answer.unwrap()
     assert chosen.packages.desktop == "plasma"
     assert chosen.packages.display_manager == "sddm"
@@ -2952,7 +2953,7 @@ def test_a_desktop_proposes_its_login_screen_and_a_network_manager() -> None:
     picked = replace(
         config(), packages=replace(config().packages, display_manager="greetd")
     )
-    kept = screens.desktop_screen(
+    kept = tui_packages.desktop_screen(
         FakeScreen(keys=[*down(4), "\n", "\n"], lines=30), picked, context()
     ).unwrap()
     assert kept.packages.display_manager == "greetd"
@@ -2962,7 +2963,7 @@ def test_a_desktop_withdraws_derived_networking_but_keeps_an_operator_choice() -
     from gentoo_install.model.config import Networking
 
     at = context()
-    plasma = screens.desktop_screen(
+    plasma = tui_packages.desktop_screen(
         FakeScreen(keys=[*down(4), "\n", "\n"], lines=30), config(), at
     ).unwrap()
     assert plasma.system.networking is Networking.NETWORKMANAGER_WPA
@@ -2972,7 +2973,7 @@ def test_a_desktop_withdraws_derived_networking_but_keeps_an_operator_choice() -
         FakeScreen(keys=["KEY_UP", "\n"], lines=30), config(), explicit_at
     ).unwrap()
     assert explicit.system.networking is Networking.BUILTIN
-    kept = screens.desktop_screen(
+    kept = tui_packages.desktop_screen(
         FakeScreen(keys=[*down(4), "\n", "\n"], lines=30), explicit, explicit_at
     ).unwrap()
     assert kept.system.networking is Networking.BUILTIN
@@ -2980,24 +2981,24 @@ def test_a_desktop_withdraws_derived_networking_but_keeps_an_operator_choice() -
 
 def test_a_proposed_display_manager_is_withdrawn_but_an_operator_choice_is_kept() -> None:
     at = context()
-    plasma = screens.desktop_screen(
+    plasma = tui_packages.desktop_screen(
         FakeScreen(keys=[*down(4), "\n", "\n"], lines=30), config(), at
     ).unwrap()
     assert "proposed" in settings._display_manager(plasma, at)
 
-    gnome = screens.desktop_screen(
+    gnome = tui_packages.desktop_screen(
         FakeScreen(keys=["KEY_UP", "KEY_UP", "\n", "\n"], lines=30), plasma, at
     ).unwrap()
     assert gnome.packages.display_manager == "gdm"
     assert "sddm" not in gnome.portage.use
 
     explicit_at = context()
-    proposed = screens.desktop_screen(
+    proposed = tui_packages.desktop_screen(
         FakeScreen(keys=[*down(4), "\n", "\n"], lines=30),
         config(),
         explicit_at,
     ).unwrap()
-    explicit = screens.display_manager_screen(
+    explicit = tui_packages.display_manager_screen(
         FakeScreen(keys=["\n"], lines=30), proposed, explicit_at
     ).unwrap()
     assert "proposed" not in settings._display_manager(explicit, explicit_at)
@@ -3005,7 +3006,7 @@ def test_a_proposed_display_manager_is_withdrawn_but_an_operator_choice_is_kept(
     kept_screen = FakeScreen(
         keys=["KEY_UP", "KEY_UP", "\n", "\n"], lines=30, columns=100
     )
-    kept = screens.desktop_screen(kept_screen, explicit, explicit_at).unwrap()
+    kept = tui_packages.desktop_screen(kept_screen, explicit, explicit_at).unwrap()
     assert kept.packages.display_manager == "sddm"
     assert "Display manager: sddm (kept)" in "\n".join(
         "\n".join(frame) for frame in kept_screen.frames
@@ -3016,7 +3017,7 @@ def test_what_a_desktop_brings_is_listed_in_one_place() -> None:
     """Every place the choice reaches, on the screen that asks about it."""
     at = context()
     screen = FakeScreen(keys=[*down(4), "\n", "q"], lines=30, columns=120)
-    screens.desktop_screen(screen, config(), at)
+    tui_packages.desktop_screen(screen, config(), at)
     listed = "\n".join(screen.frames[-1])
     for named in ("Display manager", "sddm", "Network", "networkmanager", "Profile"):
         assert named in listed, f"{named} is not on the confirmation: {listed}"
@@ -3028,13 +3029,13 @@ def test_switching_desktops_takes_the_last_one_s_use_flags_with_it() -> None:
     `portage.use` and nothing was ever taken out, so Qt and SDDM followed an
     operator onto a GNOME desktop that has no use for either."""
     at = context()
-    plasma = screens.desktop_screen(
+    plasma = tui_packages.desktop_screen(
         FakeScreen(keys=[*down(4), "\n", "\n"], lines=30), config(), at
     ).unwrap()
     assert "qt6" in plasma.portage.use and "sddm" in plasma.portage.use
 
     # The cursor opens on what is set, so gnome is two rows up from plasma.
-    swapped = screens.desktop_screen(
+    swapped = tui_packages.desktop_screen(
         FakeScreen(keys=["KEY_UP", "KEY_UP", "\n", "\n"], lines=30), plasma, at
     ).unwrap()
     assert swapped.packages.desktop == "gnome"
@@ -3044,7 +3045,7 @@ def test_switching_desktops_takes_the_last_one_s_use_flags_with_it() -> None:
 
     # What the operator typed is not derivable and stays.
     typed = replace(plasma, portage=replace(plasma.portage, use=(*plasma.portage.use, "lto")))
-    after = screens.desktop_screen(
+    after = tui_packages.desktop_screen(
         FakeScreen(keys=["KEY_UP", "KEY_UP", "\n", "\n"], lines=30), typed, at
     ).unwrap()
     assert "lto" in after.portage.use
@@ -3052,14 +3053,14 @@ def test_switching_desktops_takes_the_last_one_s_use_flags_with_it() -> None:
 
 def test_an_operator_use_flag_survives_the_desktop_that_derived_the_same_flag() -> None:
     at = context()
-    plasma = screens.desktop_screen(
+    plasma = tui_packages.desktop_screen(
         FakeScreen(keys=[*down(4), "\n", "\n"], lines=30), config(), at
     ).unwrap()
-    explicit = screens.use_flags_screen(
+    explicit = tui_packages.use_flags_screen(
         FakeScreen(keys=["\n", "\n"], lines=30), plasma, at
     ).unwrap()
     assert "qt6" in explicit.portage.use
-    swapped = screens.desktop_screen(
+    swapped = tui_packages.desktop_screen(
         FakeScreen(keys=["KEY_UP", "KEY_UP", "\n", "\n"], lines=30), explicit, at
     ).unwrap()
     assert "qt6" in swapped.portage.use


### PR DESCRIPTION
The same computation as `tui/partitions.py`, applied to what is left. No single package screen's closure is a module — `desktop_screen`, `graphics_screen`, `display_manager_screen`, `packages_screen`, `cjk_fonts_screen`, `input_method_screen` and `extra_packages_screen` all share `Effects`, `derive_effects`, `settle` and the operator-choice helpers, so each closure alone leaves seven to nine names crossing. The union of the seven is the module: **49 definitions, 1158 lines, six names crossing outward and none inward.**

`screens.py` is 2653 lines, from 5457 this morning.

The test holds the direction and requires each of the six crossings to be imported from there. Controls: an import of `screens` from the new module, and a crossing name used without importing it.

The dead-import rule caught six more imports the move stranded, which is what it was added for.