### PR TITLE
cluster: an expected failure needs a collected exit code

### DIFF
--- a/tests/unit/test_cluster.py
+++ b/tests/unit/test_cluster.py
@@ -1230,6 +1230,17 @@ def test_a_fixture_that_passes_by_failing_is_not_recorded_as_a_failure() -> None
     assert failing == set(cluster.EXPECTED_TO_FAIL), (failing, cluster.EXPECTED_TO_FAIL)
 
 
+def test_an_expected_failure_with_no_exit_code_is_not_a_pass() -> None:
+    """`vm-proxy-dead` passes by stopping, and the rule for that was
+    `code != b"0"`. A guest whose results never came back hands the caller an
+    empty code, which satisfies it: the one fixture whose verdict is a failure
+    was green whenever the collection failed.
+    """
+    assert cluster._did_not_stop(b"4") == ""
+    assert "wrote no exit code" in cluster._did_not_stop(b"")
+    assert "did not" in cluster._did_not_stop(b"0")
+
+
 def test_a_refused_login_says_what_the_guest_was_showing(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:

--- a/tests/vm/cluster.py
+++ b/tests/vm/cluster.py
@@ -1731,12 +1731,12 @@ def install_one(
         if job.name in EXPECTED_TO_FAIL:
             # The install stopping is the whole answer here, so there is no
             # installed system to boot afterwards and the run ends on this line.
-            stopped = code != b"0"
+            why = _did_not_stop(code)
             return Outcome(
                 job.name,
-                Verdict.OK if stopped else Verdict.FAIL,
+                Verdict.FAIL if why else Verdict.OK,
                 time.monotonic() - started,
-                "" if stopped else "the install was supposed to stop and did not",
+                why,
                 log,
                 phase=phase,
                 revision=revision,
@@ -2214,6 +2214,20 @@ def _remaining(deadline: float) -> float:
 #: fixture that could never be green, and it was counted as unverified for
 #: weeks. `campaign.py` knew this and the cluster did not.
 EXPECTED_TO_FAIL: Final[frozenset[str]] = frozenset({"vm-proxy-dead"})
+
+
+def _did_not_stop(code: bytes) -> str:
+    """Why an expected-to-fail fixture is not a pass, or empty when it is.
+
+    An absent code is not a stop. `code != b"0"` was the whole rule, and a
+    guest whose results never came back leaves it empty, so a run that
+    collected nothing read as the failure the fixture exists to produce.
+    """
+    if not code:
+        return "the install was supposed to stop and wrote no exit code"
+    if code == b"0":
+        return "the install was supposed to stop and did not"
+    return ""
 
 #: Fixtures whose mirror site is the thing under test, so `--site` must not
 #: move it. `vm-binhost-fallback` names `xtom-hk`, whose binary package index


### PR DESCRIPTION
`vm-proxy-dead` passes by stopping, and the rule was `code != b"0"`. A guest whose results never came back leaves `code` empty, which satisfies it, so the one fixture whose verdict is a failure was `ok` whenever the collection failed — the same shape as the absent `install.rc` the ordinary path already names.

The run that prompted this was real: `vm-proxy-dead` answered `ok` in 11.2 minutes with `install.rc` holding `4`.