### PR TITLE
model: judge a conversion by the rules a layout is not needed for

### DIFF
--- a/gentoo_install/model/compat.py
+++ b/gentoo_install/model/compat.py
@@ -489,11 +489,52 @@ def _password_can_authenticate(password_hash: str) -> bool:
     return bool(_MODULAR_CRYPT.fullmatch(password_hash) or _DES_CRYPT.fullmatch(password_hash))
 
 
+#: The traits `traits_of` reads out of the device graph. An in-place
+#: conversion has no graph — the layout is the running machine's — so each of
+#: these answers "absent" there rather than "false", and a rule naming one
+#: would refuse every conversion. The rest are read from the configuration and
+#: hold in any mode.
+FROM_THE_DEVICE_GRAPH: Final[frozenset[Trait]] = frozenset(
+    {
+        Trait.ROOT_ON_ZFS,
+        Trait.BOOT_ON_ZFS,
+        Trait.NO_ZFS_ROOT,
+        Trait.LUKS,
+        Trait.NO_MOUNTED_ESP,
+        Trait.ESP_ENCRYPTED,
+        Trait.KERNEL_OFF_ESP,
+        Trait.ESP_ON_MDRAID,
+        Trait.ESP_MDRAID_SUPERBLOCK_AT_START,
+        Trait.GPT_WITHOUT_BIOS_BOOT,
+        Trait.NO_ENCRYPTED_CONTAINER,
+        Trait.GRUB_UNLOCKS_BOOT,
+        Trait.NATIVE_ZFS_SYSTEM_INITRAMFS,
+    }
+)
+
+
 def violations(
     config: InstallConfig, storage_facts: StorageFacts | None = None
 ) -> tuple[Rule, ...]:
     present = traits_of(config, storage_facts)
     return tuple(rule for rule in RULES if rule.when in present and rule.excludes in present)
+
+
+def violations_without_a_graph(config: InstallConfig) -> tuple[Rule, ...]:
+    """The rules a configuration carrying no device graph can still break.
+
+    A locked root with no other login and an ssh unlock with no key are the
+    configuration's own doing, and an in-place conversion produces the same
+    unreachable machine as an install onto a disk.
+    """
+    present = traits_of(config, None)
+    return tuple(
+        rule
+        for rule in RULES
+        if rule.when in present
+        and rule.excludes in present
+        and not {rule.when, rule.excludes} & FROM_THE_DEVICE_GRAPH
+    )
 
 
 def excluded_by(present: frozenset[Trait]) -> tuple[Rule, ...]:

--- a/gentoo_install/model/validate.py
+++ b/gentoo_install/model/validate.py
@@ -232,10 +232,16 @@ def validate(
             *_array_problems(config),
             *(rule.describe() for rule in compat.violations(config, storage_facts)),
         ]
