### PR TITLE
proxmox: a guest replaced between the two reads is not deleted

### DIFF
--- a/tests/unit/test_proxmox.py
+++ b/tests/unit/test_proxmox.py
@@ -2682,7 +2682,7 @@ def test_a_status_failure_does_not_mark_the_guest_stopped() -> None:
         def call(self, method: str, path: str, **form: Any) -> Any:
             raise ProxmoxError("status failed")
 
-    guest = Guest(Refusing(), "node", 9300, GuestSpec(name="x", iso="x"))
+    guest = Guest(Refusing(), "node", 9300, GuestSpec(name="x", iso="x", nonce="gi-owned"))
     guest._booted = True
     with pytest.raises(ProxmoxError, match="status failed"):
         guest.stop()
@@ -2696,16 +2696,16 @@ def test_a_stop_task_failure_does_not_mark_the_guest_stopped() -> None:
                 return {"status": "running"}
             # The ownership check reads this before anything is stopped.
             if path.endswith("/config"):
-                return {"tags": TAG}
+                return {"tags": f"{TAG};gi-owned"}
             return "UPID:node:stop"
 
         def wait(self, node: str, upid: str, patience: float = 1800.0) -> None:
             raise ProxmoxError("stop task failed")
 
-    guest = Guest(Refusing(), "node", 9300, GuestSpec(name="x", iso="x"))
+    guest = Guest(Refusing(), "node", 9300, GuestSpec(name="x", iso="x", nonce="gi-owned"))
     guest._booted = True
     with pytest.raises(ProxmoxError, match="stop task failed"):
-        guest.stop()
+        guest.stop(patience=0.0)
     assert guest._booted
 
 
@@ -3257,14 +3257,14 @@ def test_a_stop_still_stops_this_runs_machine() -> None:
             if path.endswith("/status/current"):
                 return {"status": "running"}
             if path.endswith("/config"):
-                return {"tags": f"other;{TAG}"}
+                return {"tags": f"other;{TAG};gi-owned"}
             stopped.append(path)
             return "UPID:node:stop"
 
         def wait(self, node: str, upid: str, patience: float = 1800.0) -> None:
             return None
 
-    guest = Guest(Ours(), "node", 9302, GuestSpec(name="x", iso="x"))
+    guest = Guest(Ours(), "node", 9302, GuestSpec(name="x", iso="x", nonce="gi-owned"))
     guest._booted = True
     guest.stop()
 
@@ -4420,4 +4420,40 @@ def test_a_stop_the_gateway_ate_is_sent_again() -> None:
     stubborn._booted = True
     with pytest.raises(ProxmoxError, match="403 Forbidden"):
         stubborn.stop()
+
+
+def test_a_guest_replaced_between_the_two_reads_is_not_deleted() -> None:
+    """`destroy` checks the tag and the nonce, then stops, then deletes. A
+    VMID is handed back and reused inside one campaign, so the guest can be
+    replaced between those reads; the stop notices and `destroy` swallowed it
+    and deleted anyway. Measured by hand on 9311 the same day: a `DELETE` sent
+    at a vmid that had changed owner was refused only because Proxmox will not
+    destroy a running guest."""
+
+    @dataclass
+    class Replaced(Api):
+        reads: int = 0
+        deleted: bool = False
+
+        def call(self, method: str, path: str, **form: Any) -> Any:
+            if path.endswith("/config"):
+                self.reads += 1
+                # Ours on the first read, somebody else's by the second.
+                tags = f"{TAG};gi-owned" if self.reads == 1 else f"{TAG};gi-another-run"
+                return {"tags": tags}
+            if path.endswith("/status/current"):
+                return {"status": "running"}
+            if method == "DELETE":
+                self.deleted = True
+                return "UPID:node:qmdestroy"
+            raise AssertionError((method, path))
+
+        def wait(self, node: str, upid: str, patience: float = 1800.0) -> None:
+            return None
+
+    api = Replaced()
+    guest = Guest(api, "node", 9300, GuestSpec(name="x", iso="x", nonce="gi-owned"))
+    with pytest.raises(ForeignGuest, match="not this run's machine"):
+        guest.destroy(patience=5.0)
+    assert not api.deleted, "the guest that replaced ours was deleted"
 

