### PR TITLE
cluster: the summary names a guest the run could not remove

### DIFF
--- a/tests/unit/test_cluster.py
+++ b/tests/unit/test_cluster.py
@@ -2999,3 +2999,20 @@ def test_a_schedule_says_which_revision_it_measures() -> None:
     # says nothing about what it was carrying.
     assert said < source.index("_reserve_job("), source[said : said + 200]
 
+
+def test_the_summary_names_a_guest_the_run_could_not_remove() -> None:
+    """`removed=False` kept `Verdict.OK`, which is right — the install did
+    work — and the summary printed `10/10 passed` and nothing else. run114
+    left `ext2` on `infra-node4` for hours that way, and the only trace was one
+    line thousands of lines earlier."""
+    import inspect
+
+    from tests.vm import cluster
+
+    source = inspect.getsource(cluster.main)
+    counted = source.index("passed")
+    said = source.index("still on the cluster")
+    assert counted < said, source[counted : counted + 300]
+    # On stderr, where the operator reading a redirected run still sees it.
+    assert "file=sys.stderr" in source[said : said + 120], source[said : said + 200]
+

--- a/tests/vm/cluster.py
+++ b/tests/vm/cluster.py
@@ -3768,6 +3768,13 @@ def main(argv: list[str] | None = None) -> int:
         if one.verdict is Verdict.OK and trusted_revision(one.revision)
     ]
     print(f"\n{len(passed)}/{len(jobs)} passed")
+    # A guest that could not be removed does not make its install a failure,
+    # but a summary that says only `10/10 passed` hides a machine still
+    # holding a node's memory: run114 left `ext2` on `infra-node4` for hours
+    # after `qmdestroy` answered `rbd error: listing images failed`.
+    for one in outcomes:
+        if not one.removed:
+            print(f"  still on the cluster: {one.name}", file=sys.stderr)
     for one in outcomes:
         if one.verdict is not Verdict.OK or not trusted_revision(one.revision):
             # A job refused before a guest existed has no log, and `(None)`


### PR DESCRIPTION
A cleanup failure sets `removed=False` and keeps `Verdict.OK`, which is right — the install worked — and the summary then printed `10/10 passed` and nothing else. run114 left `ext2` on `infra-node4` with its 40 GiB image for hours after `qmdestroy` answered `rbd error: rbd: listing images failed`, and the only trace was one line thousands of lines earlier in the log.

The summary now names those guests on stderr, so a redirected unattended run still shows them. `#756` makes the removal retry, which should make this rare; rare is exactly when a silent one is missed.