### PR TITLE
log: a pretend merges nothing, so it records nothing

### DIFF
--- a/gentoo_install/exec/runner.py
+++ b/gentoo_install/exec/runner.py
@@ -104,7 +104,7 @@ class Runner:
         self.history.append(result)
         if self.journal is not None:
             self.journal.command(_display_argv(result.argv), result.returncode, result.seconds)
-            if "emerge" in full:
+            if "emerge" in full and not _pretending(full):
                 self.journal.packages(result.stdout)
         if check and result.returncode != 0:
             raise CommandFailed(
@@ -306,6 +306,19 @@ class Runner:
         if not values:
             return None
         return {**os.environ, **values}
+
+
+def _pretending(argv: Sequence[str]) -> bool:
+    """Whether this emerge only says what it would do.
+
+    `VerifyPackages` resolves the whole request with `emerge --pretend
+    --quiet` before anything is merged, and it prints the same
+    `[binary]`/`[ebuild]` lines the real merge does. Recorded as merges they
+    doubled the journal: one guest listed 63 packages for the 40 it installed,
+    and a package the pretend named and the merge never installed was in the
+    record as installed.
+    """
+    return any(one in ("--pretend", "-p") for one in argv)
 
 
 def _display_argv(argv: Sequence[str]) -> tuple[str, ...]:

--- a/tests/unit/test_log.py
+++ b/tests/unit/test_log.py
@@ -87,3 +87,19 @@ def test_an_identity_entry_missing_a_field_is_not_an_identity(tmp_path: Path) ->
         }
         path.write_text(json.dumps(entry) + "\n")
         assert Journal(path=path).identity() is None, missing
+
+
+def test_a_pretend_is_not_a_merge(tmp_path: Path) -> None:
+    """`VerifyPackages` runs `emerge --pretend --quiet` before anything is
+    installed and it prints the same lines the merge does. Measured on a
+    guest: 31 lines from the pretend and 32 from the merge, and the journal
+    held all 63 as installed packages."""
+    journal = Journal(path=tmp_path / "install.jsonl")
+    runner = Runner(log=lambda line: None, journal=journal)
+    runner.run(["sh", "-c", "cat", "emerge", "--pretend", "--quiet"], input_text=EMERGE_OUTPUT)
+    assert journal.counts() == {}, journal.counts()
+    # The control: the same output from a command that is not a pretend is
+    # recorded, so this is a rule about the flag rather than about `sh`.
+    runner.run(["sh", "-c", "cat", "emerge", "--verbose"], input_text=EMERGE_OUTPUT)
+    assert journal.counts() == {"binary": 2, "compiled": 1}, journal.counts()
+


### PR DESCRIPTION
Measured on `vm-zram`: the guest`s log has 31 `[binary]`/`[ebuild]` lines under `emerge --pretend --quiet` and 32 under the real merge, and `install.jsonl` recorded all 63 as installed packages — 22 of its 40 atoms twice. The runner scans the stdout of every command whose argv holds `emerge`.

The record is not decoration: it is what says whether a binary host served this machine, and a package the pretend named and the merge never installed was in it as installed.