### PR TITLE
cluster: a schedule says which revision it measures

### DIFF
--- a/tests/unit/test_cluster.py
+++ b/tests/unit/test_cluster.py
@@ -2981,3 +2981,21 @@ def test_a_binhost_fixture_that_compiled_everything_is_not_a_pass() -> None:
     said = inspect.getsource(cluster.install_one)
     assert "_binary_packages_missing(" in said, said[:200]
 
+
+def test_a_schedule_says_which_revision_it_measures() -> None:
+    """Each guest's log opens with `installer revision:`, and the schedule's
+    own output did not. Identifying what run109 measured meant reading a guest
+    log, and a later round running the same fixture on the same vmid had
+    overwritten it."""
+    import inspect
+
+    from tests.vm import cluster
+
+    source = inspect.getsource(cluster.run)
+    computed = source.index("revision_identity(driver_path)")
+    said = source.index('print(f"installer revision: {revision}"')
+    assert computed < said, source[computed : computed + 200]
+    # Before the first guest is created, or a schedule that dies placing one
+    # says nothing about what it was carrying.
+    assert said < source.index("_reserve_job("), source[said : said + 200]
+

--- a/tests/vm/cluster.py
+++ b/tests/vm/cluster.py
@@ -2045,6 +2045,10 @@ def run(
     driver_path = retain_driver(workdir, built_path)
     driver = driver_path.name
     revision = revision_identity(driver_path)
+    # Said once here as well as in every guest's log: a schedule's own output
+    # is the file a reader opens first, and identifying which revision run109
+    # measured meant reading a guest log that a later round had overwritten.
+    print(f"installer revision: {revision}", flush=True)
     medium, urls, medium_sha512 = current_minimal()
     prepared: set[str] = set()
     # A node whose console proxy went away takes no more guests: three runs on


### PR DESCRIPTION
Each guest log opens with `installer revision: ...`; the schedule`s own output — the file a reader opens first — did not. Naming what run109 measured meant reading one of its guest logs, and a later round running the same fixture on the same vmid had overwritten it, which is what `#749` closed for the future and could not recover for the past.

The line is printed before the first guest is reserved, so a schedule that dies while placing one still says what it was carrying. The test holds both the order and that position.