### PR TITLE
cluster: a converted machine is asked whether /home survived

### DIFF
--- a/tests/unit/test_cluster.py
+++ b/tests/unit/test_cluster.py
@@ -2873,3 +2873,43 @@ def test_two_rounds_cannot_write_one_guest_log() -> None:
     # empty tag, because the log is where a failure is read.
     assert guest_log(workdir, "ext2", 9303, "local.iso").name == "ext2-9303-driver.log"
 
+
+def test_a_cluster_conversion_writes_and_reads_the_home_marker() -> None:
+    """`/home` surviving is what an in-place conversion promises, and the
+    cluster row said the converted machine carried what the conversion asked
+    for while nothing had looked at `/home`. The local runner has checked it
+    since `#697`; this path had not."""
+    import inspect
+
+    from tests.vm import cluster
+    from tests.vm.convert import HOME_MARKER_CHECK
+
+    source = inspect.getsource(cluster.convert_and_check)
+    # The constant, not a second copy of the path: the local runner writes the
+    # same file and reads the same marker.
+    written = source.index("HOME_MARKER_PATH")
+    converted = source.index("install.sh")
+    assert written < converted, source
+    assert "extra=(HOME_MARKER_CHECK,)" in source, source
+
+    # The check itself asks the guest to count, so neither the shell's echo of
+    # the command nor `cat`'s own diagnostic can answer it.
+    assert "grep -Fc" in HOME_MARKER_CHECK.command
+    import re
+
+    assert not re.search(HOME_MARKER_CHECK.pattern, HOME_MARKER_CHECK.command)
+    assert re.search(HOME_MARKER_CHECK.pattern, "home=1\n")
+    assert not re.search(HOME_MARKER_CHECK.pattern, "home=0\n")
+
+
+def test_the_extra_checks_reach_the_installed_reader() -> None:
+    """`boot_and_check` grew a parameter, and a parameter nothing forwards is
+    a check that never runs."""
+    import inspect
+
+    from tests.vm import cluster
+
+    source = inspect.getsource(cluster.boot_and_check)
+    asked = source.index("_asked_for(installation)")
+    assert "extra" in source[asked : asked + 200], source[asked : asked + 200]
+

--- a/tests/vm/cluster.py
+++ b/tests/vm/cluster.py
@@ -109,7 +109,8 @@ from .results import (
     read_console,
 )
 from .workdir import WorkdirError, confined
-from .installed import checks, stage_passphrase_commands
+from .convert import HOME_MARKER, HOME_MARKER_CHECK, HOME_MARKER_PATH
+from .installed import InstalledCheck, checks, stage_passphrase_commands
 from .run import SEEDED, remote_config, remote_unlock, ssh_keypair
 
 REPOSITORY: Final[Path] = Path(__file__).resolve().parents[2]
@@ -3143,6 +3144,11 @@ def convert_and_check(
     """
     installation = load(fixture)
     wait_for_network(link, guest.vmid, address)
+    # Before the conversion, because the promise is that it survives one:
+    # `/home` is the path an operator has data on, and the cluster row said
+    # the converted machine carried what the conversion asked for without
+    # anything having looked at it.
+    link.run(f"printf '%s\\n' {HOME_MARKER} > {HOME_MARKER_PATH}")
     link.run(FIND_DRIVER)
     link.run(f"mkdir -p {RESULT_DIR}")
     link.wait_for(
@@ -3162,7 +3168,7 @@ def convert_and_check(
         return f"the conversion exited {code!r}"
     # The same reader as the first install: a converted machine that reaches a
     # login prompt with the old hostname booted the system it was replacing.
-    return boot_and_check(guest, link, log, installation)
+    return boot_and_check(guest, link, log, installation, extra=(HOME_MARKER_CHECK,))
 
 
 def boot_and_check(
@@ -3172,6 +3178,7 @@ def boot_and_check(
     installation: InstallConfig,
     remote_key: Path | None = None,
     remote_host: str = "127.0.0.1",
+    extra: Sequence[InstalledCheck] = (),
 ) -> str:
     """Boot the newly written disk and read the system back.
 
@@ -3233,7 +3240,10 @@ def boot_and_check(
     if refused:
         return f"{missed_the_prompt}; {refused}"[:VERDICT_BYTES] if missed_the_prompt else refused
 
-    for name, command, wanted in _asked_for(installation):
+    for name, command, wanted in [
+        *_asked_for(installation),
+        *((one.name, one.command, one.pattern) for one in extra),
+    ]:
         said = link.expect_output(command, timeout=120.0)
         if said != wanted.encode() and re.search(wanted.encode(), said) is None:
             # With the answer, not only the pattern: `greetd config: the


### PR DESCRIPTION
`convert_and_check` runs the shared installed-state checks, which for an in-place configuration are the base set plus `fstab`. None of them looks at `/home` — the one path the conversion promises not to replace, and the reason an operator would run it at all. The local runner writes a marker into `/home` before converting and counts it afterwards; the cluster never did, so `TESTED.md` carries a conversion row that says the machine "answered every installed-state check" without that being one of them.

The marker and its check are the ones `tests/vm/convert.py` already defines, so there is one definition rather than two. `boot_and_check` takes the extra checks as a parameter, and a test holds that the parameter reaches the loop: one that nothing forwards is a check that never runs.