### PR TITLE
readme: document ZFS, remote unlock, image modes and greetd

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -18,7 +18,7 @@ gentoo-install は Linux ライブ環境で動作し、amd64 アーキテクチ�
 
 <!-- fact: storage-device-graph -->
 
-**ストレージ** デバイスグラフは、GPT と MBR のパーティションテーブル、ext2、ext3、ext4、xfs、f2fs、vfat、subvolume を含む btrfs、swap、LUKS2 暗号化、LVM、mdraid を扱います。既存のパーティションテーブルを保持し、各パーティションに対して保持、フォーマット、削除のいずれかを個別に指定できます。
+**ストレージ** デバイスグラフは、GPT と MBR のパーティションテーブル、ext2、ext3、ext4、xfs、f2fs、vfat、subvolume を含む btrfs、swap、LUKS2 暗号化、LVM、mdraid を扱います。ZFS も同じグラフに属します。プールは vdev の上で stripe、mirror、raidz1、raidz2、raidz3 のいずれかを取り、ネイティブ暗号化はプールの属性であり、各 dataset はそれぞれ独立したノードです。既存のパーティションテーブルを保持し、各パーティションに対して保持、フォーマット、削除のいずれかを個別に指定できます。
 
 <!-- fact: zram-system -->
 
@@ -30,13 +30,21 @@ gentoo-install は Linux ライブ環境で動作し、amd64 アーキテクチ�
 
 ステージングされたシステムは稼働中のシステムに触れずに `/gentoo-install.new` 以下で構築され、その後 `rename(2)` でディレクトリごとに交換されます。交換より後に実行されるのは、esp またはブートセクタへの書き込みだけです。ルートが LUKS、LVM、mdraid の下にある場合、ルートファイルシステムがこのインストーラで記述できない種類である場合、ルートファイルシステムの空き容量が 10 GiB 未満の場合、ライブメディア上で実行された場合は、いずれも何も書き込む前に理由を挙げて拒否されます。
 
+<!-- fact: prepared-image -->
+
+**ディスクイメージ** `mode = "image"` は、ディスクではなく `disk.image` が指定し `disk.size` が大きさを決めるスパースファイルにインストールします。成果物は他所へ複製して後から書き込めるファイルです。`mode = "dd"` はインストールを行いません。`disk.source` のイメージを `disk.destination` のディスク全体へストリーム書き込みし、読み取りながら `raw`、`gz`、`xz`、`zst`、`tar` を展開し、そのイメージが持つレイアウトとブートローダーをそのまま残します。両モードは互いのキーを受け付けず、`partition` モードはどちらのキーも受け付けません。
+
 <!-- fact: boot-system -->
 
-**起動とシステム** インストーラでは、ブートローダーとして GRUB または systemd-boot を選択できます。GRUB は UEFI と BIOS に対応し、systemd-boot は UEFI に対応しています。また、systemd または OpenRC、dracut、locale、キーボードレイアウト、タイムゾーン、ホスト名、DNS、静的アドレス、選択したネットワークマネージャを設定できます。
+**起動とシステム** インストーラでは、ブートローダーとして GRUB、systemd-boot、ZFSBootMenu を選択できます。GRUB は UEFI と BIOS に対応し、systemd-boot は UEFI に対応しています。ZFSBootMenu は UEFI で ZFS ルートを起動し、カーネルはプール内のブート環境自身の `/boot` から取得します。また、systemd または OpenRC、dracut、locale、キーボードレイアウト、タイムゾーン、ホスト名、DNS、静的アドレス、選択したネットワークマネージャを設定できます。
+
+<!-- fact: remote-unlock -->
+
+**暗号化されたルートを ssh で解除する** `[kernel.remote_unlock]` は、パスフレーズの入力を求める画面の前に誰もいないマシンのために、起動経路へ ssh デーモンを配置します。`enabled` がこの経路を有効にします。`port` の既定値は 22 ではなく 222 で、稼働中システムに対するクライアントの `known_hosts` 項目と initramfs の項目が衝突しないようにしています。`address`、`gateway`、`interface` はそのデーモンに静的アドレスを与え、アドレスが空の場合は DHCP を使います。LUKS ルートはシステム initramfs 内の `sys-kernel/dracut-crypt-ssh` が開き、ZFS ルートは ZFSBootMenu が自身のイメージへ組み込む dropbear が開きます。認証鍵は `system.authorized_keys` のものです。この経路を有効にしながら鍵を一つも挙げていない設定は理由を挙げて拒否されます。誰もログインできないデーモンを記述しているためです。
 
 <!-- fact: desktop-language -->
 
