### PR TITLE
kernel: describe the keyword the unlock operation writes

### DIFF
--- a/gentoo_install/plan/kernel.py
+++ b/gentoo_install/plan/kernel.py
@@ -356,9 +356,13 @@ class ConfigureRemoteUnlock(Operation):
     system_initramfs: bool = True
 
     def describe(self) -> str:
+        # The keyword in both, because `apply` writes it in both: a dry run
+        # that names only the second file leaves the reader unaware of a
+        # `package.accept_keywords` fragment a real run puts on the disk.
+        keyworded = f"accept {REMOTE_UNLOCK_PACKAGE} as testing"
         if not self.system_initramfs:
-            return f"write {REMOTE_UNLOCK_CONFIG} to omit ssh from the system initramfs"
-        return f"configure remote unlock over ssh on port {self.port}"
+            return f"{keyworded} and write {REMOTE_UNLOCK_CONFIG} to omit ssh from the system initramfs"
+        return f"{keyworded} and configure remote unlock over ssh on port {self.port}"
 
     def apply(self, context: Context) -> None:
         WritePortageConfig(

--- a/tests/golden/vm-unlock.txt
+++ b/tests/golden/vm-unlock.txt
@@ -46,7 +46,7 @@
   ask for sys-apps/systemd[cryptsetup], which provides the unlock generator
   accept the linux-firmware licence
   ask for dhclient and arping, which the legacy network module requires
-  configure remote unlock over ssh on port 2222
+  accept sys-kernel/dracut-crypt-ssh as testing and configure remote unlock over ssh on port 2222
   resolve net-misc/openssh sys-process/cronie sys-kernel/installkernel sys-apps/systemd sys-kernel/dracut sys-kernel/linux-firmware sys-kernel/dracut-crypt-ssh sys-apps/iproute2 net-misc/dhcp net-misc/iputils sys-fs/cryptsetup sys-fs/btrfs-progs sys-fs/dosfstools sys-fs/e2fsprogs sys-kernel/gentoo-kernel-bin sys-boot/grub sys-boot/efibootmgr together before installing the requested packages
 
 [system]

--- a/tests/golden/zbm-unlock.txt
+++ b/tests/golden/zbm-unlock.txt
@@ -45,7 +45,7 @@
   verify the selected kernel against the target sys-fs/zfs ceiling
   accept the linux-firmware licence
   ask for dhclient and arping, which the legacy network module requires
-  write /etc/dracut.conf.d/zz-gentoo-install-crypt-ssh.conf to omit ssh from the system initramfs
+  accept sys-kernel/dracut-crypt-ssh as testing and write /etc/dracut.conf.d/zz-gentoo-install-crypt-ssh.conf to omit ssh from the system initramfs
   accept sys-kernel/gentoo-cjk-kernel-bin as testing, with cjk on
   unmask virtual/dist-kernel, which the cjk kernel depends on by revision
   tell sys-fs/zfs to build against the dist-kernel

--- a/tests/unit/test_plan_kernel.py
+++ b/tests/unit/test_plan_kernel.py
@@ -40,6 +40,42 @@ def test_no_dracut_config_this_installer_writes_is_a_file_a_package_owns() -> No
     assert all(ours.name > one for one in owned), ours
 
 
+def test_the_unlock_operation_describes_the_keyword_it_writes() -> None:
+    """`apply` writes the `dracut-crypt-ssh` keyword in both branches, and the
+    ZFSBootMenu branch's `describe` named only the dracut omission file. A dry
+    run has to say every file a real run puts on the disk.
+    """
+    from gentoo_install.plan.portage import PortageConfigKind
+
+    for fixture in ("vm-unlock", "zbm-unlock"):
+        installation = load(Path("tests/fixtures") / f"{fixture}.toml")
+        operation = next(
+            one
+            for one in kernel.build(installation)
+            if isinstance(one, kernel.ConfigureRemoteUnlock)
+        )
+        recorder = Recorder()
+        operation.apply(recorder)
+        keyworded = [
+            path
+            for path in recorder.files
+            if PortageConfigKind.KEYWORDS.value in str(path)
+        ]
+        assert keyworded, f"{fixture}: nothing wrote the keyword"
+        assert kernel.REMOTE_UNLOCK_PACKAGE in operation.describe(), (
+            fixture,
+            operation.describe(),
+        )
+    # And the two branches really are different, so this covers both.
+    assert (
+        next(
+            one for one in kernel.build(load(Path("tests/fixtures/zbm-unlock.toml")))
+            if isinstance(one, kernel.ConfigureRemoteUnlock)
+        ).system_initramfs
+        is False
+    )
+
+
 def test_grub_remote_unlock_keeps_the_system_dracut_path() -> None:
     installation = load(Path("tests/fixtures/vm-unlock.toml"))
     operation = next(


### PR DESCRIPTION
`ConfigureRemoteUnlock.apply` writes `package.accept_keywords/dracut-crypt-ssh` in both branches. Its `describe` named only the dracut omission file on the ZFSBootMenu path and only "configure remote unlock" on the other, so a `--dry-run` reader was not told about a file a real run writes.

The two golden files the change moves are regenerated in the same commit.