### PR TITLE
vm: the zfs unlock proof travels in the unlock session

### DIFF
--- a/tests/unit/test_harness.py
+++ b/tests/unit/test_harness.py
@@ -4843,3 +4843,45 @@ def test_a_declared_user_is_read_back_from_the_machine() -> None:
     assert named("zbm-unlock", "user zakk groups") is None
     assert named("ext3", "user zakk") is None
 
+
+def test_the_zfs_unlock_proof_travels_in_the_unlock_session(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """ZFSBootMenu's dropbear lives in the image it boots from, so unlocking
+    hands over to the kernel it loads and the daemon goes with it. `zbm-unlock`
+    unlocked and its second connection, carrying `zfs get keystatus`, hung
+    until the timeout and left `TimeoutExpired` as the whole verdict."""
+    from gentoo_install.exec.config import load
+    from tests.vm import run as runner
+
+    seen: dict[str, object] = {}
+    opened: list[str] = []
+
+    class FakeProcess:
+        returncode = 0
+
+        def communicate(
+            self, text: str | None = None, timeout: float | None = None
+        ) -> tuple[str, str]:
+            seen["stdin"] = text
+            return ("Enter passphrase:\navailable\n", "")
+
+    def fake_popen(argv: list[str], **_: object) -> FakeProcess:
+        seen["argv"] = argv
+        return FakeProcess()
+
+    def refuse_a_second_connection(*arguments: object, **_: object) -> None:
+        opened.append(str(arguments))
+        raise AssertionError("the proof must not open a second connection")
+
+    monkeypatch.setattr(runner, "wait_for_unlock_daemon", lambda *a, **k: None)
+    monkeypatch.setattr("subprocess.Popen", fake_popen)
+    monkeypatch.setattr(runner, "ssh", refuse_a_second_connection)
+
+    installation = load(Path("tests/fixtures/zbm-unlock.toml"))
+    assert runner.remote_unlock(Path("key"), 2222, installation) == "available"
+    asked = cast(list[str], seen["argv"])[-1]
+    assert "zfs load-key -a" in asked and "keystatus" in asked, asked
+    # The control: a second connection would be the race this closes.
+    assert not opened, opened
+

--- a/tests/vm/run.py
+++ b/tests/vm/run.py
@@ -308,6 +308,11 @@ def remote_unlock(
     if commands is None:
         raise RuntimeError("remote unlock is disabled")
     command, proof = commands
+    # One session for the unlock and its proof. ZFSBootMenu's dropbear runs
+    # inside the image it boots from, so unlocking hands over to the kernel it
+    # then loads and the daemon goes with it: `zbm-unlock` unlocked, and the
+    # second connection carrying `zfs get keystatus` hung until its timeout.
+    asked = f"{command} && {proof}" if proof is not None else command
     # Before the unlock, not racing it: the daemon comes up inside an initramfs
     # that has to be unpacked first.
     wait_for_unlock_daemon(key, port, host=host)
@@ -316,7 +321,7 @@ def remote_unlock(
             "ssh", "-p", str(port), "-i", str(key),
             "-o", "StrictHostKeyChecking=no", "-o", "UserKnownHostsFile=/dev/null",
             "-o", "BatchMode=yes", "-o", "ConnectTimeout=10", f"root@{host}",
-            command,
+            asked,
         ], stdin=subprocess.PIPE, stdout=subprocess.PIPE, stderr=subprocess.STDOUT,
         text=True,
     )
@@ -330,10 +335,12 @@ def remote_unlock(
         raise RuntimeError(f"remote unlock failed: {output.strip()[-300:]}")
     if proof is None:
         return "unlocked"
-    checked = ssh(key, port, proof, host=host)
-    status = checked.stdout.strip()
-    if checked.returncode != 0 or status != "available":
-        raise RuntimeError(f"remote ZFS unlock reported keystatus {status!r}")
+    said = [line.strip() for line in output.splitlines() if line.strip()]
+    status = said[-1] if said else ""
+    if status != "available":
+        raise RuntimeError(
+            f"remote ZFS unlock reported keystatus {status!r}; it said {output.strip()[-300:]!r}"
+        )
     return status
 
 


### PR DESCRIPTION
run112 ERRORed `zbm-unlock` with a bare `TimeoutExpired: Command [ssh -p 2222 ... zfs get -H -o value keystatus ...]`. The unlock itself succeeded; the proof was a second connection, and ZFSBootMenu`s dropbear runs inside the image it boots from, so unlocking hands over to the kernel it loads and the daemon goes with it.

Both halves of that verdict are closed by one change: the proof is chained onto the unlock in the same session, and its answer is read from the same output. `subprocess.TimeoutExpired` is not a `RuntimeError`, which is why the cluster`s handler — the one that attaches the console to the verdict — never saw it.