### PR TITLE
readme: how to install from memory and how to convert a running system

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -145,6 +145,55 @@ cd gentoo-install-master
 
 対話型インストールでは、成功時と失敗時のどちらでも、アンマウント前にターゲットシステム内で root シェルを開く選択肢が提示されます。`--no-shell` を使用すると、この確認を省略できます。
 
+## メモリからのインストール
+
+<!-- fact: install-memory -->
+
+`--ram` と `--lowram` は、メモリ上のライブ環境への起動を一度だけ設定します。コンソールもレスキューイメージも持たないレンタルマシンが自分のディスクを上書きするには、これが必要です。インストーラ、選んだ設定、認証鍵は initramfs の中を運ばれるため、環境はそれを設定したリビジョンで起動します。
+
+```sh
+./bootstrap.sh --ram --ssh-key github:zakkaus --root-password 'replace this'
+reboot
+ssh root@the-machine
+```
+
+既定の起動項目は変更されないので、環境で起動しなかったマシンは以前と同じものを起動します。`--disarm` は設定を取り消します。`--bypass` は既定の項目自体を置き換えるもので、一度きりの項目を捨てるファームウェア向けです。環境が起動しなかったときにマシンがまったく起動しなくなるのは、この経路だけです。
+
+最初の画面はインストールとレスキューシェルを示し、タイムアウトはありません。答えるまで何も消去されません。`--ram` は ZFS を含む Gentoo CJK ISO を起動し、約 2 GiB のメモリを必要とします。`--lowram` はより小さく `zfs.ko` を持たない Alpine netboot 書庫を起動します。`--ssh-port` はデーモンを 22 番から動かします。
+
+## 稼働中のシステムの変換
+
+<!-- fact: install-in-place -->
+
+`[disk]` テーブルの `mode = "in-place"` は、ディスクをパーティション分割する代わりに、稼働中のディストリビューションのユーザ空間を置き換えます。レイアウトはマシンから読み取るため、このテーブルはデバイス一覧を持ちません。
+
+```toml
+config_version = 1
+
+[system]
+hostname = "converted"
+timezone = "UTC"
+locales = ["en_US.UTF-8"]
+locale = "en_US.UTF-8"
+init = "systemd"
+root_password_hash = "$6$gentooinst$IR3GrdJ862XljQYDqocr4tKniIRDIT.jQNFzIrHE3U75H6B6YSWZoSYoVd5edSHpqaYBdiNfXHCoIPRVgb9lT/"
+
+[portage]
+profile = "default/linux/amd64/23.0/systemd"
+makeopts = "-j4"
+
+[bootloader]
+kind = "grub"
+firmware = "uefi"
+
+[disk]
+mode = "in-place"
+```
+
+上のハッシュは例であり、実行前に置き換える必要があります。対話的な実行は変換が置き換えるディレクトリを表示し、何かを書き込む前に `convert` の入力を求めます。端末のない実行は尋ねられません。設定ファイルの `mode = "in-place"` が承認であり、そこで質問すればシリアルコンソールを永久に待たせることになるからです。
+
+**この実行を始めたセッションが生命線です。**`/usr` と `/etc` が新しいシステムのものになると新しい SSH ログインは成立しなくなり、実行を始めたセッションだけがすでに対応付けたバイナリを保持します。
+
 ## 中断した実行の再開
 
 <!-- fact: resume-behavior -->

--- a/README.ko.md
+++ b/README.ko.md
@@ -145,6 +145,55 @@ cd gentoo-install-master
 
 대화형 설치에서는 성공하거나 실패한 경우 모두 마운트를 해제하기 전에 대상 시스템 안에서 root 셸을 여는 선택지를 제공한다. `--no-shell`을 사용하면 이 확인을 생략할 수 있다.
 
