### PR TITLE
packages: accept a group's licence for its own atoms

### DIFF
--- a/gentoo_install/data/locale/ja.toml
+++ b/gentoo_install/data/locale/ja.toml
@@ -234,7 +234,7 @@
 "GCN 1.2 and newer" = "GCN 1.2 以降"
 "AMD up to Sea Islands" = "Sea Islands までの AMD"
 "the in-kernel NVIDIA driver" = "カーネル内蔵の NVIDIA ドライバ"
-"proprietary, widens ACCEPT_LICENSE, and blacklists nouveau itself" = "プロプライエタリ。ACCEPT_LICENSE を広げ、nouveau は自身で無効化します"
+"proprietary, accepts its own licence for its own packages, and blacklists nouveau itself" = "プロプライエタリ。自身のパッケージにのみライセンスを受け入れ、nouveau は自身で無効化します"
 "virtio-gpu, QXL and VMware, with fbdev left as the fallback" = "virtio-gpu、QXL、VMware。フォールバックとして fbdev を残します"
 "a text console login" = "テキストコンソールのログイン"
 "the one Plasma expects" = "Plasma が想定するもの"

--- a/gentoo_install/data/locale/ko.toml
+++ b/gentoo_install/data/locale/ko.toml
@@ -234,7 +234,7 @@
 "GCN 1.2 and newer" = "GCN 1.2 이후"
 "AMD up to Sea Islands" = "Sea Islands 및 그 이전 세대의 AMD"
 "the in-kernel NVIDIA driver" = "커널 내장 NVIDIA 드라이버"
-"proprietary, widens ACCEPT_LICENSE, and blacklists nouveau itself" = "독점 드라이버. ACCEPT_LICENSE 를 넓히고 nouveau 를 스스로 차단합니다"
+"proprietary, accepts its own licence for its own packages, and blacklists nouveau itself" = "독점 드라이버. 자신의 패키지에만 라이선스를 허용하고 nouveau 를 스스로 차단합니다"
 "virtio-gpu, QXL and VMware, with fbdev left as the fallback" = "virtio-gpu, QXL, VMware. 대체 수단으로 fbdev 를 남깁니다"
 "a text console login" = "텍스트 콘솔 로그인"
 "the one Plasma expects" = "Plasma 가 기대하는 것"

--- a/gentoo_install/data/locale/zh-CN.toml
+++ b/gentoo_install/data/locale/zh-CN.toml
@@ -234,7 +234,7 @@
 "GCN 1.2 and newer" = "GCN 1.2 及更新版本"
 "AMD up to Sea Islands" = "Sea Islands 及更早的 AMD GPU"
 "the in-kernel NVIDIA driver" = "内核内建的 NVIDIA 驱动"
-"proprietary, widens ACCEPT_LICENSE, and blacklists nouveau itself" = "专有驱动，会放宽 ACCEPT_LICENSE，并自动停用 nouveau"
+"proprietary, accepts its own licence for its own packages, and blacklists nouveau itself" = "专有驱动，只对自己那几个软件包接受许可，并自动停用 nouveau"
 "virtio-gpu, QXL and VMware, with fbdev left as the fallback" = "virtio-gpu、QXL 与 VMware，并保留 fbdev 作为后备方案"
 "a text console login" = "文本控制台登录"
 "the one Plasma expects" = "Plasma 默认搭配"

--- a/gentoo_install/data/locale/zh-TW.toml
+++ b/gentoo_install/data/locale/zh-TW.toml
@@ -234,7 +234,7 @@
 "GCN 1.2 and newer" = "GCN 1.2 及更新版本"
 "AMD up to Sea Islands" = "Sea Islands 及更早的 AMD GPU"
 "the in-kernel NVIDIA driver" = "核心內建的 NVIDIA 驅動"
-"proprietary, widens ACCEPT_LICENSE, and blacklists nouveau itself" = "專有驅動，會放寬 ACCEPT_LICENSE，並自動停用 nouveau"
+"proprietary, accepts its own licence for its own packages, and blacklists nouveau itself" = "專有驅動，只對自己那幾個套件接受授權，並自動停用 nouveau"
 "virtio-gpu, QXL and VMware, with fbdev left as the fallback" = "virtio-gpu、QXL 與 VMware，並保留 fbdev 作為後備方案"
 "a text console login" = "文字主控台登入"
 "the one Plasma expects" = "Plasma 預設搭配"

--- a/gentoo_install/plan/build.py
+++ b/gentoo_install/plan/build.py
@@ -117,7 +117,6 @@ def build(
             stage3_mirror(config, mirror),
             packages._required_use(chosen),
             packages._required_video_cards(config, chosen),
-            packages._required_licenses(config, chosen),
         ),
         *system.build(config),
         *kernel.build(config),
