### PR TITLE
readme: name every command-line option and configuration key

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -69,6 +69,26 @@ cd gentoo-install-master
 
 対話型インストールでは、成功時と失敗時のどちらでも、アンマウント前にターゲットシステム内で root シェルを開く選択肢が提示されます。`--no-shell` を使用すると、この確認を省略できます。
 
+| オプション | 引数と既定値 | 効果 |
+| --- | --- | --- |
+| `--config` | file または URL; unset | メニューを開かずに、そのソースを読み込みます。 |
+| `--dry-run` | none; `false` | 派生した操作と概要を表示し、操作を適用せずに終了します。 |
+| `--mirror` | stage3 mirror string; installer default | 通常のインストールで使用する stage3 のソースを選択します。メモリ起動の設定では、地域を設定から導出します。 |
+| `--lang` | language tag; `""` | メニューが設定を作成する間、`LC_ALL`、`LC_MESSAGES`、`LANG` を上書きします。 |
+| `--target` | path; `/mnt/gentoo` | 通常のインストールのマウント先を選択します。変換とメモリ起動の設定では `/` を使用します。 |
+| `--work` | path; `/run/gentoo-install` | レポートとジャーナルを含む実行状態を保持します。 |
+| `--missing-commands` | none; `false` | 不足しているホストコマンドを一行に一つずつ表示して終了します。 |
+| `--resume` | none; `false` | 既存のジャーナルを使用して、互換性のある完了済み操作を省略します。 |
+| `--no-shell` | none; `false` | ターゲットの root シェルを提示しません。メモリ起動の設定も無人で行います。 |
+| `--skip-preflight` | none; `false` | 通常のインストールの事前検査を省略します。 |
+| `--ram` | none; unset memory mode | メモリ上に保持した Gentoo CJK ISO への一回の起動を設定します。`--lowram` とは競合します。 |
+| `--lowram` | none; unset memory mode | メモリ上に保持した Alpine netboot 環境への一回の起動を設定します。`--ram` とは競合します。 |
+| `--ssh-key` | key, file, HTTP(S) URL, or `github:`/`gitlab:` reference; `""` | メモリ環境で認証される公開鍵を設定します。メモリモードが必要です。 |
+| `--ssh-port` | integer; unset | メモリ環境の `sshd` ポートを設定します。メモリモードが必要です。 |
+| `--root-password` | string; `""` | メモリ環境の root パスワードを設定します。メモリモードが必要です。 |
+| `--bypass` | none; `false` | 一回限りの起動項目を設定する代わりに、既定の起動項目を置き換えます。メモリモードが必要です。 |
+| `--disarm` | none; `false` | 以前に設定されたメモリ起動と、設定の読み込み前に配置されたファイルを削除します。 |
+
 ## メモリからのインストール
 
 <!-- fact: install-memory -->
@@ -148,6 +168,31 @@ mode = "in-place"
 - デバイスグラフは、GPT と MBR のパーティションテーブル、ext2、ext3、ext4、xfs、f2fs、vfat、subvolume を含む btrfs、swap、LUKS2 暗号化、LVM、mdraid を扱います。
 - ZFS も同じグラフに属します。プールは vdev の上で stripe、mirror、raidz1、raidz2、raidz3 のいずれかを取り、ネイティブ暗号化はプールの属性であり、各 dataset はそれぞれ独立したノードです。
 - 既存のパーティションテーブルを保持し、各パーティションに対して保持、フォーマット、削除のいずれかを個別に指定できます。
+
+| モデルノード | `id` 以外のフィールド | 結果 |
+| --- | --- | --- |
+| `Existing` | `selector`, `wipe` | 既存のデバイスを選択します。 |
+| `PartitionTable` | `disk`, `table`, `create`, `remove` | パーティションテーブルを作成または編集します。 |
+| `Partition` | `table`, `index`, `role`, `size`, `label` | パーティションを定義します。最後の `size` は残りの領域を消費できます。 |
+| `Luks` | `backing`, `name`, `passphrase_file` | LUKS コンテナを定義します。 |
+| `MdRaid` | `members`, `level`, `name`, `metadata` | mdraid アレイを定義します。 |
+| `VolumeGroup` | `members`, `name` | LVM ボリュームグループを定義します。 |
+| `LogicalVolume` | `group`, `name`, `size` | LVM 論理ボリュームを定義します。 |
+| `ZfsPool` | `vdevs`, `name`, `topology`, `encrypted`, `passphrase_file` | ZFS プールを定義します。 |
+| `ZfsDataset` | `pool`, `name` | ZFS dataset を定義します。 |
+| `Filesystem` | `device`, `kind`, `label`, `create` | デバイスをフォーマットします。`create = false` の場合は検証します。 |
+| `Subvolume` | `filesystem`, `name` | Btrfs subvolume を定義します。 |
+| `Swap` | `device` | 参照されたデバイス上の swap を定義します。 |
+| `Mountpoint` | `source`, `path`, `options` | ファイルシステム、Btrfs subvolume、または ZFS dataset をマウントします。 |
+
+| 選択肢 | 値 |
+| --- | --- |
+| パーティションテーブル | `gpt`, `mbr` |
+| パーティションの役割 | `esp`, `bios-boot`, `swap`, `raid`, `lvm`, `zfs`, `data` |
+| mdraid レベル | `raid0`, `raid1`, `raid5`, `raid6` |
+| mdraid メタデータ | `0.90`, `1.0`, `1.1`, `1.2` |
+| ファイルシステム | `ext2`, `ext3`, `ext4`, `btrfs`, `xfs`, `f2fs`, `vfat` |
+| ZFS トポロジ | `stripe`, `mirror`, `raidz1`, `raidz2`, `raidz3` |
 
 <!-- fact: zram-system -->
 
@@ -241,6 +286,34 @@ mode = "in-place"
 - メニューは設定を `paste.gentoozh.org` にアップロードする前に、`password_hash` と `root_password_hash` の値を `removed-before-publishing` に置き換え、プロキシの `username` と `password` は鍵ごと出力しません。
 - その他の設定値はアップロードに残ります。メニューはアップロード先ページのアドレスをテキストと QR コードで表示します。
 
+### 互換性規則
+
+検証では次の組み合わせを拒否します。
+
+| 拒否される組み合わせ |
+| --- |
+| パスワード認証するユーザーも、利用可能な SSH 鍵によるログインもない状態で、root ハッシュが空、ロック済み、または不正な形式である組み合わせ。 |
+| ZFS root と GRUB の組み合わせ。 |
+| GRUB を使用する ZFS 上の `/boot`。 |
+| BIOS 起動と ZFS root の組み合わせ。 |
+| LUKS root chain と ZFS root の組み合わせ。 |
+| ZFS ではない root と ZFSBootMenu の組み合わせ。 |
+| マウントされた ESP がない UEFI 起動。 |
+| 暗号化された ESP を使用する UEFI 起動。 |
+| BIOS 起動と systemd-boot の組み合わせ。 |
+| `/boot` が暗号化されているか vfat ではないため、ESP から kernel または initramfs にアクセスできない systemd-boot。 |
+| メタデータが `1.1` または `1.2` である mdraid 上の ESP。 |
+| `bios-boot` パーティションがない GPT ディスク上の BIOS 起動。 |
+| cjktty を欠く kernel での CJK コンソール描画。 |
+| 認証済み SSH 鍵がないリモート解除。 |
+| 暗号化された root コンテナまたはプールがないリモート解除。 |
+| initramfs SSH が開始する前に `/boot` を解除しなければならない GRUB を使用するリモート解除。 |
+| GRUB または systemd-boot のシステム initramfs によるネイティブ ZFS 暗号化のリモート解除。 |
+| `gentoo-zh` overlay がない CJK kernel。 |
+| `8x16` 以外のコンソールフォントによる CJK コンソール描画。 |
+| `gentoo-zh` overlay がない ZFSBootMenu。 |
+| `gentoo-zh` overlay がない gentoo-zh community binhost。 |
+
 ## 検証状況
 
 <!-- fact: verification-scope -->
@@ -277,6 +350,166 @@ mode = "in-place"
 <!-- fact: config-dry-run -->
 
 解析と計画ではストレージハードウェアを調査しないため、ターゲットディスクがないマシンでも `--dry-run` で設定を確認できます。
