### PR TITLE
vm: find the driver CD the same way in every runner

### DIFF
--- a/tests/unit/test_harness.py
+++ b/tests/unit/test_harness.py
@@ -1886,6 +1886,12 @@ def test_the_walk_does_not_escape_out_of_a_row_that_never_opened(
         def run(self, line: str, timeout: float = 0.0) -> str:
             return ""
 
+        # Echoed first, the way a shell answers: `wait_for_driver` reads the
+        # value the guest computed and a double that skips the echo hides
+        # every check that could match its own question.
+        def expect_command(self, command: str, timeout: float = 0.0) -> bytes:
+            return f"{command}\r\ndriver=0\r\n".encode()
+
         def send_raw(self, keys: str) -> None:
             self.sent.append(keys)
 
@@ -1953,6 +1959,9 @@ def test_the_walk_waits_for_a_drawn_menu_after_the_echoed_launch_command(
         def expect(self, pattern: str, timeout: float, idle: float = 0.0) -> bytes:
             self.asked += 1
             return b"python3 -m gentoo_install # gentoo-install\r\n"
+
+        def expect_command(self, command: str, timeout: float = 0.0) -> bytes:
+            return f"{command}\r\ndriver=0\r\n".encode()
 
         def snapshot(self, seconds: float) -> bytes:
             self.snapshots += 1
@@ -4924,4 +4933,25 @@ def test_the_menu_walk_makes_its_target_under_its_own_root(tmp_path: Path) -> No
     ]
     assert len(asked) == 1, ast.dump(body)
     assert [one.arg for one in asked[0].keywords] == ["root"], ast.dump(asked[0])
+
+
+def test_only_the_driver_module_names_a_cd_device() -> None:
+    """`FIND_DRIVER` tries the label first and two device nodes after it,
+    because a medium that boots from a squashfs has no `/dev/sr*` at all. Two
+    runners mounted `/dev/sr1` themselves instead, and the menu walk died on
+    `Can't open blockdev` with the tarball never unpacked."""
+    import re
+    from pathlib import Path as _Path
+
+    here = _Path(__file__).resolve().parents[1] / "vm"
+    guilty: list[str] = []
+    for module in sorted(here.glob("*.py")):
+        if module.name == "driver.py":
+            continue
+        for number, line in enumerate(module.read_text().splitlines(), start=1):
+            if line.lstrip().startswith("#"):
+                continue
+            if re.search(r"mount\b[^\n]*/dev/sr", line):
+                guilty.append(f"{module.name}:{number}: {line.strip()}")
+    assert not guilty, guilty
 

--- a/tests/vm/netcheck.py
+++ b/tests/vm/netcheck.py
@@ -30,7 +30,7 @@ from pathlib import Path
 from typing import Final
 
 from .console import SerialConsole
-from .driver import build as build_driver
+from .driver import build as build_driver, wait_for_driver
 from .workdir import WorkdirError, confined
 from .media import MEDIA
 from .qemu import Firmware, Vm, VmSpec
@@ -98,8 +98,7 @@ def _check(console: SerialConsole, families: str, driver: str) -> Result:
     if waited:
         found.egress = waited
         return found
-    console.run("mkdir -p /mnt/driver")
-    console.run("mountpoint -q /mnt/driver || mount -o ro /dev/sr1 /mnt/driver")
+    wait_for_driver(console)
     console.run(f"mkdir -p {driver} && tar xzf /mnt/driver/driver.tar.gz -C {driver}")
 
     wants4, wants6 = EXPECTED[families]

--- a/tests/vm/tui.py
+++ b/tests/vm/tui.py
@@ -24,7 +24,7 @@ from pathlib import Path
 from typing import Final
 
 from .console import ConsoleTimeout, SerialConsole
-from .driver import build as build_driver
+from .driver import build as build_driver, wait_for_driver
 from .run import create_target
 from .media import MEDIA
 from .qemu import Firmware, Vm, VmSpec
@@ -559,8 +559,10 @@ def _wait_for_menu(
 
 
 def _open_menu(console: SerialConsole, lang: str) -> None:
-    console.run("mkdir -p /mnt/driver")
-    console.run("mountpoint -q /mnt/driver || mount -o ro /dev/sr1 /mnt/driver")
+    # Through the shared search, not a device node: the walk hardcoded
+    # `/dev/sr1` and the guest answered `Can't open blockdev`, so the tarball
+    # was never unpacked and the menu never started.
+    wait_for_driver(console)
     console.run("mkdir -p /tmp/driver && tar xzf /mnt/driver/driver.tar.gz -C /tmp/driver")
     console.run(f"stty rows {LINES} cols {COLUMNS}")
     # `TERM` explicitly: a serial getty leaves it unset and curses then refuses


### PR DESCRIPTION
`python3 -m tests.vm.tui` reached the shell, mounted nothing (`mount: /dev/sr1: Can't open blockdev`), unpacked nothing, and timed out waiting for a menu that was never started. Two runners had their own copy of the mount; both now call `wait_for_driver`, and a test refuses a `mount … /dev/sr` anywhere under `tests/vm/` except the module that owns the search.