### PR TITLE
proxmox: wait for the line the editor is going to edit

### DIFF
--- a/tests/unit/test_proxmox.py
+++ b/tests/unit/test_proxmox.py
@@ -3611,9 +3611,58 @@ def test_a_silent_console_is_not_reported_as_a_stubborn_grub(
     with pytest.raises(ProxmoxError, match="GRUB never opened its editor"):
         proxmox._editor_screen(cast(Any, Console(menu)), 0.2)
 
-    # And a screen holding `setparams` is the editor, so neither fires.
-    editor = b"setparams 'Gentoo'\r\n  linux /boot/vmlinuz root=UUID=...\r\n"
-    assert b"setparams" in proxmox._editor_screen(cast(Any, Console(editor)), 0.2)
+    # And the editor is the editor, so neither fires. Positioned the way GRUB
+    # draws it, copied from `vm-sdboot`'s console.
+    assert b"setparams" in proxmox._editor_screen(cast(Any, Console(EDITOR_SCREEN)), 0.2)
+
+
+def test_the_editor_screen_waits_for_the_line_it_is_going_to_edit(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """GRUB draws the entry line by line. `btrfs-luks` was ended at 0.3
+    minutes with `no GRUB entry to edit on this screen` on a screen holding
+    `setparams` and the entry's `search` line, the `linux` line still to come:
+    the reader returned the moment it saw `setparams`.
+    """
+    from tests.vm import proxmox
+
+    monkeypatch.setattr("time.sleep", lambda seconds: None)
+
+    class Piecewise:
+        """A console that delivers the entry the way one arrived."""
+
+        def __init__(self, pieces: list[bytes]) -> None:
+            self.pieces = pieces
+            self.keys: list[str] = []
+
+        def send_raw(self, keys: str) -> None:
+            self.keys.append(keys)
+
+        def snapshot(self, seconds: float) -> bytes:
+            return self.pieces.pop(0) if self.pieces else b""
+
+    console = Piecewise([EDITOR_HEAD, EDITOR_TAIL])
+    screen = proxmox._editor_screen(cast(Any, console), 5.0)
+
+    assert b"setparams" in screen and b"linux /boot/gentoo" in screen, screen
+    # And it did not press ESC between the two, which discards the edit and
+    # returns to the menu.
+    assert console.keys == ["e"], console.keys
+    # The caller can count the rows it needs.
+    assert proxmox._line_of_linux(screen) == 3
+
+
+#: The GRUB editor as `vm-sdboot` drew it: `setparams` on row 5, the entry's
+#: `search` on row 7 and the kernel on row 8, each placed with `ESC[row;colH`.
+EDITOR_HEAD: Final[bytes] = (
+    b"\x1b[05;03Hsetparams 'Boot LiveCD (kernel: gentoo)'"
+    b"\x1b[07;03Hsearch --no-floppy --set=root -l Gentoo-amd64-20260816"
+)
+EDITOR_TAIL: Final[bytes] = (
+    b"\x1b[08;03Hlinux /boot/gentoo dokeymap nodhcp root=live:CDLABEL=Gentoo-amd64-20260816"
+    b"\x1b[09;03Hinitrd /boot/gentoo.igz"
+)
+EDITOR_SCREEN: Final[bytes] = EDITOR_HEAD + EDITOR_TAIL
 
 
 #: What `run60/vm-openrc-desktop.log` held, in the order it arrived. The first

--- a/tests/vm/proxmox.py
+++ b/tests/vm/proxmox.py
@@ -1210,6 +1210,24 @@ ESCAPE_SETTLES: Final[float] = 2.0
 SILENT_CONSOLE_BYTES: Final[int] = 16
 
 
+#: What GRUB calls the line that names the kernel, whichever medium drew it.
+_KERNEL_COMMANDS: Final[tuple[bytes, ...]] = (b"linux", b"linuxefi", b"linux16")
+
+
+def _drawn_rows(screen: bytes) -> dict[int, bytes]:
+    """Every row GRUB placed text on, the last write to each winning."""
+    rows: dict[int, bytes] = {}
+    for row, text in _PLACED.findall(screen):
+        said = text.strip()
+        if said:
+            rows[int(row)] = said
+    return rows
+
+
+def _kernel_rows(rows: dict[int, bytes]) -> list[int]:
+    return [at for at, said in rows.items() if said.split(b" ", 1)[0] in _KERNEL_COMMANDS]
+
+
 def _editor_screen(console: Line, timeout: float) -> bytes:
     """Press `e` until GRUB draws the entry, and answer with that screen.
 
@@ -1223,14 +1241,19 @@ def _editor_screen(console: Line, timeout: float) -> bytes:
     # had already gone past, so every press landed after it. Nineteen guests of
     # one round ended at `GRUB never opened its editor` that way.
     deadline = time.monotonic() + timeout
-    seen = b""
     everything = b""
     console.send_raw("e")
     while time.monotonic() < deadline:
-        seen = console.snapshot(3.0)
-        everything += seen
-        if b"setparams" in seen:
-            return seen
+        everything += console.snapshot(3.0)
+        # Both lines, because both are what the caller needs: `btrfs-luks` was
+        # ended at 0.3 minutes on a screen holding `setparams` and the entry's
+        # `search` line, with the `linux` line still to come.
+        if b"setparams" in everything and _kernel_rows(_drawn_rows(everything)):
+            return everything
+        if b"setparams" in everything:
+            # The editor is open and the rest of the entry is still arriving.
+            # ESC here would discard it and go back to the menu.
+            continue
         # ESC first, and only then `e` again: in the editor it discards the
         # edits and returns to the menu, and in the menu it does nothing. A
         # bare second `e` would type the letter into the command line. The gap
@@ -1258,17 +1281,9 @@ def _line_of_linux(screen: bytes) -> int:
     neither is a medium whose bootloader is not GRUB; guessing a number there
     would edit whatever happened to sit on that row.
     """
-    rows: dict[int, bytes] = {}
-    for row, text in _PLACED.findall(screen):
-        said = text.strip()
-        if said:
-            rows[int(row)] = said
+    rows = _drawn_rows(screen)
     top = [at for at, said in rows.items() if said.startswith(b"setparams")]
-    body = [
-        at
-        for at, said in rows.items()
-        if said.split(b" ", 1)[0] in (b"linux", b"linuxefi", b"linux16")
-    ]
+    body = _kernel_rows(rows)
     if not top or not body:
         raise ProxmoxError(f"no GRUB entry to edit on this screen: {screen[-400:]!r}")
     return min(body) - min(top)


### PR DESCRIPTION
`btrfs-luks` was ended at 0.3 minutes with `no GRUB entry to edit on this screen`. Its console shows why: `setparams 'Boot LiveCD (kernel: gentoo)'` on row 5 and `search --no-floppy --set=root -l Gentoo-amd64-20260816` on row 7, and nothing else — `_editor_screen` returned the moment it saw `setparams`, and `_line_of_linux` then found no kernel line to count to.

It now returns when the screen holds both, and while the editor is open it keeps reading rather than pressing ESC, which would discard the entry and go back to the menu. The test's editor screen is positioned the way GRUB draws it, copied from `vm-sdboot`'s console; the one it replaces was plain text with no `ESC[row;colH` at all.