### PR TITLE
vm: let the menu walk confine its target to its own root

### DIFF
--- a/tests/unit/test_harness.py
+++ b/tests/unit/test_harness.py
@@ -4885,3 +4885,43 @@ def test_the_zfs_unlock_proof_travels_in_the_unlock_session(
     # The control: a second connection would be the race this closes.
     assert not opened, opened
 
+
+def test_the_menu_walk_makes_its_target_under_its_own_root(tmp_path: Path) -> None:
+    """`create_target` refuses a path outside the directory it confines to, and
+    the menu walk keeps its guests under `lab/vm/tui`. Without a root of its
+    own `python3 -m tests.vm.tui` raised before it booted anything, so the one
+    check of the interface on a real 80-column console could not run."""
+    import ast
+    import inspect
+    import textwrap
+
+    import pytest
+
+    from tests.vm import tui
+    from tests.vm.run import DEFAULT_TARGET_SIZE, create_target
+
+    mine = tmp_path / "walk"
+    mine.mkdir()
+    made = create_target(mine / "target.qcow2", DEFAULT_TARGET_SIZE, root=tmp_path)
+    assert made.exists() and made.stat().st_size > 0
+
+    # The named root is a boundary, not a switch that turns the guard off.
+    outside = tmp_path.parent / "not-the-walk.qcow2"
+    outside.write_bytes(b"stands for a downloaded cloud image")
+    with pytest.raises(ValueError, match="deletes what it is given"):
+        create_target(outside, DEFAULT_TARGET_SIZE, root=mine)
+    assert outside.read_bytes().startswith(b"stands for")
+
+    # And the walk asks for it: the default root would refuse its own workdir.
+    body = ast.parse(textwrap.dedent(inspect.getsource(tui.main))).body[0]
+    assert isinstance(body, ast.FunctionDef)
+    asked = [
+        call
+        for call in ast.walk(body)
+        if isinstance(call, ast.Call)
+        and isinstance(call.func, ast.Name)
+        and call.func.id == "create_target"
+    ]
+    assert len(asked) == 1, ast.dump(body)
+    assert [one.arg for one in asked[0].keywords] == ["root"], ast.dump(asked[0])
+

--- a/tests/vm/run.py
+++ b/tests/vm/run.py
@@ -160,7 +160,10 @@ SEEDED: dict[str, tuple[str, ...]] = {
 
 
 def create_target(
-    path: Path, size: str = DEFAULT_TARGET_SIZE, seed: tuple[str, ...] = ()
+    path: Path,
+    size: str = DEFAULT_TARGET_SIZE,
+    seed: tuple[str, ...] = (),
+    root: Path | None = None,
 ) -> Path:
     """A disk for the installer to partition, thrown away with the run.
 
@@ -170,10 +173,15 @@ def create_target(
     # The first thing this does is delete the file, and the images an in-place
     # conversion will be given are downloaded once and kept: `lab/vm/cloud/`
     # holds three of them. A run writes only inside its own directory, so a
-    # path outside `WORKROOT` is a mistake rather than a target, and it is
-    # refused before the unlink rather than diagnosed after it.
-    if WORKROOT not in path.resolve().parents:
-        raise ValueError(f"{path} is not inside {WORKROOT}, and this deletes what it is given")
+    # path outside its root is a mistake rather than a target, and it is
+    # refused before the unlink rather than diagnosed after it. `root`,
+    # because the menu walk keeps its guests under `lab/vm/tui` and this
+    # refused every one of them.
+    # Read here rather than bound as a default, so a test that moves WORKROOT
+    # still moves the guard.
+    confine = WORKROOT if root is None else root
+    if confine not in path.resolve().parents:
+        raise ValueError(f"{path} is not inside {confine}, and this deletes what it is given")
     path.unlink(missing_ok=True)
     if not seed:
         subprocess.run(

--- a/tests/vm/tui.py
+++ b/tests/vm/tui.py
@@ -647,7 +647,7 @@ def main(argv: list[str] | None = None) -> int:
     # A guest with no disk to install onto never reaches the menu: the two
     # recordings this walk produced returned to the shell before any screen was
     # drawn, and the review of them found nothing because there was nothing.
-    target = create_target(workdir / "target.qcow2")
+    target = create_target(workdir / "target.qcow2", root=root)
     spec = VmSpec(
         medium=medium,
         workdir=workdir,


### PR DESCRIPTION
`python3 -m tests.vm.tui` died on `ValueError: … is not inside …/lab/vm/runs` before booting anything, so the only check of the interface on a real 80-column serial console had been dead since `create_target` gained that guard. The guard stays; the caller names the root it already confined.