### PR TITLE
tests: assert what the pointer test's call returned

### DIFF
--- a/tests/unit/test_stage3_pointer.py
+++ b/tests/unit/test_stage3_pointer.py
@@ -80,8 +80,9 @@ def test_the_variant_picks_the_pointer(monkeypatch: pytest.MonkeyPatch, variant:
         return POINTER.replace("systemd", variant)
 
     monkeypatch.setattr(fetch, "_read", record)
-    fetch._newest("https://distfiles.gentoo.org/releases/amd64/autobuilds", variant)
+    found = fetch._newest("https://distfiles.gentoo.org/releases/amd64/autobuilds", variant)
     assert asked[0].endswith(f"latest-stage3-amd64-{variant}.txt")
+    assert found == f"20260802T163058Z/stage3-amd64-{variant}-20260802T163058Z.tar.xz"
 
 
 def test_the_pause_between_attempts_grows(monkeypatch: pytest.MonkeyPatch) -> None:


### PR DESCRIPTION
`test_the_variant_picks_the_pointer` discarded `_newest()`'s return value and asserted only the URL it asked for. Returning `sorted(paths)[-1].split("/")[-1]` — the bare name rather than the dated path, which is the defect the file's first test exists for — left it green in all three variants.