### PR TITLE
packages: a commented flag is not the flag

### DIFF
--- a/gentoo_install/plan/packages.py
+++ b/gentoo_install/plan/packages.py
@@ -676,7 +676,13 @@ class AppendWaylandFlags(Operation):
         return f"add the Wayland input method flags for {self.group} to {self.file.path}"
 
     def apply(self, context: Context) -> None:
-        if self.file.content.strip() in context.read(self.file.path):
+        # A line of its own, not the text anywhere in the file: the shipped
+        # `/etc/chromium/default` carries commented settings, and a commented
+        # copy of this one satisfied a substring test while chromium read
+        # nothing, so an install that appeared to configure the input method
+        # left it unconfigured.
+        wanted = self.file.content.strip()
+        if any(line.strip() == wanted for line in context.read(self.file.path).splitlines()):
             return
         context.append(self.file.path, f"{self.file.content.rstrip()}\n")
 

--- a/tests/unit/test_plan.py
+++ b/tests/unit/test_plan.py
@@ -580,6 +580,33 @@ def test_the_flag_is_not_added_twice_to_a_file_that_already_has_it() -> None:
     assert recorder.files[PurePosixPath("/etc/chromium/default")].count("wayland-ime") == 1
 
 
+def test_a_commented_flag_does_not_count_as_the_flag() -> None:
+    """`/etc/chromium/default` ships as commented settings, and a substring
+    test took a commented copy of this line for the line itself: the install
+    appeared to configure the input method and chromium read nothing.
+    """
+    wanted = replace(
+        config(),
+        packages=PackagesConfig(desktop="plasma", applications=("fcitx5", "rime", "chromium")),
+    )
+    recorder = Recorder()
+    recorder.files[PurePosixPath("/etc/chromium/default")] = (
+        "# Default settings for chromium.\n"
+        '#CHROMIUM_FLAGS="${CHROMIUM_FLAGS} --enable-wayland-ime"\n'
+    )
+    for operation in plan_packages.build(wanted, load_catalog()):
+        if isinstance(operation, plan_packages.AppendWaylandFlags):
+            operation.apply(recorder)
+
+    written = recorder.files[PurePosixPath("/etc/chromium/default")]
+    live = [
+        line
+        for line in written.splitlines()
+        if line.strip().startswith("CHROMIUM_FLAGS=")
+    ]
+    assert live == ['CHROMIUM_FLAGS="${CHROMIUM_FLAGS} --enable-wayland-ime"'], written
+
+
 def test_chromium_on_an_x11_desktop_gets_no_wayland_flag() -> None:
     wanted = replace(
         config(),


### PR DESCRIPTION
`AppendWaylandFlags.apply` skipped its work when the line appeared anywhere in `/etc/chromium/default`. That file ships as commented settings, so a commented copy of `CHROMIUM_FLAGS="\${CHROMIUM_FLAGS} --enable-wayland-ime"` satisfied the test while chromium read nothing: the install appeared to configure the input method and left it unconfigured.

A line of its own now counts, a commented one does not, and appending twice is still refused.