### PR TITLE
packages: describe both files the dconf operation writes

### DIFF
--- a/gentoo_install/plan/packages.py
+++ b/gentoo_install/plan/packages.py
@@ -676,7 +676,13 @@ class AppendWaylandFlags(Operation):
         return f"add the Wayland input method flags for {self.group} to {self.file.path}"
 
     def apply(self, context: Context) -> None:
-        if self.file.content.strip() in context.read(self.file.path):
+        # A line of its own, not the text anywhere in the file: the shipped
+        # `/etc/chromium/default` carries commented settings, and a commented
+        # copy of this one satisfied a substring test while chromium read
+        # nothing, so an install that appeared to configure the input method
+        # left it unconfigured.
+        wanted = self.file.content.strip()
+        if any(line.strip() == wanted for line in context.read(self.file.path).splitlines()):
             return
         context.append(self.file.path, f"{self.file.content.rstrip()}\n")
 

--- a/gentoo_install/plan/packages.py
+++ b/gentoo_install/plan/packages.py
@@ -647,7 +647,13 @@ class ConfigureGnomeInputSources(Operation):
     engines: tuple[str, ...]
 
     def describe(self) -> str:
-        return f"write the GNOME dconf default with {', '.join(self.engines)}"
+        # Both files, because `apply` writes both: the profile is what makes
+        # dconf read the database at all, and a dry run that named only the
+        # database did not say every file a real run puts on the disk.
+        return (
+            f"write {DCONF_PROFILE} and the GNOME dconf default in "
+            f"{GNOME_INPUT_SOURCES} with {', '.join(self.engines)}"
+        )
 
     def apply(self, context: Context) -> None:
         sources = [("xkb", self.layout), *(("ibus", engine) for engine in self.engines)]

--- a/tests/golden/vm-gnome.txt
+++ b/tests/golden/vm-gnome.txt
@@ -81,7 +81,7 @@
   install the pipewire group: emerge media-video/pipewire media-video/wireplumber
   enable pipewire.socket, pipewire-pulse.socket, wireplumber.service for every user
   set XMODIFIERS, GTK_IM_MODULE, QT_IM_MODULE in /etc/environment for ibus
-  write the GNOME dconf default with libpinyin
+  write /etc/dconf/profile/user and the GNOME dconf default in /etc/dconf/db/local.d/00-gentoo-install-input-sources with libpinyin
 
 [finish]
   delete the downloaded stage3 from /var/cache/gentoo-install

--- a/tests/unit/test_packages.py
+++ b/tests/unit/test_packages.py
@@ -295,7 +295,21 @@ def test_ibus_has_declared_chinese_engines() -> None:
         ),
     )
     operations = build(selected, load_catalog())
-    assert any(type(operation).__name__ == "ConfigureGnomeInputSources" for operation in operations)
+    configured = [
+        one for one in operations if type(one).__name__ == "ConfigureGnomeInputSources"
+    ]
+    assert configured
+    # Every file it writes, in what a dry run prints: the profile is what
+    # makes dconf read the database at all, and naming only the database
+    # left a real run writing a file nobody had been told about.
+    from gentoo_install.plan.packages import DCONF_PROFILE, GNOME_INPUT_SOURCES
+
+    recorder = Recorder()
+    configured[0].apply(recorder)
+    described = configured[0].describe()
+    assert set(recorder.files) == {DCONF_PROFILE, GNOME_INPUT_SOURCES}, recorder.files
+    for path in recorder.files:
+        assert str(path) in described, (path, described)
     selected = replace(
         installation,
         packages=replace(

--- a/tests/unit/test_plan.py
+++ b/tests/unit/test_plan.py
@@ -580,6 +580,33 @@ def test_the_flag_is_not_added_twice_to_a_file_that_already_has_it() -> None:
     assert recorder.files[PurePosixPath("/etc/chromium/default")].count("wayland-ime") == 1
 
 
+def test_a_commented_flag_does_not_count_as_the_flag() -> None:
+    """`/etc/chromium/default` ships as commented settings, and a substring
+    test took a commented copy of this line for the line itself: the install
+    appeared to configure the input method and chromium read nothing.
+    """
+    wanted = replace(
+        config(),
+        packages=PackagesConfig(desktop="plasma", applications=("fcitx5", "rime", "chromium")),
+    )
+    recorder = Recorder()
+    recorder.files[PurePosixPath("/etc/chromium/default")] = (
+        "# Default settings for chromium.\n"
+        '#CHROMIUM_FLAGS="${CHROMIUM_FLAGS} --enable-wayland-ime"\n'
+    )
+    for operation in plan_packages.build(wanted, load_catalog()):
+        if isinstance(operation, plan_packages.AppendWaylandFlags):
+            operation.apply(recorder)
+
+    written = recorder.files[PurePosixPath("/etc/chromium/default")]
+    live = [
+        line
+        for line in written.splitlines()
+        if line.strip().startswith("CHROMIUM_FLAGS=")
+    ]
+    assert live == ['CHROMIUM_FLAGS="${CHROMIUM_FLAGS} --enable-wayland-ime"'], written
+
+
 def test_chromium_on_an_x11_desktop_gets_no_wayland_flag() -> None:
     wanted = replace(
         config(),


### PR DESCRIPTION
`ConfigureGnomeInputSources.apply` writes `/etc/dconf/profile/user` and then the input-source database; its `describe` named only the second. The profile is what makes dconf read the database at all, so a `--dry-run` reader was not told about the file that makes the rest work.

The test applies the operation against the recorder and requires every path it wrote to appear in the description, so the rule holds for whatever the operation writes next. The golden file it moves is regenerated in the same commit.