### PR TITLE
cluster: each schedule rewrites its fixtures into its own directory

### DIFF
--- a/tests/unit/test_cluster.py
+++ b/tests/unit/test_cluster.py
@@ -3168,3 +3168,32 @@ def test_the_unlock_addresses_go_back_after_the_guests_do() -> None:
     assert abandoned and released, ast.dump(ast.Module(body=closing, type_ignores=[]))
     assert abandoned[0] < released[0], [abandoned, released]
 
+
+def test_each_schedule_rewrites_its_fixtures_into_its_own_directory(tmp_path: Path) -> None:
+    """Every schedule on this machine shares one work directory, and the
+    verdict re-reads the configuration file after the guest is installed.
+    `static-ip` was installed with `10.31.0.172/24` from its own reservation,
+    a later schedule rewrote the same path with `10.31.0.186/24`, and the
+    check then failed the machine for not holding an address nothing had ever
+    asked it for."""
+    from tests.vm import cluster
+
+    first = cluster._fixture_dir(tmp_path)
+    second = cluster._fixture_dir(tmp_path)
+    assert first != second, first
+    assert first.parent == tmp_path and second.parent == tmp_path
+
+    # And the writer keeps them apart: the same fixture name rewritten by two
+    # schedules leaves two files, each holding what its own guest was given.
+    for where, address in ((first, "10.31.0.172/24"), (second, "10.31.0.186/24")):
+        where.mkdir()
+        (where / "static-ip.toml").write_text(f'addresses = ["{address}"]\n')
+    assert (first / "static-ip.toml").read_text() != (second / "static-ip.toml").read_text()
+
+    # The scheduler asks for one rather than naming a fixed path.
+    import inspect
+
+    source = inspect.getsource(cluster.run)
+    assert "_fixture_dir(workdir)" in source, source[:200]
+    assert 'workdir / "fixtures"' not in source, source[:200]
+

--- a/tests/vm/cluster.py
+++ b/tests/vm/cluster.py
@@ -1162,6 +1162,18 @@ def stage_passphrases(link: Reconnecting, installation: InstallConfig) -> None:
         link.run(command)
 
 
+def _fixture_dir(workdir: Path) -> Path:
+    """Where this schedule writes the configurations its guests are given.
+
+    Its own directory, because every schedule shares `workdir` and the verdict
+    re-reads the file after the guest is installed: `static-ip` was installed
+    with `10.31.0.172/24`, a later schedule rewrote the same file with its own
+    reservation, and the check then failed the machine for not holding
+    `10.31.0.186/24` — an address nothing had ever asked it for.
+    """
+    return workdir / f"fixtures-{uuid.uuid4().hex[:12]}"
+
+
 def rewrite_fixtures(
     jobs: list[Job],
     into: Path,
@@ -2029,7 +2041,7 @@ def run(
     public_key = remote_key.with_suffix(".pub").read_text().strip() if remote_key else ""
     # Packed: the ingress refuses the 1.4 MiB loose-file CD with `413`.
     staging = workdir / f".driver-{uuid.uuid4().hex}.iso"
-    fixture_dir = workdir / "fixtures"
+    fixture_dir = _fixture_dir(workdir)
     # Reserved before the CD is written, not at dispatch: a fixture that
     # unlocks over SSH pins the initramfs address, and the harness has to ssh
     # to that address. `vm-unlock` carried `192.0.2.10`, which is a


### PR DESCRIPTION
run128's `static-ip` was installed with `10.31.0.172/24` — its own reservation, and the plan line in its log says so — and failed with `the installed system does not say '10.31.0.186/24'`. `lab/vm/cluster/fixtures/static-ip.toml` on disk now holds `10.31.0.186/24`: a later schedule rewrote the shared file, and `job.installed_config` points at that mutable path rather than at what the driver CD carried.