-**デスクトップと言語対応** GNOME、KDE Plasma、Xfce を選択し、GDM、SDDM、LightDM のいずれかと組み合わせられます。グラフィックス設定は AMD、Intel、NVIDIA、仮想マシンに対応しています。パッケージカタログには Fcitx 5、Rime、Anthy、Mozc、Hangul、CJK フォントが含まれます。カーネルの選択肢には、cjktty パッチを含む `sys-kernel/gentoo-cjk-kernel-bin` と `sys-kernel/gentoo-cjk-kernel` があります。
+**デスクトップと言語対応** GNOME、KDE Plasma、Xfce を選択し、GDM、SDDM、LightDM、または greetd とその tuigreet コンソールグリータのいずれかと組み合わせられます。グラフィックス設定は AMD、Intel、NVIDIA、仮想マシンに対応しています。パッケージカタログには Fcitx 5、Rime、Anthy、Mozc、Hangul、CJK フォントが含まれます。カーネルの選択肢には、cjktty パッチを含む `sys-kernel/gentoo-cjk-kernel-bin` と `sys-kernel/gentoo-cjk-kernel` があります。
 
 <!-- fact: portage -->
 
@@ -72,7 +80,9 @@ gentoo-install は Linux ライブ環境で動作し、amd64 アーキテクチ�
 
 `--ram` と `--lowram` にはそれぞれ QEMU の記録があります。Debian 12 の計算機が一度だけの起動を設定し、既定の起動項目を変えずに再起動し、配信された環境——`--ram` は Gentoo CJK ISO、`--lowram` は Alpine netboot 書庫——で起動し、渡された設定を保持しました。その画面で `install` と答えた記録が環境ごとに一件ずつあります。計算機は Gentoo を導入し、書き込んだディスクから起動し、共有の導入後検査に合格しました。別の計算機では設定済み項目の initramfs を削除し、ハーネスが計算機を入れ替える際の電源再投入のあと、続く二回の起動はいずれも元のクラウド系に到達しました。`dd` には記録が一件あります。live 媒体から準備済みイメージをディスク全体へ書き込み、raw と gzip の両形式で 1 バイトずつ読み戻しました。
 
-静的アドレス、ext2、ext3 にはそれぞれクラスタでの記録があります。ソースからビルドするカーネルと binhost のフォールバックには runner レベルの試験しかなく、runner レベルの試験はエンドツーエンドの記録ではありません。
+静的アドレス、ext2、ext3 にはそれぞれクラスタでの記録があります。ZFS の記録は stripe、mirror、raidz、暗号化プール、そして ZFSBootMenu が起動したプールを含みます。遠隔解除の二経路にはいずれもクラスタでの記録があります。システム initramfs が開いた LUKS ルートと、ZFSBootMenu 自身のイメージが開いた ZFS プールです。greetd には記録が二件あります。
+
+ファイルへの導入には記録が一件あります。書き出したイメージを `losetup -Pf` で接続し、そのレイアウトが宣言する二つのファイルシステムとして読み戻しましたが、そのファイルから起動したマシンはまだありません。ソースからビルドするカーネルと binhost のフォールバックには runner レベルの試験しかなく、runner レベルの試験はエンドツーエンドの記録ではありません。
 
 `tests/fixtures/` 以下のファイルが対象とするのは設定モデルであり、その存在は導入されたマシンについて何も示しません。
 

--- a/README.ko.md
+++ b/README.ko.md
@@ -18,7 +18,7 @@ gentoo-install은 Linux 라이브 환경에서 실행되어 amd64 아키텍처�
 
 <!-- fact: storage-device-graph -->
 
-**저장 장치** 장치 그래프는 GPT와 MBR 파티션 테이블, ext2, ext3, ext4, xfs, f2fs, vfat, subvolume을 포함하는 btrfs, swap, LUKS2 암호화, LVM, mdraid를 다룬다. 기존 파티션 테이블을 유지할 수 있으며 각 파티션에 유지, 포맷, 삭제 작업을 각각 지정할 수 있다.
+**저장 장치** 장치 그래프는 GPT와 MBR 파티션 테이블, ext2, ext3, ext4, xfs, f2fs, vfat, subvolume을 포함하는 btrfs, swap, LUKS2 암호화, LVM, mdraid를 다룬다. ZFS도 같은 그래프에 속한다. 풀은 vdev 위에서 stripe, mirror, raidz1, raidz2, raidz3 중 하나를 취하고, 네이티브 암호화는 풀의 속성이며, 각 dataset은 그 자체로 하나의 노드다. 기존 파티션 테이블을 유지할 수 있으며 각 파티션에 유지, 포맷, 삭제 작업을 각각 지정할 수 있다.
 
 <!-- fact: zram-system -->
 
@@ -30,13 +30,21 @@ gentoo-install은 Linux 라이브 환경에서 실행되어 amd64 아키텍처�
 
 스테이징된 시스템은 실행 중인 시스템을 건드리지 않은 채 `/gentoo-install.new` 아래에 구축되고, 그다음 `rename(2)`으로 디렉터리마다 교환된다. 교환 이후에 실행되는 것은 esp 또는 부트 섹터에 쓰는 작업뿐이다. 루트가 LUKS, LVM, mdraid 아래에 있는 경우, 루트 파일 시스템이 이 설치 도구가 기술할 수 없는 종류인 경우, 루트 파일 시스템의 여유 공간이 10 GiB 미만인 경우, 라이브 미디어에서 실행한 경우는 모두 아무것도 쓰기 전에 이유를 밝히고 거부한다.
 
