### PR TITLE
cluster: a binhost fixture that compiled everything is not a pass

### DIFF
--- a/tests/unit/test_cluster.py
+++ b/tests/unit/test_cluster.py
@@ -2913,3 +2913,59 @@ def test_the_extra_checks_reach_the_installed_reader() -> None:
     asked = source.index("_asked_for(installation)")
     assert "extra" in source[asked : asked + 200], source[asked : asked + 200]
 
+
+def test_a_binhost_fixture_that_compiled_everything_is_not_a_pass() -> None:
+    """The mirror image of `MUST_DEGRADE`. An install that gave the binary
+    host up and compiled instead finishes, boots and answers every other
+    check, so `vm-binpkg` — the blocking fixture for that path — was green
+    whether or not a single package came from the host it names.
+
+    Measured on the journals the cluster had kept: every `vm-binpkg` recorded
+    binary packages and none of them degraded, so this rule is red only when
+    the path it guards has broken.
+    """
+    import json
+
+    from gentoo_install.plan.portage import BINARY_PACKAGES
+    from tests.vm import cluster
+
+    def journal(*rows: dict[str, object]) -> dict[str, bytes]:
+        return {"install.jsonl": "\n".join(json.dumps(one) for one in rows).encode()}
+
+    served = journal(
+        {"event": "package", "source": "binary", "atom": "sys-apps/portage-3.0.70"},
+        {"event": "package", "source": "compiled", "atom": "dev-vcs/git-2.51.0"},
+    )
+    assert cluster._binary_packages_missing("vm-binpkg", served) == ""
+
+    compiled = journal({"event": "package", "source": "compiled", "atom": "dev-vcs/git-2.51.0"})
+    assert "no package from a binary host" in cluster._binary_packages_missing(
+        "vm-binpkg", compiled
+    )
+
+    # A degradation is the loud form of the same thing, and its reason is
+    # carried: `the host answered 404` and `the key is not trusted` are
+    # different problems.
+    gave_up = journal(
+        {"event": "degraded", "what": BINARY_PACKAGES, "reason": "the host answered 404"},
+        {"event": "package", "source": "binary", "atom": "sys-apps/portage-3.0.70"},
+    )
+    said = cluster._binary_packages_missing("vm-binpkg", gave_up)
+    assert "gave up" in said and "404" in said, said
+
+    # No journal is not a pass either: a guest that handed nothing back says
+    # nothing about where its packages came from.
+    assert "no journal" in cluster._binary_packages_missing("vm-binpkg", {})
+
+    # The control: the rule fires on the table, not on every fixture.
+    assert cluster._binary_packages_missing("vm-xfs", compiled) == ""
+    assert "vm-binhost-fallback" not in cluster.MUST_USE_A_BINARY_HOST
+    assert set(cluster.MUST_USE_A_BINARY_HOST) & set(cluster.MUST_DEGRADE) == set()
+
+    # And it is asked where the verdict is decided: a rule nothing calls is
+    # the same as no rule, and `tests/vm/` has no unreachable-code check.
+    import inspect
+
+    said = inspect.getsource(cluster.install_one)
+    assert "_binary_packages_missing(" in said, said[:200]
+

--- a/tests/vm/cluster.py
+++ b/tests/vm/cluster.py
@@ -1822,7 +1822,11 @@ def install_one(
                 phase=phase,
                 revision=revision,
             )
-        missing = _degradation_missing(job.name, files) if code == b"0" else ""
+        missing = (
+            _degradation_missing(job.name, files) or _binary_packages_missing(job.name, files)
+            if code == b"0"
+            else ""
+        )
         if missing:
             return Outcome(
                 job.name,
@@ -2347,6 +2351,40 @@ KEEPS_ITS_SITE: Final[frozenset[str]] = frozenset({"vm-binhost-fallback"})
 MUST_DEGRADE: Final[Mapping[str, str]] = MappingProxyType(
     {"vm-binhost-fallback": BINARY_PACKAGES}
 )
+
+
+#: Fixtures whose point is that the binary host served them. The mirror image
+#: of `MUST_DEGRADE`: a binhost install that quietly compiled everything after
+#: a degradation finishes, boots and passes every other check, and `vm-binpkg`
+#: is the blocking fixture for that path. `install.jsonl` carries one entry
+#: per package with where it came from, and `#746` stopped `emerge --pretend`
+#: from being counted as a merge.
+MUST_USE_A_BINARY_HOST: Final[frozenset[str]] = frozenset({"vm-binpkg"})
+
+
+def _binary_packages_missing(name: str, files: Mapping[str, bytes]) -> str:
+    """Empty when this fixture's journal records packages from a binary host."""
+    if name not in MUST_USE_A_BINARY_HOST:
+        return ""
+    journal = files.get("install.jsonl")
+    if journal is None:
+        return f"{name} has to install from a binary host and the guest handed back no journal"
+    binary = 0
+    for line in journal.splitlines():
+        try:
+            entry = json.loads(line)
+        except json.JSONDecodeError:
+            continue
+        if entry.get("event") == "degraded" and entry.get("what") == BINARY_PACKAGES:
+            return (
+                f"{name} gave up on {BINARY_PACKAGES!r} and compiled instead, "
+                f"which is what it exists to measure not happening: {entry.get('reason', '')}"
+            )[:REASON_BYTES]
+        if entry.get("event") == "package" and entry.get("source") == "binary":
+            binary += 1
+    if not binary:
+        return f"{name} finished with no package from a binary host"
+    return ""
 
 
 def _degradation_missing(name: str, files: Mapping[str, bytes]) -> str:


### PR DESCRIPTION
The mirror image of `MUST_DEGRADE`. An install that gives the binary host up and compiles instead finishes, boots and answers every installed-state check, so `vm-binpkg` — the blocking fixture for that path — passed whether or not one package came from the host it names.

`install.jsonl` already carries where each package came from, and `#746` stopped `emerge --pretend` from being counted as a merge, so the count means what it says. Measured on the journals the cluster had kept: every `vm-binpkg` recorded binary packages and none degraded, so this is red only when the path it guards has broken.

The test also holds the wiring, because `tests/vm/` has no unreachable-code check and a rule nothing calls is the same as no rule.