### PR TITLE
vm: judge an image install by the image it wrote

### DIFF
--- a/tests/unit/test_harness.py
+++ b/tests/unit/test_harness.py
@@ -516,6 +516,76 @@ def test_an_installed_check_matches_the_value_and_not_the_text_around_it() -> No
     assert not re.search(systemd, "vmtestlonger\n")
 
 
+def test_an_image_install_is_judged_by_the_image_it_wrote() -> None:
+    """The product is a file on the scratch filesystem this runner mounts, and
+    nothing here can boot a file on the guest's own disk. `--and-boot` booted
+    the target disk, which in this mode carries that scratch filesystem and no
+    installed system: the check ended at `UEFI Interactive Shell` with
+    `install.rc` holding 0 and the install correct.
+    """
+    import re
+
+    from gentoo_install.exec.config import load
+    from tests.vm import run as runner
+
+    installation = load(Path("tests/fixtures/vm-image.toml"))
+    expectation = runner._from_config(Path("tests/fixtures/vm-image.toml"))
+    assert [name for name, _ in expectation] == ["image"]
+    pattern = expectation[0][1]
+
+    # What `lsblk` prints for the loop device the image was attached to.
+    assert re.search(pattern, "loop0\nloop0p1 vfat\nloop0p2 ext4\n", re.MULTILINE)
+    # A partition table with no root filesystem, and what losetup says when
+    # the image was never written.
+    assert not re.search(pattern, "loop0\nloop0p1 vfat\n", re.MULTILINE)
+    assert not re.search(
+        pattern,
+        "losetup: /mnt/scratch/target.raw: failed to set up loop device\n",
+        re.MULTILINE,
+    )
+
+    class Console:
+        def __init__(self) -> None:
+            self.commands: list[str] = []
+
+        def run(self, command: str, timeout: float = 0.0) -> None:
+            self.commands.append(command)
+
+    console = Console()
+    runner.check_image(cast(Any, console), installation)
+    said = " ".join(console.commands)
+    assert f"losetup -Pf --show {installation.disk.image}" in said
+    assert "losetup -d" in said, "the loop device has to be given back"
+
+    # And an ordinary install asks for nothing: there is no image to read.
+    plain = Console()
+    runner.check_image(cast(Any, plain), load(Path("tests/fixtures/vm-binpkg.toml")))
+    assert plain.commands == []
+
+    # And the verdict really reads it. This is the answer a guest of this
+    # campaign gave, copied from `image.txt`.
+    written = Path("tests/fixtures/vm-image.toml")
+    real = b"loop1   \nloop1p1 vfat\nloop1p2 ext4\n"
+    assert runner.check_expected({"image.txt": real, "install.rc": b"0\n"}, written) == 0
+    # The esp alone: the install stopped before it made the root filesystem.
+    assert runner.check_expected({"image.txt": b"loop1\nloop1p1 vfat\n"}, written) != 0
+    # And nothing collected at all, which is how the check stayed inert.
+    assert runner.check_expected({}, written) != 0
+
+    # And the install phase really asks for that verdict: `report` was called
+    # with no assertions there, so `image.txt` was collected, printed, and
+    # never compared to anything.
+    assert runner._reads_an_image("fixtures/vm-image.toml", False)
+    assert not runner._reads_an_image("fixtures/vm-image.toml", True)
+    assert not runner._reads_an_image("fixtures/vm-binpkg.toml", False)
+    assert not runner._reads_an_image(None, False)
+
+    import inspect
+
+    wiring = inspect.getsource(runner._perform)
+    assert "_reads_an_image(args.install, args.dry_run)" in wiring
+
+
 def test_every_input_framework_has_a_binary_to_ask_for() -> None:
     """The check asks `command -v <binary>`, and the map from framework to
     binary is a second table beside the catalog's own `input_framework`. A
@@ -805,16 +875,29 @@ def test_every_fixture_has_a_boot_check_that_can_fail() -> None:
 
 
 def test_local_and_cluster_use_the_same_installed_contract() -> None:
-    """Both transport adapters must derive checks from one specification."""
+    """Both transport adapters must derive checks from one specification.
+
+    Except where there is no installed system to ask: `dd` writes an image
+    onto a disk and `image` writes one into a file, and the cluster refuses
+    an image fixture at dispatch because it has no scratch filesystem to put
+    it on. Their local contract is the product, not a booted machine.
+    """
     from gentoo_install.model.config import DiskMode
     from tests.vm.cluster import _asked_for
     from tests.vm.installed import checks
     from tests.vm.run import _from_config
     from gentoo_install.exec.config import load
 
+    without_a_machine = {DiskMode.DD, DiskMode.IMAGE}
+    covered = {
+        load(path).disk.mode
+        for path in Path("tests/fixtures").glob("*.toml")
+    }
+    assert without_a_machine <= covered, "every exempted mode needs a fixture"
+
     for path in sorted(Path("tests/fixtures").glob("*.toml")):
         installation = load(path)
-        if installation.disk.mode is DiskMode.DD:
+        if installation.disk.mode in without_a_machine:
             continue
         expected = [(one.name, one.pattern) for one in checks(installation)]
         assert _from_config(path) == expected

--- a/tests/vm/run.py
+++ b/tests/vm/run.py
@@ -552,6 +552,35 @@ def interrupt_and_resume(console: SerialConsole, config: str) -> None:
     console.run(collect_command(RESULT_DIR))
 
 
+#: Where the loop device the image was attached to is remembered, so the
+#: detach names the same one the attach chose.
+IMAGE_LOOP_FILE: Final[str] = "/run/vm-image.dev"
+
+
+def check_image(console: SerialConsole, installation: InstallConfig) -> None:
+    """Read the layout back out of the image an image install produced.
+
+    The image never leaves the guest: it sits on the scratch filesystem this
+    runner mounts, and nothing here can boot a file on it. `--boot-installed`
+    booted the target disk instead, which in this mode carries that scratch
+    filesystem and no installed system at all, so the check ended at the UEFI
+    shell with the install already finished and correct.
+    """
+    if installation.disk.mode is not DiskMode.IMAGE:
+        return
+    image = installation.disk.image
+    console.run(f"mkdir -p {RESULT_DIR}")
+    console.run(
+        f"{{ losetup -Pf --show {image} > {IMAGE_LOOP_FILE} && sleep 1 && "
+        f"lsblk --noheadings --list --output NAME,FSTYPE $(cat {IMAGE_LOOP_FILE}); }} "
+        f"> {RESULT_DIR}/image.txt 2>&1",
+        timeout=300.0,
+    )
+    console.run(f"losetup -d $(cat {IMAGE_LOOP_FILE}) || true")
+    console.run(collect_command(RESULT_DIR))
+    console.run("sync")
+
+
 def run_installer(console: SerialConsole, config: str, extra: str = "") -> None:
     """Run the installer from the driver CD and keep everything it printed."""
     console.run(FIND_DRIVER)
@@ -668,6 +697,14 @@ def main(argv: list[str] | None = None) -> int:
     )
     parser.add_argument("--keep", action="store_true", help="keep the run directory")
     args = parser.parse_args(argv)
+
+    if args.and_boot and args.install and load(
+        REPOSITORY / "tests" / args.install
+    ).disk.mode is DiskMode.IMAGE:
+        # The product is a file on the guest's own scratch filesystem, so
+        # there is no installed disk to boot: `check_image` is the whole
+        # answer and it runs in the install itself.
+        return main([one for one in (argv or sys.argv[1:]) if one != "--and-boot"])
 
     if args.and_boot:
         # The install first, then the same arguments again with the boot check.
@@ -826,11 +863,31 @@ def _perform(args: argparse.Namespace, medium: Medium, workdir: Path) -> int:
                 mount_scratch_for_image(console, installation)
                 stage_passphrases(console, load(REPOSITORY / "tests" / args.install))
                 run_installer(console, config, "--dry-run" if args.dry_run else "")
+                if not args.dry_run:
+                    check_image(console, installation)
             else:
                 probe(console)
             power_off(console, vm)
 
-    return report(result_disk, keep=args.keep, installed=bool(args.install and not args.dry_run))
+    # With the assertions when the product is a file: an image run has no
+    # second phase, so this is the only place its verdict can be decided.
+    return report(
+        result_disk,
+        keep=args.keep,
+        assertions=(
+            REPOSITORY / "tests" / args.install
+            if _reads_an_image(args.install, args.dry_run)
+            else None
+        ),
+        installed=bool(args.install and not args.dry_run),
+    )
+
+
+def _reads_an_image(install: str | None, dry_run: bool) -> bool:
+    """Whether this run's whole verdict is the image it wrote."""
+    if not install or dry_run:
+        return False
+    return load(REPOSITORY / "tests" / install).disk.mode is DiskMode.IMAGE
 
 
 def power_off(console: SerialConsole, vm: Vm) -> None:
@@ -898,7 +955,20 @@ def report(
 def _from_config(config: Path) -> list[tuple[str, str]]:
     """Return the shared contract in the local result format."""
     installation = load(config)
+    if installation.disk.mode is DiskMode.IMAGE:
+        # Nothing booted, so none of the installed-state checks ran: what
+        # this mode produces is a file, and `check_image` reads its layout.
+        return [("image", _image_pattern(installation))]
     return [(check.name, check.pattern) for check in checks(installation)]
+
+
+def _image_pattern(installation: InstallConfig) -> str:
+    """Every filesystem the layout declares, as `lsblk` names it."""
+    graph = installation.disk.graph
+    wanted = sorted({node.kind.value for node in graph.of_type(Filesystem)})
+    if not wanted:
+        raise SystemExit("an image configuration with no filesystem proves nothing")
+    return "".join(rf"(?=[\s\S]*^\S+\s+{one}$)" for one in wanted)
 
 
 def verdict(
@@ -932,7 +1002,13 @@ def check_expected(results: dict[str, bytes], config: Path) -> int:
     # From the configuration rather than hardcoded: a second fixture installs a
     # different name, and a check that only ever matched the first one would
     # pass on a system that ignored the setting.
-    for name, pattern in [*EXPECTED, *_from_config(config)]:
+    # `EXPECTED` is what a booted machine leaves behind, and an image install
+    # boots nothing: its whole product is the file, which `check_image` reads
+    # while the live medium is still up. Asking for the rest would fail every
+    # image run; asking for none of it left the image check inert, collected
+    # and printed and never compared.
+    installed = [] if load(config).disk.mode is DiskMode.IMAGE else list(EXPECTED)
+    for name, pattern in [*installed, *_from_config(config)]:
         text = results.get(f"{name}.txt", b"").decode("utf-8", "replace")
         if re.search(pattern, text, re.MULTILINE) is None:
             missing.append(f"{name}.txt does not match {pattern}")


### PR DESCRIPTION
`vm-image` had no record anywhere. Its install succeeds — `install.rc` holds 0 and the log ends `installed 54 operations into /mnt/gentoo; 55 packages from a binary host, 12 compiled` — and then `--and-boot` booted the target disk, which in this mode carries the scratch filesystem the image sits on and no installed system at all, so the run ended at `UEFI Interactive Shell` after 300 seconds waiting for a login.

The image is read where it exists: `losetup -Pf` inside the live medium, then `lsblk`, and every filesystem the layout declares has to be in the answer. Measured on this workstation: the guest wrote `loop1 / loop1p1 vfat / loop1p2 ext4`, which is the text the test uses. The verdict is decided in the install phase, because an image run has no second one.