+
+次の参照は、永続化されるすべてのキーを挙げます。テーブルのパスは TOML テーブル記法であり、`[[disk.devices]]` にはグラフノードが格納されます。
+
+| キー | 意味と既定値または選択肢 |
+| --- | --- |
+| `config_version` | 永続化されるスキーマバージョン。`1`。 |
+| `proxy.kind` | プロキシスキーム。`http`、`https`、または `socks5`。既定値は `http` です。 |
+| `proxy.host` | プロキシホスト。`""` でプロキシを無効にします。 |
+| `proxy.port` | プロキシポート。`0`。 |
+| `proxy.username` | 任意のプロキシユーザー名。`""`。 |
+| `proxy.password` | 任意のプロキシパスワード。`""`。 |
+| `proxy.bypass` | プロキシをバイパスするホスト。`[]`。 |
+
+| `system` キー | 意味と既定値または選択肢 |
+| --- | --- |
+| `hostname` | ターゲットのホスト名。`gentoo`。 |
+| `timezone` | ターゲットのタイムゾーン。`Asia/Shanghai`。 |
+| `locales` | 生成する locale。`en_US.UTF-8`、`zh_CN.UTF-8`、`zh_TW.UTF-8`。 |
+| `locale` | 選択する locale。`zh_CN.UTF-8`。 |
+| `keymap` | インストール後のシステムのキーマップ。`us`。 |
+| `keymap_initramfs` | initramfs のキーマップ。`""` は `keymap` に従います。 |
+| `interface` | ネットワークインターフェースパターン。`""` は `en*` と `eth*` に一致します。 |
+| `addresses` | 静的 CIDR アドレス。`[]` は DHCP またはルーター広告を選択します。 |
+| `gateways` | ゲートウェイ。アドレスファミリーごとに最大一つです。`[]`。 |
+| `dns` | リゾルバーアドレス。`[]`。 |
+| `authorized_keys` | root および sudo ユーザー用の鍵。`[]`。 |
+| `console_cjk` | CJK コンソール描画を要求します。`false`。cjktty が必要です。 |
+| `console_font` | コンソールのセルサイズ。`8x8`、`8x16`、または `16x32`。既定値は `8x16` です。 |
+| `init` | init システム。`openrc` または `systemd`。既定値は `systemd` です。 |
+| `zram` | 圧縮 RAM の swap サイズ。unset では無効です。 |
+| `hardware_clock_utc` | RTC に UTC を保存します。`true`。 |
+| `users` | ユーザーレコード。`[]`。 |
+| `root_password_hash` | root の `crypt(3)` hash。`""` は root をロックします。 |
+| `logger` | logger。`none`、`sysklogd`、`syslog-ng`、または `metalog`。既定値は `sysklogd` です。 |
+| `cron` | `sys-process/cronie` をインストールします。`true`。 |
+| `sshd` | SSH デーモンのサポートをインストールして設定します。`false`。 |
+| `sshd_password_login` | SSH デーモンがパスワードを受け入れます。`false`。 |
+| `sshd_root_login` | root が SSH でログインできます。`false`。 |
+| `networking` | リンク管理。`builtin`、`networkmanager-wpa`、`networkmanager-iwd`、または `none`。既定値は `builtin` です。 |
+| `firewall` | パケットフィルターパッケージ。`none`、`nftables`、または `iptables`。既定値は `none` です。 |
+| `first_boot` | 初回起動レコード。既定では空のレコードです。 |
+
+| `system.users` 項目 | 意味と既定値 |
+| --- | --- |
+| `name` | ユーザー名。必須です。 |
+| `groups` | 補助グループ。`[]`。 |
+| `shell` | ログインシェル。`/bin/bash`。 |
+| `sudo` | ユーザーを sudo ユーザーにします。`false`。 |
+| `password_hash` | ユーザーの `crypt(3)` hash。`""` はアカウントをロックします。 |
+
+| `system.first_boot` キー | 意味と既定値 |
+| --- | --- |
+| `commands` | 取得したスクリプトの後に順番に実行するシェル行。`[]`。 |
+| `url` | スクリプト URL。`""` は取得したスクリプトを省略します。 |
+
+| `portage` キー | 意味と既定値または選択肢 |
+| --- | --- |
+| `profile` | Portage プロファイル。`default/linux/amd64/23.0/systemd`。 |
+| `keywords` | グローバルキーワードチャネル。`stable` または `testing`。既定値は `stable` です。 |
+| `sync` | 継続同期。`git`、`webrsync`、または `rsync`。既定値は `git` です。最初の同期では `webrsync` を使用します。 |
+| `testing_packages` | システムが stable のままで受け入れる testing の atom。`[]`。 |
+| `makeopts` | `MAKEOPTS`。`""`。 |
+| `common_flags` | 共通のコンパイラフラグ。`-O2 -pipe`。 |
+| `use` | `USE` フラグ。`[]`。 |
+| `video_cards` | `VIDEO_CARDS` の値。`[]`。 |
+| `l10n` | `L10N`。`[]` は生成する locale から値を導出します。 |
+| `input_devices` | `INPUT_DEVICES`。`["libinput"]`。 |
+| `accept_license` | 受諾するライセンス。`["@FREE"]`。 |
+| `cpu_flags` | CPU フラグ。`[]` はプロファイル値を保持します。 |
+| `build_in_ram` | `/var/tmp/portage` の tmpfs サイズ。unset ではディスク上でビルドします。 |
+| `mirrors` | ミラーレコード。既定値は下記です。 |
+| `binhost` | バイナリホストレコード。既定値は下記です。 |
+| `overlays` | overlay レコード。`[]`。 |
+
+| `portage.mirrors` キー | 意味と既定値または選択肢 |
+| --- | --- |
+| `region` | Gentoo ミラーの地域。`cn` または `global`。既定値は `global` です。 |
+| `speed_test` | 提示されたミラーの速度をテストします。`false`。 |
+| `distfiles` | カスタム distfile ベース。空でない一覧は組み込みの一覧を置き換えます。 |
+| `repo_sync_uri` | 明示的なリポジトリ同期 URI。`""`。 |
+| `site` | `region` 内のサイトキー。`""` は地域の最初のサイトを選択します。 |
+| `gentoo_distfiles` | `GENTOO_MIRRORS` を書き込みます。`true`。 |
+| `gentoo_zh` | gentoo-zh ミラー。`upstream`、`cernet`、`nju`、`nyist`、または `ha`。既定値は `upstream` です。 |
+| `gentoo_zh_distfiles` | gentoo-zh の distfile を `GENTOO_MIRRORS` に追加します。`true`。 |
+
+| ミラー地域 | サイトキー |
+| --- | --- |
+| `cn` | `ustc`, `nju`, `bfsu`, `tuna`, `zju`, `sdu`, `hust`, `sustech`, `hit`, `lzu`, `aliyun`, `netease`, `cernet`, `cicku-hk`, `planetunix-hk`, `xtom-hk`, `rackspace-hk`, `aditsu-hk`, `nchc-tw`, `cicku-tw`, `freedif-sg`, `cicku-sg`, `planetunix-sg` |
+| `global` | `gentoo`, `osuosl` |
+
+| `portage.binhost` キー | 意味と既定値または選択肢 |
+| --- | --- |
+| `official` | 公式バイナリホストを有効にします。`true`。 |
+| `subarch` | 公式バイナリホストのサブアーキテクチャ。`x86-64`。 |
+| `community` | gentoo-zh チャネル。`off`、`stable`、または `unstable`。既定値は `off` です。 |
+
+| `portage.overlays` 項目 | 意味 |
+| --- | --- |
+| `name` | overlay 名。必須です。 |
+| `sync_uri` | overlay の同期 URI。必須です。 |
+
+| `kernel` キー | 意味と既定値または選択肢 |
+| --- | --- |
+| `source` | kernel の選択肢。`dist-bin`、`dist-source`、`cjk-bin`、または `cjk`。既定値は `dist-bin` です。 |
+| `package` | `source` が暗黙に指定するパッケージを上書きします。`""`。 |
+| `version` | バージョン固定。`""` は Portage に最新のキーワード許可済みバージョンを選ばせます。 |
+| `dracut_modules` | ディスクレイアウトが必要とする dracut モジュールを追加します。`[]`。 |
+| `remote_unlock` | initramfs SSH 解除レコード。既定では空のレコードです。 |
+
+| `kernel.source` | パッケージと CJK の状態 |
+| --- | --- |
+| `dist-bin` | `sys-kernel/gentoo-kernel-bin`。CJK kernel ではありません。 |
+| `dist-source` | `sys-kernel/gentoo-kernel`。CJK kernel ではありません。 |
+| `cjk-bin` | `sys-kernel/gentoo-cjk-kernel-bin`。CJK kernel です。 |
+| `cjk` | `sys-kernel/gentoo-cjk-kernel`。CJK kernel です。 |
+
+| `kernel.remote_unlock` キー | 意味と既定値 |
+| --- | --- |
+| `enabled` | initramfs SSH 解除を有効にします。`false`。 |
+| `port` | initramfs の SSH ポート。`222`。 |
+| `address` | 静的 CIDR アドレス。`""` は DHCP を使用します。 |
+| `gateway` | 静的アドレスのゲートウェイ。`""`。 |
+| `interface` | initramfs のネットワークインターフェース。`""`。 |
+
+| `bootloader` キー | 意味と既定値または選択肢 |
+| --- | --- |
+| `kind` | ブートローダー。`grub`、`systemd-boot`、または `zfsbootmenu`。既定値は `grub` です。 |
+| `firmware` | ファームウェア。`uefi` または `bios`。既定値は `uefi` です。 |
+| `kernel_params` | 追加の kernel コマンドラインパラメーター。`[]`。 |
+
+| `packages` キー | 意味と既定値 |
+| --- | --- |
+| `desktop` | デスクトッププロファイル名。`""` はデスクトップを選択しません。 |
+| `applications` | パッケージグループ名。`[]`。 |
+| `graphics` | グラフィックスドライバーグループ名。`[]`。複数のグループがハイブリッドハードウェアに対応します。 |
+| `display_manager` | ディスプレイマネージャーグループ。`""` はコンソールログインを選択します。 |
+| `extra` | 他の選択後にマージするパッケージ atom。`[]`。 |
+
+| `disk` キー | 意味と既定値または選択肢 |
+| --- | --- |
+| `graph` | `[[disk.devices]]` で表すデバイスグラフ。必須です。 |
+| `root` | root グラフノード識別子。変換以外では必須です。`""` は変換時に稼働中のレイアウトを使用します。 |
+| `mode` | `partition`、`in-place`、`image`、または `dd`。既定値は `partition` です。 |
+| `image` | image モードでの疎なイメージパス。`""`。 |
+| `size` | image モードでの疎なイメージサイズ。unset。 |
+| `wipe` | ディスクレベルの消去設定。`false`。 |
+| `source` | `dd` モードでの準備済みイメージのソース。`""`。 |
+| `source_format` | ソースエンコーディング。`raw`、`gz`、`xz`、`zst`、または `tar`。既定値は `raw` です。 |
+| `destination` | ディスク全体への `dd` の宛先。`""`。 |
+
+| テンプレート入力 | 意味と既定値または選択肢 |
+| --- | --- |
+| `disk` | ディスク全体のセレクタ。必須です。 |
+| `layout` | `whole-disk`、`whole-disk-btrfs`、`whole-disk-zfs`、または `reuse`。既定値は `whole-disk` です。 |
+| `firmware` | テンプレートのファームウェア。`uefi`。 |
+| `table` | パーティションテーブルの上書き。unset では UEFI に GPT、BIOS に MBR を導出します。 |
+| `filesystem` | Btrfs および ZFS ではないディスク全体レイアウト用の root ファイルシステム。`xfs`。 |
+| `swap` | swap パーティションサイズ。unset。 |
+| `passphrase_file` | インストール側システムのパスフレーズファイルのパス。`""` はレイアウトを暗号化しません。 |
+| `pool` | ZFS プール名。`rpool`。 |
 
 次の完全な設定は、認証情報と 2 つのバイパスホストを持つプロキシを示します。認証情報は例であり、実行前に置き換える必要があります。
 

--- a/README.ko.md
+++ b/README.ko.md
@@ -69,6 +69,26 @@ cd gentoo-install-master
 
 대화형 설치에서는 성공하거나 실패한 경우 모두 마운트를 해제하기 전에 대상 시스템 안에서 root 셸을 여는 선택지를 제공한다. `--no-shell`을 사용하면 이 확인을 생략할 수 있다.
 
+| 옵션 | 인수 및 기본값 | 효과 |
+| --- | --- | --- |
+| `--config` | 파일 또는 URL; 설정되지 않음 | 메뉴를 열지 않고 해당 소스를 불러온다. |
+| `--dry-run` | 없음; `false` | 파생된 작업과 요약을 렌더링한 뒤 작업을 적용하지 않고 종료한다. |
+| `--mirror` | stage3 미러 문자열; 설치 도구 기본값 | 일반 설치에 사용할 stage3 소스를 선택한다. 메모리 설정은 구성에서 해당 지역을 도출한다. |
+| `--lang` | 언어 태그; `""` | 메뉴가 구성을 만드는 동안 `LC_ALL`, `LC_MESSAGES`, `LANG`을 재정의한다. |
+| `--target` | 경로; `/mnt/gentoo` | 일반 설치의 마운트 대상을 선택한다. 변환과 메모리 설정에는 `/`을 사용한다. |
+| `--work` | 경로; `/run/gentoo-install` | 보고서와 저널을 포함한 실행 상태를 보관한다. |
+| `--missing-commands` | 없음; `false` | 누락된 호스트 명령을 한 줄에 하나씩 출력한 뒤 종료한다. |
+| `--resume` | 없음; `false` | 기존 저널을 사용하여 호환되는 완료 작업을 건너뛴다. |
+| `--no-shell` | 없음; `false` | 대상 root 셸 제안을 표시하지 않는다. 메모리 설정도 무인으로 만든다. |
+| `--skip-preflight` | 없음; `false` | 일반 설치의 사전 점검을 건너뛴다. |
+| `--ram` | 없음; 설정되지 않은 메모리 모드 | 메모리에 올린 Gentoo CJK ISO로 한 번 부팅하도록 설정한다. `--lowram`과 충돌한다. |
+| `--lowram` | 없음; 설정되지 않은 메모리 모드 | 메모리에 올린 Alpine netboot 환경으로 한 번 부팅하도록 설정한다. `--ram`과 충돌한다. |
+| `--ssh-key` | 키, 파일, HTTP(S) URL 또는 `github:`/`gitlab:` 참조; `""` | 메모리 환경의 인증된 공개 키를 설정한다. 메모리 모드가 필요하다. |
+| `--ssh-port` | 정수; 설정되지 않음 | 메모리 환경의 `sshd` 포트를 설정한다. 메모리 모드가 필요하다. |
+| `--root-password` | 문자열; `""` | 메모리 환경의 root 비밀번호를 설정한다. 메모리 모드가 필요하다. |
+| `--bypass` | 없음; `false` | 한 번만 부팅하는 항목을 설정하는 대신 기본 부팅 항목을 교체한다. 메모리 모드가 필요하다. |
+| `--disarm` | 없음; `false` | 구성 불러오기 전에 이전에 설정한 메모리 부팅과 그 부팅이 배치한 파일을 제거한다. |
+
 ## 메모리에서 설치
 
 <!-- fact: install-memory -->
@@ -148,6 +168,31 @@ mode = "in-place"
 - 장치 그래프는 GPT와 MBR 파티션 테이블, ext2, ext3, ext4, xfs, f2fs, vfat, subvolume을 포함하는 btrfs, swap, LUKS2 암호화, LVM, mdraid를 다룬다.
 - ZFS도 같은 그래프에 속한다. 풀은 vdev 위에서 stripe, mirror, raidz1, raidz2, raidz3 중 하나를 취하고, 네이티브 암호화는 풀의 속성이며, 각 dataset은 그 자체로 하나의 노드다.
 - 기존 파티션 테이블을 유지할 수 있으며 각 파티션에 유지, 포맷, 삭제 작업을 각각 지정할 수 있다.
+
+| 모델 노드 | `id` 외 필드 | 결과 |
+| --- | --- | --- |
+| `Existing` | `selector`, `wipe` | 기존 장치를 선택한다. |
+| `PartitionTable` | `disk`, `table`, `create`, `remove` | 파티션 테이블을 만들거나 수정한다. |
+| `Partition` | `table`, `index`, `role`, `size`, `label` | 파티션을 정의한다. 마지막 `size`는 남은 공간을 모두 사용할 수 있다. |
+| `Luks` | `backing`, `name`, `passphrase_file` | LUKS 컨테이너를 정의한다. |
+| `MdRaid` | `members`, `level`, `name`, `metadata` | mdraid 배열을 정의한다. |
+| `VolumeGroup` | `members`, `name` | LVM 볼륨 그룹을 정의한다. |
+| `LogicalVolume` | `group`, `name`, `size` | LVM 논리 볼륨을 정의한다. |
+| `ZfsPool` | `vdevs`, `name`, `topology`, `encrypted`, `passphrase_file` | ZFS 풀을 정의한다. |
+| `ZfsDataset` | `pool`, `name` | ZFS dataset을 정의한다. |
+| `Filesystem` | `device`, `kind`, `label`, `create` | 장치를 포맷하거나 `create = false`이면 확인한다. |
+| `Subvolume` | `filesystem`, `name` | Btrfs subvolume을 정의한다. |
+| `Swap` | `device` | 참조한 장치에 swap을 정의한다. |
+| `Mountpoint` | `source`, `path`, `options` | 파일 시스템, Btrfs subvolume 또는 ZFS dataset을 마운트한다. |
+
+| 선택지 | 값 |
+| --- | --- |
+| 파티션 테이블 | `gpt`, `mbr` |
+| 파티션 역할 | `esp`, `bios-boot`, `swap`, `raid`, `lvm`, `zfs`, `data` |
+| mdraid 수준 | `raid0`, `raid1`, `raid5`, `raid6` |
+| mdraid 메타데이터 | `0.90`, `1.0`, `1.1`, `1.2` |
+| 파일 시스템 | `ext2`, `ext3`, `ext4`, `btrfs`, `xfs`, `f2fs`, `vfat` |
+| ZFS 토폴로지 | `stripe`, `mirror`, `raidz1`, `raidz2`, `raidz3` |
 
 <!-- fact: zram-system -->
 
