### PR TITLE
cluster: the network verdict names what the guest was missing

### DIFF
--- a/tests/unit/test_proxmox.py
+++ b/tests/unit/test_proxmox.py
@@ -1163,9 +1163,16 @@ def test_the_network_wait_gives_up_rather_than_hanging(
     monkeypatch.setattr(cluster, "NETWORK_PATIENCE", 0.3)
     monkeypatch.setattr(cluster, "NETWORK_PAUSE", 0.05)
     link = cluster.Reconnecting(Down, tries=1)
-    with pytest.raises(ConsoleTimeout, match="no network"):
+    with pytest.raises(ConsoleTimeout, match="reached no mirror") as refused:
         cluster.wait_for_network(link)
     assert asked, "it asked at least once before giving up"
+
+    # What it held, not `no network`: `vm-gnome` gave up with an address, a
+    # default route and three resolvers, and every mirror answered `Could not
+    # contact DNS servers`. A verdict that says the guest had no network sends
+    # the reader to the segment when the fault is name resolution.
+    said = str(refused.value)
+    assert "address" in said and "route" in said and "resolver" in said, said
 
 
 def test_the_network_wait_returns_as_soon_as_the_guest_answers() -> None:

--- a/tests/vm/cluster.py
+++ b/tests/vm/cluster.py
@@ -1133,13 +1133,21 @@ def wait_for_network(
     # cluster guests failed here on one round and the log held nothing but
     # `Could not connect to server`, so nothing said whether the medium never
     # configured an interface or the cluster gave it no route.
-    for question in (
-        "ip -oneline address show",
-        "ip -4 route show default; ip -6 route show default",
-        "cat /etc/resolv.conf",
-    ):
-        link.run(question, timeout=60.0)
-    raise ConsoleTimeout(f"the guest had no network after {NETWORK_PATIENCE:.0f}s")
+    # Read, not only logged: `vm-gnome` gave up with `no network` while it
+    # held 10.31.0.154, a default route and our three resolvers, and every
+    # mirror answered `Could not contact DNS servers`. Which of the three was
+    # missing is what sends a reader to the segment or to the medium.
+    held = {
+        "address": link.expect_output("ip -oneline -4 address show scope global", 60.0),
+        "route": link.expect_output("ip -4 route show default", 60.0),
+        "resolver": link.expect_output("cat /etc/resolv.conf", 60.0),
+    }
+    missing = [name for name, said in held.items() if not said.strip()]
+    had = ", ".join(name for name in held if name not in missing) or "nothing"
+    raise ConsoleTimeout(
+        f"the guest reached no mirror in {NETWORK_PATIENCE:.0f}s; it had {had}"
+        + (f" and no {', '.join(missing)}" if missing else "")
+    )
 
 
 def stage_passphrases(link: Reconnecting, installation: InstallConfig) -> None:


### PR DESCRIPTION
`the guest had no network after 900s` was recorded for a guest holding 10.31.0.154, `default via 10.31.0.254` and `nameserver 10.31.0.199`; the mirrors failed with `Could not contact DNS servers`. The harness already asked for all three and only logged them, so the verdict sent the reader to the segment when the fault was resolution.