+    without_a_graph: list[str] = []
+    if config.disk.mode is DiskMode.IN_PLACE:
+        without_a_graph = [
+            rule.describe() for rule in compat.violations_without_a_graph(config)
+        ]
     problems = [
         *_disk_mode_problems(config),
         *_proxy_problems(config),
         *graph_problems,
+        *without_a_graph,
         *_profile_problems(config),
         *_unserved_profile_problems(config),
         *_repository_profile_problems(config.portage.profile, available_profiles),

--- a/tests/unit/test_compat.py
+++ b/tests/unit/test_compat.py
@@ -1025,3 +1025,56 @@ def test_the_subarch_table_holds_what_the_menu_offers() -> None:
 
     offered = {subarch for (_, subarch), _ in BINHOSTS}
     assert offered <= BINHOST_SUBARCHS, offered - BINHOST_SUBARCHS
+
+
+#: Traits `FROM_THE_DEVICE_GRAPH` names that no fixture produces, so emptying
+#: a graph cannot show them moving. Each needs a layout the fixtures do not
+#: have: an encrypted esp, an esp on mdraid, and a native-encrypted pool under
+#: a loader that is not ZFSBootMenu.
+_UNOBSERVABLE_IN_A_FIXTURE = frozenset(
+    {
+        Trait.ESP_ENCRYPTED,
+        Trait.ESP_ON_MDRAID,
+        Trait.ESP_MDRAID_SUPERBLOCK_AT_START,
+        Trait.NATIVE_ZFS_SYSTEM_INITRAMFS,
+    }
+)
+
+
+def test_the_graph_trait_table_is_what_emptying_a_graph_changes() -> None:
+    """`violations_without_a_graph` trusts this table to say which traits an
+    in-place conversion cannot be judged by. A trait missing from it refuses
+    every conversion; a trait wrongly in it silently drops a rule that holds
+    in every mode."""
+    from gentoo_install.exec.config import load
+    from gentoo_install.model.compat import FROM_THE_DEVICE_GRAPH
+
+    moved: set[Trait] = set()
+    for path in sorted((Path(__file__).resolve().parents[1] / "fixtures").glob("*.toml")):
+        installation = load(path)
+        emptied = replace(
+            installation,
+            disk=replace(installation.disk, graph=DeviceGraph.build(()), root=i("")),
+        )
+        moved |= traits_of(installation, None) ^ traits_of(emptied, None)
+    assert moved <= FROM_THE_DEVICE_GRAPH, sorted(one.name for one in moved - FROM_THE_DEVICE_GRAPH)
+    assert FROM_THE_DEVICE_GRAPH - moved == _UNOBSERVABLE_IN_A_FIXTURE, sorted(
+        one.name for one in (FROM_THE_DEVICE_GRAPH - moved) ^ _UNOBSERVABLE_IN_A_FIXTURE
+    )
+
+
+def test_a_configuration_rule_survives_the_loss_of_the_graph() -> None:
+    """The rules kept for a conversion are exactly the ones neither of whose
+    traits is read from a layout."""
+    from gentoo_install.model.compat import FROM_THE_DEVICE_GRAPH, violations_without_a_graph
+
+    locked = replace(
+        config(),
+        system=replace(config().system, root_password_hash="", users=(), authorized_keys=()),
+    )
+    kept = violations_without_a_graph(locked)
+    assert any(
+        rule.when is Trait.ROOT_LOCKED and rule.excludes is Trait.NO_OTHER_LOGIN for rule in kept
+    ), [rule.describe() for rule in kept]
+    for rule in kept:
+        assert not {rule.when, rule.excludes} & FROM_THE_DEVICE_GRAPH, rule.describe()

--- a/tests/unit/test_validate.py
+++ b/tests/unit/test_validate.py
@@ -171,6 +171,33 @@ def test_an_in_place_configuration_validates_without_a_device_graph() -> None:
     validate(installation)
 
 
+def test_in_place_keeps_the_rules_that_need_no_device_graph() -> None:
+    """The graph rules are skipped in this mode because there is no graph, and
+    that used to take the configuration's own rules with them: a conversion
+    could lock root, name no user and authorise no key, and the machine it
+    produced had no way in with an exit code of 0."""
+    base = replace(
+        config(), disk=replace(config().disk, graph=DeviceGraph.build(()), root=i(""), mode=DiskMode.IN_PLACE)
+    )
+    locked = replace(
+        base, system=replace(base.system, root_password_hash="", users=(), authorized_keys=())
+    )
+    with pytest.raises(ValidationFailed, match="no user password and no authorised ssh key"):
+        validate(locked)
+    unlocking = replace(
+        base,
+        system=replace(base.system, authorized_keys=()),
+        kernel=replace(
+            base.kernel, remote_unlock=replace(base.kernel.remote_unlock, enabled=True)
+        ),
+    )
+    with pytest.raises(ValidationFailed, match="no authorised ssh key"):
+        validate(unlocking)
+    # The other direction: a rule that reads the graph must not fire here, or
+    # every conversion is refused for a layout it was never given.
+    validate(base)
+
+
 def test_in_place_mode_rejects_a_device_graph() -> None:
     installation = replace(config(), disk=replace(config().disk, mode=DiskMode.IN_PLACE))
     with pytest.raises(ValidationFailed, match="disk.devices is not allowed"):


### PR DESCRIPTION
An in-place conversion carries no device graph, so `validate()` skipped every compatibility rule. That was right for the rules that read a layout and wrong for the rest: measured on `tests/fixtures/vm-convert.toml`, a conversion with an empty `root_password_hash`, no user and no authorised key was accepted, and the machine it produces has no way in.

`compat.FROM_THE_DEVICE_GRAPH` names the thirteen traits derived from the graph; `violations_without_a_graph()` keeps the rules whose two ends are both outside it. `ROOT_LOCKED` excluding `NO_OTHER_LOGIN` and `REMOTE_UNLOCK` excluding `NO_AUTHORIZED_KEY` now hold in this mode too.

The table is held by a test that empties each fixture graph and compares which traits move, in both directions.