@@ -241,6 +286,34 @@ mode = "in-place"
 - 메뉴는 설정을 `paste.gentoozh.org`에 업로드하기 전에 `password_hash`와 `root_password_hash` 값을 `removed-before-publishing`으로 바꾸고, 프록시의 `username`과 `password`는 키 자체를 출력하지 않는다.
 - 다른 설정값은 업로드에 남는다. 메뉴는 업로드된 페이지의 주소를 텍스트와 QR 코드로 표시한다.
 
+### 호환성 규칙
+
+검증은 다음 조합을 거부한다.
+
+| 거부되는 조합 |
+| --- |
+| 비어 있거나 잠겨 있거나 형식이 잘못된 root hash와 비밀번호 인증 사용자가 없고 사용할 수 있는 SSH 키 로그인도 없는 조합. |
+| ZFS 루트와 GRUB의 조합. |
+| GRUB를 사용하는 `/boot`의 ZFS 배치. |
+| ZFS 루트와 BIOS 부팅의 조합. |
+| ZFS 루트와 LUKS 루트 체인의 조합. |
+| ZFS가 아닌 루트와 ZFSBootMenu의 조합. |
+| 마운트된 ESP가 없는 UEFI 부팅. |
+| 암호화된 ESP가 있는 UEFI 부팅. |
+| BIOS 부팅과 systemd-boot의 조합. |
+| `/boot`이 암호화되었거나 vfat이어서 ESP에서 접근할 수 없는 커널 또는 initramfs와 systemd-boot의 조합. |
+| 메타데이터가 `1.1` 또는 `1.2`인 mdraid 위의 ESP. |
+| `bios-boot` 파티션이 없는 GPT 디스크의 BIOS 부팅. |
+| cjktty가 없는 커널에서 CJK 콘솔 렌더링을 사용하는 경우. |
+| 인증된 SSH 키가 없는 원격 잠금 해제. |
+| 암호화된 루트 컨테이너 또는 풀이 없는 원격 잠금 해제. |
+| initramfs SSH가 시작하기 전에 `/boot` 잠금을 해제해야 하는 GRUB를 사용하는 원격 잠금 해제. |
+| GRUB 또는 systemd-boot 시스템 initramfs가 수행하는 네이티브 ZFS 암호화의 원격 잠금 해제. |
+| `gentoo-zh` overlay가 없는 CJK 커널. |
+| `8x16` 이외의 콘솔 글꼴을 사용하는 CJK 콘솔 렌더링. |
+| `gentoo-zh` overlay가 없는 ZFSBootMenu. |
+| `gentoo-zh` overlay가 없는 gentoo-zh 커뮤니티 binhost. |
+
 ## 검증 상태
 
 <!-- fact: verification-scope -->
@@ -277,6 +350,166 @@ mode = "in-place"
 <!-- fact: config-dry-run -->
 
 구문 분석과 계획 단계에서는 저장 장치 하드웨어를 조사하지 않으므로 대상 디스크가 없는 머신에서도 `--dry-run`으로 설정을 확인할 수 있다.
+
+다음 참조에는 영속되는 모든 키가 있다. 테이블 경로는 TOML 테이블 표기법이며, `[[disk.devices]]`에는 그래프 노드가 들어간다.
+
+| 키 | 의미 및 기본값 또는 선택지 |
+| --- | --- |
+| `config_version` | 영속되는 스키마 버전이며 기본값은 `1`이다. |
+| `proxy.kind` | 프록시 체계이며 `http`, `https`, `socks5` 중 하나이고 기본값은 `http`다. |
+| `proxy.host` | 프록시 호스트이며 `""`이면 프록시를 비활성화한다. |
+| `proxy.port` | 프록시 포트이며 기본값은 `0`이다. |
+| `proxy.username` | 선택적 프록시 사용자 이름이며 기본값은 `""`이다. |
+| `proxy.password` | 선택적 프록시 비밀번호이며 기본값은 `""`이다. |
+| `proxy.bypass` | 프록시를 우회하는 호스트이며 기본값은 `[]`이다. |
+
+| `system` 키 | 의미 및 기본값 또는 선택지 |
+| --- | --- |
+| `hostname` | 대상 hostname이며 기본값은 `gentoo`다. |
+| `timezone` | 대상 timezone이며 기본값은 `Asia/Shanghai`다. |
+| `locales` | 생성되는 locale이며 기본값은 `en_US.UTF-8`, `zh_CN.UTF-8`, `zh_TW.UTF-8`다. |
+| `locale` | 선택한 locale이며 기본값은 `zh_CN.UTF-8`다. |
+| `keymap` | 설치된 시스템의 keymap이며 기본값은 `us`다. |
+| `keymap_initramfs` | initramfs의 keymap이며 `""`이면 `keymap`을 따른다. |
+| `interface` | 네트워크 인터페이스 패턴이며 `""`이면 `en*`과 `eth*`에 일치한다. |
+| `addresses` | 고정 CIDR 주소이며 `[]`이면 DHCP 또는 라우터 광고를 선택한다. |
+| `gateways` | 게이트웨이이며 주소 계열마다 최대 하나이고 기본값은 `[]`이다. |
+| `dns` | 리졸버 주소이며 기본값은 `[]`이다. |
+| `authorized_keys` | root 및 sudo 사용자의 키이며 기본값은 `[]`이다. |
+| `console_cjk` | CJK 콘솔 렌더링을 요청하며 기본값은 `false`이고 cjktty가 필요하다. |
+| `console_font` | 콘솔 셀 크기이며 `8x8`, `8x16`, `16x32` 중 하나이고 기본값은 `8x16`이다. |
+| `init` | init 시스템이며 `openrc` 또는 `systemd`이고 기본값은 `systemd`다. |
+| `zram` | 압축 RAM swap 크기이며 설정하지 않으면 비활성화한다. |
+| `hardware_clock_utc` | RTC가 UTC를 저장하며 기본값은 `true`다. |
+| `users` | 사용자 기록이며 기본값은 `[]`이다. |
+| `root_password_hash` | root `crypt(3)` hash이며 `""`이면 root를 잠근다. |
+| `logger` | 로거이며 `none`, `sysklogd`, `syslog-ng`, `metalog` 중 하나이고 기본값은 `sysklogd`다. |
+| `cron` | `sys-process/cronie`를 설치하며 기본값은 `true`다. |
+| `sshd` | SSH 데몬 지원을 설치하고 구성하며 기본값은 `false`다. |
+| `sshd_password_login` | SSH 데몬이 비밀번호를 허용하며 기본값은 `false`다. |
+| `sshd_root_login` | root가 SSH로 로그인할 수 있으며 기본값은 `false`다. |
+| `networking` | 링크 관리 방식이며 `builtin`, `networkmanager-wpa`, `networkmanager-iwd`, `none` 중 하나이고 기본값은 `builtin`이다. |
+| `firewall` | 패킷 필터 패키지이며 `none`, `nftables`, `iptables` 중 하나이고 기본값은 `none`이다. |
+| `first_boot` | 첫 부팅 기록이며 기본값은 비어 있는 기록이다. |
+
+| `system.users` 항목 | 의미 및 기본값 |
+| --- | --- |
+| `name` | 사용자 이름이며 필수다. |
+| `groups` | 보조 그룹이며 기본값은 `[]`이다. |
+| `shell` | 로그인 셸이며 기본값은 `/bin/bash`다. |
+| `sudo` | 사용자를 sudo 사용자로 만들며 기본값은 `false`다. |
+| `password_hash` | 사용자 `crypt(3)` hash이며 `""`이면 계정을 잠근다. |
+
+| `system.first_boot` 키 | 의미 및 기본값 |
+| --- | --- |
+| `commands` | 가져온 script 뒤에 순서대로 실행할 셸 줄이며 기본값은 `[]`이다. |
+| `url` | script URL이며 `""`이면 가져온 script를 생략한다. |
+
+| `portage` 키 | 의미 및 기본값 또는 선택지 |
+| --- | --- |
+| `profile` | Portage profile이며 기본값은 `default/linux/amd64/23.0/systemd`다. |
+| `keywords` | 전역 keyword 채널이며 `stable` 또는 `testing`이고 기본값은 `stable`이다. |
+| `sync` | 지속 동기화 방식이며 `git`, `webrsync`, `rsync` 중 하나이고 기본값은 `git`다. 최초 동기화에는 webrsync를 사용한다. |
+| `testing_packages` | 시스템이 안정 상태를 유지하는 동안 testing으로 허용할 atom이며 기본값은 `[]`이다. |
+| `makeopts` | `MAKEOPTS`이며 기본값은 `""`이다. |
+| `common_flags` | 공통 컴파일러 플래그이며 기본값은 `-O2 -pipe`다. |
+| `use` | `USE` 플래그이며 기본값은 `[]`이다. |
+| `video_cards` | `VIDEO_CARDS` 값이며 기본값은 `[]`이다. |
+| `l10n` | `L10N`이며 기본값은 `[]`이고 생성되는 locale에서 값을 도출한다. |
+| `input_devices` | `INPUT_DEVICES`이며 기본값은 `["libinput"]`이다. |
+| `accept_license` | 수락하는 라이선스이며 기본값은 `["@FREE"]`다. |
+| `cpu_flags` | CPU 플래그이며 기본값은 `[]`이고 profile 값을 보존한다. |
+| `build_in_ram` | `/var/tmp/portage` tmpfs 크기이며 설정하지 않으면 디스크에서 빌드한다. |
+| `mirrors` | 미러 기록이며 기본값은 아래에 표시한다. |
+| `binhost` | 바이너리 호스트 기록이며 기본값은 아래에 표시한다. |
+| `overlays` | overlay 기록이며 기본값은 `[]`이다. |
+
+| `portage.mirrors` 키 | 의미 및 기본값 또는 선택지 |
+| --- | --- |
+| `region` | Gentoo 미러 지역이며 `cn` 또는 `global`이고 기본값은 `global`이다. |
+| `speed_test` | 제안된 미러의 속도를 시험하며 기본값은 `false`다. |
+| `distfiles` | 사용자 지정 distfile 기반이며 비어 있지 않은 목록은 내장 목록을 교체한다. |
+| `repo_sync_uri` | 명시적 저장소 동기화 URI이며 기본값은 `""`이다. |
+| `site` | `region`의 사이트 키이며 `""`이면 해당 지역의 첫 사이트를 선택한다. |
+| `gentoo_distfiles` | `GENTOO_MIRRORS`를 기록하며 기본값은 `true`다. |
+| `gentoo_zh` | gentoo-zh 미러이며 `upstream`, `cernet`, `nju`, `nyist`, `ha` 중 하나이고 기본값은 `upstream`이다. |
+| `gentoo_zh_distfiles` | gentoo-zh distfile을 `GENTOO_MIRRORS`에 추가하며 기본값은 `true`다. |
+
+| 미러 지역 | 사이트 키 |
+| --- | --- |
+| `cn` | `ustc`, `nju`, `bfsu`, `tuna`, `zju`, `sdu`, `hust`, `sustech`, `hit`, `lzu`, `aliyun`, `netease`, `cernet`, `cicku-hk`, `planetunix-hk`, `xtom-hk`, `rackspace-hk`, `aditsu-hk`, `nchc-tw`, `cicku-tw`, `freedif-sg`, `cicku-sg`, `planetunix-sg` |
+| `global` | `gentoo`, `osuosl` |
+
+| `portage.binhost` 키 | 의미 및 기본값 또는 선택지 |
+| --- | --- |
+| `official` | 공식 바이너리 호스트를 활성화하며 기본값은 `true`다. |
+| `subarch` | 공식 바이너리 호스트의 subarchitecture이며 기본값은 `x86-64`다. |
+| `community` | gentoo-zh 채널이며 `off`, `stable`, `unstable` 중 하나이고 기본값은 `off`다. |
+
+| `portage.overlays` 항목 | 의미 |
+| --- | --- |
+| `name` | overlay 이름이며 필수다. |
+| `sync_uri` | overlay 동기화 URI이며 필수다. |
+
+| `kernel` 키 | 의미 및 기본값 또는 선택지 |
+| --- | --- |
+| `source` | 커널 선택지이며 `dist-bin`, `dist-source`, `cjk-bin`, `cjk` 중 하나이고 기본값은 `dist-bin`이다. |
+| `package` | `source`가 암시하는 패키지를 재정의하며 기본값은 `""`이다. |
+| `version` | 버전 고정값이며 `""`이면 Portage가 keyword 허용 최신 버전을 선택한다. |
+| `dracut_modules` | 디스크 레이아웃에 필요한 dracut 모듈을 추가하며 기본값은 `[]`이다. |
+| `remote_unlock` | initramfs SSH 잠금 해제 기록이며 기본값은 비어 있는 기록이다. |
+
+| `kernel.source` | 패키지 및 CJK 상태 |
+| --- | --- |
+| `dist-bin` | `sys-kernel/gentoo-kernel-bin`이며 CJK 커널이 아니다. |
+| `dist-source` | `sys-kernel/gentoo-kernel`이며 CJK 커널이 아니다. |
+| `cjk-bin` | `sys-kernel/gentoo-cjk-kernel-bin`이며 CJK 커널이다. |
+| `cjk` | `sys-kernel/gentoo-cjk-kernel`이며 CJK 커널이다. |
+
+| `kernel.remote_unlock` 키 | 의미 및 기본값 |
+| --- | --- |
+| `enabled` | initramfs SSH 잠금 해제를 활성화하며 기본값은 `false`다. |
+| `port` | initramfs SSH 포트이며 기본값은 `222`다. |
+| `address` | 고정 CIDR 주소이며 `""`이면 DHCP를 사용한다. |
+| `gateway` | 고정 주소 게이트웨이이며 기본값은 `""`이다. |
+| `interface` | initramfs 네트워크 인터페이스이며 기본값은 `""`이다. |
+
+| `bootloader` 키 | 의미 및 기본값 또는 선택지 |
+| --- | --- |
+| `kind` | 부트로더이며 `grub`, `systemd-boot`, `zfsbootmenu` 중 하나이고 기본값은 `grub`다. |
+| `firmware` | 펌웨어이며 `uefi` 또는 `bios`이고 기본값은 `uefi`다. |
+| `kernel_params` | 추가 커널 명령줄 매개변수이며 기본값은 `[]`이다. |
+
+| `packages` 키 | 의미 및 기본값 |
+| --- | --- |
+| `desktop` | 데스크톱 profile 이름이며 `""`이면 데스크톱을 선택하지 않는다. |
+| `applications` | 패키지 그룹 이름이며 기본값은 `[]`이다. |
+| `graphics` | 그래픽 드라이버 그룹 이름이며 기본값은 `[]`이다. 여러 그룹은 하이브리드 하드웨어에 적합하다. |
+| `display_manager` | 디스플레이 관리자 그룹이며 `""`이면 콘솔 로그인을 선택한다. |
+| `extra` | 다른 선택 뒤에 병합할 패키지 atom이며 기본값은 `[]`이다. |
+
+| `disk` 키 | 의미 및 기본값 또는 선택지 |
+| --- | --- |
+| `graph` | `[[disk.devices]]`로 표현하는 장치 그래프이며 필수다. |
+| `root` | 루트 그래프 노드 식별자이며 변환 밖에서는 필수다. `""`이면 변환에서 실행 중인 레이아웃을 사용한다. |
+| `mode` | `partition`, `in-place`, `image`, `dd` 중 하나이며 기본값은 `partition`이다. |
+| `image` | image 모드의 희소 이미지 경로이며 기본값은 `""`이다. |
+| `size` | image 모드의 희소 이미지 크기이며 설정되지 않음이다. |
+| `wipe` | 디스크 수준 wipe 설정이며 기본값은 `false`다. |
+| `source` | `dd` 모드의 준비된 이미지 소스이며 기본값은 `""`이다. |
+| `source_format` | 소스 인코딩이며 `raw`, `gz`, `xz`, `zst`, `tar` 중 하나이고 기본값은 `raw`다. |
+| `destination` | 디스크 전체 `dd` 대상이며 기본값은 `""`이다. |
+
+| 템플릿 입력 | 의미 및 기본값 또는 선택지 |
+| --- | --- |
+| `disk` | 디스크 전체 선택자이며 필수다. |
+| `layout` | `whole-disk`, `whole-disk-btrfs`, `whole-disk-zfs`, `reuse` 중 하나이며 기본값은 `whole-disk`다. |
+| `firmware` | 템플릿 펌웨어이며 기본값은 `uefi`다. |
+| `table` | 파티션 테이블 재정의이며 설정하지 않으면 UEFI는 GPT, BIOS는 MBR을 도출한다. |
+| `filesystem` | Btrfs 및 ZFS가 아닌 디스크 전체 레이아웃의 루트 파일 시스템이며 기본값은 `xfs`다. |
+| `swap` | swap 파티션 크기이며 설정되지 않음이다. |
+| `passphrase_file` | 설치 시스템의 passphrase 파일 경로이며 `""`이면 레이아웃을 암호화하지 않는다. |
+| `pool` | ZFS 풀 이름이며 기본값은 `rpool`이다. |
 
 다음 완전한 설정은 인증 정보와 우회 호스트 두 개가 있는 프록시를 보여 준다. 인증 정보는 예시이므로 실행하기 전에 바꿔야 한다.
 

