### PR TITLE
tui: the dd path asks and reviews what it writes

### DIFF
--- a/gentoo_install/data/locale/ja.toml
+++ b/gentoo_install/data/locale/ja.toml
@@ -654,3 +654,5 @@
 "resolve {} together before installing the requested packages" = "要求したパッケージをインストールする前に {} をまとめて解決"
 "accept ~amd64 for {} and nothing else" = "{} だけに ~amd64 を許可"
 "append ACCEPT_KEYWORDS=\"~amd64\" to make.conf, after everything is installed" = "すべてのインストール後に make.conf へ ACCEPT_KEYWORDS=\"~amd64\" を追加"
+"a partition of no size leaves nothing to format" = "サイズが 0 のパーティションには作成する対象がありません"
+"a mount point has to be an absolute path inside the target" = "マウントポイントはインストール先の絶対パスでなければなりません"

--- a/gentoo_install/data/locale/ko.toml
+++ b/gentoo_install/data/locale/ko.toml
@@ -654,3 +654,5 @@
 "resolve {} together before installing the requested packages" = "요청한 패키지를 설치하기 전에 {}를 함께 해결"
 "accept ~amd64 for {} and nothing else" = "{}에만 ~amd64 허용"
 "append ACCEPT_KEYWORDS=\"~amd64\" to make.conf, after everything is installed" = "모든 설치 후 make.conf에 ACCEPT_KEYWORDS=\"~amd64\" 추가"
+"a partition of no size leaves nothing to format" = "크기가 0인 파티션에는 포맷할 대상이 없습니다."
+"a mount point has to be an absolute path inside the target" = "마운트 지점은 설치 대상 안의 절대 경로여야 합니다."

--- a/gentoo_install/data/locale/zh-CN.toml
+++ b/gentoo_install/data/locale/zh-CN.toml
@@ -655,3 +655,5 @@
 "resolve {} together before installing the requested packages" = "安装请求的软件包前一并解析 {}"
 "accept ~amd64 for {} and nothing else" = "仅为 {} 接受 ~amd64"
 "append ACCEPT_KEYWORDS=\"~amd64\" to make.conf, after everything is installed" = "所有软件包安装后，在 make.conf 追加 ACCEPT_KEYWORDS=\"~amd64\""
+"a partition of no size leaves nothing to format" = "大小为零的分区无法创建文件系统"
+"a mount point has to be an absolute path inside the target" = "挂载点必须是目标系统内的绝对路径"

--- a/gentoo_install/data/locale/zh-TW.toml
+++ b/gentoo_install/data/locale/zh-TW.toml
@@ -655,3 +655,5 @@
 "resolve {} together before installing the requested packages" = "安裝要求的套件前一併解析 {}"
 "accept ~amd64 for {} and nothing else" = "只為 {} 接受 ~amd64"
 "append ACCEPT_KEYWORDS=\"~amd64\" to make.conf, after everything is installed" = "所有套件安裝後，在 make.conf 加入 ACCEPT_KEYWORDS=\"~amd64\""
+"a partition of no size leaves nothing to format" = "大小為零的分割區無法建立檔案系統"
+"a mount point has to be an absolute path inside the target" = "掛載點必須是目標系統內的絕對路徑"

