### PR TITLE
cluster: an address lease names the schedule holding it

### DIFF
--- a/tests/unit/test_harness.py
+++ b/tests/unit/test_harness.py
@@ -2866,6 +2866,65 @@ def test_a_lease_of_a_running_guest_is_left_alone(tmp_path: Path) -> None:
     assert pool.reserve("10.31.0.150") == "10.31.0.151"
 
 
+def test_a_lease_outlives_the_age_rule_while_its_schedule_runs(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A campaign runs longer than one guest's ceiling, so the age rule alone
+    frees an address whose schedule is still using it. `vm-unlock` was on
+    10.31.0.151 when a round that started 92 minutes later was given the same
+    address, and its initramfs answered `dracut Warning: Duplicate address
+    detected for 10.31.0.151 for interface eth0`.
+    """
+    import os
+    import time
+
+    from tests.vm import cluster
+    from tests.vm.cluster import LEASE_SECONDS, AddressPool
+
+    # The pytest process is not a schedule, so the pid that stands for one is
+    # named here rather than taken from this process.
+    monkeypatch.setattr(cluster, "_scheduler_is_running", lambda pid: pid == 4242)
+
+    pool = AddressPool(tmp_path, lambda address: False)
+    leases = tmp_path / "addresses"
+    leases.mkdir()
+    mine = leases / "10.31.0.150"
+    mine.write_text("4242\n")
+    old = time.time() - LEASE_SECONDS - 60
+    os.utime(mine, (old, old))
+
+    assert pool.reserve("10.31.0.150") == "10.31.0.151"
+
+    # Negative control: the same lease held by a pid that is not a schedule of
+    # this harness is nobody's, and the age rule frees it.
+    gone = leases / "10.31.0.151"
+    gone.write_text("7\n")
+    os.utime(gone, (old, old))
+    assert pool.reserve("10.31.0.151") == "10.31.0.151"
+
+
+def test_a_schedule_releases_only_the_leases_it_holds(tmp_path: Path) -> None:
+    """`release` unlinked by name, so a schedule that ended freed an address
+    another schedule had taken over, and the guest still answering on it met a
+    second guest that had just been given it.
+    """
+    import os
+
+    from tests.vm.cluster import AddressPool
+
+    pool = AddressPool(tmp_path, lambda address: False)
+    leases = tmp_path / "addresses"
+    leases.mkdir()
+    (leases / "10.31.0.150").write_text(f"{os.getpid()}\n")
+    (leases / "10.31.0.151").write_text("1\n")
+
+    pool.release("10.31.0.150")
+    pool.release("10.31.0.151")
+
+    assert not (leases / "10.31.0.150").exists(), "its own lease goes"
+    assert (leases / "10.31.0.151").exists(), "somebody else's stays"
+
+
 def test_the_guest_is_told_not_to_ask_for_aaaa() -> None:
     """`/etc/hosts` carries IPv4 addresses only, and an `AF_UNSPEC` lookup asks
     DNS for the AAAA regardless. A resolver that does not answer turns that

--- a/tests/vm/cluster.py
+++ b/tests/vm/cluster.py
@@ -1468,6 +1468,21 @@ LEASE_MARGIN: Final[float] = 60 * 60.0
 LEASE_SECONDS: Final[float] = RUN_CEILING + LEASE_MARGIN
 
 
+#: What a running schedule's command line contains, so that a live pid can be
+#: told from a recycled one. A lease is honoured for as long as the process
+#: that took it is still that process.
+SCHEDULER_COMMAND: Final[str] = "tests.vm.cluster"
+
+
+def _scheduler_is_running(pid: int) -> bool:
+    """Whether that pid is still a schedule of this harness."""
+    try:
+        said = Path(f"/proc/{pid}/cmdline").read_bytes()
+    except OSError:
+        return False
+    return SCHEDULER_COMMAND.encode() in said
+
+
 class AddressPool:
     """Reserve static addresses under one host-wide scheduler lock."""
 
@@ -1477,20 +1492,31 @@ class AddressPool:
         self._lock_path = root / "address.lock"
         self._leases = root / "addresses"
 
+    def _owner(self, lease: Path) -> int:
+        """The pid that reserved this address, or 0 when it names nobody."""
+        try:
+            said = lease.read_text().strip()
+        except OSError:
+            return 0
+        return int(said) if said.isdigit() else 0
+
     def reserve(self, preferred: str) -> str:
         self._root.mkdir(parents=True, exist_ok=True)
         self._leases.mkdir(exist_ok=True)
         with self._lock_path.open("a+") as lock:
             fcntl.flock(lock, fcntl.LOCK_EX)
-            # A lease older than any run cannot belong to a live guest, and a
-            # schedule that was killed never released its own: sixteen rounds
-            # left a hundred of them and the pool was empty from the first
-            # dispatch of the next.
+            # A lease belongs to a schedule for as long as that schedule runs,
+            # however long that is: a campaign outlives its own ceiling, and
+            # `vm-unlock` lost 10.31.0.151 to a round that started 92 minutes
+            # after it. The age rule stays for a schedule that was killed:
+            # sixteen rounds once left a hundred leases and the pool was empty
+            # from the next dispatch.
             now = time.time()
             held = {
                 path.name
                 for path in self._leases.iterdir()
-                if now - path.stat().st_mtime < LEASE_SECONDS
+                if _scheduler_is_running(self._owner(path))
+                or now - path.stat().st_mtime < LEASE_SECONDS
             }
             network, last = preferred.rsplit(".", 1)
             ceiling = GUEST_ADDRESS_BASE + (VMID_LAST - VMID_FIRST)
@@ -1498,21 +1524,20 @@ class AddressPool:
                 address = f"{network}.{number}"
                 if address in held or self._probe(address):
                     continue
-                lease = self._leases / address
-                try:
-                    lease.touch(exist_ok=False)
-                except FileExistsError:
-                    # Only reached for a lease older than any run, which the
-                    # loop above already decided is nobody's: taking it over
-                    # is the point, and the timestamp says it is ours now.
-                    lease.touch()
+                # The name of the holder, not an empty file: `release` unlinks
+                # by name, so a schedule that ended freed an address another
+                # schedule had taken over, and the guest still answering on it
+                # met a second guest that had just been given it.
+                (self._leases / address).write_text(f"{os.getpid()}\n")
                 return address
         raise ProxmoxError(f"no static address is available from {preferred}")
 
     def release(self, address: str) -> None:
         with self._lock_path.open("a+") as lock:
             fcntl.flock(lock, fcntl.LOCK_EX)
-            (self._leases / address).unlink(missing_ok=True)
+            lease = self._leases / address
+            if self._owner(lease) in (0, os.getpid()):
+                lease.unlink(missing_ok=True)
 
 
 def _execution(


### PR DESCRIPTION
Measured from run98: `vm-unlock` held 10.31.0.151, a round that started 92 minutes later was given the same address, and the installed guest's initramfs answered `dracut Warning: Duplicate address detected for 10.31.0.151 for interface eth0` / `Error: ipv4: Address already assigned`, so dropbear never came up and the unlock timed out after 66.9 minutes.

Two halves, both in the pool: the age rule alone cannot hold an address for a campaign that runs longer than one guest's ceiling, and `release` unlinked by name, so a schedule that ended freed an address another schedule had taken over. A lease now carries the pid that took it, and is honoured while that pid is still a schedule of this harness.