### PR TITLE
report: closing the run log keeps the install's own error

### DIFF
--- a/gentoo_install/exec/report.py
+++ b/gentoo_install/exec/report.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 
 import os
 import shutil
+import sys
 import stat
 import tomllib
 from collections.abc import Callable, Iterable, Iterator
@@ -54,18 +55,28 @@ class ActiveReport:
 def recording(work: Path, target: Path) -> Iterator[ActiveReport]:
     """Open the files that record a run and close them when it finishes."""
     work.mkdir(parents=True, exist_ok=True)
-    with (work / RunFile.LOG.value).open("a") as log:
+    log = (work / RunFile.LOG.value).open("a")
 
-        def record(line: str) -> None:
-            print(line, file=log, flush=True)
-            print(line, flush=True)
+    def record(line: str) -> None:
+        print(line, file=log, flush=True)
+        print(line, flush=True)
 
+    try:
         yield ActiveReport(
             work=work,
             target=target,
             record=record,
             journal=Journal(path=work / RunFile.JOURNAL.value),
         )
+    finally:
+        # Not a `with`: this close runs while an install's own exception is
+        # unwinding, and the work directory is a tmpfs an install can fill.
+        # An errno from the last flush would replace the reason the install
+        # stopped, which is the one thing the operator needs.
+        try:
+            log.close()
+        except OSError as error:
+            print(f"WARNING: the run log could not be closed: {error}", file=sys.stderr)
 
 
 #: Target-absolute, so `open_in_target` refuses a symlink on the way. A

--- a/tests/unit/test_exec.py
+++ b/tests/unit/test_exec.py
@@ -835,6 +835,58 @@ def test_apply_uses_the_preflight_approved_passphrase_after_source_mutation(
     assert not store.path(pool.id).exists()
 
 
+def test_closing_the_run_log_does_not_replace_the_install_error(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The log is opened for the whole install and closed while the install's
+    own exception unwinds. The work directory is a tmpfs an install can fill,
+    so an errno from that last flush would have replaced the reason the
+    install stopped.
+    """
+    from typing import IO, Any
+
+    from gentoo_install.errors import CommandFailed
+    from gentoo_install.exec import report
+
+    class Refusing:
+        """A log whose close fails the way a full tmpfs fails."""
+
+        def __init__(self, real: IO[str]) -> None:
+            self.real = real
+            self.closed_once = False
+
+        def write(self, text: str) -> int:
+            return self.real.write(text)
+
+        def flush(self) -> None:
+            self.real.flush()
+
+        def close(self) -> None:
+            self.real.close()
+            self.closed_once = True
+            raise OSError(28, "No space left on device")
+
+    opened: list[Refusing] = []
+    real_open = Path.open
+
+    def watching(self: Path, *args: Any, **rest: Any) -> Any:
+        handle = real_open(self, *args, **rest)
+        if self.name.endswith(".log"):
+            refusing = Refusing(handle)
+            opened.append(refusing)
+            return refusing
+        return handle
+
+    monkeypatch.setattr(Path, "open", watching)
+
+    with pytest.raises(CommandFailed, match="the install's own reason"):
+        with report.recording(tmp_path / "work", tmp_path / "target") as active:
+            active.record("a line the log keeps")
+            raise CommandFailed("the install's own reason")
+
+    assert opened and opened[0].closed_once, "the log was never closed"
+
+
 def test_a_passphrase_that_will_not_go_does_not_replace_the_refusal(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:


### PR DESCRIPTION
`recording` held the log in a `with`, so the close ran while an install's own exception was unwinding. The work directory is a tmpfs an install can fill — that is how `vm-image` died — and an `OSError` from the last flush would have replaced the reason the install stopped with an errno from writing about it.

Same shape as the staged-passphrase cleanup: the failure is reported as a warning and the original exception continues.