### PR TITLE
plan: name in describe() every file the operation writes

### DIFF
--- a/gentoo_install/plan/bootloader.py
+++ b/gentoo_install/plan/bootloader.py
@@ -116,6 +116,7 @@ ZBM_REMOTE_CONFIG: Final[PurePosixPath] = PurePosixPath(
 ZBM_NETWORK_CONFIG: Final[PurePosixPath] = PurePosixPath(
     "/etc/cmdline.d/dracut-network.conf"
 )
+ZBM_CONFIG: Final[PurePosixPath] = PurePosixPath("/etc/zfsbootmenu/config.yaml")
 ZBM_KEY_DIRECTORY: Final[PurePosixPath] = PurePosixPath("/etc/dropbear")
 ZBM_AUTHORIZED_KEYS: Final[PurePosixPath] = ZBM_KEY_DIRECTORY / "root_key"
 #: `ssh-keygen -m PEM` refuses ed25519 — "Saving key failed: invalid format" —
@@ -455,7 +456,10 @@ class InstallZfsBootMenu(Operation):
     serial: tuple[str, int] | None
 
     def describe(self) -> str:
-        return f"build ZFSBootMenu into {self.esp}/{ZBM_DIRECTORY} and boot {self.dataset} from it"
+        return (
+            f"write {ZBM_CONFIG}, build ZFSBootMenu into {self.esp}/{ZBM_DIRECTORY}, "
+            f"and boot {self.dataset} from it"
+        )
 
     def _config(self) -> str:
         kernel = ""
@@ -512,7 +516,7 @@ class InstallZfsBootMenu(Operation):
                 self.dataset,
             ]
         )
-        context.write(PurePosixPath("/etc/zfsbootmenu/config.yaml"), self._config())
+        context.write(ZBM_CONFIG, self._config())
         context.run_in_target(["generate-zbm"])
         image = self._image(context)
         if self.unlocks_remotely:

--- a/gentoo_install/plan/kernel.py
+++ b/gentoo_install/plan/kernel.py
@@ -54,6 +54,12 @@ REMOTE_UNLOCK_PACKAGE: Final[str] = "sys-kernel/dracut-crypt-ssh"
 REMOTE_UNLOCK_CONFIG: Final[PurePosixPath] = PurePosixPath(
     "/etc/dracut.conf.d/zz-gentoo-install-crypt-ssh.conf"
 )
+INSTALL_KERNEL_CONFIG: Final[PurePosixPath] = PurePosixPath(
+    "/etc/kernel/install.conf.d/50-gentoo-install.conf"
+)
+DRACUT_MODULES_CONFIG: Final[PurePosixPath] = PurePosixPath(
+    "/etc/dracut.conf.d/10-gentoo-install.conf"
+)
 
 #: Executables required by dracut's network-legacy module. ZFSBootMenu omits
 #: systemd, so its remote-unlock image cannot use systemd-networkd instead.
@@ -129,7 +135,11 @@ class ConfigureInstallKernel(Operation):
 
     def describe(self) -> str:
         flags = " ".join(self._flags())
-        where = f", installing into {self.boot_root}" if self.boot_root else ""
+        where = (
+            f", writing BOOT_ROOT={self.boot_root} to {INSTALL_KERNEL_CONFIG}"
+            if self.boot_root
+            else ""
+        )
         return f"set sys-kernel/installkernel to {flags}{where}"
 
     def _flags(self) -> tuple[str, ...]:
@@ -157,10 +167,7 @@ class ConfigureInstallKernel(Operation):
             # the main file shadowed the one `sys-kernel/installkernel` ships
             # and took `layout=compat` and `initrd_generator=dracut` with it.
             # The next kernel merge then died on `No initrd_generator=`.
-            context.write(
-                PurePosixPath("/etc/kernel/install.conf.d/50-gentoo-install.conf"),
-                f"BOOT_ROOT={self.boot_root}\n",
-            )
+            context.write(INSTALL_KERNEL_CONFIG, f"BOOT_ROOT={self.boot_root}\n")
 
 
 @dataclass(frozen=True, kw_only=True)
@@ -309,7 +316,7 @@ class WriteDracutModules(Operation):
     drivers: tuple[str, ...] = CLOUD_DRIVERS
 
     def describe(self) -> str:
-        carried = f"tell dracut to carry {', '.join(self.modules)}"
+        carried = f"write {DRACUT_MODULES_CONFIG} so dracut carries {', '.join(self.modules)}"
         if not self.drivers:
             return carried
         return f"{carried}, and {len(self.drivers)} cloud bus drivers whatever it detects"
