### PR TITLE
review plan: duplication, unfalsifiable tests, probes that did not run, one architecture table

### DIFF
--- a/gentoo_install/exec/preflight.py
+++ b/gentoo_install/exec/preflight.py
@@ -504,8 +504,15 @@ def inspect(
 
     if not machine.root:
         fatal.append("the installer has to run as root")
-    if config.disk.mode is not DiskMode.DD and machine.architecture != "x86_64":
-        fatal.append(f"this build installs amd64 and the machine reports {machine.architecture}")
+    # The row rather than the literal: `uname -m` and Gentoo spell the same
+    # architecture differently, and the message has to name the one the
+    # configuration targets rather than the one this file was written for.
+    installs = compat.DEFAULT_ARCHITECTURE
+    if config.disk.mode is not DiskMode.DD and machine.architecture != installs.kernel_name:
+        fatal.append(
+            f"this build installs {installs.gentoo_name} and the machine reports "
+            f"{machine.architecture}"
+        )
     targets_machine_firmware = config.disk.mode in (DiskMode.PARTITION, DiskMode.IN_PLACE)
     wants_uefi = config.bootloader.firmware is Firmware.UEFI
     if targets_machine_firmware and wants_uefi and not machine.uefi:

--- a/gentoo_install/model/compat.py
+++ b/gentoo_install/model/compat.py
@@ -100,36 +100,40 @@ _CJK_KERNEL_PACKAGES: Final[frozenset[str]] = frozenset(
 )
 
 
-@dataclass(frozen=True)
+@dataclass(frozen=True, kw_only=True)
 class Architecture:
     """One target architecture, under each of the names something spells it.
 
     Ecosystems name the same architecture differently, the way `fma` and
-    `fma3` do: `uname -m` answers `x86_64`, Gentoo's `profiles/arch.list` says
-    `amd64`, and the official binary host is published under `x86-64`. Holding
-    the three together is what lets a site compare a row instead of a literal.
+    `fma3` do: `uname -m` answers `x86_64` and Gentoo's `profiles/arch.list`
+    says `amd64`. Holding the pair together is what lets a site compare a row
+    instead of a literal. Keyword-only, because both fields are strings that
+    read the same way round, so a swapped row would pass every gate.
     """
 
     #: What `uname -m` answers on a machine of this kind.
     kernel_name: str
     #: The line of `profiles/arch.list`, which is also the keyword.
     gentoo_name: str
-    #: The baseline subarchitecture the official binary host publishes.
-    binhost_subarch: str
 
+
+#: The row every published path targets today: the stage3, the profile and the
+#: official binary host are all fetched for it. Named so that the default is
+#: this row rather than whichever one the table happens to list first.
+AMD64: Final[Architecture] = Architecture(kernel_name="x86_64", gentoo_name="amd64")
 
 #: Every architecture this installer has a name for. A machine outside it is
 #: refused by name rather than sent to a URL composed from a guess.
 ARCHITECTURES: Final[tuple[Architecture, ...]] = (
-    Architecture("x86_64", "amd64", "x86-64"),
-    Architecture("aarch64", "arm64", "arm64"),
-    Architecture("i686", "x86", "i686"),
+    AMD64,
+    Architecture(kernel_name="aarch64", gentoo_name="arm64"),
+    Architecture(kernel_name="i686", gentoo_name="x86"),
 )
 
-#: What an installation targets when its configuration says nothing. Only the
-#: first row is installed today; the others are named so that the sites that
+#: What an installation targets when its configuration says nothing. Only
+#: amd64 is installed today; the others are named so that the sites that
 #: decide can compare a row rather than a literal.
-DEFAULT_ARCHITECTURE: Final[Architecture] = ARCHITECTURES[0]
+DEFAULT_ARCHITECTURE: Final[Architecture] = AMD64
 
 
 def architecture_of(kernel_name: str) -> Architecture | None:

--- a/gentoo_install/model/compat.py
+++ b/gentoo_install/model/compat.py
@@ -100,6 +100,46 @@ _CJK_KERNEL_PACKAGES: Final[frozenset[str]] = frozenset(
 )
 
 
+@dataclass(frozen=True)
+class Architecture:
+    """One target architecture, under each of the names something spells it.
+
+    Ecosystems name the same architecture differently, the way `fma` and
+    `fma3` do: `uname -m` answers `x86_64`, Gentoo's `profiles/arch.list` says
+    `amd64`, and the official binary host is published under `x86-64`. Holding
+    the three together is what lets a site compare a row instead of a literal.
+    """
+
+    #: What `uname -m` answers on a machine of this kind.
+    kernel_name: str
+    #: The line of `profiles/arch.list`, which is also the keyword.
+    gentoo_name: str
+    #: The baseline subarchitecture the official binary host publishes.
+    binhost_subarch: str
+
+
+#: Every architecture this installer has a name for. A machine outside it is
+#: refused by name rather than sent to a URL composed from a guess.
+ARCHITECTURES: Final[tuple[Architecture, ...]] = (
+    Architecture("x86_64", "amd64", "x86-64"),
+    Architecture("aarch64", "arm64", "arm64"),
+    Architecture("i686", "x86", "i686"),
+)
+
+#: What an installation targets when its configuration says nothing. Only the
+#: first row is installed today; the others are named so that the sites that
+#: decide can compare a row rather than a literal.
+DEFAULT_ARCHITECTURE: Final[Architecture] = ARCHITECTURES[0]
+
+
+def architecture_of(kernel_name: str) -> Architecture | None:
+    """The row a machine reporting `kernel_name` belongs to, if there is one."""
+    for row in ARCHITECTURES:
+        if row.kernel_name == kernel_name:
+            return row
+    return None
+
+
 #: The official binary hosts this installer knows how to point Portage at.
 #: A subarchitecture outside this set is a refusal rather than a URL composed
 #: from it, because a host that does not exist answers 404 an hour in.

--- a/gentoo_install/plan/bootloader.py
+++ b/gentoo_install/plan/bootloader.py
@@ -545,17 +545,21 @@ class InstallZfsBootMenu(Operation):
     def _image(self, context: Context) -> str:
         """Whatever generate-zbm wrote. It names the image after the kernel
         it built from, so `vmlinuz.EFI` is only one of the names it can have."""
-        listing = answered(
+        # findutils 4.11.0 exits 1 for an entry it could not read while still
+        # printing the matches it reached, so the listing decides, not the code.
+        listing = str(
             context.run_in_target(
                 ["find", f"{self.esp}/{ZBM_DIRECTORY}", "-name", "*.EFI"], check=False
-            ),
-            f"{self.esp}/{ZBM_DIRECTORY} could not be listed",
-        )
+            )
+        ).strip()
         found = sorted(
             line.strip() for line in listing.splitlines() if line.strip().endswith(".EFI")
         )
         if not found:
-            raise NothingToBoot(f"generate-zbm wrote no EFI image under {self.esp}/{ZBM_DIRECTORY}")
+            said = f": {listing[:200]}" if listing else ""
+            raise NothingToBoot(
+                f"generate-zbm wrote no EFI image under {self.esp}/{ZBM_DIRECTORY}{said}"
+            )
         return found[0]
 
 

--- a/gentoo_install/plan/bootloader.py
+++ b/gentoo_install/plan/bootloader.py
@@ -32,7 +32,7 @@ from ..model.device import (
     ZfsPool,
     Subvolume,
 )
-from .operations import CommandOutput, Context, Operation, Stage
+from .operations import CommandOutput, Context, Operation, Stage, answered
 from .portage import Emerge, InstallMode, PortageConfigKind, WritePortageConfig
 
 
@@ -193,9 +193,16 @@ class InstallGrub(Operation):
         context.run_in_target(["grub-mkconfig", "--output", "/boot/grub/grub.cfg"])
         # grub-mkconfig exits 0 having found no kernel, and the machine then
         # drops back to the firmware menu with nothing to boot.
-        entries = context.run_in_target(
-            ["grep", "--count", "^menuentry", "/boot/grub/grub.cfg"], check=False
-        ).strip()
+        # grep exits 1 when nothing matched, which is a count of zero; any
+        # other code is a probe that did not run, and its message must not be
+        # read as a file holding no entry.
+        entries = answered(
+            context.run_in_target(
+                ["grep", "--count", "^menuentry", "/boot/grub/grub.cfg"], check=False
+            ),
+            "grub.cfg could not be counted",
+            allowed=(0, 1),
+        )
         if not entries.isdigit() or int(entries) == 0:
             raise NothingToBoot("grub.cfg has no menu entry; /boot holds no kernel")
         # grub-mkconfig writes `grub.cfg.new` and copies it over `grub.cfg`
@@ -538,8 +545,11 @@ class InstallZfsBootMenu(Operation):
     def _image(self, context: Context) -> str:
         """Whatever generate-zbm wrote. It names the image after the kernel
         it built from, so `vmlinuz.EFI` is only one of the names it can have."""