+## 메모리에서 설치
+
+<!-- fact: install-memory -->
+
+`--ram`과 `--lowram`은 메모리에 올린 라이브 환경으로 한 번 부팅하도록 설정한다. 콘솔도 복구 이미지도 없는 임대 장비가 자기 디스크를 덮어쓰려면 이것이 필요하다. 설치 도구와 선택한 설정, 인가된 키는 initramfs 안에 실려 가므로 환경은 그것을 설정한 리비전으로 올라온다.
+
+```sh
+./bootstrap.sh --ram --ssh-key github:zakkaus --root-password 'replace this'
+reboot
+ssh root@the-machine
+```
+
+기본 부팅 항목은 바뀌지 않으므로 환경으로 올라오지 못한 장비는 이전과 같은 것을 부팅한다. `--disarm`은 설정을 되돌린다. `--bypass`는 기본 항목 자체를 대체하며, 일회성 항목을 버리는 펌웨어를 위한 것이다. 환경이 올라오지 못했을 때 장비가 아예 부팅하지 못하는 경로는 이것뿐이다.
+
+첫 화면은 설치와 복구 셸을 제시하며 시간 제한이 없고, 답하기 전에는 아무것도 지우지 않는다. `--ram`은 ZFS를 담은 Gentoo CJK ISO를 부팅하며 약 2 GiB의 메모리가 필요하다. `--lowram`은 더 작고 `zfs.ko`가 없는 Alpine netboot 아카이브를 부팅한다. `--ssh-port`는 데몬을 22번에서 옮긴다.
+
+## 실행 중인 시스템 변환
+
+<!-- fact: install-in-place -->
+
+`[disk]` 테이블의 `mode = "in-place"`는 디스크를 분할하는 대신 실행 중인 배포판의 사용자 공간을 교체한다. 레이아웃은 기계에서 읽어 오므로 이 테이블은 장치 목록을 담지 않는다.
+
+```toml
+config_version = 1
+
+[system]
+hostname = "converted"
+timezone = "UTC"
+locales = ["en_US.UTF-8"]
+locale = "en_US.UTF-8"
+init = "systemd"
+root_password_hash = "$6$gentooinst$IR3GrdJ862XljQYDqocr4tKniIRDIT.jQNFzIrHE3U75H6B6YSWZoSYoVd5edSHpqaYBdiNfXHCoIPRVgb9lT/"
+
+[portage]
+profile = "default/linux/amd64/23.0/systemd"
+makeopts = "-j4"
+
+[bootloader]
+kind = "grub"
+firmware = "uefi"
+
+[disk]
+mode = "in-place"
+```
+
+위 해시는 예시이며 실행 전에 교체해야 한다. 대화형 실행은 변환이 교체하는 디렉터리를 출력하고 무언가를 쓰기 전에 `convert` 입력을 요구한다. 터미널이 없는 실행은 묻지 않는다. 설정 파일의 `mode = "in-place"`가 승인이며, 거기서 질문하면 시리얼 콘솔을 영원히 기다리게 하기 때문이다.
+
+**이 실행을 시작한 세션이 생명줄이다.** `/usr`와 `/etc`가 새 시스템의 것이 되면 새 SSH 로그인은 성립하지 않으며, 실행을 시작한 세션만 이미 매핑한 바이너리를 유지한다. 
+
 ## 중단된 실행 재개
 
 <!-- fact: resume-behavior -->

--- a/README.md
+++ b/README.md
@@ -143,6 +143,55 @@ The menu can save its answers as `my-install.toml` and exit. The configuration-f
 
 Before unmounting, an interactive run offers a root shell in the target after either success or failure. `--no-shell` suppresses that question.
 
+## Installing from memory
+
+<!-- fact: install-memory -->
+
+`--ram` and `--lowram` arm one boot into a live environment held in memory, which is what a rented machine with no console and no rescue image needs before its own disk can be installed over. The installer, the chosen configuration and the authorised keys travel inside the initramfs, so the environment comes up running the revision that armed it:
+
+```sh
+./bootstrap.sh --ram --ssh-key github:zakkaus --root-password 'replace this'
+reboot
+ssh root@the-machine
+```
+
+The default boot entry is not changed, so a machine that does not come up in the environment boots what it booted before; `--disarm` takes the arming back. `--bypass` replaces the default entry instead, for firmware that drops a one-shot entry, and it is the one path where an environment that fails to come up leaves a machine that does not boot at all.
+
+The first screen offers the install and a rescue shell and has no timeout, and nothing is erased until it is answered. `--ram` boots the Gentoo CJK ISO, which carries ZFS and needs about 2 GiB of RAM; `--lowram` boots the Alpine netboot bundle, which is smaller and has no `zfs.ko`. `--ssh-port` moves the daemon off 22.
+
+## Converting a running system
+
+<!-- fact: install-in-place -->
+
+`mode = "in-place"` in the `[disk]` table replaces the userland of the running distribution instead of partitioning a disk. The table carries no device list, because the layout is read from the machine:
+
+```toml
+config_version = 1
+
+[system]
+hostname = "converted"
+timezone = "UTC"
+locales = ["en_US.UTF-8"]
+locale = "en_US.UTF-8"
+init = "systemd"
+root_password_hash = "$6$gentooinst$IR3GrdJ862XljQYDqocr4tKniIRDIT.jQNFzIrHE3U75H6B6YSWZoSYoVd5edSHpqaYBdiNfXHCoIPRVgb9lT/"
+
+[portage]
+profile = "default/linux/amd64/23.0/systemd"
+makeopts = "-j4"
+
+[bootloader]
+kind = "grub"
+firmware = "uefi"
+
+[disk]
+mode = "in-place"
+```
+
+The hash above is an example and must be replaced before execution. An interactive run prints what the conversion replaces and requires the word `convert` before anything is written; a run with no terminal is not asked, because `mode = "in-place"` in the file is the authorisation and a question there would hold a serial console open for ever.
+
+**The session that started the run is the lifeline.** A new SSH login stops working once `/usr` and `/etc` belong to the new system, while the session that started the run keeps the binaries it already mapped.
+
 ## Resuming an interrupted run
 
 <!-- fact: resume-behavior -->

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -145,6 +145,55 @@ cd gentoo-install-master
 
 交互式安装无论成功或失败，都会在卸载前提供在目标系统内打开 root shell 的选项。`--no-shell` 跳过这项确认。
 