--- a/README.md
+++ b/README.md
@@ -69,6 +69,26 @@ The menu can save its answers as `my-install.toml` and exit. The configuration-f
 
 Before unmounting, an interactive run offers a root shell in the target after either success or failure. `--no-shell` suppresses that question.
 
+| Option | Argument and default | Effect |
+| --- | --- | --- |
+| `--config` | file or URL; unset | Loads that source instead of opening the menu. |
+| `--dry-run` | none; `false` | Renders the derived operations and summary, then exits without applying operations. |
+| `--mirror` | stage3 mirror string; installer default | Selects the stage3 source for a normal installation. Memory arming derives its region from configuration. |
+| `--lang` | language tag; `""` | Overrides `LC_ALL`, `LC_MESSAGES`, and `LANG` while the menu creates configuration. |
+| `--target` | path; `/mnt/gentoo` | Selects the normal installation mount target. Conversion and memory arming use `/`. |
+| `--work` | path; `/run/gentoo-install` | Holds run state, including the report and journal. |
+| `--missing-commands` | none; `false` | Prints missing host commands, one per line, then exits. |
+| `--resume` | none; `false` | Uses the existing journal to skip compatible completed operations. |
+| `--no-shell` | none; `false` | Suppresses the target root-shell offer. It also makes memory arming unattended. |
+| `--skip-preflight` | none; `false` | Skips normal-installation preflight checks. |
+| `--ram` | none; unset memory mode | Arms one boot into the Gentoo CJK ISO held in memory. It conflicts with `--lowram`. |
+| `--lowram` | none; unset memory mode | Arms one boot into the Alpine netboot environment held in memory. It conflicts with `--ram`. |
+| `--ssh-key` | key, file, HTTP(S) URL, or `github:`/`gitlab:` reference; `""` | Sets a memory-environment authorised public key. It requires a memory mode. |
+| `--ssh-port` | integer; unset | Sets the memory environment's `sshd` port. It requires a memory mode. |
+| `--root-password` | string; `""` | Sets the memory environment root password. It requires a memory mode. |
+| `--bypass` | none; `false` | Replaces the default boot entry instead of arming a one-shot entry. It requires a memory mode. |
+| `--disarm` | none; `false` | Removes a previously armed memory boot and files it placed before configuration loading. |
+
 ## Installing from memory
 
 <!-- fact: install-memory -->
@@ -148,6 +168,31 @@ The paths below are implemented and have automated unit or plan coverage unless 
 - The device graph covers GPT and MBR; ext2, ext3, ext4, btrfs subvolumes, xfs, f2fs and vfat; swap; and LUKS2, LVM and mdraid.
 - ZFS belongs to the same graph: a pool is a stripe, a mirror, or raidz1, raidz2 or raidz3 over its vdevs, native encryption is a property of the pool, and each dataset is a node of its own.
 - Existing partition tables can be retained, with a separate keep, format or delete decision for each partition.
+
+| Model node | Fields beyond `id` | Result |
+| --- | --- | --- |
+| `Existing` | `selector`, `wipe` | Selects a pre-existing device. |
+| `PartitionTable` | `disk`, `table`, `create`, `remove` | Creates or edits a partition table. |
+| `Partition` | `table`, `index`, `role`, `size`, `label` | Defines a partition; final `size` may consume remaining space. |
+| `Luks` | `backing`, `name`, `passphrase_file` | Defines a LUKS container. |
+| `MdRaid` | `members`, `level`, `name`, `metadata` | Defines an mdraid array. |
+| `VolumeGroup` | `members`, `name` | Defines an LVM volume group. |
+| `LogicalVolume` | `group`, `name`, `size` | Defines an LVM logical volume. |
+| `ZfsPool` | `vdevs`, `name`, `topology`, `encrypted`, `passphrase_file` | Defines a ZFS pool. |
+| `ZfsDataset` | `pool`, `name` | Defines a ZFS dataset. |
+| `Filesystem` | `device`, `kind`, `label`, `create` | Formats a device, or verifies it when `create = false`. |
+| `Subvolume` | `filesystem`, `name` | Defines a Btrfs subvolume. |
+| `Swap` | `device` | Defines swap on a referenced device. |
+| `Mountpoint` | `source`, `path`, `options` | Mounts a filesystem, Btrfs subvolume, or ZFS dataset. |
+
+| Choice | Values |
+| --- | --- |
+| Partition table | `gpt`, `mbr` |
+| Partition role | `esp`, `bios-boot`, `swap`, `raid`, `lvm`, `zfs`, `data` |
+| mdraid level | `raid0`, `raid1`, `raid5`, `raid6` |
+| mdraid metadata | `0.90`, `1.0`, `1.1`, `1.2` |
+| Filesystem | `ext2`, `ext3`, `ext4`, `btrfs`, `xfs`, `f2fs`, `vfat` |
+| ZFS topology | `stripe`, `mirror`, `raidz1`, `raidz2`, `raidz3` |
 
 <!-- fact: zram-system -->
 
@@ -241,6 +286,34 @@ The system configuration can configure zram independently of the device graph an
 - Before uploading a configuration to `paste.gentoozh.org`, the menu replaces `password_hash` and `root_password_hash` with `removed-before-publishing` and omits the proxy `username` and `password` keys entirely; the other configuration values remain in the upload.
 - The menu displays the resulting page address as text and as a QR code.
 
+### Compatibility rules
+
+Validation rejects these combinations:
+
+| Refused combination |
+| --- |
+| An empty, locked, or malformed root hash with no password-authenticating user and no usable SSH-key login. |
+| A ZFS root with GRUB. |
+| `/boot` on ZFS with GRUB. |
+| A ZFS root with BIOS boot. |
+| A ZFS root with a LUKS root chain. |
+| ZFSBootMenu with a root that is not ZFS. |
+| UEFI boot without a mounted ESP. |
+| UEFI boot with an encrypted ESP. |
+| systemd-boot with BIOS boot. |
+| systemd-boot with a kernel or initramfs inaccessible from the ESP because `/boot` is encrypted or not vfat. |
+| An ESP on mdraid with metadata `1.1` or `1.2`. |
+| BIOS boot on a GPT disk without a `bios-boot` partition. |
+| CJK console rendering with a kernel lacking cjktty. |
+| Remote unlock without an authorised SSH key. |
+| Remote unlock without an encrypted root container or pool. |
+| Remote unlock with GRUB that must unlock `/boot` before initramfs SSH starts. |
+| Remote unlock of native ZFS encryption by a GRUB or systemd-boot system initramfs. |
+| A CJK kernel without the `gentoo-zh` overlay. |
+| CJK console rendering with a console font other than `8x16`. |
+| ZFSBootMenu without the `gentoo-zh` overlay. |
+| A gentoo-zh community binhost without the `gentoo-zh` overlay. |
+
 ## Verification status
 
 <!-- fact: verification-scope -->
@@ -277,6 +350,166 @@ Configuration files use TOML. The top-level `config_version` field selects the s
 <!-- fact: config-dry-run -->
 
 Parsing and planning do not probe storage hardware. A machine without the target disk can therefore check a configuration with `--dry-run`.
