### PR TITLE
cli: --ssh-key names every source it already takes

### DIFF
--- a/gentoo_install/cli.py
+++ b/gentoo_install/cli.py
@@ -165,7 +165,11 @@ def parser() -> argparse.ArgumentParser:
     parsed.add_argument(
         "--ssh-key",
         default="",
-        help="a readable public-key file or an ssh- prefixed public key for the memory environment",
+        help=(
+            "the public key the memory environment authorises: a key itself "
+            "(`ssh-ed25519 ...`, `ssh-rsa ...`, `ecdsa-sha2-nistp256/384/521 ...`), "
+            "a file, an https:// or http:// URL, or github:/gitlab: and a username"
+        ),
     )
     parsed.add_argument(
         "--ssh-port",

--- a/gentoo_install/model/authorized.py
+++ b/gentoo_install/model/authorized.py
@@ -73,8 +73,10 @@ def classify(value: str) -> KeySource:
         return KeySource(KeySourceKind.LITERAL, candidate)
     # Before the path: `ftp://host/key` is a scheme this cannot fetch, and
     # treating it as a filename reports a missing file instead of saying so.
+    # A single letter is a Windows drive rather than a scheme, and the honest
+    # answer for `C:\keys\id.pub` is that no such file is here.
     named = _SCHEME.match(candidate)
-    if named is not None:
+    if named is not None and len(named.group()) > 2:
         raise ConfigError(f"unknown --ssh-key source scheme: {named.group()[:-1]}")
     return KeySource(KeySourceKind.PATH, candidate)
 

--- a/tests/unit/test_model_authorized.py
+++ b/tests/unit/test_model_authorized.py
@@ -40,6 +40,18 @@ CASES: tuple[tuple[str, KeySource], ...] = (
     ),
     ("github:zakkaus", KeySource(KeySourceKind.URL, "https://github.com/zakkaus.keys")),
     ("gitlab:zakkaus", KeySource(KeySourceKind.URL, "https://gitlab.com/zakkaus.keys")),
+    # A drive letter, not a scheme: the operator copying a command line from
+    # Windows is told the file is not here, which is true, rather than that
+    # `C:` is a transport this installer cannot fetch.
+    (
+        r"C:\Users\zakk\.ssh\id_ed25519.pub",
+        KeySource(KeySourceKind.PATH, r"C:\Users\zakk\.ssh\id_ed25519.pub"),
+    ),
+    (_key("ssh-rsa"), KeySource(KeySourceKind.LITERAL, _key("ssh-rsa"))),
+    (
+        _key("ecdsa-sha2-nistp521"),
+        KeySource(KeySourceKind.LITERAL, _key("ecdsa-sha2-nistp521")),
+    ),
 )
 
 
@@ -56,6 +68,29 @@ def test_the_cases_cover_every_kind_and_every_shorthand() -> None:
         assert any(value.startswith(f"{service}:") for value, _ in CASES), service
     for scheme in SCHEMES:
         assert any(value.startswith(scheme) for value, _ in CASES), scheme
+
+    # Every key type the checker accepts is a form somebody may paste, and
+    # `--help` names three of them: those three are classified here.
+    from gentoo_install.model import sshkey
+
+    for kind in ("ssh-ed25519", "ssh-rsa", "ecdsa-sha2-nistp521"):
+        assert kind in sshkey.KEY_TYPES, kind
+        assert any(value.startswith(f"{kind} ") for value, _ in CASES), kind
+
+
+def test_the_help_names_every_source_the_classifier_takes() -> None:
+    """The option took a URL and `github:` from the day it was written and
+    named neither, so an operator reading `--help` had no way to know: the
+    form was asked about as though it did not exist, and it had always
+    worked."""
+    import inspect
+
+    from gentoo_install import cli
+
+    source = inspect.getsource(cli)
+    said = source[source.index('"--ssh-key"') : source.index('"--ssh-port"')]
+    for named in ("ssh-ed25519", "ssh-rsa", "ecdsa-sha2-nistp", "http", "github:", "gitlab:"):
+        assert named in said, (named, said)
 
 
 @pytest.mark.parametrize("value", ("", "   ", "\n"))


### PR DESCRIPTION
`--ssh-key github:zakkaus`, `--ssh-key https://…`, a literal `ssh-rsa`/`ssh-ed25519`/`ecdsa-sha2-nistp256|384|521` key and a path all work today; `--help` named two of them, so the rest read as unsupported. `C:\path\to\key.pub` was refused as `unknown --ssh-key source scheme: C` — a single letter is a drive, and the honest answer is that no such file is here.