### PR TITLE
model: dd mode refuses the machine it would not configure

### DIFF
--- a/gentoo_install/model/validate.py
+++ b/gentoo_install/model/validate.py
@@ -19,13 +19,18 @@ from ..errors import CommandFailed, ValidationFailed
 from . import compat
 from .config import (
     Bootloader,
+    BootloaderConfig,
     DiskMode,
     InitSystem,
     InstallConfig,
+    KernelConfig,
     MemoryLaunch,
     MemoryMode,
     Networking,
+    PackagesConfig,
+    PortageConfig,
     ProxyKind,
+    SystemConfig,
 )
 from .device import (
     DeviceGraph,
@@ -212,7 +217,11 @@ def validate(
         # host with no port is a configuration nobody can satisfy, and
         # refusing it in every mode except this one is a rule that fires by
         # accident.
-        problems = [*_disk_mode_problems(config), *_proxy_problems(config)]
+        problems = [
+            *_disk_mode_problems(config),
+            *_proxy_problems(config),
+            *_ignored_by_dd(config),
+        ]
         if problems:
             raise ValidationFailed(
                 "the configuration does not describe an installable system:\n  "
@@ -296,6 +305,29 @@ def validate_memory_launch(config: InstallConfig, launch: MemoryLaunch) -> None:
         raise ValidationFailed(
             "the memory environment cannot start:\n  " + "\n  ".join(problems)
         )
+
+
+def _ignored_by_dd(config: InstallConfig) -> list[str]:
+    """Sections a dd run cannot act on.
+
+    Its whole plan is one `WriteImage`, so a configuration naming a hostname,
+    a user and a desktop was accepted and produced an image copy: the operator
+    described a machine and got none of it. Compared against the defaults,
+    because a file that omits a section still carries one.
+    """
+    described = (
+        ("system", config.system, SystemConfig()),
+        ("packages", config.packages, PackagesConfig()),
+        ("portage", config.portage, PortageConfig()),
+        ("kernel", config.kernel, KernelConfig()),
+        ("bootloader", config.bootloader, BootloaderConfig()),
+    )
+    return [
+        f"[{name}] is not allowed in dd mode: the image is written as it is and "
+        "nothing in it is configured"
+        for name, given, default in described
+        if given != default
+    ]
 
 
 def _disk_mode_problems(config: InstallConfig) -> list[str]:

--- a/gentoo_install/tui/screens.py
+++ b/gentoo_install/tui/screens.py
@@ -33,6 +33,7 @@ from ..model.config import (
     GentooZhMirror,
     InitSystem,
     InstallConfig,
+    KernelConfig,
     KernelSource,
     Keywords,
     Logger,
@@ -188,6 +189,10 @@ def install_mode_screen(
         if agreed is not None:
             return agreed
     if mode is DiskMode.DD:
+        # Cleared with the disk keys: this mode writes the image as it is
+        # and configures nothing in it, and `validate` refuses a configuration
+        # that describes a machine it will not produce. Left standing they
+        # would block an install from a menu that no longer shows those rows.
         return Answer(
             Outcome.CHOSE,
             replace(
@@ -201,6 +206,11 @@ def install_mode_screen(
                     size=None,
                     wipe=False,
                 ),
+                system=SystemConfig(),
+                packages=PackagesConfig(),
+                portage=PortageConfig(),
+                kernel=KernelConfig(),
+                bootloader=BootloaderConfig(),
             ),
         )
     return Answer(

--- a/tests/unit/test_plan_dd.py
+++ b/tests/unit/test_plan_dd.py
@@ -6,7 +6,16 @@ from dataclasses import replace
 import pytest
 
 from gentoo_install.data import load_catalog
-from gentoo_install.model.config import DiskMode, ImageFormat, InstallConfig
+from gentoo_install.model.config import (
+    BootloaderConfig,
+    DiskMode,
+    ImageFormat,
+    InstallConfig,
+    KernelConfig,
+    PackagesConfig,
+    PortageConfig,
+    SystemConfig,
+)
 from gentoo_install.model.device import DeviceGraph
 from gentoo_install.plan import dd
 from gentoo_install.plan.build import build
@@ -27,9 +36,17 @@ _FORMATS: tuple[tuple[ImageFormat, tuple[str, ...]], ...] = (
 
 
 def dd_config(source_format: ImageFormat) -> InstallConfig:
+    # Only the disk section: this mode writes the image as it is, and
+    # `validate` refuses a configuration describing a machine it will not
+    # produce.
     installation = config()
     return replace(
         installation,
+        system=SystemConfig(),
+        packages=PackagesConfig(),
+        portage=PortageConfig(),
+        kernel=KernelConfig(),
+        bootloader=BootloaderConfig(),
         disk=replace(
             installation.disk,
             graph=DeviceGraph.build(()),
@@ -71,6 +88,29 @@ def test_dd_plan_has_no_target_configuration_or_bootloader_operation() -> None:
 
     assert [type(operation) for operation in operations] == [dd.WriteImage]
     assert all(operation.stage is not Stage.FINISH for operation in operations)
+
+
+def test_a_dd_configuration_cannot_describe_the_machine_it_will_not_produce() -> None:
+    """The plan above drops everything but the write, which is why a section
+    it drops must not be accepted: an operator who named a hostname, a user
+    and a desktop got an image copy and no word about the rest."""
+    from gentoo_install.errors import ValidationFailed
+    from gentoo_install.model.config import User
+
+    installation = dd_config(ImageFormat.RAW)
+    named = replace(
+        installation, system=replace(installation.system, hostname="expected-this")
+    )
+    with pytest.raises(ValidationFailed, match=r"\[system\] is not allowed in dd mode"):
+        build(named, load_catalog())
+    with_user = replace(
+        installation,
+        system=replace(
+            installation.system, users=(User(name="zakk", password_hash="$6$x$" + "a" * 40),)
+        ),
+    )
+    with pytest.raises(ValidationFailed, match=r"\[system\] is not allowed in dd mode"):
+        build(with_user, load_catalog())
 
 
 def test_reader_table_covers_every_image_format() -> None:

--- a/tests/unit/test_tui_app.py
+++ b/tests/unit/test_tui_app.py
@@ -3303,6 +3303,33 @@ def test_dd_mode_is_offered_only_from_a_live_or_memory_environment() -> None:
         "image_format",
         "image_destination",
     ]
+    # What the operator configured before switching, dropped with the layout:
+    # this mode writes the image as it is, `validate` refuses a configuration
+    # describing a machine it will not produce, and the rows that would carry
+    # those values are no longer on the menu.
+    from gentoo_install.model.config import (
+        BootloaderConfig,
+        KernelConfig,
+        PackagesConfig,
+        PortageConfig,
+        SystemConfig,
+    )
+    from gentoo_install.model.validate import validate
+
+    assert config().system != SystemConfig(), "the fixture describes a machine"
+    assert chosen.system == SystemConfig()
+    assert chosen.packages == PackagesConfig()
+    assert chosen.portage == PortageConfig()
+    assert chosen.kernel == KernelConfig()
+    assert chosen.bootloader == BootloaderConfig()
+    validate(
+        replace(
+            chosen,
+            disk=replace(
+                chosen.disk, source="/run/image.raw", destination="/dev/disk/by-id/virtio-target"
+            ),
+        )
+    )
 
 
 

--- a/tests/unit/test_validate.py
+++ b/tests/unit/test_validate.py
@@ -11,11 +11,16 @@ import pytest
 from gentoo_install.errors import ConfigError, ValidationFailed
 from gentoo_install.model import compat
 from gentoo_install.model.config import (
+    BootloaderConfig,
     DiskMode,
     InitSystem,
     InstallConfig,
+    KernelConfig,
     MemoryLaunch,
     MemoryMode,
+    PackagesConfig,
+    PortageConfig,
+    SystemConfig,
 )
 from gentoo_install.model.device import DeviceGraph
 from gentoo_install.model.device import (
@@ -62,6 +67,11 @@ def dd_config() -> InstallConfig:
     installation = config()
     return replace(
         installation,
+        system=SystemConfig(),
+        packages=PackagesConfig(),
+        portage=PortageConfig(),
+        kernel=KernelConfig(),
+        bootloader=BootloaderConfig(),
         disk=replace(
             installation.disk,
             graph=DeviceGraph.build(()),


### PR DESCRIPTION
Measured on `tests/fixtures/vm-dd-raw.toml`: a configuration with a hostname, a user and `desktop = "kde"` validated, and `build()` returned one operation, `stream the raw image ... onto ...`. The operator described a machine and got an image copy with no word about the rest.

`[system]`, `[packages]`, `[portage]`, `[kernel]` and `[bootloader]` are now refused by name in this mode, compared against their defaults so a file that omits a section is unaffected. `[proxy]` is untouched: its port rule is deliberately checked in every mode.

`install_mode_screen` clears the same five when the mode becomes dd, as it already clears the disk keys — the rows are not on the dd menu, so a configuration left standing would block the install with nothing to edit.