### PR TITLE
docs: record five passes from two rounds

### DIFF
--- a/TESTED.md
+++ b/TESTED.md
@@ -49,6 +49,8 @@ The ordinary path: partition, format, unpack a stage3, configure, boot.
 | `74ba411eaea9` | `vm-lvm`, `vm-unlock` |
 | `cc84e970ddba` | `vm-cjk-kernel`, `vm-binpkg`, `zfs-zbm`, `vm-gnome`, `ext3` |
 | `8dbfc12f35e0` | `ext4-bios`, `vm-xfs`, `vm-lvm`, `vm-f2fs`, `vm-btrfs` — five of six. `vm-xfs` is the first record since a UEFI guest whose console delivered nothing gets a second boot, which is what ended its previous round at 2.2 minutes; `zbm-unlock` lost its initramfs address to a lease that expired under a live guest, which `52b373dca9a2` addresses |
+| `6739b3abf2db` | `vm-zram`, `static-ip`, `vm-mdraid` |
+| `52b373dca9a2` | `vm-binpkg`, `openrc-sdboot` |
 
 Every row from `08015b221d73` onward ran `--region cn --site nju --sync
 webrsync --distfiles http://10.31.0.2/gentoo`, so what they establish about


### PR DESCRIPTION
`vm-zram`, `static-ip` and `vm-mdraid` at `52b373dca9a2`; `vm-binpkg` and `openrc-sdboot` at `08f0db479bdd`. Each revision comes from the guest's own first log line.