### PR TITLE
cluster: say what qemu calls a guest that stopped moving

### DIFF
--- a/tests/unit/test_cluster.py
+++ b/tests/unit/test_cluster.py
@@ -261,7 +261,11 @@ def _timed_wait(
     serial = SerialConsole(TimedChannel(clock, output_at), BytesIO())
     link = cluster.Reconnecting(lambda: serial)
     watch = cluster.Watchdog(
-        tmp_path / "install.log", counters, where="infra-node2", load=lambda: 0.99
+        tmp_path / "install.log",
+        counters,
+        where="infra-node2",
+        load=lambda: 0.99,
+        state=lambda: "io-error",
     )
     return link, watch
 
@@ -306,6 +310,9 @@ def test_install_wait_names_silent_console_and_flat_counters(
     # is the cluster having no time for it, which is not the same finding as a
     # guest that stopped. Two were ended this way on one day.
     assert "the node itself at 99%" in message, message
+    # And what qemu calls it, when that is not `running`: a guest paused by a
+    # storage error reads exactly like one that stopped on its own.
+    assert "qemu calls the guest io-error" in message, message
 
 
 def test_run_ceiling_ends_silent_guest_that_keeps_moving_bytes(
@@ -1562,6 +1569,20 @@ def test_two_rounds_carrying_one_fixture_keep_separate_logs(tmp_path: Path) -> N
     assert first.watch.log != second.watch.log
     assert first.watch.log.name == "vm-greetd-9301.log"
     assert second.watch.log.name == "vm-greetd-9302.log"
+
+
+def test_a_guest_qemu_calls_running_adds_nothing_to_the_reason(tmp_path: Path) -> None:
+    """`running` is the ordinary answer and saying it would push the counters
+    out of a verdict that is cut to length."""
+    watch = cluster.Watchdog(
+        tmp_path / "install.log",
+        lambda: (0, 0.0),
+        where="infra-node4",
+        state=lambda: "running",
+    )
+    reason = watch.idle_reason()
+    assert reason is not None
+    assert "qemu calls the guest" not in reason, reason
 
 
 def test_a_node_that_will_not_answer_leaves_the_reason_readable(tmp_path: Path) -> None:

--- a/tests/vm/cluster.py
+++ b/tests/vm/cluster.py
@@ -485,6 +485,10 @@ class Watchdog:
     #: this campaign does not own, and the verdict could not tell a guest that
     #: stopped from a node with no time to give it.
     load: Callable[[], float | None] | None = None
+    #: What qemu says the guest is doing, read at the same moment. A guest
+    #: paused by a storage error reads exactly like one that stopped on its
+    #: own: flat counters and `cpu 0.00`.
+    state: Callable[[], str] | None = None
     strikes: int = 0
     _seen: int = field(default=0, init=False)
     _moved: int = field(default=0, init=False)
@@ -556,6 +560,9 @@ class Watchdog:
             node = f" on {self.where}" if self.where else ""
             busy = self.load() if self.load is not None else None
             said = "" if busy is None else f", the node itself at {busy * 100:.0f}%"
+            qemu = self.state() if self.state is not None else ""
+            if qemu and qemu != "running":
+                said += f", and qemu calls the guest {qemu}"
             return (
                 f"counters were flat{node} "
                 f"({self._counter_before} -> {self._counter_after} bytes, "
@@ -1591,6 +1598,7 @@ def _execution(
             counters=lambda: guest.transferred(),
             where=node,
             load=lambda: api.node_load(node),
+            state=lambda: guest.qmp_state(),
         ),
         job.reservation_bytes,
         address,

--- a/tests/vm/proxmox.py
+++ b/tests/vm/proxmox.py
@@ -597,6 +597,23 @@ class Guest:
         assert last is not None
         raise last
 
+    def qmp_state(self) -> str:
+        """What qemu says this guest is doing, or empty when it will not say.
+
+        `running` is the ordinary answer. A guest whose storage returned an
+        error is `io-error` and one somebody paused is `paused`: both read as
+        `cpu 0.00` with flat counters, which is what a guest that stopped on
+        its own reads as too.
+        """
+        try:
+            status = self.api.call(
+                "GET", f"/nodes/{self.node}/qemu/{self.vmid}/status/current"
+            )
+        except ProxmoxError:
+            return ""
+        said = status.get("qmpstatus")
+        return said if isinstance(said, str) else ""
+
     def transferred(self) -> tuple[int, float] | None:
         """Bytes this guest has received and written, and its CPU share.
 


### PR DESCRIPTION
`vm-luks` was ended at 39.1 minutes with `counters were flat on infra-node5 (9438923716 -> 9438924016 bytes, cpu 0.00), the node itself at 0%` — the node load that #711 added, answering for the first time, and answering that this one was **not** CPU starvation: 300 bytes in twenty minutes on an idle node, the console cut mid-line while unpacking the kernel sources.

A guest paused by a storage error reads the same way. `qmpstatus` is in the status call the watchdog already makes; when it is anything but `running` the verdict now says so. The cluster's rbd storage is an external Ceph this token cannot query, so the guest's own state is the closest thing to an answer available here.