### PR TITLE
cluster: an expected failure is the failure the fixture measures

### DIFF
--- a/tests/unit/test_cluster.py
+++ b/tests/unit/test_cluster.py
@@ -1325,15 +1325,31 @@ def test_a_failed_install_verdict_carries_the_installer_s_own_reason() -> None:
     assert "CommandFailed" in cluster._why_it_stopped({"install.txt": said})
 
 
-def test_an_expected_failure_with_no_exit_code_is_not_a_pass() -> None:
+def test_an_expected_failure_is_the_failure_the_fixture_measures() -> None:
     """`vm-proxy-dead` passes by stopping, and the rule for that was
     `code != b"0"`. A guest whose results never came back hands the caller an
-    empty code, which satisfies it: the one fixture whose verdict is a failure
-    was green whenever the collection failed.
+    empty code, which satisfied it; so did any other stop — a syntax error, a
+    refused preflight, a failed disk — while the fixture exists to show that
+    nothing bypassed a proxy pointed at a dead port.
+
+    Measured on a passing run: `install.rc` held `4` and `Connection refused`
+    appeared 26 times in the log it handed back.
     """
-    assert cluster._did_not_stop(b"4") == ""
-    assert "wrote no exit code" in cluster._did_not_stop(b"")
-    assert "did not" in cluster._did_not_stop(b"0")
+    from tests.vm.results import LOG_TAIL
+
+    refused = {LOG_TAIL: b"wget: unable to connect: Connection refused\n"}
+    assert cluster._did_not_stop("vm-proxy-dead", b"4", refused) == ""
+    assert "wrote no exit code" in cluster._did_not_stop("vm-proxy-dead", b"", refused)
+    assert "did not" in cluster._did_not_stop("vm-proxy-dead", b"0", refused)
+    # A stop for another reason is not this fixture's result.
+    assert "not the b'4'" in cluster._did_not_stop("vm-proxy-dead", b"1", refused)
+    other = {LOG_TAIL: b"the install stopped: DeviceNotFound: /dev/disk/by-id/x\n"}
+    said = cluster._did_not_stop("vm-proxy-dead", b"4", other)
+    assert "Connection refused" in said and "not what this fixture measures" in said
+    # The whole log counts as well as the tail: a log under the size limit
+    # travels whole and the tail is the fallback.
+    whole = {"install.txt": b"wget: unable to connect: Connection refused\n"}
+    assert cluster._did_not_stop("vm-proxy-dead", b"4", whole) == ""
 
 
 def test_a_refused_login_says_what_the_guest_was_showing(

--- a/tests/vm/cluster.py
+++ b/tests/vm/cluster.py
@@ -1819,7 +1819,7 @@ def install_one(
         if job.name in EXPECTED_TO_FAIL:
             # The install stopping is the whole answer here, so there is no
             # installed system to boot afterwards and the run ends on this line.
-            why = _did_not_stop(code)
+            why = _did_not_stop(job.name, code, files)
             return Outcome(
                 job.name,
                 Verdict.FAIL if why else Verdict.OK,
@@ -2309,7 +2309,14 @@ def _remaining(deadline: float) -> float:
 #: result it exists to produce; recording that as a failure made it the only
 #: fixture that could never be green, and it was counted as unverified for
 #: weeks. `campaign.py` knew this and the cluster did not.
-EXPECTED_TO_FAIL: Final[frozenset[str]] = frozenset({"vm-proxy-dead"})
+#: Mapped to the exit code and the words the machine has to produce, because
+#: "stopped" is not the claim: `vm-proxy-dead` exists to show that nothing
+#: bypassed the proxy, and a syntax error, a refused preflight or a failed
+#: disk stops the install just as non-zero. Measured on a passing run:
+#: `install.rc` held `4` and `Connection refused` appeared 26 times.
+EXPECTED_TO_FAIL: Final[Mapping[str, tuple[bytes, str]]] = MappingProxyType(
+    {"vm-proxy-dead": (b"4", "Connection refused")}
+)
 
 
 #: What `cli.py` prints as its last line when an install fails. The verdict
@@ -2335,17 +2342,31 @@ def _why_it_stopped(files: Mapping[str, bytes]) -> str:
     return ""
 
 
-def _did_not_stop(code: bytes) -> str:
+def _did_not_stop(name: str, code: bytes, files: Mapping[str, bytes]) -> str:
     """Why an expected-to-fail fixture is not a pass, or empty when it is.
 
     An absent code is not a stop. `code != b"0"` was the whole rule, and a
     guest whose results never came back leaves it empty, so a run that
-    collected nothing read as the failure the fixture exists to produce.
+    collected nothing read as the failure the fixture exists to produce. The
+    code and the reason, because the local runner has checked both since it
+    was written and the cluster checked neither.
     """
+    wanted, marker = EXPECTED_TO_FAIL[name]
     if not code:
         return "the install was supposed to stop and wrote no exit code"
     if code == b"0":
         return "the install was supposed to stop and did not"
+    if code != wanted:
+        return (
+            f"the install stopped with {code!r}, not the {wanted!r} this fixture "
+            "exists to produce"
+        )
+    said = files.get(LOG_TAIL, b"") + files.get("install.txt", b"")
+    if marker.encode() not in said:
+        return (
+            f"the install stopped without {marker!r}, so what stopped it is not "
+            "what this fixture measures"
+        )
     return ""
 
 #: Fixtures whose mirror site is the thing under test, so `--site` must not


### PR DESCRIPTION
`_did_not_stop` accepted every non-zero exit code. `vm-proxy-dead` points every fetch at a port nothing listens on and exists to show that nothing bypassed the proxy, so a syntax error, a refused preflight or a failed disk passed it just as well. `campaign.py` has required the code *and* a marker from the log since it was written; the cluster required neither.

The pair comes from a passing run rather than from the fixture: `install.rc` held `4`, and `Connection refused` appears 26 times in the log it handed back. Both halves have a control — a stop with another code, and a stop for another reason — and the marker is searched in the tail and in the whole log, because `#751` sends the whole one when it fits.