### PR TITLE
results: carry the tail of the install log, not all of it

### DIFF
--- a/tests/unit/test_cluster.py
+++ b/tests/unit/test_cluster.py
@@ -1247,25 +1247,47 @@ def test_a_fixture_that_passes_by_failing_is_not_recorded_as_a_failure() -> None
     assert failing == set(cluster.EXPECTED_TO_FAIL), (failing, cluster.EXPECTED_TO_FAIL)
 
 
+def test_the_console_carries_the_tail_of_the_install_log_and_not_all_of_it() -> None:
+    """`vm-source-kernel` writes 80 MB of build output, which gzips to 4.5 MiB
+    and reaches the reader as one base64 line of about six. It is the only
+    fixture that has ever failed while its results were being read, and it did
+    so twice; everything else in that archive is kilobytes.
+    """
+    from tests.vm.results import LOG_TAIL, LOG_TAIL_BYTES, console_command
+
+    said = console_command("/tmp/gentoo-install-results")
+    assert f"tail -c {LOG_TAIL_BYTES}" in said, said
+    assert f"/{LOG_TAIL}" in said, said
+    assert "--exclude=./install.txt" in said, said
+    # And the exclusion is of the log alone: the journal, the exit code and
+    # every check's output are what the verdict is made of.
+    assert "--exclude" not in said.split("--exclude=./install.txt", 1)[1], said
+
+
 def test_a_failed_install_verdict_carries_the_installer_s_own_reason() -> None:
     """`the installer exited b'4'` was the whole verdict, and `vm-greetd`'s
     reason was 294910 lines into `install.txt`. `cli` writes that reason as
     its last line, and the guest hands the file back with everything else.
     """
+    from tests.vm.results import LOG_TAIL
+
     said = (
         "| >>> Installing app-i18n/ibus-1.5.33\n"
         "|  * ERROR: app-i18n/ibus-1.5.33::gentoo failed (compile phase):\n"
         "the install stopped: CommandFailed: emerge ended with exit 1: "
         "keybindingmanager.c:1422:1: error: type defaults to 'int'\n"
     ).encode()
-    reason = cluster._why_it_stopped({"install.txt": said})
+    reason = cluster._why_it_stopped({LOG_TAIL: said})
     assert reason.startswith(": CommandFailed: emerge ended with exit 1"), reason
     assert "keybindingmanager.c" in reason, reason
 
     # A run whose installer never got that far says nothing rather than
     # guessing from the build output above it.
-    assert cluster._why_it_stopped({"install.txt": b"| >>> Emerging app-i18n/ibus\n"}) == ""
+    assert cluster._why_it_stopped({LOG_TAIL: b"| >>> Emerging app-i18n/ibus\n"}) == ""
     assert cluster._why_it_stopped({}) == ""
+
+    # An archive an older revision made carries the whole log instead.
+    assert "CommandFailed" in cluster._why_it_stopped({"install.txt": said})
 
 
 def test_an_expected_failure_with_no_exit_code_is_not_a_pass() -> None:

--- a/tests/unit/test_proxmox.py
+++ b/tests/unit/test_proxmox.py
@@ -1098,16 +1098,18 @@ def test_the_command_a_real_shell_runs_produces_a_readable_archive(tmp_path: Pat
     carries one: the markers have to survive `printf` and still be found."""
     import subprocess
 
-    from tests.vm.results import console_command, read_console
+    from tests.vm.results import LOG_TAIL, console_command, read_console
 
     (tmp_path / "install.rc").write_bytes(b"0\n")
     (tmp_path / "install.txt").write_bytes(b"installed 53 operations\n")
     command = console_command(str(tmp_path))
     printed = subprocess.run(["sh", "-c", command], capture_output=True).stdout
     said = f"root@livecd ~ # {command}\r\n".encode() + printed
+    # The log itself stays on the guest and its tail travels: a source-kernel
+    # install writes 80 MB of it into a channel that has dropped twice.
     assert read_console(said) == {
         "install.rc": b"0\n",
-        "install.txt": b"installed 53 operations\n",
+        LOG_TAIL: b"installed 53 operations\n",
     }
 
 

--- a/tests/vm/cluster.py
+++ b/tests/vm/cluster.py
@@ -96,6 +96,7 @@ from .proxmox import (
 )
 from .results import (
     CONSOLE_CLOSE,
+    LOG_TAIL,
     RESULT_BUFFER_BYTES,
     ResultError,
     console_command,
@@ -2283,7 +2284,11 @@ REASON_BYTES: Final[int] = 400
 
 def _why_it_stopped(files: Mapping[str, bytes]) -> str:
     """The installer's own last word, or empty when it did not say one."""
-    said = files.get("install.txt", b"").decode("utf-8", "replace")
+    # The tail the console carries back, and the whole log for an archive an
+    # older revision made: the guest stopped shipping 80 MB of build output
+    # through a channel that had dropped on it twice.
+    carried = files.get(LOG_TAIL) or files.get("install.txt", b"")
+    said = carried.decode("utf-8", "replace")
     for line in reversed(said.splitlines()):
         found = line.find(INSTALL_STOPPED)
         if found >= 0:

--- a/tests/vm/results.py
+++ b/tests/vm/results.py
@@ -47,6 +47,18 @@ CONSOLE_OPEN = "GI_RESULTS_BEGIN"
 CONSOLE_CLOSE = "GI_RESULTS_END"
 
 
+#: How much of the install log the console carries back. A source-kernel
+#: install writes 80 MB of it, which gzips to 4.5 MiB and reaches the reader
+#: as one base64 line of about six: `vm-source-kernel` is the only fixture
+#: that has ever failed while its results were being read, and it did so
+#: twice. The last quarter of a megabyte holds the failure and the tail of
+#: whatever emerge was doing, which is what anybody reads.
+LOG_TAIL_BYTES: Final[int] = 256 * 1024
+
+#: What the guest writes the tail to, beside the log it came from.
+LOG_TAIL: Final[str] = "install.tail"
+
+
 def console_command(directory: str) -> str:
     """Print the results as one base64 line between two markers.
 
@@ -63,7 +75,10 @@ def console_command(directory: str) -> str:
     stem, opened = CONSOLE_OPEN.rsplit("_", 1)
     closed = CONSOLE_CLOSE.rsplit("_", 1)[1]
     return (
-        f"printf '{stem}_%s\\n' {opened}; tar cz -C {directory} . | base64 -w0; "
+        f"printf '{stem}_%s\\n' {opened}; "
+        f"tail -c {LOG_TAIL_BYTES} {directory}/install.txt > {directory}/{LOG_TAIL} "
+        "2>/dev/null || true; "
+        f"tar cz --exclude=./install.txt -C {directory} . | base64 -w0; "
         f"echo; printf '{stem}_%s\\n' {closed}"
     )
 


### PR DESCRIPTION
The cluster's only channel back is the console, and it carries the whole result directory as one base64 line. `vm-source-kernel`'s console log is 80 MB where an ordinary fixture's is 5 MB; measured here, it gzips to 4.5 MiB and reaches the reader as about six megabytes of base64. It is the only fixture that has ever failed while its results were being read, and it did so twice, each attempt starting the transfer again.

The guest keeps the log and ships its last 256 KB as `install.tail`, which is where the failure and the tail of whatever emerge was doing are. `install.jsonl`, `install.rc` and every check's output are unchanged — the verdict is made of those. Run against a real `sh`, the command produces an archive holding `install.jsonl`, `install.rc` and `install.tail`.