+## 从内存安装
+
+<!-- fact: install-memory -->
+
+`--ram` 与 `--lowram` 武装一次进入内存中活环境的引导，那是一台没有控制台、也没有救援镜像的租用机器覆盖自己磁盘之前所需要的。安装程序、选定的配置与授权密钥都随 initramfs 送达，因此环境起来时运行的正是武装它的那一版：
+
+```sh
+./bootstrap.sh --ram --ssh-key github:zakkaus --root-password 'replace this'
+reboot
+ssh root@the-machine
+```
+
+默认引导项不会改动，所以没有进入该环境的机器仍引导回原本的系统；`--disarm` 收回武装。`--bypass` 改为取代默认项，供会丢弃一次性引导项的固件使用，那也是唯一一条「环境起不来就连机器都引导不了」的路径。
+
+第一个界面提供安装与救援 shell，没有超时，未回答之前不会擦除任何数据。`--ram` 引导的是带 ZFS 的 Gentoo CJK ISO，约需 2 GiB 内存；`--lowram` 引导的是较小、没有 `zfs.ko` 的 Alpine netboot 压缩包。`--ssh-port` 把服务移离 22 端口。
+
+## 转换运行中的系统
+
+<!-- fact: install-in-place -->
+
+在 `[disk]` 表设 `mode = "in-place"`，安装程序取代运行中发行版的用户空间，而不是分区磁盘。该表不带设备列表，因为布局由机器读出：
+
+```toml
+config_version = 1
+
+[system]
+hostname = "converted"
+timezone = "UTC"
+locales = ["en_US.UTF-8"]
+locale = "en_US.UTF-8"
+init = "systemd"
+root_password_hash = "$6$gentooinst$IR3GrdJ862XljQYDqocr4tKniIRDIT.jQNFzIrHE3U75H6B6YSWZoSYoVd5edSHpqaYBdiNfXHCoIPRVgb9lT/"
+
+[portage]
+profile = "default/linux/amd64/23.0/systemd"
+makeopts = "-j4"
+
+[bootloader]
+kind = "grub"
+firmware = "uefi"
+
+[disk]
+mode = "in-place"
+```
+
+上面那个哈希是示例，执行前必须替换。交互式执行会打印这次转换取代哪些目录，并要求输入 `convert` 才会写入任何数据；没有终端的执行不会被询问，因为配置文件里的 `mode = "in-place"` 就是授权，而在那里发问会让串口控制台永远等下去。
+
+**发起这次执行的 session 是生命线。**`/usr` 与 `/etc` 换成新系统之后，新的 SSH 登录不再成立，而发起执行的 session 仍持有它已经映射的可执行文件。
+
 ## 从中断处继续
 
 <!-- fact: resume-behavior -->

--- a/README.zh-TW.md
+++ b/README.zh-TW.md
@@ -145,6 +145,55 @@ cd gentoo-install-master
 
 互動式安裝無論成功或失敗，都會在卸載前提供於目標系統內開啟 root shell 的選項。`--no-shell` 可略過這項確認。
 