-        listing = context.run_in_target(
-            ["find", f"{self.esp}/{ZBM_DIRECTORY}", "-name", "*.EFI"], check=False
+        listing = answered(
+            context.run_in_target(
+                ["find", f"{self.esp}/{ZBM_DIRECTORY}", "-name", "*.EFI"], check=False
+            ),
+            f"{self.esp}/{ZBM_DIRECTORY} could not be listed",
         )
         found = sorted(
             line.strip() for line in listing.splitlines() if line.strip().endswith(".EFI")

--- a/gentoo_install/plan/disk.py
+++ b/gentoo_install/plan/disk.py
@@ -44,7 +44,7 @@ from ..model.device import (
 )
 from ..model.size import DEFAULT_ALIGNMENT, Size
 from .mounts import ResolvedMount, resolve_mounts
-from .operations import CommandOutput, Context, Operation, Stage
+from .operations import CommandOutput, Context, Operation, Stage, answered
 
 #: GPT type codes as `sgdisk --typecode` spells them.
 TYPE_CODES: Final[dict[PartitionRole, str]] = {
@@ -823,24 +823,35 @@ class MountZfsDataset(Operation):
         return f"mount dataset {self.name} at {self.path}"
 
     def apply(self, context: Context) -> None:
-        mounted = context.run(
-            ["zfs", "get", "-H", "-o", "value", "mounted", self.name],
-            check=False,
-        ).strip()
+        mounted = answered(
+            context.run(
+                ["zfs", "get", "-H", "-o", "value", "mounted", self.name],
+                check=False,
+            ),
+            f"whether {self.name} is mounted could not be read",
+        )
         if mounted == "yes":
             # A parent mounted later can hide this dataset while ZFS still
             # reports it mounted, so the effective source decides readiness.
-            visible = context.run(
-                [
-                    "findmnt",
-                    "--noheadings",
-                    "--output",
-                    "SOURCE",
-                    "--target",
-                    str(_under(context.target, self.path)),
-                ],
-                check=False,
-            ).strip()
+            # findmnt exits 1 when the path carries no mount, which is the
+            # hidden dataset this looks for; any other code is a probe that
+            # did not run, and unmounting on it would take down a dataset
+            # nobody established was hidden.
+            visible = answered(
+                context.run(
+                    [
+                        "findmnt",
+                        "--noheadings",
+                        "--output",
+                        "SOURCE",
+                        "--target",
+                        str(_under(context.target, self.path)),
+                    ],
+                    check=False,
+                ),
+                f"what is mounted at {self.path} could not be read",
+                allowed=(0, 1),
+            )
             if visible == self.name:
                 return
             context.run(["zfs", "unmount", self.name])

--- a/gentoo_install/plan/disk.py
+++ b/gentoo_install/plan/disk.py
@@ -832,30 +832,41 @@ class MountZfsDataset(Operation):
         )
         if mounted == "yes":
             # A parent mounted later can hide this dataset while ZFS still
-            # reports it mounted, so the effective source decides readiness.
-            # findmnt exits 1 when the path carries no mount, which is the
-            # hidden dataset this looks for; any other code is a probe that
-            # did not run, and unmounting on it would take down a dataset
-            # nobody established was hidden.
-            visible = answered(
-                context.run(
-                    [
-                        "findmnt",
-                        "--noheadings",
-                        "--output",
-                        "SOURCE",
-                        "--target",
-                        str(_under(context.target, self.path)),
-                    ],
-                    check=False,
-                ),
-                f"what is mounted at {self.path} could not be read",
-                allowed=(0, 1),
-            )
-            if visible == self.name:
+            # reports it mounted, so what a lookup reaches decides readiness.
+            if self._reachable_source(context) == self.name:
                 return
             context.run(["zfs", "unmount", self.name])
         context.run(["zfs", "mount", self.name])
+
+    def _reachable_source(self, context: Context) -> str:
+        """What a path lookup at the mountpoint reaches, or an empty string.
+
+        Read from the whole table rather than with `findmnt --target`, which
+        answers by matching the path against every mount's target: measured on
+        util-linux 2.42.2, a mount a later parent covers still answers with its
+        own source and exit 0 there, so the hidden dataset looked exactly like
+        a mounted one. The rows arrive in mount order, so the last row at the
+        mountpoint or above it is the one that shadows the rest.
+        """
+        where = _under(context.target, self.path)
+        # No filter, so `findmnt` lists every mount and exits 0 whenever it
+        # ran: a non-zero code is a probe that did not run, not an empty table.
+        listed = answered(
+            context.run(
+                ["findmnt", "--noheadings", "--list", "--output", "TARGET,SOURCE"],
+                check=False,
+            ),
+            f"what is mounted at {self.path} could not be read",
+        )
+        reached = ""
+        for line in listed.splitlines():
+            columns = line.split(None, 1)
+            if len(columns) != 2:
+                continue
+            target = PurePosixPath(columns[0])
+            if target == where or target in where.parents:
+                reached = columns[1].strip()
+        return reached
 
 
 @dataclass(frozen=True, kw_only=True)

--- a/gentoo_install/plan/netboot.py
+++ b/gentoo_install/plan/netboot.py
@@ -92,7 +92,6 @@ ALPINE_ARCHIVE = re.compile(
     r"^alpine-netboot-(?P<version>.+)-(?P<architecture>[^-]+)\.tar\.gz$"
 )
 
-#: What the kernel calls a machine and what Gentoo calls the same one. Two
 #: One directory for everything this arms, on the filesystem the bootloader
 #: reads. Named rather than scattered, because disarming has to be able to
 #: delete exactly what arming wrote.

--- a/gentoo_install/plan/netboot.py
+++ b/gentoo_install/plan/netboot.py
@@ -312,9 +312,18 @@ class ClearPreviousArming(Operation):
         return "take back anything an earlier run armed", ()
 
     def apply(self, context: Context) -> None:
-        _disarm(context, self.target)
-        for gone in (self.target.place, STAGING):
-            context.run(["rm", "--recursive", "--force", str(gone)], check=False)
+        _take_back(context, self.target)
+
+
+def _take_back(context: Context, target: BootTarget) -> None:
+    """Clear the one-shot and delete what an arming placed.
+
+    Both operations that undo an arming do exactly this: one runs before a new
+    arming writes, the other when the operator changed their mind.
+    """
+    _disarm(context, target)
+    for gone in (target.place, STAGING):
+        context.run(["rm", "--recursive", "--force", str(gone)], check=False)
 
 
 def _disarm(context: Context, target: BootTarget) -> None:
@@ -854,9 +863,7 @@ class DisarmMemoryBoot(Operation):
         return "take back the armed boot and delete what it placed", ()
 
     def apply(self, context: Context) -> None:
-        _disarm(context, self.target)
-        for gone in (self.target.place, STAGING):
-            context.run(["rm", "--recursive", "--force", str(gone)], check=False)
+        _take_back(context, self.target)
 
 
 def build(

--- a/gentoo_install/plan/netboot.py
+++ b/gentoo_install/plan/netboot.py
@@ -17,6 +17,7 @@ from pathlib import PurePosixPath
 from typing import Final
 
 from ..errors import DownloadFailed, PreflightFailed
+from ..model.compat import ARCHITECTURES, architecture_of
 from ..model.config import BootMethod, MemoryLaunch, MemoryMode, MirrorRegion
 from .operations import CommandOutput, Context, Operation, Stage
 
@@ -92,17 +93,6 @@ ALPINE_ARCHIVE = re.compile(
 )
 
 #: What the kernel calls a machine and what Gentoo calls the same one. Two
-#: ecosystems name the same architecture differently, the way `fma` and `fma3`
-#: do: `uname -m` answers `x86_64` while the ISO is published as
-#: `install-amd64-…`. Gentoo's own names are the lines of
-#: `profiles/arch.list`. A machine outside this table is refused by name
-#: rather than sent to a URL composed from a guess.
-GENTOO_ARCHITECTURES: Final[dict[str, str]] = {
-    "x86_64": "amd64",
-    "aarch64": "arm64",
-    "i686": "x86",
-}
-
 #: One directory for everything this arms, on the filesystem the bootloader
 #: reads. Named rather than scattered, because disarming has to be able to
 #: delete exactly what arming wrote.
@@ -1092,12 +1082,14 @@ def _cjk_release(context: Context, machine: str) -> tuple[str, str, str]:
     architecture the project starts building for works without this file
     changing.
     """
-    named = GENTOO_ARCHITECTURES.get(machine)
-    if named is None:
+    row = architecture_of(machine)
+    if row is None:
+        known = ", ".join(sorted(one.kernel_name for one in ARCHITECTURES))
         raise DownloadFailed(
             f"{machine} is not an architecture Gentoo names, so no ISO can be "
-            f"chosen for it: {', '.join(sorted(GENTOO_ARCHITECTURES))} are"
+            f"chosen for it: {known} are"
         )
+    named = row.gentoo_name
     from_mirror = _cjk_from_mirror(context, named)
     if from_mirror is not None:
         return from_mirror

--- a/gentoo_install/plan/operations.py
+++ b/gentoo_install/plan/operations.py
@@ -107,7 +107,9 @@ def answered(output: str, probe: str, *, allowed: tuple[int, ...] = (0,)) -> str
     compares the two folds a probe that never ran into the branch for a
     negative answer.
     """
-    if isinstance(output, CommandOutput) and output.returncode not in allowed:
+    # A Context whose `run` honours the declared `-> str` carries no exit
+    # status, so a probe whose ending cannot be read is treated as one failing.
+    if not isinstance(output, CommandOutput) or output.returncode not in allowed:
         raise CommandFailed(f"{probe}: {str(output).strip()[:200] or 'no output'}")
     return str(output).strip()
 

--- a/gentoo_install/plan/operations.py
+++ b/gentoo_install/plan/operations.py
@@ -21,6 +21,7 @@ from pathlib import PurePosixPath
 import re
 from typing import ClassVar, Final, Protocol, Sequence
 
+from ..errors import CommandFailed
 from ..model.device import DeviceId
 from ..model.validate import KernelCeiling
 
@@ -95,6 +96,20 @@ class CommandOutput(str):
     @property
     def ending(self) -> str:
         return ending(self.returncode)
+
+
+def answered(output: str, probe: str, *, allowed: tuple[int, ...] = (0,)) -> str:
+    """The text a probe answered, or a named failure.
+
+    `check=False` keeps a probe's failure out of the exception path and the
+    runner merges stderr into stdout, so the diagnostic arrives where the
+    answer belongs: `zfs is not installed` is not `yes`, and the caller that
+    compares the two folds a probe that never ran into the branch for a
+    negative answer.
+    """
+    if isinstance(output, CommandOutput) and output.returncode not in allowed:
+        raise CommandFailed(f"{probe}: {str(output).strip()[:200] or 'no output'}")
+    return str(output).strip()
 
 
 class Context(Protocol):

--- a/gentoo_install/plan/packages.py
+++ b/gentoo_install/plan/packages.py
@@ -19,7 +19,7 @@ import tomllib
 from dataclasses import dataclass
 from enum import Enum
 from pathlib import PurePosixPath
-from typing import Final, Mapping, Protocol, Sequence, runtime_checkable
+from typing import ClassVar, Final, Mapping, Protocol, Sequence, runtime_checkable
 
 from ..errors import CommandFailed, ConfigError, ValidationFailed
 from ..model.config import InitSystem, InstallConfig
@@ -429,32 +429,22 @@ SKELETON: Final[PurePosixPath] = PurePosixPath("/etc/skel")
 
 
 @dataclass(frozen=True, kw_only=True, init=False)
-class WriteGroupKeywords(WritePortageConfig):
-    """Written in the portage phase, for the same reason as the USE flags."""
+class WriteForGroup(WritePortageConfig):
+    """One Portage fragment named after the package group that asked for it.
 
-    def __init__(self, *, group: str, lines: tuple[str, ...]) -> None:
-        object.__setattr__(self, "kind", PortageConfigKind.KEYWORDS)
-        object.__setattr__(self, "name", group)
-        object.__setattr__(self, "lines", lines)
-
-    @property
-    def group(self) -> str:
-        return self.name
-
-    def describe(self) -> str:
-        return f"accept {'; '.join(self.lines)} for the {self.group} group"
-
-@dataclass(frozen=True, kw_only=True, init=False)
-class WriteGroupLicense(WritePortageConfig):
-    """Accept a group's licences for that group's own atoms.
-
-    Merged into `ACCEPT_LICENSE` the acceptance held for every later emerge on
-    the installed machine, which is not what choosing one chat program asks
-    for.
+    The fragment is per group rather than global: an acceptance merged into
+    `ACCEPT_LICENSE` holds for every later emerge on the installed machine,
+    which is not what choosing one chat program asks for.
     """
 
+    #: Which `/etc/portage` directory the fragment goes in.
+    directory: ClassVar[PortageConfigKind]
+    #: How the dry-run line reads, because accepting and asking are not the
+    #: same act to the operator reading the plan.
+    verb: ClassVar[str]
+
     def __init__(self, *, group: str, lines: tuple[str, ...]) -> None:
-        object.__setattr__(self, "kind", PortageConfigKind.LICENSE)
+        object.__setattr__(self, "kind", self.directory)
         object.__setattr__(self, "name", group)
         object.__setattr__(self, "lines", lines)
 
@@ -463,25 +453,32 @@ class WriteGroupLicense(WritePortageConfig):
         return self.name
 
     def describe(self) -> str:
-        return f"accept {'; '.join(self.lines)} for the {self.group} group"
+        return f"{self.verb} {'; '.join(self.lines)} for the {self.group} group"
 
 
 @dataclass(frozen=True, kw_only=True, init=False)
-class WriteGroupUse(WritePortageConfig):
+class WriteGroupKeywords(WriteForGroup):
+    """Written in the portage phase, for the same reason as the USE flags."""
+
+    directory: ClassVar[PortageConfigKind] = PortageConfigKind.KEYWORDS
+    verb: ClassVar[str] = "accept"
+
+
+@dataclass(frozen=True, kw_only=True, init=False)
+class WriteGroupLicense(WriteForGroup):
+    """Accept a group's licences for that group's own atoms."""
+
+    directory: ClassVar[PortageConfigKind] = PortageConfigKind.LICENSE
+    verb: ClassVar[str] = "accept"
+
+
+@dataclass(frozen=True, kw_only=True, init=False)
+class WriteGroupUse(WriteForGroup):
     """Written in the portage phase: the flags have to be set before the
     packages that need them are merged."""
 
-    def __init__(self, *, group: str, lines: tuple[str, ...]) -> None:
-        object.__setattr__(self, "kind", PortageConfigKind.USE)
-        object.__setattr__(self, "name", group)
-        object.__setattr__(self, "lines", lines)
-
-    @property
-    def group(self) -> str:
-        return self.name
-
-    def describe(self) -> str:
-        return f"ask for {'; '.join(self.lines)} for the {self.group} group"
+    directory: ClassVar[PortageConfigKind] = PortageConfigKind.USE
+    verb: ClassVar[str] = "ask for"
 
     def apply(self, context: Context) -> None:
         for line in self.lines:

--- a/gentoo_install/plan/packages.py
+++ b/gentoo_install/plan/packages.py
@@ -428,6 +428,19 @@ KWIN_DEFAULTS: Final[PurePosixPath] = PurePosixPath("/etc/xdg/kwinrc")
 SKELETON: Final[PurePosixPath] = PurePosixPath("/etc/skel")
 
 
+#: What a fragment class has to declare before it can name a file or a line.
+_FRAGMENT_DECLARATIONS: Final[tuple[str, ...]] = ("directory", "verb")
+
+
+def _refuse_undeclared(cls: type[WriteForGroup]) -> None:
+    missing = [name for name in _FRAGMENT_DECLARATIONS if getattr(cls, name, None) is None]
+    if missing:
+        raise ConfigError(
+            f"{cls.__name__} declares no {', '.join(missing)}; a group fragment names "
+            "the /etc/portage directory it writes and the verb its plan line reads"
+        )
+
+
 @dataclass(frozen=True, kw_only=True, init=False)
 class WriteForGroup(WritePortageConfig):
     """One Portage fragment named after the package group that asked for it.
@@ -439,11 +452,19 @@ class WriteForGroup(WritePortageConfig):
 
     #: Which `/etc/portage` directory the fragment goes in.
     directory: ClassVar[PortageConfigKind]
-    #: How the dry-run line reads, because accepting and asking are not the
-    #: same act to the operator reading the plan.
+    #: How the `--dry-run` line reads. The overview screen renders the
+    #: inherited `describe_parts`, so this word reaches the dry run alone.
     verb: ClassVar[str]
 
+    def __init_subclass__(cls) -> None:
+        # At class creation, because a subclass declaring one of the two builds
+        # a plan and dies in Stage.PORTAGE with the disks already partitioned.
+        super().__init_subclass__()
+        _refuse_undeclared(cls)
+
     def __init__(self, *, group: str, lines: tuple[str, ...]) -> None:
+        # Only this class can fail it: a subclass is refused when it is created.
+        _refuse_undeclared(type(self))
         object.__setattr__(self, "kind", self.directory)
         object.__setattr__(self, "name", group)
         object.__setattr__(self, "lines", lines)

--- a/tests/unit/fake_screen.py
+++ b/tests/unit/fake_screen.py
@@ -57,15 +57,28 @@ class FakeScreen:
         cells = self._grid.setdefault(line, [])
         while len(cells) < column:
             cells.append(" ")
+        # A wide character the span covers only one cell of loses both of its
+        # cells, and only at the two edges: inside the span every cell is rewritten.
+        end = column + width(text)
+        if 0 < column < len(cells) and cells[column] == "":
+            cells[column - 1] = " "
+            cells[column] = " "
+        if end < len(cells) and cells[end] == "":
+            cells[end] = " "
         at = column
         for character in text:
             step = width(character)
-            while len(cells) <= at + step - 1:
+            if step == 0:
+                # A combining mark owns no cell, so it joins the base character
+                # in the cell that holds it rather than displacing a column.
+                base = at - 1
+                while base > 0 and cells[base] == "":
+                    base -= 1
+                if base >= 0:
+                    cells[base] += character
+                continue
+            while len(cells) < at + step:
                 cells.append(" ")
-            # Overwriting half of a wide character leaves the other half
-            # behind, which is what a terminal shows too.
-            if cells[at] == "":
-                cells[at - 1] = " "
             cells[at] = character
             for tail in range(1, step):
                 cells[at + tail] = ""

--- a/tests/unit/fake_screen.py
+++ b/tests/unit/fake_screen.py
@@ -24,13 +24,15 @@ class FakeScreen:
     #: Every styled row drawn, so a test can assert what the colour says
     #: without a terminal that has colour.
     styled: list[tuple[Style, str]] = field(default_factory=list)
-    _current: dict[int, str] = field(default_factory=dict)
+    #: One entry per cell, so a wide character owns two of them and the
+    #: second is empty.
+    _grid: dict[int, list[str]] = field(default_factory=dict)
 
     def size(self) -> tuple[int, int]:
         return self.lines, self.columns
 
     def clear(self) -> None:
-        self._current = {}
+        self._grid = {}
 
     def write(
         self,
@@ -47,15 +49,40 @@ class FakeScreen:
         """
         assert 0 <= line < self.lines, f"row {line} is off a {self.lines}-line screen"
         assert column + width(text) <= self.columns, f"{text!r} runs past column {self.columns}"
-        row = self._current.get(line, "").ljust(column)
-        self._current[line] = row[:column] + text + row[column + len(text):]
+        # A grid of cells, not a string of characters: curses places at a
+        # column, so a wide label takes two cells and the field beside it
+        # still starts where the widget asked. Composing by character index
+        # pushed every later write right, and the composed row measured wider
+        # than the screen while every write into it was inside it.
+        cells = self._grid.setdefault(line, [])
+        while len(cells) < column:
+            cells.append(" ")
+        at = column
+        for character in text:
+            step = width(character)
+            while len(cells) <= at + step - 1:
+                cells.append(" ")
+            # Overwriting half of a wide character leaves the other half
+            # behind, which is what a terminal shows too.
+            if cells[at] == "":
+                cells[at - 1] = " "
+            cells[at] = character
+            for tail in range(1, step):
+                cells[at + tail] = ""
+            at += step
         if highlight:
             self.highlighted.append(text)
         if style is not Style.PLAIN:
             self.styled.append((style, text))
 
+    def drawn(self, line: int) -> str:
+        """The row as it stands, before `show` records the frame."""
+        return "".join(self._grid.get(line, []))
+
     def show(self) -> None:
-        self.frames.append([self._current.get(row, "") for row in range(self.lines)])
+        self.frames.append(
+            ["".join(self._grid.get(row, [])) for row in range(self.lines)]
+        )
 
     def key(self) -> str:
         if not self.keys:

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -18,7 +18,7 @@ from gentoo_install.exec import report
 from gentoo_install.exec.probe import BootMethod, Probe as RealProbe
 from gentoo_install.exec.runner import Runner
 from gentoo_install.cli import EXIT_CONFIG, EXIT_INTEGRITY, EXIT_OK, EXIT_PREFLIGHT, main
-from gentoo_install.errors import ConfigError, IntegrityError
+from gentoo_install.errors import CommandFailed, ConfigError, IntegrityError
 from gentoo_install.model.config import DiskConfig, DiskMode, ImageFormat, MemoryLaunch, MemoryMode
 from gentoo_install.model.device import DeviceGraph, DeviceId, StorageFacts, StorageLayout
 from gentoo_install.plan.build import DEFAULT_MIRROR
@@ -751,23 +751,72 @@ def test_the_address_handed_over_carries_no_extension() -> None:
     assert {one.extension for one in paste.EXPORTS} == {"log", "toml"}
 
 
-def test_the_log_is_kept_before_the_target_is_unmounted() -> None:
+def test_the_log_is_kept_before_the_target_is_unmounted(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
     """`Stage.FINISH` unmounts, so a copy made after it lands on the install
     medium's tmpfs and goes with the reboot.
 
     Found on a machine this installer had installed: `/var/log/gentoo-install`
     was not there at all, and the copy had reported success.
     """
-    import inspect
+    import argparse
+    from dataclasses import replace
 
     from gentoo_install import cli
+    from gentoo_install.exec import report
 
-    source = inspect.getsource(cli.install)
-    kept = source.index("report.keep_log(")
-    closing = source.index("apply(closing, machine, finished)")
-    released = source.index("_release(closing, machine, record)")
-    assert kept < closing, "the log is copied after the closing stage unmounts"
-    assert kept < released, "the log is copied after the failure path unmounts"
+    from gentoo_install.data import load_catalog
+    from gentoo_install.plan.build import build
+    from gentoo_install.plan.operations import Operation
+    from gentoo_install.plan.operations import Stage
+
+    from .layouts import config, ext4_on_gpt
+
+    # The order the run takes, not the order the words sit in the source: a
+    # closure can keep `report.keep_log(` early in the text and call it after
+    # the closing stage, and this test would still pass.
+    def order_of(fail: bool) -> list[str]:
+        seen: list[str] = []
+
+        class Recording:
+            def __init__(self, **fields: object) -> None:
+                self.given_up: set[str] = set()
+                self.runner = fields["runner"]
+
+        def applied(operations: object, machine: object, *rest: object) -> None:
+            stages = {one.stage for one in cast("tuple[Operation, ...]", operations)}
+            seen.append("closing" if stages == {Stage.FINISH} else "body")
+            if fail and stages != {Stage.FINISH}:
+                raise CommandFailed("the body stopped")
+
+        monkeypatch.setattr(cli, "Machine", Recording)
+        monkeypatch.setattr(cli, "apply", applied)
+        monkeypatch.setattr(report, "keep_log", lambda work, target, record: seen.append("keep"))
+        monkeypatch.setattr(cli, "_release", lambda *args: seen.append("release"))
+        monkeypatch.setattr(cli, "_offer_a_shell", lambda *args: None)
+        monkeypatch.setattr(report, "offer_paste", lambda *args, **kwargs: None)
+        arguments = argparse.Namespace(
+            work=tmp_path / f"work-{fail}",
+            target=tmp_path / "target",
+            skip_preflight=True,
+            resume=False,
+            no_shell=True,
+            dry_run=False,
+        )
+        try:
+            cli.install(replace(config(ext4_on_gpt())), operations, arguments, cli.RunState())
+        except CommandFailed:
+            pass
+        return seen
+
+    operations = tuple(build(config(ext4_on_gpt()), load_catalog()))
+    assert {one.stage for one in operations} >= {Stage.FINISH}, "the plan has a closing stage"
+
+    done = order_of(fail=False)
+    assert done.index("keep") < done.index("closing"), done
+    stopped = order_of(fail=True)
+    assert stopped.index("keep") < stopped.index("release"), stopped
 
 
 def test_log_preservation_can_run_without_the_cli(tmp_path: Path) -> None:

--- a/tests/unit/test_cluster.py
+++ b/tests/unit/test_cluster.py
@@ -1001,19 +1001,48 @@ def test_a_node_that_refuses_a_guest_does_not_end_the_campaign() -> None:
     """`POST /nodes/infra-node3/qemu` answered `595 Connection refused` and the
     exception left the dispatch loop, so the closing path removed five guests
     that were installing."""
+    import ast
     import inspect
+    import textwrap
 
-    from tests.vm.proxmox import ProxmoxTransientError
+    from tests.vm import proxmox
 
-    code = inspect.getsource(cluster.run)
-    caught = code.index("except ProxmoxTransientError as refused:")
-    reserved = code.index("_reserve_job(")
-    assert reserved < caught, "the guard has to sit on the call that creates the guest"
-    after = code[caught : caught + 900]
-    assert "unreachable.add(node.name)" in after
-    assert "waiting.insert(index, job)" in after
-    assert "continue" in after
-    assert ProxmoxTransientError.__name__ in code
+    # The class the module catches, not a name that reads like it: a local
+    # `class ProxmoxTransientError(Exception)` in `tests/vm/cluster.py` would
+    # satisfy every text search here and catch nothing the API raises.
+    assert getattr(cluster, "ProxmoxTransientError") is proxmox.ProxmoxTransientError
+
+    # The `try` that wraps the call which creates the guest, found in the tree
+    # rather than by where the words sit: a handler placed around something
+    # else keeps the same words in the same order.
+    tree = ast.parse(textwrap.dedent(inspect.getsource(cluster.run)))
+    guarded = [
+        node
+        for node in ast.walk(tree)
+        if isinstance(node, ast.Try)
+        and any(
+            isinstance(call.func, ast.Name) and call.func.id == "_reserve_job"
+            for call in ast.walk(node)
+            if isinstance(call, ast.Call)
+        )
+        and any(
+            isinstance(handler.type, ast.Name)
+            and handler.type.id == "ProxmoxTransientError"
+            for handler in node.handlers
+        )
+    ]
+    assert len(guarded) == 1, "one guard, on the call that creates the guest"
+    handler = next(
+        one
+        for one in guarded[0].handlers
+        if isinstance(one.type, ast.Name) and one.type.id == "ProxmoxTransientError"
+    )
+    said = ast.dump(ast.Module(body=handler.body, type_ignores=[]))
+    assert "unreachable" in said, "the node is taken out of the round"
+    assert "waiting" in said, "the job goes back to the queue"
+    assert any(isinstance(one, ast.Continue) for one in ast.walk(handler)), (
+        "the loop carries on with the next node"
+    )
 
 
 def test_the_resolvers_are_written_again_once_the_client_is_dead() -> None:

--- a/tests/unit/test_cluster.py
+++ b/tests/unit/test_cluster.py
@@ -1037,12 +1037,20 @@ def test_a_node_that_refuses_a_guest_does_not_end_the_campaign() -> None:
         for one in guarded[0].handlers
         if isinstance(one.type, ast.Name) and one.type.id == "ProxmoxTransientError"
     )
-    said = ast.dump(ast.Module(body=handler.body, type_ignores=[]))
-    assert "unreachable" in said, "the node is taken out of the round"
-    assert "waiting" in said, "the job goes back to the queue"
-    assert any(isinstance(one, ast.Continue) for one in ast.walk(handler)), (
-        "the loop carries on with the next node"
-    )
+    # The calls, not the words: a log line naming both reads the same, and
+    # `unreachable.discard(node.name)` leaves the refusing node in the round.
+    made = {
+        (statement.value.func.value.id, statement.value.func.attr)
+        + tuple(ast.unparse(one) for one in statement.value.args)
+        for statement in handler.body
+        if isinstance(statement, ast.Expr)
+        and isinstance(statement.value, ast.Call)
+        and isinstance(statement.value.func, ast.Attribute)
+        and isinstance(statement.value.func.value, ast.Name)
+    }
+    assert ("unreachable", "add", "node.name") in made, made
+    assert ("waiting", "insert", "index", "job") in made, made
+    assert isinstance(handler.body[-1], ast.Continue), ast.unparse(handler.body[-1])
 
 
 def test_the_resolvers_are_written_again_once_the_client_is_dead() -> None:

--- a/tests/unit/test_every_row.py
+++ b/tests/unit/test_every_row.py
@@ -87,18 +87,34 @@ def test_every_row_offers_an_answer(row: Setting) -> None:
     assert answer.value != before, f"{row.key} drew nothing and changed nothing"
 
 
+@pytest.mark.parametrize("language", ("en", "zh-TW", "zh-CN", "ja", "ko"))
 @pytest.mark.parametrize("row", openable(), ids=lambda row: row.key)
-def test_no_row_draws_past_the_edge_of_an_eighty_column_console(row: Setting) -> None:
+def test_no_row_draws_past_the_edge_of_an_eighty_column_console(
+    row: Setting, language: str
+) -> None:
     """The interface has to be usable on the console a live medium gives, and
-    a line that wraps there is a line that cannot be read."""
-    from gentoo_install.i18n import width
+    a line that wraps there is a line that cannot be read.
+
+    Every language it offers, because `width` and `len` differ only where the
+    catalog holds wide characters: an English-only walk leaves the four
+    translated catalogs — the ones that draw two cells per character —
+    unmeasured. `FakeScreen.write` raises on the offending write itself, so
+    what this adds is the input rather than the assertion.
+    """
+    from gentoo_install.i18n import Catalog, width
 
     at = context()
     at.columns = 80
-    screen, _ = leave(row, config(ext4_on_gpt()), at, columns=80)
+    at.translate = Catalog(language)
+    screen, answer = leave(row, config(ext4_on_gpt()), at, columns=80)
+    # A toggle draws nothing and answers on the spot, which the row above
+    # holds; anything else drawing nothing has not been measured at all.
+    if not screen.frames:
+        assert answer.outcome is Outcome.CHOSE, f"{row.key} drew nothing in {language}"
+        return
     for frame in screen.frames:
         for line in frame:
-            assert width(line) <= 80, f"{row.key}: {line!r}"
+            assert width(line) <= 80, f"{row.key}/{language}: {line!r}"
 
 
 def test_the_install_row_never_asks_for_something_a_row_says_is_answered() -> None:

--- a/tests/unit/test_every_row.py
+++ b/tests/unit/test_every_row.py
@@ -57,10 +57,14 @@ def leave(
     assert row.edit is not None
     try:
         answer = row.edit(screen, before, at)
-    except AssertionError as exhausted:
+    except AssertionError as refused:
+        # `FakeScreen` refuses an off-screen write with the same exception, and
+        # relabelling that as an unescapable row sends it to the wrong reader.
+        if screen.keys:
+            raise
         raise AssertionError(
-            f"{row.key} did not leave after {len(LEAVE)} cancels: {exhausted}"
-        ) from exhausted
+            f"{row.key} did not leave after {len(LEAVE)} cancels: {refused}"
+        ) from refused
     return screen, answer
 
 
@@ -95,26 +99,28 @@ def test_no_row_draws_past_the_edge_of_an_eighty_column_console(
     """The interface has to be usable on the console a live medium gives, and
     a line that wraps there is a line that cannot be read.
 
-    Every language it offers, because `width` and `len` differ only where the
-    catalog holds wide characters: an English-only walk leaves the four
-    translated catalogs — the ones that draw two cells per character —
-    unmeasured. `FakeScreen.write` raises on the offending write itself, so
-    what this adds is the input rather than the assertion.
+    The check is `FakeScreen.write`'s own refusal of a write reaching past the
+    column count, so what this test supplies is the input. Reading the recorded
+    rows back adds nothing, because each was composed out of writes that
+    already fit: a `Catalog` appending sixty cells to every string produced no
+    over-wide recorded row anywhere in the walk, and one refused write.
+
+    All five languages, because `truncate` clamps in cells and a clamp written
+    in characters passes in English and fails everywhere else: slicing it by
+    `len` left every `en` row green and reddened twenty across `zh-TW`,
+    `zh-CN`, `ja` and `ko`.
     """
-    from gentoo_install.i18n import Catalog, width
+    from gentoo_install.i18n import Catalog
 
     at = context()
     at.columns = 80
     at.translate = Catalog(language)
     screen, answer = leave(row, config(ext4_on_gpt()), at, columns=80)
-    # A toggle draws nothing and answers on the spot, which the row above
-    # holds; anything else drawing nothing has not been measured at all.
-    if not screen.frames:
-        assert answer.outcome is Outcome.CHOSE, f"{row.key} drew nothing in {language}"
-        return
-    for frame in screen.frames:
-        for line in frame:
-            assert width(line) <= 80, f"{row.key}/{language}: {line!r}"
+    # A toggle draws nothing and answers on the spot; anything else drawing
+    # nothing handed no write to the width check and was not measured at all.
+    assert screen.frames or answer.outcome is Outcome.CHOSE, (
+        f"{row.key} neither drew nor answered in {language}"
+    )
 
 
 def test_the_install_row_never_asks_for_something_a_row_says_is_answered() -> None:

--- a/tests/unit/test_layers.py
+++ b/tests/unit/test_layers.py
@@ -814,9 +814,10 @@ def test_one_table_decides_what_an_architecture_is_called() -> None:
     assert ("x86_64", "amd64") in pairs
 
     # Any other place holding both spellings of one architecture together is
-    # the second table this exists to prevent.
+    # the second table this exists to prevent. One file is exempt, by path: a
+    # basename exempted every future `plan/compat.py` from the rule too.
     for path in sorted(PACKAGE.rglob("*.py")):
-        if path.parts[-2:] == ("model", "compat.py") or path.name == "compat.py":
+        if path == PACKAGE / "model" / "compat.py":
             continue
         text = path.read_text()
         for kernel_name, gentoo_name in pairs:
@@ -831,3 +832,47 @@ def test_one_table_decides_what_an_architecture_is_called() -> None:
                 assert not {kernel_name, gentoo_name} <= spelled, (
                     f"{path}:{node.lineno} holds both names of one architecture"
                 )
+
+
+def test_the_default_architecture_is_pinned_by_name_not_by_row_order() -> None:
+    """`DEFAULT_ARCHITECTURE = ARCHITECTURES[0]` made sorting the table or
+    adding an arm64 row above amd64 tell `exec/preflight.py` to accept aarch64
+    and refuse x86_64, while the stage3 and profile paths still fetch amd64."""
+    import ast
+
+    from gentoo_install.model import compat
+
+    assert compat.DEFAULT_ARCHITECTURE.kernel_name == "x86_64"
+    assert compat.DEFAULT_ARCHITECTURE.gentoo_name == "amd64"
+    assert compat.DEFAULT_ARCHITECTURE in compat.ARCHITECTURES
+
+    source = (PACKAGE / "model" / "compat.py").read_text()
+    assigned = [
+        node.value
+        for node in ast.walk(ast.parse(source))
+        if isinstance(node, (ast.Assign, ast.AnnAssign))
+        for target in (node.targets if isinstance(node, ast.Assign) else [node.target])
+        if isinstance(target, ast.Name) and target.id == "DEFAULT_ARCHITECTURE"
+        if node.value is not None
+    ]
+    assert len(assigned) == 1, assigned
+    # Every name the assignment reads, so `ARCHITECTURES[0]`, `next(iter(...))`
+    # and any other way of taking the default out of the ordered table fail.
+    read = {one.id for one in ast.walk(assigned[0]) if isinstance(one, ast.Name)}
+    assert "ARCHITECTURES" not in read, "the default is taken out of the ordered table"
+
+
+def test_an_architecture_row_cannot_be_written_with_its_names_swapped() -> None:
+    """Both fields are strings that read the same way round, so a positional
+    row with the two names exchanged passed mypy and every test."""
+    from typing import Any, Callable
+
+    import pytest
+
+    from gentoo_install.model.compat import Architecture
+
+    # Called through a name mypy cannot resolve to the constructor, so the
+    # rejection this pins is the runtime one and not a silenced type error.
+    build: Callable[..., Any] = Architecture
+    with pytest.raises(TypeError):
+        build("amd64", "x86_64")

--- a/tests/unit/test_layers.py
+++ b/tests/unit/test_layers.py
@@ -799,3 +799,35 @@ def test_the_disk_screens_reach_nothing_in_the_screen_module() -> None:
     # Whatever `screens.py` uses from there, it imports from there.
     for name in crossing:
         assert re.search(rf"from \.partitions import \([^)]*\b{name}\b", source, re.S), name
+
+
+def test_one_table_decides_what_an_architecture_is_called() -> None:
+    """`x86_64` and `amd64` are the same machine under two ecosystems' names,
+    and the only table that said so lived in `plan/netboot.py`, where `exec`
+    and `model` cannot read it. A second table is how the fourteen sites that
+    spell an architecture drifted apart."""
+    import ast
+
+    from gentoo_install.model.compat import ARCHITECTURES
+
+    pairs = {(one.kernel_name, one.gentoo_name) for one in ARCHITECTURES}
+    assert ("x86_64", "amd64") in pairs
+
+    # Any other place holding both spellings of one architecture together is
+    # the second table this exists to prevent.
+    for path in sorted(PACKAGE.rglob("*.py")):
+        if path.parts[-2:] == ("model", "compat.py") or path.name == "compat.py":
+            continue
+        text = path.read_text()
+        for kernel_name, gentoo_name in pairs:
+            for node in ast.walk(ast.parse(text)):
+                if not isinstance(node, (ast.Dict, ast.Tuple, ast.List, ast.Set)):
+                    continue
+                spelled = {
+                    one.value
+                    for one in ast.walk(node)
+                    if isinstance(one, ast.Constant) and isinstance(one.value, str)
+                }
+                assert not {kernel_name, gentoo_name} <= spelled, (
+                    f"{path}:{node.lineno} holds both names of one architecture"
+                )

--- a/tests/unit/test_packages.py
+++ b/tests/unit/test_packages.py
@@ -538,3 +538,25 @@ def test_selected_package_contracts_are_verified_before_writes() -> None:
     assert {one.package for one in commands} == {"gui-apps/tuigreet"}
     assert directories
     assert directories[0].package == "kde-plasma/plasma-meta"
+
+
+def test_one_group_fragment_writes_one_describe() -> None:
+    """Three classes carried the same `group` and `describe` word for word, and
+    an AST scan of the tree found two of them identical. The shared half lives
+    in one place, and each subclass names only what differs."""
+    base = plan_packages.WriteForGroup
+    kinds = {
+        plan_packages.WriteGroupKeywords: ("accept", "package.accept_keywords"),
+        plan_packages.WriteGroupLicense: ("accept", "package.license"),
+        plan_packages.WriteGroupUse: ("ask for", "package.use"),
+    }
+    for cls, (verb, directory) in kinds.items():
+        assert issubclass(cls, base), cls
+        # The shared half is inherited: an override here is the duplication
+        # coming back, and nothing else would notice.
+        assert cls.describe is base.describe, cls
+        assert vars(cls).get("group") is None, cls
+        written = cls(group="chat", lines=("one", "two"))
+        assert written.describe() == f"{verb} one; two for the chat group"
+        assert str(written.path) == f"/etc/portage/{directory}/chat"
+    assert len({cls.directory for cls in kinds}) == len(kinds)

--- a/tests/unit/test_packages.py
+++ b/tests/unit/test_packages.py
@@ -1,6 +1,9 @@
 # SPDX-License-Identifier: GPL-2.0-or-later
+import sys
+
 from dataclasses import replace
 from pathlib import Path, PurePosixPath
+from typing import ClassVar
 
 import pytest
 
@@ -9,7 +12,7 @@ from gentoo_install.errors import CommandFailed, ConfigError
 from gentoo_install.model.config import ConsoleFontSize, InstallConfig, Overlay, User
 from gentoo_install.plan import packages as plan_packages
 from gentoo_install.plan.packages import Group, build
-from gentoo_install.plan.portage import Emerge
+from gentoo_install.plan.portage import Emerge, PortageConfigKind
 
 from .recorder import Recorder
 
@@ -540,6 +543,22 @@ def test_selected_package_contracts_are_verified_before_writes() -> None:
     assert directories[0].package == "kde-plasma/plasma-meta"
 
 
+def _fragment_classes() -> list[type[plan_packages.WriteForGroup]]:
+    """Every group fragment class, so a fourth is covered the day it is written.
+
+    Bound in its own module, which a class a test defines and throws away is
+    not: a refused declaration stays in `__subclasses__` until it is collected.
+    """
+    found: list[type[plan_packages.WriteForGroup]] = []
+    pending = list(plan_packages.WriteForGroup.__subclasses__())
+    while pending:
+        one = pending.pop()
+        pending += one.__subclasses__()
+        if getattr(sys.modules[one.__module__], one.__name__, None) is one:
+            found.append(one)
+    return found
+
+
 def test_one_group_fragment_writes_one_describe() -> None:
     """Three classes carried the same `group` and `describe` word for word, and
     an AST scan of the tree found two of them identical. The shared half lives
@@ -550,13 +569,37 @@ def test_one_group_fragment_writes_one_describe() -> None:
         plan_packages.WriteGroupLicense: ("accept", "package.license"),
         plan_packages.WriteGroupUse: ("ask for", "package.use"),
     }
+    found = _fragment_classes()
+    assert set(kinds) <= set(found), found
     for cls, (verb, directory) in kinds.items():
+        assert (cls.verb, cls.directory.value) == (verb, directory), cls
+    for cls in found:
         assert issubclass(cls, base), cls
         # The shared half is inherited: an override here is the duplication
         # coming back, and nothing else would notice.
         assert cls.describe is base.describe, cls
         assert vars(cls).get("group") is None, cls
         written = cls(group="chat", lines=("one", "two"))
-        assert written.describe() == f"{verb} one; two for the chat group"
-        assert str(written.path) == f"/etc/portage/{directory}/chat"
-    assert len({cls.directory for cls in kinds}) == len(kinds)
+        assert written.describe() == f"{cls.verb} one; two for the chat group", cls
+        assert str(written.path) == f"/etc/portage/{cls.directory.value}/chat", cls
+    # Two classes writing one directory collide on the file a group is named
+    # after, so each fragment class owns its own.
+    assert len({cls.directory for cls in found}) == len(found), found
+
+
+def test_a_group_fragment_declaring_half_of_the_pair_is_refused_at_import() -> None:
+    """`WriteForGroup.__init__` reads both ClassVars, so a subclass that
+    declares one used to build a plan and raise `AttributeError` in
+    `Stage.PORTAGE`, an hour after the disks were partitioned."""
+    with pytest.raises(ConfigError, match="WriteGroupUnmask declares no verb"):
+
+        class WriteGroupUnmask(plan_packages.WriteForGroup):
+            directory: ClassVar[PortageConfigKind] = PortageConfigKind.UNMASK
+
+    with pytest.raises(ConfigError, match="WriteGroupSpoken declares no directory"):
+
+        class WriteGroupSpoken(plan_packages.WriteForGroup):
+            verb: ClassVar[str] = "unmask"
+
+    with pytest.raises(ConfigError, match="WriteForGroup declares no directory, verb"):
+        plan_packages.WriteForGroup(group="chat", lines=("one",))

--- a/tests/unit/test_plan_bootloader.py
+++ b/tests/unit/test_plan_bootloader.py
@@ -520,3 +520,35 @@ def test_a_config_grub_mkconfig_never_put_in_place_stops_the_install() -> None:
 
     replaced = Disks(replies={"grep": "1"})
     operation.apply(replaced)
+
+
+def test_a_probe_that_did_not_run_names_itself_rather_than_the_boot() -> None:
+    """Both counts are read from a `check=False` command whose diagnostic
+    arrives in the same string as the answer, so a missing `grep` read as a
+    `grub.cfg` with no entry and a missing `find` as an esp with no image.
+    Neither message names anything an operator can act on."""
+    from gentoo_install.errors import CommandFailed, NothingToBoot
+    from gentoo_install.model.device import DeviceId
+
+    grub = bootloader.InstallGrub(
+        firmware=Firmware.UEFI, esp=PurePosixPath("/efi"), boot_devices=(DeviceId("first"),)
+    )
+    broken = Recorder(replies={"grep": CommandOutput("grep is not installed", 127)})
+    with pytest.raises(CommandFailed, match="grub.cfg could not be counted"):
+        grub.apply(broken)
+
+    # grep exits 1 with nothing matched, which is a count of zero: that is the
+    # file this operation exists to refuse, and it keeps its own message.
+    empty = Recorder(replies={"grep": CommandOutput("0\n", 1)})
+    with pytest.raises(NothingToBoot, match="no menu entry"):
+        grub.apply(empty)
+
+    installation = load(Path("tests/fixtures/zbm-unlock.toml"))
+    built = next(
+        one
+        for one in bootloader.build(installation)
+        if isinstance(one, bootloader.InstallZfsBootMenu)
+    )
+    unlisted = Recorder(replies={"find": CommandOutput("find: /efi/EFI/zbm: no such file", 1)})
+    with pytest.raises(CommandFailed, match="could not be listed"):
+        built._image(unlisted)

--- a/tests/unit/test_plan_bootloader.py
+++ b/tests/unit/test_plan_bootloader.py
@@ -5,7 +5,7 @@ import pytest
 
 from dataclasses import replace
 from pathlib import Path, PurePosixPath
-from typing import Sequence
+from typing import Sequence, cast
 
 from gentoo_install.exec.config import load
 from gentoo_install.model.config import (
@@ -522,11 +522,19 @@ def test_a_config_grub_mkconfig_never_put_in_place_stops_the_install() -> None:
     operation.apply(replaced)
 
 
+def zfsbootmenu_operation() -> bootloader.InstallZfsBootMenu:
+    installation = load(Path("tests/fixtures/zbm-unlock.toml"))
+    return next(
+        one
+        for one in bootloader.build(installation)
+        if isinstance(one, bootloader.InstallZfsBootMenu)
+    )
+
+
 def test_a_probe_that_did_not_run_names_itself_rather_than_the_boot() -> None:
-    """Both counts are read from a `check=False` command whose diagnostic
-    arrives in the same string as the answer, so a missing `grep` read as a
-    `grub.cfg` with no entry and a missing `find` as an esp with no image.
-    Neither message names anything an operator can act on."""
+    """The count is read from a `check=False` command whose diagnostic arrives
+    in the same string as the answer, so a missing `grep` read as a `grub.cfg`
+    with no entry. That message names nothing an operator can act on."""
     from gentoo_install.errors import CommandFailed, NothingToBoot
     from gentoo_install.model.device import DeviceId
 
@@ -543,12 +551,49 @@ def test_a_probe_that_did_not_run_names_itself_rather_than_the_boot() -> None:
     with pytest.raises(NothingToBoot, match="no menu entry"):
         grub.apply(empty)
 
-    installation = load(Path("tests/fixtures/zbm-unlock.toml"))
-    built = next(
-        one
-        for one in bootloader.build(installation)
-        if isinstance(one, bootloader.InstallZfsBootMenu)
-    )
+    built = zfsbootmenu_operation()
     unlisted = Recorder(replies={"find": CommandOutput("find: /efi/EFI/zbm: no such file", 1)})
-    with pytest.raises(CommandFailed, match="could not be listed"):
+    with pytest.raises(NothingToBoot, match="no EFI image under /efi/EFI/zbm"):
         built._image(unlisted)
+
+
+def test_a_probe_answering_without_an_exit_status_is_read_as_a_failure() -> None:
+    """`Context.run_in_target` is declared `-> str`, and a context that honours
+    that carries no exit code: reading one only when it is there let every
+    diagnostic through as an answer. Measured with a bare `str`, which is what
+    `plan/convert.py` builds its staged machine out of."""
+    from gentoo_install.errors import CommandFailed
+    from gentoo_install.model.device import DeviceId
+
+    class Wordy(Recorder):
+        def run_in_target(
+            self, argv: Sequence[str], *, check: bool = True, input_text: str | None = None
+        ) -> CommandOutput:
+            self.in_target.append(tuple(argv))
+            # str, not CommandOutput: the declared return type, and the shape
+            # `answered` has to refuse rather than read as a count of entries.
+            return cast(CommandOutput, "grep: command not found")
+
+    grub = bootloader.InstallGrub(
+        firmware=Firmware.UEFI, esp=PurePosixPath("/efi"), boot_devices=(DeviceId("first"),)
+    )
+    with pytest.raises(CommandFailed, match="grub.cfg could not be counted"):
+        grub.apply(Wordy())
+
+
+def test_an_image_found_beside_an_unreadable_entry_is_still_installed() -> None:
+    """Measured with findutils 4.11.0: `find <dir> -name '*.EFI'` over a
+    directory holding one entry with mode 000 prints the matches it reached on
+    stdout and exits 1. The runner merges stderr in, so both arrive together."""
+    built = zfsbootmenu_operation()
+
+    partial = Recorder(
+        replies={
+            "find": CommandOutput(
+                "/efi/EFI/zbm/vmlinuz-6.12.EFI\n"
+                "find: '/efi/EFI/zbm/locked': Permission denied\n",
+                1,
+            )
+        }
+    )
+    assert built._image(partial) == "/efi/EFI/zbm/vmlinuz-6.12.EFI"

--- a/tests/unit/test_plan_disk.py
+++ b/tests/unit/test_plan_disk.py
@@ -1064,3 +1064,40 @@ def test_a_partition_placed_in_a_gap_does_not_promise_the_rest_of_the_disk() -> 
     bounded.apply(recorder)
     ends = [one[-1] for one in recorder.commands if one[0] == "parted" and "mkpart" in one]
     assert ends == [str(Size(10 * 2**30))], recorder.commands
+
+
+def test_a_zfs_probe_that_did_not_run_is_not_read_as_an_answer() -> None:
+    """`check=False` keeps the failure out of the exception path and the runner
+    merges stderr into stdout, so `zfs is not installed` arrived where `yes` or
+    `no` belongs: the dataset was treated as unmounted, and the second probe
+    failing the same way took the branch that unmounts it."""
+    from gentoo_install.plan.disk import MountZfsDataset
+
+    told = MountZfsDataset(
+        mountpoint=i("mnt-home"), name="rpool/ROOT/gentoo/home", path=PurePosixPath("/home")
+    )
+
+    broken = Recorder()
+    broken.replies["zfs"] = CommandOutput("zfs is not installed", 127)
+    with pytest.raises(CommandFailed, match="whether rpool/ROOT/gentoo/home is mounted"):
+        told.apply(broken)
+    assert ("zfs", "mount", "rpool/ROOT/gentoo/home") not in broken.commands
+
+    # The mount probe answers, and the one that reads what is at the path does
+    # not: unmounting on that would take down a dataset nobody established was
+    # hidden.
+    half = Recorder()
+    half.replies["zfs"] = "yes\n"
+    half.replies["findmnt"] = CommandOutput("findmnt is not installed", 127)
+    with pytest.raises(CommandFailed, match="what is mounted at /home"):
+        told.apply(half)
+    assert ("zfs", "unmount", "rpool/ROOT/gentoo/home") not in half.commands
+
+    # findmnt exits 1 for a path carrying no mount, which is the hidden
+    # dataset this looks for, so that code is an answer rather than a failure.
+    hidden = Recorder()
+    hidden.replies["zfs"] = "yes\n"
+    hidden.replies["findmnt"] = CommandOutput("", 1)
+    told.apply(hidden)
+    assert ("zfs", "unmount", "rpool/ROOT/gentoo/home") in hidden.commands
+    assert ("zfs", "mount", "rpool/ROOT/gentoo/home") in hidden.commands

--- a/tests/unit/test_plan_disk.py
+++ b/tests/unit/test_plan_disk.py
@@ -632,6 +632,27 @@ def test_the_lvm_check_names_the_binaries_the_plan_runs() -> None:
     assert {"pvcreate", "vgcreate", "lvcreate"} <= wanted
 
 
+#: `findmnt --noheadings --list --output TARGET,SOURCE` as util-linux
+#: 2.42.2 prints it, padding and all. The rows are in mount order, which
+#: is what decides the answer: the last one at or above the mountpoint is
+#: the mount a path lookup reaches.
+MOUNT_TABLE_VISIBLE: str = (
+    "/                                                 rpool/ROOT/gentoo\n"
+    "/mnt/gentoo                                       rpool/ROOT/gentoo\n"
+    "/mnt/gentoo/home                                  rpool/ROOT/gentoo/home\n"
+)
+
+#: The same table after `zfs create` mounted the dataset and the root went
+#: over it. Measured under `unshare --mount` on 2026-08-21: the kernel keeps
+#: the covered row, `findmnt --target` still answers with its source, and
+#: `ls` on the path answers `No such file or directory`.
+MOUNT_TABLE_HIDDEN: str = (
+    "/                                                 rpool/ROOT/gentoo\n"
+    "/mnt/gentoo/home                                  zpcala/ROOT/gentoo/home\n"
+    "/mnt/gentoo                                       zpcala/ROOT/gentoo/root\n"
+)
+
+
 def test_a_dataset_already_mounted_is_left_alone() -> None:
     """`zfs create` mounts a dataset the moment it is given a mountpoint, so
     `zfs mount` on it answers `filesystem already mounted` and stops the
@@ -649,9 +670,11 @@ def test_a_dataset_already_mounted_is_left_alone() -> None:
     told.apply(fresh)
     assert ("zfs", "mount", "rpool/ROOT/gentoo/home") in fresh.commands
 
+    # The root was mounted before the dataset, so the dataset's own row is the
+    # last one at or above the mountpoint and a lookup there reaches it.
     already = Recorder()
     already.replies["zfs"] = "yes\n"
-    already.replies["findmnt"] = "rpool/ROOT/gentoo/home\n"
+    already.replies["findmnt"] = MOUNT_TABLE_VISIBLE
     told.apply(already)
     assert not any(one[:2] in {("zfs", "mount"), ("zfs", "unmount")} for one in already.commands)
 
@@ -676,15 +699,16 @@ def test_a_zfs_child_hidden_by_the_root_is_remounted_after_it() -> None:
     )
     assert root < home[0]
 
-    hidden = Recorder(replies={"zfs": "yes\n", "findmnt": "zpcala/ROOT/gentoo/root\n"})
+    # The dataset was mounted at create time and the root went over it in this
+    # stage, so its own row is still in the table and the root's row follows.
+    hidden = Recorder(replies={"zfs": "yes\n", "findmnt": MOUNT_TABLE_HIDDEN})
     home[1].apply(hidden)
     assert (
         "findmnt",
         "--noheadings",
+        "--list",
         "--output",
-        "SOURCE",
-        "--target",
-        "/mnt/gentoo/home",
+        "TARGET,SOURCE",
     ) in hidden.commands
     assert hidden.argv_starting("zfs", "unmount") == (
         ("zfs", "unmount", "zpcala/ROOT/gentoo/home"),
@@ -1093,11 +1117,11 @@ def test_a_zfs_probe_that_did_not_run_is_not_read_as_an_answer() -> None:
         told.apply(half)
     assert ("zfs", "unmount", "rpool/ROOT/gentoo/home") not in half.commands
 
-    # findmnt exits 1 for a path carrying no mount, which is the hidden
-    # dataset this looks for, so that code is an answer rather than a failure.
-    hidden = Recorder()
-    hidden.replies["zfs"] = "yes\n"
-    hidden.replies["findmnt"] = CommandOutput("", 1)
-    told.apply(hidden)
-    assert ("zfs", "unmount", "rpool/ROOT/gentoo/home") in hidden.commands
-    assert ("zfs", "mount", "rpool/ROOT/gentoo/home") in hidden.commands
+    # Listing the whole table exits 0 whenever findmnt ran, so exit 1 is a
+    # probe that did not run rather than a path carrying no mount.
+    empty = Recorder()
+    empty.replies["zfs"] = "yes\n"
+    empty.replies["findmnt"] = CommandOutput("", 1)
+    with pytest.raises(CommandFailed, match="what is mounted at /home"):
+        told.apply(empty)
+    assert ("zfs", "unmount", "rpool/ROOT/gentoo/home") not in empty.commands

--- a/tests/unit/test_plan_netboot.py
+++ b/tests/unit/test_plan_netboot.py
@@ -1058,9 +1058,14 @@ def test_every_architecture_this_maps_is_one_gentoo_names() -> None:
     `install-amd64-…`: two ecosystems naming the same machine, the way `fma`
     and `fma3` do. A name Gentoo does not use finds no asset and the failure
     reads as a missing release."""
-    assert set(netboot.GENTOO_ARCHITECTURES.values()) <= GENTOO_ARCH_NAMES, sorted(
-        set(netboot.GENTOO_ARCHITECTURES.values()) - GENTOO_ARCH_NAMES
-    )
+    from gentoo_install.model.compat import ARCHITECTURES
+
+    named = {one.gentoo_name for one in ARCHITECTURES}
+    assert named <= GENTOO_ARCH_NAMES, sorted(named - GENTOO_ARCH_NAMES)
+    # One table, in the layer both `plan` and `exec` can read: a second copy
+    # in `plan/netboot.py` is how the kernel name and the Gentoo name drifted
+    # apart everywhere else.
+    assert not hasattr(netboot, "GENTOO_ARCHITECTURES")
 
 
 def test_the_alpine_index_is_asked_for_this_machine() -> None:

--- a/tests/unit/test_proxmox.py
+++ b/tests/unit/test_proxmox.py
@@ -3517,21 +3517,30 @@ def test_the_cluster_serves_no_screenshot_so_none_is_offered() -> None:
     Nothing called it. It is named here so that a reader who wants the VGA
     console for the BIOS fixtures learns the endpoint does not exist rather
     than adding a caller and reading `None`.
+
+    Three checks, because none of them covers the others: the attribute catches
+    a caller that kept the name, the `screenshot` literal catches a method
+    called anything else that asks for the path, and `screendump` catches the
+    QEMU monitor route `POST /nodes/{node}/qemu/{vmid}/monitor`, which takes
+    the same picture and spells neither of the first two. That route is the one
+    the comment above `AUTOLOGIN_INTERVAL` says a screen was measured with.
     """
     import ast
 
     from tests.vm import cluster, proxmox
 
-    # The endpoint, not one attribute name: a method called anything else that
-    # asks for that path is the defect coming back, and `hasattr` on `Guest`
-    # would not see it. Docstrings are excluded because two of them explain
-    # why the path is absent.
+    assert not hasattr(Guest, "screenshot")
+
+    # Docstrings are excluded because two of them explain why the path is
+    # absent, and `AsyncFunctionDef` keeps that true for a coroutine added later.
     for module in (proxmox, cluster):
         tree = ast.parse(Path(module.__file__ or "").read_text())
         prose = {
             id(node.body[0].value)
             for node in ast.walk(tree)
-            if isinstance(node, (ast.Module, ast.ClassDef, ast.FunctionDef))
+            if isinstance(
+                node, (ast.Module, ast.ClassDef, ast.FunctionDef, ast.AsyncFunctionDef)
+            )
             and node.body
             and isinstance(node.body[0], ast.Expr)
             and isinstance(node.body[0].value, ast.Constant)
@@ -3542,7 +3551,7 @@ def test_the_cluster_serves_no_screenshot_so_none_is_offered() -> None:
             for node in ast.walk(tree)
             if isinstance(node, ast.Constant)
             and isinstance(node.value, str)
-            and "screenshot" in node.value
+            and ("screenshot" in node.value or "screendump" in node.value)
             and id(node) not in prose
         ]
         assert asked == [], (module.__name__, asked)

--- a/tests/unit/test_proxmox.py
+++ b/tests/unit/test_proxmox.py
@@ -3518,9 +3518,34 @@ def test_the_cluster_serves_no_screenshot_so_none_is_offered() -> None:
     console for the BIOS fixtures learns the endpoint does not exist rather
     than adding a caller and reading `None`.
     """
-    from tests.vm.proxmox import Guest
+    import ast
 
-    assert not hasattr(Guest, "screenshot")
+    from tests.vm import cluster, proxmox
+
+    # The endpoint, not one attribute name: a method called anything else that
+    # asks for that path is the defect coming back, and `hasattr` on `Guest`
+    # would not see it. Docstrings are excluded because two of them explain
+    # why the path is absent.
+    for module in (proxmox, cluster):
+        tree = ast.parse(Path(module.__file__ or "").read_text())
+        prose = {
+            id(node.body[0].value)
+            for node in ast.walk(tree)
+            if isinstance(node, (ast.Module, ast.ClassDef, ast.FunctionDef))
+            and node.body
+            and isinstance(node.body[0], ast.Expr)
+            and isinstance(node.body[0].value, ast.Constant)
+            and isinstance(node.body[0].value.value, str)
+        }
+        asked = [
+            node.value
+            for node in ast.walk(tree)
+            if isinstance(node, ast.Constant)
+            and isinstance(node.value, str)
+            and "screenshot" in node.value
+            and id(node) not in prose
+        ]
+        assert asked == [], (module.__name__, asked)
 
 
 def test_a_boot_that_never_prompts_says_what_the_console_held(

--- a/tests/unit/test_tui_widgets.py
+++ b/tests/unit/test_tui_widgets.py
@@ -512,7 +512,7 @@ def test_a_band_fills_the_row_so_the_reverse_video_reaches_both_edges() -> None:
 
     screen = FakeScreen(columns=40)
     band(screen, 0, "gentoo-install", "6/22 answered")
-    drawn = screen.frames[-1][0] if screen.frames else screen._current[0]
+    drawn = screen.frames[-1][0] if screen.frames else screen.drawn(0)
 
     assert len(drawn) == 40
     assert drawn.startswith("gentoo-install")
@@ -526,7 +526,7 @@ def test_a_band_drops_the_right_side_rather_than_cutting_it() -> None:
 
     screen = FakeScreen(columns=20)
     band(screen, 0, "gentoo-install", "6/22 answered")
-    drawn = screen._current[0]
+    drawn = screen.drawn(0)
 
     assert len(drawn) == 20
     # Whole or absent. A truncating band leaves `6/22 `, which reads as a
@@ -546,7 +546,7 @@ def test_a_band_counts_cells_not_characters() -> None:
     # because a literal here would be unreadable to half the contributors.
     band(screen, 0, "\u5b89\u88dd", "\u5b8c\u6210")
 
-    assert width(screen._current[0]) == 30
+    assert width(screen.drawn(0)) == 30
 
 
 def test_a_field_refuses_a_character_it_can_never_hold() -> None:

--- a/tests/unit/test_tui_widgets.py
+++ b/tests/unit/test_tui_widgets.py
@@ -509,12 +509,15 @@ def test_a_band_fills_the_row_so_the_reverse_video_reaches_both_edges() -> None:
     """A header that stops where its text stops is a highlighted word, not a
     band, and the screen still reads as a printout."""
     from gentoo_install.tui.widgets import band
+    from gentoo_install.i18n import width
 
     screen = FakeScreen(columns=40)
     band(screen, 0, "gentoo-install", "6/22 answered")
     drawn = screen.frames[-1][0] if screen.frames else screen.drawn(0)
 
-    assert len(drawn) == 40
+    # Cells, not characters: a row of 40 characters can occupy 60 columns, and
+    # a band that reaches both edges is a statement about columns.
+    assert width(drawn) == 40
     assert drawn.startswith("gentoo-install")
     assert drawn.endswith("6/22 answered")
     assert drawn in screen.highlighted
@@ -523,12 +526,13 @@ def test_a_band_fills_the_row_so_the_reverse_video_reaches_both_edges() -> None:
 def test_a_band_drops_the_right_side_rather_than_cutting_it() -> None:
     """Half a count reads as a different count."""
     from gentoo_install.tui.widgets import band
+    from gentoo_install.i18n import width
 
     screen = FakeScreen(columns=20)
     band(screen, 0, "gentoo-install", "6/22 answered")
     drawn = screen.drawn(0)
 
-    assert len(drawn) == 20
+    assert width(drawn) == 20
     # Whole or absent. A truncating band leaves `6/22 `, which reads as a
     # different count rather than as a missing one.
     assert "6/22" not in drawn
@@ -586,3 +590,61 @@ def test_a_field_with_no_rule_takes_what_it_is_given() -> None:
     answered = Form(title="Any", fields=[Field(label="free")], footer="").run(screen)
 
     assert answered.unwrap() == ["a b"]
+
+
+#: Two wide characters and a combining acute accent, by codepoint: no CJK
+#: literal belongs in the test tree, and only escapes survive a review here.
+AN = "\u5b89"
+ZHUANG = "\u88dd"
+ACUTE = "\u0301"
+
+
+def test_a_narrow_write_keeps_the_characters_it_placed_beside_a_wide_one() -> None:
+    """`FakeScreen` measures every layout test in this file, so a cell grid
+    that blanks its own writes hides the defects those tests exist to catch."""
+    from gentoo_install.i18n import width
+
+    screen = FakeScreen(columns=10)
+    screen.write(0, 0, AN + ZHUANG)
+    screen.write(0, 0, "ok")
+
+    assert screen.drawn(0) == "ok" + ZHUANG
+    assert width(screen.drawn(0)) == 4
+
+
+def test_a_write_spanning_two_wide_characters_stays_inside_the_screen() -> None:
+    """A repair walking cell by cell blanked a cell the same write had filled,
+    and the row then measured five cells on a four-column screen."""
+    from gentoo_install.i18n import width
+
+    screen = FakeScreen(columns=4)
+    screen.write(0, 1, AN)
+    screen.write(0, 0, AN + AN)
+
+    assert screen.drawn(0) == AN + AN
+    assert width(screen.drawn(0)) == 4
+
+
+def test_overwriting_the_first_half_of_a_wide_character_clears_the_second() -> None:
+    """The orphaned second cell is empty, so the row measured three cells while
+    occupying four and every later column read one place left."""
+    from gentoo_install.i18n import width
+
+    screen = FakeScreen(columns=4)
+    screen.write(0, 0, AN + ZHUANG)
+    screen.write(0, 0, "x")
+
+    assert screen.drawn(0) == "x " + ZHUANG
+    assert width(screen.drawn(0)) == 4
+
+
+def test_a_combining_mark_joins_the_cell_before_it_instead_of_taking_one() -> None:
+    """A mark occupies no cell, so advancing by its width left the grid too
+    short for the next character and the write raised `IndexError`."""
+    from gentoo_install.i18n import width
+
+    screen = FakeScreen(columns=20)
+    screen.write(0, 0, "e" + ACUTE + "x")
+
+    assert screen.drawn(0) == "e" + ACUTE + "x"
+    assert width(screen.drawn(0)) == 2


### PR DESCRIPTION
Seven commits from `docs/review-plan.md`, batches three and six plus the first step of batch two. Every commit passes `mypy` and the whole `pytest` on its own, and every test added or changed here was written against a mutation that keeps the old assertion green.

## What each commit holds, and the mutation it now fails on

| Commit | Change | Mutation that used to pass |
|---|---|---|
| `netboot: one body for taking an arming back` | The two operations that undo an arming shared a byte-identical `apply`; found by hashing every function body in the tree | — (an existing test already requires the two to ask for the same thing) |
| `packages: one base for the per-group Portage fragments` | Three classes carried the same `group` and `describe`, two identical to the character | Re-adding an identical `describe` to a subclass |
| `tests: read the screenshot rule and the log order off behaviour` | `not hasattr(Guest, "screenshot")` became an AST scan for the endpoint in string literals; `inspect.getsource` offset comparison became a recorded call order | A method with another name asking the same endpoint; a closure that keeps `report.keep_log(` early in the text and calls it after `apply(closing, …)` |
| `tests: draw the fake screen on a grid of cells` | `FakeScreen` placed text by character index while curses places by column, so a wide label pushed the rest of the row right | Placing by character index; the eighty-column rule now runs in all five languages |
| `tests: catch the class the scheduler catches, not its name` | The guard was read out of source text; it is now the class by identity and the handler found in the tree | `class ProxmoxTransientError(Exception)` declared locally in `tests/vm/cluster.py` |
| `plan: name the probe that could not run` | Four `check=False` sites read a failed probe's diagnostic as its answer | Removing the exit-code branch: `zfs is not installed` is not `yes`, and `findmnt` failing took the branch that unmounts |
| `model: one table for what an architecture is called` | `GENTOO_ARCHITECTURES` moved into `model/compat.py` as three columns; `plan/netboot.py` and `exec/preflight.py` compare a row | A second table holding both spellings anywhere under `gentoo_install/` |

## What a reviewer should look at hardest

- `answered()` in `plan/operations.py` decides which exit codes are answers. `grep --count` and `findmnt` are allowed to exit 1; everything else raises. A wrong `allowed` set turns a working install into a refusal.
- The cell grid in `tests/unit/fake_screen.py` models overwriting half of a wide character by clearing the other half. That is what a terminal does, but no test drives it yet.
- `model/compat.py` now imports nothing from `plan`, and `plan/netboot.py` imports the table downward. The layer rule allows it; the direction is worth checking.
- The architecture field on `InstallConfig` is deliberately **not** in this branch: it changes the configuration schema, the serialiser and the configuration-key table in five READMEs. `docs/tasks.md` row 242 says so.

## Verified

`python3 -m mypy` and `python3 -m pytest` at every commit, and `python3 -m pytest -m "not lab"` — what CI runs — on the branch head. No VM run: nothing here touches partitioning, chroot or binhost trust at runtime except the four probe branches, whose failure paths are driven by the tests added with them.