+
+The following reference names every persisted key. A table path is TOML table notation, and `[[disk.devices]]` carries the graph nodes.
+
+| Key | Meaning and default or choices |
+| --- | --- |
+| `config_version` | Persisted schema version; `1`. |
+| `proxy.kind` | Proxy scheme: `http`, `https`, or `socks5`; `http`. |
+| `proxy.host` | Proxy host; `""` disables the proxy. |
+| `proxy.port` | Proxy port; `0`. |
+| `proxy.username` | Optional proxy user name; `""`. |
+| `proxy.password` | Optional proxy password; `""`. |
+| `proxy.bypass` | Hosts that bypass the proxy; `[]`. |
+
+| `system` key | Meaning and default or choices |
+| --- | --- |
+| `hostname` | Target hostname; `gentoo`. |
+| `timezone` | Target timezone; `Asia/Shanghai`. |
+| `locales` | Generated locales; `en_US.UTF-8`, `zh_CN.UTF-8`, `zh_TW.UTF-8`. |
+| `locale` | Selected locale; `zh_CN.UTF-8`. |
+| `keymap` | Installed-system keymap; `us`. |
+| `keymap_initramfs` | Initramfs keymap; `""` follows `keymap`. |
+| `interface` | Network-interface pattern; `""` matches `en*` and `eth*`. |
+| `addresses` | Static CIDR addresses; `[]` selects DHCP or router advertisements. |
+| `gateways` | Gateways, at most one per address family; `[]`. |
+| `dns` | Resolver addresses; `[]`. |
+| `authorized_keys` | Keys for root and sudo users; `[]`. |
+| `console_cjk` | Requests CJK console rendering; `false`; it needs cjktty. |
+| `console_font` | Console cell size: `8x8`, `8x16`, or `16x32`; `8x16`. |
+| `init` | Init system: `openrc` or `systemd`; `systemd`. |
+| `zram` | Compressed-RAM swap size; unset disables it. |
+| `hardware_clock_utc` | RTC stores UTC; `true`. |
+| `users` | User records; `[]`. |
+| `root_password_hash` | Root `crypt(3)` hash; `""` locks root. |
+| `logger` | Logger: `none`, `sysklogd`, `syslog-ng`, or `metalog`; `sysklogd`. |
+| `cron` | Installs `sys-process/cronie`; `true`. |
+| `sshd` | Installs and configures SSH daemon support; `false`. |
+| `sshd_password_login` | SSH daemon accepts passwords; `false`. |
+| `sshd_root_login` | Root may log in through SSH; `false`. |
+| `networking` | Link management: `builtin`, `networkmanager-wpa`, `networkmanager-iwd`, or `none`; `builtin`. |
+| `firewall` | Packet-filter package: `none`, `nftables`, or `iptables`; `none`. |
+| `first_boot` | First-boot record; empty record by default. |
+
+| `system.users` item | Meaning and default |
+| --- | --- |
+| `name` | User name; required. |
+| `groups` | Supplementary groups; `[]`. |
+| `shell` | Login shell; `/bin/bash`. |
+| `sudo` | Makes the user a sudo user; `false`. |
+| `password_hash` | User `crypt(3)` hash; `""` locks the account. |
+
+| `system.first_boot` key | Meaning and default |
+| --- | --- |
+| `commands` | Shell lines run in order after the fetched script; `[]`. |
+| `url` | Script URL; `""` omits a fetched script. |
+
+| `portage` key | Meaning and default or choices |
+| --- | --- |
+| `profile` | Portage profile; `default/linux/amd64/23.0/systemd`. |
+| `keywords` | Global keyword channel: `stable` or `testing`; `stable`. |
+| `sync` | Ongoing sync: `git`, `webrsync`, or `rsync`; `git`. First sync uses webrsync. |
+| `testing_packages` | Atoms accepted as testing while the system remains stable; `[]`. |
+| `makeopts` | `MAKEOPTS`; `""`. |
+| `common_flags` | Common compiler flags; `-O2 -pipe`. |
+| `use` | `USE` flags; `[]`. |
+| `video_cards` | `VIDEO_CARDS` values; `[]`. |
+| `l10n` | `L10N`; `[]` derives values from generated locales. |
+| `input_devices` | `INPUT_DEVICES`; `["libinput"]`. |
+| `accept_license` | Accepted licenses; `["@FREE"]`. |
+| `cpu_flags` | CPU flags; `[]` preserves the profile value. |
+| `build_in_ram` | `/var/tmp/portage` tmpfs size; unset builds on disk. |
+| `mirrors` | Mirror record; defaults shown below. |
+| `binhost` | Binary-host record; defaults shown below. |
+| `overlays` | Overlay records; `[]`. |
+
+| `portage.mirrors` key | Meaning and default or choices |
+| --- | --- |
+| `region` | Gentoo mirror region: `cn` or `global`; `global`. |
+| `speed_test` | Speed-tests offered mirrors; `false`. |
+| `distfiles` | Custom distfile bases; a nonempty list replaces the built-in list. |
+| `repo_sync_uri` | Explicit repository sync URI; `""`. |
+| `site` | Site key in `region`; `""` selects the region's first site. |
+| `gentoo_distfiles` | Writes `GENTOO_MIRRORS`; `true`. |
+| `gentoo_zh` | gentoo-zh mirror: `upstream`, `cernet`, `nju`, `nyist`, or `ha`; `upstream`. |
+| `gentoo_zh_distfiles` | Appends gentoo-zh distfiles to `GENTOO_MIRRORS`; `true`. |
+
+| Mirror region | Site keys |
+| --- | --- |
+| `cn` | `ustc`, `nju`, `bfsu`, `tuna`, `zju`, `sdu`, `hust`, `sustech`, `hit`, `lzu`, `aliyun`, `netease`, `cernet`, `cicku-hk`, `planetunix-hk`, `xtom-hk`, `rackspace-hk`, `aditsu-hk`, `nchc-tw`, `cicku-tw`, `freedif-sg`, `cicku-sg`, `planetunix-sg` |
+| `global` | `gentoo`, `osuosl` |
+
+| `portage.binhost` key | Meaning and default or choices |
+| --- | --- |
+| `official` | Enables the official binary host; `true`. |
+| `subarch` | Official binary-host subarchitecture; `x86-64`. |
+| `community` | gentoo-zh channel: `off`, `stable`, or `unstable`; `off`. |
+
+| `portage.overlays` item | Meaning |
+| --- | --- |
+| `name` | Overlay name; required. |
+| `sync_uri` | Overlay synchronization URI; required. |
+
+| `kernel` key | Meaning and default or choices |
+| --- | --- |
+| `source` | Kernel choice: `dist-bin`, `dist-source`, `cjk-bin`, or `cjk`; `dist-bin`. |
+| `package` | Overrides the package implied by `source`; `""`. |
+| `version` | Version pin; `""` lets Portage choose the newest keyword-allowed version. |
+| `dracut_modules` | Adds dracut modules required by the disk layout; `[]`. |
+| `remote_unlock` | Initramfs SSH-unlock record; empty record by default. |
+
+| `kernel.source` | Package and CJK status |
+| --- | --- |
+| `dist-bin` | `sys-kernel/gentoo-kernel-bin`; not a CJK kernel. |
+| `dist-source` | `sys-kernel/gentoo-kernel`; not a CJK kernel. |
+| `cjk-bin` | `sys-kernel/gentoo-cjk-kernel-bin`; CJK kernel. |
+| `cjk` | `sys-kernel/gentoo-cjk-kernel`; CJK kernel. |
+
+| `kernel.remote_unlock` key | Meaning and default |
+| --- | --- |
+| `enabled` | Enables initramfs SSH unlocking; `false`. |
+| `port` | Initramfs SSH port; `222`. |
+| `address` | Static CIDR address; `""` uses DHCP. |
+| `gateway` | Static-address gateway; `""`. |
+| `interface` | Initramfs network interface; `""`. |
+
+| `bootloader` key | Meaning and default or choices |
+| --- | --- |
+| `kind` | Bootloader: `grub`, `systemd-boot`, or `zfsbootmenu`; `grub`. |
+| `firmware` | Firmware: `uefi` or `bios`; `uefi`. |
+| `kernel_params` | Additional kernel command-line parameters; `[]`. |
+
+| `packages` key | Meaning and default |
+| --- | --- |
+| `desktop` | Desktop profile name; `""` selects no desktop. |
+| `applications` | Package-group names; `[]`. |
+| `graphics` | Graphics-driver group names; `[]`; multiple groups fit hybrid hardware. |
+| `display_manager` | Display-manager group; `""` selects console login. |
+| `extra` | Package atoms merged after other selections; `[]`. |
+
+| `disk` key | Meaning and default or choices |
+| --- | --- |
+| `graph` | Device graph represented by `[[disk.devices]]`; required. |
+| `root` | Root graph-node identifier; required outside conversion; `""` uses the running layout in conversion. |
+| `mode` | `partition`, `in-place`, `image`, or `dd`; `partition`. |
+| `image` | Sparse image path in image mode; `""`. |
+| `size` | Sparse image size in image mode; unset. |
+| `wipe` | Disk-level wipe setting; `false`. |
+| `source` | Prepared-image source in `dd` mode; `""`. |
+| `source_format` | Source encoding: `raw`, `gz`, `xz`, `zst`, or `tar`; `raw`. |
+| `destination` | Whole-disk `dd` destination; `""`. |
+
+| Template input | Meaning and default or choices |
+| --- | --- |
+| `disk` | Whole-disk selector; required. |
+| `layout` | `whole-disk`, `whole-disk-btrfs`, `whole-disk-zfs`, or `reuse`; `whole-disk`. |
+| `firmware` | Template firmware; `uefi`. |
+| `table` | Partition-table override; unset derives GPT for UEFI and MBR for BIOS. |
+| `filesystem` | Root filesystem for non-Btrfs and non-ZFS whole-disk layouts; `xfs`. |
+| `swap` | Swap-partition size; unset. |
+| `passphrase_file` | Installing-system passphrase-file path; `""` leaves the layout unencrypted. |
+| `pool` | ZFS pool name; `rpool`. |
 
 The following complete configuration demonstrates a proxy with credentials and two bypass hosts. The credential is an example and must be replaced before execution:
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -69,6 +69,26 @@ cd gentoo-install-master
 
 交互式安装无论成功或失败，都会在卸载前提供在目标系统内打开 root shell 的选项。`--no-shell` 跳过这项确认。
 
+| 选项 | 参数与默认值 | 效果 |
+| --- | --- | --- |
+| `--config` | 文件或 URL；未设置 | 加载该来源，而不是打开菜单。 |
+| `--dry-run` | 无；`false` | 显示推导出的操作和摘要，然后在不应用操作的情况下退出。 |
+| `--mirror` | stage3 镜像字符串；安装程序默认值 | 为普通安装选择 stage3 来源。内存环境武装从配置推导其区域。 |
+| `--lang` | 语言标签；`""` | 菜单创建配置时覆盖 `LC_ALL`、`LC_MESSAGES` 和 `LANG`。 |
+| `--target` | 路径；`/mnt/gentoo` | 选择普通安装的挂载目标。转换和内存环境武装使用 `/`。 |
+| `--work` | 路径；`/run/gentoo-install` | 保存运行状态，包括报告和日志。 |
+| `--missing-commands` | 无；`false` | 每行显示一个缺少的主机命令，然后退出。 |
+| `--resume` | 无；`false` | 使用现有日志跳过兼容的已完成操作。 |
+| `--no-shell` | 无；`false` | 不提供目标 root shell。它还会使内存环境武装无需值守。 |
+| `--skip-preflight` | 无；`false` | 跳过普通安装的预检。 |
+| `--ram` | 无；未设置内存模式 | 武装一次进入保存在内存中的 Gentoo CJK ISO 的启动。它与 `--lowram` 冲突。 |
+| `--lowram` | 无；未设置内存模式 | 武装一次进入保存在内存中的 Alpine netboot 环境的启动。它与 `--ram` 冲突。 |
+| `--ssh-key` | 密钥、文件、HTTP(S) URL 或 `github:`/`gitlab:` 引用；`""` | 设置内存环境的授权公钥。它需要内存模式。 |
+| `--ssh-port` | 整数；未设置 | 设置内存环境的 `sshd` 端口；设置内存模式时可用。 |
+| `--root-password` | 字符串；`""` | 设置内存环境的 root 密码；仅支持内存模式。 |
+| `--bypass` | 无；`false` | 以替换默认引导项的方式取代武装一次性引导项；只适用于内存模式。 |
+| `--disarm` | 无；`false` | 在加载配置前移除先前武装的内存启动及其放置的文件。 |
+
 ## 从内存安装
 
 <!-- fact: install-memory -->
