### PR TITLE
tests: read a declared user back from the machine

### DIFF
--- a/tests/unit/test_harness.py
+++ b/tests/unit/test_harness.py
@@ -4802,3 +4802,44 @@ def test_a_machine_asked_for_sshd_is_asked_whether_it_has_one() -> None:
     # is not failed for having none.
     assert sshd("openrc-sdboot") is None
 
+
+def test_a_declared_user_is_read_back_from_the_machine() -> None:
+    """`btrfs-luks` names a user with three groups and a shell, and the
+    guest`s console log never mentioned the name: a machine that created no
+    account passed. The uid fields are the machine`s own answer, which the
+    command cannot supply."""
+    import re
+
+    from gentoo_install.exec.config import load
+    from tests.vm.installed import checks
+
+    def named(fixture: str, name: str) -> str | None:
+        for one in checks(load(Path(f"tests/fixtures/{fixture}.toml"))):
+            if one.name == name:
+                return one.pattern
+        return None
+
+    account = named("btrfs-luks", "user zakk")
+    assert account is not None
+    # `getent passwd zakk` on this workstation, with the shell the fixture
+    # asks for in place of the one this machine has.
+    assert re.search(account, "zakk:x:1000:1000:Zakk:/home/zakk:/bin/bash\n")
+    # The controls: no account at all, and an account with another shell.
+    assert not re.search(account, "")
+    assert not re.search(account, "zakk:x:1000:1000:Zakk:/home/zakk:/usr/bin/zsh\n")
+    # A name that only appears as a group, which `getent passwd` would not
+    # print and a looser pattern would have accepted.
+    assert not re.search(account, "wheel:x:10:zakk\n")
+
+    groups = named("btrfs-luks", "user zakk groups")
+    assert groups is not None
+    # `id -nG zakk` on this workstation.
+    assert re.search(groups, "zakk wheel audio video usb input kvm render libvirt\n")
+    assert not re.search(groups, "zakk wheel audio usb input kvm libvirt\n")
+
+    # A fixture whose user has no group list gets no group check, and one
+    # with no user gets neither.
+    assert named("zbm-unlock", "user zakk") is not None
+    assert named("zbm-unlock", "user zakk groups") is None
+    assert named("ext3", "user zakk") is None
+

--- a/tests/vm/installed.py
+++ b/tests/vm/installed.py
@@ -133,6 +133,26 @@ def checks(installation: InstallConfig) -> tuple[InstalledCheck, ...]:
                 )
                 for resolver in installation.system.dns
             )
+    for user in installation.system.users:
+        # The account the machine holds, not the operation that asked for it:
+        # `btrfs-luks` names a user with three groups and a shell, and its
+        # console log never mentioned the name.
+        shell = re.escape(user.shell) if user.shell else "[^:]*"
+        result.append(
+            InstalledCheck(
+                f"user {user.name}",
+                f"getent passwd {user.name}",
+                rf"(?m)^{re.escape(user.name)}:[^:]*:\d+:\d+:[^:]*:[^:]*:{shell}$",
+            )
+        )
+        if user.groups:
+            result.append(
+                InstalledCheck(
+                    f"user {user.name} groups",
+                    f"id -nG {user.name}",
+                    "".join(rf"(?=.*\b{re.escape(one)}\b)" for one in user.groups),
+                )
+            )
     if installation.system.sshd:
         # Sixteen fixtures ask for sshd and nothing asked the machine for it.
         # `UnitFileState` rather than `is-enabled`: `systemctl` colours its


### PR DESCRIPTION
Three fixtures declare a user; `btrfs-luks` gives it `wheel`, `video`, `render` and `/bin/bash`. Its guest console log does not contain the string `zakk` once, so nothing asked whether the account exists, which groups it is in, or what shell it has.

The passwd pattern is anchored on the uid and gid fields, which are the machine`s own answer and cannot come from the command; the group check uses `id -nG`. Both are held against this workstation`s real `getent passwd zakk` and `id -nG zakk`, with a wrong shell, a missing group, a `wheel:x:10:zakk` group line and an empty answer as the controls.