### PR TITLE
validate: refuse a broken proxy in dd mode too

### DIFF
--- a/gentoo_install/model/validate.py
+++ b/gentoo_install/model/validate.py
@@ -195,7 +195,11 @@ def validate(
     supports_v3: bool | None = None,
 ) -> None:
     if config.disk.mode is DiskMode.DD:
-        problems = _disk_mode_problems(config)
+        # The proxy with it: `dd` reads a local path and never uses one, but a
+        # host with no port is a configuration nobody can satisfy, and
+        # refusing it in every mode except this one is a rule that fires by
+        # accident.
+        problems = [*_disk_mode_problems(config), *_proxy_problems(config)]
         if problems:
             raise ValidationFailed(
                 "the configuration does not describe an installable system:\n  "

--- a/tests/unit/test_validate.py
+++ b/tests/unit/test_validate.py
@@ -73,6 +73,28 @@ def dd_config() -> InstallConfig:
     )
 
 
+def test_a_broken_proxy_is_refused_in_dd_mode_too() -> None:
+    """`dd` reads a local path and uses no proxy, so its validation returned
+    before the proxy was looked at: a host with no port was refused in every
+    other mode and accepted here.
+    """
+    from gentoo_install.model.config import ProxyConfig, ProxyKind
+
+    broken = replace(
+        dd_config(),
+        proxy=ProxyConfig(kind=ProxyKind.HTTP, host="proxy.example", port=0),
+    )
+    with pytest.raises(ValidationFailed, match="proxy port"):
+        validate(broken)
+
+    # And a sound one still validates, in this mode as in the others.
+    working = replace(
+        dd_config(),
+        proxy=ProxyConfig(kind=ProxyKind.HTTP, host="proxy.example", port=3128),
+    )
+    validate(working)
+
+
 def test_the_profile_probe_reads_current_amd64_paths(tmp_path: Path) -> None:
     desc = tmp_path / "profiles.desc"
     desc.write_text(


### PR DESCRIPTION
`validate` returns after `_disk_mode_problems` for `DiskMode.DD`, so `ProxyConfig(host="proxy.example", port=0)` was refused in every other mode and accepted there. `dd` reads a local path and never uses a proxy, which is why it went unnoticed; a host with no port is still a configuration nobody can satisfy, and a rule that fires in four modes out of five fires by accident.