@@ -148,6 +168,31 @@ mode = "in-place"
 - 设备图涵盖 GPT 和 MBR 分区表、ext2、ext3、ext4、xfs、f2fs、vfat、包含 subvolume 的 btrfs、swap、LUKS2 加密、LVM 和 mdraid。
 - ZFS 属于同一张设备图：pool 在其 vdev 之上采用 stripe、mirror 或 raidz1、raidz2、raidz3，原生加密是 pool 的属性，每个 dataset 各为一个节点。
 - 现有分区表可以保留，每个分区可以分别指定保留、格式化或删除操作。
+
+| 模型节点 | `id` 之外的字段 | 结果 |
+| --- | --- | --- |
+| `Existing` | `selector`, `wipe` | 选择预先存在的设备。 |
+| `PartitionTable` | `disk`, `table`, `create`, `remove` | 创建或编辑分区表。 |
+| `Partition` | `table`, `index`, `role`, `size`, `label` | 定义分区；最后一个 `size` 可占用剩余空间。 |
+| `Luks` | `backing`, `name`, `passphrase_file` | 定义 LUKS 容器。 |
+| `MdRaid` | `members`, `level`, `name`, `metadata` | 定义 mdraid 阵列。 |
+| `VolumeGroup` | `members`, `name` | 定义 LVM 卷组。 |
+| `LogicalVolume` | `group`, `name`, `size` | 定义 LVM 逻辑卷。 |
+| `ZfsPool` | `vdevs`, `name`, `topology`, `encrypted`, `passphrase_file` | 定义 ZFS pool。 |
+| `ZfsDataset` | `pool`, `name` | 定义 ZFS dataset。 |
+| `Filesystem` | `device`, `kind`, `label`, `create` | 格式化设备；`create = false` 时验证设备。 |
+| `Subvolume` | `filesystem`, `name` | 定义 Btrfs subvolume。 |
+| `Swap` | `device` | 在引用的设备上定义 swap。 |
+| `Mountpoint` | `source`, `path`, `options` | 挂载文件系统、Btrfs subvolume 或 ZFS dataset。 |
+
+| 选项 | 值 |
+| --- | --- |
+| 分区表 | `gpt`, `mbr` |
+| 分区角色 | `esp`, `bios-boot`, `swap`, `raid`, `lvm`, `zfs`, `data` |
+| mdraid 级别 | `raid0`, `raid1`, `raid5`, `raid6` |
+| mdraid 元数据 | `0.90`, `1.0`, `1.1`, `1.2` |
+| 文件系统 | `ext2`, `ext3`, `ext4`, `btrfs`, `xfs`, `f2fs`, `vfat` |
+| ZFS 拓扑 | `stripe`, `mirror`, `raidz1`, `raidz2`, `raidz3` |
 
 <!-- fact: zram-system -->
 
@@ -241,6 +286,34 @@ mode = "in-place"
 - 菜单将配置上传至 `paste.gentoozh.org` 前，会把 `password_hash` 和 `root_password_hash` 的值替换为 `removed-before-publishing`，并且完全不写出代理的 `username` 和 `password` 这两个键；其他配置值仍会上传。
 - 菜单会以文本和 QR 码显示上传页面的网址。
 
+### 兼容性规则
+
+验证拒绝下列组合：
+
+| 被拒绝的组合 |
+| --- |
+| 没有可使用密码认证的用户或可用 SSH 密钥登录时，空的、锁定的或格式错误的 root hash。 |
+| ZFS 根与 GRUB。 |
+| ZFS 上的 `/boot` 与 GRUB。 |
+| ZFS 根与 BIOS 引导。 |
+| ZFS 根与 LUKS 根链。 |
+| ZFSBootMenu 与非 ZFS 根。 |
+| 未挂载 ESP 的 UEFI 引导。 |
+| 使用加密 ESP 的 UEFI 引导。 |
+| systemd-boot 与 BIOS 引导。 |
+| systemd-boot 与因 `/boot` 已加密或不是 vfat 而无法从 ESP 访问的 kernel 或 initramfs。 |
+| 带有元数据 `1.1` 或 `1.2` 的 mdraid 上的 ESP。 |
+| 没有 `bios-boot` 分区的 GPT 磁盘上的 BIOS 引导。 |
+| 使用缺少 cjktty 的 kernel 进行 CJK 控制台渲染。 |
+| 没有授权 SSH 密钥的远程解锁。 |
+| 没有加密根容器或 pool 的远程解锁。 |
+| 使用必须在 initramfs SSH 启动前解锁 `/boot` 的 GRUB 的远程解锁。 |
+| 由 GRUB 或 systemd-boot 系统 initramfs 解锁的原生 ZFS 加密远程解锁。 |
+| 没有 `gentoo-zh` overlay 的 CJK kernel。 |
+| 使用非 `8x16` 控制台字体的 CJK 控制台渲染。 |
+| 没有 `gentoo-zh` overlay 的 ZFSBootMenu。 |
+| 没有 `gentoo-zh` overlay 的 gentoo-zh 社区 binhost。 |
+
 ## 验证状态
 
 <!-- fact: verification-scope -->
@@ -277,6 +350,166 @@ mode = "in-place"
 <!-- fact: config-dry-run -->
 
 解析与计划阶段不会探测存储硬件，因此没有目标磁盘的机器也能通过 `--dry-run` 检查配置。
+
+以下参考列出每个持久化键。表路径采用 TOML 表记法，`[[disk.devices]]` 包含图节点。
+
+| 键 | 含义和默认值或选项 |
+| --- | --- |
+| `config_version` | 持久化的结构版本；`1`。 |
+| `proxy.kind` | 代理协议：`http`、`https` 或 `socks5`；`http`。 |
+| `proxy.host` | 代理主机；`""` 禁用代理。 |
+| `proxy.port` | 代理端口；`0`。 |
+| `proxy.username` | 可选代理用户名；`""`。 |
+| `proxy.password` | 可选代理密码；`""`。 |
+| `proxy.bypass` | 绕过代理的主机；`[]`。 |
+
+| `system` 键 | 含义和默认值或选项 |
+| --- | --- |
+| `hostname` | 目标主机名；`gentoo`。 |
+| `timezone` | 目标时区；`Asia/Shanghai`。 |
+| `locales` | 生成的 locale；`en_US.UTF-8`、`zh_CN.UTF-8`、`zh_TW.UTF-8`。 |
+| `locale` | 选定的 locale；`zh_CN.UTF-8`。 |
+| `keymap` | 已安装系统的键盘映射；`us`。 |
+| `keymap_initramfs` | initramfs 键盘映射；`""` 表示跟随 `keymap`。 |
+| `interface` | 网络接口模式；`""` 匹配 `en*` 和 `eth*`。 |
+| `addresses` | 静态 CIDR 地址；`[]` 选择 DHCP 或路由器通告。 |
+| `gateways` | 网关，每个地址族最多一个；`[]`。 |
+| `dns` | 解析器地址；`[]`。 |
+| `authorized_keys` | root 和 sudo 用户的密钥；`[]`。 |
+| `console_cjk` | 要求 CJK 控制台渲染；`false`；需要 cjktty。 |
+| `console_font` | 控制台单元格大小：`8x8`、`8x16` 或 `16x32`；`8x16`。 |
+| `init` | init 系统：`openrc` 或 `systemd`；`systemd`。 |
+| `zram` | 压缩 RAM swap 大小；未设置则禁用。 |
+| `hardware_clock_utc` | RTC 存储 UTC；`true`。 |
+| `users` | 用户记录；`[]`。 |
+| `root_password_hash` | root `crypt(3)` 哈希；`""` 锁定 root。 |
+| `logger` | 日志程序：`none`、`sysklogd`、`syslog-ng` 或 `metalog`；`sysklogd`。 |
+| `cron` | 安装 `sys-process/cronie`；`true`。 |
+| `sshd` | 安装并配置 SSH 守护进程支持；`false`。 |
+| `sshd_password_login` | SSH 守护进程接受密码；`false`。 |
+| `sshd_root_login` | root 可通过 SSH 登录；`false`。 |
+| `networking` | 链路管理：`builtin`、`networkmanager-wpa`、`networkmanager-iwd` 或 `none`；`builtin`。 |
+| `firewall` | 数据包过滤软件包：`none`、`nftables` 或 `iptables`；`none`。 |
+| `first_boot` | 首次启动记录；默认为空记录。 |
+
+| `system.users` 项 | 含义和默认值 |
+| --- | --- |
+| `name` | 用户名；必填。 |
+| `groups` | 补充组；`[]`。 |
+| `shell` | 登录 shell；`/bin/bash`。 |
+| `sudo` | 使该用户成为 sudo 用户；`false`。 |
+| `password_hash` | 用户 `crypt(3)` 哈希；`""` 锁定账户。 |
+
+| `system.first_boot` 键 | 含义和默认值 |
+| --- | --- |
+| `commands` | 在获取的脚本之后按顺序执行的 shell 行；`[]`。 |
+| `url` | 脚本 URL；`""` 表示不获取脚本。 |
+
+| `portage` 键 | 含义和默认值或选项 |
+| --- | --- |
+| `profile` | Portage profile；`default/linux/amd64/23.0/systemd`。 |
+| `keywords` | 全局关键词通道：`stable` 或 `testing`；`stable`。 |
+| `sync` | 持续同步：`git`、`webrsync` 或 `rsync`；`git`。首次同步使用 webrsync。 |
+| `testing_packages` | 系统保持稳定时允许使用 testing 的 atom；`[]`。 |
+| `makeopts` | `MAKEOPTS`；`""`。 |
+| `common_flags` | 通用编译器标志；`-O2 -pipe`。 |
+| `use` | `USE` 标志；`[]`。 |
+| `video_cards` | `VIDEO_CARDS` 值；`[]`。 |
+| `l10n` | `L10N`；`[]` 从生成的 locale 推导值。 |
+| `input_devices` | `INPUT_DEVICES`；`["libinput"]`。 |
+| `accept_license` | 接受的许可证；`["@FREE"]`。 |
+| `cpu_flags` | CPU 标志；`[]` 保留 profile 值。 |
+| `build_in_ram` | `/var/tmp/portage` tmpfs 大小；未设置则在磁盘上构建。 |
+| `mirrors` | 镜像记录；默认值见下文。 |
+| `binhost` | 二进制主机记录；默认值见下文。 |
+| `overlays` | Overlay 记录；`[]`。 |
+
+| `portage.mirrors` 键 | 含义和默认值或选项 |
+| --- | --- |
+| `region` | Gentoo 镜像区域：`cn` 或 `global`；`global`。 |
+| `speed_test` | 对提供的镜像执行速度测试；`false`。 |
+| `distfiles` | 自定义 distfile 基地址；非空列表会替换内置列表。 |
+| `repo_sync_uri` | 显式仓库同步 URI；`""`。 |
+| `site` | `region` 中的站点键；`""` 选择该区域的第一个站点。 |
+| `gentoo_distfiles` | 写入 `GENTOO_MIRRORS`；`true`。 |
+| `gentoo_zh` | gentoo-zh 镜像：`upstream`、`cernet`、`nju`、`nyist` 或 `ha`；`upstream`。 |
+| `gentoo_zh_distfiles` | 将 gentoo-zh distfile 追加到 `GENTOO_MIRRORS`；`true`。 |
+
+| 镜像区域 | 站点键 |
+| --- | --- |
+| `cn` | `ustc`, `nju`, `bfsu`, `tuna`, `zju`, `sdu`, `hust`, `sustech`, `hit`, `lzu`, `aliyun`, `netease`, `cernet`, `cicku-hk`, `planetunix-hk`, `xtom-hk`, `rackspace-hk`, `aditsu-hk`, `nchc-tw`, `cicku-tw`, `freedif-sg`, `cicku-sg`, `planetunix-sg` |
+| `global` | `gentoo`, `osuosl` |
+
+| `portage.binhost` 键 | 含义和默认值或选项 |
+| --- | --- |
+| `official` | 启用官方二进制主机；`true`。 |
+| `subarch` | 官方二进制主机子架构；`x86-64`。 |
+| `community` | gentoo-zh 通道：`off`、`stable` 或 `unstable`；`off`。 |
+
+| `portage.overlays` 项 | 含义 |
+| --- | --- |
+| `name` | Overlay 名称；必填。 |
+| `sync_uri` | Overlay 同步 URI；必填。 |
+
+| `kernel` 键 | 含义和默认值或选项 |
+| --- | --- |
+| `source` | kernel 选择：`dist-bin`、`dist-source`、`cjk-bin` 或 `cjk`；`dist-bin`。 |
+| `package` | 覆盖 `source` 隐含的软件包；`""`。 |
+| `version` | 版本固定；`""` 让 Portage 选择允许的最新关键词版本。 |
+| `dracut_modules` | 添加磁盘布局所需的 dracut 模块；`[]`。 |
+| `remote_unlock` | initramfs SSH 解锁记录；默认为空记录。 |
+
+| `kernel.source` | 软件包和 CJK 状态 |
+| --- | --- |
+| `dist-bin` | `sys-kernel/gentoo-kernel-bin`；不是 CJK kernel。 |
+| `dist-source` | `sys-kernel/gentoo-kernel`；不属于 CJK kernel。 |
+| `cjk-bin` | `sys-kernel/gentoo-cjk-kernel-bin`；CJK kernel。 |
+| `cjk` | `sys-kernel/gentoo-cjk-kernel`；CJK kernel。 |
+
+| `kernel.remote_unlock` 键 | 含义和默认值 |
+| --- | --- |
+| `enabled` | 启用 initramfs SSH 解锁；`false`。 |
+| `port` | initramfs SSH 端口；`222`。 |
+| `address` | 静态 CIDR 地址；`""` 使用 DHCP。 |
+| `gateway` | 静态地址网关；`""`。 |
+| `interface` | initramfs 网络接口；`""`。 |
+
+| `bootloader` 键 | 含义和默认值或选项 |
+| --- | --- |
+| `kind` | 引导程序：`grub`、`systemd-boot` 或 `zfsbootmenu`；`grub`。 |
+| `firmware` | 固件：`uefi` 或 `bios`；`uefi`。 |
+| `kernel_params` | 额外 kernel 命令行参数；`[]`。 |
+
+| `packages` 键 | 含义和默认值 |
+| --- | --- |
+| `desktop` | 桌面 profile 名称；`""` 表示不选择桌面。 |
+| `applications` | 软件包组名称；`[]`。 |
+| `graphics` | 图形驱动程序组名称；`[]`；多个组适用于混合硬件。 |
+| `display_manager` | 显示管理器组；`""` 选择控制台登录。 |
+| `extra` | 在其他选择之后合并的软件包 atom；`[]`。 |
+
+| `disk` 键 | 含义和默认值或选项 |
+| --- | --- |
+| `graph` | 由 `[[disk.devices]]` 表示的设备图；必填。 |
+| `root` | 根图节点标识符；转换之外必填；`""` 在转换时使用运行中布局。 |
+| `mode` | `partition`、`in-place`、`image` 或 `dd`；`partition`。 |
+| `image` | image 模式下的稀疏镜像路径；`""`。 |
+| `size` | image 模式下的稀疏镜像大小；未设置。 |
+| `wipe` | 磁盘级擦除设置；`false`。 |
+| `source` | `dd` 模式下的准备镜像来源；`""`。 |
+| `source_format` | 来源编码：`raw`、`gz`、`xz`、`zst` 或 `tar`；`raw`。 |
+| `destination` | 整盘 `dd` 目标；`""`。 |
+
+| 模板输入 | 含义和默认值或选项 |
+| --- | --- |
+| `disk` | 整盘选择器；必填。 |
+| `layout` | `whole-disk`、`whole-disk-btrfs`、`whole-disk-zfs` 或 `reuse`；`whole-disk`。 |
+| `firmware` | 模板固件；`uefi`。 |
+| `table` | 分区表覆盖；未设置时 UEFI 推导为 GPT，BIOS 推导为 MBR。 |
+| `filesystem` | 非 Btrfs、非 ZFS 整盘布局的根文件系统；`xfs`。 |
+| `swap` | swap 分区大小；未设置。 |
+| `passphrase_file` | 安装系统的 passphrase 文件路径；`""` 表示布局不加密。 |
+| `pool` | ZFS pool 名称；`rpool`。 |
 
 以下完整配置演示包含认证信息和两个绕过主机。认证信息只是示例，执行前必须替换：
 

