### PR TITLE
vm: ask the installed system for its timezone

### DIFF
--- a/tests/unit/test_harness.py
+++ b/tests/unit/test_harness.py
@@ -497,6 +497,19 @@ def test_an_installed_check_matches_the_value_and_not_the_text_around_it() -> No
     # The esp by UUID and the root still named by device.
     assert not re.search(fstab, "/dev/vda2\t/\text4\tdefaults\t0\t1\nUUID=0AB2\t/efi\tvfat\t0\t2\n")
 
+    # Nothing asked for the timezone at all until this: a machine installed in
+    # the wrong zone passed every check the campaign made.
+    zone = pattern("vm-cjk-kernel", "timezone")
+    assert re.search(zone, "/usr/share/zoneinfo/UTC\nUTC\n")
+    assert not re.search(zone, "/usr/share/zoneinfo/Asia/Taipei\nAsia/Taipei\n")
+    assert not re.search(zone, "readlink: /etc/localtime: No such file or directory\n")
+    # A different zone that carries this one's name: `UTC-8` and `Etc/GMT+8`
+    # are zones of their own, and an unanchored pattern took either for `UTC`.
+    assert not re.search(zone, "/usr/share/zoneinfo/UTC-8\nUTC-8\n")
+    taipei = pattern("btrfs-luks", "timezone")
+    assert re.search(taipei, "/usr/share/zoneinfo/Asia/Taipei\nAsia/Taipei\n")
+    assert not re.search(taipei, "/usr/share/zoneinfo/UTC\nUTC\n")
+
     esp = pattern("vm-binpkg", "esp")
     assert re.search(esp, "/efi /dev/vda1 vfat\n")
     # Mounted there, but not something the firmware can read.
@@ -2517,6 +2530,10 @@ def test_a_healthy_init_is_judged_by_the_marker_it_prints() -> None:
         "kernel": b"6.18.43-gentoo-dist-bin\n/boot/kernel-6.18.43-gentoo-dist-bin\n",
         "fstab": b"UUID=ab2e555d\t/\tbtrfs\tdefaults,subvol=@\t0\t1\n",
         "esp": b"/efi /dev/vda1 vfat\n",
+        "timezone": (
+            f"/usr/share/zoneinfo/{installation.system.timezone}\n"
+            f"{installation.system.timezone}\n"
+        ).encode(),
     }
     healthy = {
         f"{one.name}.txt": written.get(

--- a/tests/vm/installed.py
+++ b/tests/vm/installed.py
@@ -74,6 +74,15 @@ def checks(installation: InstallConfig) -> tuple[InstalledCheck, ...]:
         InstalledCheck("os-release", "cat /etc/os-release", r"(?m)^ID=['\"]?gentoo['\"]?$"),
         InstalledCheck("mounts", "findmnt --noheadings --list --output TARGET,SOURCE,FSTYPE", "/"),
         InstalledCheck("locale", "locale", f"LANG={installation.system.locale}"),
+        # Nothing asked for the timezone at all, and the installer writes two
+        # files for it: a machine installed in the wrong zone passed every
+        # check. Either line answers, so the resolution of `UTC` — a file on
+        # Gentoo, a symlink elsewhere — does not decide the verdict.
+        InstalledCheck(
+            "timezone",
+            "readlink -f /etc/localtime; cat /etc/timezone 2>/dev/null",
+            rf"(?m)^(?:/usr/share/zoneinfo/)?{re.escape(installation.system.timezone)}$",
+        ),
         InstalledCheck("hostname", _hostname_command(installation), _hostname_pattern(installation)),
         InstalledCheck("kernel", "uname -r; find /boot -maxdepth 4 -type f "
                        r"\( -name 'vmlinuz*' -o -name 'kernel-*' -o -name linux -o -name '*.conf' \) | sort",


### PR DESCRIPTION
`SetTimezone` links `/etc/localtime` and writes `/etc/timezone`, and the installed-state contract asked for neither: a machine installed in the wrong zone passed every check the campaign makes. Thirty-eight fixtures set one, nine of them `Asia/Taipei`.

Both lines are read, so the resolution of `UTC` — a file on Gentoo, a symlink elsewhere — does not decide the verdict, and the pattern is anchored: `UTC-8` and `Etc/GMT+8` are zones of their own that an unanchored one took for `UTC`.