### PR TITLE
vm: strip carriage returns from the local reader too

### DIFF
--- a/tests/unit/test_harness.py
+++ b/tests/unit/test_harness.py
@@ -3754,6 +3754,23 @@ def test_a_check_reads_the_output_and_not_the_question(tmp_path: Path) -> None:
     assert b"RESOLVCONF-OK" in whole, "the echo is what the old reading carried"
 
 
+def test_the_local_reader_hands_back_lines_a_dollar_anchor_can_match(
+    tmp_path: Path,
+) -> None:
+    """`convert.py` matches `installed.py` patterns against what this reader
+    answers, and four of them anchor on `$`. A serial line ends `\r\n`, so
+    those four could not match a correct machine.
+    """
+    from tests.vm.console import SerialConsole
+
+    channel = _EchoingChannel()
+    with (tmp_path / "console.log").open("wb") as log:
+        said = SerialConsole(cast(Any, channel), log).expect_output("true", timeout=5.0)
+
+    assert b"\r" not in said, said
+    assert re.search(rb"(?m)^RESOLVCONF-EMPTY$", said), said
+
+
 @pytest.mark.lab
 def test_the_driver_medium_reaches_a_guest_with_no_ata_driver(tmp_path: Path) -> None:
     """The Debian genericcloud kernel builds no ATA or AHCI driver, so a

--- a/tests/vm/console.py
+++ b/tests/vm/console.py
@@ -285,7 +285,10 @@ class SerialConsole:
         self.send(marked_command(command, token))
         self.expect(command_begin(token), timeout)
         said = self.expect(command_done(token), timeout)
-        return said.split(command_done(token).encode())[0]
+        # Without the carriage returns, for the reason the cluster's own reader
+        # gives: a serial line ends every one of them `\r\n`, and `convert.py`
+        # applies the same `installed.py` patterns, four of which anchor on `$`.
+        return said.split(command_done(token).encode())[0].replace(b"\r", b"")
 
     def login(self, user: str, password: str | None, prompt: str) -> None:
         self.expect(r"login:", timeout=300.0)


### PR DESCRIPTION
`SerialConsole.expect_output` kept the carriage returns while `cluster.py`'s reader strips them. `convert.py:286` applies the same `installed.py` patterns, and four of them (`installed.py:118`, `126`, `140`, `154`) anchor on `$`, so on the conversion path those four could not match a correct machine.