### PR TITLE
tests: a converted machine is asked whether /etc was replaced

### DIFF
--- a/tests/unit/test_cluster.py
+++ b/tests/unit/test_cluster.py
@@ -2890,7 +2890,8 @@ def test_a_cluster_conversion_writes_and_reads_the_home_marker() -> None:
     written = source.index("HOME_MARKER_PATH")
     converted = source.index("install.sh")
     assert written < converted, source
-    assert "extra=(HOME_MARKER_CHECK,)" in source, source
+    assert source.index("ETC_MARKER_PATH") < converted, source
+    assert "HOME_MARKER_CHECK, ETC_MARKER_CHECK" in source, source
 
     # The check itself asks the guest to count, so neither the shell's echo of
     # the command nor `cat`'s own diagnostic can answer it.
@@ -2900,6 +2901,17 @@ def test_a_cluster_conversion_writes_and_reads_the_home_marker() -> None:
     assert not re.search(HOME_MARKER_CHECK.pattern, HOME_MARKER_CHECK.command)
     assert re.search(HOME_MARKER_CHECK.pattern, "home=1\n")
     assert not re.search(HOME_MARKER_CHECK.pattern, "home=0\n")
+
+    # `/etc` is the other half of the same promise: replaced, not merged, so
+    # the count there has to be zero, and the same counting keeps the echo
+    # and the diagnostic out of the answer.
+    from tests.vm.convert import ETC_MARKER_CHECK
+
+    assert "grep -Fc" in ETC_MARKER_CHECK.command
+    assert not re.search(ETC_MARKER_CHECK.pattern, ETC_MARKER_CHECK.command)
+    assert re.search(ETC_MARKER_CHECK.pattern, "etc=0\n")
+    assert not re.search(ETC_MARKER_CHECK.pattern, "etc=1\n")
+    assert not re.search(ETC_MARKER_CHECK.pattern, "")
 
 
 def test_the_extra_checks_reach_the_installed_reader() -> None:

--- a/tests/vm/cluster.py
+++ b/tests/vm/cluster.py
@@ -109,7 +109,14 @@ from .results import (
     read_console,
 )
 from .workdir import WorkdirError, confined
-from .convert import HOME_MARKER, HOME_MARKER_CHECK, HOME_MARKER_PATH
+from .convert import (
+    ETC_MARKER,
+    ETC_MARKER_CHECK,
+    ETC_MARKER_PATH,
+    HOME_MARKER,
+    HOME_MARKER_CHECK,
+    HOME_MARKER_PATH,
+)
 from .installed import InstalledCheck, checks, stage_passphrase_commands
 from .run import SEEDED, remote_config, remote_unlock, ssh_keypair
 
@@ -3182,11 +3189,13 @@ def convert_and_check(
     """
     installation = load(fixture)
     wait_for_network(link, guest.vmid, address)
-    # Before the conversion, because the promise is that it survives one:
-    # `/home` is the path an operator has data on, and the cluster row said
-    # the converted machine carried what the conversion asked for without
-    # anything having looked at it.
+    # Before the conversion, one sentinel on each side of the swap: `/home` is
+    # the path an operator has data on and has to survive, and `/etc` is
+    # replaced rather than merged, so a file put there has to be gone. The
+    # cluster row said the converted machine carried what the conversion asked
+    # for without anything having looked at either.
     link.run(f"printf '%s\\n' {HOME_MARKER} > {HOME_MARKER_PATH}")
+    link.run(f"printf '%s\\n' {ETC_MARKER} > {ETC_MARKER_PATH}")
     link.run(FIND_DRIVER)
     link.run(f"mkdir -p {RESULT_DIR}")
     link.wait_for(
@@ -3206,7 +3215,9 @@ def convert_and_check(
         return f"the conversion exited {code!r}"
     # The same reader as the first install: a converted machine that reaches a
     # login prompt with the old hostname booted the system it was replacing.
-    return boot_and_check(guest, link, log, installation, extra=(HOME_MARKER_CHECK,))
+    return boot_and_check(
+        guest, link, log, installation, extra=(HOME_MARKER_CHECK, ETC_MARKER_CHECK)
+    )
 
 
 def boot_and_check(

--- a/tests/vm/convert.py
+++ b/tests/vm/convert.py
@@ -54,6 +54,19 @@ HOME_MARKER_CHECK: Final[InstalledCheck] = InstalledCheck(
     r"(?m)^home=1$",
 )
 
+#: The same sentinel inside the tree the conversion replaces. `/etc` is
+#: replaced rather than merged, which is what keeps the old distribution's
+#: units, sources and package manager from configuring a Gentoo: a file put
+#: there before the swap has to be gone afterwards. Counted the same way, so
+#: neither the echo nor `cat`'s own diagnostic can answer it.
+ETC_MARKER: Final[str] = "gentoo-install-etc-is-replaced-8b7c1d05"
+ETC_MARKER_PATH: Final[Path] = Path("/etc") / f".{ETC_MARKER}"
+ETC_MARKER_CHECK: Final[InstalledCheck] = InstalledCheck(
+    "etc marker",
+    f"printf 'etc=%s\\n' \"$(grep -Fc {ETC_MARKER} {ETC_MARKER_PATH} 2>/dev/null || echo 0)\"",
+    r"(?m)^etc=0$",
+)
+
 #: Bigger than every image here, so cloud-init's `growpart` and `resizefs`
 #: run on first boot. A 5 GiB Fedora root cannot hold a stage3 and a kernel.
 OVERLAY_SIZE: Final[str] = "24G"
@@ -266,17 +279,21 @@ def install_tools(
             "so the run would refuse for a command nobody installed"
         )
 
-def write_home_marker(console: SerialConsole) -> None:
-    """Write the conversion's unique sentinel outside the replaced tree."""
+def write_markers(console: SerialConsole) -> None:
+    """Write the conversion's sentinels on both sides of the swap."""
     console.run(
         f"printf '%s\\n' {HOME_MARKER} > {HOME_MARKER_PATH}",
+        timeout=60.0,
+    )
+    console.run(
+        f"printf '%s\\n' {ETC_MARKER} > {ETC_MARKER_PATH}",
         timeout=60.0,
     )
 
 
 def conversion_checks(installation: InstallConfig) -> tuple[InstalledCheck, ...]:
     """Add the in-place preservation check to the installed-state contract."""
-    return (*checks(installation), HOME_MARKER_CHECK)
+    return (*checks(installation), HOME_MARKER_CHECK, ETC_MARKER_CHECK)
 
 
 def check_installed(console: SerialConsole, installation: InstallConfig) -> str:
@@ -292,7 +309,7 @@ def check_installed(console: SerialConsole, installation: InstallConfig) -> str:
 
 def convert(console: SerialConsole, config: str) -> None:
     """Run the installer in place and keep everything it printed."""
-    write_home_marker(console)
+    write_markers(console)
     console.run("mkdir -p /tmp/gentoo-install-results", timeout=60.0)
     console.run(
         f"{{ sh /mnt/driver/install.sh --config {config}; echo $? "


### PR DESCRIPTION
The conversion promises two things about the filesystem: `/home` and the other preserved paths survive, and `/etc` is replaced rather than merged. `#753` added the first to the cluster; this adds the second to both runners.

A sentinel goes into `/etc` before the swap and the check requires the count to be **zero** afterwards — the mirror of the home marker, counted the same way so that neither the shell`s echo of the command nor `cat`s own diagnostic can answer it. Merging instead of replacing would leave the old distribution`s units, repository lists and package manager configuring a Gentoo, and every other installed-state check would still be green.