### PR TITLE
disk: read the covered mount rather than acting on the cover

### DIFF
--- a/gentoo_install/plan/disk.py
+++ b/gentoo_install/plan/disk.py
@@ -832,42 +832,32 @@ class MountZfsDataset(Operation):
         )
         if mounted == "yes":
             # A parent mounted later can hide this dataset while ZFS still
-            # reports it mounted, so what a lookup reaches decides readiness.
-            if self._reachable_source(context) == self.name:
+            # reports it mounted, so what a lookup answers decides readiness.
+            # `findmnt --target` answers with the covered mount's own source,
+            # measured on util-linux 2.42.2, and that is the answer this wants:
+            # ZFS refuses to unmount a dataset whose mount is covered, so a
+            # dataset mounted where it belongs is left alone either way.
+            # Exit 1 means the path does not resolve, which is a mountpoint
+            # this run has not created yet rather than a probe that failed.
+            visible = answered(
+                context.run(
+                    [
+                        "findmnt",
+                        "--noheadings",
+                        "--output",
+                        "SOURCE",
+                        "--target",
+                        str(_under(context.target, self.path)),
+                    ],
+                    check=False,
+                ),
+                f"what is mounted at {self.path} could not be read",
+                allowed=(0, 1),
+            )
+            if visible == self.name:
                 return
             context.run(["zfs", "unmount", self.name])
         context.run(["zfs", "mount", self.name])
-
-    def _reachable_source(self, context: Context) -> str:
-        """What a path lookup at the mountpoint reaches, or an empty string.
-
-        Read from the whole table rather than with `findmnt --target`, which
-        answers by matching the path against every mount's target: measured on
-        util-linux 2.42.2, a mount a later parent covers still answers with its
-        own source and exit 0 there, so the hidden dataset looked exactly like
-        a mounted one. The rows arrive in mount order, so the last row at the
-        mountpoint or above it is the one that shadows the rest.
-        """
-        where = _under(context.target, self.path)
-        # No filter, so `findmnt` lists every mount and exits 0 whenever it
-        # ran: a non-zero code is a probe that did not run, not an empty table.
-        listed = answered(
-            context.run(
-                ["findmnt", "--noheadings", "--list", "--output", "TARGET,SOURCE"],
-                check=False,
-            ),
-            f"what is mounted at {self.path} could not be read",
-        )
-        reached = ""
-        for line in listed.splitlines():
-            columns = line.split(None, 1)
-            if len(columns) != 2:
-                continue
-            target = PurePosixPath(columns[0])
-            if target == where or target in where.parents:
-                reached = columns[1].strip()
-        return reached
-
 
 @dataclass(frozen=True, kw_only=True)
 class DiscardStage3(Operation):

--- a/tests/unit/test_cluster.py
+++ b/tests/unit/test_cluster.py
@@ -3150,7 +3150,7 @@ def test_a_conversion_counts_the_modules_its_bootloader_needs() -> None:
             GRUB_PREFIX_CHECK,
             "grubstub=163840 grubprefix=1 boot=c866ae3a-68e7-4096-9703-dfa17070c3ed"
             " esp=1234-ABCD stub=c866ae3a-68e7-4096-9703-dfa17070c3ed"
-            " embedded=(hd0,gpt2)/boot/grub\n",
+            " embedded=(hd0,gpt2)/boot/grub drive=hd0,gpt2 fs=xfs\n",
         ),
     ):
         assert "wc -" in check.command or "grep -ac" in check.command
@@ -3169,7 +3169,7 @@ def test_a_conversion_counts_the_modules_its_bootloader_needs() -> None:
     # cannot tell them apart.
     healthy = (
         "grubstub=163840 grubprefix=1 boot=aaaa esp=1234-ABCD stub=aaaa"
-        " embedded=(hd0,gpt2)/boot/grub\n"
+        " embedded=(hd0,gpt2)/boot/grub drive=hd0,gpt2 fs=xfs\n"
     )
     assert re.search(GRUB_PREFIX_CHECK.pattern, healthy)
     assert re.search(GRUB_PREFIX_CHECK.pattern, healthy.replace("prefix=1", "prefix=0")) is None