--- a/README.zh-TW.md
+++ b/README.zh-TW.md
@@ -69,6 +69,26 @@ cd gentoo-install-master
 
 互動式安裝無論成功或失敗，都會在卸載前提供於目標系統內開啟 root shell 的選項。`--no-shell` 可略過這項確認。
 
+| 選項 | 引數與預設值 | 效果 |
+| --- | --- | --- |
+| `--config` | 檔案或 URL；未設定 | 從該來源載入，而不開啟選單。 |
+| `--dry-run` | 無；`false` | 呈現衍生的操作與摘要，然後結束且不套用操作。 |
+| `--mirror` | stage3 鏡像字串；安裝器預設值 | 選取一般安裝的 stage3 來源。記憶體武裝會從設定衍生其區域。 |
+| `--lang` | 語言標籤；`""` | 選單建立設定時，覆寫 `LC_ALL`、`LC_MESSAGES` 與 `LANG`。 |
+| `--target` | 路徑；`/mnt/gentoo` | 選取一般安裝的掛載目標。轉換與記憶體武裝使用 `/`。 |
+| `--work` | 路徑；`/run/gentoo-install` | 保存本次執行狀態，包含報告與日誌。 |
+| `--missing-commands` | 無；`false` | 每行印出一個缺少的主機指令，然後結束。 |
+| `--resume` | 無；`false` | 使用既有日誌略過相容的已完成操作。 |
+| `--no-shell` | 無；`false` | 略過目標 root shell 的提供。它也使記憶體武裝成為無人值守。 |
+| `--skip-preflight` | 無；`false` | 略過一般安裝的 preflight 檢查。 |
+| `--ram` | 無；未設定記憶體模式 | 武裝一次進入記憶體內 Gentoo CJK ISO 的開機。它與 `--lowram` 衝突。 |
+| `--lowram` | 無；未設定記憶體模式 | 武裝一次進入記憶體內 Alpine netboot 環境的開機。它與 `--ram` 衝突。 |
+| `--ssh-key` | 金鑰、檔案、HTTP(S) URL 或 `github:`/`gitlab:` 參照；`""` | 設定記憶體環境的授權公開金鑰。它需要記憶體模式。 |
+| `--ssh-port` | 整數；未設定 | 設定記憶體環境的 `sshd` 連接埠。這個選項只在記憶體模式下有效。 |
+| `--root-password` | 字串；`""` | 設定記憶體環境 root 密碼。這個選項需要啟用記憶體模式。 |
+| `--bypass` | 無；`false` | 以替換預設開機項目的方式武裝，而非建立一次性項目。這個選項只可與記憶體模式一同使用。 |
+| `--disarm` | 無；`false` | 在載入設定前移除先前武裝的記憶體開機及其放置的檔案。 |
+
 ## 從記憶體安裝
 
 <!-- fact: install-memory -->
@@ -148,6 +168,31 @@ mode = "in-place"
 - 裝置圖涵蓋 GPT 與 MBR 分割表、ext2、ext3、ext4、xfs、f2fs、vfat、含 subvolume 的 btrfs、swap、LUKS2 加密、LVM 與 mdraid。
 - ZFS 屬於同一張裝置圖：pool 在其 vdev 之上採 stripe、mirror 或 raidz1、raidz2、raidz3，原生加密是 pool 的屬性，每個 dataset 各為一個節點。
 - 既有分割表可以保留，每個分割區可分別指定保留、格式化或刪除。
+
+| 模型節點 | 除了 `id` 以外的欄位 | 結果 |
+| --- | --- | --- |
+| `Existing` | `selector`, `wipe` | 選取預先存在的裝置。 |
+| `PartitionTable` | `disk`, `table`, `create`, `remove` | 建立或編輯分割表。 |
+| `Partition` | `table`, `index`, `role`, `size`, `label` | 定義分割區；最後一個 `size` 可耗盡剩餘空間。 |
+| `Luks` | `backing`, `name`, `passphrase_file` | 定義 LUKS 容器。 |
+| `MdRaid` | `members`, `level`, `name`, `metadata` | 定義 mdraid 陣列。 |
+| `VolumeGroup` | `members`, `name` | 定義 LVM 磁碟區群組。 |
+| `LogicalVolume` | `group`, `name`, `size` | 定義 LVM 邏輯磁碟區。 |
+| `ZfsPool` | `vdevs`, `name`, `topology`, `encrypted`, `passphrase_file` | 定義 ZFS pool。 |
+| `ZfsDataset` | `pool`, `name` | 定義 ZFS dataset。 |
+| `Filesystem` | `device`, `kind`, `label`, `create` | 格式化裝置；`create = false` 時會驗證裝置。 |
+| `Subvolume` | `filesystem`, `name` | 定義 Btrfs subvolume。 |
+| `Swap` | `device` | 在參照的裝置上定義 swap。 |
+| `Mountpoint` | `source`, `path`, `options` | 掛載檔案系統、Btrfs subvolume 或 ZFS dataset。 |
+
+| 選項 | 值 |
+| --- | --- |
+| 分割表 | `gpt`, `mbr` |
+| 分割區角色 | `esp`, `bios-boot`, `swap`, `raid`, `lvm`, `zfs`, `data` |
+| mdraid 層級 | `raid0`, `raid1`, `raid5`, `raid6` |
+| mdraid 中繼資料 | `0.90`, `1.0`, `1.1`, `1.2` |
+| 檔案系統 | `ext2`, `ext3`, `ext4`, `btrfs`, `xfs`, `f2fs`, `vfat` |
+| ZFS 拓撲 | `stripe`, `mirror`, `raidz1`, `raidz2`, `raidz3` |
 
 <!-- fact: zram-system -->
 
@@ -241,6 +286,34 @@ mode = "in-place"
 - 選單將設定上傳至 `paste.gentoozh.org` 前，會把 `password_hash` 與 `root_password_hash` 的值替換為 `removed-before-publishing`，並且完全不寫出代理的 `username` 與 `password` 這兩個鍵；其他設定值仍會上傳。
 - 選單會以文字與 QR 碼顯示上傳頁面的網址。
 
+### 相容性規則
+
+驗證會拒絕以下組合：
+
+| 拒絕的組合 |
+| --- |
+| root 雜湊為空白、鎖定或格式錯誤，且沒有可透過密碼驗證的使用者與可用的 SSH 金鑰登入方式。 |
+| ZFS 根搭配 GRUB。 |
+| `/boot` 位於 ZFS 且搭配 GRUB。 |
+| ZFS 根搭配 BIOS 開機。 |
+| ZFS 根搭配 LUKS 根鏈。 |
+| ZFSBootMenu 搭配非 ZFS 的根。 |
+| UEFI 開機未掛載 ESP。 |
+| UEFI 開機搭配已加密的 ESP。 |
+| systemd-boot 搭配 BIOS 開機。 |
+| systemd-boot 搭配無法從 ESP 存取的核心或 initramfs，原因是 `/boot` 已加密或不是 vfat。 |
+| ESP 位於中繼資料為 `1.1` 或 `1.2` 的 mdraid。 |
+| GPT 磁碟上的 BIOS 開機未設 `bios-boot` 分割區。 |
+| CJK 主控台呈現搭配缺少 cjktty 的核心。 |
+| 遠端解鎖沒有授權 SSH 金鑰。 |
+| 遠端解鎖沒有加密的根容器或 pool。 |
+| 遠端解鎖搭配必須在 initramfs SSH 啟動前解開 `/boot` 的 GRUB。 |
+| GRUB 或 systemd-boot 的系統 initramfs 遠端解鎖原生 ZFS 加密。 |
+| CJK 核心沒有 `gentoo-zh` overlay。 |
+| CJK 主控台呈現搭配非 `8x16` 的主控台字型。 |
+| ZFSBootMenu 沒有 `gentoo-zh` overlay。 |
+| gentoo-zh 社群 binhost 沒有 `gentoo-zh` overlay。 |
+
 ## 驗證狀態
 
 <!-- fact: verification-scope -->
@@ -277,6 +350,166 @@ mode = "in-place"
 <!-- fact: config-dry-run -->
 
 解析與計畫階段不會探測儲存硬體，因此沒有目標磁碟的機器也能以 `--dry-run` 檢查設定。
