### PR TITLE
portage: a configuration with no binary host reaches none

### DIFF
--- a/gentoo_install/plan/build.py
+++ b/gentoo_install/plan/build.py
@@ -136,7 +136,21 @@ def build(
             index for index, operation in enumerate(ordered) if operation.stage is Stage.PORTAGE
         ) + 1
         ordered.insert(after_configuration, portage.VerifyPackages(requests=requests))
-    return tuple(ordered)
+    return tuple(_told_about_the_binary_host(one, config) for one in ordered)
+
+
+def _told_about_the_binary_host(operation: Operation, config: InstallConfig) -> Operation:
+    """Every merge learns whether this run has a binary host.
+
+    Set here rather than at each of the twenty-seven places an `Emerge` is
+    built: a construction site that forgot it would fetch from a host the
+    configuration turned off, which is the defect this exists to close.
+    """
+    if portage.uses_binhost(config.portage) or not isinstance(
+        operation, (portage.Emerge, portage.VerifyPackages)
+    ):
+        return operation
+    return replace(operation, binary_host=False)
 
 
 #: The only bootloader operations that cannot be done before the swap: they

--- a/gentoo_install/plan/portage.py
+++ b/gentoo_install/plan/portage.py
@@ -846,6 +846,11 @@ class Emerge(Operation):
     repository_bootstrap: bool = False
     mode: InstallMode = InstallMode.NORMAL
     source: SourcePolicy = SourcePolicy.binaries_allowed()
+    #: Whether this run has a binary host at all. The stage3 ships an enabled
+    #: `binrepos.conf` for the official one, so `--getbinpkg=y` reaches it
+    #: even when the configuration turned every host off: `ext2` compiled 48
+    #: packages and fetched 20 from a host it had not asked for.
+    binary_host: bool = True
     #: What to degrade rather than fail, when this emerge is what enables an
     #: optional path. Empty means the install stops, which is right for
     #: everything the machine needs to boot.
@@ -875,7 +880,9 @@ class Emerge(Operation):
         return self.source.built_from(self.packages)
 
     def apply(self, context: Context) -> None:
-        command = self._argv(context, source_only=context.degraded(BINARY_PACKAGES))
+        command = self._argv(
+            context, source_only=context.degraded(BINARY_PACKAGES) or not self.binary_host
+        )
         try:
             result = context.run_in_target(command, check=False)
         except CommandFailed as error:
@@ -1172,6 +1179,9 @@ class VerifyPackages(Operation):
 
     stage: Stage = Stage.PORTAGE
     requests: tuple[PackageRequest, ...]
