### PR TITLE
vm: ask whether grub's stub names the filesystem holding /boot

### DIFF
--- a/tests/unit/test_cluster.py
+++ b/tests/unit/test_cluster.py
@@ -3045,9 +3045,10 @@ def test_a_conversion_counts_the_modules_its_bootloader_needs() -> None:
 
     from tests.vm import cluster
     from tests.vm.convert import (
-        BEFORE_THE_REBOOT,
         GRUB_MODULES_CHECK,
+        GRUB_PREFIX_CHECK,
         GRUB_READS_ITS_MODULE,
+        before_the_reboot,
     )
 
     # In the function's own body, not inside a branch: a loop the reboot can
@@ -3058,8 +3059,9 @@ def test_a_conversion_counts_the_modules_its_bootloader_needs() -> None:
         n
         for n, one in enumerate(body.body)
         if isinstance(one, ast.For)
-        and isinstance(one.iter, ast.Name)
-        and one.iter.id == "BEFORE_THE_REBOOT"
+        and isinstance(one.iter, ast.Call)
+        and isinstance(one.iter.func, ast.Name)
+        and one.iter.func.id == "before_the_reboot"
     ]
     booted = [
         n
@@ -3070,16 +3072,32 @@ def test_a_conversion_counts_the_modules_its_bootloader_needs() -> None:
         and one.value.func.id == "boot_and_check"
     ]
     assert asked and booted and asked[0] < booted[0], ast.dump(body)
-    assert GRUB_MODULES_CHECK in BEFORE_THE_REBOOT
-    assert GRUB_READS_ITS_MODULE in BEFORE_THE_REBOOT
+
+    # Derived from the configuration, because every one of these reads a UEFI
+    # GRUB installation: a BIOS conversion has no `x86_64-efi` directory and
+    # no stub on an esp, so asking it these three fails a working machine.
+    from dataclasses import replace
+
+    from gentoo_install.exec.config import load
+    from gentoo_install.model.config import Firmware
+
+    conversion = load(FIXTURES / "vm-convert.toml")
+    asked_for = before_the_reboot(conversion)
+    assert asked_for == (GRUB_MODULES_CHECK, GRUB_READS_ITS_MODULE, GRUB_PREFIX_CHECK)
+    on_bios = replace(
+        conversion,
+        bootloader=replace(conversion.bootloader, firmware=Firmware.BIOS),
+    )
+    assert before_the_reboot(on_bios) == ()
 
     # Both answers are counted by the guest, so neither can come from the
     # echo, and neither counts nothing as a pass.
     for check, answer in (
         (GRUB_MODULES_CHECK, "grubmods=214\n"),
         (GRUB_READS_ITS_MODULE, "grubread=182672\n"),
+        (GRUB_PREFIX_CHECK, "grubprefix=1\n"),
     ):
-        assert "wc -" in check.command
+        assert "wc -" in check.command or "grep -ac" in check.command
         assert not re.search(check.pattern, check.command)
         assert re.search(check.pattern, answer)
         assert not re.search(check.pattern, answer.split("=")[0] + "=0\n")

--- a/tests/vm/cluster.py
+++ b/tests/vm/cluster.py
@@ -110,13 +110,13 @@ from .results import (
 )
 from .workdir import WorkdirError, confined
 from .convert import (
-    BEFORE_THE_REBOOT,
     ETC_MARKER,
     ETC_MARKER_CHECK,
     ETC_MARKER_PATH,
     HOME_MARKER,
     HOME_MARKER_CHECK,
     HOME_MARKER_PATH,
+    before_the_reboot,
 )
 from .installed import InstalledCheck, checks, stage_passphrase_commands
 from .run import SEEDED, remote_config, remote_unlock, ssh_keypair
@@ -3241,7 +3241,7 @@ def convert_and_check(
         return f"the conversion exited {code!r}"
     # Asked before the reboot: a guest that drops to `grub rescue>` for a
     # missing module answers nothing afterwards.
-    for check in BEFORE_THE_REBOOT:
+    for check in before_the_reboot(installation):
         said = link.expect_output(check.command, timeout=120.0)
         if re.search(check.pattern.encode(), said) is None:
             return (

--- a/tests/vm/convert.py
+++ b/tests/vm/convert.py
@@ -86,12 +86,32 @@ GRUB_READS_ITS_MODULE: Final[InstalledCheck] = InstalledCheck(
     r"(?m)^grubread=[1-9][0-9]*$",
 )
 
-#: What a conversion is asked before it reboots, in this order: the machine is
-#: still answering here and a rescue shell answers nothing.
-BEFORE_THE_REBOOT: Final[tuple[InstalledCheck, ...]] = (
-    GRUB_MODULES_CHECK,
-    GRUB_READS_ITS_MODULE,
+#: Where `--bootloader-id=Gentoo` puts the stub the firmware starts.
+GRUB_STUB: Final[str] = "/efi/EFI/Gentoo/grubx64.efi"
+
+#: `grub-install` embeds `search.fs_uuid <uuid>` in the stub, and that uuid is
+#: what decides which filesystem `$prefix` is read from. The guest computes
+#: both sides, so the echo cannot answer it.
+GRUB_PREFIX_CHECK: Final[InstalledCheck] = InstalledCheck(
+    "grub's prefix",
+    "printf 'grubprefix=%s\\n' "
+    f"\"$(grep -ac \"$(grub-probe --target=fs_uuid /boot)\" {GRUB_STUB} 2>/dev/null)\"",
+    r"(?m)^grubprefix=[1-9][0-9]*$",
 )
+
+
+def before_the_reboot(installation: InstallConfig) -> tuple[InstalledCheck, ...]:
+    """What a conversion is asked while it still answers.
+
+    Every one of these reads a UEFI GRUB installation: the module directory is
+    `x86_64-efi` and the stub is on the esp, so a conversion to any other
+    bootloader is asked none of them rather than asked the wrong questions.
+    """
+    bootloader = installation.bootloader
+    if bootloader.kind.value != "grub" or bootloader.firmware.value != "uefi":
+        return ()
+    return (GRUB_MODULES_CHECK, GRUB_READS_ITS_MODULE, GRUB_PREFIX_CHECK)
+
 
 #: Bigger than every image here, so cloud-init's `growpart` and `resizefs`
 #: run on first boot. A 5 GiB Fedora root cannot hold a stage3 and a kernel.


### PR DESCRIPTION
A complete `/boot/grub/x86_64-efi` still leaves the machine in the rescue shell when the stub searches for another filesystem's uuid, so the conversion is asked that too while it still answers. The three questions now come from the configuration: they all read a UEFI GRUB installation, and a BIOS conversion has no `x86_64-efi` directory to count.