+
+以下參考列出每個保存的鍵。表格路徑使用 TOML 表格表示法，且 `[[disk.devices]]` 載有圖節點。
+
+| 鍵 | 說明與預設值或選項 |
+| --- | --- |
+| `config_version` | 保存的結構版本；`1`。 |
+| `proxy.kind` | 代理協定：`http`、`https` 或 `socks5`；`http`。 |
+| `proxy.host` | 代理主機；`""` 會停用代理。 |
+| `proxy.port` | 代理連接埠；`0`。 |
+| `proxy.username` | 可選的代理使用者名稱；`""`。 |
+| `proxy.password` | 可選的代理密碼；`""`。 |
+| `proxy.bypass` | 略過代理的主機；`[]`。 |
+
+| `system` 鍵 | 說明與預設值或選項 |
+| --- | --- |
+| `hostname` | 目標主機名稱；`gentoo`。 |
+| `timezone` | 目標時區；`Asia/Shanghai`。 |
+| `locales` | 產生的 locale；`en_US.UTF-8`、`zh_CN.UTF-8`、`zh_TW.UTF-8`。 |
+| `locale` | 選定的 locale；`zh_CN.UTF-8`。 |
+| `keymap` | 已安裝系統的鍵盤對應；`us`。 |
+| `keymap_initramfs` | initramfs 的鍵盤對應；`""` 會沿用 `keymap`。 |
+| `interface` | 網路介面模式；`""` 會比對 `en*` 與 `eth*`。 |
+| `addresses` | 靜態 CIDR 位址；`[]` 會選取 DHCP 或路由器宣告。 |
+| `gateways` | 閘道；每個位址系列至多一個；`[]`。 |
+| `dns` | 解析器位址；`[]`。 |
+| `authorized_keys` | root 與 sudo 使用者的金鑰；`[]`。 |
+| `console_cjk` | 要求 CJK 主控台呈現；`false`；它需要 cjktty。 |
+| `console_font` | 主控台字元格大小：`8x8`、`8x16` 或 `16x32`；`8x16`。 |
+| `init` | Init 系統：`openrc` 或 `systemd`；`systemd`。 |
+| `zram` | 壓縮 RAM 的 swap 大小；未設定會停用。 |
+| `hardware_clock_utc` | RTC 保存 UTC；`true`。 |
+| `users` | 使用者記錄；`[]`。 |
+| `root_password_hash` | root 的 `crypt(3)` 雜湊；`""` 會鎖定 root。 |
+| `logger` | 日誌程式：`none`、`sysklogd`、`syslog-ng` 或 `metalog`；`sysklogd`。 |
+| `cron` | 安裝 `sys-process/cronie`；`true`。 |
+| `sshd` | 安裝並設定 SSH daemon 支援；`false`。 |
+| `sshd_password_login` | SSH daemon 接受密碼；`false`。 |
+| `sshd_root_login` | root 可透過 SSH 登入；`false`。 |
+| `networking` | 連線管理：`builtin`、`networkmanager-wpa`、`networkmanager-iwd` 或 `none`；`builtin`。 |
+| `firewall` | 封包過濾套件：`none`、`nftables` 或 `iptables`；`none`。 |
+| `first_boot` | 首次開機記錄；預設為空白記錄。 |
+
+| `system.users` 項目 | 說明與預設值 |
+| --- | --- |
+| `name` | 使用者名稱；必填。 |
+| `groups` | 補充群組；`[]`。 |
+| `shell` | 登入 shell；`/bin/bash`。 |
+| `sudo` | 將使用者設為 sudo 使用者；`false`。 |
+| `password_hash` | 使用者的 `crypt(3)` 雜湊；`""` 會鎖定帳號。 |
+
+| `system.first_boot` 鍵 | 說明與預設值 |
+| --- | --- |
+| `commands` | 擷取的指令碼後依序執行的 shell 行；`[]`。 |
+| `url` | 指令碼 URL；`""` 不會擷取指令碼。 |
+
+| `portage` 鍵 | 說明與預設值或選項 |
+| --- | --- |
+| `profile` | Portage profile；`default/linux/amd64/23.0/systemd`。 |
+| `keywords` | 全域關鍵字通道：`stable` 或 `testing`；`stable`。 |
+| `sync` | 持續同步：`git`、`webrsync` 或 `rsync`；`git`。首次同步使用 webrsync。 |
+| `testing_packages` | 系統維持 stable 時接受為 testing 的 atom；`[]`。 |
+| `makeopts` | `MAKEOPTS`；`""`。 |
+| `common_flags` | 通用編譯器旗標；`-O2 -pipe`。 |
+| `use` | `USE` 旗標；`[]`。 |
+| `video_cards` | `VIDEO_CARDS` 值；`[]`。 |
+| `l10n` | `L10N`；`[]` 會從產生的 locale 衍生值。 |
+| `input_devices` | `INPUT_DEVICES`；`["libinput"]`。 |
+| `accept_license` | 接受的授權；`["@FREE"]`。 |
+| `cpu_flags` | CPU 旗標；`[]` 會保留 profile 值。 |
+| `build_in_ram` | `/var/tmp/portage` 的 tmpfs 大小；未設定時在磁碟上建置。 |
+| `mirrors` | 鏡像記錄；下方列出預設值。 |
+| `binhost` | binhost 記錄；下方列出預設值。 |
+| `overlays` | overlay 記錄；`[]`。 |
+
+| `portage.mirrors` 鍵 | 說明與預設值或選項 |
+| --- | --- |
+| `region` | Gentoo 鏡像區域：`cn` 或 `global`；`global`。 |
+| `speed_test` | 測試提供的鏡像速度；`false`。 |
+| `distfiles` | 自訂 distfile 基底；非空清單會取代內建清單。 |
+| `repo_sync_uri` | 明確指定的儲存庫同步 URI；`""`。 |
+| `site` | `region` 中的站台鍵；`""` 會選取該區域的第一個站台。 |
+| `gentoo_distfiles` | 寫入 `GENTOO_MIRRORS`；`true`。 |
+| `gentoo_zh` | gentoo-zh 鏡像：`upstream`、`cernet`、`nju`、`nyist` 或 `ha`；`upstream`。 |
+| `gentoo_zh_distfiles` | 將 gentoo-zh distfile 附加至 `GENTOO_MIRRORS`；`true`。 |
+
+| 鏡像區域 | 站台鍵 |
+| --- | --- |
+| `cn` | `ustc`, `nju`, `bfsu`, `tuna`, `zju`, `sdu`, `hust`, `sustech`, `hit`, `lzu`, `aliyun`, `netease`, `cernet`, `cicku-hk`, `planetunix-hk`, `xtom-hk`, `rackspace-hk`, `aditsu-hk`, `nchc-tw`, `cicku-tw`, `freedif-sg`, `cicku-sg`, `planetunix-sg` |
+| `global` | `gentoo`, `osuosl` |
+
+| `portage.binhost` 鍵 | 說明與預設值或選項 |
+| --- | --- |
+| `official` | 啟用官方二進位主機；`true`。 |
+| `subarch` | 官方 binhost 子架構；`x86-64`。 |
+| `community` | gentoo-zh 通道：`off`、`stable` 或 `unstable`；`off`。 |
+
+| `portage.overlays` 項目 | 說明 |
+| --- | --- |
+| `name` | overlay 名稱；必填。 |
+| `sync_uri` | overlay 同步 URI；必填。 |
+
+| `kernel` 鍵 | 說明與預設值或選項 |
+| --- | --- |
+| `source` | 核心選擇：`dist-bin`、`dist-source`、`cjk-bin` 或 `cjk`；`dist-bin`。 |
+| `package` | 覆寫 `source` 所隱含的套件；`""`。 |
+| `version` | 版本固定；`""` 會讓 Portage 選取最新且關鍵字允許的版本。 |
+| `dracut_modules` | 新增磁碟版面所需的 dracut 模組；`[]`。 |
+| `remote_unlock` | initramfs SSH 解鎖記錄；預設為空白記錄。 |
+
+| `kernel.source` | 套件與 CJK 狀態 |
+| --- | --- |
+| `dist-bin` | `sys-kernel/gentoo-kernel-bin`；不是 CJK 核心。 |
+| `dist-source` | `sys-kernel/gentoo-kernel`；屬於非 CJK 核心。 |
+| `cjk-bin` | `sys-kernel/gentoo-cjk-kernel-bin`；是 CJK 核心。 |
+| `cjk` | `sys-kernel/gentoo-cjk-kernel`；屬於 CJK 核心。 |
+
+| `kernel.remote_unlock` 鍵 | 說明與預設值 |
+| --- | --- |
+| `enabled` | 啟用 initramfs SSH 解鎖；`false`。 |
+| `port` | initramfs SSH 連接埠；`222`。 |
+| `address` | 靜態 CIDR 位址；`""` 會使用 DHCP。 |
+| `gateway` | 靜態位址閘道；`""`。 |
+| `interface` | initramfs 網路介面；`""`。 |
+
+| `bootloader` 鍵 | 說明與預設值或選項 |
+| --- | --- |
+| `kind` | 開機載入器：`grub`、`systemd-boot` 或 `zfsbootmenu`；`grub`。 |
+| `firmware` | 韌體：`uefi` 或 `bios`；`uefi`。 |
+| `kernel_params` | 額外核心命令列參數；`[]`。 |
+
+| `packages` 鍵 | 說明與預設值 |
+| --- | --- |
+| `desktop` | 桌面 profile 名稱；`""` 不選取桌面。 |
+| `applications` | 套件群組名稱；`[]`。 |
+| `graphics` | 圖形驅動程式群組名稱；`[]`；多個群組可配合混合硬體。 |
+| `display_manager` | 顯示管理程式群組；`""` 會選取主控台登入。 |
+| `extra` | 在其他選項後合併的套件 atom；`[]`。 |
+
+| `disk` 鍵 | 說明與預設值或選項 |
+| --- | --- |
+| `graph` | 由 `[[disk.devices]]` 表示的裝置圖；必填。 |
+| `root` | root 圖節點識別碼；轉換外為必填；`""` 在轉換中使用執行中版面。 |
+| `mode` | `partition`、`in-place`、`image` 或 `dd`；`partition`。 |
+| `image` | image 模式的稀疏映像路徑；`""`。 |
+| `size` | image 模式的稀疏映像大小；未設定。 |
+| `wipe` | 磁碟層級的清除設定；`false`。 |
+| `source` | `dd` 模式的準備映像來源；`""`。 |
+| `source_format` | 來源編碼：`raw`、`gz`、`xz`、`zst` 或 `tar`；`raw`。 |
+| `destination` | 整顆磁碟的 `dd` 目的地；`""`。 |
+
+| 範本輸入 | 說明與預設值或選項 |
+| --- | --- |
+| `disk` | 整顆磁碟選擇器；必填。 |
+| `layout` | `whole-disk`、`whole-disk-btrfs`、`whole-disk-zfs` 或 `reuse`；`whole-disk`。 |
+| `firmware` | 範本韌體；`uefi`。 |
+| `table` | 分割表覆寫；未設定時為 UEFI 衍生 GPT，為 BIOS 衍生 MBR。 |
+| `filesystem` | 非 Btrfs 與非 ZFS 整顆磁碟版面的根檔案系統；`xfs`。 |
+| `swap` | swap 分割區大小；未設定。 |
+| `passphrase_file` | 安裝系統的密語檔路徑；`""` 會讓版面保持未加密。 |
+| `pool` | ZFS pool 名稱；`rpool`。 |
 
 以下完整設定示範包含認證資訊與兩個略過主機的 Proxy。認證資訊只是範例，執行前必須替換：
 

--- a/tests/unit/test_readme.py
+++ b/tests/unit/test_readme.py
@@ -474,10 +474,40 @@ def test_the_readme_gives_each_memory_option_the_outcome_its_record_holds() -> N
         assert all(outcome in row for row in mine), mine
         assert not any(forbidden in row for row in mine), mine
 
+        # The verification table only: the option table in `Installation`
+        # carries a row for the same option, and that one describes the flag.
         table = [
             line
-            for line in readme("README.md").splitlines()
+            for line in fact_bodies("README.md")["verification-scope"].splitlines()
             if line.startswith("| ") and line.split("|")[1].strip() == option
         ]
         assert len(table) == 1, table
         assert forbidden not in table[0], table[0]
+
+
+def test_every_table_row_carries_the_same_identifiers_in_every_readme() -> None:
+    """A reference table is names and values, and a translation that renders
+    one of them into its own language documents a key nobody can type. Four
+    cells lost `dd` this way while every structural check stayed green."""
+    import re
+
+    single = re.compile(r"^`[^`]+`$")
+
+    def rows(name: str) -> dict[str, list[frozenset[str]]]:
+        found: dict[str, list[frozenset[str]]] = {}
+        for line in readme(name).splitlines():
+            if not line.startswith("| "):
+                continue
+            cells = line.split("|")
+            key = cells[1].strip()
+            if single.match(key):
+                found.setdefault(key, []).append(
+                    frozenset(re.findall(r"`([^`]+)`", "|".join(cells[2:])))
+                )
+        return found
+
+    english = rows("README.md")
+    assert len(english) >= 100, len(english)
+    for name in READMES:
+        if name != "README.md":
+            assert rows(name) == english, name


### PR DESCRIPTION
The README described the installation paths but not the settings: a reader could not find out what `--resume`, `portage.mirrors.site` or `kernel.remote_unlock.port` does without reading the source.

Four reference tables now carry them in all five languages — the seventeen command-line options, the thirteen device-graph node kinds with their choices, the twenty-one combinations `model/compat.py` refuses, and every persisted configuration key with its default. Each table's identifier cells were checked against `dataclasses.fields()` and `RULES`.

A test holds the five tables in step: it reads every row whose first cell is a single backticked name and requires the same identifiers and the same backticked values in every translation. Four cells had already rendered `dd` as prose, and every structural check stayed green.