@@ -189,7 +188,6 @@ def _in_place(
             stage3_mirror(derived, mirror),
             packages._required_use(chosen),
             packages._required_video_cards(derived, chosen),
-            packages._required_licenses(derived, chosen),
         ),
         *system.build(derived),
         # After `WriteFstab`, which is in the same stage and earlier in this

--- a/gentoo_install/plan/packages.py
+++ b/gentoo_install/plan/packages.py
@@ -445,6 +445,28 @@ class WriteGroupKeywords(WritePortageConfig):
         return f"accept {'; '.join(self.lines)} for the {self.group} group"
 
 @dataclass(frozen=True, kw_only=True, init=False)
+class WriteGroupLicense(WritePortageConfig):
+    """Accept a group's licences for that group's own atoms.
+
+    Merged into `ACCEPT_LICENSE` the acceptance held for every later emerge on
+    the installed machine, which is not what choosing one chat program asks
+    for.
+    """
+
+    def __init__(self, *, group: str, lines: tuple[str, ...]) -> None:
+        object.__setattr__(self, "kind", PortageConfigKind.LICENSE)
+        object.__setattr__(self, "name", group)
+        object.__setattr__(self, "lines", lines)
+
+    @property
+    def group(self) -> str:
+        return self.name
+
+    def describe(self) -> str:
+        return f"accept {'; '.join(self.lines)} for the {self.group} group"
+
+
+@dataclass(frozen=True, kw_only=True, init=False)
 class WriteGroupUse(WritePortageConfig):
     """Written in the portage phase: the flags have to be set before the
     packages that need them are merged."""