@@ -3214,6 +3214,18 @@ def test_a_conversion_counts_the_modules_its_bootloader_needs() -> None:
     # a stub whose prefix is `(hd0,gpt2)/boot/grub`, measured on 2026-08-20.
     assert r"'^\([^)]+\)/[^ ]*|^/[^ ]*grub$'" in GRUB_PREFIX_CHECK.command
     assert "embedded=%s" in GRUB_PREFIX_CHECK.command
+
+    # run138 answered `embedded=(,gpt2)/boot/grub`: a partition with no drive
+    # and no filesystem driver, from a `grub-install` that reported success.
+    # The two probes it composes that prefix from are asked here, so the next
+    # failure names the one that answered nothing instead of leaving it open.
+    assert "grub-probe --target=drive /boot" in GRUB_PREFIX_CHECK.command
+    assert "grub-probe --target=fs /boot" in GRUB_PREFIX_CHECK.command
+    # Their diagnosis, not only their answer: `grub-probe` writes the reason
+    # on stderr, and a field of spaces would break the line into two.
+    assert GRUB_PREFIX_CHECK.command.count("2>&1 | tr ' ' '_'") == 2
+    assert _re.search(GRUB_PREFIX_CHECK.pattern, healthy.replace("drive=hd0,gpt2", "drive="))
+    assert _re.search(GRUB_PREFIX_CHECK.pattern, healthy.replace(" fs=xfs", "")) is None
 
 
 def test_the_unlock_addresses_go_back_after_the_guests_do() -> None:

--- a/tests/unit/test_plan_disk.py
+++ b/tests/unit/test_plan_disk.py
@@ -632,27 +632,6 @@ def test_the_lvm_check_names_the_binaries_the_plan_runs() -> None:
     assert {"pvcreate", "vgcreate", "lvcreate"} <= wanted
 
 
