### PR TITLE
exec: every fetch the machine makes carries the configured proxy

### DIFF
--- a/gentoo_install/exec/apply.py
+++ b/gentoo_install/exec/apply.py
@@ -271,13 +271,16 @@ class Machine:
         return self.probe.filesystem_type_of(self.device_path(device))
 
     def rank_mirrors(self, candidates: tuple[str, ...]) -> tuple[str, ...]:
-        ranked = fetch.rank_mirrors(candidates)
+        # Through the proxy, like the stage3 below: on a machine whose only
+        # route out is the proxy every candidate times out instead, and the
+        # ranking degrades to the order it was given.
+        ranked = fetch.rank_mirrors(candidates, self.config.proxy)
         self.runner.log(f"mirrors, fastest first: {', '.join(ranked)}")
         return ranked
 
     def fetch_text(self, url: str) -> str:
         self.runner.log(f"fetching {url}")
-        return fetch.text(url)
+        return fetch.text(url, self.config.proxy)
 
     def fetch_stage3(
         self,

--- a/tests/unit/test_exec.py
+++ b/tests/unit/test_exec.py
@@ -2769,3 +2769,46 @@ def test_one_reader_flattens_both_of_the_json_trees_the_probe_reads() -> None:
     assert _entries(blocks, "filesystems") == ()
     assert _entries("not a document", "filesystems") == ()
     assert _entries({"filesystems": "not a list"}, "filesystems") == ()
+
+
+def test_every_fetch_the_machine_makes_carries_the_configured_proxy(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The stage3 download passed `config.proxy` and the two fetches beside it
+    did not. On a machine whose only route out is the proxy, ranking measures
+    every mirror as unreachable and a first-boot URL is not fetched at all."""
+    from dataclasses import replace as _replace
+
+    from gentoo_install.exec import fetch
+    from gentoo_install.model.config import ProxyConfig, ProxyKind
+
+    seen: list[object] = []
+
+    def ranked(candidates: tuple[str, ...], proxy: object = None) -> tuple[str, ...]:
+        seen.append(proxy)
+        return candidates
+
+    def text(url: str, proxy: object = None) -> str:
+        seen.append(proxy)
+        return "answered"
+
+    monkeypatch.setattr(fetch, "rank_mirrors", ranked)
+    monkeypatch.setattr(fetch, "text", text)
+
+    through = ProxyConfig(kind=ProxyKind.SOCKS5, host="proxy.example", port=1080)
+    installation = _replace(config(), proxy=through)
+    runner = Runner(log=lambda line: None)
+    machine = apply.Machine(
+        config=installation,
+        runner=runner,
+        probe=Probe(runner=runner, work=tmp_path),
+        work=tmp_path,
+    )
+
+    assert machine.rank_mirrors(("https://a.example", "https://b.example")) == (
+        "https://a.example",
+        "https://b.example",
+    )
+    assert machine.fetch_text("https://first-boot.example/script") == "answered"
+    assert seen == [through, through], seen
+


### PR DESCRIPTION
Found by a read-only scan and checked against the source: `Machine.fetch_stage3` passes `self.config.proxy`, and the two fetches directly above it — `rank_mirrors` and `fetch_text` — did not. Both take a proxy and both defaulted to none.

On a machine whose only route out is the proxy, the in-run mirror ranking measures every candidate as unreachable, so the ranking degrades to the order it was given, and a first-boot URL is not fetched at all. The README carves out only the checks that run *before* the configuration exists; these run after it.

The test drives `Machine` with a SOCKS5 configuration and asserts both calls carried it.