### PR TITLE
vm: say what an image run proved, and record it

### DIFF
--- a/TESTED.md
+++ b/TESTED.md
@@ -76,6 +76,7 @@ a way to pass firmware arguments is available to a non-root API token.
 | `7b08c47f383a` | `vm-bios` | BIOS serial console; 53 operations, 55 packages from a binary host, 20 compiled, then the disk it wrote booted, logged in on the console and passed every installed-state check |
 | `90516741321b` | `vm-proxy` (SOCKS5, password), `vm-proxy-http` | the proxy runs on the host, which a bridged cluster guest cannot reach; each installed 57 operations, 69 packages from a binary host and 46 compiled, and each disk then booted and passed every installed-state check |
 | `f466b89d8206` | `vm-bios-luks` | BIOS serial console; 57 operations, 59 packages from a binary host, 20 compiled, then the disk it wrote booted, unlocked its root and passed every installed-state check |
+| `cbd22d88417a6` | `vm-image` | the product is a file on a filesystem this runner mounts on the spare disk, and the cluster has none to offer; 54 operations, 55 packages from a binary host, 12 compiled, then the image was attached with `losetup -Pf` inside the live medium and answered `loop1p1 vfat` and `loop1p2 ext4`, the two filesystems the layout declares. Nothing booted it: reading a file on the guest's own disk is what this record covers |
 
 ### Historical records
 

--- a/tests/unit/test_harness.py
+++ b/tests/unit/test_harness.py
@@ -566,7 +566,15 @@ def test_an_image_install_is_judged_by_the_image_it_wrote() -> None:
     # campaign gave, copied from `image.txt`.
     written = Path("tests/fixtures/vm-image.toml")
     real = b"loop1   \nloop1p1 vfat\nloop1p2 ext4\n"
-    assert runner.check_expected({"image.txt": real, "install.rc": b"0\n"}, written) == 0
+    import contextlib
+    from io import StringIO
+
+    printed = StringIO()
+    with contextlib.redirect_stdout(printed):
+        assert runner.check_expected({"image.txt": real, "install.rc": b"0\n"}, written) == 0
+    # What was read, not what a different mode reads: nothing booted here.
+    assert "the image holds every filesystem" in printed.getvalue(), printed.getvalue()
+    assert "booted" not in printed.getvalue(), printed.getvalue()
     # The esp alone: the install stopped before it made the root filesystem.
     assert runner.check_expected({"image.txt": b"loop1\nloop1p1 vfat\n"}, written) != 0
     # And nothing collected at all, which is how the check stayed inert.

--- a/tests/unit/test_readme.py
+++ b/tests/unit/test_readme.py
@@ -423,6 +423,6 @@ def test_every_fixture_a_record_used_is_named_in_it() -> None:
     # fixture failed: this rule is about a record a reader can trace back to a
     # configuration, not about a fixture having passed. These two appear
     # nowhere at all.
-    without_a_record = {"vm-image", "vm-source-kernel"}
+    without_a_record = {"vm-source-kernel"}
     assert without_a_record <= fixtures, without_a_record
     assert fixtures - recorded == without_a_record, sorted(fixtures - recorded)

--- a/tests/vm/run.py
+++ b/tests/vm/run.py
@@ -1007,7 +1007,8 @@ def check_expected(results: dict[str, bytes], config: Path) -> int:
     # while the live medium is still up. Asking for the rest would fail every
     # image run; asking for none of it left the image check inert, collected
     # and printed and never compared.
-    installed = [] if load(config).disk.mode is DiskMode.IMAGE else list(EXPECTED)
+    writes_an_image = load(config).disk.mode is DiskMode.IMAGE
+    installed = [] if writes_an_image else list(EXPECTED)
     for name, pattern in [*installed, *_from_config(config)]:
         text = results.get(f"{name}.txt", b"").decode("utf-8", "replace")
         if re.search(pattern, text, re.MULTILINE) is None:
@@ -1022,7 +1023,13 @@ def check_expected(results: dict[str, bytes], config: Path) -> int:
         print(f"FAIL {problem}", file=sys.stderr)
     if missing:
         return 1
-    print("the installed system booted, mounted its layout and has no failed unit")
+    # What was read, not what a different mode reads: an image run boots
+    # nothing, and saying it did is a report of a check that never ran.
+    print(
+        "the image holds every filesystem the layout declares"
+        if writes_an_image
+        else "the installed system booted, mounted its layout and has no failed unit"
+    )
     return 0
 
 


### PR DESCRIPTION
The passing line read `the installed system booted, mounted its layout and has no failed unit` for a mode that boots nothing — a report of a check that never ran. It now says what was read.

`vm-image` gets its first record with it: revision `cbd22d88417a6`, 54 operations, 55 packages from a binary host and 12 compiled, then `loop1p1 vfat` and `loop1p2 ext4` read back out of the image with `losetup -Pf` inside the live medium. `test_every_fixture_a_record_used_is_named_in_it` loses `vm-image` from its exemption in the same commit.