### PR TITLE
tui: the layout menu offers no layout that is not one

### DIFF
--- a/gentoo_install/tui/app.py
+++ b/gentoo_install/tui/app.py
@@ -16,13 +16,13 @@ from typing import Final
 
 from ..i18n import width
 from ..model import compat
-from ..model.config import DiskMode, InstallConfig
+from ..model.config import InstallConfig
 from ..errors import GentooInstallError
 from ..plan.build import build
 from .overview import overview_screen
 from .context import Context
 from .context import say
-from .settings import SETTINGS, Setting, settings_for, shown_value, style_of, unanswered
+from .settings import Setting, settings_for, shown_value, style_of, unanswered
 from .widgets import Item, Menu, Outcome, Screen, Style, TextField
 
 
@@ -91,7 +91,7 @@ def run(screen: Screen, start: InstallConfig, context: Context) -> Finished:
     while True:
         # Before the rows are built: a grouped row fits its summary to this.
         context.columns = screen.size()[1]
-        table = settings_for(current) if current.disk.mode is DiskMode.DD else SETTINGS
+        table = settings_for(current)
         cursor = min(cursor, len(table))
         blocked = _blocked(current, context)
         items: list[Item[int]] = [

--- a/gentoo_install/tui/screens.py
+++ b/gentoo_install/tui/screens.py
@@ -399,7 +399,7 @@ def _template_screen(
 ) -> Answer[InstallConfig]:
     """What the installer writes when it lays the disk out itself."""
     translate = context.translate
-    items: list[Item[tuple[Layout | None, FilesystemType]]] = [
+    items: list[Item[tuple[Layout, FilesystemType]]] = [
         Item(label="ext4", value=(Layout.WHOLE_DISK, FilesystemType.EXT4)),
         Item(label="xfs", value=(Layout.WHOLE_DISK, FilesystemType.XFS)),
         Item(
@@ -425,7 +425,7 @@ def _template_screen(
         ),
         0,
     )
-    menu: Menu[tuple[Layout | None, FilesystemType]] = Menu(
+    menu: Menu[tuple[Layout, FilesystemType]] = Menu(
         title=translate("Layout"),
         preamble=(translate("This choice sets the root filesystem and partition graph."),),
         items=items, footer=footer(translate), cursor=here
@@ -436,8 +436,6 @@ def _template_screen(
     layout, filesystem = answer.unwrap()
     was_manual, was_choice = context.manual, context.choice
     context.manual = False
-    if layout is None:
-        return partitions_screen(screen, config, context)
     context.choice = replace(context.choice, layout=layout, filesystem=filesystem)
     changed = _rebuild(config, context)
     if layout is Layout.WHOLE_DISK_ZFS:

--- a/tests/unit/test_tui_app.py
+++ b/tests/unit/test_tui_app.py
@@ -1902,7 +1902,7 @@ def test_staying_after_a_cancel_keeps_the_answers_that_came_with_it(
     index = row("Hostname")
     patched = replace(settings.SETTINGS[index], edit=lambda s, c, x: cancelled)
     replaced = (*settings.SETTINGS[:index], patched, *settings.SETTINGS[index + 1 :])
-    monkeypatch.setattr(tui_app, "SETTINGS", replaced)
+    monkeypatch.setattr(settings, "SETTINGS", replaced)
     # The menu steps over the one row it cannot open.
     reachable = [one for one in replaced if one.edit is not None]
     steps = next(n for n, one in enumerate(reachable) if one.label == "Hostname")
@@ -2440,7 +2440,7 @@ def test_the_main_menu_reads_the_same_precondition_the_nested_one_does() -> None
     )
     screen = FakeScreen(keys=["q", "KEY_DOWN", "\n"], lines=40, columns=110)
     with pytest.MonkeyPatch.context() as patch:
-        patch.setattr(tui_app, "SETTINGS", blocked)
+        patch.setattr(tui_settings, "SETTINGS", blocked)
         tui_app.run(screen, config(), at)
     assert "not on this machine" in "\n".join(screen.frames[0])
 
@@ -3412,3 +3412,20 @@ def test_every_language_default_names_a_zone_the_screen_can_show() -> None:
     )
 
     assert not missing, missing
+
+
+def test_the_layout_menu_offers_no_layout_that_is_not_one() -> None:
+    """`_template_screen` carried `if layout is None: return partitions_screen(...)`
+    while every item on that menu holds a concrete `Layout`. A second route into
+    manual partitioning that nothing can take reads as though the template
+    screen owned that choice, and `layout_screen` owns it."""
+    import inspect
+
+    from gentoo_install.tui import screens
+
+    source = inspect.getsource(screens._template_screen)
+    assert "Layout | None" not in source, source[:400]
+    assert "layout is None" not in source, source[:400]
+    # The route that does exist is the one the manual row takes.
+    assert "partitions_screen(" in inspect.getsource(screens.layout_screen)
+


### PR DESCRIPTION
Two findings from a read-only scan, both checked against the source before acting.

`_template_screen` typed its items `Layout | None` and carried `if layout is None: return partitions_screen(...)`. All four items hold a concrete `Layout`, so that branch was a second route into manual partitioning that nothing could take — and `layout_screen` owns that choice, one screen above.

The main menu asked `current.disk.mode is DiskMode.DD` and then called `settings_for()`, which asks the same question. It now calls `settings_for()` alone. Two tests patched `app.SETTINGS`, the name that import created; they patch `settings.SETTINGS`, where the table is defined, which is the seam that survives the caller changing.