--- a/tests/vm/proxmox.py
+++ b/tests/vm/proxmox.py
@@ -670,7 +670,7 @@ class Guest:
                 raise ProxmoxError(f"{key!r} was not delivered to vm {self.vmid}: {last}")
             time.sleep(self.KEY_PAUSE)
 
-    def stop(self) -> None:
+    def stop(self, patience: float = STOP_PATIENCE) -> None:
         """Stop the machine this run created, and only that one.
 
         `destroy` has checked the tag since a VMID was found not to be proof of
@@ -690,7 +690,7 @@ class Guest:
             self._booted = False
             return
         if not self._is_ours():
-            raise ProxmoxError(
+            raise ForeignGuest(
                 f"vm {self.vmid} on {self.node} is not this run's machine; not stopping it"
             )
         # Retried, because the cluster proxy answering `502 Bad Gateway` is not
@@ -698,7 +698,7 @@ class Guest:
         # install that had already finished, on the stop that precedes booting
         # the disk it wrote. The status is read again each round, so a stop
         # whose answer was eaten is seen as the guest already being down.
-        deadline = time.monotonic() + STOP_PATIENCE
+        deadline = time.monotonic() + patience
         last = "the guest is still running"
         while True:
             try:
@@ -730,10 +730,14 @@ class Guest:
         self._booted = False
 
     def _is_ours(self) -> bool:
-        """Whether the machine at this VMID still carries this harness's tag.
+        """Whether the machine at this VMID is the one this run built.
 
         A VMID is not proof: the range already held a production template, and
         within one campaign a failed run's VMID is handed straight to the next.
+        The nonce as well as the tag, because the tag says only that some run
+        of this harness built it — `destroy` has required both since a VMID
+        was found to be recycled, and `stop` asking for less let a guest
+        another schedule had just created pass as ours.
         """
         if not VMID_FIRST <= self.vmid <= VMID_LAST:
             return False
@@ -741,7 +745,8 @@ class Guest:
             config = self.api.call("GET", f"/nodes/{self.node}/qemu/{self.vmid}/config")
         except ProxmoxNotFound:
             return False
-        return TAG in str(config.get("tags", "")).split(";")
+        tags = str(config.get("tags", "")).split(";")
+        return TAG in tags and bool(self.spec.nonce) and self.spec.nonce in tags
 
     def destroy(self, patience: float = CLEANUP_PATIENCE) -> None:
         """Remove the machine and its disks.
@@ -786,6 +791,13 @@ class Guest:
                 )
             try:
                 self.stop()
+            except ForeignGuest:
+                # Not swallowed: the ownership check above passed a moment
+                # ago, and a VMID is recycled inside one campaign, so a stop
+                # that answers `not this run's machine` means the guest was
+                # replaced between the two reads. Deleting then deletes
+                # somebody else's run.
+                raise
             except ProxmoxError as error:
                 # A running guest is the one cleanup must still try to delete.
                 last = str(error)


### PR DESCRIPTION
`destroy` reads the config, checks the tag *and* the nonce, calls `stop`, then deletes. `stop` checked the tag alone — which says only that some run of this harness built the guest — and `destroy` swallowed its refusal as "a running guest is the one cleanup must still try to delete".

A VMID is handed back and reused inside one campaign, so between those two reads the guest can be another schedule`s. Then the tag still matches, `stop` proceeds, and the DELETE removes a machine that was installing. I nearly did this by hand the same day on 9311: the DELETE was refused only because Proxmox will not destroy a running guest.

`_is_ours` now requires the nonce as well, `stop` raises `ForeignGuest`, and `destroy` re-raises it. Both real construction sites already pass a nonce; the two tests that did not were exercising the looser rule.