### PR TITLE
TESTED: the translated menu fits the console too

### DIFF
--- a/TESTED.md
+++ b/TESTED.md
@@ -225,6 +225,7 @@ console, so what they stopped at is unknown. The open defect is row 238 of
 | Revision | What ran | Result |
 |---|---|---|
 | `d348174548035` | `python3 -m tests.vm.tui --lang en` on the official minimal medium, UEFI | opened all nineteen rows of the menu on an 80x24 serial console and read each screen back: 20 screens drawn, no line wider than the terminal, and every row returned to the menu. Nothing was installed; this record covers the interface, not an installation |
+| `1df424c0d0840` | the same walk with `--lang zh-TW` | 20 screens and no finding again, on a medium carrying no CJK font: every title was drawn from the catalog rather than the English source. What this measures is width, because a Han character takes two cells and a translated label is the one that overflows 80 columns |
 
 The walk is what `FakeScreen` cannot do. It found the Hostname screen had no
 way back, because backspace deletes while the field has content and escape is


### PR DESCRIPTION
`python3 -m tests.vm.tui --lang zh-TW` at `1df424c0d0840` drew 20 screens with no finding on a medium carrying no CJK font. A Han character takes two cells, so the layout that overflows 80 columns is the translated one and the English walk cannot see it.