### PR TITLE
disk: one entry per filesystem instead of two tables

### DIFF
--- a/gentoo_install/exec/preflight.py
+++ b/gentoo_install/exec/preflight.py
@@ -237,7 +237,7 @@ def _configured_commands(config: InstallConfig) -> frozenset[str]:
             continue
         # Taken from the table the operations themselves use, so a filesystem
         # added there can never be missing here.
-        wanted.add(MKFS[filesystem.kind][0])
+        wanted.add(MKFS[filesystem.kind].argv[0])
         wanted |= set(EXTRA_FILESYSTEM_COMMANDS.get(filesystem.kind, ()))
     return frozenset(wanted)
 

--- a/gentoo_install/plan/disk.py
+++ b/gentoo_install/plan/disk.py
@@ -63,25 +63,29 @@ TYPE_CODES: Final[dict[PartitionRole, str]] = {
 #: because `exec/apply.py` writes it and `DiscardStage3` deletes it.
 STAGE3_CACHE: Final[str] = "var/cache/gentoo-install"
 
-MKFS: Final[dict[FilesystemType, tuple[str, ...]]] = {
-    FilesystemType.EXT2: ("mkfs.ext2", "-F"),
-    FilesystemType.EXT3: ("mkfs.ext3", "-F"),
-    FilesystemType.EXT4: ("mkfs.ext4", "-F"),
-    FilesystemType.BTRFS: ("mkfs.btrfs", "-f"),
-    FilesystemType.XFS: ("mkfs.xfs", "-f"),
-    FilesystemType.F2FS: ("mkfs.f2fs", "-f"),
-    FilesystemType.VFAT: ("mkfs.vfat", "-F", "32"),
-}
+@dataclass(frozen=True)
+class MakeCommand:
+    """How one filesystem is made, and how it is told its label.
 
-#: `-L` everywhere except vfat, which spells its label option `-n`.
-LABEL_OPTION: Final[dict[FilesystemType, str]] = {
-    FilesystemType.EXT2: "-L",
-    FilesystemType.EXT3: "-L",
-    FilesystemType.EXT4: "-L",
-    FilesystemType.BTRFS: "-L",
-    FilesystemType.XFS: "-L",
-    FilesystemType.F2FS: "-l",
-    FilesystemType.VFAT: "-n",
+    One entry rather than two tables keyed the same way: `MakeFilesystem`
+    indexes both on the same line, so a filesystem added to one and not the
+    other raises `KeyError` while the disk is already partitioned.
+    """
+
+    argv: tuple[str, ...]
+    label_option: str
+
+
+#: `-L` everywhere except vfat, which spells its label option `-n`, and f2fs,
+#: which spells it `-l`.
+MKFS: Final[dict[FilesystemType, MakeCommand]] = {
+    FilesystemType.EXT2: MakeCommand(("mkfs.ext2", "-F"), "-L"),
+    FilesystemType.EXT3: MakeCommand(("mkfs.ext3", "-F"), "-L"),
+    FilesystemType.EXT4: MakeCommand(("mkfs.ext4", "-F"), "-L"),
+    FilesystemType.BTRFS: MakeCommand(("mkfs.btrfs", "-f"), "-L"),
+    FilesystemType.XFS: MakeCommand(("mkfs.xfs", "-f"), "-L"),
+    FilesystemType.F2FS: MakeCommand(("mkfs.f2fs", "-f"), "-l"),
+    FilesystemType.VFAT: MakeCommand(("mkfs.vfat", "-F", "32"), "-n"),
 }
 
 #: The first partition starts here, which is also the alignment every later one
@@ -560,16 +564,16 @@ class MakeFilesystem(Operation):
     label: str
 
     def required_host_commands(self) -> frozenset[str]:
-        return frozenset((MKFS[self.kind][0],))
+        return frozenset((MKFS[self.kind].argv[0],))
 
     def describe(self) -> str:
         name = f" labelled {self.label}" if self.label else ""
         return f"make a {self.kind.value} filesystem on {self.device} as {self.filesystem}{name}"
 
     def apply(self, context: Context) -> None:
-        argv = list(MKFS[self.kind])
+        argv = list(MKFS[self.kind].argv)
         if self.label:
-            argv += [LABEL_OPTION[self.kind], self.label]
+            argv += [MKFS[self.kind].label_option, self.label]
         context.run([*argv, context.device_path(self.device)])
 
 

--- a/tests/unit/test_plan_disk.py
+++ b/tests/unit/test_plan_disk.py
@@ -203,6 +203,29 @@ def test_a_filesystem_is_made_with_the_label_option_its_tool_uses() -> None:
     assert "ESP" in vfat
 
 
+def test_every_filesystem_names_its_label_with_an_option_that_tool_takes() -> None:
+    """`MKFS` and `LABEL_OPTION` were two tables keyed the same way and
+    indexed on one line, so a filesystem added to one and not the other raised
+    `KeyError` with the disk already partitioned. One entry carries both, and
+    every entry has to produce a command that names the label.
+    """
+    from gentoo_install.model.device import FilesystemType
+    from gentoo_install.plan.disk import MKFS, MakeFilesystem
+
+    assert set(MKFS) == set(FilesystemType)
+    for kind in FilesystemType:
+        recorder = Recorder()
+        MakeFilesystem(
+            filesystem=i("rootfs"), device=i("rootpart"), kind=kind, label="tag"
+        ).apply(recorder)
+        argv = recorder.only(MKFS[kind].argv[0])
+        assert argv[-1] == "/dev/mapper/rootpart", kind
+        assert argv[-2] == "tag", kind
+        # The option, not an empty string: `["", "tag"]` is what an entry with
+        # no label option would hand the tool.
+        assert argv[-3].startswith("-") and len(argv[-3]) > 1, kind
+
+
 @pytest.mark.parametrize(
     ("name", "command"),
     [("ext2", "mkfs.ext2"), ("ext3", "mkfs.ext3")],


### PR DESCRIPTION
`MKFS` and `LABEL_OPTION` were two dictionaries keyed by `FilesystemType`, indexed on the same line of `MakeFilesystem.apply`. Only the first had a test asserting it covered the enum, so a filesystem added to one and not the other raised `KeyError` after the disk was already partitioned. `MakeCommand` carries both, and the new test drives every member of the enum through `apply` and requires the label to reach the command behind a real option.