### PR TITLE
probe: one /proc root for every path under it

### DIFF
--- a/gentoo_install/exec/probe.py
+++ b/gentoo_install/exec/probe.py
@@ -58,6 +58,9 @@ EFI_VARIABLES: Final[Path] = EFI_MARKER / "efivars"
 #: it, so the scan below never ran and the install stopped anyway.
 UDEV_NAMES: Final[tuple[str, ...]] = ("udevd", "systemd-udevd")
 
+#: The one `/proc` in this module. `MEMINFO`, `CMDLINE` and `CPUINFO` each
+#: wrote the path out again, so a probe pointed at another root — a container,
+#: a test — would have moved some of them and not the others.
 PROC: Final[Path] = Path("/proc")
 
 #: What makes one live session different from the next. A resumed install must
@@ -425,10 +428,10 @@ def _efi_bits() -> int:
         return 0
 #: Where both install media keep the release engineering public key.
 RELEASE_KEY: Final[Path] = Path("/usr/share/openpgp-keys/gentoo-release.asc")
-MEMINFO: Final[Path] = Path("/proc/meminfo")
+MEMINFO: Final[Path] = PROC / "meminfo"
 
 #: Read rather than asked for: `findmnt` cannot say what booted this.
-CMDLINE: Final[Path] = Path("/proc/cmdline")
+CMDLINE: Final[Path] = PROC / "cmdline"
 PROFILES_DESC: Final[Path] = Path("/var/db/repos/gentoo/profiles/profiles.desc")
 MEMORY_PAYLOAD: Final[Path] = Path("/gentoo-install")
 
@@ -519,7 +522,7 @@ IMPLIED_CPU_FLAGS: Final[dict[str, str]] = {"sse": "mmxext"}
 
 #: Named rather than written inline, so the fallback can be exercised against
 #: a file holding one CPU's flags instead of whatever this machine has.
-CPUINFO: Final[Path] = Path("/proc/cpuinfo")
+CPUINFO: Final[Path] = PROC / "cpuinfo"
 
 #: Directories under zoneinfo that are not regions: legacy aliases, and the
 #: right and posix trees, which repeat every zone with another leap-second

--- a/tests/unit/test_probe.py
+++ b/tests/unit/test_probe.py
@@ -359,6 +359,29 @@ NO_SYSTEMD_BOOT_AT_ALL: Final[str] = (
 )
 
 
+def test_every_proc_path_is_built_from_one_root() -> None:
+    """`MEMINFO`, `CMDLINE` and `CPUINFO` each wrote `/proc` out again beside
+    the constant that declares it, so a probe pointed at another root would
+    have moved some of them and not the others.
+    """
+    import ast
+    import inspect
+
+    assert probe.MEMINFO.parent == probe.PROC
+    assert probe.CMDLINE.parent == probe.PROC
+    assert probe.CPUINFO.parent == probe.PROC
+
+    tree = ast.parse(inspect.getsource(probe))
+    spelled = [
+        node
+        for node in ast.walk(tree)
+        if isinstance(node, ast.Constant)
+        and isinstance(node.value, str)
+        and node.value.startswith("/proc")
+    ]
+    assert len(spelled) == 1, [node.lineno for node in spelled]
+
+
 def test_only_the_loader_that_booted_the_machine_answers_for_it() -> None:
     """`systemd-boot` anywhere in `bootctl status` was the test, and the
     command prints those words on machines it did not boot: in the esp file


### PR DESCRIPTION
`PROC` declares the root and `BOOT_ID` is built from it; `MEMINFO`, `CMDLINE` and `CPUINFO` each spelled `/proc` again. The test reads the module's AST: exactly one string constant in it may start with `/proc`.