### PR TITLE
fetch: the stage3 is hashed once for one download

### DIFF
--- a/gentoo_install/exec/fetch.py
+++ b/gentoo_install/exec/fetch.py
@@ -142,16 +142,14 @@ def _stage3_from(
     _import_release_key(runner, work, selected)
     _verify_signature(digests, fingerprint, runner)
     try:
-        _verify_digest(archive, digests)
+        digest = _verify_digest(archive, digests)
     except ArchiveDigestMismatch:
         # Removed before the next mirror is asked: the download below skips a
         # file that is already there, so leaving the bad one would make every
         # fallback verify the same corrupt copy.
         archive.unlink(missing_ok=True)
         raise
-    marker.write_text(
-        f"{MARKER_SCHEMA}\n{name}\n{_sha512(archive)}\n{fingerprint.lower()}\n"
-    )
+    marker.write_text(f"{MARKER_SCHEMA}\n{name}\n{digest}\n{fingerprint.lower()}\n")
     return archive
 
 
@@ -1088,13 +1086,20 @@ def _signing_key(status: str) -> str | None:
     return None
 
 
-def _verify_digest(archive: Path, digests: Path) -> None:
+def _verify_digest(archive: Path, digests: Path) -> str:
+    """The archive's SHA-512, once it matches what `DIGESTS` says it is.
+
+    Answered rather than discarded: the marker beside the archive holds the
+    same digest, and computing it a second time reads a quarter of a gigabyte
+    off the disk again before anything is unpacked.
+    """
     wanted = _expected_sha512(digests, archive.name)
     got = _sha512(archive)
     if got != wanted:
         raise ArchiveDigestMismatch(
             f"{archive.name} has SHA512 {got}, the DIGESTS file says {wanted}"
         )
+    return got
 
 
 def _expected_sha512(digests: Path, name: str) -> str:

--- a/tests/unit/test_fetch.py
+++ b/tests/unit/test_fetch.py
@@ -377,3 +377,44 @@ def test_an_unreplaceable_stage3_tries_the_next_mirror_and_cleans_up(
     archive = tmp_path / "stage3.tar.xz"
     assert not archive.exists()
     assert not archive.with_suffix(archive.suffix + ".part").exists()
+
+
+def test_the_stage3_is_hashed_once_for_one_download(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """The archive is about a quarter of a gigabyte and it was read twice:
+    once to compare with `DIGESTS`, once again to write the marker beside it.
+    Both hashes are of the same bytes, so the second read is a disk pass an
+    install pays for before it can unpack anything."""
+    from gentoo_install.exec import fetch
+
+    archive = tmp_path / "stage3-amd64-systemd-1.tar.xz"
+    archive.write_bytes(b"the verified bytes")
+    digests = tmp_path / "stage3-amd64-systemd-1.tar.xz.DIGESTS"
+    digests.write_text(f"# SHA512 HASH\n{fetch._sha512(archive)}  {archive.name}\n")
+
+    reads = 0
+    real = fetch._sha512
+
+    def counted(path: Path) -> str:
+        nonlocal reads
+        reads += 1
+        return real(path)
+
+    monkeypatch.setattr(fetch, "_sha512", counted)
+    digest = fetch._verify_digest(archive, digests)
+    assert reads == 1, reads
+
+    # What the caller writes into the marker has to be the digest it was
+    # given, or the second read comes back with it.
+    key = "13EBBDBEDE7A12775DFDB1BABB572E0E2D182910"
+    marker = tmp_path / f"{archive.name}.verified"
+    marker.write_text(f"{fetch.MARKER_SCHEMA}\n{archive.name}\n{digest}\n{key.lower()}\n")
+    assert fetch._marker_matches(marker, archive, key)
+
+    # And the caller does not ask again: one call for the whole sequence.
+    import inspect
+
+    source = inspect.getsource(fetch._stage3_from)
+    assert "_sha512(archive)" not in source, source
+


### PR DESCRIPTION
`_verify_digest` hashed the archive to compare it with `DIGESTS` and discarded the answer; the marker written beside the archive then hashed the same bytes again. Both passes read about a quarter of a gigabyte, and they happen before anything is unpacked. Controls: a marker that recomputes the digest goes red, and a second hash inside the verify goes red.