### PR TITLE
portage: try a name that would not resolve again

### DIFF
--- a/gentoo_install/plan/portage.py
+++ b/gentoo_install/plan/portage.py
@@ -74,12 +74,19 @@ CURL_PROXY_CONFIG: Final[PurePosixPath] = PurePosixPath(
     "/etc/gentoo-install/curl-proxy.conf"
 )
 
+#: `--retry-on-host-error` with the tries: without it `-t 3` resolves the
+#: name once and gives up, which wget calls a fatal error and `vm-desktop`
+#: met six times in one burst — `Resolving mirrors.nju.edu.cn... failed:
+#: Temporary failure in name resolution.` and six binary packages lost after
+#: fifty-six minutes of installing. Measured on wget 1.25.0: one `Resolving`
+#: line without the flag, three with it. The curl commands below need
+#: nothing: curl retries a resolution failure under plain `--retry`.
 FETCHCOMMAND: Final[str] = (
-    'wget -t 3 -T 60 --passive-ftp -U "Portage (Gentoo, '
+    'wget -t 3 -T 60 --retry-on-host-error --passive-ftp -U "Portage (Gentoo, '
     'https://www.gentoo.org) distfile-fetch" -O "${DISTDIR}/${FILE}" "${URI}"'
 )
 RESUMECOMMAND: Final[str] = (
-    'wget -c -t 3 -T 60 --passive-ftp -U "Portage (Gentoo, '
+    'wget -c -t 3 -T 60 --retry-on-host-error --passive-ftp -U "Portage (Gentoo, '
     'https://www.gentoo.org) distfile-fetch" -O "${DISTDIR}/${FILE}" "${URI}"'
 )
 #: `-K` rather than the command line: `/proc/<pid>/cmdline` is world readable

--- a/tests/unit/test_plan_portage.py
+++ b/tests/unit/test_plan_portage.py
@@ -986,6 +986,24 @@ def test_a_failed_emerge_says_why_and_not_what_came_after() -> None:
             assert "str(result).strip()" not in head, head
 
 
+def test_a_name_that_would_not_resolve_is_tried_again() -> None:
+    """`-t 3` resolves the name once and gives up: wget calls a resolution
+    failure fatal. `vm-desktop` met six of them in one burst at fifty-six
+    minutes — `Resolving mirrors.nju.edu.cn... failed: Temporary failure in
+    name resolution.` — and lost six binary packages to a resolver that was
+    answering a minute earlier and a minute later.
+    """
+    for command in (portage.FETCHCOMMAND, portage.RESUMECOMMAND):
+        assert command.startswith("wget"), command
+        assert "--retry-on-host-error" in command, command
+        assert "-t 3" in command, command
+
+    # The curl commands need nothing: curl retries a resolution failure under
+    # plain `--retry`, which both of them already pass.
+    for command in (portage.CURL_FETCHCOMMAND, portage.CURL_RESUMECOMMAND):
+        assert "--retry 3" in command, command
+
+
 def test_both_binhost_detectors_read_one_marker() -> None:
     """The failing path finds the line and the succeeding path parses the host
     and the url out of it. The two spelled Portage's diagnostic separately, so


### PR DESCRIPTION
`vm-desktop` was ended at 56.0 minutes with six packages listed as failed. Its console says why: six consecutive `Resolving mirrors.nju.edu.cn... failed: Temporary failure in name resolution.` lines, each followed by `wget: unable to resolve host address` and `Failed to emerge`. The same name resolved to `210.28.130.3` earlier in that run and again later.

wget treats a resolution failure as fatal, so `-t 3` did not apply. Measured here on wget 1.25.0: one `Resolving` line without `--retry-on-host-error`, three with it, and its own help calls the flag "consider host errors as non-fatal, transient errors". The curl commands need nothing — curl retries a resolution failure under plain `--retry`, which was measured the same way.