### PR TITLE
proxmox: a stop the gateway ate is sent again

### DIFF
--- a/tests/unit/test_proxmox.py
+++ b/tests/unit/test_proxmox.py
@@ -4370,3 +4370,54 @@ def test_a_destroy_whose_task_failed_is_tried_again() -> None:
             patience=1.0
         )
 
+
+def test_a_stop_the_gateway_ate_is_sent_again() -> None:
+    """run118 lost `vm-binpkg` after 48 minutes: the install had finished and
+    `POST .../status/stop` answered `502 Bad Gateway`, which `_http_exception`
+    already classifies as transient. `destroy` retried such answers and this
+    did not, so one gateway hiccup threw away a completed install."""
+
+    @dataclass
+    class Flaky(Api):
+        attempts: int = 0
+        running: bool = True
+
+        def call(self, method: str, path: str, **form: Any) -> Any:
+            if path.endswith("/status/current"):
+                return {"status": "running" if self.running else "stopped"}
+            if path.endswith("/config"):
+                return {"tags": f"{TAG};gi-owned"}
+            if path.endswith("/status/stop"):
+                self.attempts += 1
+                if self.attempts == 1:
+                    raise ProxmoxTransientError(
+                        "POST /nodes/n/qemu/9300/status/stop answered 502 Bad Gateway"
+                    )
+                self.running = False
+                return "UPID:node:qmstop"
+            raise AssertionError((method, path))
+
+        def wait(self, node: str, upid: str, patience: float = 1800.0) -> None:
+            return None
+
+    api = Flaky()
+    guest = Guest(api, "node", 9300, GuestSpec(name="x", iso="x", nonce="gi-owned"))
+    guest._booted = True
+    guest.stop()
+    assert api.attempts == 2, api.attempts
+    assert not guest._booted
+
+    # The control: an answer that is not transient still ends the run, and the
+    # message carries what the cluster said.
+    @dataclass
+    class Refusing(Flaky):
+        def call(self, method: str, path: str, **form: Any) -> Any:
+            if path.endswith("/status/stop"):
+                raise ProxmoxError("POST /nodes/n/qemu/9300/status/stop answered 403 Forbidden")
+            return super().call(method, path, **form)
+
+    stubborn = Guest(Refusing(), "node", 9300, GuestSpec(name="x", iso="x", nonce="gi-owned"))
+    stubborn._booted = True
+    with pytest.raises(ProxmoxError, match="403 Forbidden"):
+        stubborn.stop()
+

--- a/tests/vm/proxmox.py
+++ b/tests/vm/proxmox.py
@@ -89,6 +89,10 @@ DRIVER_PREFIX: Final[str] = "gi-driver-"
 STILL_RUNNING: Final[str] = "is running - destroy failed"
 CLEANUP_PAUSE: Final[float] = 2.0
 CLEANUP_PATIENCE: Final[float] = 300.0
+#: How long a stop is retried. Shorter than cleanup: the guest is wanted down
+#: so the disk it wrote can be booted, and a run that cannot stop it has
+#: nothing left to measure.
+STOP_PATIENCE: Final[float] = 120.0
 
 
 class ProxmoxError(Exception):
@@ -689,11 +693,40 @@ class Guest:
             raise ProxmoxError(
                 f"vm {self.vmid} on {self.node} is not this run's machine; not stopping it"
             )
-        self.api.wait(
-            self.node,
-            self.api.call("POST", f"/nodes/{self.node}/qemu/{self.vmid}/status/stop"),
-            patience=180.0,
-        )
+        # Retried, because the cluster proxy answering `502 Bad Gateway` is not
+        # the node refusing: one such answer ended `vm-binpkg` after a 48-minute
+        # install that had already finished, on the stop that precedes booting
+        # the disk it wrote. The status is read again each round, so a stop
+        # whose answer was eaten is seen as the guest already being down.
+        deadline = time.monotonic() + STOP_PATIENCE
+        last = "the guest is still running"
+        while True:
+            try:
+                self.api.wait(
+                    self.node,
+                    self.api.call("POST", f"/nodes/{self.node}/qemu/{self.vmid}/status/stop"),
+                    patience=180.0,
+                )
+                break
+            except ProxmoxNotFound:
+                break
+            except ProxmoxError as error:
+                last = str(error)
+                if not _transient(error) or time.monotonic() >= deadline:
+                    raise ProxmoxError(
+                        f"vm {self.vmid} on {self.node} was not stopped: {last}"
+                    ) from error
+                time.sleep(min(CLEANUP_PAUSE, max(0.0, deadline - time.monotonic())))
+                try:
+                    again = self.api.call(
+                        "GET", f"/nodes/{self.node}/qemu/{self.vmid}/status/current"
+                    )
+                except ProxmoxNotFound:
+                    break
+                except ProxmoxError:
+                    continue
+                if str(again.get("status")) != "running":
+                    break
         self._booted = False
 
     def _is_ours(self) -> bool:


### PR DESCRIPTION
run118 ERRORed `vm-binpkg` at 48.2 minutes with `POST /nodes/infra-node5/qemu/9302/status/stop answered 502 Bad Gateway`. The install had finished; that stop is the one before booting the disk it wrote.

`_http_exception` already classifies 502 as transient — the cluster proxy could not reach the node, which is not the node refusing — and `destroy` retried such answers while `stop` did not. It now retries within `STOP_PATIENCE`, re-reading the status each round so a stop whose answer was eaten is seen as the guest already being down, and a non-transient answer still ends the run with what the cluster said.

Third instance this session of one shape: an error the code calls retryable, at a call site that does not retry.