### PR TITLE
tui: give the partition editor a way out that keeps the edit

### DIFF
--- a/gentoo_install/tui/partitions.py
+++ b/gentoo_install/tui/partitions.py
@@ -792,11 +792,15 @@ def _edit_slice(
 def _slice_fields(
     entry: manual.Slice, purpose: manual.Purpose, translate: Catalog
 ) -> list[Item[str]]:
-    return [
-        descriptor.row((entry, purpose), translate)
-        for descriptor in _SLICE_FIELDS
-        if descriptor.key in {item.value for item in _slice_field_items(entry, purpose, translate)}
-    ]
+    """Every row the editor shows, which is the one table that lists them.
+
+    Filtered through `_SLICE_FIELDS` before, and that table holds the fields
+    an operator edits rather than the rows a menu draws: `Done` has no field
+    to edit, so it was dropped, and the editor's only way out became the
+    cancel that answers with the slice it opened on. Every size, filesystem,
+    mount point and label typed into it was thrown away.
+    """
+    return _slice_field_items(entry, purpose, translate)
 
 
 def _slice_field_items(

--- a/tests/unit/test_tui_partitions.py
+++ b/tests/unit/test_tui_partitions.py
@@ -315,6 +315,32 @@ def test_every_field_of_a_partition_is_visible_with_its_value() -> None:
     assert "Encryption" in shown and "Size" in shown and "Label" in shown
 
 
+def test_a_partition_editor_can_be_left_with_the_edit_kept() -> None:
+    """`Done` is the only exit that keeps a change: cancelling returns the
+    slice the editor opened with. The menu was built from a second table that
+    had no `Done` row, so every size, filesystem, mount point and label a
+    reader typed was thrown away on the way out.
+    """
+    from tests.unit.fake_screen import FakeScreen
+
+    at = opened()
+    at.layout = manual.suggest("/dev/vda", Firmware.UEFI)
+    entry = at.layout.slices[1]
+
+    rows = partitions._slice_fields(entry, manual.purpose_of(entry), at.translate)
+    from gentoo_install.tui.context import DONE
+
+    assert DONE in {one.value for one in rows}, [one.label for one in rows]
+
+    # And the editor answers with what it was given when that row is chosen,
+    # rather than with the slice it opened on. `Done` is the last row.
+    changed = replace(entry, label="carried")
+    to_done = ["KEY_DOWN"] * (len(rows) - 1)
+    screen = FakeScreen(keys=[*to_done, "\n"])
+    kept = partitions._edit_slice(screen, at, at.layout.disks[0], changed)
+    assert kept is not None and kept.label == "carried", kept
+
+
 def test_a_zfs_member_has_no_partition_encryption_field() -> None:
     entry = manual.Slice(index=2, role=PartitionRole.ZFS, size=None, mountpoint="/")
     fields = partitions._slice_fields(entry, manual.purpose_of(entry), opened().translate)


### PR DESCRIPTION
`_slice_fields` built the editor's menu by filtering `_SLICE_FIELDS` — the table of fields an operator edits — against the table of rows the editor lists. `Done` is a row and not a field, so it was dropped, `if field == DONE: return entry` was unreachable, and the only way out was the cancel that answers with the slice the editor opened on. Every size, filesystem, mount point and label typed into that screen was discarded.

No fixture could see it: the campaign builds its layouts from TOML. The rows come from the one table that lists them now, and the test drives the editor to `Done` and requires the change to come back.