+    #: As `Emerge.binary_host`: the pretend has to resolve against the same
+    #: package set the real merge will use, or it accepts what emerge refuses.
+    binary_host: bool = True
 
     def describe_parts(self) -> tuple[str, tuple[str, ...]]:
         return "resolve {} together before installing the requested packages", (
@@ -1180,7 +1190,9 @@ class VerifyPackages(Operation):
 
     def apply(self, context: Context) -> None:
         atoms = tuple(request.atom for request in self.requests)
-        output = self._resolve(context, atoms, source_only=context.degraded(BINARY_PACKAGES))
+        output = self._resolve(
+            context, atoms, source_only=context.degraded(BINARY_PACKAGES) or not self.binary_host
+        )
         if output.returncode == 0:
             return
         output = self._without_the_binary_host(context, atoms, output)
@@ -1360,7 +1372,7 @@ def build(
         WriteProxyClients(proxy=config.proxy),
         CreateAutounmaskFiles(),
     ]
-    if _uses_binhost(portage):
+    if uses_binhost(portage):
         # Before the first emerge, not after it. `make.conf` above already
         # carries `FEATURES=getbinpkg`, so `emerge dev-vcs/git` fetches binary
         # packages; without the keyring a profile with
@@ -1571,7 +1583,7 @@ def _features(config: InstallConfig) -> tuple[str, ...]:
     password: curl answered `cannot read config from` for every distfile.
     """
     wanted: list[str] = []
-    if _uses_binhost(config.portage):
+    if uses_binhost(config.portage):
         wanted.append("getbinpkg")
     if config.proxy.enabled and (config.proxy.over_socks or config.proxy.username):
         wanted.append("-userfetch")
@@ -1603,7 +1615,8 @@ def _proxy_toml(proxy: ProxyConfig) -> str:
     )
 
 
-def _uses_binhost(portage: PortageConfig) -> bool:
+def uses_binhost(portage: PortageConfig) -> bool:
+    """Whether any binary host is configured at all."""
     return portage.binhost.official or portage.binhost.community is not BinhostChannel.OFF
 
 

--- a/tests/unit/test_plan_portage.py
+++ b/tests/unit/test_plan_portage.py
@@ -2587,3 +2587,56 @@ def test_a_healthy_binhost_records_nothing() -> None:
     portage.Emerge(packages=("net-misc/openssh",), summary="install ssh").apply(recorder)
 
     assert not recorder.degraded(portage.BINARY_PACKAGES)
+
+
+def test_a_configuration_with_no_binary_host_reaches_none() -> None:
+    """The stage3 ships an enabled `binrepos.conf` for the official host, so
+    `--getbinpkg=y` fetches from it whatever the configuration says. Measured
+    on the cluster: `ext2` has `official = false` and `community = "off"`, and
+    its journal recorded 20 packages from `/var/cache/binhost/gentoo`."""
+    from gentoo_install.data import load_catalog
+    from gentoo_install.exec.config import load
+    from gentoo_install.plan.build import build
+
+    def emerges(fixture: str) -> list[tuple[str, ...]]:
+        operations = build(load(Path(f"tests/fixtures/{fixture}.toml")), load_catalog())
+        found: list[tuple[str, ...]] = []
+        for one in operations:
+            if not isinstance(one, portage.Emerge):
+                continue
+            recorder = Recorder()
+            one.apply(recorder)
+            found += [argv for argv in recorder.in_target if argv[0] == "emerge"]
+        return found
+
+    off = emerges("ext2")
+    assert off, "the fixture merges something"
+    for argv in off:
+        assert "--getbinpkg=n" in argv and "--usepkg=n" in argv, argv
+        assert "--getbinpkg=y" not in argv, argv
+
+    # The control, and the reason this cannot be done by dropping the flag:
+    # a configuration that asks for the official host still gets it.
+    on = emerges("vm-binpkg")
+    assert on, "the fixture merges something"
+    assert all("--getbinpkg=y" in argv for argv in on), on
+
+
+def test_the_pretend_resolves_against_the_packages_the_merge_will_use() -> None:
+    """`VerifyPackages` runs `emerge --pretend` before the merges. Resolved
+    with binary packages the merge will not use, it accepts a set the merge
+    then refuses, and the run stops with the disks already partitioned."""
+    from gentoo_install.data import load_catalog
+    from gentoo_install.exec.config import load
+    from gentoo_install.plan.build import build
+
+    def pretend(fixture: str) -> tuple[str, ...]:
+        operations = build(load(Path(f"tests/fixtures/{fixture}.toml")), load_catalog())
+        verify = next(one for one in operations if isinstance(one, portage.VerifyPackages))
+        recorder = Recorder()
+        verify.apply(recorder)
+        return next(argv for argv in recorder.in_target if argv[0] == "emerge")
+
+    assert "--getbinpkg=n" in pretend("ext2")
+    assert "--getbinpkg=n" not in pretend("vm-binpkg")
+


### PR DESCRIPTION
Measured on the cluster rather than reasoned about: `tests/fixtures/ext2.toml` sets `official = false` and `community = "off"`, its plan ran neither `PrepareBinhostTrust` nor `ConfigureBinhost`, and its journal still records 48 packages compiled and **20 binary**, downloaded to `/var/cache/binhost/gentoo/`. The stage3 ships catalyst`s own `/etc/portage/binrepos.conf/gentoobinhost.conf` with the official host enabled, and `BINPKG_OPTIONS` passed `--getbinpkg=y` unconditionally, so the operator could not turn binary packages off.

`docs/design.md` already said the flag belongs to an enabled binhost; the code did not. `Emerge` and `VerifyPackages` now carry `binary_host`, and `plan/build.py` sets it once for the whole plan rather than at each of the twenty-seven construction sites. With no host the flags are the ones the degraded path already uses, `--usepkg=n --getbinpkg=n`.

The pretend moves with it: resolving against packages the merge will not use accepts a set the merge then refuses, with the disks already partitioned.