### PR TITLE
vm: require the esp to be vfat, not merely mounted

### DIFF
--- a/tests/unit/test_harness.py
+++ b/tests/unit/test_harness.py
@@ -497,6 +497,12 @@ def test_an_installed_check_matches_the_value_and_not_the_text_around_it() -> No
     # The esp by UUID and the root still named by device.
     assert not re.search(fstab, "/dev/vda2\t/\text4\tdefaults\t0\t1\nUUID=0AB2\t/efi\tvfat\t0\t2\n")
 
+    esp = pattern("vm-binpkg", "esp")
+    assert re.search(esp, "/efi /dev/vda1 vfat\n")
+    # Mounted there, but not something the firmware can read.
+    assert not re.search(esp, "/efi /dev/vda1 ext4\n")
+    assert not re.search(esp, "findmnt: /efi: not a mountpoint\n")
+
     release = pattern("vm-binpkg", "os-release")
     assert re.search(release, "NAME=Gentoo\nID='gentoo'\n")
     assert not re.search(release, "NAME=\"Ubuntu\"\nID=ubuntu\nID_LIKE=Gentoo\n")
@@ -2419,6 +2425,7 @@ def test_a_healthy_init_is_judged_by_the_marker_it_prints() -> None:
         "hostname": installation.system.hostname.encode() + b"\n",
         "kernel": b"6.18.43-gentoo-dist-bin\n/boot/kernel-6.18.43-gentoo-dist-bin\n",
         "fstab": b"UUID=ab2e555d\t/\tbtrfs\tdefaults,subvol=@\t0\t1\n",
+        "esp": b"/efi /dev/vda1 vfat\n",
     }
     healthy = {
         f"{one.name}.txt": written.get(

--- a/tests/vm/installed.py
+++ b/tests/vm/installed.py
@@ -194,7 +194,16 @@ def checks(installation: InstallConfig) -> tuple[InstalledCheck, ...]:
     graph = installation.disk.graph
     esp = compat.esp_mount(graph)
     if esp is not None:
-        result.append(InstalledCheck("esp", f"findmnt --noheadings --output TARGET,SOURCE,FSTYPE {esp.path}", str(esp.path)))
+        # The type as well as the path: the path is the argument `findmnt` was
+        # given, so the check said only that something was mounted there,
+        # while an esp the firmware cannot read is one that is not vfat.
+        result.append(
+            InstalledCheck(
+                "esp",
+                f"findmnt --noheadings --output TARGET,SOURCE,FSTYPE {esp.path}",
+                rf"(?m)^{re.escape(str(esp.path))}\s+\S+\s+vfat$",
+            )
+        )
     root = graph[installation.disk.root]
     source = graph[root.source] if isinstance(root, Mountpoint) else root
     if isinstance(source, ZfsDataset):


### PR DESCRIPTION
The esp check matched `str(esp.path)`, which is the argument `findmnt` was given, so it proved only that something was mounted at that path. An esp the firmware cannot read is one that is not vfat, and the check could not see that. The pattern now anchors on the target and requires `vfat` in the type column, read against `/efi /dev/vda1 vfat` from a guest of this campaign.