### PR TITLE
tui: build the profile list from the base profile

### DIFF
--- a/gentoo_install/tui/screens.py
+++ b/gentoo_install/tui/screens.py
@@ -78,6 +78,7 @@ from ..plan.packages import FONT_CONFIGURATION_DISABLED, FONT_CONFIGURATION_ENAB
 from ..plan.packages import INPUT_CONFIGURATION_DISABLED, INPUT_CONFIGURATION_ENABLED
 from ..plan import system as plan_system
 from .packages import (
+    BASE_PROFILE,
     _profile_for,
     _record_operator,
     _set_font_configuration,
@@ -1090,19 +1091,27 @@ def configuration_groups(groups: Groups) -> tuple[str, ...]:
 
 
 
-#: Taken from profiles.desc for amd64 23.0. A systemd profile is the same path
-#: plus /systemd, which `_profile_for` relies on.
-PROFILES: tuple[str, ...] = (
-    "default/linux/amd64/23.0",
-    "default/linux/amd64/23.0/systemd",
-    "default/linux/amd64/23.0/desktop",
-    "default/linux/amd64/23.0/desktop/systemd",
-    "default/linux/amd64/23.0/desktop/plasma",
-    "default/linux/amd64/23.0/desktop/plasma/systemd",
-    "default/linux/amd64/23.0/desktop/gnome",
-    "default/linux/amd64/23.0/desktop/gnome/systemd",
-    "default/linux/amd64/23.0/no-multilib",
-    "default/linux/amd64/23.0/no-multilib/systemd",
+#: What profiles.desc lists for amd64 beside the base, as suffixes of it. A
+#: systemd profile is the same path plus /systemd, which `_profile_for`
+#: relies on.
+PROFILE_VARIANTS: Final[tuple[str, ...]] = (
+    "",
+    "systemd",
+    "desktop",
+    "desktop/systemd",
+    "desktop/plasma",
+    "desktop/plasma/systemd",
+    "desktop/gnome",
+    "desktop/gnome/systemd",
+    "no-multilib",
+    "no-multilib/systemd",
+)
+
+#: Built from `BASE_PROFILE`, not written out: the release was spelled ten
+#: times here and once there, so moving it was eleven edits and the ten that
+#: are missed are silent.
+PROFILES: tuple[str, ...] = tuple(
+    f"{BASE_PROFILE}/{one}" if one else BASE_PROFILE for one in PROFILE_VARIANTS
 )
 
 #: Offered as a list rather than free text: a mistyped locale is only found

--- a/tests/unit/test_layers.py
+++ b/tests/unit/test_layers.py
@@ -138,6 +138,24 @@ def test_no_suppression_hides_a_finding() -> None:
 SPDX: Final[str] = "# SPDX-License-Identifier: GPL-2.0-or-later"
 
 
+def test_the_profile_release_is_written_once() -> None:
+    """`PROFILES` spelled `default/linux/amd64/23.0` ten times beside
+    `BASE_PROFILE`'s eleventh, so moving off 23.0 is eleven edits and the ten
+    that are missed are silent: the menu offers a profile the tree no longer
+    carries and the install stops at `emerge --sync`.
+    """
+    from gentoo_install.tui.packages import BASE_PROFILE
+
+    release = BASE_PROFILE.rsplit("/", 1)[1]
+    written = {
+        path.name: path.read_text(encoding="utf-8").count(release)
+        for path in sorted((PACKAGE / "tui").glob("*.py"))
+    }
+    assert {name: count for name, count in written.items() if count} == {
+        "packages.py": 1
+    }, written
+
+
 def test_every_source_file_states_the_licence() -> None:
     """The repository is GPL-2 or later. A file that says nothing leaves the
     question to whoever finds it, and the `or later` clause is what lets code


### PR DESCRIPTION
`PROFILES` wrote `default/linux/amd64/23.0` ten times and `packages.BASE_PROFILE` wrote it an eleventh, so the profile release lived in two places for one fact. `PROFILE_VARIANTS` holds the suffixes and `PROFILES` is built from the base; the list it produces is identical.

The test counts the release string across `gentoo_install/tui/*.py` and requires exactly one file to carry it.