### PR TITLE
vm: the prefix check says which half of it failed

### DIFF
--- a/tests/unit/test_cluster.py
+++ b/tests/unit/test_cluster.py
@@ -3095,18 +3095,24 @@ def test_a_conversion_counts_the_modules_its_bootloader_needs() -> None:
     for check, answer in (
         (GRUB_MODULES_CHECK, "grubmods=214\n"),
         (GRUB_READS_ITS_MODULE, "grubread=182672\n"),
-        (GRUB_PREFIX_CHECK, "grubprefix=1\n"),
+        (GRUB_PREFIX_CHECK, "grubstub=544768 grubprefix=1\n"),
     ):
         assert "wc -" in check.command or "grep -ac" in check.command
         assert not re.search(check.pattern, check.command)
         assert re.search(check.pattern, answer)
-        assert not re.search(check.pattern, answer.split("=")[0] + "=0\n")
+        assert not re.search(check.pattern, re.sub(r"=\d+", "=0", answer))
         assert not re.search(check.pattern, "")
 
     # The second reads through GRUB's own driver rather than the kernel's: a
     # module the kernel lists and GRUB cannot follow is the failure this
     # exists for.
     assert "grub-fstest" in GRUB_READS_ITS_MODULE.command
+
+    # The third answers with two counts, because a stub that is not there and
+    # a stub naming another filesystem are different defects and one number
+    # cannot tell them apart.
+    assert re.search(GRUB_PREFIX_CHECK.pattern, "grubstub=544768 grubprefix=0\n") is None
+    assert re.search(GRUB_PREFIX_CHECK.pattern, "grubstub=0 grubprefix=1\n") is None
 
 
 def test_the_unlock_addresses_go_back_after_the_guests_do() -> None:

--- a/tests/vm/convert.py
+++ b/tests/vm/convert.py
@@ -89,14 +89,16 @@ GRUB_READS_ITS_MODULE: Final[InstalledCheck] = InstalledCheck(
 #: Where `--bootloader-id=Gentoo` puts the stub the firmware starts.
 GRUB_STUB: Final[str] = "/efi/EFI/Gentoo/grubx64.efi"
 
-#: `grub-install` embeds `search.fs_uuid <uuid>` in the stub, and that uuid is
-#: what decides which filesystem `$prefix` is read from. The guest computes
-#: both sides, so the echo cannot answer it.
+#: `grub-install` embeds `search.fs_uuid <uuid>` in the stub as plain text,
+#: and that uuid is what decides which filesystem `$prefix` is read from. Two
+#: values because one cannot say which half failed: a stub that is not there
+#: and a stub that names another filesystem both counted zero.
 GRUB_PREFIX_CHECK: Final[InstalledCheck] = InstalledCheck(
     "grub's prefix",
-    "printf 'grubprefix=%s\\n' "
+    "printf 'grubstub=%s grubprefix=%s\\n' "
+    f"\"$(wc -c < {GRUB_STUB} 2>/dev/null || echo 0)\" "
     f"\"$(grep -ac \"$(grub-probe --target=fs_uuid /boot)\" {GRUB_STUB} 2>/dev/null)\"",
-    r"(?m)^grubprefix=[1-9][0-9]*$",
+    r"(?m)^grubstub=[1-9][0-9]* grubprefix=[1-9][0-9]*$",
 )
 
 


### PR DESCRIPTION
The first run of the prefix check failed with `grubprefix=0`, and that reads the same whether `/efi/EFI/Gentoo/grubx64.efi` is missing or is there and names another filesystem. Measured on this workstation that grub-mkimage keeps the embedded `search.fs_uuid` line as plain text, so the count is the right question; the stub's size now says which half answered zero.