### PR TITLE
TESTED: record the fourth conversion and the one that did not boot

### DIFF
--- a/TESTED.md
+++ b/TESTED.md
@@ -204,11 +204,19 @@ written.
 
 | Revision | Fixture | Result |
 |---|---|---|
+| `d32b9d4aa6fb4` | `vm-convert` | the same again in 125.8 minutes, and the first row where the `/etc` sentinel was measured: a file written there before the swap was gone afterwards, so `/etc` was replaced rather than merged |
 | `d97a5eb98c743` | `vm-convert` | the same again in 95.4 minutes, at a revision carrying the verdict that names the installer's own reason. The home-marker check that changed the same day belongs to the local conversion runner and is not in this row |
 | `ce95e7df72cd` | `vm-convert` | installed Gentoo onto a cluster guest, converted that machine in place with the same driver CD, and the converted machine booted as `convertedbox` and answered every installed-state check, in 137.6 minutes |
 
 The cluster runs a conversion by installing a system first and converting what
-that produced, so this row covers both halves and the reboot between them.
+that produced, so these rows cover both halves and the reboot between them.
+
+The conversion is not reliable. Five cluster conversions have reached the
+reboot: four booted, and one stopped at `grub rescue>` for a missing
+`/boot/grub/x86_64-efi/normal.mod` while the conversion itself exited `0`. Two
+earlier ones never reached a login prompt at revisions that did not record the
+console, so what they stopped at is unknown. The open defect is row 238 of
+`docs/tasks.md`.
 
 ### Not verified
 


### PR DESCRIPTION
Four of the five cluster conversions that reached the reboot booted; one stopped at `grub rescue>` for a missing `/boot/grub/x86_64-efi/normal.mod` while the conversion exited `0`. A record naming only the four reads as a path that works.