-#: `findmnt --noheadings --list --output TARGET,SOURCE` as util-linux
-#: 2.42.2 prints it, padding and all. The rows are in mount order, which
-#: is what decides the answer: the last one at or above the mountpoint is
-#: the mount a path lookup reaches.
-MOUNT_TABLE_VISIBLE: str = (
-    "/                                                 rpool/ROOT/gentoo\n"
-    "/mnt/gentoo                                       rpool/ROOT/gentoo\n"
-    "/mnt/gentoo/home                                  rpool/ROOT/gentoo/home\n"
-)
-
-#: The same table after `zfs create` mounted the dataset and the root went
-#: over it. Measured under `unshare --mount` on 2026-08-21: the kernel keeps
-#: the covered row, `findmnt --target` still answers with its source, and
-#: `ls` on the path answers `No such file or directory`.
-MOUNT_TABLE_HIDDEN: str = (
-    "/                                                 rpool/ROOT/gentoo\n"
-    "/mnt/gentoo/home                                  zpcala/ROOT/gentoo/home\n"
-    "/mnt/gentoo                                       zpcala/ROOT/gentoo/root\n"
-)
-
-
 def test_a_dataset_already_mounted_is_left_alone() -> None:
     """`zfs create` mounts a dataset the moment it is given a mountpoint, so
     `zfs mount` on it answers `filesystem already mounted` and stops the
@@ -674,7 +653,7 @@ def test_a_dataset_already_mounted_is_left_alone() -> None:
     # last one at or above the mountpoint and a lookup there reaches it.
     already = Recorder()
     already.replies["zfs"] = "yes\n"
-    already.replies["findmnt"] = MOUNT_TABLE_VISIBLE
+    already.replies["findmnt"] = CommandOutput("rpool/ROOT/gentoo/home\n", 0)
     told.apply(already)
     assert not any(one[:2] in {("zfs", "mount"), ("zfs", "unmount")} for one in already.commands)
 
@@ -700,22 +679,19 @@ def test_a_zfs_child_hidden_by_the_root_is_remounted_after_it() -> None:
     assert root < home[0]
 
     # The dataset was mounted at create time and the root went over it in this
-    # stage, so its own row is still in the table and the root's row follows.
-    hidden = Recorder(replies={"zfs": "yes\n", "findmnt": MOUNT_TABLE_HIDDEN})
+    # stage. `findmnt --target` answers with the covered mount's own source,
+    # so the dataset is recognised where it belongs and left alone: ZFS
+    # refuses to unmount a covered mount, and two cluster fixtures stopped at
+    # `cannot unmount '/mnt/gentoo/home': no such pool or dataset` when this
+    # acted on the cover instead.
+    hidden = Recorder(
+        replies={"zfs": "yes\n", "findmnt": CommandOutput("zpcala/ROOT/gentoo/home\n", 0)}
+    )
     home[1].apply(hidden)
-    assert (
-        "findmnt",
-        "--noheadings",
-        "--list",
-        "--output",
-        "TARGET,SOURCE",
-    ) in hidden.commands
-    assert hidden.argv_starting("zfs", "unmount") == (
-        ("zfs", "unmount", "zpcala/ROOT/gentoo/home"),
-    )
-    assert hidden.argv_starting("zfs", "mount") == (
-        ("zfs", "mount", "zpcala/ROOT/gentoo/home"),
-    )
+    assert ("findmnt", "--noheadings", "--output", "SOURCE", "--target",
+            "/mnt/gentoo/home") in hidden.commands
+    assert hidden.argv_starting("zfs", "unmount") == ()
+    assert hidden.argv_starting("zfs", "mount") == ()
 
 
 #: What `parted --machine --script <disk> unit B print free` printed for a
@@ -1117,11 +1093,48 @@ def test_a_zfs_probe_that_did_not_run_is_not_read_as_an_answer() -> None:
         told.apply(half)
     assert ("zfs", "unmount", "rpool/ROOT/gentoo/home") not in half.commands
 
-    # Listing the whole table exits 0 whenever findmnt ran, so exit 1 is a
-    # probe that did not run rather than a path carrying no mount.
-    empty = Recorder()
-    empty.replies["zfs"] = "yes\n"
-    empty.replies["findmnt"] = CommandOutput("", 1)
+    # `findmnt --target` exits 1 when the path does not resolve, which is a
+    # mountpoint this run has not created yet: the dataset is mounted there
+    # rather than the probe being called a failure.
+    fresh = Recorder()
+    fresh.replies["zfs"] = "yes\n"
+    fresh.replies["findmnt"] = CommandOutput("", 1)
+    told.apply(fresh)
+    assert ("zfs", "mount", "rpool/ROOT/gentoo/home") in fresh.commands
+
+
+def test_a_dataset_a_later_parent_covers_is_left_where_it_is() -> None:
+    """`zbm-unlock` and `zfs-zbm` both stopped at `cannot unmount
+    '/mnt/gentoo/home': no such pool or dataset`, with `/mnt/gentoo` listed
+    after `/mnt/gentoo/home`: ZFS refuses to unmount a dataset whose mount is
+    covered, so acting on the cover is what breaks the install. `findmnt
+    --target` answers with the covered mount's own source, which is what this
+    reads."""
+    from gentoo_install.plan.disk import MountZfsDataset
+
+    told = MountZfsDataset(
+        mountpoint=i("mnt-home"), name="zpcala/ROOT/gentoo/home", path=PurePosixPath("/home")
+    )
+    settled = Recorder()
+    settled.replies["zfs"] = "yes\n"
+    settled.replies["findmnt"] = CommandOutput("zpcala/ROOT/gentoo/home\n", 0)
+    told.apply(settled)
+    assert [one for one in settled.commands if one[0] == "zfs"] == [
+        ("zfs", "get", "-H", "-o", "value", "mounted", "zpcala/ROOT/gentoo/home")
+    ], settled.commands
+
+    # A mountpoint this run has not created yet: findmnt exits 1 because the
+    # path does not resolve, and the dataset is mounted rather than refused.
+    fresh = Recorder()
+    fresh.replies["zfs"] = "yes\n"
+    fresh.replies["findmnt"] = CommandOutput("", 1)
+    told.apply(fresh)
+    assert ("zfs", "mount", "zpcala/ROOT/gentoo/home") in fresh.commands
+
+    # And a probe that did not run is still refused by name.
+    broken = Recorder()
+    broken.replies["zfs"] = "yes\n"
+    broken.replies["findmnt"] = CommandOutput("findmnt is not installed", 127)
     with pytest.raises(CommandFailed, match="what is mounted at /home"):
-        told.apply(empty)
-    assert ("zfs", "unmount", "rpool/ROOT/gentoo/home") not in empty.commands
+        told.apply(broken)
+    assert ("zfs", "unmount", "zpcala/ROOT/gentoo/home") not in broken.commands

--- a/tests/vm/convert.py
+++ b/tests/vm/convert.py
@@ -114,17 +114,25 @@ _STUB_PREFIX: Final[str] = (
 
 GRUB_PREFIX_CHECK: Final[InstalledCheck] = InstalledCheck(
     "grub's prefix",
-    "printf 'grubstub=%s grubprefix=%s boot=%s esp=%s stub=%s embedded=%s\\n' "
+    "printf 'grubstub=%s grubprefix=%s boot=%s esp=%s stub=%s embedded=%s "
+    "drive=%s fs=%s\\n' "
     f"\"$(wc -c < {GRUB_STUB} 2>/dev/null || echo 0)\" "
     f"\"$(grep -ac \"$(grub-probe --target=fs_uuid /boot)\" {GRUB_STUB} 2>/dev/null)\" "
     "\"$(grub-probe --target=fs_uuid /boot 2>/dev/null)\" "
     "\"$(grub-probe --target=fs_uuid /efi 2>/dev/null)\" "
     f"\"$({_STUB_UUID})\" "
-    f"\"$({_STUB_PREFIX})\"",
+    f"\"$({_STUB_PREFIX})\" "
+    # The two probes grub-install itself uses to compose the prefix. It wrote
+    # `(,gpt2)/boot/grub` — a partition with no drive and no filesystem
+    # driver — and reported success, so which of them answered nothing is the
+    # whole question.
+    "\"$(grub-probe --target=drive /boot 2>&1 | tr ' ' '_' | head -n 1)\" "
+    "\"$(grub-probe --target=fs /boot 2>&1 | tr ' ' '_' | head -n 1)\"",
     # `embedded` decides nothing: `grubprefix` already says whether the stub
     # names the filesystem holding `/boot`, and this field is the evidence the
     # next failure needs, which an empty match must not hide.
-    r"(?m)^grubstub=[1-9][0-9]* grubprefix=[1-9][0-9]* boot=\S+ esp=\S+ stub=\S+ embedded=\S*$",
+    r"(?m)^grubstub=[1-9][0-9]* grubprefix=[1-9][0-9]* boot=\S+ esp=\S+ stub=\S+ "
+    r"embedded=\S* drive=\S* fs=\S*$",
 )
 
 


### PR DESCRIPTION
Two fixtures caught this within minutes of the branch that introduced it. `zfs-zbm` and `zbm-unlock` both stopped at `cannot unmount '/mnt/gentoo/home': no such pool or dataset`, and the guest's own mount table at that moment reads:

```
/mnt/gentoo/home   zpcala/ROOT/gentoo/home
/mnt/gentoo        zpcala/ROOT/gentoo/root
/mnt/gentoo/efi    /dev/vda1
```

The parent is listed after the dataset, so a rule that takes the last covering row called the dataset hidden and unmounted it — and ZFS refuses to unmount a covered mount, which is why the previous `findmnt --target` probe was green for months: it answers with the covered mount's own source. That answer is what this needs, so the probe goes back, with the exit codes read from a measurement (`--target` exits 0 for a path that resolves, 1 for one that does not) rather than from the old comment.

The second commit adds `drive=` and `fs=` to the conversion's pre-reboot check. run138 answered `embedded=(,gpt2)/boot/grub` — a partition with no drive and no filesystem driver, from a `grub-install` that reported `Installation finished. No error reported.` — so the open question for row 238 is which of the two probes `grub-install` composes that prefix from answered nothing.