### PR TITLE
model: the profile release is written once for the whole package

### DIFF
--- a/gentoo_install/model/config.py
+++ b/gentoo_install/model/config.py
@@ -401,11 +401,19 @@ class Binhost:
     community: BinhostChannel = BinhostChannel.OFF
 
 
+#: The profile release every path in this installer is built against, and the
+#: profile a machine with no desktop is built on. Written once: the release
+#: was in four places across three layers and the test that pinned it read
+#: only `tui/`, so moving off it was four edits of which two were unguarded.
+PROFILE_RELEASE: Final[str] = "23.0"
+BASE_PROFILE: Final[str] = f"default/linux/amd64/{PROFILE_RELEASE}"
+
+
 @dataclass(frozen=True)
 class PortageConfig:
     #: Matches the default init. A systemd profile has `systemd` as a path
     #: component; the two disagreeing leaves packages built for the other.
-    profile: str = "default/linux/amd64/23.0/systemd"
+    profile: str = f"{BASE_PROFILE}/systemd"
     keywords: Keywords = Keywords.STABLE
     #: git by default: it carries the history a `verify-commit` sync checks,
     #: and it is what an ongoing system uses.

--- a/gentoo_install/model/mirrors.py
+++ b/gentoo_install/model/mirrors.py
@@ -12,7 +12,7 @@ from __future__ import annotations
 from dataclasses import dataclass
 from typing import Final
 
-from .config import GentooZhMirror, MirrorRegion
+from .config import PROFILE_RELEASE, GentooZhMirror, MirrorRegion
 
 
 @dataclass(frozen=True)
@@ -232,9 +232,9 @@ def gentoo_rsync_uri(region: MirrorRegion, preferred: str = "") -> str:
     return within or _GENTOO["gentoo"].rsync
 
 
-#: Where a mirror keeps the official binary packages for 23.0, relative to the
+#: Where a mirror keeps the official binary packages, relative to the
 #: distfiles base. Every site that carries the releases tree carries these.
-BINPACKAGES: Final[str] = "releases/amd64/binpackages/23.0"
+BINPACKAGES: Final[str] = f"releases/amd64/binpackages/{PROFILE_RELEASE}"
 
 
 def gentoo_binhost(region: MirrorRegion, preferred: str = "", subarch: str = "x86-64") -> str:

