### PR TITLE
errors: TargetEscape is a named installer error

### DIFF
--- a/gentoo_install/errors.py
+++ b/gentoo_install/errors.py
@@ -91,6 +91,16 @@ class ArchiveDigestMismatch(IntegrityError):
     """
 
 
+class TargetEscape(GentooInstallError):
+    """A path inside the target resolved to something outside it.
+
+    Under `GentooInstallError` because it is raised from inside an operation:
+    `apply` records only the failures it can catch, and `cli` maps only those
+    to an exit code, so a plain `Exception` here left the one refusal that
+    stops the installer writing to the live system unrecorded and untyped.
+    """
+
+
 class ResumeRefused(GentooInstallError):
     """A `--resume` whose journal was written by a different run."""
 

--- a/gentoo_install/exec/apply.py
+++ b/gentoo_install/exec/apply.py
@@ -16,7 +16,7 @@ from functools import lru_cache
 from pathlib import Path, PurePosixPath
 from typing import Callable, Sequence
 
-from ..errors import CommandFailed, GentooInstallError, InvalidLayout
+from ..errors import CommandFailed, GentooInstallError, InvalidLayout, TargetEscape
 from ..model.config import InstallConfig
 from ..model.validate import KernelCeiling
 from ..model.device import (
@@ -36,7 +36,7 @@ from ..plan.operations import CommandOutput, Operation
 from . import fetch, packages
 from .preflight import SecretStore
 from .probe import Probe
-from .runner import Runner, TargetEscape, open_in_target, under
+from .runner import Runner, open_in_target, under
 
 
 @dataclass

--- a/gentoo_install/exec/packages.py
+++ b/gentoo_install/exec/packages.py
@@ -8,8 +8,8 @@ import re
 
 from pathlib import Path, PurePosixPath
 
-from ..errors import CommandFailed
-from .runner import TargetEscape, open_in_target
+from ..errors import CommandFailed, TargetEscape
+from .runner import open_in_target
 
 
 _ATOM = re.compile(r"^[A-Za-z0-9+_.-]+/[A-Za-z0-9+_.-]+$")

--- a/gentoo_install/exec/report.py
+++ b/gentoo_install/exec/report.py
@@ -15,7 +15,7 @@ from typing import Final
 from pathlib import Path, PurePosixPath
 
 from .. import errors
-from ..errors import GentooInstallError
+from ..errors import GentooInstallError, TargetEscape
 from ..log import Journal
 from ..model import config as model_config
 from ..model import paste
@@ -23,7 +23,7 @@ from ..model.config import InstallConfig
 from ..model.serialise import to_toml
 from . import fetch, preflight
 from .probe import Probe
-from .runner import TargetEscape, open_in_target, write_file
+from .runner import open_in_target, write_file
 
 
 class RunFile(Enum):

--- a/gentoo_install/exec/runner.py
+++ b/gentoo_install/exec/runner.py
@@ -20,7 +20,7 @@ from dataclasses import dataclass, field
 from pathlib import Path, PurePosixPath
 from typing import Callable, Sequence, TextIO
 
-from ..errors import CommandFailed
+from ..errors import CommandFailed, TargetEscape
 from ..log import Journal
 from ..model.config import ProxyConfig
 from ..plan.operations import ending, worth_reading
@@ -353,10 +353,6 @@ def _kill_group(process: subprocess.Popen[str]) -> None:
         os.killpg(os.getpgid(process.pid), signal.SIGKILL)
     except (ProcessLookupError, PermissionError):
         process.kill()
-
-
-class TargetEscape(Exception):
-    """A path inside the target resolved to something outside it."""
 
 
 def open_in_target(

--- a/tests/unit/test_exec.py
+++ b/tests/unit/test_exec.py
@@ -1407,7 +1407,7 @@ def test_a_symlink_in_the_target_cannot_reach_the_live_system(tmp_path: Path) ->
     """`target / path` is a lexical join, so an absolute symlink under the
     target -- shipped by a stage3 or left on a reused filesystem -- made the
     installer write to the live system as root."""
-    from gentoo_install.exec.runner import TargetEscape
+    from gentoo_install.errors import TargetEscape
 
     target = tmp_path / "mnt"
     (target / "etc").mkdir(parents=True)
@@ -1427,7 +1427,7 @@ def test_a_symlink_in_the_target_cannot_reach_the_live_system(tmp_path: Path) ->
 def test_a_symlinked_parent_directory_cannot_reach_the_live_system(tmp_path: Path) -> None:
     """The final component is not the only way out: a directory on the way can
     be the symlink."""
-    from gentoo_install.exec.runner import TargetEscape
+    from gentoo_install.errors import TargetEscape
 
     target = tmp_path / "mnt"
     target.mkdir()
@@ -2436,10 +2436,50 @@ def test_a_written_file_is_whole_or_absent(
     assert not leftovers, f"the file it was written through stayed: {leftovers}"
 
 
+def test_a_refused_target_path_is_recorded_and_typed(tmp_path: Path) -> None:
+    """`TargetEscape` was a plain `Exception`, so the one refusal that stops
+    the installer writing to the live system through a symlink escaped
+    `apply`'s handler: the journal recorded nothing for the operation and
+    `cli` had no clause to turn it into an exit code.
+    """
+    from dataclasses import dataclass
+
+    from gentoo_install.errors import GentooInstallError, TargetEscape
+    from gentoo_install.log import Journal
+    from gentoo_install.plan.operations import Context, Operation, Stage
+
+    assert issubclass(TargetEscape, GentooInstallError)
+
+    @dataclass(frozen=True, kw_only=True)
+    class Escaping(Operation):
+        stage: Stage = Stage.SYSTEM
+
+        def describe(self) -> str:
+            return "write a file the target points out of"
+
+        def apply(self, context: Context) -> None:
+            raise TargetEscape("/etc/mtab in the target is a symlink")
+
+    journal = Journal(tmp_path / "install.jsonl")
+    runner = Runner(log=lambda line: None, journal=journal)
+    machine = apply.Machine(
+        config=config(),
+        runner=runner,
+        probe=Probe(runner=runner, work=tmp_path),
+        work=tmp_path,
+    )
+
+    with pytest.raises(TargetEscape):
+        apply.apply((Escaping(),), machine)
+
+    operations = [one for one in journal.replay() if one["event"] == "operation"]
+    assert [one["status"] for one in operations] == ["failed"], operations
+
+
 def test_a_symlink_at_the_destination_is_refused_rather_than_replaced(tmp_path: Path) -> None:
     """`os.replace` takes a symlink's place instead of following it, so the
     refusal the other paths get has to be made here too."""
-    from gentoo_install.exec.runner import TargetEscape
+    from gentoo_install.errors import TargetEscape
 
     target = tmp_path / "target"
     (target / "etc").mkdir(parents=True)


### PR DESCRIPTION
`TargetEscape` is the refusal that stops the installer following a symlink out of the target and writing to the live system as root. It was declared in `exec/runner.py` as a plain `Exception`, so the one raised from `Machine.write` (`apply.py:111`) escaped `apply`'s `except GentooInstallError`: the journal recorded no `failed` entry for the operation and `cli` reached it only as an untyped traceback.

It moves to `errors.py` under `GentooInstallError`, where `cli`'s catch-all names it and returns `EXIT_COMMAND`. The call sites that already converted it to `CommandFailed` are unchanged.