### PR TITLE
docs: say which package counts here were counted twice

### DIFF
--- a/TESTED.md
+++ b/TESTED.md
@@ -10,6 +10,13 @@ installation exit code is `0`, the installed system boots, and the post-boot
 configuration checks pass. `tests/fixtures/` files exercise the configuration
 model; their presence establishes nothing about an installed machine.
 
+A package count in a row written before `d75aaa0f94806` is about twice what
+the machine installed. `VerifyPackages` runs `emerge --pretend --quiet` before
+anything is merged and it prints the same `[binary]` and `[ebuild]` lines the
+merge does, and the journal counted both until that revision: one guest
+recorded 63 packages for the 40 it installed. Rows from before it are not
+comparable with rows after it.
+
 Three modes are planned and this file has a section for each. Only the first
 two exist today, and the third's table is empty on purpose.
 


### PR DESCRIPTION
Rows quote the installer`s own closing line — `57 operations, 59 packages from a binary host, 20 compiled`. Until `d75aaa0f94806` the journal counted `emerge --pretend --quiet` as a merge, so those numbers are about twice what the machine installed: one guest recorded 63 packages for the 40 it had.

A reader comparing an old row with a new one would read the correction as the binary host getting worse. The note says where the boundary is.