### PR TITLE
vm: the conversion verdict names the prefix grub embedded

### DIFF
--- a/tests/unit/test_cluster.py
+++ b/tests/unit/test_cluster.py
@@ -3112,7 +3112,8 @@ def test_a_conversion_counts_the_modules_its_bootloader_needs() -> None:
         (
             GRUB_PREFIX_CHECK,
             "grubstub=163840 grubprefix=1 boot=c866ae3a-68e7-4096-9703-dfa17070c3ed"
-            " esp=1234-ABCD stub=c866ae3a-68e7-4096-9703-dfa17070c3ed\n",
+            " esp=1234-ABCD stub=c866ae3a-68e7-4096-9703-dfa17070c3ed"
+            " embedded=(hd0,gpt2)/boot/grub\n",
         ),
     ):
         assert "wc -" in check.command or "grep -ac" in check.command
@@ -3129,7 +3130,10 @@ def test_a_conversion_counts_the_modules_its_bootloader_needs() -> None:
     # The third answers with two counts, because a stub that is not there and
     # a stub naming another filesystem are different defects and one number
     # cannot tell them apart.
-    healthy = "grubstub=163840 grubprefix=1 boot=aaaa esp=1234-ABCD stub=aaaa\n"
+    healthy = (
+        "grubstub=163840 grubprefix=1 boot=aaaa esp=1234-ABCD stub=aaaa"
+        " embedded=(hd0,gpt2)/boot/grub\n"
+    )
     assert re.search(GRUB_PREFIX_CHECK.pattern, healthy)
     assert re.search(GRUB_PREFIX_CHECK.pattern, healthy.replace("prefix=1", "prefix=0")) is None
     assert re.search(GRUB_PREFIX_CHECK.pattern, healthy.replace("stub=163840", "stub=0")) is None
@@ -3156,6 +3160,23 @@ def test_a_conversion_counts_the_modules_its_bootloader_needs() -> None:
     assert reader.search("1234-ABCD"), "a vfat serial is a filesystem name too"
     assert reader.search("c866ae3a-68e7-4096-9703-dfa17070c3ed")
     assert reader.pattern in GRUB_PREFIX_CHECK.command, GRUB_PREFIX_CHECK.command
+
+    # `vm-convert` then answered `stub=` empty on a 163840-byte stub, which
+    # says the stub names no filesystem and not which directory it will read.
+    # The prefix itself is that answer, and it decides nothing: an empty match
+    # must not turn a healthy conversion into a failure.
+    assert _re.search(GRUB_PREFIX_CHECK.pattern, healthy.replace("(hd0,gpt2)/boot/grub", ""))
+    # `grep -ac ""` counts every line, so a `grub-probe` that fails leaves
+    # `grubprefix` large and healthy-looking; `boot=` is what catches it.
+    assert (
+        _re.search(GRUB_PREFIX_CHECK.pattern, healthy.replace("boot=aaaa", "boot=").replace("grubprefix=1", "grubprefix=772"))
+        is None
+    )
+    # Anchored, because grub-2.14 carries its own build paths: an unanchored
+    # reader answered `/var/tmp/portage/…/grub-2.14/grub-core/bus/pci.c` from
+    # a stub whose prefix is `(hd0,gpt2)/boot/grub`, measured on 2026-08-20.
+    assert r"'^\([^)]+\)/[^ ]*|^/[^ ]*grub$'" in GRUB_PREFIX_CHECK.command
+    assert "embedded=%s" in GRUB_PREFIX_CHECK.command
 
 
 def test_the_unlock_addresses_go_back_after_the_guests_do() -> None:

--- a/tests/vm/convert.py
+++ b/tests/vm/convert.py
@@ -103,15 +103,28 @@ _STUB_UUID: Final[str] = (
     + " 2>/dev/null | head -n 1"
 )
 
+#: What the stub will look for its modules in, as text. `grub-install` writes
+#: the prefix as one null-terminated string, so the bytes are cut on NUL and
+#: each pattern is anchored: grub-2.14 also carries its own build paths, and
+#: an unanchored `/*/grub` answers `.../grub-2.14/grub-core/bus/pci.c` first.
+_STUB_PREFIX: Final[str] = (
+    f"tr '\\000' '\\n' < {GRUB_STUB} 2>/dev/null | "
+    r"grep -aoE '^\([^)]+\)/[^ ]*|^/[^ ]*grub$' | head -n 1"
+)
+
 GRUB_PREFIX_CHECK: Final[InstalledCheck] = InstalledCheck(
     "grub's prefix",
-    "printf 'grubstub=%s grubprefix=%s boot=%s esp=%s stub=%s\\n' "
+    "printf 'grubstub=%s grubprefix=%s boot=%s esp=%s stub=%s embedded=%s\\n' "
     f"\"$(wc -c < {GRUB_STUB} 2>/dev/null || echo 0)\" "
     f"\"$(grep -ac \"$(grub-probe --target=fs_uuid /boot)\" {GRUB_STUB} 2>/dev/null)\" "
     "\"$(grub-probe --target=fs_uuid /boot 2>/dev/null)\" "
     "\"$(grub-probe --target=fs_uuid /efi 2>/dev/null)\" "
-    f"\"$({_STUB_UUID})\"",
-    r"(?m)^grubstub=[1-9][0-9]* grubprefix=[1-9][0-9]* boot=\S+ esp=\S+ stub=\S+$",
+    f"\"$({_STUB_UUID})\" "
+    f"\"$({_STUB_PREFIX})\"",
+    # `embedded` decides nothing: `grubprefix` already says whether the stub
+    # names the filesystem holding `/boot`, and this field is the evidence the
+    # next failure needs, which an empty match must not hide.
+    r"(?m)^grubstub=[1-9][0-9]* grubprefix=[1-9][0-9]* boot=\S+ esp=\S+ stub=\S+ embedded=\S*$",
 )
 
 


### PR DESCRIPTION
run136's `vm-convert` failed at 78.6 minutes with `grubstub=163840 grubprefix=0 boot=2b6ec861-f52f-4dea-a2a7-d8a288e48dbd esp=D7DD-F311 stub=`. The widened reader from #810 works — it printed the esp's vfat serial — and the stub carries no filesystem name at all, which is why GRUB cannot find `normal.mod`. What it does not say is where the stub will look instead.

The check now also prints the prefix as text. Verified against real images rather than a reading of the format: `sys-boot/grub-2.14-r5` was installed on the workstation, `grub-mkimage -p '(hd0,gpt2)/boot/grub'` and `-p /boot/grub` each produced a stub, and the check's own command answered `embedded=(hd0,gpt2)/boot/grub` and `embedded=/boot/grub`. Both patterns are anchored because an unanchored reader answers `…/grub-2.14/grub-core/bus/pci.c` from grub's own build paths first.