@@ -899,6 +921,10 @@ def _operations(
             operations.append(
                 WriteGroupKeywords(group=group.name, lines=group.accept_keywords)
             )
+        if group.accept_license:
+            operations.append(
+                WriteGroupLicense(group=group.name, lines=_licence_lines(group))
+            )
         if group.user_services and config.system.init is InitSystem.SYSTEMD:
             operations.append(
                 EnableUserUnits(group=group.name, units=group.user_services)
@@ -1155,18 +1181,10 @@ def _display_manager(name: str, packages: Sequence[str], init: InitSystem) -> li
     ]
 
 
-def required_licenses(config: InstallConfig, catalog: Catalog) -> tuple[str, ...]:
-    return _required_licenses(config, groups(config, catalog))
-
-
-def _required_licenses(config: InstallConfig, chosen: Sequence[Group]) -> tuple[str, ...]:
-    """What the configuration accepts, widened by what a chosen group needs."""
-    wanted = list(config.portage.accept_license)
-    for group in chosen:
-        for licence in group.accept_license:
-            if licence not in wanted:
-                wanted.append(licence)
-    return tuple(wanted)
+def _licence_lines(group: Group) -> tuple[str, ...]:
+    """One `package.license` line per atom the group installs."""
+    accepted = " ".join(group.accept_license)
+    return tuple(f"{atom} {accepted}" for atom in group.packages)
 
 
 def _known(catalog: Catalog) -> str:

--- a/gentoo_install/plan/portage.py
+++ b/gentoo_install/plan/portage.py
@@ -1325,7 +1325,6 @@ def build(
     mirror: str,
     use: tuple[str, ...] = (),
     video_cards: tuple[str, ...] = (),
-    licenses: tuple[str, ...] = (),
 ) -> list[Operation]:
     portage = config.portage
     gentoo = PurePosixPath("/var/db/repos/gentoo")
@@ -1341,7 +1340,7 @@ def build(
     ]
     operations += [
         WriteMakeConf(
-            settings=make_conf(config, use, video_cards, licenses),
+            settings=make_conf(config, use, video_cards),
             mirrors=_distfiles(portage),
             speed_test=portage.mirrors.speed_test,
             appended=_appended_distfiles(portage),
@@ -1487,7 +1486,6 @@ def make_conf(
     config: InstallConfig,
     use: tuple[str, ...] = (),
     video_cards: tuple[str, ...] = (),
-    licenses: tuple[str, ...] = (),
 ) -> tuple[tuple[str, str], ...]:
     """Everything but `GENTOO_MIRRORS`, which is settled when the operation runs.
 
@@ -1519,7 +1517,7 @@ def make_conf(
     if portage.input_devices:
         settings.append(("INPUT_DEVICES", " ".join(portage.input_devices)))
     settings += [
-        ("ACCEPT_LICENSE", " ".join(licenses or portage.accept_license)),
+        ("ACCEPT_LICENSE", " ".join(portage.accept_license)),
         ("L10N", " ".join(_l10n(config))),
     ]
     # Only when a proxy is configured: `emerge-webrsync` runs `FETCHCOMMAND`

--- a/gentoo_install/tui/packages.py
+++ b/gentoo_install/tui/packages.py
@@ -478,7 +478,7 @@ GRAPHICS: tuple[tuple[str, str], ...] = (
     ("amdgpu", "GCN 1.2 and newer"),
     ("radeon", "AMD up to Sea Islands"),
     ("nouveau", "the in-kernel NVIDIA driver"),
-    ("nvidia", "proprietary, widens ACCEPT_LICENSE, and blacklists nouveau itself"),
+    ("nvidia", "proprietary, accepts its own licence for its own packages, and blacklists nouveau itself"),
     ("virtual-machine", "virtio-gpu, QXL and VMware, with fbdev left as the fallback"),
 )
 #: The display managers. A desktop no longer names one, because which login

--- a/tests/unit/test_automatic.py
+++ b/tests/unit/test_automatic.py
@@ -318,7 +318,7 @@ def test_input_devices_is_never_left_empty_by_default() -> None:
     so a machine installed with the row untouched would have no pointer."""
     from gentoo_install.plan.portage import make_conf
 
-    written = dict(make_conf(config(ext4_on_gpt()), (), (), ()))
+    written = dict(make_conf(config(ext4_on_gpt()), (), ()))
     assert written["INPUT_DEVICES"] == "libinput"
 
 

--- a/tests/unit/test_plan.py
+++ b/tests/unit/test_plan.py
@@ -262,10 +262,14 @@ def test_a_driver_group_adds_its_video_cards_and_writes_no_file() -> None:
     # ours would have set `modeset=1`, which 595.84 removed from that file
     # because the driver now defaults to it.
     assert written == []
-    assert plan_packages.required_licenses(wanted, catalog) == (
-        "@FREE",
-        "@BINARY-REDISTRIBUTABLE",
-    )
+    accepted = [
+        operation
+        for operation in plan_packages.build(wanted, catalog)
+        if isinstance(operation, plan_packages.WriteGroupLicense)
+    ]
+    assert [one.lines for one in accepted] == [
+        ("x11-drivers/nvidia-drivers @BINARY-REDISTRIBUTABLE",)
+    ]
 
 
 def test_an_input_method_group_configures_fcitx_for_every_user() -> None:

--- a/tests/unit/test_tui_app.py
+++ b/tests/unit/test_tui_app.py
@@ -1155,15 +1155,31 @@ def test_a_login_screen_is_not_offered_without_a_desktop_to_start() -> None:
     assert "console login - choose" not in drawn
 
 
-def test_the_proprietary_driver_widens_the_licences_it_needs() -> None:
+def test_the_proprietary_driver_accepts_its_licence_for_its_own_atoms() -> None:
     """NVIDIA-2025 is in @BINARY-REDISTRIBUTABLE, so the default @FREE refuses
-    it and the emerge dies an hour into the install."""
+    it and the emerge dies an hour into the install. Accepting it in
+    `ACCEPT_LICENSE` would accept it for every later emerge as well, which
+    choosing a graphics driver does not ask for.
+    """
     from gentoo_install.plan import packages as plan_packages
+    from gentoo_install.plan.portage import make_conf
 
+    catalog = load_catalog()
     chosen = replace(config(), packages=replace(config().packages, graphics=("nvidia",)))
-    assert "@BINARY-REDISTRIBUTABLE" in plan_packages.required_licenses(chosen, load_catalog())
+    lines = [
+        one.lines
+        for one in plan_packages.build(chosen, catalog)
+        if isinstance(one, plan_packages.WriteGroupLicense)
+    ]
+    assert lines == [("x11-drivers/nvidia-drivers @BINARY-REDISTRIBUTABLE",)]
+    assert dict(make_conf(chosen))["ACCEPT_LICENSE"] == "@FREE"
+
     plain = replace(config(), packages=replace(config().packages, graphics=("nouveau",)))
-    assert plan_packages.required_licenses(plain, load_catalog()) == ("@FREE",)
+    assert not [
+        one
+        for one in plan_packages.build(plain, catalog)
+        if isinstance(one, plan_packages.WriteGroupLicense)
+    ]
 
 
 def test_the_nvidia_group_writes_no_file_of_its_own() -> None:


### PR DESCRIPTION
A group's `accept_license` was merged into `ACCEPT_LICENSE`, so choosing the `wechat` group accepted `all-rights-reserved` for every later emerge on the installed machine. `WriteGroupLicense` writes `/etc/portage/package.license/<group>` instead, one line per atom, as `AcceptFirmwareLicence` already does for `sys-kernel/linux-firmware`.

Measured with `PORTAGE_CONFIGROOT` against a `ACCEPT_LICENSE="@FREE"` configuration: with that one line, `emerge -pq` resolves all five groups (`wechat`, `nvidia`, `wemeet`, `dingtalk`, `tencent-qq`) and no dependency needs the licence; without it, all five answer `masked by: … license(s)`.