@@ -319,7 +326,7 @@ class WriteDracutModules(Operation):
         if self.drivers:
             lines.append(f'add_drivers+=" {" ".join(self.drivers)} "')
         context.write(
-            PurePosixPath("/etc/dracut.conf.d/10-gentoo-install.conf"),
+            DRACUT_MODULES_CONFIG,
             "\n".join(lines) + "\n",
         )
 

--- a/gentoo_install/plan/packages.py
+++ b/gentoo_install/plan/packages.py
@@ -591,6 +591,13 @@ DCONF_PROFILE: Final[PurePosixPath] = PurePosixPath("/etc/dconf/profile/user")
 GNOME_INPUT_SOURCES: Final[PurePosixPath] = PurePosixPath(
     "/etc/dconf/db/local.d/00-gentoo-install-input-sources"
 )
+#: Relative to a home directory, so `/etc/skel` and each real user get
+#: the same set.
+FCITX_PROFILE: Final[str] = ".config/fcitx5/profile"
+RIME_CUSTOM: Final[str] = ".local/share/fcitx5/rime/default.custom.yaml"
+GTK_SETTINGS: Final[str] = ".config/gtk-{version}/settings.ini"
+GTK_VERSIONS: Final[tuple[str, ...]] = ("3.0", "4.0")
+
 INPUT_CONFIGURATION_ENABLED: Final[str] = "enabled"
 INPUT_CONFIGURATION_DISABLED: Final[str] = "disabled"
 INPUT_CONFIGURATION_STATES: Final[frozenset[str]] = frozenset(
@@ -745,20 +752,24 @@ class WriteInputMethodProfile(Operation):
     def describe(self) -> str:
         who = ", ".join(owner or "skel" for _, owner in self.homes)
         listed = " ".join(self.schemas) or "no rime schema"
-        return f"configure fcitx with {', '.join(self.engines)} and {listed} for {who}"
+        written = [FCITX_PROFILE, *(GTK_SETTINGS.format(version=one) for one in GTK_VERSIONS)]
+        if self.schemas:
+            written.append(RIME_CUSTOM)
+        return (
+            f"configure fcitx with {', '.join(self.engines)} and {listed} for {who}, "
+            f"writing {', '.join(written)} under each"
+        )
 
     def apply(self, context: Context) -> None:
         for home, owner in self.homes:
-            context.write(home / ".config/fcitx5/profile", self._profile())
-            for version in ("3.0", "4.0"):
+            context.write(home / FCITX_PROFILE, self._profile())
+            for version in GTK_VERSIONS:
                 context.write(
-                    home / f".config/gtk-{version}/settings.ini",
+                    home / GTK_SETTINGS.format(version=version),
                     "[Settings]\ngtk-im-module=fcitx\n",
                 )
             if self.schemas:
-                context.write(
-                    home / ".local/share/fcitx5/rime/default.custom.yaml", self._rime()
-                )
+                context.write(home / RIME_CUSTOM, self._rime())
             if owner:
                 context.run_in_target(["chown", "--recursive", f"{owner}:{owner}", str(home)])
 

--- a/tests/golden/btrfs-luks.txt
+++ b/tests/golden/btrfs-luks.txt
@@ -85,7 +85,7 @@
   install the initramfs builder and firmware: emerge sys-kernel/dracut sys-kernel/linux-firmware
   install the storage tools: emerge sys-fs/cryptsetup sys-fs/btrfs-progs sys-fs/dosfstools
   install the kernel: emerge sys-kernel/gentoo-cjk-kernel-bin, from source
-  tell dracut to carry crypt, btrfs, and 13 cloud bus drivers whatever it detects
+  write /etc/dracut.conf.d/10-gentoo-install.conf so dracut carries crypt, btrfs, and 13 cloud bus drivers whatever it detects
   rebuild the initramfs from sys-kernel/gentoo-cjk-kernel-bin with the modules written above
   check the installkernel payload names existing kernel files
 
@@ -102,7 +102,7 @@
   install the noto-cjk group: emerge media-fonts/noto-cjk media-fonts/noto media-libs/fontconfig
   install the flclash group: emerge net-proxy/flclash-bin
   set XMODIFIERS, QT_IM_MODULES in /etc/environment for fcitx
-  configure fcitx with rime and luna_pinyin pinyin_simp for skel, zakk
+  configure fcitx with rime and luna_pinyin pinyin_simp for skel, zakk, writing .config/fcitx5/profile, .config/gtk-3.0/settings.ini, .config/gtk-4.0/settings.ini, .local/share/fcitx5/rime/default.custom.yaml under each
   verify app-i18n/fcitx installed /usr/share/applications/fcitx5-wayland-launcher.desktop
   set /etc/xdg/kwinrc so the Wayland session starts /usr/share/applications/fcitx5-wayland-launcher.desktop
   enable /etc/fonts/conf.d/70-noto-cjk.conf

--- a/tests/golden/vm-bios-luks.txt
+++ b/tests/golden/vm-bios-luks.txt
@@ -64,7 +64,7 @@
   install the initramfs builder and firmware: emerge sys-kernel/dracut sys-kernel/linux-firmware
   install the storage tools: emerge sys-fs/cryptsetup sys-fs/e2fsprogs
   install the kernel: emerge sys-kernel/gentoo-kernel-bin
-  tell dracut to carry crypt, and 13 cloud bus drivers whatever it detects
+  write /etc/dracut.conf.d/10-gentoo-install.conf so dracut carries crypt, and 13 cloud bus drivers whatever it detects
   rebuild the initramfs from sys-kernel/gentoo-kernel-bin with the modules written above
   check the installkernel payload names existing kernel files
 

--- a/tests/golden/vm-btrfs.txt
+++ b/tests/golden/vm-btrfs.txt
@@ -60,7 +60,7 @@
   install the initramfs builder and firmware: emerge sys-kernel/dracut sys-kernel/linux-firmware
   install the storage tools: emerge sys-fs/btrfs-progs sys-fs/dosfstools
   install the kernel: emerge sys-kernel/gentoo-kernel-bin
-  tell dracut to carry btrfs, and 13 cloud bus drivers whatever it detects
+  write /etc/dracut.conf.d/10-gentoo-install.conf so dracut carries btrfs, and 13 cloud bus drivers whatever it detects
   rebuild the initramfs from sys-kernel/gentoo-kernel-bin with the modules written above
   check the installkernel payload names existing kernel files
 

--- a/tests/golden/vm-desktop.txt
+++ b/tests/golden/vm-desktop.txt
@@ -81,7 +81,7 @@
   install the pipewire group: emerge media-video/pipewire media-video/wireplumber
   enable pipewire.socket, pipewire-pulse.socket, wireplumber.service for every user
   set XMODIFIERS, QT_IM_MODULES in /etc/environment for fcitx
-  configure fcitx with rime and luna_pinyin pinyin_simp for skel
+  configure fcitx with rime and luna_pinyin pinyin_simp for skel, writing .config/fcitx5/profile, .config/gtk-3.0/settings.ini, .config/gtk-4.0/settings.ini, .local/share/fcitx5/rime/default.custom.yaml under each
   verify app-i18n/fcitx installed /usr/share/applications/fcitx5-wayland-launcher.desktop
   set /etc/xdg/kwinrc so the Wayland session starts /usr/share/applications/fcitx5-wayland-launcher.desktop
 

--- a/tests/golden/vm-luks.txt
+++ b/tests/golden/vm-luks.txt
@@ -67,7 +67,7 @@
   install the initramfs builder and firmware: emerge sys-kernel/dracut sys-kernel/linux-firmware
   install the storage tools: emerge sys-fs/cryptsetup sys-fs/btrfs-progs sys-fs/dosfstools
   install the kernel: emerge sys-kernel/gentoo-kernel-bin
-  tell dracut to carry crypt, btrfs, and 13 cloud bus drivers whatever it detects
+  write /etc/dracut.conf.d/10-gentoo-install.conf so dracut carries crypt, btrfs, and 13 cloud bus drivers whatever it detects
   rebuild the initramfs from sys-kernel/gentoo-kernel-bin with the modules written above
   check the installkernel payload names existing kernel files
 

--- a/tests/golden/vm-lvm.txt
+++ b/tests/golden/vm-lvm.txt
@@ -70,7 +70,7 @@
   install the storage tools: emerge sys-fs/dosfstools sys-fs/e2fsprogs
   install the storage tools that need a flag the default build lacks: emerge sys-fs/lvm2, from source
   install the kernel: emerge sys-kernel/gentoo-kernel-bin
-  tell dracut to carry lvm, and 13 cloud bus drivers whatever it detects
+  write /etc/dracut.conf.d/10-gentoo-install.conf so dracut carries lvm, and 13 cloud bus drivers whatever it detects
   rebuild the initramfs from sys-kernel/gentoo-kernel-bin with the modules written above
   check the installkernel payload names existing kernel files
 

--- a/tests/golden/vm-mdraid.txt
+++ b/tests/golden/vm-mdraid.txt
@@ -66,7 +66,7 @@
   install the initramfs builder and firmware: emerge sys-kernel/dracut sys-kernel/linux-firmware
   install the storage tools: emerge sys-fs/mdadm sys-fs/dosfstools sys-fs/e2fsprogs
   install the kernel: emerge sys-kernel/gentoo-kernel-bin
-  tell dracut to carry mdraid, and 13 cloud bus drivers whatever it detects
+  write /etc/dracut.conf.d/10-gentoo-install.conf so dracut carries mdraid, and 13 cloud bus drivers whatever it detects
   rebuild the initramfs from sys-kernel/gentoo-kernel-bin with the modules written above
   check the installkernel payload names existing kernel files
 

--- a/tests/golden/vm-proxy-dead.txt
+++ b/tests/golden/vm-proxy-dead.txt
@@ -61,7 +61,7 @@
   install the initramfs builder and firmware: emerge sys-kernel/dracut sys-kernel/linux-firmware
   install the storage tools: emerge sys-fs/btrfs-progs sys-fs/dosfstools
   install the kernel: emerge sys-kernel/gentoo-kernel-bin
-  tell dracut to carry btrfs, and 13 cloud bus drivers whatever it detects
+  write /etc/dracut.conf.d/10-gentoo-install.conf so dracut carries btrfs, and 13 cloud bus drivers whatever it detects
   rebuild the initramfs from sys-kernel/gentoo-kernel-bin with the modules written above
   check the installkernel payload names existing kernel files
 

--- a/tests/golden/vm-proxy-http.txt
+++ b/tests/golden/vm-proxy-http.txt
@@ -61,7 +61,7 @@
   install the initramfs builder and firmware: emerge sys-kernel/dracut sys-kernel/linux-firmware
   install the storage tools: emerge sys-fs/btrfs-progs sys-fs/dosfstools
   install the kernel: emerge sys-kernel/gentoo-kernel-bin
-  tell dracut to carry btrfs, and 13 cloud bus drivers whatever it detects
+  write /etc/dracut.conf.d/10-gentoo-install.conf so dracut carries btrfs, and 13 cloud bus drivers whatever it detects
   rebuild the initramfs from sys-kernel/gentoo-kernel-bin with the modules written above
   check the installkernel payload names existing kernel files
 

--- a/tests/golden/vm-proxy.txt
+++ b/tests/golden/vm-proxy.txt
@@ -61,7 +61,7 @@
   install the initramfs builder and firmware: emerge sys-kernel/dracut sys-kernel/linux-firmware
   install the storage tools: emerge sys-fs/btrfs-progs sys-fs/dosfstools
   install the kernel: emerge sys-kernel/gentoo-kernel-bin
-  tell dracut to carry btrfs, and 13 cloud bus drivers whatever it detects
+  write /etc/dracut.conf.d/10-gentoo-install.conf so dracut carries btrfs, and 13 cloud bus drivers whatever it detects
   rebuild the initramfs from sys-kernel/gentoo-kernel-bin with the modules written above
   check the installkernel payload names existing kernel files
 

--- a/tests/golden/vm-raidz.txt
+++ b/tests/golden/vm-raidz.txt
@@ -47,7 +47,7 @@
   point repository gentoo-zh at https://github.com/gentoo-zh/overlay.git
   sync repository gentoo-zh, 4 other sites to fall back on
   accept ~amd64 for packages from gentoo-zh only
-  set sys-kernel/installkernel to dracut, installing into /boot
+  set sys-kernel/installkernel to dracut, writing BOOT_ROOT=/boot to /etc/kernel/install.conf.d/50-gentoo-install.conf
   verify the selected kernel against the target sys-fs/zfs ceiling
   accept the linux-firmware licence
   tell sys-fs/zfs to build against the dist-kernel
@@ -75,7 +75,7 @@
   install the initramfs builder and firmware: emerge sys-kernel/dracut sys-kernel/linux-firmware
   install the storage tools: emerge sys-fs/dosfstools
   install the kernel and the tools that build a module for it: emerge sys-kernel/gentoo-kernel-bin sys-fs/zfs, building sys-fs/zfs here
-  tell dracut to carry zfs, and 13 cloud bus drivers whatever it detects
+  write /etc/dracut.conf.d/10-gentoo-install.conf so dracut carries zfs, and 13 cloud bus drivers whatever it detects
   copy the installing system's hostid into the target so the pool imports
   rebuild the initramfs from sys-kernel/gentoo-kernel-bin with the modules written above
   check the installkernel payload names existing kernel files
@@ -83,7 +83,7 @@
 [bootloader]
   install the bootloader: emerge sys-boot/zfsbootmenu sys-boot/efibootmgr
   install the EFI stub generate-zbm builds around: emerge sys-apps/systemd
-  build ZFSBootMenu into /efi/EFI/zbm and boot rpool/ROOT/gentoo from it
+  write /etc/zfsbootmenu/config.yaml, build ZFSBootMenu into /efi/EFI/zbm, and boot rpool/ROOT/gentoo from it
 
 [packages]
   enable zfs-import-scan.service at boot

--- a/tests/golden/vm-unlock.txt
+++ b/tests/golden/vm-unlock.txt
@@ -78,7 +78,7 @@
   install the initramfs ssh daemon: emerge sys-kernel/dracut-crypt-ssh sys-apps/iproute2 net-misc/dhcp net-misc/iputils
   install the storage tools: emerge sys-fs/cryptsetup sys-fs/btrfs-progs sys-fs/dosfstools sys-fs/e2fsprogs
   install the kernel: emerge sys-kernel/gentoo-kernel-bin
-  tell dracut to carry crypt, btrfs, crypt-ssh, network-legacy, and 13 cloud bus drivers whatever it detects
+  write /etc/dracut.conf.d/10-gentoo-install.conf so dracut carries crypt, btrfs, crypt-ssh, network-legacy, and 13 cloud bus drivers whatever it detects
   rebuild the initramfs from sys-kernel/gentoo-kernel-bin with the modules written above
   check the installkernel payload names existing kernel files
 

--- a/tests/golden/vm-zfs-encrypted.txt
+++ b/tests/golden/vm-zfs-encrypted.txt
@@ -39,7 +39,7 @@
   point repository gentoo-zh at https://github.com/gentoo-zh/overlay.git
   sync repository gentoo-zh, 4 other sites to fall back on
   accept ~amd64 for packages from gentoo-zh only
-  set sys-kernel/installkernel to dracut, installing into /boot
+  set sys-kernel/installkernel to dracut, writing BOOT_ROOT=/boot to /etc/kernel/install.conf.d/50-gentoo-install.conf
   verify the selected kernel against the target sys-fs/zfs ceiling
   accept the linux-firmware licence
   tell sys-fs/zfs to build against the dist-kernel
@@ -67,7 +67,7 @@
   install the initramfs builder and firmware: emerge sys-kernel/dracut sys-kernel/linux-firmware
   install the storage tools: emerge sys-fs/dosfstools
   install the kernel and the tools that build a module for it: emerge sys-kernel/gentoo-kernel-bin sys-fs/zfs, building sys-fs/zfs here
-  tell dracut to carry zfs, and 13 cloud bus drivers whatever it detects
+  write /etc/dracut.conf.d/10-gentoo-install.conf so dracut carries zfs, and 13 cloud bus drivers whatever it detects
   copy the installing system's hostid into the target so the pool imports
   rebuild the initramfs from sys-kernel/gentoo-kernel-bin with the modules written above
   check the installkernel payload names existing kernel files
@@ -75,7 +75,7 @@
 [bootloader]
   install the bootloader: emerge sys-boot/zfsbootmenu sys-boot/efibootmgr
   install the EFI stub generate-zbm builds around: emerge sys-apps/systemd
-  build ZFSBootMenu into /efi/EFI/zbm and boot rpool/ROOT/gentoo from it
+  write /etc/zfsbootmenu/config.yaml, build ZFSBootMenu into /efi/EFI/zbm, and boot rpool/ROOT/gentoo from it
 
 [packages]
   enable zfs-import-scan.service at boot

--- a/tests/golden/vm-zfs-mirror.txt
+++ b/tests/golden/vm-zfs-mirror.txt
@@ -43,7 +43,7 @@
   point repository gentoo-zh at https://github.com/gentoo-zh/overlay.git
   sync repository gentoo-zh, 4 other sites to fall back on
   accept ~amd64 for packages from gentoo-zh only
-  set sys-kernel/installkernel to dracut, installing into /boot
+  set sys-kernel/installkernel to dracut, writing BOOT_ROOT=/boot to /etc/kernel/install.conf.d/50-gentoo-install.conf
   verify the selected kernel against the target sys-fs/zfs ceiling
   accept the linux-firmware licence
   tell sys-fs/zfs to build against the dist-kernel
@@ -71,7 +71,7 @@
   install the initramfs builder and firmware: emerge sys-kernel/dracut sys-kernel/linux-firmware
   install the storage tools: emerge sys-fs/dosfstools
   install the kernel and the tools that build a module for it: emerge sys-kernel/gentoo-kernel-bin sys-fs/zfs, building sys-fs/zfs here
-  tell dracut to carry zfs, and 13 cloud bus drivers whatever it detects
+  write /etc/dracut.conf.d/10-gentoo-install.conf so dracut carries zfs, and 13 cloud bus drivers whatever it detects
   copy the installing system's hostid into the target so the pool imports
   rebuild the initramfs from sys-kernel/gentoo-kernel-bin with the modules written above
   check the installkernel payload names existing kernel files
@@ -79,7 +79,7 @@
 [bootloader]
   install the bootloader: emerge sys-boot/zfsbootmenu sys-boot/efibootmgr
   install the EFI stub generate-zbm builds around: emerge sys-apps/systemd
-  build ZFSBootMenu into /efi/EFI/zbm and boot rpool/ROOT/gentoo from it
+  write /etc/zfsbootmenu/config.yaml, build ZFSBootMenu into /efi/EFI/zbm, and boot rpool/ROOT/gentoo from it
 
 [packages]
   enable zfs-import-scan.service at boot

--- a/tests/golden/vm-zfs.txt
+++ b/tests/golden/vm-zfs.txt
@@ -39,7 +39,7 @@
   point repository gentoo-zh at https://github.com/gentoo-zh/overlay.git
   sync repository gentoo-zh, 4 other sites to fall back on
   accept ~amd64 for packages from gentoo-zh only
-  set sys-kernel/installkernel to dracut, installing into /boot
+  set sys-kernel/installkernel to dracut, writing BOOT_ROOT=/boot to /etc/kernel/install.conf.d/50-gentoo-install.conf
   verify the selected kernel against the target sys-fs/zfs ceiling
   accept the linux-firmware licence
   tell sys-fs/zfs to build against the dist-kernel
@@ -67,7 +67,7 @@
   install the initramfs builder and firmware: emerge sys-kernel/dracut sys-kernel/linux-firmware
   install the storage tools: emerge sys-fs/dosfstools
   install the kernel and the tools that build a module for it: emerge sys-kernel/gentoo-kernel-bin sys-fs/zfs, building sys-fs/zfs here
-  tell dracut to carry zfs, and 13 cloud bus drivers whatever it detects
+  write /etc/dracut.conf.d/10-gentoo-install.conf so dracut carries zfs, and 13 cloud bus drivers whatever it detects
   copy the installing system's hostid into the target so the pool imports
   rebuild the initramfs from sys-kernel/gentoo-kernel-bin with the modules written above
   check the installkernel payload names existing kernel files
@@ -75,7 +75,7 @@
 [bootloader]
   install the bootloader: emerge sys-boot/zfsbootmenu sys-boot/efibootmgr
   install the EFI stub generate-zbm builds around: emerge sys-apps/systemd
-  build ZFSBootMenu into /efi/EFI/zbm and boot rpool/ROOT/gentoo from it
+  write /etc/zfsbootmenu/config.yaml, build ZFSBootMenu into /efi/EFI/zbm, and boot rpool/ROOT/gentoo from it
 
 [packages]
   enable zfs-import-scan.service at boot

--- a/tests/golden/zbm-unlock.txt
+++ b/tests/golden/zbm-unlock.txt
@@ -41,7 +41,7 @@
   point repository gentoo-zh at https://mirrors.cernet.edu.cn/gentoo-zh.git
   sync repository gentoo-zh, 4 other sites to fall back on
   accept ~amd64 for packages from gentoo-zh only
-  set sys-kernel/installkernel to dracut, installing into /boot
+  set sys-kernel/installkernel to dracut, writing BOOT_ROOT=/boot to /etc/kernel/install.conf.d/50-gentoo-install.conf
   verify the selected kernel against the target sys-fs/zfs ceiling
   accept the linux-firmware licence
   ask for dhclient and arping, which the legacy network module requires
@@ -82,7 +82,7 @@
   install ZFSBootMenu ssh support: emerge sys-kernel/dracut-crypt-ssh sys-apps/iproute2 net-misc/dhcp net-misc/iputils
   install the storage tools: emerge sys-fs/dosfstools
   install the kernel and the tools that build a module for it: emerge sys-kernel/gentoo-cjk-kernel-bin sys-fs/zfs, from source
-  tell dracut to carry zfs, and 13 cloud bus drivers whatever it detects
+  write /etc/dracut.conf.d/10-gentoo-install.conf so dracut carries zfs, and 13 cloud bus drivers whatever it detects
   copy the installing system's hostid into the target so the pool imports
   rebuild the initramfs from sys-kernel/gentoo-cjk-kernel-bin with the modules written above
   check the installkernel payload names existing kernel files
@@ -91,7 +91,7 @@
   install the bootloader: emerge sys-boot/zfsbootmenu sys-boot/efibootmgr
   install the EFI stub generate-zbm builds around: emerge sys-apps/systemd
   write /etc/zfsbootmenu/dracut.conf.d/dropbear.conf and /etc/cmdline.d/dracut-network.conf, authorise keys at /etc/dropbear/root_key, and generate dedicated host keys under /etc/dropbear
-  build ZFSBootMenu into /efi/EFI/zbm and boot zpcala/ROOT/gentoo/root from it
+  write /etc/zfsbootmenu/config.yaml, build ZFSBootMenu into /efi/EFI/zbm, and boot zpcala/ROOT/gentoo/root from it
 
 [packages]
   enable zfs-import-scan.service at boot

--- a/tests/golden/zfs-zbm.txt
+++ b/tests/golden/zfs-zbm.txt
@@ -41,7 +41,7 @@
   point repository gentoo-zh at https://mirrors.cernet.edu.cn/gentoo-zh.git
   sync repository gentoo-zh, 4 other sites to fall back on
   accept ~amd64 for packages from gentoo-zh only
-  set sys-kernel/installkernel to dracut, installing into /boot
+  set sys-kernel/installkernel to dracut, writing BOOT_ROOT=/boot to /etc/kernel/install.conf.d/50-gentoo-install.conf
   verify the selected kernel against the target sys-fs/zfs ceiling
   accept the linux-firmware licence
   accept sys-kernel/gentoo-cjk-kernel-bin as testing, with cjk on
@@ -79,7 +79,7 @@
   install the initramfs builder and firmware: emerge sys-kernel/dracut sys-kernel/linux-firmware
   install the storage tools: emerge sys-fs/dosfstools
   install the kernel and the tools that build a module for it: emerge sys-kernel/gentoo-cjk-kernel-bin sys-fs/zfs, from source
-  tell dracut to carry zfs, and 13 cloud bus drivers whatever it detects
+  write /etc/dracut.conf.d/10-gentoo-install.conf so dracut carries zfs, and 13 cloud bus drivers whatever it detects
   copy the installing system's hostid into the target so the pool imports
   rebuild the initramfs from sys-kernel/gentoo-cjk-kernel-bin with the modules written above
   check the installkernel payload names existing kernel files
@@ -87,7 +87,7 @@
 [bootloader]
   install the bootloader: emerge sys-boot/zfsbootmenu sys-boot/efibootmgr
   install the EFI stub generate-zbm builds around: emerge sys-apps/systemd
-  build ZFSBootMenu into /efi/EFI/zbm and boot zpcala/ROOT/gentoo/root from it
+  write /etc/zfsbootmenu/config.yaml, build ZFSBootMenu into /efi/EFI/zbm, and boot zpcala/ROOT/gentoo/root from it
 
 [packages]
   enable zfs-import-scan.service at boot

--- a/tests/unit/test_layers.py
+++ b/tests/unit/test_layers.py
@@ -422,6 +422,70 @@ def test_every_operation_still_has_to_say_what_it_does() -> None:
     assert len(found) > 60, len(found)
 
 
+def _written_names(expr: ast.expr, known: Mapping[str, ast.expr]) -> set[str]:
+    """What a reader of `describe()` could recognise the written path by: the
+    expression itself, any module constant it names, and the last component of
+    every string those reach."""
+    found = {ast.unparse(expr)}
+    reachable = [expr]
+    if isinstance(expr, ast.Name) and expr.id in known:
+        reachable.append(known[expr.id])
+        found.add(ast.unparse(known[expr.id]))
+    for node in list(reachable):
+        for inner in ast.walk(node):
+            if isinstance(inner, ast.Name) and inner.id in known:
+                found.add(inner.id)
+                reachable.append(known[inner.id])
+    for node in reachable:
+        for inner in ast.walk(node):
+            if isinstance(inner, ast.Constant) and isinstance(inner.value, str):
+                found.add(inner.value.rsplit("/", 1)[-1])
+    return {one for one in found if one}
+
+
+def test_every_operation_names_the_files_it_writes() -> None:
+    """`--dry-run` prints `describe()` for the same operations `apply()` runs,
+    so a file named by neither is a file an operator learns about by finding it
+    on the disk. Two operations had this fixed by hand and three others still
+    had it, so the rule moves out of their comments and into a check.
+
+    Only the paths `apply()` writes itself: an operation that delegates to
+    another one is described by the operation it delegates to.
+    """
+    for module in _modules("plan"):
+        tree = ast.parse(module.read_text(encoding="utf-8"))
+        known: dict[str, ast.expr] = {}
+        for node in tree.body:
+            if isinstance(node, ast.AnnAssign) and isinstance(node.target, ast.Name):
+                if node.value is not None:
+                    known[node.target.id] = node.value
+            elif isinstance(node, ast.Assign) and node.value is not None:
+                known.update(
+                    {one.id: node.value for one in node.targets if isinstance(one, ast.Name)}
+                )
+        for cls in (one for one in ast.walk(tree) if isinstance(one, ast.ClassDef)):
+            body = {one.name: one for one in cls.body if isinstance(one, ast.FunctionDef)}
+            if "apply" not in body or "describe" not in body:
+                continue
+            said = ast.unparse(body["describe"])
+            reachable = dict(known)
+            for step in ast.walk(body["apply"]):
+                if isinstance(step, ast.Assign) and step.value is not None:
+                    reachable.update(
+                        {one.id: step.value for one in step.targets if isinstance(one, ast.Name)}
+                    )
+            for call in ast.walk(body["apply"]):
+                if not isinstance(call, ast.Call) or not isinstance(call.func, ast.Attribute):
+                    continue
+                if call.func.attr != "write" or not call.args:
+                    continue
+                names = _written_names(call.args[0], reachable)
+                assert any(one in said for one in names), (
+                    f"{module.name}:{call.lineno} {cls.name}.describe names none of "
+                    f"{sorted(names)}"
+                )
+
+
 def test_the_proxy_endpoint_is_defined_once() -> None:
     """It was written twice, byte for byte, in `plan/portage.py` and
     `plan/system.py`, while `system.py` already imported from `portage.py`. A

--- a/tests/unit/test_plan.py
+++ b/tests/unit/test_plan.py
@@ -181,11 +181,11 @@ def test_bios_installs_no_efibootmgr() -> None:
 
 def test_dracut_carries_a_module_for_every_layer_of_the_stack() -> None:
     described = " ".join(operation.describe() for operation in plan(config()))
-    assert "tell dracut to carry" not in described  # plain ext4 needs no extra module
+    assert "so dracut carries" not in described  # plain ext4 needs no extra module
     with_luks = " ".join(
         operation.describe() for operation in plan(load(FIXTURES / "btrfs-luks.toml"), load_catalog())
     )
-    assert "tell dracut to carry crypt, btrfs" in with_luks
+    assert "so dracut carries crypt, btrfs" in with_luks
 
 
 def test_an_openrc_target_gets_netifrc_which_stage3_does_not_carry() -> None:

--- a/tests/unit/test_plan_boot.py
+++ b/tests/unit/test_plan_boot.py
@@ -800,14 +800,17 @@ def test_the_kernel_is_merged_before_anything_that_builds_a_module_for_it() -> N
     """`sys-fs/zfs[dist-kernel]` depends on `virtual/dist-kernel`. Merged while
     the chosen kernel is still masked, Portage satisfies that virtual with a
     second kernel and builds zfs.ko for the one that will not boot."""
-    described = [one.describe() for one in kernel.build(zfs_installation())]
+    operations = kernel.build(zfs_installation())
+    described = [one.describe() for one in operations]
     merged = next(at for at, one in enumerate(described) if one.startswith("install the kernel"))
     told = next(at for at, one in enumerate(described) if "build against the dist-kernel" in one)
     initramfs = next(at for at, one in enumerate(described) if one.startswith("rebuild the initramfs"))
     # The dracut module list is written after the merge, or the kernel's own
     # postinst asks for a zfs module whose userland is not installed yet.
     listed = next(
-        at for at, one in enumerate(described) if one.startswith("tell dracut to carry zfs")
+        at
+        for at, one in enumerate(operations)
+        if isinstance(one, kernel.WriteDracutModules) and "zfs" in one.modules
     )
     assert told < merged < listed < initramfs
 


### PR DESCRIPTION
A file that neither `describe()` nor `apply()` names is one the operator learns about by finding it on the disk. `ConfigureInstallKernel`, `WriteDracutModules`, `InstallZfsBootMenu` and `WriteInputMethodProfile` each wrote one silently; the last writes four per home directory.

`test_every_operation_names_the_files_it_writes` reads `plan/*.py` and requires each `context.write()` target to be recognisable in the same class's `describe()`. Reverting any of the four describes turns it red.