### PR TITLE
preflight: a passphrase that will not go keeps the real error

### DIFF
--- a/gentoo_install/exec/apply.py
+++ b/gentoo_install/exec/apply.py
@@ -183,7 +183,8 @@ class Machine:
         return (self.secrets or SecretStore(self.work)).path(device)
 
     def cleanup_secrets(self) -> None:
-        (self.secrets or SecretStore(self.work)).cleanup()
+        for stayed in (self.secrets or SecretStore(self.work)).cleanup():
+            self.runner.log(f"WARNING: a staged passphrase stayed: {stayed}")
 
     def key_file(self, device: DeviceId) -> PurePosixPath:
         """Where the passphrase is staged, as a path on the installing system.

--- a/gentoo_install/exec/preflight.py
+++ b/gentoo_install/exec/preflight.py
@@ -187,13 +187,27 @@ class SecretStore:
     def stage(self, device: DeviceId, passphrase: str) -> None:
         write_file(self.path(device), passphrase, 0o600)
 
-    def cleanup(self) -> None:
+    def cleanup(self) -> tuple[str, ...]:
+        """Remove every staged passphrase, and answer the ones that stayed.
+
+        Raising here replaces the failure that brought the run to the closing
+        path — a preflight refusal, or the install's own error — with an
+        `unlink` errno, and that is never the more useful of the two. The
+        caller reports what stayed, because a passphrase left on disk is not
+        something to drop quietly either.
+        """
         keys = self.work / "keys" / "approved"
         if not keys.is_dir():
-            return
+            return ()
+        stayed: list[str] = []
         for path in keys.iterdir():
-            if path.is_file():
+            if not path.is_file():
+                continue
+            try:
                 path.unlink()
+            except OSError as error:
+                stayed.append(f"{path}: {error}")
+        return tuple(stayed)
 
 
 @dataclass(frozen=True)
@@ -204,10 +218,12 @@ class Report:
 
     def raise_if_fatal(self) -> None:
         if self.fatal:
-            if self.secrets is not None:
-                self.secrets.cleanup()
+            # After the reasons, never instead of them: what the operator has
+            # to read first is why this machine was refused.
+            stayed = self.secrets.cleanup() if self.secrets is not None else ()
             raise PreflightFailed(
-                "this machine cannot run the install:\n  " + "\n  ".join(self.fatal)
+                "this machine cannot run the install:\n  "
+                + "\n  ".join([*self.fatal, *(f"a staged passphrase stayed: {one}" for one in stayed)])
             )
 
 

--- a/tests/unit/test_exec.py
+++ b/tests/unit/test_exec.py
@@ -835,6 +835,63 @@ def test_apply_uses_the_preflight_approved_passphrase_after_source_mutation(
     assert not store.path(pool.id).exists()
 
 
+def test_a_passphrase_that_will_not_go_does_not_replace_the_refusal(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """`raise_if_fatal` cleans the staged passphrases and then raises, and the
+    unlink was unguarded: an errno there reached the operator instead of the
+    reasons this machine was refused. A passphrase left on disk is still named,
+    after them.
+    """
+    from gentoo_install.errors import PreflightFailed
+    from gentoo_install.exec.preflight import Report, SecretStore
+
+    store = SecretStore(tmp_path)
+    store.stage(i("rootpart"), "approved-passphrase")
+
+    def refusing(self: Path, missing_ok: bool = False) -> None:
+        raise OSError(30, "Read-only file system")
+
+    monkeypatch.setattr(Path, "unlink", refusing)
+
+    with pytest.raises(PreflightFailed) as raised:
+        Report(fatal=("the firmware variables are not readable",), warnings=(), secrets=store).raise_if_fatal()
+
+    said = str(raised.value)
+    assert "the firmware variables are not readable" in said
+    assert said.index("firmware") < said.index("staged passphrase"), said
+    assert "Read-only file system" in said
+
+
+def test_a_passphrase_that_will_not_go_is_logged_by_the_install(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The same closing path runs in `apply`'s `finally`, where an errno would
+    replace the install's own failure."""
+    from gentoo_install.exec.preflight import SecretStore
+
+    store = SecretStore(tmp_path)
+    store.stage(i("rootpart"), "approved-passphrase")
+
+    def refusing(self: Path, missing_ok: bool = False) -> None:
+        raise OSError(30, "Read-only file system")
+
+    monkeypatch.setattr(Path, "unlink", refusing)
+
+    said: list[str] = []
+    runner = Runner(log=said.append)
+    machine = apply.Machine(
+        config=config(),
+        runner=runner,
+        probe=Probe(runner=runner, work=tmp_path),
+        work=tmp_path,
+        secrets=store,
+    )
+    machine.cleanup_secrets()
+
+    assert [one for one in said if "a staged passphrase stayed" in one], said
+
+
 def test_apply_uses_the_approved_passphrase_after_source_disappearance(tmp_path: Path) -> None:
     from gentoo_install.exec.preflight import SecretStore
     from gentoo_install.model.device import ZfsPool


### PR DESCRIPTION
`SecretStore.cleanup` unlinked without a guard. `Report.raise_if_fatal` calls it before raising `PreflightFailed`, and `apply` calls it in its `finally`, so an `OSError` from the unlink reached the operator instead of why the machine was refused or why the install stopped.

`cleanup` answers with what stayed instead of raising. The preflight names it after the reasons and the install logs it as a warning: a passphrase left on disk is not something to drop quietly either.