--- a/gentoo_install/tui/packages.py
+++ b/gentoo_install/tui/packages.py
@@ -16,6 +16,7 @@ from ..errors import ConfigError
 from ..i18n import Catalog
 from ..model import atoms
 from ..model.config import (
+    BASE_PROFILE,
     InitSystem,
     InstallConfig,
     Networking,
@@ -69,7 +70,7 @@ def _profile_for(profile: str, init: InitSystem) -> str:
 #: its own profile in `data/profiles/<name>.toml`.
 
 
-BASE_PROFILE: Final[str] = "default/linux/amd64/23.0"
+
 
 
 def desktop_profiles(groups: Groups, profile_paths: Sequence[str] = ()) -> dict[str, str]:

--- a/gentoo_install/tui/screens.py
+++ b/gentoo_install/tui/screens.py
@@ -18,6 +18,7 @@ from ..i18n import Catalog
 from ..exec import fetch
 from ..model import compat
 from ..model.config import (
+    BASE_PROFILE,
     SystemConfig,
     FirstBoot,
     ConsoleFontSize,
@@ -63,7 +64,6 @@ from ..plan.packages import FONT_CONFIGURATION_DISABLED, FONT_CONFIGURATION_ENAB
 from ..plan.packages import INPUT_CONFIGURATION_DISABLED, INPUT_CONFIGURATION_ENABLED
 from ..plan import system as plan_system
 from .packages import (
-    BASE_PROFILE,
     _profile_for,
     _record_operator,
     _set_font_configuration,

--- a/tests/unit/test_layers.py
+++ b/tests/unit/test_layers.py
@@ -144,17 +144,46 @@ def test_the_profile_release_is_written_once() -> None:
     `BASE_PROFILE`'s eleventh, so moving off 23.0 is eleven edits and the ten
     that are missed are silent: the menu offers a profile the tree no longer
     carries and the install stops at `emerge --sync`.
-    """
-    from gentoo_install.tui.packages import BASE_PROFILE
 
-    release = BASE_PROFILE.rsplit("/", 1)[1]
-    written = {
-        path.name: path.read_text(encoding="utf-8").count(release)
-        for path in sorted((PACKAGE / "tui").glob("*.py"))
-    }
-    assert {name: count for name, count in written.items() if count} == {
-        "packages.py": 1
-    }, written
+    The whole package, not `tui/`: reading one directory left the default in
+    `model/config.py` and the binary package path in `model/mirrors.py`
+    outside the rule, so the release was still written in three places.
+    """
+    from gentoo_install.model.config import PROFILE_RELEASE
+
+    # String literals, read with `ast`: a comment quoting a real log line is
+    # evidence and stays, and a release spelled inside a longer path — which
+    # is how `model/mirrors.py` carried its second copy — is still a copy.
+    written: dict[str, int] = {}
+    for path in sorted(PACKAGE.rglob("*.py")):
+        found = sum(
+            1
+            for node in ast.walk(ast.parse(path.read_text(encoding="utf-8")))
+            if isinstance(node, ast.Constant)
+            and isinstance(node.value, str)
+            and PROFILE_RELEASE in node.value
+        )
+        if found:
+            written[str(path.relative_to(PACKAGE))] = found
+    assert written == {"model/config.py": 1}, written
+
+    # And the paths that carry it are built from it rather than spelled again.
+    from gentoo_install.model.config import BASE_PROFILE
+    from gentoo_install.model.mirrors import BINPACKAGES
+
+    assert BASE_PROFILE.endswith(f"/{PROFILE_RELEASE}"), BASE_PROFILE
+    assert BINPACKAGES.endswith(f"/{PROFILE_RELEASE}"), BINPACKAGES
+
+    # The shipped desktop files spell the whole profile, and the menu rebuilds
+    # theirs with `str.replace(BASE_PROFILE, ...)`, which does nothing at all
+    # when it does not match: a release moved here and not there installs
+    # every desktop against the profile that is going away, silently.
+    import tomllib
+
+    for path in sorted((PACKAGE / "data" / "profiles").rglob("*.toml")):
+        said = tomllib.loads(path.read_text(encoding="utf-8")).get("profile", "")
+        if said:
+            assert said.startswith(BASE_PROFILE), (str(path), said)
 
 
 def test_every_source_file_states_the_licence() -> None:

--- a/tests/unit/test_tui_app.py
+++ b/tests/unit/test_tui_app.py
@@ -1832,7 +1832,9 @@ def test_the_desktops_offered_are_the_ones_with_a_profile_file() -> None:
     shipped = {path.stem for path in (Path(data.__file__).parent / "data/profiles").glob("*.toml")}
     # One row per file, plus the machine with no desktop at all.
     assert set(offered) == {"", *shipped}
-    assert offered[""] == tui_packages.BASE_PROFILE
+    from gentoo_install.model.config import BASE_PROFILE
+
+    assert offered[""] == BASE_PROFILE
     # Every desktop the menu shows can be built: the profile comes from its file.
     for name, path in offered.items():
         assert path.startswith("default/linux/amd64/23.0"), name


### PR DESCRIPTION
`23.0` was written in three modules across two layers and spelled again in four shipped profile files. The guard read `tui/` only, so two copies sat outside it, and `desktop_profiles` reconciles the files with `str.replace(BASE_PROFILE, …)` — a silent no-op when the release moved. The test now reads string literals across the package with `ast`, so a comment quoting a real log line stays evidence while a release inside a longer path is still a copy. Controls: moving the release with the data files left behind goes red; a second copy inside `releases/amd64/binpackages/23.0` goes red.