### PR TITLE
validate: only one logical volume takes the rest of a group

### DIFF
--- a/gentoo_install/model/validate.py
+++ b/gentoo_install/model/validate.py
@@ -836,11 +836,26 @@ def _partition_size_problems(graph: DeviceGraph, table: PartitionTable) -> list[
 
 
 def _logical_volume_size_problems(graph: DeviceGraph) -> list[str]:
-    return [
+    problems = [
         f"logical volume {volume.id} is {volume.size}"
         for volume in graph.of_type(LogicalVolume)
         if volume.size is not None and volume.size.bytes == 0
     ]
+    # The same rule partitions have, and for the same reason: `lvcreate
+    # --extents 100%FREE` gives the group's whole remainder to whichever
+    # volume asks first, so a second one asking is a group with no room and an
+    # install that stops with the disk partitioned and the group already made.
+    taking_the_rest: dict[str, list[str]] = {}
+    for volume in graph.of_type(LogicalVolume):
+        if volume.size is None:
+            taking_the_rest.setdefault(str(volume.group), []).append(str(volume.id))
+    problems += [
+        f"volume group {group} has {len(volumes)} logical volumes taking the rest of it "
+        f"({', '.join(sorted(volumes))}), and only one can"
+        for group, volumes in sorted(taking_the_rest.items())
+        if len(volumes) > 1
+    ]
+    return problems
 
 
 def _mbr_index_problems(table: PartitionTable, indexes: list[int]) -> list[str]:

--- a/tests/unit/test_validate.py
+++ b/tests/unit/test_validate.py
@@ -1078,6 +1078,35 @@ def _with_non_root_logical_volume(size: Size) -> InstallConfig:
     )
 
 
+def test_two_logical_volumes_cannot_both_take_the_rest_of_a_group() -> None:
+    """`lvcreate --extents 100%FREE` gives the remainder to whichever volume
+    asks first, so the second one fails with the disk already partitioned and
+    the group already made. Partitions have had this rule from the start.
+    """
+    nodes = [
+        *ext4_on_gpt(),
+        Existing(id=i("data-pv"), selector="/dev/disk/by-id/data", wipe=True),
+        VolumeGroup(id=i("data-vg"), members=(i("data-pv"),), name="data"),
+        LogicalVolume(id=i("cache-lv"), group=i("data-vg"), name="cache", size=None),
+        LogicalVolume(id=i("spool-lv"), group=i("data-vg"), name="spool", size=None),
+    ]
+    with pytest.raises(ValidationFailed, match="only one can") as refused:
+        validate(config(nodes))
+    assert "cache-lv" in str(refused.value) and "spool-lv" in str(refused.value)
+
+    # One of them may, which is what every shipped layout does.
+    validate(config(nodes[:-1]))
+
+    # And two groups each with one are two separate remainders.
+    beside = [
+        *nodes[:-1],
+        Existing(id=i("spool-pv"), selector="/dev/disk/by-id/spool", wipe=True),
+        VolumeGroup(id=i("spool-vg"), members=(i("spool-pv"),), name="spool"),
+        LogicalVolume(id=i("spool-lv"), group=i("spool-vg"), name="spool", size=None),
+    ]
+    validate(config(beside))
+
+
 def test_a_zero_sized_non_root_logical_volume_is_refused_and_named() -> None:
     with pytest.raises(ValidationFailed, match="logical volume cache-lv is 0B"):
         validate(_with_non_root_logical_volume(Size(0)))


### PR DESCRIPTION
`LogicalVolume.size = None` means the group's whole remainder, and `CreateLogicalVolume.apply` runs `lvcreate --extents 100%FREE` for it. Two such volumes in one group were accepted: the first takes everything and the second fails with the disk already partitioned, the PV made and the group made — the expensive kind of failure the model layer exists to prevent.

Partitions have carried the equivalent rule from the start ("the last one, so nothing after it has room"). Two groups with one each are still two remainders.