### PR TITLE
vm: a dd fixture names the runner that can run it

### DIFF
--- a/tests/unit/test_harness.py
+++ b/tests/unit/test_harness.py
@@ -4972,3 +4972,26 @@ def test_the_walk_leaves_a_row_with_the_key_every_widget_answers() -> None:
     assert not any(r"\x7f" in line for line in left), left
     assert 'console.send_raw("\\x1b")' not in left, left
 
+
+def test_a_dd_fixture_names_the_runner_that_can_run_it(
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """`tests.vm.dd` generates the source image per run and stages it onto the
+    CD. Handed to the ordinary runner the fixture builds a guest, boots it and
+    stops at `image source ... is not a regular file` minutes later."""
+    from tests.vm import run as runner
+
+    code = runner.main(["--install", "fixtures/vm-dd-raw.toml", "--dry-run"])
+    said = capsys.readouterr()
+    assert code == 1, said
+    assert "tests.vm.dd" in said.err, said
+
+    # The control names a fixture this runner does own, with the firmware
+    # deliberately wrong so it is refused by the check below this one rather
+    # than booting a machine: the dd message belongs to the dd branch alone.
+    code = runner.main(["--install", "fixtures/ext4-bios.toml", "--firmware", "uefi"])
+    also = capsys.readouterr()
+    assert code == 1, also
+    assert "tests.vm.dd" not in also.err, also
+    assert "--firmware says uefi" in also.err, also
+

--- a/tests/vm/run.py
+++ b/tests/vm/run.py
@@ -739,7 +739,19 @@ def main(argv: list[str] | None = None) -> int:
         print("--boot-installed needs the same --install argument as the run it checks", file=sys.stderr)
         return 1
     if args.install:
-        wanted = load(REPOSITORY / "tests" / args.install).bootloader.firmware.value
+        chosen = load(REPOSITORY / "tests" / args.install)
+        if chosen.disk.mode is DiskMode.DD:
+            # Refused before a guest is built: the source image is generated
+            # per run and staged onto the CD by `tests.vm.dd`, so this runner
+            # boots a machine and stops at `image source ... is not a regular
+            # file` several minutes later.
+            print(
+                f"{args.install} streams a prepared image; run it with "
+                "python3 -m tests.vm.dd, which generates the source",
+                file=sys.stderr,
+            )
+            return 1
+        wanted = chosen.bootloader.firmware.value
         if wanted != args.firmware:
             # Refused here rather than after the install: a BIOS layout booted
             # with UEFI firmware reaches the EDK2 shell, and the run spends


### PR DESCRIPTION
`python3 -m tests.vm.run --install fixtures/vm-dd-raw.toml` builds a driver CD, boots a guest and stops three minutes later at `image source '/mnt/driver/fixtures/dd-source.raw' is not a regular file`, because that file is generated per run by `tests.vm.dd`. The refusal now comes before anything is built.