### PR TITLE
portage: the recorded reason carries Portage's own diagnosis

### DIFF
--- a/gentoo_install/plan/portage.py
+++ b/gentoo_install/plan/portage.py
@@ -1006,10 +1006,15 @@ BINHOST_INDEX_FAILURE: Final[str] = "Error fetching binhost package info"
 #: Portage compiles everything and exits 0 after printing it, so nothing else
 #: in this file sees it: a run against a host whose index answered 404
 #: compiled all 69 of its packages in 84 minutes and recorded no reason.
+#: Portage prints its own diagnosis on the line after the one above, as
+#: `!!! [gentoo] <urlopen error [Errno -3] Temporary failure in name
+#: resolution>`. Captured, because without it the recorded reason says the
+#: host has no index when the guest could not resolve its name at all.
 _INDEX_UNREADABLE: Final[re.Pattern[str]] = re.compile(
     r"!!! \[(?P<host>[^\]]+)\] "
     + re.escape(BINHOST_INDEX_FAILURE)
     + r" from '(?P<url>[^']+)'"
+    + r"(?:\s*\n\s*!!! \[(?P=host)\] (?P<detail>[^\n]+))?"
 )
 
 
@@ -1018,7 +1023,9 @@ def _unreadable_index(said: str) -> str | None:
     found = _INDEX_UNREADABLE.search(said)
     if found is None:
         return None
-    return f"{found.group('host')} answered no package index at {found.group('url')}"
+    detail = (found.group("detail") or "").strip()
+    where = f"{found.group('host')} could not read its package index at {found.group('url')}"
+    return f"{where}: {detail}" if detail else where
 
 
 def _binhost_killed_emerge(result: CommandOutput) -> str | None:

--- a/tests/unit/test_plan_portage.py
+++ b/tests/unit/test_plan_portage.py
@@ -2640,3 +2640,37 @@ def test_the_pretend_resolves_against_the_packages_the_merge_will_use() -> None:
     assert "--getbinpkg=n" in pretend("ext2")
     assert "--getbinpkg=n" not in pretend("vm-binpkg")
 
+
+#: What Portage printed when the guest could not resolve the host's name,
+#: verbatim from `vm-binpkg` on run125.
+BINHOST_UNRESOLVED: Final[str] = (
+    "!!! [gentoo] Error fetching binhost package info from "
+    "'https://mirrors.nju.edu.cn/gentoo/releases/amd64/binpackages/23.0/x86-64'\n"
+    "!!! [gentoo] <urlopen error [Errno -3] Temporary failure in name resolution>\n"
+    "\n[gentoo] Local copy of unavailable remote index will be used due to --pretend\n"
+)
+
+
+def test_the_recorded_reason_carries_portage_own_diagnosis() -> None:
+    """`vm-binpkg` was recorded as `gentoo answered no package index at <url>`
+    while the guest's log said `[Errno -3] Temporary failure in name
+    resolution` on the next line. A reason that names the host's index sends
+    the reader to the mirror; the guest's resolver is where the fault was."""
+    from gentoo_install.plan import portage as plan_portage
+
+    said = plan_portage._unreadable_index(BINHOST_UNRESOLVED)
+    assert said is not None
+    assert "name resolution" in said, said
+    assert "answered no package index" not in said, said
+
+    # The timeout sample carries its own words, and neither reason invents a
+    # cause the log does not hold.
+    timed_out = plan_portage._unreadable_index(BINHOST_TIMED_OUT)
+    assert timed_out is not None and "timed out" in timed_out, timed_out
+
+    # Portage sometimes prints the first line alone; that still answers.
+    alone = plan_portage._unreadable_index(
+        "!!! [gentoo] Error fetching binhost package info from 'https://example.invalid/x'\n"
+    )
+    assert alone is not None and "example.invalid" in alone, alone
+


### PR DESCRIPTION
A binhost degradation was recorded as `gentoo answered no package index at <url>`, and the index answers 200 from here. Portage prints its diagnosis on the following line — `!!! [gentoo] <urlopen error [Errno -3] Temporary failure in name resolution>` — and the pattern stopped one line short, so a resolver failure inside the guest read as a broken mirror. Parsed against the two real samples: the timeout from `vm-gnome` and the resolution failure from `vm-binpkg` on run125.