### PR TITLE
vm: read the module with grub's own driver before the reboot

### DIFF
--- a/tests/unit/test_cluster.py
+++ b/tests/unit/test_cluster.py
@@ -3038,21 +3038,54 @@ def test_a_conversion_counts_the_modules_its_bootloader_needs() -> None:
     normal.mod' not found. Entering rescue mode...` while the conversion's own
     log said `Installation finished. No error reported.` twice. A guest in the
     rescue shell answers nothing, so the count is taken before the reboot."""
+    import ast
     import inspect
     import re
+    import textwrap
 
     from tests.vm import cluster
-    from tests.vm.convert import GRUB_MODULES_CHECK
+    from tests.vm.convert import (
+        BEFORE_THE_REBOOT,
+        GRUB_MODULES_CHECK,
+        GRUB_READS_ITS_MODULE,
+    )
 
-    source = inspect.getsource(cluster.convert_and_check)
-    asked = source.index("GRUB_MODULES_CHECK.command")
-    booted = source.index("boot_and_check(")
-    assert asked < booted, source[asked : asked + 200]
+    # In the function's own body, not inside a branch: a loop the reboot can
+    # walk past is a check the failing machine never answers.
+    body = ast.parse(textwrap.dedent(inspect.getsource(cluster.convert_and_check))).body[0]
+    assert isinstance(body, ast.FunctionDef)
+    asked = [
+        n
+        for n, one in enumerate(body.body)
+        if isinstance(one, ast.For)
+        and isinstance(one.iter, ast.Name)
+        and one.iter.id == "BEFORE_THE_REBOOT"
+    ]
+    booted = [
+        n
+        for n, one in enumerate(body.body)
+        if isinstance(one, ast.Return)
+        and isinstance(one.value, ast.Call)
+        and isinstance(one.value.func, ast.Name)
+        and one.value.func.id == "boot_and_check"
+    ]
+    assert asked and booted and asked[0] < booted[0], ast.dump(body)
+    assert GRUB_MODULES_CHECK in BEFORE_THE_REBOOT
+    assert GRUB_READS_ITS_MODULE in BEFORE_THE_REBOOT
 
-    # The count is the guest's answer: `wc -l` cannot come from the echo, and
-    # an empty directory is not a pass.
-    assert "wc -l" in GRUB_MODULES_CHECK.command
-    assert not re.search(GRUB_MODULES_CHECK.pattern, GRUB_MODULES_CHECK.command)
-    assert re.search(GRUB_MODULES_CHECK.pattern, "grubmods=214\n")
-    assert not re.search(GRUB_MODULES_CHECK.pattern, "grubmods=0\n")
-    assert not re.search(GRUB_MODULES_CHECK.pattern, "")
+    # Both answers are counted by the guest, so neither can come from the
+    # echo, and neither counts nothing as a pass.
+    for check, answer in (
+        (GRUB_MODULES_CHECK, "grubmods=214\n"),
+        (GRUB_READS_ITS_MODULE, "grubread=182672\n"),
+    ):
+        assert "wc -" in check.command
+        assert not re.search(check.pattern, check.command)
+        assert re.search(check.pattern, answer)
+        assert not re.search(check.pattern, answer.split("=")[0] + "=0\n")
+        assert not re.search(check.pattern, "")
+
+    # The second reads through GRUB's own driver rather than the kernel's: a
+    # module the kernel lists and GRUB cannot follow is the failure this
+    # exists for.
+    assert "grub-fstest" in GRUB_READS_ITS_MODULE.command

--- a/tests/vm/cluster.py
+++ b/tests/vm/cluster.py
@@ -110,10 +110,10 @@ from .results import (
 )
 from .workdir import WorkdirError, confined
 from .convert import (
+    BEFORE_THE_REBOOT,
     ETC_MARKER,
     ETC_MARKER_CHECK,
     ETC_MARKER_PATH,
-    GRUB_MODULES_CHECK,
     HOME_MARKER,
     HOME_MARKER_CHECK,
     HOME_MARKER_PATH,
@@ -3241,12 +3241,13 @@ def convert_and_check(
         return f"the conversion exited {code!r}"
     # Asked before the reboot: a guest that drops to `grub rescue>` for a
     # missing module answers nothing afterwards.
-    said = link.expect_output(GRUB_MODULES_CHECK.command, timeout=120.0)
-    if re.search(GRUB_MODULES_CHECK.pattern.encode(), said) is None:
-        return (
-            f"the conversion left no bootloader modules: {GRUB_MODULES_CHECK.name} "
-            f"answered {said[-ANSWER_BYTES:]!r}"
-        )[:VERDICT_BYTES]
+    for check in BEFORE_THE_REBOOT:
+        said = link.expect_output(check.command, timeout=120.0)
+        if re.search(check.pattern.encode(), said) is None:
+            return (
+                f"the conversion left a bootloader that cannot start: {check.name} "
+                f"answered {said[-ANSWER_BYTES:]!r}"
+            )[:VERDICT_BYTES]
     # The same reader as the first install: a converted machine that reaches a
     # login prompt with the old hostname booted the system it was replacing.
     return boot_and_check(

--- a/tests/vm/convert.py
+++ b/tests/vm/convert.py
@@ -77,6 +77,22 @@ GRUB_MODULES_CHECK: Final[InstalledCheck] = InstalledCheck(
     r"(?m)^grubmods=[1-9][0-9]*$",
 )
 
+#: The kernel answering that the module is there does not say GRUB's own
+#: driver can follow it, and `grub-fstest` is that driver on the same device.
+GRUB_READS_ITS_MODULE: Final[InstalledCheck] = InstalledCheck(
+    "grub reads its module",
+    "printf 'grubread=%s\\n' \"$(grub-fstest \"$(grub-probe --target=device /boot)\" "
+    f"cat \"$(grub-mkrelpath {GRUB_MODULE_DIRECTORY}/normal.mod)\" 2>/dev/null | wc -c)\"",
+    r"(?m)^grubread=[1-9][0-9]*$",
+)
+
+#: What a conversion is asked before it reboots, in this order: the machine is
+#: still answering here and a rescue shell answers nothing.
+BEFORE_THE_REBOOT: Final[tuple[InstalledCheck, ...]] = (
+    GRUB_MODULES_CHECK,
+    GRUB_READS_ITS_MODULE,
+)
+
 #: Bigger than every image here, so cloud-init's `growpart` and `resizefs`
 #: run on first boot. A 5 GiB Fedora root cannot hold a stage3 and a kernel.
 OVERLAY_SIZE: Final[str] = "24G"


### PR DESCRIPTION
The kernel listing `/boot/grub/x86_64-efi/normal.mod` says nothing about whether GRUB's filesystem driver can follow it, and that is what stops the converted machine. `grub-fstest` is that driver, run against the device `grub-probe` names, while the machine still answers.