### PR TITLE
tests: ask an installed machine whether it has the sshd it was given

### DIFF
--- a/tests/unit/test_harness.py
+++ b/tests/unit/test_harness.py
@@ -4742,3 +4742,63 @@ def test_zram_is_checked_on_the_device_rather_than_the_file_that_asks_for_one() 
     assert not re.search(pattern, "")
     assert zram(replace(installation, system=replace(installation.system, zram=None))) is None
 
+
+#: `rc-update show default` on `vm-openrc-desktop`, which asks for sshd, and
+#: on `openrc-sdboot`, which does not. Both copied from the guests.
+_RC_UPDATE_WITH_SSHD = (
+    "       NetworkManager | default\n"
+    "               cronie | default\n"
+    "                 dbus | default\n"
+    "      display-manager | default\n"
+    "                local | default\n"
+    "             netmount | default\n"
+    "                 sshd | default\n"
+    "             sysklogd | default\n"
+)
+_RC_UPDATE_WITHOUT_SSHD = (
+    "               cronie | default\n"
+    "               dhcpcd | default\n"
+    "                local | default\n"
+    "             netmount | default\n"
+    "             sysklogd | default\n"
+)
+
+
+def test_a_machine_asked_for_sshd_is_asked_whether_it_has_one() -> None:
+    """Sixteen fixtures set `system.sshd` and no check looked at it, so a
+    machine that came up without a daemon passed. `UnitFileState` rather than
+    `list-unit-files`: on a serial console `systemctl` colours its output and
+    prints `\x1b[0;4msshd.service`, which no pattern anchored at the start of
+    a line matches."""
+    import re
+
+    from gentoo_install.exec.config import load
+    from tests.vm.installed import checks
+
+    def sshd(fixture: str) -> tuple[str, str] | None:
+        for one in checks(load(Path(f"tests/fixtures/{fixture}.toml"))):
+            if one.name == "sshd":
+                return one.command, one.pattern
+        return None
+
+    openrc = sshd("vm-openrc-desktop")
+    assert openrc is not None
+    command, pattern = openrc
+    assert command == "rc-update show default", command
+    assert re.search(pattern, _RC_UPDATE_WITH_SSHD)
+    assert not re.search(pattern, _RC_UPDATE_WITHOUT_SSHD)
+
+    systemd = sshd("vm-greetd")
+    assert systemd is not None
+    command, pattern = systemd
+    assert "UnitFileState" in command, command
+    # `systemctl show --property=UnitFileState --value sshd.service` on this
+    # workstation, which runs one.
+    assert re.search(pattern, "enabled\n")
+    assert not re.search(pattern, "disabled\n")
+    assert not re.search(pattern, "")
+
+    # The rule fires on the configuration: a machine that asked for no daemon
+    # is not failed for having none.
+    assert sshd("openrc-sdboot") is None
+

--- a/tests/vm/installed.py
+++ b/tests/vm/installed.py
@@ -27,6 +27,7 @@ from gentoo_install.model.device import (
     ZfsTopology,
 )
 from gentoo_install.plan.system import _network_service as network_service
+from gentoo_install.plan.system import _sshd_service as sshd_service
 from gentoo_install.plan.packages import ENVIRONMENT_FILE, input_environment
 
 from .console import DISK_PASSPHRASE
@@ -131,6 +132,27 @@ def checks(installation: InstallConfig) -> tuple[InstalledCheck, ...]:
                     re.escape(resolver),
                 )
                 for resolver in installation.system.dns
+            )
+    if installation.system.sshd:
+        # Sixteen fixtures ask for sshd and nothing asked the machine for it.
+        # `UnitFileState` rather than `is-enabled`: `systemctl` colours its
+        # output on a console that is a terminal, and the serial console is
+        # one, so `list-unit-files` prints `\x1b[0;4msshd.service`.
+        if installation.system.init is InitSystem.SYSTEMD:
+            result.append(
+                InstalledCheck(
+                    "sshd",
+                    f"systemctl show --property=UnitFileState --value {sshd_service()}.service",
+                    r"(?m)^enabled\b",
+                )
+            )
+        else:
+            result.append(
+                InstalledCheck(
+                    "sshd",
+                    "rc-update show default",
+                    rf"(?m)^\s*{sshd_service()}\s*\|",
+                )
             )
     if installation.system.zram is not None:
         # The device the machine brought up, not the file the installer wrote:


### PR DESCRIPTION
Sixteen fixtures set `system.sshd`; the installer emerges `net-misc/openssh`, writes a config drop-in and enables the service, and no installed-state check looked at any of it.

Both patterns are held against real guest output. openrc: `rc-update show default` from `vm-openrc-desktop`, which lists `                 sshd | default`, with `openrc-sdboot`, which asks for no daemon, as the control. systemd: `systemctl show --property=UnitFileState --value sshd.service` answers a bare `enabled` — `list-unit-files` was rejected because the serial console is a terminal and systemd colours it, printing `\x1b[0;4msshd.service` where a start-of-line pattern matches nothing.