--- a/gentoo_install/model/compat.py
+++ b/gentoo_install/model/compat.py
@@ -17,6 +17,7 @@ from pathlib import PurePosixPath
 
 from .config import (
     BinhostChannel,
+    DiskMode,
     Bootloader,
     ConsoleFontSize,
     Firmware,
@@ -628,6 +629,18 @@ def _on_esp(graph: DeviceGraph, device: DeviceId) -> bool:
     return any(
         one.kind is FilesystemType.VFAT for one in _nodes_under(graph, device, Filesystem)
     )
+
+
+def destroyed_selectors(config: InstallConfig) -> tuple[str, ...]:
+    """Every device this configuration overwrites, by selector.
+
+    `dd` streams an image over the whole disk named by `disk.destination` and
+    builds no graph, so reading the graph alone answered "nothing is erased"
+    for the one mode that always destroys a disk.
+    """
+    if config.disk.mode is DiskMode.DD:
+        return (config.disk.destination,) if config.disk.destination else ()
+    return tuple(one.selector for one in destroyed(config.disk.graph))
 
 
 def destroyed(graph: DeviceGraph) -> tuple[Existing, ...]:

--- a/gentoo_install/plan/automatic.py
+++ b/gentoo_install/plan/automatic.py
@@ -16,7 +16,7 @@ from __future__ import annotations
 from dataclasses import dataclass
 from typing import Final
 
-from ..model.config import Bootloader, InstallConfig
+from ..model.config import Bootloader, DiskMode, InstallConfig
 from ..model.device import Mountpoint, Subvolume, ZfsDataset, ZfsPool
 from .bootloader import initramfs_devices, initramfs_keymap, unlock_parameters
 from .packages import Catalog, groups
@@ -71,6 +71,12 @@ def kernel_parameters(config: InstallConfig) -> tuple[Added, ...]:
     and `ro` in `10_linux` and takes only the rest from `/etc/default/grub`,
     and ZFSBootMenu finds the dataset itself.
     """
+    # `dd` writes an image as it is: it configures no bootloader and its graph
+    # holds no root, so asking what the boot entry carries answers with an
+    # exception. The review screen asked, and the interface died on the last
+    # screen before a whole disk is written.
+    if config.disk.mode is DiskMode.DD:
+        return ()
     kind = config.bootloader.kind
     added: list[Added] = []
     if kind is Bootloader.SYSTEMD_BOOT:

--- a/gentoo_install/tui/overview.py
+++ b/gentoo_install/tui/overview.py
@@ -13,7 +13,7 @@ from ..plan.build import build as plan_build
 from ..plan.operations import Operation
 from ..plan.render import counts
 from .context import Context, answers, footer, say, show_address
-from .settings import SETTINGS, UNSET
+from .settings import UNSET, settings_for
 from .widgets import Answer, Confirm, Item, Menu, Outcome, Screen
 
 
@@ -50,7 +50,11 @@ def overview_screen(
         say(screen, context, str(error).splitlines()[-1].strip())
         return Answer(Outcome.CANCELLED)
     items: list[Item[int]] = []
-    for group in SETTINGS:
+    # The table the menu asked from, not every table: in `dd` mode the menu
+    # asks two rows and this listed the twenty-three of a disk install, so the
+    # last screen before writing reviewed rows nobody answered and hid the
+    # ones they did.
+    for group in settings_for(config):
         for row in group.rows or (group,):
             value = row.value(config, context)
             items.append(

--- a/gentoo_install/tui/partitions.py
+++ b/gentoo_install/tui/partitions.py
@@ -16,7 +16,7 @@ from dataclasses import dataclass, replace
 from enum import Enum
 from typing import Callable, Final, Sequence
 
-from ..i18n import Catalog
+from ..i18n import Catalog, truncate, width
 from ..model import manual
 from ..model.config import (
     Bootloader,
@@ -105,7 +105,9 @@ def _zfs_bootloader(
             portage=with_gentoo_zh(config),
         )
 
-    return answer.map(apply)
+    # BACK whichever key was pressed. Nothing under this module is the main
+    # menu, and CANCELLED is what `app.py` answers with the quit prompt.
+    return answer.map(apply) if answer.chosen else Answer(Outcome.BACK)
 
 
 def _edit_passphrase(
@@ -120,7 +122,7 @@ def _edit_passphrase(
         current=bool(staged_path),
     ).run(screen)
     if not enabled.chosen:
-        return Answer(enabled.outcome)
+        return Answer(Outcome.BACK)
     if not enabled.unwrap():
         return Answer(Outcome.CHOSE, "")
     return _ask_passphrase(screen, context)
@@ -143,7 +145,7 @@ def _ask_passphrase(screen: Screen, context: Context) -> Answer[str]:
             footer=footer(translate),
         ).run(screen)
         if not first.chosen:
-            return Answer(first.outcome)
+            return Answer(Outcome.BACK)
         typed = first.unwrap()
         if len(typed) < PASSPHRASE_MINIMUM:
             # Checked here, not at preflight: zfs refuses a short passphrase
@@ -157,7 +159,7 @@ def _ask_passphrase(screen: Screen, context: Context) -> Answer[str]:
             footer=footer(translate),
         ).run(screen)
         if not again.chosen:
-            return Answer(again.outcome)
+            return Answer(Outcome.BACK)
         if again.unwrap() != typed:
             say(screen, context, translate("The two do not match."))
             continue
@@ -216,7 +218,9 @@ def partitions_screen(
             preamble=(translate("This editor controls which partitions are kept, formatted, mounted, or erased."),),
             items=items,
             cursor=cursor,
-            footer=f"{_layout_problem(context, config)}  {footer(translate)}".strip(),
+            footer=_status_line(
+                _layout_problem(context, config), footer(translate), screen.size()[1]
+            ),
         )
         answer = menu.run(screen)
         cursor = menu.cursor
@@ -229,7 +233,10 @@ def partitions_screen(
             context.layout = saved_layout
             context.layout.disks.extend(added)
             context.manual = saved_manual
-            return Answer(answer.outcome)
+            # `esc` is Back everywhere but the main menu, and this is not it.
+            # Answering CANCELLED made the main loop ask whether to end the
+            # install, one screen after the same key had meant one step back.
+            return Answer(Outcome.BACK)
         row = answer.unwrap()
         if row.kind is _RowKind.DONE:
             # Marked here rather than by whoever opened this screen: the row can
@@ -245,15 +252,37 @@ def partitions_screen(
                 # had no way out.
                 picked = _zfs_bootloader(screen, built, context)
                 if not picked.chosen:
-                    if picked.outcome is Outcome.CANCELLED:
-                        return Answer(picked.outcome)
-                    # Back to the editor rather than out of it: the table the
-                    # operator drew is still there, and a ZFS root with GRUB
-                    # is what committing this would have written.
+                    # Back to the editor whichever key was pressed: the table
+                    # the operator drew is still there, and a ZFS root with
+                    # GRUB is what committing this would have written.
                     continue
                 built = picked.unwrap()
             return Answer(Outcome.CHOSE, built)
         _act_on(screen, context, row)
+
+
+#: Cells between the keys and the validator's message on the status line.
+_GAP: Final[int] = 2
+
+
+#: What a shortened message ends with, so a cut one never reads as a whole one.
+_CUT: Final[str] = "…"
+
+
+def _status_line(problem: str, keys: str, columns: int) -> str:
+    """The keys first, the validator's message in whatever room is left.
+
+    `spread` cuts the footer from the right, so a message written ahead of the
+    keys took them off the row exactly when the table was wrong and Back was
+    the key the operator needed.
+    """
+    if not problem:
+        return keys
+    room = columns - width(keys) - _GAP
+    if room <= width(_CUT):
+        return keys
+    shown = problem if width(problem) <= room else truncate(problem, room - width(_CUT)) + _CUT
+    return f"{keys}{' ' * _GAP}{shown}"
 
 
 def _partitions_title(context: Context) -> str:
@@ -744,13 +773,14 @@ def _edit_slice(
 ) -> manual.Slice | None:
     """One partition as a list of fields, or None to delete it."""
     translate = context.translate
-    entry = current or manual.Slice(
+    opened_with = current or manual.Slice(
         index=disk.next_index(),
         role=PartitionRole.DATA,
         size=None,
         filesystem=FilesystemType.EXT4,
         mountpoint="",
     )
+    entry = opened_with
     cursor = 0
     while True:
         purpose = manual.purpose_of(entry)
@@ -763,7 +793,11 @@ def _edit_slice(
         answer = menu.run(screen)
         cursor = menu.cursor
         if not answer.chosen:
-            return current
+            if current is None and entry == opened_with:
+                # Nothing was filled in, so there is nothing to keep and the
+                # row the operator opened by mistake is not added.
+                return None
+            return _kept_on_back(screen, context, entry, opened_with)
         field = answer.unwrap()
         if field == DONE:
             return entry
@@ -772,6 +806,72 @@ def _edit_slice(
         changed = _edit_field(screen, context, entry, purpose, field)
         if changed is not None:
             entry = changed
+
+
+@dataclass(frozen=True)
+class _SliceRule:
+    """One field the table cannot hold a value for, and what to say about it."""
+
+    #: The row of `_slice_field_items` the message names.
+    field: str
+    refuses: Callable[[manual.Slice], bool]
+    revert: Callable[[manual.Slice, manual.Slice], manual.Slice]
+    said: Callable[[Catalog], str]
+
+
+def _mountpoint_refused(entry: manual.Slice) -> bool:
+    # The two conditions `validate` reads off the built graph, where the
+    # message names a node rather than the field the operator typed into.
+    return bool(entry.mountpoint) and (
+        not entry.mountpoint.startswith("/") or ".." in entry.mountpoint.split("/")
+    )
+
+
+def _no_size_said(translate: Catalog) -> str:
+    # A literal inside `translate(...)` rather than a field of the rule: the
+    # catalog check reads these out of the source, and a string it cannot see
+    # ships as English in the middle of a translated screen.
+    return (
+        f"{translate('Size')}: "
+        f"{translate('a partition of no size leaves nothing to format')}"
+    )
+
+
+def _mountpoint_said(translate: Catalog) -> str:
+    return (
+        f"{translate('Mount point')}: "
+        f"{translate('a mount point has to be an absolute path inside the target')}"
+    )
+
+
+_SLICE_RULES: Final[tuple[_SliceRule, ...]] = (
+    _SliceRule(
+        _SIZE,
+        lambda entry: entry.size is not None and entry.size.bytes <= 0,
+        lambda entry, opened: replace(entry, size=opened.size),
+        _no_size_said,
+    ),
+    _SliceRule(
+        _MOUNTPOINT,
+        _mountpoint_refused,
+        lambda entry, opened: replace(entry, mountpoint=opened.mountpoint),
+        _mountpoint_said,
+    ),
+)
+
+
+def _kept_on_back(
+    screen: Screen, context: Context, entry: manual.Slice, opened_with: manual.Slice
+) -> manual.Slice:
+    """Back writes the edited fields back; a field the table cannot hold goes
+    back to what it held, named with the reason it was refused."""
+    kept = entry
+    for rule in _SLICE_RULES:
+        if not rule.refuses(kept):
+            continue
+        kept = rule.revert(kept, opened_with)
+        say(screen, context, rule.said(context.translate))
+    return kept
 
 
 def _slice_fields(

--- a/gentoo_install/tui/screens.py
+++ b/gentoo_install/tui/screens.py
@@ -435,10 +435,10 @@ def erase_screen(screen: Screen, config: InstallConfig, context: Context) -> Ans
     translate = context.translate
     original = set(context.confirmed)
     pending = set(original)
-    for target in compat.destroyed(config.disk.graph):
-        if target.selector in pending:
+    for selector in compat.destroyed_selectors(config):
+        if selector in pending:
             continue
-        answered = _confirm_one(screen, context, target.selector, pending)
+        answered = _confirm_one(screen, context, selector, pending)
         if answered is not None:
             context.confirmed = original
             return answered

--- a/gentoo_install/tui/settings.py
+++ b/gentoo_install/tui/settings.py
@@ -688,7 +688,7 @@ def _erase(config: InstallConfig, context: Context) -> str:
     operator kept is `mkfs` over their data with no disk-level wipe and no
     rewritten table, and this row read that layout as harmless.
     """
-    targets = {one.selector for one in compat.destroyed(config.disk.graph)}
+    targets = set(compat.destroyed_selectors(config))
     if not targets:
         return context.translate("nothing is erased")
     # Every one of them: a layout can destroy content on more than one device,
@@ -949,6 +949,17 @@ DD_SETTINGS: Final[tuple[Setting, ...]] = (
         nested("Write image", IMAGE_WRITE),
         required=True,
         rows=IMAGE_WRITE,
+    ),
+    # The same row every other destructive path carries. `dd` writes a whole
+    # disk and this table did not hold it, so the one mode that always
+    # destroys was the one mode the menu never asked about.
+    Setting(
+        "erase",
+        "Confirm erasing the drive",
+        _erase,
+        screens.erase_screen,
+        required=True,
+        missing="not confirmed",
     ),
 )
 