+<!-- fact: prepared-image -->
+
+**디스크 이미지** `mode = "image"`는 디스크가 아니라 `disk.image`가 지정하고 `disk.size`가 크기를 정하는 희소 파일에 설치한다. 결과물은 다른 곳으로 복사해 두었다가 나중에 쓸 수 있는 파일이다. `mode = "dd"`는 설치를 수행하지 않는다. `disk.source`의 이미지를 `disk.destination` 디스크 전체로 스트리밍해 쓰고, 읽으면서 `raw`, `gz`, `xz`, `zst`, `tar`를 푼다. 그 이미지가 이미 담고 있는 레이아웃과 부트로더는 그대로 둔다. 두 모드는 서로의 키를 받지 않으며 `partition` 모드는 어느 쪽 키도 받지 않는다.
+
 <!-- fact: boot-system -->
 
-**부팅 및 시스템** 설치 도구에서는 GRUB과 systemd-boot 부트로더를 선택할 수 있다. GRUB은 UEFI와 BIOS를 지원하고 systemd-boot는 UEFI를 지원한다. 설치 도구는 systemd 또는 OpenRC, dracut, locale, 키보드 배열, 시간대, 호스트 이름, DNS, 고정 주소, 선택한 네트워크 관리자를 설정할 수도 있다.
+**부팅 및 시스템** 설치 도구에서는 GRUB, systemd-boot, ZFSBootMenu 부트로더를 선택할 수 있다. GRUB은 UEFI와 BIOS를 지원하고 systemd-boot는 UEFI를 지원한다. ZFSBootMenu는 UEFI에서 ZFS 루트를 부팅하며 커널은 풀 안 부트 환경 자체의 `/boot`에서 가져온다. 설치 도구는 systemd 또는 OpenRC, dracut, locale, 키보드 배열, 시간대, 호스트 이름, DNS, 고정 주소, 선택한 네트워크 관리자를 설정할 수도 있다.
+
+<!-- fact: remote-unlock -->
+
+**암호화된 루트를 ssh로 여는 경로** `[kernel.remote_unlock]`은 암호 구절 프롬프트 앞에 아무도 없는 기계를 위해 부팅 경로에 ssh 데몬을 놓는다. `enabled`가 이 경로를 켠다. `port`의 기본값은 22가 아니라 222이며, 실행 중인 시스템에 대한 클라이언트의 `known_hosts` 항목이 initramfs의 항목과 충돌하지 않게 한다. `address`, `gateway`, `interface`는 그 데몬에 고정 주소를 주고, 주소가 비어 있으면 DHCP를 쓴다. LUKS 루트는 시스템 initramfs 안의 `sys-kernel/dracut-crypt-ssh`가 열고, ZFS 루트는 ZFSBootMenu가 자기 이미지에 넣는 dropbear가 연다. 인가 키는 `system.authorized_keys`의 것이다. 이 경로를 켜고도 키를 하나도 적지 않은 설정은 이유를 밝히고 거부된다. 아무도 로그인할 수 없는 데몬을 기술하기 때문이다.
 
 <!-- fact: desktop-language -->
 
-**데스크톱 및 언어 지원** 설치 도구에서는 GNOME, KDE Plasma, Xfce를 선택하고 GDM, SDDM, LightDM 중 하나와 조합할 수 있다. 그래픽 설정은 AMD, Intel, NVIDIA, 가상 머신을 지원한다. 패키지 카탈로그에는 Fcitx 5, Rime, Anthy, Mozc, Hangul, CJK 글꼴이 포함된다. 커널 선택 항목에는 cjktty 패치가 적용된 `sys-kernel/gentoo-cjk-kernel-bin`과 `sys-kernel/gentoo-cjk-kernel`이 포함된다.
+**데스크톱 및 언어 지원** 설치 도구에서는 GNOME, KDE Plasma, Xfce를 선택하고 GDM, SDDM, LightDM, 또는 greetd와 그 tuigreet 콘솔 그리터 중 하나와 조합할 수 있다. 그래픽 설정은 AMD, Intel, NVIDIA, 가상 머신을 지원한다. 패키지 카탈로그에는 Fcitx 5, Rime, Anthy, Mozc, Hangul, CJK 글꼴이 포함된다. 커널 선택 항목에는 cjktty 패치가 적용된 `sys-kernel/gentoo-cjk-kernel-bin`과 `sys-kernel/gentoo-cjk-kernel`이 포함된다.
 
 <!-- fact: portage -->
 
