### PR TITLE
cli: the refusal says why the package site did not answer

### DIFF
--- a/gentoo_install/cli.py
+++ b/gentoo_install/cli.py
@@ -886,9 +886,10 @@ def _require_network() -> None:
     Alpine or Debian as well as on a Gentoo medium, and no install of any kind
     finishes without fetching a stage3.
     """
-    if not fetch.online():
+    if refused := fetch.why_offline():
         raise errors.PreflightFailed(
-            "this machine cannot reach packages.gentoo.org; the installer needs a network"
+            "this machine cannot reach packages.gentoo.org, so the version menu "
+            f"has nothing to read: {refused}"
         )
 
 

--- a/gentoo_install/exec/fetch.py
+++ b/gentoo_install/exec/fetch.py
@@ -441,10 +441,20 @@ def reachable(url: str, proxy: ProxyConfig | None = None) -> bool:
     return not (why_unreachable(url) if proxy is None else why_unreachable(url, proxy))
 
 
+def why_offline(proxy: ProxyConfig | None = None) -> str:
+    """Empty when the package site answers, and why it did not otherwise.
+
+    The url names one atom, so a rename upstream answers 404 while the network
+    is perfectly well: the caller refuses to start and the reason it gives has
+    to be the site's, not a guess about the machine.
+    """
+    url = f"{PACKAGES_API}/sys-kernel/gentoo-kernel-bin.json"
+    return why_unreachable(url) if proxy is None else why_unreachable(url, proxy)
+
+
 def online(proxy: ProxyConfig | None = None) -> bool:
     """Whether the package site answers. The menu reads every version from it."""
-    url = f"{PACKAGES_API}/sys-kernel/gentoo-kernel-bin.json"
-    return reachable(url) if proxy is None else reachable(url, proxy)
+    return not why_offline(proxy)
 
 
 def why_mirror_unreachable(

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -272,9 +272,17 @@ def test_an_install_stops_at_preflight_rather_than_touching_a_disk(
     assert "run as root" in printed or "not present" in printed
 
 
-def online(monkeypatch: pytest.MonkeyPatch, answer: bool = True) -> None:
-    """No test opens a connection: the answer is given rather than measured."""
+def online(monkeypatch: pytest.MonkeyPatch, answer: bool = True, said: str = "") -> None:
+    """No test opens a connection: the answer is given rather than measured.
+
+    Both spellings, because `cli` asks for the reason and everything else asks
+    the question: a double that answers one and not the other lets the caller
+    change which it uses without a test noticing.
+    """
     monkeypatch.setattr(fetch, "online", lambda: answer)
+    monkeypatch.setattr(
+        fetch, "why_offline", lambda: "" if answer else (said or "HTTP Error 503")
+    )
 
 
 def test_the_menu_stops_when_the_machine_cannot_reach_the_package_site(
@@ -283,9 +291,13 @@ def test_the_menu_stops_when_the_machine_cannot_reach_the_package_site(
     """Kernel versions and the ZFS ceiling are read live so the installer runs
     on a medium with no Gentoo repository; offline there is nothing to offer."""
     monkeypatch.setattr(os, "geteuid", lambda: 0)
-    online(monkeypatch, False)
+    online(monkeypatch, False, said="HTTP Error 404: Not Found")
     assert main([]) == EXIT_PREFLIGHT
-    assert "needs a network" in capsys.readouterr().err
+    said = capsys.readouterr().err
+    # The site's own answer, not a guess about the machine: the url names one
+    # atom, so a package rename upstream reads as a broken network.
+    assert "cannot reach packages.gentoo.org" in said, said
+    assert "HTTP Error 404: Not Found" in said, said
 
 
 def test_the_two_offline_answers_are_still_given_without_a_network(


### PR DESCRIPTION
`fetch.online()` asks `packages.gentoo.org` for `sys-kernel/gentoo-kernel-bin.json` and returns a bool, so the day that atom is renamed the installer refuses to start with `this machine cannot reach packages.gentoo.org; the installer needs a network` — an accusation about the machine when the site answered 404. `why_unreachable` exists to carry the reason out and is already used by the mirror probe; `why_offline` is the same thing for this one.