### PR TITLE
compat: read the cjk kernel choices out of the package table

### DIFF
--- a/gentoo_install/model/compat.py
+++ b/gentoo_install/model/compat.py
@@ -11,7 +11,7 @@ from __future__ import annotations
 
 import re
 from dataclasses import dataclass
-from typing import Callable, Final
+from typing import Callable, Final, Mapping
 from enum import Enum
 from pathlib import PurePosixPath
 
@@ -78,10 +78,23 @@ KERNEL_PACKAGES: Final[dict[KernelSource, str]] = {
     KernelSource.CJK: "sys-kernel/gentoo-cjk-kernel",
 }
 
-#: The kernel choices patched with cjktty, and the packages that carry them.
-#: Derived, not listed again: a second copy of these two names disagrees with
-#: the table above the first time a package is renamed.
-CJK_KERNELS: Final[tuple[KernelSource, ...]] = (KernelSource.CJK_BIN, KernelSource.CJK)
+#: What names a cjktty package, and the only thing that decides whether a
+#: kernel choice is one. `sys-kernel/gentoo-cjk-kernel` and its `-bin` are
+#: what the gentoo-zh overlay carries today.
+CJK_PACKAGE_MARK: Final[str] = "cjk-kernel"
+
+def cjk_kernels(packages: Mapping[KernelSource, str]) -> tuple[KernelSource, ...]:
+    """The choices in that table whose package carries the cjktty patch."""
+    return tuple(
+        source for source, package in packages.items() if CJK_PACKAGE_MARK in package
+    )
+
+
+#: The kernel choices patched with cjktty. Read out of the table above rather
+#: than listed again: the two names were written a second time under a comment
+#: claiming they were derived, so a renamed package would have left this stale
+#: while the comment said it could not.
+CJK_KERNELS: Final[tuple[KernelSource, ...]] = cjk_kernels(KERNEL_PACKAGES)
 _CJK_KERNEL_PACKAGES: Final[frozenset[str]] = frozenset(
     KERNEL_PACKAGES[source] for source in CJK_KERNELS
 )

--- a/tests/unit/test_plan_boot.py
+++ b/tests/unit/test_plan_boot.py
@@ -722,6 +722,25 @@ def test_the_prebuilt_patched_kernel_is_the_one_a_chinese_interface_takes() -> N
         assert any("from source" in line for line in described), source
 
 
+def test_a_cjk_kernel_choice_is_read_out_of_the_package_table() -> None:
+    """`CJK_KERNELS` was a second list of the same two names under a comment
+    saying it was derived. A renamed or added cjktty package would have left
+    it stale, and the comment said that could not happen.
+    """
+    from gentoo_install.model.compat import CJK_PACKAGE_MARK, cjk_kernels
+
+    # The rule, against a table this repository does not ship: whichever
+    # choice names a cjktty package is the cjk choice, whatever it is called.
+    assert cjk_kernels(
+        {
+            KernelSource.DIST_BIN: "sys-kernel/gentoo-cjk-kernel-rt",
+            KernelSource.DIST_SOURCE: "sys-kernel/gentoo-kernel",
+        }
+    ) == (KernelSource.DIST_BIN,)
+    assert cjk_kernels({KernelSource.DIST_BIN: "sys-kernel/gentoo-kernel-bin"}) == ()
+    assert CJK_PACKAGE_MARK not in "sys-kernel/gentoo-kernel-bin"
+
+
 def test_the_prebuilt_patched_kernel_sits_beside_the_source_one() -> None:
     """`sys-kernel/gentoo-cjk-kernel-bin` is in gentoo-zh: same cjktty patch,
     same `+cjk` flag, same `virtual/dist-kernel`, nothing to compile."""


### PR DESCRIPTION
`CJK_KERNELS` was a literal pair under a comment claiming it was derived from `KERNEL_PACKAGES`, so renaming or adding a cjktty package would have left it stale while the comment said that could not happen. `cjk_kernels()` reads the table, and its test exercises the rule against a table this repository does not ship.