@@ -72,7 +80,9 @@ gentoo-install은 Linux 라이브 환경에서 실행되어 amd64 아키텍처�
 
 `--ram`과 `--lowram`은 각각 QEMU 기록이 있다. Debian 12 기기가 한 번의 부팅을 설정하고, 기본 부팅 항목을 바꾸지 않은 채 재부팅하여 전달된 환경——`--ram`은 Gentoo CJK ISO, `--lowram`은 Alpine netboot 아카이브——으로 올라왔고, 전달받은 설정을 지니고 있었다. 그 화면에서 `install`을 답한 기록이 환경마다 하나씩 있다. 기기는 Gentoo를 설치했고, 기록한 디스크로 부팅했으며, 공용 설치 후 검사를 통과했다. 다른 기기에서는 설정된 항목의 initramfs를 지웠고, 하네스가 기기를 교체하며 수행하는 전원 재투입 뒤 이어진 두 번의 부팅 모두 원래 클라우드 시스템에 도달했다. `dd`는 기록이 하나 있다. live 매체에서 준비된 이미지를 디스크 전체에 쓰고 raw와 gzip 두 형식 모두 바이트 단위로 읽어 냈다.
 
-고정 주소, ext2, ext3에는 각각 클러스터 기록이 있다. 소스에서 빌드하는 커널과 binhost 폴백에는 runner 수준의 시험만 있으며, runner 수준의 시험은 엔드투엔드 기록이 아니다.
+고정 주소, ext2, ext3에는 각각 클러스터 기록이 있다. ZFS 기록은 stripe, mirror, raidz, 암호화된 풀, 그리고 ZFSBootMenu가 부팅한 풀을 포함한다. 원격 잠금 해제의 두 경로에도 각각 클러스터 기록이 있다. 시스템 initramfs가 연 LUKS 루트와 ZFSBootMenu 자체 이미지가 연 ZFS 풀이다. greetd에는 기록이 둘 있다.
+
+파일에 설치하는 경로에는 기록이 하나 있다. 쓴 이미지를 `losetup -Pf`로 붙여 그 레이아웃이 선언한 두 파일 시스템으로 읽어 냈으나, 그 파일로 부팅한 기계는 아직 없다. 소스에서 빌드하는 커널과 binhost 폴백에는 runner 수준의 시험만 있으며, runner 수준의 시험은 엔드투엔드 기록이 아니다.
 
 `tests/fixtures/` 아래의 파일이 다루는 것은 구성 모델이며, 그 존재는 설치된 기계에 대해 아무것도 입증하지 않는다.
 

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ The paths below are implemented and have automated unit or plan coverage unless 
 
 <!-- fact: storage-device-graph -->
 
-**Storage.** The device graph covers GPT and MBR; ext2, ext3, ext4, btrfs subvolumes, xfs, f2fs and vfat; swap; and LUKS2, LVM and mdraid. Existing partition tables can be retained, with a separate keep, format or delete decision for each partition.
+**Storage.** The device graph covers GPT and MBR; ext2, ext3, ext4, btrfs subvolumes, xfs, f2fs and vfat; swap; and LUKS2, LVM and mdraid. ZFS belongs to the same graph: a pool is a stripe, a mirror, or raidz1, raidz2 or raidz3 over its vdevs, native encryption is a property of the pool, and each dataset is a node of its own. Existing partition tables can be retained, with a separate keep, format or delete decision for each partition.
 
 <!-- fact: zram-system -->
 
@@ -30,13 +30,21 @@ The system configuration can configure zram independently of the device graph an
 
 The staged system is built under `/gentoo-install.new` while the running one is untouched, each directory is then exchanged with `rename(2)`, and only the writes to the esp or the boot sector follow the exchange. A root below LUKS, LVM or mdraid, a root filesystem this installer cannot describe, a machine with less than 10 GiB free on the root filesystem, and a live medium are each refused by name before anything is written.
 
+<!-- fact: prepared-image -->
+
+**Disk images.** `mode = "image"` installs into the sparse file named by `disk.image` and sized by `disk.size` instead of onto a disk, so the product is a file that can be copied elsewhere and written later. `mode = "dd"` installs nothing: it streams the image at `disk.source` onto the whole disk at `disk.destination`, decoding `raw`, `gz`, `xz`, `zst` or `tar` as it reads, and keeps whatever layout and bootloader that image already carries. Neither mode accepts the keys of the other, and `partition` mode accepts neither set.
+
 <!-- fact: boot-system -->
 
-**Boot and system.** GRUB supports UEFI and BIOS, and systemd-boot supports UEFI. The installer configures systemd or OpenRC, dracut, locale, keyboard layout, timezone, hostname, DNS, static addresses and the selected network manager.
+**Boot and system.** GRUB supports UEFI and BIOS, systemd-boot supports UEFI, and ZFSBootMenu boots a ZFS root on UEFI, taking each kernel from the boot environment's own `/boot` inside the pool. The installer configures systemd or OpenRC, dracut, locale, keyboard layout, timezone, hostname, DNS, static addresses and the selected network manager.
+
+<!-- fact: remote-unlock -->
+
+**Unlocking an encrypted root over SSH.** `[kernel.remote_unlock]` puts an SSH daemon in the boot path, for a machine whose passphrase prompt nobody is sitting in front of. `enabled` turns it on, `port` defaults to 222 rather than 22 so a client's `known_hosts` entry for the running system does not collide with the initramfs one, and `address`, `gateway` and `interface` give that daemon a static address; an empty address asks for DHCP. A LUKS root is opened by `sys-kernel/dracut-crypt-ssh` in the system initramfs, and a ZFS root by the dropbear ZFSBootMenu builds into its own image. The authorised keys are the ones in `system.authorized_keys`: a configuration that enables the unlock and lists no key is refused by name, because the daemon it describes is one nobody can log in to.
 
 <!-- fact: desktop-language -->
 