--- a/gentoo_install/tui/widgets.py
+++ b/gentoo_install/tui/widgets.py
@@ -12,7 +12,17 @@ from __future__ import annotations
 from dataclasses import dataclass, field
 from enum import Enum
 import textwrap
-from typing import Callable, ClassVar, Final, Generic, Mapping, Protocol, Sequence, TypeVar
+from typing import (
+    Callable,
+    ClassVar,
+    Final,
+    Generic,
+    Iterable,
+    Mapping,
+    Protocol,
+    Sequence,
+    TypeVar,
+)
 
 from ..i18n import truncate, width
 
@@ -684,3 +694,178 @@ class Form:
             # [q] cancel * required ~ never opened` reads as neither.
             screen.write(lines - 1, 0, spread(self.footer, self.legend, columns))
         screen.show()
+
+
+#: The left pane is the widest label in the catalog plus a marker and a space,
+#: held between these two: narrower cuts an English name, wider leaves the
+#: right pane too narrow for a device path and a filesystem beside it.
+LEFT_PANE_MINIMUM: Final[int] = 20
+LEFT_PANE_MAXIMUM: Final[int] = 34
+
+#: The marker column and the space after it, before every label.
+MARKER_ROOM: Final[int] = 2
+
+#: The separator column and the space after it, between the two panes.
+PANE_GAP: Final[int] = 2
+
+#: ASCII: the medium's own console font carries no box-drawing set.
+SEPARATOR: Final[str] = "|"
+
+#: Left behind by every truncation. Without it a cut mirror URL reads as a
+#: whole one, which is what `i18n.truncate` alone gets wrong here.
+CUT: Final[str] = "…"
+
+
+def clip(text: str, cells: int) -> str:
+    """`text` in at most `cells` columns, marked when something was cut."""
+    if cells <= 0:
+        return ""
+    if width(text) <= cells:
+        return text
+    return truncate(text, cells - width(CUT)) + CUT
+
+
+def left_pane_width(labels: Iterable[str]) -> int:
+    """How wide the left pane stands for this catalog.
+
+    Measured, not a constant: the same rows are 25 cells in English and 30 in
+    Japanese, and a pane sized for one of them truncates the other.
+    """
+    widest = max((width(label) for label in labels), default=0)
+    return min(LEFT_PANE_MAXIMUM, max(LEFT_PANE_MINIMUM, widest + MARKER_ROOM))
+
+
+def right_pane_width(columns: int, left: int) -> int:
+    """What is left for the right pane once the separator and its space are."""
+    return columns - left - PANE_GAP
+
+
+@dataclass(frozen=True)
+class PaneRow(Generic[V]):
+    """One row of the left pane, and what the right pane says about it."""
+
+    label: str
+    value: V
+    #: Drawn at the right of the left pane, and dropped rather than cut when
+    #: the label fills the pane: half a state word names another state.
+    state: str = ""
+    style: Style = Style.PLAIN
+    #: The right pane's lines while the cursor is on this row. The first two
+    #: are what a screen too small for two panes shows under the row.
+    detail: tuple[str, ...] = ()
+
+
+@dataclass
+class TwoPane(Generic[V]):
+    """The settings list beside the current value of the row under the cursor.
+
+    Focus never leaves the left pane. Two panes that both take the cursor need
+    a third key to move between them, and on a serial console another key is
+    another state the operator cannot see.
+    """
+
+    title: str
+    rows: Sequence[PaneRow[V]]
+    #: Right-aligned on the title row, answered against total.
+    counter: str = ""
+    footer: str = ""
+    #: What the marks mean, at the end of the status line so it does not read
+    #: as one more key.
+    legend: str = ""
+    #: Where the cursor was left. Reopening after editing a row comes back to
+    #: that row.
+    cursor: int = 0
+
+    def run(self, screen: Screen) -> Answer[V]:
+        cursor = self.cursor if 0 <= self.cursor < len(self.rows) else 0
+        while True:
+            self.cursor = cursor
+            self._draw(screen, cursor)
+            pressed = screen.key()
+            if pressed == "KEY_UP":
+                cursor = max(0, cursor - 1)
+            elif pressed == "KEY_DOWN":
+                cursor = min(max(0, len(self.rows) - 1), cursor + 1)
+            elif pressed in ("\n", "KEY_ENTER", "KEY_RIGHT"):
+                if self.rows:
+                    return Answer(Outcome.CHOSE, self.rows[cursor].value)
+            elif pressed in ("KEY_LEFT", "\x1b"):
+                # Both answer Back at every depth, and what Back means here is
+                # the caller's: the main menu asks whether to end the run.
+                return Answer(Outcome.BACK)
+            elif pressed == "\x03":
+                return Answer(Outcome.CANCELLED)
+
+    def _draw(self, screen: Screen, cursor: int) -> None:
+        lines, columns = screen.size()
+        screen.clear()
+        screen.write(0, 0, spread(self.title, self.counter, columns))
+        if columns < MINIMUM_COLUMNS or lines < MINIMUM_LINES:
+            self._draw_one_pane(screen, cursor, lines, columns)
+        else:
+            self._draw_two_panes(screen, cursor, lines, columns)
+        if lines > 1 and (self.footer or self.legend):
+            screen.write(lines - 1, 0, spread(self.footer, self.legend, columns))
+        screen.show()
+
+    def _draw_two_panes(self, screen: Screen, cursor: int, lines: int, columns: int) -> None:
+        left = left_pane_width(row.label for row in self.rows)
+        right = right_pane_width(columns, left)
+        room = lines - 3
+        for line in range(2, lines - 1):
+            screen.write(line, left, SEPARATOR)
+        top = _window(cursor, room, len(self.rows))
+        for offset, index in enumerate(range(top, min(len(self.rows), top + room))):
+            self._draw_row(
+                screen, offset + 2, index, index == cursor, MARKER_ROOM, left - MARKER_ROOM
+            )
+        detail = self.rows[cursor].detail if self.rows else ()
+        for offset, line_text in enumerate(detail[:room]):
+            screen.write(offset + 2, left + PANE_GAP, clip(line_text, right))
+
+    def _draw_one_pane(self, screen: Screen, cursor: int, lines: int, columns: int) -> None:
+        """One pane, and the row under the cursor carries two of its lines.
+
+        The floor is a measured boundary rather than best effort: below it the
+        right pane cannot hold a value, so it stops existing.
+        """
+        room = lines - 3
+        if room <= 0:
+            return
+        entries: list[tuple[int | None, str]] = []
+        for index, row in enumerate(self.rows):
+            entries.append((index, ""))
+            if index == cursor:
+                entries.extend((None, line) for line in row.detail[:2])
+        here = next((at for at, (which, _) in enumerate(entries) if which == cursor), 0)
+        top = _window(here, room, len(entries))
+        for offset, (which, text) in enumerate(entries[top : top + room]):
+            if which is None:
+                screen.write(offset + 2, 4, clip(text, columns - 4))
+                continue
+            self._draw_row(
+                screen, offset + 2, which, which == cursor, MARKER_ROOM, columns - MARKER_ROOM
+            )
+
+    def _draw_row(
+        self, screen: Screen, line: int, index: int, focused: bool, column: int, room: int
+    ) -> None:
+        row = self.rows[index]
+        if row.style is not Style.PLAIN:
+            # The marker is the signal and the colour repeats it: a monochrome
+            # serial console has to show the same thing.
+            screen.write(line, 0, MARKS[row.style], style=row.style)
+        screen.write(
+            line,
+            column,
+            spread(clip(row.label, room), row.state, room),
+            highlight=focused,
+            style=row.style,
+        )
+
+
+def _window(cursor: int, room: int, total: int) -> int:
+    """The first row drawn, so the cursor stays on screen without wrapping."""
+    if room <= 0 or total <= room:
+        return 0
+    return max(0, min(cursor - room // 2, total - room))

--- a/tests/unit/test_layers.py
+++ b/tests/unit/test_layers.py
@@ -9,6 +9,7 @@ of these was true when it was written and each one drifted once.
 from __future__ import annotations
 
 import ast
+import subprocess
 import re
 from collections.abc import Iterator, Mapping
 from pathlib import Path
@@ -400,6 +401,24 @@ CJK_EXCEPTIONS: Final[frozenset[str]] = frozenset({"tests/vm/console.py"})
 WIDE: Final[re.Pattern[str]] = re.compile("[\u4e00-\u9fff]")
 
 
+def _tracked(where: str) -> bool:
+    """Whether git tracks this path, cached for one run of the suite."""
+    if not _TRACKED:
+        listed = subprocess.run(
+            ["git", "ls-files", "-z"],
+            cwd=PACKAGE.parent,
+            capture_output=True,
+            text=True,
+            check=True,
+        )
+        _TRACKED.update(one for one in listed.stdout.split("\0") if one)
+    return where in _TRACKED
+
+
+#: Filled once by `_tracked`.
+_TRACKED: set[str] = set()
+
+
 def _wide_character_scan() -> tuple[list[str], list[str]]:
     """Return the offending `path:line` list and every path that was read.
 
@@ -413,7 +432,10 @@ def _wide_character_scan() -> tuple[list[str], list[str]]:
     for pattern in ("*.py", "*.toml"):
         for path in sorted(root.rglob(pattern)):
             where = str(path.relative_to(root))
-            if "/.git/" in f"/{where}" or "__pycache__" in where:
+            # A worktree the agent tooling opens inside the repository carries
+            # a copy of every excepted file, and the scan read all of them as
+            # offenders. What the repository holds is what git tracks.
+            if not _tracked(where):
                 continue
             body = path.read_text()
             scanned.append(where)

--- a/tests/unit/test_tui_app.py
+++ b/tests/unit/test_tui_app.py
@@ -3299,7 +3299,13 @@ def test_dd_mode_is_offered_only_from_a_live_or_memory_environment() -> None:
     assert chosen.disk.mode is DiskMode.DD
     assert not chosen.disk.graph.nodes
     assert not chosen.disk.root
-    assert [setting.key for setting in settings.settings_for(chosen)] == ["mode", "image_write"]
+    # `erase` joined the table: `dd` writes a whole disk, and every other
+    # destructive path asks for that confirmation by name.
+    assert [setting.key for setting in settings.settings_for(chosen)] == [
+        "mode",
+        "image_write",
+        "erase",
+    ]
     assert [setting.key for setting in settings.IMAGE_WRITE] == [
         "image_source",
         "image_format",
@@ -3431,3 +3437,76 @@ def test_the_layout_menu_offers_no_layout_that_is_not_one() -> None:
     # The route that does exist is the one the manual row takes.
     assert "partitions_screen(" in inspect.getsource(screens.layout_screen)
 
+
+
+def test_the_review_screen_lists_the_rows_the_chosen_mode_asks() -> None:
+    """In `dd` mode the menu asks two rows and the review screen listed the
+    twenty-three of a disk install, so the last screen before a whole disk is
+    written reviewed rows nobody answered and hid the ones they did.
+
+    The menu draws a window rather than every row, so what this holds is the
+    two halves that fit: the mode's own rows are there, and no row belonging
+    only to the other mode is.
+    """
+    from pathlib import Path as _Path
+
+    from gentoo_install.exec.config import load
+    from gentoo_install.tui.settings import settings_for
+
+    from .layouts import config, ext4_on_gpt
+
+    partitioned = config(ext4_on_gpt())
+    # A real one: validation refuses `[kernel]` in `dd` mode, so a partition
+    # configuration with the mode flipped never reaches the row list at all.
+    written = load(_Path("tests/fixtures/vm-dd-raw.toml"))
+
+    def labels(chosen: InstallConfig) -> set[str]:
+        return {
+            row.label
+            for group in settings_for(chosen)
+            for row in (group.rows or (group,))
+        }
+
+    at = context()
+    at.columns = 100
+    screen = FakeScreen(keys=["q"], columns=100)
+    overview_screen(screen, written, at)
+    drawn = " ".join(line for frame in screen.frames for line in frame)
+    # `dd` asks two rows, and both fit on one screen.
+    for label in labels(written):
+        assert at.translate(label) in drawn, label
+    # And nothing the disk install asks: those are questions nobody answered.
+    unasked = labels(partitioned) - labels(written)
+    assert not [one for one in unasked if at.translate(one) in drawn], sorted(unasked)[:3]
+
+
+def test_writing_an_image_asks_the_same_erase_confirmation_as_every_other_path() -> None:
+    """`dd` streams over a whole disk and its table held no confirmation row,
+    so the one mode that always destroys a disk was the one the menu never
+    asked about. The row reads the destination, because a `dd` configuration
+    builds no graph and `compat.destroyed` answered `nothing is erased`."""
+    from pathlib import Path as _Path
+
+    from gentoo_install.exec.config import load
+    from gentoo_install.model import compat
+    from gentoo_install.tui.settings import settings_for
+
+    written = load(_Path("tests/fixtures/vm-dd-raw.toml"))
+    assert compat.destroyed_selectors(written) == (written.disk.destination,)
+
+    rows = {row.key for group in settings_for(written) for row in (group.rows or (group,))}
+    assert "erase" in rows, sorted(rows)
+
+    at = context()
+    erase = next(
+        row
+        for group in settings_for(written)
+        for row in (group.rows or (group,))
+        if row.key == "erase"
+    )
+    assert erase.required
+    # Unanswered until the destination is confirmed by name, the way a
+    # partition install's disks are.
+    assert erase.value(written, at) == settings.UNSET
+    at.confirmed.add(written.disk.destination)
+    assert erase.value(written, at) == at.translate("confirmed")

--- a/tests/unit/test_tui_app.py
+++ b/tests/unit/test_tui_app.py
@@ -466,7 +466,7 @@ def test_declining_encryption_clears_the_passphrase() -> None:
 
 @pytest.mark.parametrize(
     ("leave", "outcome"),
-    [("KEY_BACKSPACE", Outcome.BACK), ("\x1b", Outcome.CANCELLED)],
+    [("KEY_BACKSPACE", Outcome.BACK), ("\x1b", Outcome.BACK)],
 )
 def test_reopening_template_encryption_preserves_its_passphrase_on_child_exit(
     leave: str, outcome: Outcome
@@ -528,7 +528,7 @@ def test_array_encryption_replaces_its_staged_passphrase_after_success() -> None
 
 @pytest.mark.parametrize(
     ("leave", "outcome"),
-    [("KEY_BACKSPACE", Outcome.BACK), ("\x1b", Outcome.CANCELLED)],
+    [("KEY_BACKSPACE", Outcome.BACK), ("\x1b", Outcome.BACK)],
 )
 def test_reopening_pool_encryption_preserves_its_passphrase_on_child_exit(
     leave: str, outcome: Outcome,
@@ -2129,9 +2129,13 @@ def test_cancelling_a_nested_prompt_reaches_the_screen_as_cancelled() -> None:
     assert screens.root_password_screen(
         FakeScreen(keys=["\x1b"]), config(), at
     ).outcome is Outcome.CANCELLED
+    # Escape inside the encryption question reaches the passphrase prompts in
+    # `partitions.py`, which answer Back: the key table gives escape one
+    # meaning at depth, and the quit prompt only at the main menu. The screens
+    # around it follow in the commits that take the rest of the table.
     assert screens.encryption_screen(
         FakeScreen(keys=["KEY_DOWN", "\n", "\x1b"]), config(), at
-    ).outcome is Outcome.CANCELLED
+    ).outcome is Outcome.BACK
     assert screens.keymap_screen(
         FakeScreen(keys=["\x1b"]), config(), at
     ).outcome is Outcome.CANCELLED
@@ -2933,7 +2937,7 @@ def test_a_reopened_selector_starts_on_what_is_already_set() -> None:
 
 @pytest.mark.parametrize(
     ("leaving", "outcome"),
-    [("KEY_BACKSPACE", Outcome.BACK), ("\x1b", Outcome.CANCELLED)],
+    [("KEY_BACKSPACE", Outcome.BACK), ("\x1b", Outcome.BACK)],
 )
 def test_the_zfs_bootloader_outcome_leaves_the_layout_screen(
     leaving: str, outcome: Outcome

--- a/tests/unit/test_tui_partitions.py
+++ b/tests/unit/test_tui_partitions.py
@@ -8,10 +8,12 @@ edited, validated and turned into a graph without a terminal or a disk.
 from __future__ import annotations
 
 from dataclasses import replace
+from typing import Callable, Final, TypeVar
 
 import pytest
 
 from gentoo_install.errors import ValidationFailed
+from gentoo_install.i18n import width
 from gentoo_install.model import manual
 from gentoo_install.model.config import (
     Bootloader,
@@ -40,11 +42,14 @@ from gentoo_install.model.templates import Layout
 from gentoo_install.tui import context as tui_context
 from gentoo_install.tui import partitions
 from gentoo_install.tui import screens
-from gentoo_install.tui.widgets import Outcome
+from gentoo_install.tui.widgets import Item, Outcome
 
 from .fake_screen import FakeScreen
 from .layouts import config, ext4_on_gpt, i
 from .test_tui_app import context
+
+
+V = TypeVar("V")
 
 
 def one_disk(
@@ -1345,3 +1350,233 @@ def test_the_comment_names_every_purpose_that_asks_for_a_mount_point() -> None:
     for key in sorted(asking):
         assert f"`{key}`" in said, f"the comment does not name {key}"
     assert "Only `other` asks" not in said
+
+
+def reachable(items: list[Item[V]]) -> list[str]:
+    """The labels a cursor can land on, in order: `_step` skips a disabled row,
+    so counting every row overshoots the one the test meant to open."""
+    return [one.label for one in items if not one.disabled_because]
+
+
+def steps(items: list[Item[V]], start: str, end: str) -> list[str]:
+    labels = reachable(items)
+    return ["KEY_DOWN"] * (labels.index(end) - labels.index(start))
+
+
+def suggested() -> tuple[tui_context.Context, manual.Slice]:
+    """The table and its root row. On the disk the context chose, or the screen
+    reseeds and the rows counted here are not the rows it draws."""
+    at = opened()
+    at.layout = manual.suggest(at.choice.disk, Firmware.UEFI)
+    return at, sorted(at.layout.disks[0].slices, key=lambda one: one.index)[1]
+
+
+def test_back_out_of_a_partition_keeps_the_field_that_was_edited() -> None:
+    """Back writes what was typed into the table. The editor answered with the
+    slice it opened on, so a label typed one keystroke before pressing left
+    never reached the graph the installer builds.
+    """
+    at, root = suggested()
+    rows = partitions._partition_rows(at)
+    fields = partitions._slice_fields(root, manual.purpose_of(root), at.translate)
+    row = f"  {root.describe()}"
+    screen = FakeScreen(
+        keys=[
+            *steps(rows, reachable(rows)[0], row),
+            "\n",
+            *steps(fields, reachable(fields)[0], "Label"),
+            "\n",
+            *(["\x7f"] * len(root.label)),
+            *"carried",
+            "\n",
+            "KEY_LEFT",
+            *steps(rows, row, "Done"),
+            "\n",
+        ]
+    )
+    answer = partitions.partitions_screen(screen, config(), at)
+    assert answer.outcome is Outcome.CHOSE
+    labels = {node.label for node in answer.unwrap().disk.graph.of_type(Filesystem)}
+    assert "carried" in labels, labels
+
+
+def test_escape_goes_back_one_screen_at_both_depths_of_the_editor() -> None:
+    """`esc` is Back everywhere but the main menu. It ended the whole run from
+    the partition screen and went back one screen from the slice editor, which
+    is the same key meaning two things one keystroke apart.
+    """
+    at, root = suggested()
+    rows = partitions._partition_rows(at)
+    screen = FakeScreen(
+        keys=[
+            *steps(rows, reachable(rows)[0], f"  {root.describe()}"),
+            "\n",
+            "\x1b",
+            "\x1b",
+        ]
+    )
+    answer = partitions.partitions_screen(screen, config(), at)
+    assert answer.outcome is Outcome.BACK
+    # Both were consumed, so the first one went back into the partition screen
+    # rather than out of the editor with the second left unread.
+    assert screen.keys == []
+
+
+def test_a_long_validator_message_leaves_the_keys_on_the_status_line() -> None:
+    """The message was written before the keys and the row is cut from the
+    right, so a table the validator had a sentence about drew no keys at all
+    and Back was named nowhere on the screen.
+    """
+    at = opened()
+    # The disk the context chose, or the screen reseeds the table from the
+    # template and the validator has nothing to say about it.
+    at.layout = one_disk(
+        disk=at.choice.disk,
+        slices=[
+            manual.Slice(index=1, role=PartitionRole.ESP, size=Size.parse("1GiB"),
+                         filesystem=FilesystemType.VFAT, mountpoint="/efi"),
+            manual.Slice(index=2, role=PartitionRole.DATA, size=Size.parse("4GiB"),
+                         filesystem=FilesystemType.EXT4, mountpoint="/"),
+        ],
+    )
+    problem = partitions._layout_problem(at, config())
+    assert width(problem) > 80 - width(tui_context.footer(at.translate))
+    screen = FakeScreen(keys=["\x1b"], columns=80, lines=24)
+    partitions.partitions_screen(screen, config(), at)
+    line = screen.frames[-1][-1]
+    assert "[enter]" in line and "[backspace]" in line and "[esc]" in line, line
+    assert problem not in line and "\u2026" in line, line
+    assert width(line) <= 80
+
+
+def test_the_status_line_drops_the_message_rather_than_the_keys() -> None:
+    keys = "[enter] Continue  [backspace] Back  [esc] Cancel"
+    assert partitions._status_line("", keys, 80) == keys
+    # No room for a mark and one cell of message: the keys are the whole line.
+    assert partitions._status_line("busy", keys, width(keys) + 3) == keys
+    room = partitions._status_line("busy", keys, 80)
+    assert room.startswith(keys) and room.endswith("busy")
+
+
+GOOD: Final[manual.Slice] = manual.Slice(
+    index=3,
+    role=PartitionRole.DATA,
+    size=Size.parse("20GiB"),
+    filesystem=FilesystemType.EXT4,
+    mountpoint="/srv",
+    label="before",
+)
+
+
+#: One slice per rule in `partitions._SLICE_RULES`, each breaking that rule and
+#: no other, with a second field edited so the refusal cannot be a wholesale
+#: revert wearing a message.
+BREAKS: Final[dict[str, manual.Slice]] = {
+    "size": replace(GOOD, size=Size.parse("0MiB"), label="typed"),
+    "mountpoint": replace(GOOD, mountpoint="srv", label="typed"),
+}
+
+
+def test_every_slice_rule_has_a_case_that_breaks_it_and_only_it() -> None:
+    assert {one.field for one in partitions._SLICE_RULES} == set(BREAKS)
+    for rule in partitions._SLICE_RULES:
+        fired = {
+            one.field for one in partitions._SLICE_RULES if one.refuses(BREAKS[rule.field])
+        }
+        assert fired == {rule.field}, (rule.field, fired)
+    assert not [one.field for one in partitions._SLICE_RULES if one.refuses(GOOD)]
+
+
+@pytest.mark.parametrize("field", sorted(BREAKS))
+def test_back_reverts_only_the_field_that_fails_and_names_it(field: str) -> None:
+    """Everything typed is written back except the one field the table cannot
+    hold, which returns to what it was with the reason on the screen."""
+    at = opened()
+    screen = FakeScreen(keys=["\n"])
+    kept = partitions._kept_on_back(screen, at, BREAKS[field], GOOD)
+    assert kept == replace(GOOD, label="typed"), kept
+    rule = next(one for one in partitions._SLICE_RULES if one.field == field)
+    said = rule.said(at.translate)
+    assert said in screen.last, screen.last
+    # The label of the row the operator opened, so the message names the field
+    # they edited rather than the attribute the model calls it.
+    row = next(
+        one
+        for one in partitions._slice_fields(GOOD, manual.purpose_of(GOOD), at.translate)
+        if one.value == field
+    )
+    assert said.startswith(f"{row.label}: "), (said, row.label)
+    assert screen.keys == []
+
+
+def test_a_relative_mount_point_typed_into_the_editor_never_reaches_the_table() -> None:
+    """The whole path, from the keystrokes: the field is edited, `←` is pressed,
+    and the mount point the validator would refuse is not what comes back.
+    """
+    at = opened()
+    at.layout = one_disk(slices=[GOOD])
+    fields = partitions._slice_fields(GOOD, manual.purpose_of(GOOD), at.translate)
+    screen = FakeScreen(
+        keys=[
+            *steps(fields, reachable(fields)[0], "Mount point"),
+            "\n",
+            *(["\x7f"] * len(GOOD.mountpoint)),
+            *"srv",
+            "\n",
+            "KEY_LEFT",
+            "\n",
+        ]
+    )
+    kept = partitions._edit_slice(screen, at, at.layout.disks[0], GOOD)
+    assert kept is not None and kept.mountpoint == "/srv", kept
+
+
+def test_backing_out_of_a_partition_nobody_filled_in_adds_nothing() -> None:
+    """`Add a partition` then `←`: keeping what was typed must not turn an
+    editor nobody typed into into a row on the disk."""
+    at, _ = suggested()
+    rows = partitions._partition_rows(at)
+    add = "  Add a partition"
+    before = len(at.layout.disks[0].slices)
+    # Out through `Done`, not through Back: backing out of the screen restores
+    # the table it opened with, which hides the row this test is looking for.
+    screen = FakeScreen(
+        keys=[
+            *steps(rows, reachable(rows)[0], add),
+            "\n",
+            "KEY_LEFT",
+            *steps(rows, add, "Done"),
+            "\n",
+        ]
+    )
+    answer = partitions.partitions_screen(screen, config(), at)
+    assert answer.outcome is Outcome.CHOSE
+    assert len(answer.unwrap().disk.graph.of_type(Partition)) == before
+
+
+def test_no_door_of_this_module_answers_with_the_quit_prompt() -> None:
+    """`app.py:149` turns CANCELLED into "do you want to end the install".
+    None of these is the main menu, so `esc` at any of them is one step back.
+    """
+    at, _ = suggested()
+    # The outcome and not the answer: each of these is generic over a different
+    # value, and one dictionary of them has no type the four share.
+    doors: dict[str, Callable[[], Outcome]] = {
+        "partitions_screen": lambda: partitions.partitions_screen(
+            FakeScreen(keys=["\x1b"]), config(), at
+        ).outcome,
+        "_zfs_bootloader": lambda: partitions._zfs_bootloader(
+            FakeScreen(keys=["\x1b"]), config(), at
+        ).outcome,
+        "_edit_passphrase": lambda: partitions._edit_passphrase(
+            FakeScreen(keys=["\x1b"]), at, "", "Encrypt the pool?"
+        ).outcome,
+        "_ask_passphrase": lambda: partitions._ask_passphrase(
+            FakeScreen(keys=["\x1b"]), at
+        ).outcome,
+        "_ask_passphrase, second field": lambda: partitions._ask_passphrase(
+            FakeScreen(keys=[*("x" * tui_context.PASSPHRASE_MINIMUM), "\n", "\x1b"]), at
+        ).outcome,
+    }
+    answered = {name: door() for name, door in doors.items()}
+    assert set(answered.values()) == {Outcome.BACK}, answered

--- a/tests/unit/test_tui_widgets.py
+++ b/tests/unit/test_tui_widgets.py
@@ -13,6 +13,8 @@ from gentoo_install.tui.widgets import (
     Menu,
     MultipleChoiceMenu,
     Outcome,
+    PaneRow,
+    Style,
     TextField,
 )
 
@@ -648,3 +650,256 @@ def test_a_combining_mark_joins_the_cell_before_it_instead_of_taking_one() -> No
 
     assert screen.drawn(0) == "e" + ACUTE + "x"
     assert width(screen.drawn(0)) == 2
+
+
+class Recording(FakeScreen):
+    """A `FakeScreen` that keeps every write, so a test can assert where a
+    widget wrote and not only what the row ended up reading."""
+
+    def __init__(self, keys: list[str], lines: int = 24, columns: int = 80) -> None:
+        super().__init__(keys=keys, lines=lines, columns=columns)
+        self.spans: list[tuple[int, int, str]] = []
+
+    def write(
+        self,
+        line: int,
+        column: int,
+        text: str,
+        highlight: bool = False,
+        style: Style = Style.PLAIN,
+    ) -> None:
+        self.spans.append((line, column, text))
+        super().write(line, column, text, highlight, style)
+
+
+def cell(screen: FakeScreen, line: int, column: int) -> str:
+    """What occupies that column. Walked by cells: indexing the row as a
+    string reads one place left for every wide character before it."""
+    from gentoo_install.i18n import width
+
+    at = 0
+    for character in screen.drawn(line):
+        step = width(character)
+        if at <= column < at + step:
+            return character
+        at += step
+    return " "
+
+
+def catalog_labels(tag: str) -> list[str]:
+    """Every setting label the main menu can draw, in one language."""
+    from gentoo_install.i18n import Catalog
+    from gentoo_install.tui.settings import SETTINGS, Setting
+
+    translate = Catalog(tag)
+
+    def walk(rows: tuple[Setting, ...]) -> list[str]:
+        found: list[str] = []
+        for one in rows:
+            found.append(translate(one.label))
+            found.extend(walk(one.rows))
+        return found
+
+    return walk(SETTINGS)
+
+
+def pane_rows(count: int = 4, label: str = "Mirrors") -> list[PaneRow[int]]:
+    return [
+        PaneRow(label=f"{label}{index}", value=index, state="set", detail=(f"line {index}",))
+        for index in range(count)
+    ]
+
+
+@pytest.mark.parametrize(
+    "tag,left,right",
+    [("en", 27, 51), ("zh-TW", 20, 58), ("zh-CN", 20, 58), ("ja", 32, 46), ("ko", 26, 52)],
+)
+def test_the_panes_are_measured_from_the_catalog_they_will_draw(
+    tag: str, left: int, right: int
+) -> None:
+    """One rule, five answers. A pane sized for English cuts every Japanese
+    label, and one sized for Japanese leaves 46 columns for a device path."""
+    from gentoo_install.tui.widgets import left_pane_width, right_pane_width
+
+    assert left_pane_width(catalog_labels(tag)) == left
+    assert right_pane_width(80, left) == right
+    assert left + right + 2 == 80
+
+
+def test_a_label_wider_than_the_clamp_is_cut_and_says_so() -> None:
+    """No catalog reaches it today, so the boundary is held by a test rather
+    than by the input: a cut name that reads as a whole one is the defect."""
+    from gentoo_install.tui.widgets import CUT, SEPARATOR, TwoPane
+
+    screen = Recording(keys=["\x1b"])
+    TwoPane(title="gentoo-install", rows=[PaneRow(label="x" * 40, value=0)]).run(screen)
+
+    assert screen.drawn(2)[2:34] == "x" * 31 + CUT
+    assert cell(screen, 2, 34) == SEPARATOR
+
+
+def test_a_wide_label_is_cut_by_cells_and_not_by_characters() -> None:
+    """Sixteen characters are 32 cells, and a cut counted in characters puts
+    half of the seventeenth into the separator column."""
+    from gentoo_install.i18n import width
+    from gentoo_install.tui.widgets import CUT, SEPARATOR, TwoPane
+
+    screen = Recording(keys=["\x1b"])
+    TwoPane(title="gentoo-install", rows=[PaneRow(label=WIDE[0] * 20, value=0)]).run(screen)
+
+    drawn = screen.drawn(2)
+    assert CUT in drawn
+    assert width(drawn[: drawn.index(CUT) + 1]) <= 34
+    assert cell(screen, 2, 34) == SEPARATOR
+
+
+def test_a_right_pane_line_too_long_for_the_pane_is_cut_and_says_so() -> None:
+    """A truncated mirror URL is indistinguishable from a whole one, which is
+    why every cut leaves a mark."""
+    from gentoo_install.i18n import width
+    from gentoo_install.tui.widgets import CUT, TwoPane
+
+    address = "https://mirror.example.org/gentoo/releases/amd64/autobuilds/latest-stage3"
+    screen = Recording(keys=["\x1b"])
+    TwoPane(
+        title="gentoo-install",
+        rows=[PaneRow(label="Mirrors", value=0, detail=(address,))],
+    ).run(screen)
+
+    drawn = screen.drawn(2)
+    assert address not in drawn
+    assert drawn.endswith(CUT)
+    assert width(drawn) == 80
+
+
+def test_no_write_lands_on_the_separator_column() -> None:
+    """The column between the panes belongs to neither. A label that spills
+    into it is what makes the right pane start one column late."""
+    from gentoo_install.i18n import width
+    from gentoo_install.tui.widgets import SEPARATOR, TwoPane, left_pane_width
+
+    rows = [
+        PaneRow(label="x" * 40, value=0, state="set", detail=("y" * 90,)),
+        PaneRow(label="Mirrors", value=1, state="not set", detail=("z" * 90,)),
+    ]
+    screen = Recording(keys=["KEY_DOWN", "\x1b"])
+    TwoPane(title="gentoo-install", rows=rows, footer="[enter] open").run(screen)
+    left = left_pane_width(row.label for row in rows)
+
+    # The title and the status line are full width by definition, so the
+    # claim is about the rows between them.
+    body = [span for span in screen.spans if 2 <= span[0] <= 22]
+    assert body
+    for line, column, text in body:
+        if text == SEPARATOR and column == left:
+            continue
+        assert column + width(text) <= left or column > left, (line, column, text)
+    for line in range(2, 23):
+        assert cell(screen, line, left) == SEPARATOR
+
+
+def test_below_the_floor_one_pane_carries_two_lines_under_the_cursor() -> None:
+    """79 columns and 23 lines are each below the only size guaranteed to
+    exist, and the right pane has nowhere to stand."""
+    from gentoo_install.tui.widgets import SEPARATOR, TwoPane
+
+    rows = [
+        PaneRow(label="Mirrors", value=0, state="set", detail=("first", "second", "third")),
+        PaneRow(label="Kernel", value=1, state="set", detail=("other",)),
+    ]
+    for lines, columns in ((24, 79), (23, 80)):
+        screen = Recording(keys=["\x1b"], lines=lines, columns=columns)
+        TwoPane(title="gentoo-install", rows=rows).run(screen)
+
+        assert "Mirrors" in screen.drawn(2)
+        assert screen.drawn(3).strip() == "first"
+        assert screen.drawn(4).strip() == "second"
+        assert "Kernel" in screen.drawn(5)
+        assert "third" not in screen.last
+        assert SEPARATOR not in screen.last
+
+
+def test_a_screen_too_small_for_a_row_draws_what_fits_and_raises_nothing() -> None:
+    """A serial console that came up at 80x10, and a resize down to nothing:
+    neither is an error the operator can act on."""
+    from gentoo_install.tui.widgets import TwoPane
+
+    for lines, columns in ((10, 40), (4, 20), (2, 12), (1, 8)):
+        screen = Recording(keys=["\x1b"], lines=lines, columns=columns)
+        assert TwoPane(title="gentoo-install", rows=pane_rows()).run(screen).outcome is Outcome.BACK
+
+
+def test_the_cursor_moves_and_enter_answers_with_the_row_under_it() -> None:
+    from gentoo_install.tui.widgets import TwoPane
+
+    rows = pane_rows()
+    assert TwoPane(title="t", rows=rows).run(FakeScreen(keys=["KEY_DOWN", "\n"])).unwrap() == 1
+    moved = TwoPane(title="t", rows=rows)
+    assert moved.run(FakeScreen(keys=["KEY_DOWN", "KEY_DOWN", "KEY_UP", "KEY_RIGHT"])).unwrap() == 1
+    # Stops rather than wraps: wrapping past either end loses the operator's
+    # place in a list of twenty-two rows.
+    assert TwoPane(title="t", rows=rows).run(FakeScreen(keys=["KEY_UP", "\n"])).unwrap() == 0
+
+
+def test_left_and_escape_both_answer_back_and_the_caller_decides() -> None:
+    """One meaning for `KEY_LEFT` at every depth. What Back means here is the
+    main menu's business: it is where the run is ended."""
+    from gentoo_install.tui.widgets import TwoPane
+
+    rows = pane_rows()
+    assert TwoPane(title="t", rows=rows).run(FakeScreen(keys=["KEY_LEFT"])).outcome is Outcome.BACK
+    assert TwoPane(title="t", rows=rows).run(FakeScreen(keys=["\x1b"])).outcome is Outcome.BACK
+    interrupted = TwoPane(title="t", rows=rows).run(FakeScreen(keys=["\x03"]))
+    assert interrupted.outcome is Outcome.CANCELLED
+
+
+def test_the_title_row_carries_the_counter_at_the_right_edge() -> None:
+    from gentoo_install.i18n import width
+    from gentoo_install.tui.widgets import TwoPane
+
+    screen = Recording(keys=["\x1b"])
+    TwoPane(title="gentoo-install", rows=pane_rows(), counter="6/22 answered").run(screen)
+
+    title = screen.drawn(0)
+    assert width(title) == 80
+    assert title.startswith("gentoo-install")
+    assert title.endswith("6/22 answered")
+
+
+def test_the_status_line_stays_on_the_last_line_of_both_layouts() -> None:
+    from gentoo_install.tui.widgets import TwoPane
+
+    for lines, columns in ((24, 80), (23, 80)):
+        screen = Recording(keys=["\x1b"], lines=lines, columns=columns)
+        TwoPane(
+            title="gentoo-install",
+            rows=pane_rows(),
+            footer="[enter] open",
+            legend="* required",
+        ).run(screen)
+
+        assert screen.drawn(lines - 1).startswith("[enter] open")
+        assert screen.drawn(lines - 1).endswith("* required")
+
+
+def test_the_left_pane_fills_every_row_between_the_title_and_the_status_line() -> None:
+    """Twenty-one rows fit under a title and above a status line on 24 lines,
+    and a pane that stops one row early hides the row it stops on."""
+    from gentoo_install.tui.widgets import TwoPane
+
+    rows = [PaneRow(label=f"row{index:02d}", value=index) for index in range(21)]
+    screen = Recording(keys=["\x1b"])
+    TwoPane(title="gentoo-install", rows=rows, footer="[enter] open").run(screen)
+
+    assert screen.drawn(2).strip().startswith("row00")
+    assert screen.drawn(22).strip().startswith("row20")
+    assert screen.drawn(23).startswith("[enter] open")
+
+
+def test_a_list_longer_than_the_pane_scrolls_to_keep_the_cursor_on_screen() -> None:
+    from gentoo_install.tui.widgets import TwoPane
+
+    rows = [PaneRow(label=f"row{index:02d}", value=index) for index in range(40)]
+    screen = Recording(keys=["KEY_DOWN"] * 30 + ["\n"])
+    assert TwoPane(title="gentoo-install", rows=rows).run(screen).unwrap() == 30
+    assert "row30" in screen.last


### PR DESCRIPTION
Three defects on the `dd` path, all in the last screens before a whole disk is written.

The review screen was built from `SETTINGS` while every other reader goes through `settings_for(config)`, so in `dd` mode it listed the twenty-three rows of a disk install and hid the two the operator answered. It then died: `kernel_parameters` derives a root device, a `dd` configuration has none, and `UnknownDeviceId` escaped the `try` that only wraps `plan_build`.

The erase confirmation — the row that guards every other destructive path — was not in `DD_SETTINGS`, and would have answered `nothing is erased` if it had been: it reads `compat.destroyed(graph)` and a `dd` configuration builds no graph. `compat.destroyed_selectors` answers the destination for that mode, and both the row and the confirmation screen read it.

The third commit is the harness: a worktree opened inside the repository carries a copy of every file the wide-character scan excepts, so the scan read them all as offenders. It now reads what `git ls-files` lists.