### PR TITLE
cluster: put the installer's own reason in the verdict

### DIFF
--- a/tests/unit/test_cluster.py
+++ b/tests/unit/test_cluster.py
@@ -1225,7 +1225,7 @@ def test_a_fixture_that_passes_by_failing_is_not_recorded_as_a_failure() -> None
 
     code = inspect.getsource(cluster.install_one)
     expected = code.index("EXPECTED_TO_FAIL")
-    ordinary = code.index('f"the installer exited {code!r}"')
+    ordinary = code.index('f"the installer exited {code!r}')
     assert expected < ordinary, "the exception has to be read before the general rule"
 
     # And the two agree on which fixture it is: one fact, two runners.
@@ -1238,6 +1238,27 @@ def test_a_fixture_that_passes_by_failing_is_not_recorded_as_a_failure() -> None
         if one.expect_failure
     }
     assert failing == set(cluster.EXPECTED_TO_FAIL), (failing, cluster.EXPECTED_TO_FAIL)
+
+
+def test_a_failed_install_verdict_carries_the_installer_s_own_reason() -> None:
+    """`the installer exited b'4'` was the whole verdict, and `vm-greetd`'s
+    reason was 294910 lines into `install.txt`. `cli` writes that reason as
+    its last line, and the guest hands the file back with everything else.
+    """
+    said = (
+        "| >>> Installing app-i18n/ibus-1.5.33\n"
+        "|  * ERROR: app-i18n/ibus-1.5.33::gentoo failed (compile phase):\n"
+        "the install stopped: CommandFailed: emerge ended with exit 1: "
+        "keybindingmanager.c:1422:1: error: type defaults to 'int'\n"
+    ).encode()
+    reason = cluster._why_it_stopped({"install.txt": said})
+    assert reason.startswith(": CommandFailed: emerge ended with exit 1"), reason
+    assert "keybindingmanager.c" in reason, reason
+
+    # A run whose installer never got that far says nothing rather than
+    # guessing from the build output above it.
+    assert cluster._why_it_stopped({"install.txt": b"| >>> Emerging app-i18n/ibus\n"}) == ""
+    assert cluster._why_it_stopped({}) == ""
 
 
 def test_an_expected_failure_with_no_exit_code_is_not_a_pass() -> None:

--- a/tests/vm/cluster.py
+++ b/tests/vm/cluster.py
@@ -1806,7 +1806,7 @@ def install_one(
                 Verdict.FAIL,
                 time.monotonic() - started,
                 (
-                    f"the installer exited {code!r}"
+                    f"the installer exited {code!r}{_why_it_stopped(files)}"
                     if code
                     else "the installer wrote no exit code, so it died before its "
                     "last line: read the log"
@@ -2262,6 +2262,25 @@ def _remaining(deadline: float) -> float:
 #: fixture that could never be green, and it was counted as unverified for
 #: weeks. `campaign.py` knew this and the cluster did not.
 EXPECTED_TO_FAIL: Final[frozenset[str]] = frozenset({"vm-proxy-dead"})
+
+
+#: What `cli.py` prints as its last line when an install fails. The verdict
+#: carried the exit code alone, and reading `vm-greetd`'s reason out of
+#: `install.txt` meant 294910 lines of build output first.
+INSTALL_STOPPED: Final[str] = "the install stopped: "
+
+#: How much of that line the verdict keeps.
+REASON_BYTES: Final[int] = 400
+
+
+def _why_it_stopped(files: Mapping[str, bytes]) -> str:
+    """The installer's own last word, or empty when it did not say one."""
+    said = files.get("install.txt", b"").decode("utf-8", "replace")
+    for line in reversed(said.splitlines()):
+        found = line.find(INSTALL_STOPPED)
+        if found >= 0:
+            return f": {line[found + len(INSTALL_STOPPED):].strip()[:REASON_BYTES]}"
+    return ""
 
 
 def _did_not_stop(code: bytes) -> str:


### PR DESCRIPTION
`vm-greetd` was recorded as `FAIL … the installer exited b'4'` at 236.1 minutes. Its reason — `app-i18n/ibus-1.5.33` failing to compile, with `keybindingmanager.c:1422:1: error: type defaults to 'int' in declaration of 'eybinding_manager_type_id__once'`, a source line missing its first byte — was 294910 lines into `install.txt`.

`cli` already writes `the install stopped: <reason>` as its last line and the guest hands the file back. The verdict now carries it. Run against that guest's own `install.txt` it answers `CommandFailed: emerge ended with exit 1: * IMPORTANT: 28 news items…`, because that guest predates the change that made emerge say why it failed; with both, the verdict names the ebuild.