### PR TITLE
cli: make --disarm the option the armed message names

### DIFF
--- a/gentoo_install/cli.py
+++ b/gentoo_install/cli.py
@@ -37,7 +37,7 @@ from .exec.probe import (
 )
 from .exec.runner import Runner
 from .log import Journal
-from .model.device import StorageFacts, StorageLayout, ZfsPool
+from .model.device import DeviceGraph, DeviceId, StorageFacts, StorageLayout, ZfsPool
 from .model.size import Size
 from .tui import app, screens
 from .tui import context as tui_context
@@ -182,6 +182,11 @@ def parser() -> argparse.ArgumentParser:
         action="store_true",
         help="replace the default boot entry instead of arming one boot",
     )
+    parsed.add_argument(
+        "--disarm",
+        action="store_true",
+        help="take back an armed boot and delete what it placed",
+    )
     return parsed
 
 
@@ -256,6 +261,34 @@ def _boot_target(probe: Probe) -> netboot.BootTarget:
         secure_boot=secure_boot(),
         architecture=architecture(),
     )
+
+
+def _disarm_memory_environment(arguments: argparse.Namespace) -> int:
+    """Take back an arming from a later invocation.
+
+    The message an unattended arming prints names this, and for a while the
+    parser did not: an operator who followed it was answered `unrecognized
+    arguments: --disarm`. The target is read from the machine, the same way
+    the arming read it, so nothing has to have been kept from that run.
+    """
+    _require_root(arguments)
+    probe = _probe_for(arguments)
+    # A configuration with nothing in it: disarming reads the machine and
+    # writes to the machine, and every field of an install's configuration is
+    # about a target this run does not touch.
+    machine = Machine(
+        config=InstallConfig(disk=DiskConfig(graph=DeviceGraph.build(()), root=DeviceId(""))),
+        runner=probe.runner,
+        probe=probe,
+        work=arguments.work,
+        mountpoint=Path("/"),
+    )
+    apply(
+        netboot.disarm(target=_boot_target(probe)),
+        machine,
+        on_start=lambda one: print(one.describe()),
+    )
+    return EXIT_OK
 
 
 def _arm_memory_environment(
@@ -334,6 +367,11 @@ def main(argv: Sequence[str] | None = None) -> int:
     arguments = parser().parse_args(argv)
     state = RunState(disk_was_written=bool(arguments.resume))
     try:
+        if arguments.disarm:
+            # Before everything else: the machine is armed and the operator
+            # wants it not to be, which needs no configuration beyond the one
+            # they already have and no network at all.
+            return _disarm_memory_environment(arguments)
         launch = _memory_launch(arguments)
         _require_root(arguments)
         if arguments.config is None and _needs_network(arguments):

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -1602,6 +1602,35 @@ def test_bypass_prints_the_replacing_operation_instead(
     assert "arm one boot" not in said.out, said.out
 
 
+def test_the_disarm_the_message_names_is_one_the_parser_takes(
+    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """An unattended arming prints ``armed. `reboot` when ready; `--disarm`
+    takes it back.`` and the parser did not take that option, so an operator
+    who followed it was answered `unrecognized arguments: --disarm`.
+    """
+    import inspect
+
+    from gentoo_install import cli as command_line
+
+    said = inspect.getsource(command_line._reboot_or_disarm)
+    named = [one for one in said.split("`") if one.startswith("--")]
+    assert named == ["--disarm"], named
+
+    _memory_machine(monkeypatch)
+    ran: list[str] = []
+    monkeypatch.setattr(
+        command_line, "apply", lambda operations, machine, on_start=None: ran.extend(
+            one.describe() for one in operations
+        )
+    )
+
+    code = main(["--disarm"])
+    printed = capsys.readouterr()
+    assert code == EXIT_OK, printed
+    assert ran == ["take back the armed boot and delete what it placed"], ran
+
+
 def test_bypass_without_a_memory_mode_is_refused() -> None:
     """It changes what a machine boots by default, so it may not be a flag
     that does nothing when the mode it belongs to was not asked for."""


### PR DESCRIPTION
An unattended arming prints ``armed. \`reboot\` when ready; \`--disarm\` takes it back.`` and `--disarm` was not in the parser: an operator who followed that message was answered `gentoo-install: error: unrecognized arguments: --disarm`, which is what the negative control prints.

The disarm plan already existed for the interactive path. A later invocation reads the boot target from the machine the same way the arming did, so nothing has to have been kept from that run, and it needs neither a configuration nor the network.