### PR TITLE
tui: left goes back out of a field that arrived filled

### DIFF
--- a/gentoo_install/tui/widgets.py
+++ b/gentoo_install/tui/widgets.py
@@ -400,13 +400,18 @@ class TextField:
         typed = list(self.value)
         # Backspace leaves the screen only while the field is untouched: a
         # field that had content could not be cleared otherwise, and several
-        # of them mean something by empty.
+        # of them mean something by empty. Left always leaves, because a
+        # prefilled field otherwise has no way back at all: the hostname
+        # screen answered backspace by deleting and escape by offering to end
+        # the run.
         touched = False
         while True:
             self._draw(screen, typed)
             pressed = screen.key()
             if pressed in ("\n", "KEY_ENTER"):
                 return Answer(Outcome.CHOSE, "".join(typed))
+            if pressed == "KEY_LEFT":
+                return Answer(Outcome.BACK)
             if pressed in ("\x7f", "KEY_BACKSPACE"):
                 if typed:
                     typed.pop()
@@ -613,6 +618,8 @@ class Form:
             elif pressed == " " and cursor < len(self.fields) and self.fields[cursor].toggle:
                 typed[cursor] = [] if typed[cursor] else ["x"]
                 touched = True
+            elif pressed == "KEY_LEFT":
+                return Answer(Outcome.BACK)
             elif pressed in ("\x7f", "KEY_BACKSPACE"):
                 if cursor < len(self.fields) and typed[cursor] and not self.fields[cursor].toggle:
                     typed[cursor].pop()

--- a/tests/unit/test_harness.py
+++ b/tests/unit/test_harness.py
@@ -4956,20 +4956,19 @@ def test_only_the_driver_module_names_a_cd_device() -> None:
     assert not guilty, guilty
 
 
-def test_the_walk_cancels_a_row_rather_than_editing_it() -> None:
-    """The walk that left rows with backspace deleted a character inside the
-    hostname field and the menu came back reading `Hostname  gento`. Escape
-    cancels, which changes nothing, and the wait after it has to outlast
-    ncurses' ESCDELAY or the next key is read as the rest of a sequence and
-    the escape never arrives."""
+def test_the_walk_leaves_a_row_with_the_key_every_widget_answers() -> None:
+    """Two leave keys were tried on a real console and both were wrong.
+    Escape is Cancel, and `app.run` answers Cancel with the prompt that ends
+    the install: the recording held two screens and nineteen rows reported as
+    never opening. Backspace deletes inside a field the row arrived with
+    filled, and that walk left the machine calling itself `gento`."""
     import inspect
 
     from tests.vm import tui
 
     walking = inspect.getsource(tui.walk)
     left = [line.strip() for line in walking.splitlines() if "send_raw" in line]
-    assert 'console.send_raw("\\x1b")' in left, left
+    assert 'console.send_raw("\\x1b[D")' in left, left
     assert not any(r"\x7f" in line for line in left), left
-    assert "time.sleep(ESCAPE_SETTLES)" in walking, walking
-    assert tui.ESCAPE_SETTLES > 1.0, tui.ESCAPE_SETTLES
+    assert 'console.send_raw("\\x1b")' not in left, left
 

--- a/tests/unit/test_tui_widgets.py
+++ b/tests/unit/test_tui_widgets.py
@@ -181,6 +181,22 @@ def test_backspace_on_an_empty_field_goes_back() -> None:
     assert TextField(title="Hostname").run(FakeScreen(keys=["\x7f"])).outcome is Outcome.BACK
 
 
+def test_left_leaves_a_prefilled_field_without_editing_it() -> None:
+    """A field that arrives with a value answers backspace by deleting, and
+    escape by offering to end the run, so there was no way back out of the
+    hostname screen at all: a menu walk on a real console left the machine
+    calling itself `gento`."""
+    answer = TextField(title="Hostname", value="gentoo").run(FakeScreen(keys=["KEY_LEFT"]))
+    assert answer.outcome is Outcome.BACK
+    assert answer.value is None
+
+    filled = Form(
+        title="User account",
+        fields=[Field(label="name", value="zakk"), Field(label="shell", value="/bin/bash")],
+    )
+    assert filled.run(FakeScreen(keys=["KEY_LEFT"])).outcome is Outcome.BACK
+
+
 def test_a_password_is_not_drawn() -> None:
     screen = FakeScreen(keys=["s", "e", "c", "r", "e", "t", "\n"])
     assert TextField(title="Password", masked=True).run(screen).unwrap() == "secret"

--- a/tests/vm/tui.py
+++ b/tests/vm/tui.py
@@ -32,10 +32,6 @@ from .workdir import WorkdirError, confined
 
 WORKROOT: Final[Path] = Path.home() / "code/gentoo-install/lab/vm/tui"
 
-#: How long the walk waits after a lone escape. ncurses holds one for
-#: ESCDELAY, a second by default, in case it starts a sequence.
-ESCAPE_SETTLES: Final[float] = 1.5
-
 #: The console the menu is drawn on. Eighty by twenty-four is what the medium
 #: gives over a serial port and the smallest the interface supports, so a row
 #: that only fits a wider terminal is a defect an operator meets first.
@@ -610,15 +606,12 @@ def walk(console: SerialConsole, lang: str) -> Walk:
         for line in opened.lines:
             if cells(line) > COLUMNS:
                 seen.note(f"row {step} opened", f"{cells(line)} cells: {line!r}")
-        # Escape cancels, and cancelling is the only leave that changes
-        # nothing: backspace deletes inside a text field, and the walk that
-        # used it left the machine's hostname as `gento`.
+        # Left, which every widget answers with Back. Escape is Cancel and
+        # `app.run` answers that with the prompt that ends the install, and
+        # backspace deletes inside a field the row arrived with filled.
         if opened.opened_from(drawn):
-            console.send_raw("\x1b")
-            # Longer than ncurses' ESCDELAY, which is a second by default: a
-            # key sent inside it is read as the rest of an escape sequence and
-            # the escape never reaches the screen it was meant to leave.
-            time.sleep(ESCAPE_SETTLES)
+            console.send_raw("\x1b[D")
+            time.sleep(0.5)
         else:
             seen.note(f"row {step}", "enter opened nothing")
         console.send_raw("\x1b[B")


### PR DESCRIPTION
Walking the menu on a real 80-column console found a row with no way out: on the Hostname screen backspace deletes a character while the field has content, and escape is Cancel, which `app.run` answers with the prompt that ends the install. An operator who opens that row by accident has to retype the value or leave. Left already means Back in a menu; it now does in a field and a form, and the walk uses it.