+## 從記憶體安裝
+
+<!-- fact: install-memory -->
+
+`--ram` 與 `--lowram` 武裝一次進入記憶體中活環境的開機，那是一台沒有主控台、也沒有救援映像的租用機器覆蓋自己磁碟之前所需要的。安裝器、選定的設定與授權金鑰都隨 initramfs 送達，因此環境起來時執行的正是武裝它的那一版：
+
+```sh
+./bootstrap.sh --ram --ssh-key github:zakkaus --root-password 'replace this'
+reboot
+ssh root@the-machine
+```
+
+預設開機項目不會更動，所以沒有進入該環境的機器仍開回原本的系統；`--disarm` 收回武裝。`--bypass` 改為取代預設項目，供會丟棄一次性項目的韌體使用，那也是唯一一條「環境起不來就連機器都開不起來」的路徑。
+
+第一個畫面提供安裝與救援 shell，沒有逾時，未回答之前不會抹除任何資料。`--ram` 開的是帶 ZFS 的 Gentoo CJK ISO，約需 2 GiB 記憶體；`--lowram` 開的是較小、沒有 `zfs.ko` 的 Alpine netboot 壓縮檔。`--ssh-port` 把服務移離 22 埠。
+
+## 轉換執行中的系統
+
+<!-- fact: install-in-place -->
+
+在 `[disk]` 表設 `mode = "in-place"`，安裝器取代執行中發行版的使用者空間，而不是分割磁碟。該表不帶裝置清單，因為版面由機器讀出：
+
+```toml
+config_version = 1
+
+[system]
+hostname = "converted"
+timezone = "UTC"
+locales = ["en_US.UTF-8"]
+locale = "en_US.UTF-8"
+init = "systemd"
+root_password_hash = "$6$gentooinst$IR3GrdJ862XljQYDqocr4tKniIRDIT.jQNFzIrHE3U75H6B6YSWZoSYoVd5edSHpqaYBdiNfXHCoIPRVgb9lT/"
+
+[portage]
+profile = "default/linux/amd64/23.0/systemd"
+makeopts = "-j4"
+
+[bootloader]
+kind = "grub"
+firmware = "uefi"
+
+[disk]
+mode = "in-place"
+```
+
+上面那個雜湊是範例，執行前必須替換。互動式執行會印出這次轉換取代哪些目錄，並要求輸入 `convert` 才會寫入任何資料；沒有終端機的執行不會被詢問，因為設定檔裡的 `mode = "in-place"` 就是授權，而在那裡發問會讓序列主控台永遠等下去。
+
+**發起這次執行的 session 是生命線。**`/usr` 與 `/etc` 換成新系統之後，新的 SSH 登入不再成立，而發起執行的 session 仍持有它已經映射的執行檔。
+
 ## 從中斷處繼續
 
 <!-- fact: resume-behavior -->

