### PR TITLE
validate: partition mode refuses the keys of other modes

### DIFF
--- a/gentoo_install/model/validate.py
+++ b/gentoo_install/model/validate.py
@@ -295,7 +295,20 @@ def validate_memory_launch(config: InstallConfig, launch: MemoryLaunch) -> None:
 def _disk_mode_problems(config: InstallConfig) -> list[str]:
     disk = config.disk
     if disk.mode is DiskMode.PARTITION:
-        return []
+        # The ordinary mode refused nothing, so a key belonging to another one
+        # was accepted and ignored: `disk.size` in a partition configuration
+        # even survived a save as `None`, because `serialise` writes it only
+        # for image mode. The dd branch below has had this table from the
+        # start.
+        elsewhere = (
+            ("disk.image", bool(disk.image)),
+            ("disk.size", disk.size is not None),
+            ("disk.source", bool(disk.source)),
+            ("disk.destination", bool(disk.destination)),
+        )
+        return [
+            f"{name} is not allowed in partition mode" for name, used in elsewhere if used
+        ]
     if disk.mode is DiskMode.IMAGE:
         image_problems: list[str] = []
         if not disk.image:

--- a/tests/unit/test_validate.py
+++ b/tests/unit/test_validate.py
@@ -73,6 +73,34 @@ def dd_config() -> InstallConfig:
     )
 
 
+def test_partition_mode_refuses_the_keys_of_other_modes() -> None:
+    """The ordinary mode refused nothing, so a key belonging to another one
+    was accepted and ignored — and `disk.size` did not even survive a save,
+    because `serialise` writes it only in image mode.
+    """
+    from gentoo_install.model import parse as model_parse
+    from gentoo_install.model.serialise import to_toml
+    import tomllib
+
+    sound = config(ext4_on_gpt())
+    validate(sound)
+
+    for field, wrong in (
+        ("image", replace(sound.disk, image="/run/image.raw")),
+        ("size", replace(sound.disk, size=Size.parse("20GiB"))),
+        ("source", replace(sound.disk, source="/run/source.raw")),
+        ("destination", replace(sound.disk, destination="/dev/disk/by-id/target")),
+    ):
+        with pytest.raises(ValidationFailed, match=f"disk.{field} is not allowed"):
+            validate(replace(sound, disk=wrong))
+
+    # The save that lost it: a partition configuration carrying a size wrote
+    # TOML without one, so reloading changed the configuration.
+    carried = replace(sound, disk=replace(sound.disk, size=Size.parse("20GiB")))
+    again = model_parse.parse(tomllib.loads(to_toml(carried)))
+    assert again.disk.size is None, again.disk.size
+
+
 def test_every_port_is_judged_against_one_range() -> None:
     """Three checks spelled the same two numbers and the same sentence, so a
     correction to one would have left the other two saying something the


### PR DESCRIPTION
`_disk_mode_problems` returned `[]` for `DiskMode.PARTITION`, so `disk.image`, `disk.size`, `disk.source` and `disk.destination` were accepted there and ignored. `disk.size` was worse than ignored: `serialise` writes it only in the image branch, so saving a partition configuration that carried one and loading it back changed the configuration — `20GiB` in, `None` out, which the test asserts.

The dd branch has had the equivalent table from the start; this is the same table for the mode that had none.