### PR TITLE
portage: say why an emerge failed, not what it printed after

### DIFF
--- a/gentoo_install/exec/runner.py
+++ b/gentoo_install/exec/runner.py
@@ -10,7 +10,6 @@ from __future__ import annotations
 
 import errno
 import os
-import re
 import shlex
 import signal
 import subprocess
@@ -24,7 +23,7 @@ from typing import Callable, Sequence, TextIO
 from ..errors import CommandFailed
 from ..log import Journal
 from ..model.config import ProxyConfig
-from ..plan.operations import ending
+from ..plan.operations import ending, worth_reading
 
 
 @dataclass(frozen=True)
@@ -110,7 +109,7 @@ class Runner:
         if check and result.returncode != 0:
             raise CommandFailed(
                 f"{result.command} ended with {result.ending}: "
-                f"{_tail(result.stderr or result.stdout)}"
+                f"{worth_reading(result.stderr or result.stdout)}"
             )
         return result
 
@@ -211,7 +210,7 @@ class Runner:
             if result.returncode != 0:
                 raise CommandFailed(
                     f"{result.command} ended with {result.ending}: "
-                    f"{_tail(result.stderr or result.stdout)}"
+                    f"{worth_reading(result.stderr or result.stdout)}"
                 )
 
     def _stream(
@@ -329,19 +328,6 @@ def _display_argv(argv: Sequence[str]) -> tuple[str, ...]:
             )
         shown.append(value)
     return tuple(shown)
-
-
-#: What a failing command's own error looks like. Portage keeps printing after
-#: one, so the last lines of the output are news items rather than the cause.
-_COMPLAINT = re.compile(r"\b(ERROR|error:|failed|Call stack|died|cannot|No such file)", re.I)
-
-
-def _tail(text: str, lines: int = 5) -> str:
-    """The lines worth reading, which are rarely the last ones."""
-    kept = [line.strip() for line in text.splitlines() if line.strip()]
-    complaints = [line for line in kept if _COMPLAINT.search(line)]
-    chosen = complaints[:lines] if complaints else kept[-lines:]
-    return " | ".join(chosen) if chosen else "no output"
 
 
 def write_file(path: Path, content: str, mode: int = 0o644) -> None:

--- a/gentoo_install/plan/operations.py
+++ b/gentoo_install/plan/operations.py
@@ -18,7 +18,8 @@ from abc import ABC, abstractmethod
 from dataclasses import dataclass
 from enum import Enum
 from pathlib import PurePosixPath
-from typing import ClassVar, Protocol, Sequence
+import re
+from typing import ClassVar, Final, Protocol, Sequence
 
 from ..model.device import DeviceId
 from ..model.validate import KernelCeiling
@@ -59,6 +60,26 @@ def ending(returncode: int) -> str:
         return f"{signal.Signals(-returncode).name} ({-returncode})"
     except ValueError:
         return f"signal {-returncode}"
+
+
+#: What a failing command's own error looks like. Portage keeps printing
+#: after one, so the last lines of the output are news items rather than the
+#: cause: an emerge that stopped at `!!! Couldn't download
+#: 'cjktty-font-unifont-15.1.04.patch'. Aborting.` was reported to the
+#: operator as `1 news items need reading`.
+COMPLAINT: Final[re.Pattern[str]] = re.compile(
+    r"(\bERROR|error:|\bfailed\b|Call stack|\bdied\b|\bcannot\b|No such file"
+    r"|^!!!|Aborting)",
+    re.I | re.M,
+)
+
+
+def worth_reading(text: str, lines: int = 5) -> str:
+    """The lines of a failed command worth reading, rarely the last ones."""
+    kept = [line.strip() for line in text.splitlines() if line.strip()]
+    complaints = [line for line in kept if COMPLAINT.search(line)]
+    chosen = complaints[:lines] if complaints else kept[-lines:]
+    return " | ".join(chosen) if chosen else "no output"
 
 
 class CommandOutput(str):

--- a/gentoo_install/plan/portage.py
+++ b/gentoo_install/plan/portage.py
@@ -30,7 +30,7 @@ from ..model.config import (
     Sync,
 )
 from ..model.validate import parse_profile_list, validate_profile
-from .operations import CommandOutput, Context, Operation, Stage
+from .operations import CommandOutput, Context, Operation, Stage, worth_reading
 
 #: The release engineering key, pinned. A fingerprint that does not match this
 #: is a failed install, not a prompt to trust something new.
