### PR TITLE
model: one esp size for the suggestion and the template

### DIFF
--- a/gentoo_install/model/manual.py
+++ b/gentoo_install/model/manual.py
@@ -14,6 +14,7 @@ from pathlib import PurePosixPath
 from typing import Final
 
 from .config import Firmware
+from .templates import ESP_SIZE
 from .device import (
     DeviceGraph,
     DeviceId,
@@ -287,7 +288,11 @@ def suggest(
                     Slice(
                         index=1,
                         role=PartitionRole.ESP,
-                        size=Size.parse("1GiB"),
+                        # The template's own size, not a second 1GiB: the
+                        # reason it is that big is written there, and an esp
+                        # that turns out to be too small is the same mistake
+                        # whichever screen built the table.
+                        size=ESP_SIZE,
                         filesystem=ESP_FILESYSTEM,
                         mountpoint="/efi",
                         label="ESP",

--- a/tests/unit/test_tui_partitions.py
+++ b/tests/unit/test_tui_partitions.py
@@ -359,6 +359,34 @@ def test_a_partition_editor_can_be_left_with_the_edit_kept() -> None:
     assert kept is not None and kept.label == "carried", kept
 
 
+def test_one_esp_size_for_the_suggestion_and_the_template() -> None:
+    """Both constructors sized the esp and each parsed `1GiB` of its own, so
+    an esp that turns out to be too small would have been two edits with only
+    one of them noticed.
+    """
+    import ast
+    import inspect
+
+    from gentoo_install.model import manual as model_manual
+    from gentoo_install.model import templates
+
+    suggested = model_manual.suggest("/dev/vda", Firmware.UEFI).disks[0].slices[0]
+    assert suggested.role is PartitionRole.ESP
+    assert suggested.size == templates.ESP_SIZE
+
+    # The sizes read the same today, so only the source says whether there is
+    # one of them or two.
+    tree = ast.parse(inspect.getsource(model_manual))
+    sized = [
+        node
+        for node in ast.walk(tree)
+        if isinstance(node, ast.Constant)
+        and isinstance(node.value, str)
+        and node.value.endswith(("GiB", "MiB"))
+    ]
+    assert not sized, [node.value for node in sized]
+
+
 def test_a_raid_member_has_no_partition_encryption_field() -> None:
     """`manual.build` drops a member's passphrase — the array carries the
     LUKS — so offering the row let an operator mark a member `luks` and


### PR DESCRIPTION
`templates.ESP_SIZE` carries the reason the esp is a gibibyte — "big enough for several kernels and their initramfs images, which is what fills an esp that later turns out to be too small" — and `manual.suggest` parsed `1GiB` of its own. The suggestion borrows the constant, and the test reads `manual.py`'s AST: no size literal may remain in it.