### PR TITLE
portage: one marker for the unreadable binhost index

### DIFF
--- a/gentoo_install/plan/portage.py
+++ b/gentoo_install/plan/portage.py
@@ -971,12 +971,23 @@ class Emerge(Operation):
 GPKG_SUFFIX: Final[str] = ".gpkg.tar"
 
 
-#: What Portage prints when a binary host's index cannot be read. It then
-#: compiles everything and exits 0, so nothing else in this file sees it: a
-#: run against a host whose index answered 404 compiled all 69 of its packages
-#: in 84 minutes and recorded no reason at all.
+#: What Portage prints when it cannot read a binary host's index, taken from
+#: what stopped `vm-gnome`: `!!! [gentoo] Error fetching binhost package info
+#: from 'https://mirrors.nju.edu.cn/gentoo/releases/amd64/binpackages/23.0/
+#: x86-64'`, followed by `!!! [gentoo] <urlopen error timed out>`.
+BINHOST_INDEX_FAILURE: Final[str] = "Error fetching binhost package info"
+
+
+#: The same line, with the host and the url it names. Built from the marker
+#: rather than spelling it a second time: the two detectors read one Portage
+#: diagnostic, and a reworded one would have left this half of them silent.
+#: Portage compiles everything and exits 0 after printing it, so nothing else
+#: in this file sees it: a run against a host whose index answered 404
+#: compiled all 69 of its packages in 84 minutes and recorded no reason.
 _INDEX_UNREADABLE: Final[re.Pattern[str]] = re.compile(
-    r"!!! \[(?P<host>[^\]]+)\] Error fetching binhost package info from '(?P<url>[^']+)'"
+    r"!!! \[(?P<host>[^\]]+)\] "
+    + re.escape(BINHOST_INDEX_FAILURE)
+    + r" from '(?P<url>[^']+)'"
 )
 
 
@@ -1248,13 +1259,6 @@ class VerifyPackages(Operation):
             return again
         context.degrade(BINARY_PACKAGES, f"binary host index unreadable: {unreadable}")
         return self._resolve(context, atoms, source_only=True)
-
-
-#: What Portage prints when it cannot read a binary host's index, taken from
-#: what stopped `vm-gnome`: `!!! [gentoo] Error fetching binhost package info
-#: from 'https://mirrors.nju.edu.cn/gentoo/releases/amd64/binpackages/23.0/
-#: x86-64'`, followed by `!!! [gentoo] <urlopen error timed out>`.
-BINHOST_INDEX_FAILURE: Final[str] = "Error fetching binhost package info"
 
 
 def _binhost_unreadable(output: str) -> str | None:

--- a/tests/unit/test_plan_portage.py
+++ b/tests/unit/test_plan_portage.py
@@ -900,6 +900,51 @@ BINHOST_TIMED_OUT: Final[str] = (
 
 
 
+def test_both_binhost_detectors_read_one_marker() -> None:
+    """The failing path finds the line and the succeeding path parses the host
+    and the url out of it. The two spelled Portage's diagnostic separately, so
+    a reworded one would have left half of them silent while the other half
+    went on working.
+    """
+    from gentoo_install.plan import portage as plan_portage
+
+    assert plan_portage._binhost_unreadable(BINHOST_TIMED_OUT)
+    assert plan_portage._unreadable_index(BINHOST_TIMED_OUT)
+
+    # One marker: a diagnostic that does not carry it is seen by neither.
+    reworded = BINHOST_TIMED_OUT.replace(
+        plan_portage.BINHOST_INDEX_FAILURE, "Could not read binhost index"
+    )
+    assert plan_portage._binhost_unreadable(reworded) is None
+    assert plan_portage._unreadable_index(reworded) is None
+
+    # Both spellings answer the sample above, so only the source says whether
+    # there is one marker or two: the pattern has to quote the constant.
+    import ast
+    import inspect
+
+    tree = ast.parse(inspect.getsource(plan_portage))
+    assigned = [
+        node
+        for node in ast.walk(tree)
+        if isinstance(node, ast.AnnAssign)
+        and isinstance(node.target, ast.Name)
+        and node.target.id == "_INDEX_UNREADABLE"
+    ]
+    assert len(assigned) == 1, assigned
+    written = [
+        one.value
+        for one in ast.walk(assigned[0])
+        if isinstance(one, ast.Constant) and isinstance(one.value, str)
+    ]
+    assert not [
+        one for one in written if plan_portage.BINHOST_INDEX_FAILURE in one
+    ], written
+    assert "BINHOST_INDEX_FAILURE" in {
+        one.id for one in ast.walk(assigned[0]) if isinstance(one, ast.Name)
+    }
+
+
 def test_the_binhost_fallback_fixture_degrades_the_plan_to_source() -> None:
     from gentoo_install.exec.config import load
     from gentoo_install.plan.build import stage3_mirror


### PR DESCRIPTION
`BINHOST_INDEX_FAILURE` and `_INDEX_UNREADABLE` both spelled `Error fetching binhost package info`, one for the path where `emerge` fails and one for the path where it compiles everything and exits 0. The pattern quotes the constant now.

Both spellings answer the sample line, so the test asserts the behaviour and then reads the assignment: no string constant inside `_INDEX_UNREADABLE` may carry the marker, and the name must appear in it.