### PR TITLE
convert: ask the guest to count the home marker

### DIFF
--- a/tests/unit/test_harness.py
+++ b/tests/unit/test_harness.py
@@ -3399,11 +3399,18 @@ def test_a_conversion_marks_home_and_checks_the_marker_after_boot(
         "conversion_checks",
         lambda _: (convert.HOME_MARKER_CHECK,),
     )
-    console.answer = f"{convert.HOME_MARKER}\n".encode()
+    console.answer = b"home=1\n"
     assert convert.check_installed(cast(Any, console), installation) == ""
     assert console.asked == [convert.HOME_MARKER_CHECK.command]
 
-    for answer in (b"", b"not-the-home-marker\n"):
+    # `cat` names the file it could not open, so the diagnostic for a missing
+    # marker carried the marker: the check passed on a conversion that had
+    # thrown /home away. The runner merges stderr into stdout, so that text
+    # really does reach the pattern.
+    missing = (
+        f"cat: {convert.HOME_MARKER_PATH}: No such file or directory\n".encode()
+    )
+    for answer in (b"", b"home=0\n", missing, f"{convert.HOME_MARKER}\n".encode()):
         console.answer = answer
         assert "home marker" in convert.check_installed(cast(Any, console), installation)
 

--- a/tests/vm/convert.py
+++ b/tests/vm/convert.py
@@ -41,14 +41,17 @@ WORKROOT: Final[Path] = Path.home() / "code/gentoo-install/lab/vm/converts"
 #: What cloud-init is told to set, so the harness can log in over serial. The
 #: images ship no password at all and no key the harness holds.
 ROOT_PASSWORD: Final[str] = "install"
-#: The payload is also part of the path: `expect_command` would otherwise match
-#: the shell's echo of `cat`, so the marker check must use `expect_output`.
+#: The payload is also part of the path, so nothing that quotes the path can
+#: be the answer: `cat` names the file it could not open, and
+#: `cat: /home/.gentoo-install-...: No such file or directory` carried the
+#: marker the check was looking for. The count is a value the guest computes,
+#: and neither the echo nor the diagnostic can produce it.
 HOME_MARKER: Final[str] = "gentoo-install-home-survives-conversion-4f9d6e2a"
 HOME_MARKER_PATH: Final[Path] = Path("/home") / f".{HOME_MARKER}"
 HOME_MARKER_CHECK: Final[InstalledCheck] = InstalledCheck(
     "home marker",
-    f"cat {HOME_MARKER_PATH}",
-    re.escape(HOME_MARKER),
+    f"printf 'home=%s\\n' \"$(grep -Fc {HOME_MARKER} {HOME_MARKER_PATH} 2>/dev/null || echo 0)\"",
+    r"(?m)^home=1$",
 )
 
 #: Bigger than every image here, so cloud-init's `growpart` and `resizefs`


### PR DESCRIPTION
`HOME_MARKER_CHECK` ran `cat /home/.gentoo-install-home-survives-conversion-4f9d6e2a` and looked for the marker in the answer. The marker is part of the path, `cat` names the file it could not open, and the runner merges stderr into stdout, so `cat: /home/.gentoo-install-...: No such file or directory` satisfied it: a conversion that lost `/home` passed.

The command now prints `home=<count>` from `grep -Fc`, which neither the echo nor the diagnostic can produce. Verified against a real shell: `home=0` with no file, `home=1` with it.