--- a/tests/unit/test_readme.py
+++ b/tests/unit/test_readme.py
@@ -51,24 +51,25 @@ MENU_PICTURES = {
 SECTIONS = {
     "README.md": (
         "Capabilities", "Verification status", "Requirements", "Safety", "Installation",
+        "Installing from memory", "Converting a running system",
         "Resuming an interrupted run", "Configuration files", "Binary packages", "Exit codes",
         "Questions", "Contributing", "License",
     ),
     "README.zh-TW.md": (
         "\u529f\u80fd", "\u9a57\u8b49\u72c0\u614b", "\u9700\u6c42", "\u5b89\u5168\u4e8b\u9805",
-        "\u5b89\u88dd", "\u5f9e\u4e2d\u65b7\u8655\u7e7c\u7e8c", "\u8a2d\u5b9a\u6a94",
+        "\u5b89\u88dd", "\u5f9e\u8a18\u61b6\u9ad4\u5b89\u88dd", "\u8f49\u63db\u57f7\u884c\u4e2d\u7684\u7cfb\u7d71", "\u5f9e\u4e2d\u65b7\u8655\u7e7c\u7e8c", "\u8a2d\u5b9a\u6a94",
         "\u4e8c\u9032\u4f4d\u5957\u4ef6", "\u9000\u51fa\u78bc", "\u5e38\u898b\u554f\u984c", "\u53c3\u8207\u958b\u767c",
         "\u6388\u6b0a",
     ),
     "README.zh-CN.md": (
         "\u529f\u80fd", "\u9a8c\u8bc1\u72b6\u6001", "\u8981\u6c42", "\u5b89\u5168\u4e8b\u9879",
-        "\u5b89\u88c5", "\u4ece\u4e2d\u65ad\u5904\u7ee7\u7eed", "\u914d\u7f6e\u6587\u4ef6",
+        "\u5b89\u88c5", "\u4ece\u5185\u5b58\u5b89\u88c5", "\u8f6c\u6362\u8fd0\u884c\u4e2d\u7684\u7cfb\u7edf", "\u4ece\u4e2d\u65ad\u5904\u7ee7\u7eed", "\u914d\u7f6e\u6587\u4ef6",
         "\u4e8c\u8fdb\u5236\u8f6f\u4ef6\u5305", "\u9000\u51fa\u7801", "\u5e38\u89c1\u95ee\u9898", "\u53c2\u4e0e\u5f00\u53d1",
         "\u8bb8\u53ef",
     ),
     "README.ja.md": (
         "\u6a5f\u80fd", "\u691c\u8a3c\u72b6\u6cc1", "\u8981\u4ef6", "\u5b89\u5168\u4e0a\u306e\u6ce8\u610f",
-        "\u30a4\u30f3\u30b9\u30c8\u30fc\u30eb", "\u4e2d\u65ad\u3057\u305f\u5b9f\u884c\u306e\u518d\u958b",
+        "\u30a4\u30f3\u30b9\u30c8\u30fc\u30eb", "\u30e1\u30e2\u30ea\u304b\u3089\u306e\u30a4\u30f3\u30b9\u30c8\u30fc\u30eb", "\u7a3c\u50cd\u4e2d\u306e\u30b7\u30b9\u30c6\u30e0\u306e\u5909\u63db", "\u4e2d\u65ad\u3057\u305f\u5b9f\u884c\u306e\u518d\u958b",
         "\u8a2d\u5b9a\u30d5\u30a1\u30a4\u30eb", "\u30d0\u30a4\u30ca\u30ea\u30d1\u30c3\u30b1\u30fc\u30b8",
         "\u7d42\u4e86\u30b3\u30fc\u30c9", "\u3088\u304f\u3042\u308b\u8cea\u554f",
         "\u958b\u767a\u3078\u306e\u53c2\u52a0",
@@ -76,7 +77,7 @@ SECTIONS = {
     ),
     "README.ko.md": (
         "\uae30\ub2a5", "\uac80\uc99d \uc0c1\ud0dc", "\uc694\uad6c \uc0ac\ud56d", "\uc548\uc804",
-        "\uc124\uce58", "\uc911\ub2e8\ub41c \uc2e4\ud589 \uc7ac\uac1c", "\uc124\uc815 \ud30c\uc77c",
+        "\uc124\uce58", "\uba54\ubaa8\ub9ac\uc5d0\uc11c \uc124\uce58", "\uc2e4\ud589 \uc911\uc778 \uc2dc\uc2a4\ud15c \ubcc0\ud658", "\uc911\ub2e8\ub41c \uc2e4\ud589 \uc7ac\uac1c", "\uc124\uc815 \ud30c\uc77c",
         "\ubc14\uc774\ub108\ub9ac \ud328\ud0a4\uc9c0", "\uc885\ub8cc \ucf54\ub4dc",
         "\uc790\uc8fc \ubb3b\ub294 \uc9c8\ubb38", "\uae30\uc5ec",
         "\ub77c\uc774\uc120\uc2a4",
@@ -92,7 +93,9 @@ FACT_UNITS = (
     "requirements-runtime",
     "requirements-version-sources", "requirements-network-filter", "requirements-bootstrap",
     "safety-destructive", "safety-review-backup", "install-download", "install-terminal",
-    "install-config-workflow", "install-root-shell", "resume-behavior", "resume-limits",
+    "install-config-workflow", "install-root-shell",
+    "install-memory", "install-in-place",
+    "resume-behavior", "resume-limits",
     "config-model", "config-fixtures", "config-dry-run", "binary-packages", "exit-codes",
     "faq-customisation", "contributing", "license",
 )


### PR DESCRIPTION
The capability list described both paths and neither had a command anywhere in the file. The two things this installer does that another one does not — arming a live environment in RAM on a machine with no console, and replacing a running distribution in place — were the two a reader could not run.

Two sections after Installation, in all five files, with the same command blocks: `--ram --ssh-key github:user --root-password`, then the reboot and the reconnect; and a complete in-place configuration that `parse()` and `validate()` accept, which is what `test_every_configuration_a_readme_prints_can_produce_a_plan` requires of every TOML block here.

Each carries the thing that costs an operator a machine if it is not said: the armed boot leaves the default entry alone and `--bypass` does not; and the session that started a conversion is the lifeline, because a new SSH login stops working once `/usr` and `/etc` belong to the new system.