### PR TITLE
cluster: name the node in a flat-counter verdict

### DIFF
--- a/tests/unit/test_cluster.py
+++ b/tests/unit/test_cluster.py
@@ -260,7 +260,7 @@ def _timed_wait(
     monkeypatch.setattr(time, "monotonic", lambda: clock[0])
     serial = SerialConsole(TimedChannel(clock, output_at), BytesIO())
     link = cluster.Reconnecting(lambda: serial)
-    watch = cluster.Watchdog(tmp_path / "install.log", counters)
+    watch = cluster.Watchdog(tmp_path / "install.log", counters, where="infra-node2")
     return link, watch
 
 
@@ -296,6 +296,10 @@ def test_install_wait_names_silent_console_and_flat_counters(
     assert "console was silent" in message
     assert "counters were flat" in message
     assert "0 -> 0 bytes" in message
+    # And where, because the cluster's other tenants are not this campaign's:
+    # a guest that goes to cpu 0.00 mid-compile is a different finding on a
+    # node at 100% than on an idle one, and the verdict was the only record.
+    assert "on infra-node2" in message, message
 
 
 def test_run_ceiling_ends_silent_guest_that_keeps_moving_bytes(

--- a/tests/vm/cluster.py
+++ b/tests/vm/cluster.py
@@ -475,6 +475,11 @@ class Watchdog:
 
     log: Path
     counters: Callable[[], tuple[int, float] | None]
+    #: Where the guest is. A verdict that says only `counters were flat` is a
+    #: guess about a cluster whose other tenants this campaign does not
+    #: control: `static-ip` went to cpu 0.00 mid-compile and the node it was
+    #: on had to be read back out of the dispatch line to say anything at all.
+    where: str = ""
     strikes: int = 0
     _seen: int = field(default=0, init=False)
     _moved: int = field(default=0, init=False)
@@ -543,8 +548,9 @@ class Watchdog:
                     f"the hypervisor did not answer for {minutes:.0f}m "
                     "and the console said nothing"
                 )
+            node = f" on {self.where}" if self.where else ""
             return (
-                "counters were flat "
+                f"counters were flat{node} "
                 f"({self._counter_before} -> {self._counter_after} bytes, "
                 f"cpu {self._cpu:.2f})"
             )
@@ -1573,7 +1579,7 @@ def _execution(
     )
     return Running(
         guest,
-        Watchdog(log=log, counters=lambda: guest.transferred()),
+        Watchdog(log=log, counters=lambda: guest.transferred(), where=node),
         job.reservation_bytes,
         address,
     )


### PR DESCRIPTION
`static-ip` was ended at 56.4 minutes with `the console was silent for 1200s and counters were flat (16875777711 -> 16875840765 bytes, cpu 0.00)`, its console cut mid-line while compiling `sys-boot/grub-2.14-r5`. Two nodes were at 100% CPU at the time and the verdict said nothing about where the guest was, so which of those it was had to be read back out of the dispatch line.

The node goes in the reason.