### PR TITLE
vm: match the installed value, not the text around it

### DIFF
--- a/tests/unit/test_harness.py
+++ b/tests/unit/test_harness.py
@@ -462,6 +462,54 @@ def test_the_installed_checks_read_the_files_the_plan_writes() -> None:
     assert named == {expected}, named
 
 
+def test_an_installed_check_matches_the_value_and_not_the_text_around_it() -> None:
+    """Four checks accepted text that carried the answer without the machine
+    having produced it: `Gentoo` anywhere in `os-release`, `UUID=` anywhere in
+    `fstab` when every layout writes one for the esp, `/boot/` for any file at
+    all while `uname -r` was read and never compared, and a bare hostname that
+    is a substring of openrc's `hostname="name"`.
+
+    The passing text is copied from guests this campaign ran.
+    """
+    import re
+
+    from gentoo_install.exec.config import load
+    from tests.vm.installed import checks
+
+    def pattern(fixture: str, name: str) -> str:
+        return next(
+            one.pattern for one in checks(load(Path(f"tests/fixtures/{fixture}.toml")))
+            if one.name == name
+        )
+
+    kernel = pattern("vm-binpkg", "kernel")
+    assert re.search(kernel, "\n6.18.43-gentoo-dist-bin\n/boot/kernel-6.18.43-gentoo-dist-bin\n")
+    assert re.search(
+        kernel,
+        "\n6.18.43-gentoo-dist-bin\n/boot/3c3b/6.18.43-gentoo-dist-bin/linux\n"
+        "/boot/loader/loader.conf\n",
+    )
+    # The kernel that is installed is not the kernel that booted.
+    assert not re.search(kernel, "\n6.18.43-gentoo-dist-bin\n/boot/kernel-6.17.1-gentoo\n")
+
+    fstab = pattern("vm-binpkg", "fstab")
+    assert re.search(fstab, "UUID=8979\t/\text4\tdefaults\t0\t1\nUUID=0AB2\t/efi\tvfat\t0\t2\n")
+    # The esp by UUID and the root still named by device.
+    assert not re.search(fstab, "/dev/vda2\t/\text4\tdefaults\t0\t1\nUUID=0AB2\t/efi\tvfat\t0\t2\n")
+
+    release = pattern("vm-binpkg", "os-release")
+    assert re.search(release, "NAME=Gentoo\nID='gentoo'\n")
+    assert not re.search(release, "NAME=\"Ubuntu\"\nID=ubuntu\nID_LIKE=Gentoo\n")
+
+    # openrc keeps the name in a shell assignment, systemd in a bare line.
+    openrc = pattern("openrc-sdboot", "hostname")
+    assert re.search(openrc, 'hostname="openrcsdbox"\n')
+    assert not re.search(openrc, 'hostname="openrcsdboxlonger"\n')
+    systemd = pattern("vm-binpkg", "hostname")
+    assert re.search(systemd, "vmtest\n")
+    assert not re.search(systemd, "vmtestlonger\n")
+
+
 def test_every_input_framework_has_a_binary_to_ask_for() -> None:
     """The check asks `command -v <binary>`, and the map from framework to
     binary is a second table beside the catalog's own `input_framework`. A
@@ -2362,9 +2410,21 @@ def test_a_healthy_init_is_judged_by_the_marker_it_prints() -> None:
     from gentoo_install.exec.config import load
 
     fixture = Path(__file__).resolve().parents[1] / "fixtures" / "vm-btrfs.toml"
+    installation = load(fixture)
+    # The pattern as its own output holds only while every pattern is a
+    # literal. Four of them relate one part of the machine's answer to
+    # another, so those four carry a line copied from a guest instead.
+    written = {
+        "os-release": b"NAME=Gentoo\nID='gentoo'\n",
+        "hostname": installation.system.hostname.encode() + b"\n",
+        "kernel": b"6.18.43-gentoo-dist-bin\n/boot/kernel-6.18.43-gentoo-dist-bin\n",
+        "fstab": b"UUID=ab2e555d\t/\tbtrfs\tdefaults,subvol=@\t0\t1\n",
+    }
     healthy = {
-        f"{one.name}.txt": one.pattern.replace("\\", "").encode() + b"\n"
-        for one in checks(load(fixture))
+        f"{one.name}.txt": written.get(
+            one.name, one.pattern.replace("\\", "").encode() + b"\n"
+        )
+        for one in checks(installation)
     }
     assert check_expected(healthy, fixture) == 0
     broken = dict(healthy)

--- a/tests/vm/installed.py
+++ b/tests/vm/installed.py
@@ -62,10 +62,16 @@ INPUT_METHOD_BINARIES: Final[dict[str, str]] = {
 }
 
 
+#: The root entry, not any `UUID=` in the file. Every layout writes an esp
+#: line by UUID as well, so `UUID=` alone was satisfied by a machine whose
+#: root was still named by device. The separator is a tab on every guest read.
+ROOT_BY_UUID: Final[str] = r"(?m)^UUID=\S+\s+/\s"
+
+
 def checks(installation: InstallConfig) -> tuple[InstalledCheck, ...]:
     """Derive every installed-state check from the configuration."""
     result = [
-        InstalledCheck("os-release", "cat /etc/os-release", "Gentoo"),
+        InstalledCheck("os-release", "cat /etc/os-release", r"(?m)^ID=['\"]?gentoo['\"]?$"),
         InstalledCheck("mounts", "findmnt --noheadings --list --output TARGET,SOURCE,FSTYPE", "/"),
         InstalledCheck("locale", "locale", f"LANG={installation.system.locale}"),
         InstalledCheck("hostname", _hostname_command(installation), _hostname_pattern(installation)),
@@ -183,7 +189,7 @@ def checks(installation: InstallConfig) -> tuple[InstalledCheck, ...]:
         # converted, and the esp and root filesystem are whatever it already
         # had. `fstab` still has to name the root by UUID, which is the part
         # the conversion writes.
-        result.append(InstalledCheck("fstab", "cat /etc/fstab", "UUID="))
+        result.append(InstalledCheck("fstab", "cat /etc/fstab", ROOT_BY_UUID))
         return tuple(result)
     graph = installation.disk.graph
     esp = compat.esp_mount(graph)
@@ -198,7 +204,7 @@ def checks(installation: InstallConfig) -> tuple[InstalledCheck, ...]:
         kind = filesystem.kind.value if isinstance(filesystem, Filesystem) else ""
         result.append(InstalledCheck("root filesystem", "findmnt --noheadings --output FSTYPE /", kind))
     if not isinstance(source, ZfsDataset):
-        result.append(InstalledCheck("fstab", "cat /etc/fstab", "UUID="))
+        result.append(InstalledCheck("fstab", "cat /etc/fstab", ROOT_BY_UUID))
     return tuple(result)
 
 
@@ -208,15 +214,31 @@ def _hostname_command(installation: InstallConfig) -> str:
 
 
 def _hostname_pattern(installation: InstallConfig) -> str:
-    """Match the init system's hostname representation."""
-    return installation.system.hostname
+    """Match the init system's hostname representation.
+
+    Both branches answered the bare name, which is a substring of the openrc
+    file's `hostname="name"` and of any longer name installed by mistake.
+    """
+    name = re.escape(installation.system.hostname)
+    if installation.system.init is InitSystem.SYSTEMD:
+        return rf"(?m)^{name}$"
+    return rf'(?m)^hostname="{name}"$'
+
+
+#: The release `uname -r` printed, and a `/boot` file whose own name carries
+#: it. Both branches of the layout rule answered `/boot/`, which any file
+#: under `/boot` satisfies while the release the machine is running is read
+#: and never compared: `grub` and `systemd-boot` alike passed on a stale
+#: kernel. The release is a backreference, so nothing but the machine's own
+#: answer can satisfy it. Measured against fourteen guests: `kernel-<release>`
+#: (dist-bin), `vmlinuz-<release>` (BIOS), and systemd-boot's
+#: `<machine-id>/<release>/linux` all carry it.
+KERNEL_MATCHES_ITS_RELEASE: Final[str] = r"(?ms)\A\s*(?P<release>[0-9]\S*)$.*^/boot/\S*(?P=release)"
 
 
 def _kernel_pattern(installation: InstallConfig) -> str:
-    """Match the selected bootloader's kernel layout."""
-    if installation.bootloader.kind is Bootloader.SYSTEMD_BOOT:
-        return "/boot/"
-    return "/boot/"
+    """Match a `/boot` file against the release the machine is running."""
+    return KERNEL_MATCHES_ITS_RELEASE
 
 
 def stage_passphrase_commands(installation: InstallConfig) -> tuple[str, ...]:


### PR DESCRIPTION
`os-release` accepted `Gentoo` anywhere in the file, `fstab` accepted `UUID=` anywhere when every layout writes one for the esp, the kernel check accepted any file under `/boot` while the release `uname -r` printed was collected and never compared, and the hostname pattern was the bare name for both init systems, which is a substring of openrc's `hostname="name"`.

The kernel pattern makes the release a backreference, so only the machine's own answer satisfies it; it was read against the fourteen guest logs this campaign kept, covering `kernel-<release>`, `vmlinuz-<release>` and systemd-boot's `<machine-id>/<release>/linux`.