### PR TITLE
validate: one range for every port

### DIFF
--- a/gentoo_install/model/validate.py
+++ b/gentoo_install/model/validate.py
@@ -184,6 +184,19 @@ class _ConfiguredAddressFacts:
     remote_unlock: _RemoteUnlockAddressFacts
 
 
+#: What a TCP port can be. Three checks spelled the same two numbers and the
+#: same sentence, so a correction to one of them would have left the other
+#: two saying something the installer no longer does.
+PORTS: Final[range] = range(1, 65536)
+
+
+def _port_problem(what: str, port: int) -> str:
+    """Empty when that port is one, the sentence to report when it is not."""
+    if port in PORTS:
+        return ""
+    return f"{what} must be between {PORTS.start} and {PORTS.stop - 1}"
+
+
 def validate(
     config: InstallConfig,
     *,
@@ -260,8 +273,8 @@ def validate_memory_launch(config: InstallConfig, launch: MemoryLaunch) -> None:
             "the layout needs ZFS, the Alpine netboot kernel has no zfs.ko, "
             "and --ram is the mode whose Gentoo CJK ISO carries it"
         )
-    if launch.ssh_port is not None and not 1 <= launch.ssh_port <= 65535:
-        problems.append("--ssh-port must be between 1 and 65535")
+    if launch.ssh_port is not None and (refused := _port_problem("--ssh-port", launch.ssh_port)):
+        problems.append(refused)
     later = [
         name
         for name, given in (("--ssh-key", launch.ssh_key), ("--ssh-port", launch.ssh_port))
@@ -340,8 +353,8 @@ def _proxy_problems(config: InstallConfig) -> list[str]:
         if proxy.port or proxy.username or proxy.password:
             return ["proxy host is required when proxy fields are set"]
         return []
-    if proxy.port < 1 or proxy.port > 65535:
-        return ["proxy port must be between 1 and 65535"]
+    if refused := _port_problem("proxy port", proxy.port):
+        return [refused]
     if any(char.isspace() for char in proxy.host):
         return ["proxy host must not contain spaces"]
     if any(ord(char) < 0x20 or ord(char) == 0x7F for char in proxy.password):
@@ -543,8 +556,8 @@ def _unlock_problems(
     if not unlock.enabled:
         return []
     problems: list[str] = []
-    if not 1 <= unlock.port <= 65535:
-        problems.append(f"the remote unlock port {unlock.port} is not between 1 and 65535")
+    if refused := _port_problem(f"the remote unlock port {unlock.port}", unlock.port):
+        problems.append(refused)
     for named, fact in (("address", facts.address), ("gateway", facts.gateway)):
         if fact.literal and fact.parsed is None:
             problems.append(

--- a/tests/unit/test_validate.py
+++ b/tests/unit/test_validate.py
@@ -73,6 +73,34 @@ def dd_config() -> InstallConfig:
     )
 
 
+def test_every_port_is_judged_against_one_range() -> None:
+    """Three checks spelled the same two numbers and the same sentence, so a
+    correction to one would have left the other two saying something the
+    installer no longer does.
+    """
+    import ast
+    import inspect
+
+    from gentoo_install.model import validate as model_validate
+
+    assert model_validate.PORTS == range(1, 65536)
+    assert model_validate._port_problem("a port", 1) == ""
+    assert model_validate._port_problem("a port", 65535) == ""
+    assert "between 1 and 65535" in model_validate._port_problem("a port", 0)
+    assert "between 1 and 65535" in model_validate._port_problem("a port", 65536)
+
+    # And nothing else in the module writes the boundary out: the numbers read
+    # the same as the constant, so only the source says whether there is one
+    # rule or three.
+    tree = ast.parse(inspect.getsource(model_validate))
+    spelled = [
+        node
+        for node in ast.walk(tree)
+        if isinstance(node, ast.Constant) and node.value in (65535, 65536)
+    ]
+    assert len(spelled) == 1, [node.lineno for node in spelled]
+
+
 def test_a_broken_proxy_is_refused_in_dd_mode_too() -> None:
     """`dd` reads a local path and uses no proxy, so its validation returned
     before the proxy was looked at: a host with no port was refused in every


### PR DESCRIPTION
`--ssh-port`, the proxy port and the remote-unlock port each carried `1` and `65535` and each phrased the refusal itself. `PORTS` and `_port_problem` hold both, and the test reads the module's own AST: exactly one constant in it may be 65535 or 65536.