### PR TITLE
vm: the verdict reads a vfat serial as a filesystem name too

### DIFF
--- a/tests/unit/test_cluster.py
+++ b/tests/unit/test_cluster.py
@@ -3098,7 +3098,7 @@ def test_a_conversion_counts_the_modules_its_bootloader_needs() -> None:
         (
             GRUB_PREFIX_CHECK,
             "grubstub=163840 grubprefix=1 boot=c866ae3a-68e7-4096-9703-dfa17070c3ed"
-            " stub=c866ae3a-68e7-4096-9703-dfa17070c3ed\n",
+            " esp=1234-ABCD stub=c866ae3a-68e7-4096-9703-dfa17070c3ed\n",
         ),
     ):
         assert "wc -" in check.command or "grep -ac" in check.command
@@ -3115,7 +3115,7 @@ def test_a_conversion_counts_the_modules_its_bootloader_needs() -> None:
     # The third answers with two counts, because a stub that is not there and
     # a stub naming another filesystem are different defects and one number
     # cannot tell them apart.
-    healthy = "grubstub=163840 grubprefix=1 boot=aaaa stub=aaaa\n"
+    healthy = "grubstub=163840 grubprefix=1 boot=aaaa esp=1234-ABCD stub=aaaa\n"
     assert re.search(GRUB_PREFIX_CHECK.pattern, healthy)
     assert re.search(GRUB_PREFIX_CHECK.pattern, healthy.replace("prefix=1", "prefix=0")) is None
     assert re.search(GRUB_PREFIX_CHECK.pattern, healthy.replace("stub=163840", "stub=0")) is None
@@ -3126,7 +3126,22 @@ def test_a_conversion_counts_the_modules_its_bootloader_needs() -> None:
     # uuid once. `vm-convert` reported the same size and no uuid, so the check
     # asks for both sides of the comparison and the verdict names them.
     assert "grub-probe --target=fs_uuid /boot" in GRUB_PREFIX_CHECK.command
-    assert "boot=%s stub=%s" in GRUB_PREFIX_CHECK.command
+    assert "boot=%s esp=%s stub=%s" in GRUB_PREFIX_CHECK.command
+    # The values, not only the format: printf keeps the field and prints it
+    # empty when the argument goes, so the two probes are named here.
+    assert GRUB_PREFIX_CHECK.command.count("grub-probe --target=fs_uuid /boot") == 2
+    assert "grub-probe --target=fs_uuid /efi" in GRUB_PREFIX_CHECK.command
+
+    # `vm-convert` answered `stub=` empty while the stub was 163840 bytes: the
+    # reader looked for a 36-character uuid alone, and a vfat esp is named by
+    # an eight-digit serial. Both forms are read now, so an empty answer means
+    # the stub carries no filesystem at all rather than one this could not see.
+    import re as _re
+
+    reader = _re.compile(r"[0-9a-fA-F]{8}-([0-9a-fA-F]{4}-){3}[0-9a-fA-F]{12}|[0-9A-F]{4}-[0-9A-F]{4}")
+    assert reader.search("1234-ABCD"), "a vfat serial is a filesystem name too"
+    assert reader.search("c866ae3a-68e7-4096-9703-dfa17070c3ed")
+    assert reader.pattern in GRUB_PREFIX_CHECK.command, GRUB_PREFIX_CHECK.command
 
 
 def test_the_unlock_addresses_go_back_after_the_guests_do() -> None:

--- a/tests/vm/convert.py
+++ b/tests/vm/convert.py
@@ -98,17 +98,20 @@ GRUB_STUB: Final[str] = "/efi/EFI/Gentoo/grubx64.efi"
 #: beside the count so a failure says which filesystem GRUB will look for
 #: instead of only that it is the wrong one.
 _STUB_UUID: Final[str] = (
-    r"grep -aoE '[0-9a-f]{8}-([0-9a-f]{4}-){3}[0-9a-f]{12}' " + GRUB_STUB + " 2>/dev/null | head -n 1"
+    r"grep -aoE '[0-9a-fA-F]{8}-([0-9a-fA-F]{4}-){3}[0-9a-fA-F]{12}|[0-9A-F]{4}-[0-9A-F]{4}' "
+    + GRUB_STUB
+    + " 2>/dev/null | head -n 1"
 )
 
 GRUB_PREFIX_CHECK: Final[InstalledCheck] = InstalledCheck(
     "grub's prefix",
-    "printf 'grubstub=%s grubprefix=%s boot=%s stub=%s\\n' "
+    "printf 'grubstub=%s grubprefix=%s boot=%s esp=%s stub=%s\\n' "
     f"\"$(wc -c < {GRUB_STUB} 2>/dev/null || echo 0)\" "
     f"\"$(grep -ac \"$(grub-probe --target=fs_uuid /boot)\" {GRUB_STUB} 2>/dev/null)\" "
     "\"$(grub-probe --target=fs_uuid /boot 2>/dev/null)\" "
+    "\"$(grub-probe --target=fs_uuid /efi 2>/dev/null)\" "
     f"\"$({_STUB_UUID})\"",
-    r"(?m)^grubstub=[1-9][0-9]* grubprefix=[1-9][0-9]* boot=\S+ stub=\S+$",
+    r"(?m)^grubstub=[1-9][0-9]* grubprefix=[1-9][0-9]* boot=\S+ esp=\S+ stub=\S+$",
 )
 
 


### PR DESCRIPTION
run133 answered `grubstub=163840 grubprefix=0 boot=11f84ba8-3448-46a3-b7fe-d4bc8474ada3 stub=`. An empty `stub=` beside a stub of the right size means the reader could not see what it carries, not that it carries nothing: a vfat esp is named `XXXX-XXXX`, which the 36-character pattern misses. Both forms are read now and the esp's own name is printed, so the next failure distinguishes "searches for the esp" from "searches for nothing".