-**Desktop and language support.** GNOME, KDE Plasma and Xfce are available with gdm, sddm or lightdm. Graphics settings cover AMD, Intel, NVIDIA and virtual machines. The package catalog includes fcitx5, Rime, Anthy, Mozc, Hangul and CJK fonts. The kernel choices include `sys-kernel/gentoo-cjk-kernel-bin` and `sys-kernel/gentoo-cjk-kernel`, both of which carry the cjktty patch.
+**Desktop and language support.** GNOME, KDE Plasma and Xfce are available with gdm, sddm, lightdm, or greetd and its tuigreet console greeter. Graphics settings cover AMD, Intel, NVIDIA and virtual machines. The package catalog includes fcitx5, Rime, Anthy, Mozc, Hangul and CJK fonts. The kernel choices include `sys-kernel/gentoo-cjk-kernel-bin` and `sys-kernel/gentoo-cjk-kernel`, both of which carry the cjktty patch.
 
 <!-- fact: portage -->
 
@@ -72,7 +80,7 @@ Installing onto a disk has cluster and single-machine records across ext4, xfs, 
 
 `--ram` and `--lowram` each have QEMU records. A Debian 12 machine armed one boot, kept its default entry, rebooted and came up in the delivered environment — the Gentoo CJK ISO for `--ram`, the Alpine netboot archive for `--lowram` — carrying the configuration it was given. Answering `install` there has a record for each environment: the machine installed Gentoo, booted the disk it had written and passed the shared installed-state checks. A second machine had its armed entry's initramfs removed and reached its own cloud system on the two boots that followed, after the power cycle the harness performs between guests. `dd` has one record: a prepared image written onto a whole disk from a live medium and read back byte for byte, raw and gzipped.
 
-Static addressing, ext2 and ext3 have cluster records of their own. A source-built kernel and binhost degradation have runner-level tests only, and a runner-level test is not an end-to-end record.
+Static addressing, ext2 and ext3 have cluster records of their own. The ZFS records cover a stripe, a mirror, a raidz and an encrypted pool, and a pool booted by ZFSBootMenu. Both remote-unlock paths have cluster records: a LUKS root opened from the system initramfs, and a ZFS pool opened from ZFSBootMenu's own image. greetd has two records. Installing into a file has one record, in which the written image was attached with `losetup -Pf` and read back as the two filesystems its layout declares; nothing has booted from that file. A source-built kernel and binhost degradation have runner-level tests only, and a runner-level test is not an end-to-end record.
 
 Files under `tests/fixtures/` exercise the configuration model; their presence establishes nothing about an installed machine.
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -18,7 +18,7 @@ gentoo-install 在 Linux live 环境中运行，用于安装 amd64 架构的 Gen
 
 <!-- fact: storage-device-graph -->
 
-**存储设备** 设备图涵盖 GPT 和 MBR 分区表、ext2、ext3、ext4、xfs、f2fs、vfat、包含 subvolume 的 btrfs、swap、LUKS2 加密、LVM 和 mdraid。现有分区表可以保留，每个分区可以分别指定保留、格式化或删除操作。
+**存储设备** 设备图涵盖 GPT 和 MBR 分区表、ext2、ext3、ext4、xfs、f2fs、vfat、包含 subvolume 的 btrfs、swap、LUKS2 加密、LVM 和 mdraid。ZFS 属于同一张设备图：pool 在其 vdev 之上采用 stripe、mirror 或 raidz1、raidz2、raidz3，原生加密是 pool 的属性，每个 dataset 各为一个节点。现有分区表可以保留，每个分区可以分别指定保留、格式化或删除操作。
 
 <!-- fact: zram-system -->
 
@@ -30,13 +30,21 @@ gentoo-install 在 Linux live 环境中运行，用于安装 amd64 架构的 Gen
 
 暂存的系统构建在 `/gentoo-install.new`，正在运行的系统在此期间不受影响；随后以 `rename(2)` 逐个目录交换，只有写入 esp 或引导扇区的操作排在交换之后。根位于 LUKS、LVM 或 mdraid 之下、根文件系统为安装程序无法描述的类型、根文件系统可用空间低于 10 GiB，以及在 live 介质上执行，这四种情况都会在写入任何数据之前逐项指名并拒绝。
 
