### PR TITLE
vm: the menu walk cancels a row instead of editing it

### DIFF
--- a/tests/unit/test_harness.py
+++ b/tests/unit/test_harness.py
@@ -4956,19 +4956,20 @@ def test_only_the_driver_module_names_a_cd_device() -> None:
     assert not guilty, guilty
 
 
-def test_the_walk_leaves_an_opened_row_with_backspace() -> None:
-    """Two walks on a real console reported `enter opened nothing` for every
-    row after the first, and the recorded screen showed why: the escape meant
-    for the opened row reached the main menu, where escape leaves the
-    installer. Over a serial line ncurses cannot tell a lone escape from an
-    arrow whose bytes arrived apart, so the walk sends none. Backspace is one
-    byte and every widget answers it with Back."""
+def test_the_walk_cancels_a_row_rather_than_editing_it() -> None:
+    """The walk that left rows with backspace deleted a character inside the
+    hostname field and the menu came back reading `Hostname  gento`. Escape
+    cancels, which changes nothing, and the wait after it has to outlast
+    ncurses' ESCDELAY or the next key is read as the rest of a sequence and
+    the escape never arrives."""
     import inspect
 
     from tests.vm import tui
 
     walking = inspect.getsource(tui.walk)
-    left = [line for line in walking.splitlines() if "send_raw" in line]
-    assert any(r"\x7f" in line for line in left), left
-    assert not any(line.strip().startswith('console.send_raw("\\x1b")') for line in left), left
+    left = [line.strip() for line in walking.splitlines() if "send_raw" in line]
+    assert 'console.send_raw("\\x1b")' in left, left
+    assert not any(r"\x7f" in line for line in left), left
+    assert "time.sleep(ESCAPE_SETTLES)" in walking, walking
+    assert tui.ESCAPE_SETTLES > 1.0, tui.ESCAPE_SETTLES
 

--- a/tests/vm/tui.py
+++ b/tests/vm/tui.py
@@ -32,6 +32,10 @@ from .workdir import WorkdirError, confined
 
 WORKROOT: Final[Path] = Path.home() / "code/gentoo-install/lab/vm/tui"
 
+#: How long the walk waits after a lone escape. ncurses holds one for
+#: ESCDELAY, a second by default, in case it starts a sequence.
+ESCAPE_SETTLES: Final[float] = 1.5
+
 #: The console the menu is drawn on. Eighty by twenty-four is what the medium
 #: gives over a serial port and the smallest the interface supports, so a row
 #: that only fits a wider terminal is a defect an operator meets first.
@@ -606,13 +610,15 @@ def walk(console: SerialConsole, lang: str) -> Walk:
         for line in opened.lines:
             if cells(line) > COLUMNS:
                 seen.note(f"row {step} opened", f"{cells(line)} cells: {line!r}")
-        # Backspace, one byte, not escape: over a serial line ncurses splits
-        # `\x1b[B` often enough that a lone escape and a split arrow are the
-        # same thing to it, and the walk's escape reached the main menu, whose
-        # escape leaves the installer. Every widget answers `\x7f` with Back.
+        # Escape cancels, and cancelling is the only leave that changes
+        # nothing: backspace deletes inside a text field, and the walk that
+        # used it left the machine's hostname as `gento`.
         if opened.opened_from(drawn):
-            console.send_raw("\x7f")
-            time.sleep(0.5)
+            console.send_raw("\x1b")
+            # Longer than ncurses' ESCDELAY, which is a second by default: a
+            # key sent inside it is read as the rest of an escape sequence and
+            # the escape never reaches the screen it was meant to leave.
+            time.sleep(ESCAPE_SETTLES)
         else:
             seen.note(f"row {step}", "enter opened nothing")
         console.send_raw("\x1b[B")


### PR DESCRIPTION
The backspace walk got 20 screens and one finding, and the recording showed what the finding cost: inside the hostname field backspace deletes, so the menu came back reading `Hostname  gento` and the row the walk was still inside was reported as never opening. Escape cancels and changes nothing; the wait after it now outlasts ncurses' ESCDELAY.