### PR TITLE
fonts: refuse a contradictory decision in any locale

### DIFF
--- a/gentoo_install/plan/fonts.py
+++ b/gentoo_install/plan/fonts.py
@@ -168,9 +168,11 @@ def _unique(values: tuple[str, ...]) -> tuple[str, ...]:
 
 
 def build(config: InstallConfig, catalog: packages.Catalog) -> tuple[Operation, ...]:
-    locale = CjkFontconfigLocale.selected(config.system.locale)
-    if locale is None:
-        return ()
+    # The decisions are checked before the locale, not after: what this file
+    # writes is a CJK font preference and an `en_US.UTF-8` machine needs none,
+    # but a group that declines and a group that accepts is a configuration
+    # nobody can satisfy whatever the locale is, and refusing it only for some
+    # locales is a rule that fires by accident.
     chosen = packages.groups(config, catalog)
     decisions = {
         group.font_configuration for group in chosen if group.font_configuration
@@ -182,6 +184,9 @@ def build(config: InstallConfig, catalog: packages.Catalog) -> tuple[Operation, 
         )
     if len(decisions) > 1:
         raise ConfigError("font configuration was both accepted and declined")
+    locale = CjkFontconfigLocale.selected(config.system.locale)
+    if locale is None:
+        return ()
     if packages.FONT_CONFIGURATION_DISABLED in decisions:
         return ()
     if (

--- a/tests/unit/test_plan_fonts.py
+++ b/tests/unit/test_plan_fonts.py
@@ -94,6 +94,27 @@ def test_a_locale_outside_cjk_is_not_changed(locale: str) -> None:
     ]
 
 
+@pytest.mark.parametrize("locale", ["zh_TW.UTF-8", "en_US.UTF-8"])
+def test_a_contradictory_font_decision_is_refused_in_any_locale(locale: str) -> None:
+    """The decisions were checked after the locale, so a group that accepts
+    and a group that declines was a refusal on a Chinese machine and silence
+    on an English one. It is a configuration nobody can satisfy either way.
+    """
+    from gentoo_install.errors import ConfigError
+    from gentoo_install.plan import fonts
+
+    installation = config()
+    selected = replace(
+        installation,
+        system=replace(installation.system, locales=(locale,), locale=locale),
+        packages=PackagesConfig(
+            applications=("configure-fonts", "decline-font-configuration")
+        ),
+    )
+    with pytest.raises(ConfigError, match="both accepted and declined"):
+        fonts.build(selected, load_catalog())
+
+
 @pytest.mark.parametrize(("locale", "language", "face"), CJK_RULES)
 def test_the_written_file_is_a_regional_sans_match(
     locale: str, language: str, face: str


### PR DESCRIPTION
`fonts.build` returned early for a locale outside CJK and validated the groups' `font_configuration` decisions after that. A configuration where one group accepts and another declines was therefore refused on `zh_TW.UTF-8` and accepted in silence on `en_US.UTF-8`, as was a decision the model does not know.

What this module writes is a CJK font preference, so the early return itself is right; the refusal moves in front of it, because a rule that fires only for some locales fires by accident.