+<!-- fact: prepared-image -->
+
+**磁盘镜像** `mode = "image"` 把系统装进 `disk.image` 指定、`disk.size` 决定大小的稀疏文件，而不是装到磁盘上，产物因此是一份可以复制到别处、之后再写入的文件。`mode = "dd"` 不执行安装：它把 `disk.source` 的镜像流式写入 `disk.destination` 这整块磁盘，读取时解开 `raw`、`gz`、`xz`、`zst` 或 `tar`，并保留该镜像原本带的布局与引导程序。两种模式互不接受对方的键，`partition` 模式两组都不接受。
+
 <!-- fact: boot-system -->
 
-**引导与系统** 引导程序可选择 GRUB 或 systemd-boot，其中 GRUB 支持 UEFI 和 BIOS，systemd-boot 支持 UEFI。还可配置 systemd 或 OpenRC、dracut、locale、键盘布局、时区、主机名、DNS、静态地址和所选的网络管理程序。
+**引导与系统** 引导程序可选择 GRUB、systemd-boot 或 ZFSBootMenu。GRUB 支持 UEFI 和 BIOS，systemd-boot 支持 UEFI。ZFSBootMenu 在 UEFI 上引导 ZFS 根，内核取自 pool 内引导环境自己的 `/boot`。还可配置 systemd 或 OpenRC、dracut、locale、键盘布局、时区、主机名、DNS、静态地址和所选的网络管理程序。
+
+<!-- fact: remote-unlock -->
+
+**以 ssh 解开加密的根** `[kernel.remote_unlock]` 在引导路径放进一个 ssh 服务，供无人在旁边回答密语提示的机器使用。`enabled` 开启这条路径；`port` 默认 222 而不是 22，避免客户端对运行中系统的 `known_hosts` 记录与 initramfs 的那条相撞；`address`、`gateway` 和 `interface` 给该服务一个静态地址，地址留空则改用 DHCP。LUKS 根由系统 initramfs 里的 `sys-kernel/dracut-crypt-ssh` 打开，ZFS 根则由 ZFSBootMenu 构建进自己镜像的 dropbear 打开。授权密钥取自 `system.authorized_keys`：开了这条路径又没有列出任何密钥的配置会被逐项指名并拒绝，因为那描述的是一个没有人登录得进去的服务。
 
 <!-- fact: desktop-language -->
 
-**桌面与语言支持** 桌面可以选择 GNOME、KDE Plasma 和 Xfce，并搭配 GDM、SDDM 或 LightDM。图形设置涵盖 AMD、Intel、NVIDIA 和虚拟机。软件包目录包含 Fcitx 5、Rime、Anthy、Mozc、Hangul 和 CJK 字体。内核选项包括 `sys-kernel/gentoo-cjk-kernel-bin` 和 `sys-kernel/gentoo-cjk-kernel`，两者都包含 cjktty 补丁。
+**桌面与语言支持** 桌面可以选择 GNOME、KDE Plasma 和 Xfce，并搭配 GDM、SDDM、LightDM，或 greetd 和它的 tuigreet 控制台登录界面。图形设置涵盖 AMD、Intel、NVIDIA 和虚拟机。软件包目录包含 Fcitx 5、Rime、Anthy、Mozc、Hangul 和 CJK 字体。内核选项包括 `sys-kernel/gentoo-cjk-kernel-bin` 和 `sys-kernel/gentoo-cjk-kernel`，两者都包含 cjktty 补丁。
 
 <!-- fact: portage -->
 
@@ -72,7 +80,9 @@ gentoo-install 在 Linux live 环境中运行，用于安装 amd64 架构的 Gen
 
 `--ram` 和 `--lowram` 各有 QEMU 记录：一台 Debian 12 机器武装一次启动、默认启动项未变、重新启动后进入送达的环境——`--ram` 是 Gentoo CJK ISO，`--lowram` 是 Alpine netboot 压缩包——并带着交付给它的配置。在两种环境里回答 `install` 各有一条记录：机器装出 Gentoo、启动它写出的磁盘，并通过共用的安装后检查。另一台机器的武装项被移除 initramfs，在协调器换客机的电源循环之后，接下来两次启动都进入原本的云系统。`dd` 有一条记录：从活介质把准备好的镜像写入整块磁盘并逐字节读回，原始和 gzip 两种格式皆是。
 
-静态地址、ext2 和 ext3 各自有集群记录。源代码构建的内核和 binhost 降级只有 runner 层级的测试，而 runner 层级的测试不是端到端记录。
+静态地址、ext2 和 ext3 各自有集群记录。ZFS 的记录覆盖 stripe、mirror、raidz 和加密 pool，以及一个由 ZFSBootMenu 引导的 pool。两条远程解锁路径各有集群记录：由系统 initramfs 打开的 LUKS 根，以及由 ZFSBootMenu 自己镜像打开的 ZFS pool。greetd 有两条记录。
+
+装进文件有一条记录：写出的镜像以 `losetup -Pf` 挂上，读回的是它布局声明的那两个文件系统，而没有任何机器从那份文件引导过。源代码构建的内核和 binhost 降级只有 runner 层级的测试，而 runner 层级的测试不是端到端记录。
 
 `tests/fixtures/` 下的文件验证的是配置模型，它们存在并不代表任何一台装出来的机器。
 

