### PR TITLE
results: carry the whole install log until it cannot travel

### DIFF
--- a/tests/unit/test_cluster.py
+++ b/tests/unit/test_cluster.py
@@ -1247,21 +1247,56 @@ def test_a_fixture_that_passes_by_failing_is_not_recorded_as_a_failure() -> None
     assert failing == set(cluster.EXPECTED_TO_FAIL), (failing, cluster.EXPECTED_TO_FAIL)
 
 
-def test_the_console_carries_the_tail_of_the_install_log_and_not_all_of_it() -> None:
+def test_the_console_carries_the_whole_log_until_it_cannot(tmp_path: Path) -> None:
     """`vm-source-kernel` writes 80 MB of build output, which gzips to 4.5 MiB
-    and reaches the reader as one base64 line of about six. It is the only
-    fixture that has ever failed while its results were being read, and it did
-    so twice; everything else in that archive is kilobytes.
+    and reaches the reader as one base64 line of about six: it is the only
+    fixture that has ever failed while its results were being read. Everything
+    else the cluster kept is between 3.9 MB and 25 MB and crossed the console
+    before the tail existed, and the whole log is what a defect is found in.
+
+    The shell is run rather than read: it decides between the two on the
+    guest, where nothing else can.
     """
-    from tests.vm.results import LOG_TAIL, LOG_TAIL_BYTES, console_command
+    import base64
+    import io
+    import subprocess
+    import tarfile
+
+    from tests.vm.results import (
+        CONSOLE_CLOSE,
+        CONSOLE_OPEN,
+        FULL_LOG_BYTES,
+        LOG_TAIL,
+        LOG_TAIL_BYTES,
+        console_command,
+    )
 
     said = console_command("/tmp/gentoo-install-results")
     assert f"tail -c {LOG_TAIL_BYTES}" in said, said
     assert f"/{LOG_TAIL}" in said, said
-    assert "--exclude=./install.txt" in said, said
-    # And the exclusion is of the log alone: the journal, the exit code and
-    # every check's output are what the verdict is made of.
-    assert "--exclude" not in said.split("--exclude=./install.txt", 1)[1], said
+    assert str(FULL_LOG_BYTES) in said, said
+
+    def carried(size: int) -> set[str]:
+        room = tmp_path / f"results-{size}"
+        room.mkdir()
+        (room / "install.txt").write_bytes(b"x" * size)
+        (room / "install.rc").write_text("0\n")
+        (room / "install.jsonl").write_text("{}\n")
+        printed = subprocess.run(
+            ["sh", "-c", console_command(str(room), limit=1024)],
+            capture_output=True,
+            text=True,
+            check=True,
+        ).stdout
+        blob = printed.split(CONSOLE_OPEN)[1].split(CONSOLE_CLOSE)[0]
+        packed = base64.b64decode("".join(blob.split()), validate=True)
+        with tarfile.open(fileobj=io.BytesIO(packed)) as archive:
+            return {Path(one).name for one in archive.getnames() if one != "."}
+
+    assert carried(1024) == {"install.txt", "install.tail", "install.rc", "install.jsonl"}
+    # Over the limit the log stays behind and everything the verdict is made
+    # of still travels.
+    assert carried(1025) == {"install.tail", "install.rc", "install.jsonl"}
 
 
 def test_a_failed_install_verdict_carries_the_installer_s_own_reason() -> None:

--- a/tests/unit/test_proxmox.py
+++ b/tests/unit/test_proxmox.py
@@ -1105,10 +1105,11 @@ def test_the_command_a_real_shell_runs_produces_a_readable_archive(tmp_path: Pat
     command = console_command(str(tmp_path))
     printed = subprocess.run(["sh", "-c", command], capture_output=True).stdout
     said = f"root@livecd ~ # {command}\r\n".encode() + printed
-    # The log itself stays on the guest and its tail travels: a source-kernel
-    # install writes 80 MB of it into a channel that has dropped twice.
+    # A log this size travels whole, and its tail with it: the tail is the
+    # fallback for the one fixture whose 80 MB never crossed this channel.
     assert read_console(said) == {
         "install.rc": b"0\n",
+        "install.txt": b"installed 53 operations\n",
         LOG_TAIL: b"installed 53 operations\n",
     }
 

--- a/tests/vm/results.py
+++ b/tests/vm/results.py
@@ -58,8 +58,17 @@ LOG_TAIL_BYTES: Final[int] = 256 * 1024
 #: What the guest writes the tail to, beside the log it came from.
 LOG_TAIL: Final[str] = "install.tail"
 
+#: Up to this much of the log travels whole. Measured on the logs the cluster
+#: had kept when this was written: 39 fixtures between 3.9 MB and 25 MB, all
+#: of which crossed the console before the tail existed, and one
+#: `vm-source-kernel` at 80 MB, which never did. The whole log is what a
+#: defect is found in — the binary host a configuration had turned off was
+#: found by reading every `emerge` line of one — so the tail is the fallback
+#: rather than the rule.
+FULL_LOG_BYTES: Final[int] = 32 * 1024 * 1024
 
-def console_command(directory: str) -> str:
+
+def console_command(directory: str, limit: int = FULL_LOG_BYTES) -> str:
     """Print the results as one base64 line between two markers.
 
     A guest on the cluster writes its disks to shared storage the workstation
@@ -74,11 +83,13 @@ def console_command(directory: str) -> str:
     """
     stem, opened = CONSOLE_OPEN.rsplit("_", 1)
     closed = CONSOLE_CLOSE.rsplit("_", 1)[1]
+    log = f"{directory}/install.txt"
     return (
         f"printf '{stem}_%s\\n' {opened}; "
-        f"tail -c {LOG_TAIL_BYTES} {directory}/install.txt > {directory}/{LOG_TAIL} "
-        "2>/dev/null || true; "
-        f"tar cz --exclude=./install.txt -C {directory} . | base64 -w0; "
+        f"tail -c {LOG_TAIL_BYTES} {log} > {directory}/{LOG_TAIL} 2>/dev/null || true; "
+        f"if [ \"$(wc -c < {log} 2>/dev/null || echo 0)\" -le {limit} ]; "
+        "then whole=; else whole=--exclude=./install.txt; fi; "
+        f"tar cz $whole -C {directory} . | base64 -w0; "
         f"echo; printf '{stem}_%s\\n' {closed}"
     )
 


### PR DESCRIPTION
`#736` was measured on one input. `vm-source-kernel` writes 80 MB and its results were never read back; every other log the cluster had kept is between 3.9 MB and 25 MB and had crossed the console for months. Shipping a 256 KB tail for all of them removed the evidence from 39 fixtures to fix one — the binary host that a configuration had turned off was found this week by reading every `emerge` line of a full log, which would no longer exist.

The guest decides, because nothing else can: `wc -c` against `FULL_LOG_BYTES`, the whole log below it and the tail above. The test runs the generated shell against a real `sh`, `tar` and `base64` and reads the archive back on both sides of the limit.