### PR TITLE
convert: remove the merged-usr symlinks the swap set aside

### DIFF
--- a/gentoo_install/exec/convert.py
+++ b/gentoo_install/exec/convert.py
@@ -216,7 +216,14 @@ def convert(
         if not mounted and not present:
             continue
         try:
-            shutil.rmtree(kept)
+            # `/bin`, `/sbin`, `/lib` and `/lib64` are symlinks into `usr` on a
+            # merged-usr system, and `shutil.rmtree` refuses a symlink with
+            # `[Errno None] None`, so four of them stayed on every converted
+            # machine.
+            if kept.is_symlink():
+                kept.unlink()
+            else:
+                shutil.rmtree(kept)
         except OSError as error:
             print(f"{kept} stayed behind: {error}", file=sys.stderr)
 

--- a/tests/unit/test_convert.py
+++ b/tests/unit/test_convert.py
@@ -355,3 +355,23 @@ def test_a_mounted_directory_is_filled_by_copy_when_rename_cannot_cross(
     assert not (root / "var" / "old-log").exists(), "replaced, not merged"
     assert not (root / "var" / convert.KEPT_ASIDE).exists(), "the kept set is removed"
     assert (root / "usr" / "new.txt").read_text() == "new", "an ordinary directory renames"
+
+
+def test_a_merged_usr_symlink_is_removed_rather_than_left_beside_the_new_one(
+    tmp_path: Path,
+) -> None:
+    """`/bin`, `/sbin`, `/lib` and `/lib64` are symlinks into `usr`, and
+    `shutil.rmtree` answers `[Errno None] None` on a symlink rather than
+    removing it. run136's converted machine kept all four."""
+    root = tmp_path / "root"
+    staging = root / "new"
+    (root / "usr" / "bin").mkdir(parents=True)
+    (staging / "usr").mkdir(parents=True)
+    (staging / "bin").mkdir()
+    os.symlink("usr/bin", root / "bin")
+
+    convert.convert(staging, ("usr", "bin"), copy=_copy, root=root)
+
+    assert (root / "bin").is_dir() and not (root / "bin").is_symlink()
+    left = [one.name for one in root.iterdir() if one.name.endswith(convert.KEPT_ASIDE)]
+    assert left == [], left


### PR DESCRIPTION
run136's converted guest printed four lines the log had carried unread: `/bin.gentoo-install.old stayed behind: [Errno None] None`, and the same for `/sbin`, `/lib` and `/lib64`. Those four are symlinks into `usr` on a merged-usr system, and `shutil.rmtree` refuses a symlink with exactly that message — reproduced here on python 3.14. Every converted machine kept all four.

The removal now unlinks a symlink and keeps `rmtree` for a directory. The test converts a root whose `/bin` is a symlink and requires nothing ending in `.gentoo-install.old` afterwards; with `rmtree` back it fails.