### PR TITLE
tui: a raid member offers no encryption of its own

### DIFF
--- a/gentoo_install/tui/partitions.py
+++ b/gentoo_install/tui/partitions.py
@@ -854,7 +854,11 @@ def _slice_field_items(
                     ),
                 )
             ]
-            if purpose.role is not PartitionRole.ZFS
+            # Neither member kind: the pool and the array each carry their
+            # own LUKS, and `manual.build` drops a member's passphrase for
+            # that reason. A RAID member still offered the row, so a table
+            # marked `luks` produced an unencrypted array.
+            if purpose.role not in (PartitionRole.ZFS, PartitionRole.RAID)
             else []
         ),
         Item(

--- a/tests/unit/test_tui_partitions.py
+++ b/tests/unit/test_tui_partitions.py
@@ -359,6 +359,30 @@ def test_a_partition_editor_can_be_left_with_the_edit_kept() -> None:
     assert kept is not None and kept.label == "carried", kept
 
 
+def test_a_raid_member_has_no_partition_encryption_field() -> None:
+    """`manual.build` drops a member's passphrase — the array carries the
+    LUKS — so offering the row let an operator mark a member `luks` and
+    install an unencrypted array. The pool member has never offered it.
+    """
+    from gentoo_install.model.device import PartitionRole
+
+    at = opened()
+    for role in (PartitionRole.RAID, PartitionRole.ZFS):
+        entry = manual.Slice(index=2, role=role, size=None, mountpoint="")
+        rows = partitions._slice_fields(entry, manual.purpose_of(entry), at.translate)
+        assert "Encryption" not in {one.label for one in rows}, (role, rows)
+
+    # An ordinary partition still offers it: that is where LUKS belongs.
+    plain = manual.Slice(index=2, role=PartitionRole.DATA, size=None, mountpoint="/home")
+    shown = partitions._slice_fields(plain, manual.purpose_of(plain), at.translate)
+    assert "Encryption" in {one.label for one in shown}
+
+    # And the array's own row is where it is asked for instead.
+    from gentoo_install.tui.partitions import _ARRAY_FIELDS, _ENCRYPTION
+
+    assert _ENCRYPTION in {one.key for one in _ARRAY_FIELDS}
+
+
 def test_a_zfs_member_has_no_partition_encryption_field() -> None:
     entry = manual.Slice(index=2, role=PartitionRole.ZFS, size=None, mountpoint="/")
     fields = partitions._slice_fields(entry, manual.purpose_of(entry), opened().translate)


### PR DESCRIPTION
`manual.build` skips a RAID member's `passphrase_file` — "the array carries the filesystem and any LUKS, so a member carries neither" — and the slice editor offered the Encryption row on those members anyway. A member marked encrypted is drawn ` luks` in the table and installs an unencrypted array: what the operator sees and what is installed differ.

The ZFS pool member has never offered the row, for the same reason; RAID now matches it. The array's own editor still asks, which is where the passphrase belongs.