@@ -904,7 +904,7 @@ class Emerge(Operation):
         if not _binpkg_failure(str(result)) or context.degraded(BINARY_PACKAGES):
             if self._optional(context, str(result)):
                 return
-            raise CommandFailed(f"emerge ended with {result.ending}: {str(result).strip()}")
+            raise CommandFailed(f"emerge ended with {result.ending}: {worth_reading(str(result))}")
         marker = _binpkg_failure(str(result))
         if (again := self._one_more_binary_try(context, command)) is not None:
             marker = again
@@ -930,7 +930,8 @@ class Emerge(Operation):
         retry_result = context.run_in_target(self._argv(context, source_only=True), check=False)
         if isinstance(retry_result, CommandOutput) and retry_result.returncode != 0:
             raise CommandFailed(
-                f"source retry ended with {retry_result.ending}: {str(retry_result).strip()}"
+                f"source retry ended with {retry_result.ending}: "
+                f"{worth_reading(str(retry_result))}"
             )
 
     def _one_more_binary_try(self, context: Context, command: list[str]) -> str | None:

--- a/tests/unit/test_plan_portage.py
+++ b/tests/unit/test_plan_portage.py
@@ -900,6 +900,52 @@ BINHOST_TIMED_OUT: Final[str] = (
 
 
 
+#: What `zbm-unlock` printed when the cjktty patch was on no reachable host,
+#: copied from its own log. The cause is in the middle and the last three
+#: lines are Portage's news notice.
+FETCH_FAILED: Final[str] = """>>> Emerging (10 of 12) sys-kernel/gentoo-cjk-kernel-bin-6.18.44::gentoo-zh
+>>> Downloading 'http://10.31.0.2/gentoo/distfiles/0d/cjktty-font-unifont-15.1.04.patch'
+HTTP request sent, awaiting response... 404 Not Found
+2026-08-19 13:24:00 ERROR 404: Not Found.
+Resolving mirror.nju.edu.cn... failed: Temporary failure in name resolution.
+!!! Couldn't download 'cjktty-font-unifont-15.1.04.patch'. Aborting.
+ * IMPORTANT: 1 news items need reading for repository 'gentoo-zh'.
+ * IMPORTANT: 21 news items need reading for repository 'gentoo'.
+ * Use eselect news read to view new items.
+"""
+
+
+def test_a_failed_emerge_says_why_and_not_what_came_after() -> None:
+    """`zbm-unlock` was recorded as `emerge ended with exit 1: * IMPORTANT: 1
+    news items need reading`, and the run had stopped on a distfile no host
+    would answer for. Portage keeps printing after its own error, so the last
+    lines are never the cause.
+    """
+    from gentoo_install.plan.operations import worth_reading
+
+    said = worth_reading(FETCH_FAILED)
+    assert "Couldn't download 'cjktty-font-unifont-15.1.04.patch'" in said
+    assert "ERROR 404" in said
+    assert "news items" not in said, said
+
+    # Both raisers use it, not `str(result)`: the operator reads the message,
+    # not the log the message came from.
+    import inspect
+
+    from gentoo_install.plan import portage as plan_portage
+
+    for source in (
+        inspect.getsource(plan_portage.Emerge.apply),
+        inspect.getsource(plan_portage.Emerge._from_source),
+    ):
+        raised = [one for one in source.split("CommandFailed(") if "ended with" in one]
+        assert raised, source
+        for block in raised:
+            head = block.split(")")[0]
+            assert "worth_reading" in head, head
+            assert "str(result).strip()" not in head, head
+
+
 def test_both_binhost_detectors_read_one_marker() -> None:
     """The failing path finds the line and the succeeding path parses the host
     and the url out of it. The two spelled Portage's diagnostic separately, so


### PR DESCRIPTION
`zbm-unlock` was recorded as `emerge ended with exit 1: * IMPORTANT: 1 news items need reading for repository 'gentoo-zh'`. It had stopped at `!!! Couldn't download 'cjktty-font-unifont-15.1.04.patch'. Aborting.` — the local mirror answers 404 for that distfile and every fallback host fails to resolve from a guest.

`exec/runner.py` already had the helper that picks a failing command's own complaint lines, with a comment saying Portage keeps printing news after its error. The two `Emerge` raisers passed `str(result)` instead. The helper moves to `plan/operations.py`, where both layers can reach it, and the pattern also takes Portage's `!!!` prefix and `Aborting`. The test runs it over the log `zbm-unlock` actually wrote.