### PR TITLE
vm: launch the walked menu with a short escape delay

### DIFF
--- a/tests/unit/test_harness.py
+++ b/tests/unit/test_harness.py
@@ -1940,7 +1940,7 @@ def test_the_walk_waits_for_a_drawn_menu_after_the_echoed_launch_command(
         b"\x1b[24;1H[enter] Continue"
     )
     launch = (
-        "cd /tmp/driver && TERM=vt220 LINES=24 COLUMNS=80 "
+        f"cd /tmp/driver && TERM=vt220 ESCDELAY={tui.ESCDELAY} LINES=24 COLUMNS=80 "
         "python3 -m gentoo_install --lang en\n"
     )
 
@@ -4954,4 +4954,19 @@ def test_only_the_driver_module_names_a_cd_device() -> None:
             if re.search(r"mount\b[^\n]*/dev/sr", line):
                 guilty.append(f"{module.name}:{number}: {line.strip()}")
     assert not guilty, guilty
+
+
+def test_the_walk_launches_the_menu_with_a_short_escape_delay() -> None:
+    """ncurses holds a lone escape for ESCDELAY milliseconds in case it starts
+    a sequence, and the default is 1000. The walk sends escape and then an
+    arrow 0.5s later, so with the default the two arrive as one key: the first
+    walk on a real console reported every row after the first as never
+    opening, and the console showed it never left the screen it had opened."""
+    import inspect
+
+    from tests.vm import tui
+
+    launch = inspect.getsource(tui._open_menu)
+    assert "ESCDELAY={ESCDELAY}" in launch, launch
+    assert tui.ESCDELAY < 500, tui.ESCDELAY
 

--- a/tests/vm/tui.py
+++ b/tests/vm/tui.py
@@ -32,6 +32,10 @@ from .workdir import WorkdirError, confined
 
 WORKROOT: Final[Path] = Path.home() / "code/gentoo-install/lab/vm/tui"
 
+#: Milliseconds ncurses waits after a lone escape before delivering it. The
+#: default is 1000, which is longer than the walk's gap between keys.
+ESCDELAY: Final[int] = 25
+
 #: The console the menu is drawn on. Eighty by twenty-four is what the medium
 #: gives over a serial port and the smallest the interface supports, so a row
 #: that only fits a wider terminal is a defect an operator meets first.
@@ -567,8 +571,12 @@ def _open_menu(console: SerialConsole, lang: str) -> None:
     console.run(f"stty rows {LINES} cols {COLUMNS}")
     # `TERM` explicitly: a serial getty leaves it unset and curses then refuses
     # to start, which reads as the installer crashing.
+    # ESCDELAY, because ncurses holds a lone escape for a second waiting to see
+    # whether it starts a sequence: the walk's escape and the arrow key that
+    # follows it 0.5s later arrived as one keypress, so no row after the first
+    # was ever left and every one of them was reported as never opening.
     console.send_raw(
-        f"cd /tmp/driver && TERM=vt220 LINES={LINES} COLUMNS={COLUMNS} "
+        f"cd /tmp/driver && TERM=vt220 ESCDELAY={ESCDELAY} LINES={LINES} COLUMNS={COLUMNS} "
         f"python3 -m gentoo_install --lang {lang}\n"
     )
 


### PR DESCRIPTION
The first menu walk on a real 80-column console reported `enter opened nothing` for rows 1 to 19. The console showed why: after the Proxy screen opened, the next painted screen was the quit confirmation, and the main menu was never drawn again. ncurses' default ESCDELAY is 1000 ms and the walk sends its arrow 500 ms after the escape, so the two arrive as one key.