### PR TITLE
vm: the menu walk leaves a row with backspace, not escape

### DIFF
--- a/tests/unit/test_harness.py
+++ b/tests/unit/test_harness.py
@@ -1940,7 +1940,7 @@ def test_the_walk_waits_for_a_drawn_menu_after_the_echoed_launch_command(
         b"\x1b[24;1H[enter] Continue"
     )
     launch = (
-        f"cd /tmp/driver && TERM=vt220 ESCDELAY={tui.ESCDELAY} LINES=24 COLUMNS=80 "
+        "cd /tmp/driver && TERM=vt220 LINES=24 COLUMNS=80 "
         "python3 -m gentoo_install --lang en\n"
     )
 
@@ -4956,17 +4956,19 @@ def test_only_the_driver_module_names_a_cd_device() -> None:
     assert not guilty, guilty
 
 
-def test_the_walk_launches_the_menu_with_a_short_escape_delay() -> None:
-    """ncurses holds a lone escape for ESCDELAY milliseconds in case it starts
-    a sequence, and the default is 1000. The walk sends escape and then an
-    arrow 0.5s later, so with the default the two arrive as one key: the first
-    walk on a real console reported every row after the first as never
-    opening, and the console showed it never left the screen it had opened."""
+def test_the_walk_leaves_an_opened_row_with_backspace() -> None:
+    """Two walks on a real console reported `enter opened nothing` for every
+    row after the first, and the recorded screen showed why: the escape meant
+    for the opened row reached the main menu, where escape leaves the
+    installer. Over a serial line ncurses cannot tell a lone escape from an
+    arrow whose bytes arrived apart, so the walk sends none. Backspace is one
+    byte and every widget answers it with Back."""
     import inspect
 
     from tests.vm import tui
 
-    launch = inspect.getsource(tui._open_menu)
-    assert "ESCDELAY={ESCDELAY}" in launch, launch
-    assert tui.ESCDELAY < 500, tui.ESCDELAY
+    walking = inspect.getsource(tui.walk)
+    left = [line for line in walking.splitlines() if "send_raw" in line]
+    assert any(r"\x7f" in line for line in left), left
+    assert not any(line.strip().startswith('console.send_raw("\\x1b")') for line in left), left
 

--- a/tests/vm/tui.py
+++ b/tests/vm/tui.py
@@ -32,10 +32,6 @@ from .workdir import WorkdirError, confined
 
 WORKROOT: Final[Path] = Path.home() / "code/gentoo-install/lab/vm/tui"
 
-#: Milliseconds ncurses waits after a lone escape before delivering it. The
-#: default is 1000, which is longer than the walk's gap between keys.
-ESCDELAY: Final[int] = 25
-
 #: The console the menu is drawn on. Eighty by twenty-four is what the medium
 #: gives over a serial port and the smallest the interface supports, so a row
 #: that only fits a wider terminal is a defect an operator meets first.
@@ -571,12 +567,8 @@ def _open_menu(console: SerialConsole, lang: str) -> None:
     console.run(f"stty rows {LINES} cols {COLUMNS}")
     # `TERM` explicitly: a serial getty leaves it unset and curses then refuses
     # to start, which reads as the installer crashing.
-    # ESCDELAY, because ncurses holds a lone escape for a second waiting to see
-    # whether it starts a sequence: the walk's escape and the arrow key that
-    # follows it 0.5s later arrived as one keypress, so no row after the first
-    # was ever left and every one of them was reported as never opening.
     console.send_raw(
-        f"cd /tmp/driver && TERM=vt220 ESCDELAY={ESCDELAY} LINES={LINES} COLUMNS={COLUMNS} "
+        f"cd /tmp/driver && TERM=vt220 LINES={LINES} COLUMNS={COLUMNS} "
         f"python3 -m gentoo_install --lang {lang}\n"
     )
 
@@ -606,7 +598,7 @@ def walk(console: SerialConsole, lang: str) -> Walk:
             for line in body:
                 if cells(line) > COLUMNS:
                     seen.note(f"row {step}", f"{cells(line)} cells: {line!r}")
-        # Enter opens the row, then escape leaves it, then down moves on.
+        # Enter opens the row, backspace leaves it, then down moves on.
         console.send_raw("\r")
         time.sleep(1.0)
         screen.feed(console.snapshot(REDRAW_SECONDS))
@@ -614,11 +606,12 @@ def walk(console: SerialConsole, lang: str) -> Walk:
         for line in opened.lines:
             if cells(line) > COLUMNS:
                 seen.note(f"row {step} opened", f"{cells(line)} cells: {line!r}")
-        # Only when the row actually opened. Escape on the main menu leaves the
-        # installer, so sending it after a press that opened nothing ends the
-        # walk on its first row.
+        # Backspace, one byte, not escape: over a serial line ncurses splits
+        # `\x1b[B` often enough that a lone escape and a split arrow are the
+        # same thing to it, and the walk's escape reached the main menu, whose
+        # escape leaves the installer. Every widget answers `\x7f` with Back.
         if opened.opened_from(drawn):
-            console.send_raw("\x1b")
+            console.send_raw("\x7f")
             time.sleep(0.5)
         else:
             seen.note(f"row {step}", "enter opened nothing")


### PR DESCRIPTION
Two walks on a real 80-column console drew only `Proxy type` and then `Leave without installing?`, and reported `enter opened nothing` for rows 1 to 19. The escape meant for the opened row reached the main menu. #782's shorter ESCDELAY did not change the recording and is reverted; `\x7f` is one byte, and every widget answers it with Back.