### PR TITLE
cluster: a guest log names the driver that built it

### DIFF
--- a/tests/unit/test_cluster.py
+++ b/tests/unit/test_cluster.py
@@ -1589,8 +1589,8 @@ def test_two_rounds_carrying_one_fixture_keep_separate_logs(tmp_path: Path) -> N
     )
 
     assert first.watch.log != second.watch.log
-    assert first.watch.log.name == "vm-greetd-9301.log"
-    assert second.watch.log.name == "vm-greetd-9302.log"
+    assert first.watch.log.name.startswith("vm-greetd-9301-")
+    assert second.watch.log.name.startswith("vm-greetd-9302-")
 
 
 def test_a_guest_qemu_calls_running_adds_nothing_to_the_reason(tmp_path: Path) -> None:
@@ -2812,3 +2812,29 @@ def test_a_round_waits_longer_when_our_own_guests_hold_the_room() -> None:
     # a round for ever.
     assert cluster.CAPACITY_PATIENCE_SHARED > cluster.CAPACITY_PATIENCE
     assert cluster.CAPACITY_PATIENCE_SHARED <= cluster.RUN_CEILING
+
+
+def test_two_rounds_cannot_write_one_guest_log() -> None:
+    """A vmid is handed back and reused, so `ext2-9303.log` was written by
+    whichever round ran that fixture on 9303 last: run109's copy was gone when
+    its revision was asked for, and the revision is the first line of the log.
+    The driver CD is content-addressed, so its name is what says which
+    installer built the guest."""
+    from pathlib import Path as _Path
+
+    from tests.vm.cluster import guest_log
+    from tests.vm.driver import NAME_PREFIX
+
+    workdir = _Path("/lab/vm/cluster")
+    first = guest_log(workdir, "ext2", 9303, f"{NAME_PREFIX}53d1cb7f02a50952333.iso")
+    second = guest_log(workdir, "ext2", 9303, f"{NAME_PREFIX}023374df9cee160062d.iso")
+    assert first != second, first
+    assert first.name.startswith("ext2-9303-"), first.name
+    # The same driver twice is the same log: two guests of one round are told
+    # apart by the vmid, which the pool never hands out twice at once.
+    assert first == guest_log(workdir, "ext2", 9303, f"{NAME_PREFIX}53d1cb7f02a50952333.iso")
+    assert first != guest_log(workdir, "ext2", 9304, f"{NAME_PREFIX}53d1cb7f02a50952333.iso")
+    # A name that is not a driver CD still produces a path rather than an
+    # empty tag, because the log is where a failure is read.
+    assert guest_log(workdir, "ext2", 9303, "local.iso").name == "ext2-9303-driver.log"
+

--- a/tests/vm/cluster.py
+++ b/tests/vm/cluster.py
@@ -35,7 +35,7 @@ import urllib.parse
 import urllib.request
 from dataclasses import dataclass, field, replace
 from enum import Enum
-from pathlib import Path
+from pathlib import Path, PurePath
 from collections import Counter
 from collections.abc import Callable, Mapping
 from types import MappingProxyType
@@ -76,7 +76,13 @@ from .console import (
     command_done,
     marked_command,
 )
-from .driver import FIND_DRIVER, build as build_driver, digest as driver_digest, remote_name
+from .driver import (
+    FIND_DRIVER,
+    NAME_PREFIX as DRIVER_PREFIX,
+    build as build_driver,
+    digest as driver_digest,
+    remote_name,
+)
 from .monitor import keys_for
 from .proxmox import (
     Api,
@@ -1561,6 +1567,27 @@ class AddressPool:
                 lease.unlink(missing_ok=True)
 
 
+def guest_log(workdir: Path, fixture: str, vmid: int, driver: str) -> Path:
+    """Where one guest's console is kept.
+
+    The vmid, because every schedule shares this directory and two rounds
+    carrying one fixture wrote the same file at the same time: `vm-greetd` was
+    in two rounds at once on the day that was found. The driver as well,
+    because a vmid is reused between rounds: a later round running the same
+    fixture on the same vmid overwrote the earlier log, and run109's `ext2`
+    record was gone when its revision was asked for.
+    """
+    return workdir / f"{fixture}-{vmid}-{_driver_tag(driver)}.log"
+
+
+def _driver_tag(driver: str) -> str:
+    """The content-addressed part of a driver CD's name, which is what says
+    the guest was built by one installer rather than another."""
+    stem = PurePath(driver).stem
+    tag = stem.rsplit("-", 1)[-1] if stem.startswith(DRIVER_PREFIX) else ""
+    return tag[:10] or "driver"
+
+
 def _execution(
     api: Api,
     node: str,
@@ -1572,11 +1599,7 @@ def _execution(
     address: str = "",
 ) -> Running:
     chosen = vmid or api.free_vmid()
-    # The vmid in the name: every schedule shares this directory, so two
-    # rounds carrying one fixture wrote the same file at the same time and
-    # the verdict of each pointed at a log holding both. `vm-greetd` was in
-    # two rounds at once on the day this was found.
-    log = workdir / f"{job.name}-{chosen}.log"
+    log = guest_log(workdir, job.name, chosen, driver)
     guest = Guest(
         api=api,
         node=node,

--- a/tests/vm/driver.py
+++ b/tests/vm/driver.py
@@ -183,6 +183,11 @@ def digest(path: Path) -> str:
     return reader.hexdigest()
 
 
+#: What every driver CD's name begins with, so a reader can tell one from the
+#: node's other ISOs and a caller can recover the digest from the name.
+NAME_PREFIX: Final[str] = "gi-driver-"
+
+
 def remote_name(path: Path) -> str:
     """Content-addressed name used on node-local ISO storage."""
-    return f"gi-driver-{digest(path)[:20]}.iso"
+    return f"{NAME_PREFIX}{digest(path)[:20]}.iso"


### PR DESCRIPTION
Every schedule shares `lab/vm/cluster/`, and a vmid is handed back to the pool when a guest is removed. `#700` put the vmid in the log name for two rounds running at once; it does not help two rounds running one after another, and `ext2-9302.log` now holds `34cb398890c7d` while run109 also ran `ext2` on a 93xx guest. That log was the only record of the revision run109 measured — the first line of each guest log is `installer revision: ...` — and it is gone.

The driver CD is content-addressed, so its name already says which installer built the guest. `guest_log()` puts ten characters of that digest in the name, and `NAME_PREFIX` moves to `driver.py`, which builds the name, so the two spellings cannot drift.