--- a/README.zh-TW.md
+++ b/README.zh-TW.md
@@ -18,7 +18,7 @@ gentoo-install 在 Linux live 環境中執行，用於安裝 amd64 架構的 Gen
 
 <!-- fact: storage-device-graph -->
 
-**儲存裝置** 裝置圖涵蓋 GPT 與 MBR 分割表、ext2、ext3、ext4、xfs、f2fs、vfat、含 subvolume 的 btrfs、swap、LUKS2 加密、LVM 與 mdraid。既有分割表可以保留，每個分割區可分別指定保留、格式化或刪除。
+**儲存裝置** 裝置圖涵蓋 GPT 與 MBR 分割表、ext2、ext3、ext4、xfs、f2fs、vfat、含 subvolume 的 btrfs、swap、LUKS2 加密、LVM 與 mdraid。ZFS 屬於同一張裝置圖：pool 在其 vdev 之上採 stripe、mirror 或 raidz1、raidz2、raidz3，原生加密是 pool 的屬性，每個 dataset 各為一個節點。既有分割表可以保留，每個分割區可分別指定保留、格式化或刪除。
 
 <!-- fact: zram-system -->
 
@@ -30,13 +30,21 @@ gentoo-install 在 Linux live 環境中執行，用於安裝 amd64 架構的 Gen
 
 暫存的系統建置在 `/gentoo-install.new`，執行中的系統在此期間不受影響；隨後以 `rename(2)` 逐個目錄交換，只有寫入 esp 或開機磁區的操作排在交換之後。根位於 LUKS、LVM 或 mdraid 之下、根檔案系統為安裝器無法描述的類型、根檔案系統可用空間低於 10 GiB，以及在 live 媒介上執行，這四種情況都會在寫入任何資料之前逐項指名並拒絕。
 
+<!-- fact: prepared-image -->
+
+**磁碟映像** `mode = "image"` 把系統裝進 `disk.image` 指定、`disk.size` 決定大小的稀疏檔案，而不是裝到磁碟上，產物因此是一份可以複製到別處、之後再寫入的檔案。`mode = "dd"` 不執行安裝：它把 `disk.source` 的映像串流寫到 `disk.destination` 這顆整顆磁碟，讀取時解開 `raw`、`gz`、`xz`、`zst` 或 `tar`，並保留該映像原本帶的版面與開機載入器。兩種模式互不接受對方的鍵，`partition` 模式兩組都不接受。
+
 <!-- fact: boot-system -->
 
-**開機與系統** 開機載入器可選 GRUB 或 systemd-boot，其中 GRUB 支援 UEFI 與 BIOS，systemd-boot 支援 UEFI。安裝器另可設定 systemd 或 OpenRC、dracut、locale、鍵盤配置、時區、主機名稱、DNS、靜態位址與所選的網路管理程式。
+**開機與系統** 開機載入器可選 GRUB、systemd-boot 或 ZFSBootMenu。GRUB 支援 UEFI 與 BIOS，systemd-boot 支援 UEFI。ZFSBootMenu 在 UEFI 上開機 ZFS 根，核心取自 pool 內開機環境自己的 `/boot`。安裝器另可設定 systemd 或 OpenRC、dracut、locale、鍵盤配置、時區、主機名稱、DNS、靜態位址與所選的網路管理程式。
+
+<!-- fact: remote-unlock -->
+
+**以 ssh 解開加密的根** `[kernel.remote_unlock]` 在開機路徑放進一個 ssh 服務，供無人在旁邊回答密語提示的機器使用。`enabled` 開啟這條路徑；`port` 預設 222 而不是 22，避免用戶端對執行中系統的 `known_hosts` 記錄與 initramfs 的那筆相撞；`address`、`gateway` 與 `interface` 給該服務一個靜態位址，位址留空則改用 DHCP。LUKS 根由系統 initramfs 裡的 `sys-kernel/dracut-crypt-ssh` 開啟，ZFS 根則由 ZFSBootMenu 建進自己映像的 dropbear 開啟。授權金鑰取自 `system.authorized_keys`：開了這條路徑又沒有列出任何金鑰的設定會被逐項指名並拒絕，因為那描述的是一個沒有人登入得進去的服務。
 
 <!-- fact: desktop-language -->
 
