### PR TITLE
vm: count grub's modules before the conversion reboots

### DIFF
--- a/tests/unit/test_cluster.py
+++ b/tests/unit/test_cluster.py
@@ -3032,3 +3032,27 @@ def test_the_summary_names_a_guest_the_run_could_not_remove() -> None:
     # On stderr, where the operator reading a redirected run still sees it.
     assert "file=sys.stderr" in source[said : said + 120], source[said : said + 200]
 
+
+def test_a_conversion_counts_the_modules_its_bootloader_needs() -> None:
+    """`vm-convert` failed on the cluster with `file '/boot/grub/x86_64-efi/
+    normal.mod' not found. Entering rescue mode...` while the conversion's own
+    log said `Installation finished. No error reported.` twice. A guest in the
+    rescue shell answers nothing, so the count is taken before the reboot."""
+    import inspect
+    import re
+
+    from tests.vm import cluster
+    from tests.vm.convert import GRUB_MODULES_CHECK
+
+    source = inspect.getsource(cluster.convert_and_check)
+    asked = source.index("GRUB_MODULES_CHECK.command")
+    booted = source.index("boot_and_check(")
+    assert asked < booted, source[asked : asked + 200]
+
+    # The count is the guest's answer: `wc -l` cannot come from the echo, and
+    # an empty directory is not a pass.
+    assert "wc -l" in GRUB_MODULES_CHECK.command
+    assert not re.search(GRUB_MODULES_CHECK.pattern, GRUB_MODULES_CHECK.command)
+    assert re.search(GRUB_MODULES_CHECK.pattern, "grubmods=214\n")
+    assert not re.search(GRUB_MODULES_CHECK.pattern, "grubmods=0\n")
+    assert not re.search(GRUB_MODULES_CHECK.pattern, "")

--- a/tests/vm/cluster.py
+++ b/tests/vm/cluster.py
@@ -113,6 +113,7 @@ from .convert import (
     ETC_MARKER,
     ETC_MARKER_CHECK,
     ETC_MARKER_PATH,
+    GRUB_MODULES_CHECK,
     HOME_MARKER,
     HOME_MARKER_CHECK,
     HOME_MARKER_PATH,
@@ -3238,6 +3239,14 @@ def convert_and_check(
     code = files.get("install.rc", b"").strip()
     if code != b"0":
         return f"the conversion exited {code!r}"
+    # Asked before the reboot: a guest that drops to `grub rescue>` for a
+    # missing module answers nothing afterwards.
+    said = link.expect_output(GRUB_MODULES_CHECK.command, timeout=120.0)
+    if re.search(GRUB_MODULES_CHECK.pattern.encode(), said) is None:
+        return (
+            f"the conversion left no bootloader modules: {GRUB_MODULES_CHECK.name} "
+            f"answered {said[-ANSWER_BYTES:]!r}"
+        )[:VERDICT_BYTES]
     # The same reader as the first install: a converted machine that reaches a
     # login prompt with the old hostname booted the system it was replacing.
     return boot_and_check(

--- a/tests/vm/convert.py
+++ b/tests/vm/convert.py
@@ -67,6 +67,16 @@ ETC_MARKER_CHECK: Final[InstalledCheck] = InstalledCheck(
     r"(?m)^etc=0$",
 )
 
+#: GRUB's stub loads `normal.mod` from here and drops to `grub rescue>`
+#: without it, which is how `vm-convert` failed while `grub-install` reported
+#: no error. The guest computes the count, so the echo cannot supply it.
+GRUB_MODULE_DIRECTORY: Final[str] = "/boot/grub/x86_64-efi"
+GRUB_MODULES_CHECK: Final[InstalledCheck] = InstalledCheck(
+    "grub modules",
+    f"printf 'grubmods=%s\\n' \"$(ls {GRUB_MODULE_DIRECTORY} 2>/dev/null | wc -l)\"",
+    r"(?m)^grubmods=[1-9][0-9]*$",
+)
+
 #: Bigger than every image here, so cloud-init's `growpart` and `resizefs`
 #: run on first boot. A 5 GiB Fedora root cannot hold a stage3 and a kernel.
 OVERLAY_SIZE: Final[str] = "24G"


### PR DESCRIPTION
`vm-convert` reached `grub rescue>` for a missing `normal.mod` while both `grub-install` calls reported no error. A guest in the rescue shell answers nothing, so the count is taken before the reboot and the verdict names it.