### PR TITLE
cluster: say what the node was doing when a guest was called stuck

### DIFF
--- a/tests/unit/test_cluster.py
+++ b/tests/unit/test_cluster.py
@@ -260,7 +260,9 @@ def _timed_wait(
     monkeypatch.setattr(time, "monotonic", lambda: clock[0])
     serial = SerialConsole(TimedChannel(clock, output_at), BytesIO())
     link = cluster.Reconnecting(lambda: serial)
-    watch = cluster.Watchdog(tmp_path / "install.log", counters, where="infra-node2")
+    watch = cluster.Watchdog(
+        tmp_path / "install.log", counters, where="infra-node2", load=lambda: 0.99
+    )
     return link, watch
 
 
@@ -300,6 +302,10 @@ def test_install_wait_names_silent_console_and_flat_counters(
     # a guest that goes to cpu 0.00 mid-compile is a different finding on a
     # node at 100% than on an idle one, and the verdict was the only record.
     assert "on infra-node2" in message, message
+    # And what the node was doing then: a guest at `cpu 0.00` on a node at 99%
+    # is the cluster having no time for it, which is not the same finding as a
+    # guest that stopped. Two were ended this way on one day.
+    assert "the node itself at 99%" in message, message
 
 
 def test_run_ceiling_ends_silent_guest_that_keeps_moving_bytes(
@@ -1535,6 +1541,23 @@ def test_two_rounds_carrying_one_fixture_keep_separate_logs(tmp_path: Path) -> N
     assert first.watch.log != second.watch.log
     assert first.watch.log.name == "vm-greetd-9301.log"
     assert second.watch.log.name == "vm-greetd-9302.log"
+
+
+def test_a_node_that_will_not_answer_leaves_the_reason_readable(tmp_path: Path) -> None:
+    """The node's load is read once, when the guest is about to be called
+    stuck. A cluster that will not answer that request must not take the rest
+    of the reason with it.
+    """
+    def refusing() -> float | None:
+        return None
+
+    watch = cluster.Watchdog(
+        tmp_path / "install.log", lambda: (0, 0.0), where="infra-node4", load=refusing
+    )
+    reason = watch.idle_reason()
+    assert reason is not None
+    assert "on infra-node4" in reason, reason
+    assert "the node itself" not in reason, reason
 
 
 def test_a_marker_that_arrives_after_the_retry_began_still_ends_the_command() -> None:

--- a/tests/vm/cluster.py
+++ b/tests/vm/cluster.py
@@ -480,6 +480,11 @@ class Watchdog:
     #: control: `static-ip` went to cpu 0.00 mid-compile and the node it was
     #: on had to be read back out of the dispatch line to say anything at all.
     where: str = ""
+    #: What the node itself was doing, read once when the guest is about to be
+    #: called stuck. Two guests were ended mid-compile at `cpu 0.00` on nodes
+    #: this campaign does not own, and the verdict could not tell a guest that
+    #: stopped from a node with no time to give it.
+    load: Callable[[], float | None] | None = None
     strikes: int = 0
     _seen: int = field(default=0, init=False)
     _moved: int = field(default=0, init=False)
@@ -549,10 +554,12 @@ class Watchdog:
                     "and the console said nothing"
                 )
             node = f" on {self.where}" if self.where else ""
+            busy = self.load() if self.load is not None else None
+            said = "" if busy is None else f", the node itself at {busy * 100:.0f}%"
             return (
                 f"counters were flat{node} "
                 f"({self._counter_before} -> {self._counter_after} bytes, "
-                f"cpu {self._cpu:.2f})"
+                f"cpu {self._cpu:.2f}){said}"
             )
 
     @property
@@ -1579,7 +1586,12 @@ def _execution(
     )
     return Running(
         guest,
-        Watchdog(log=log, counters=lambda: guest.transferred(), where=node),
+        Watchdog(
+            log=log,
+            counters=lambda: guest.transferred(),
+            where=node,
+            load=lambda: api.node_load(node),
+        ),
         job.reservation_bytes,
         address,
     )

--- a/tests/vm/proxmox.py
+++ b/tests/vm/proxmox.py
@@ -305,6 +305,20 @@ class Api:
         ]
         return sorted(found, key=lambda one: one.free_bytes, reverse=True)
 
+    def node_load(self, name: str) -> float | None:
+        """The share of this node's cores in use, or None when it will not say.
+
+        Read when a guest is about to be called stuck, not on every sample: a
+        guest at `cpu 0.00` on a node at 99% is the cluster having no time for
+        it, and a guest at `cpu 0.00` on an idle node is a guest that stopped.
+        """
+        try:
+            status = self.call("GET", f"/nodes/{name}/status")
+        except ProxmoxError:
+            return None
+        used = status.get("cpu")
+        return float(used) if isinstance(used, (int, float)) else None
+
     def ours(self) -> list[tuple[str, int]]:
         """Every machine this harness created, as `(node, vmid)`.
 


### PR DESCRIPTION
Two guests were ended mid-compile today with `counters were flat … cpu 0.00`: `static-ip` at 56.4 minutes and `vm-zfs` at 59.7 minutes, the second on `infra-node4`, which was reading 94–99% while other tenants' machines ran on it. A guest at `cpu 0.00` on a saturated node is the cluster having no time for it; on an idle node it is a guest that stopped. The verdict said the same thing for both.

`Api.node_load` is read once, when the guest is about to be called stuck, so it costs one request per verdict rather than one per sample. A cluster that will not answer it leaves the rest of the reason intact.