-**桌面與語言支援** 桌面可選 GNOME、KDE Plasma 與 Xfce，並搭配 gdm、sddm 或 lightdm。圖形設定涵蓋 AMD、Intel、NVIDIA 與虛擬機。套件目錄包含 fcitx5、Rime、Anthy、Mozc、Hangul 與 CJK 字型。核心選項包括 `sys-kernel/gentoo-cjk-kernel-bin` 與 `sys-kernel/gentoo-cjk-kernel`，兩者都包含 cjktty 修補程式。
+**桌面與語言支援** 桌面可選 GNOME、KDE Plasma 與 Xfce，並搭配 gdm、sddm、lightdm，或 greetd 與它的 tuigreet 主控台登入畫面。圖形設定涵蓋 AMD、Intel、NVIDIA 與虛擬機。套件目錄包含 fcitx5、Rime、Anthy、Mozc、Hangul 與 CJK 字型。核心選項包括 `sys-kernel/gentoo-cjk-kernel-bin` 與 `sys-kernel/gentoo-cjk-kernel`，兩者都包含 cjktty 修補程式。
 
 <!-- fact: portage -->
 
@@ -72,7 +80,9 @@ gentoo-install 在 Linux live 環境中執行，用於安裝 amd64 架構的 Gen
 
 `--ram` 與 `--lowram` 各有 QEMU 記錄：一台 Debian 12 機器武裝一次開機、預設開機項目未變、重新開機後進入送達的環境——`--ram` 是 Gentoo CJK ISO，`--lowram` 是 Alpine netboot 壓縮檔——並帶著交付給它的設定。在兩種環境裡回答 `install` 各有一筆記錄：機器裝出 Gentoo、開起它寫出的磁碟，並通過共用的安裝後檢查。另一台機器的武裝項目被移除 initramfs，在諧和器換客機的電源循環之後，接續兩次開機都進入原本的雲系統。`dd` 有一筆記錄：從活媒體把準備好的鏡像寫入整顆磁碟並逐位元組讀回，原始與 gzip 兩種格式皆是。
 
-靜態位址、ext2 與 ext3 各自有叢集記錄。原始碼建置的核心與 binhost 降級只有 runner 層級的測試，而 runner 層級的測試不是端到端記錄。
+靜態位址、ext2 與 ext3 各自有叢集記錄。ZFS 的記錄涵蓋 stripe、mirror、raidz 與加密 pool，以及一個由 ZFSBootMenu 開機的 pool。兩條遠端解鎖路徑各有叢集記錄：由系統 initramfs 開啟的 LUKS 根，以及由 ZFSBootMenu 自己映像開啟的 ZFS pool。greetd 有兩筆記錄。
+
+裝進檔案有一筆記錄：寫出的映像以 `losetup -Pf` 掛上，讀回的是它版面宣告的那兩個檔案系統，而沒有任何機器從那份檔案開機過。原始碼建置的核心與 binhost 降級只有 runner 層級的測試，而 runner 層級的測試不是端到端記錄。
 
 `tests/fixtures/` 底下的檔案驗證的是設定模型，它們存在並不代表任何一台裝出來的機器。
 

--- a/tests/unit/test_readme.py
+++ b/tests/unit/test_readme.py
@@ -85,7 +85,7 @@ SECTIONS = {
 
 FACT_UNITS = (
     "identity", "capability-scope", "storage-device-graph", "zram-system",
-    "in-place-conversion", "boot-system",
+    "in-place-conversion", "prepared-image", "boot-system", "remote-unlock",
     "desktop-language", "portage", "proxy",
     "memory-environment", "memory-environment-access",
     "plan-records", "verification-scope",
@@ -171,6 +171,20 @@ def test_reviewed_cross_locale_claims_stay_attached_to_their_factual_units() -> 
             "gitweb.gentoo.org",
         ),
         "portage": ("zh-TW", "zh-CN", "ja", "ko", "en", "gentoo-zh"),
+        # Each of these is a name or a number a reader acts on, so a
+        # translation that drops one leaves that locale unable to use the
+        # path the other four document.
+        "storage-device-graph": ("ZFS", "stripe", "mirror", "raidz1", "raidz2", "raidz3"),
+        "prepared-image": (
+            "disk.image", "disk.size", "disk.source", "disk.destination",
+            "`raw`", "`gz`", "`xz`", "`zst`", "`tar`",
+        ),
+        "boot-system": ("GRUB", "systemd-boot", "ZFSBootMenu"),
+        "remote-unlock": (
+            "[kernel.remote_unlock]", "222", "dracut-crypt-ssh",
+            "system.authorized_keys", "ZFSBootMenu",
+        ),
+        "desktop-language": ("greetd", "tuigreet"),
         "exit-codes": ("argparse", "bootstrap.sh", "`1`", "`2`"),
     }
     backups = {


### PR DESCRIPTION
Five implemented paths the capability list never named: ZFS pools with their topologies and native encryption, ZFSBootMenu as a bootloader, `[kernel.remote_unlock]` for both a LUKS root and a ZFS one, `mode = "image"` and `mode = "dd"`, and greetd with tuigreet.

Each new claim carries its boundary. Installing into a file has one record in which the image was attached with `losetup -Pf` and read back, and nothing has booted from it; that sentence says so.

`test_reviewed_cross_locale_claims_stay_attached_to_their_factual_units` gains the identifiers a reader acts on, so a translation that drops one is a failure rather than a silent gap.