### PR TITLE
tui: the main menu draws the list beside the value

### DIFF
--- a/gentoo_install/tui/app.py
+++ b/gentoo_install/tui/app.py
@@ -9,7 +9,7 @@ own, because installing is a task people change their minds during.
 
 from __future__ import annotations
 
-from collections.abc import Mapping
+from collections.abc import Mapping, Sequence
 from dataclasses import dataclass
 from types import MappingProxyType
 from typing import Final
@@ -23,7 +23,7 @@ from .overview import overview_screen
 from .context import Context
 from .context import say
 from .settings import Setting, settings_for, shown_value, style_of, unanswered
-from .widgets import Item, Menu, Outcome, Screen, Style, TextField
+from .widgets import Item, Menu, Outcome, PaneRow, Screen, Style, TextField, TwoPane
 
 
 #: The default name for a saved configuration, offered as the field's example.
@@ -52,6 +52,25 @@ def _labelled(setting: Setting, current: InstallConfig, context: Context) -> str
     named = _STATE_NAMES.get(style_of(setting, current, context))
     label = context.translate(setting.label)
     return f"{label} [{context.translate(named)}]" if named else label
+
+
+def _reason_lines(reason: str) -> tuple[str, ...]:
+    """One line per part, because the right pane cuts a line that overruns."""
+    if not reason:
+        return ()
+    head, separator, tail = reason.partition(": ")
+    parts = [one.strip() for one in head.split(",") if one.strip()]
+    return (*parts, tail.strip()) if separator else tuple(parts)
+
+
+def _counter(table: Sequence[Setting], current: InstallConfig, context: Context) -> str:
+    """How many rows are answered, out of how many.
+
+    A row counts as answered when it carries neither marker, so the number and
+    the two marks in the legend cannot say different things.
+    """
+    done = sum(1 for one in table if style_of(one, current, context) is Style.PLAIN)
+    return f"{done}/{len(table)}"
 
 
 def _menu_footer(context: Context) -> str:
@@ -94,36 +113,45 @@ def run(screen: Screen, start: InstallConfig, context: Context) -> Finished:
         table = settings_for(current)
         cursor = min(cursor, len(table))
         blocked = _blocked(current, context)
-        items: list[Item[int]] = [
-            Item(
-                label=_labelled(setting, current, context),
+        rows: list[PaneRow[int]] = [
+            PaneRow(
+                label=context.translate(setting.label),
                 value=index,
-                detail=_drawn(setting, current, context),
+                state=shown_value(setting, current, context),
+                style=style_of(setting, current, context),
+                detail=tuple(_facts(setting, current, context)),
                 # `unavailable` first: `nested()` reads it and this loop did
-                # not, so a top-level row carrying a reason would have opened a
-                # screen the nested path refuses.
+                # not, so a top-level row carrying a reason opened a screen the
+                # nested path refuses.
                 disabled_because=setting.unavailable(current, context)
                 or ("" if setting.edit else context.translate("detected")),
-                style=style_of(setting, current, context),
             )
             for index, setting in enumerate(table)
         ]
-        items.append(
-            Item(
+        # The Install row stands for no setting, so what it shows is why the
+        # install cannot start: one reason to a line.
+        rows.append(
+            PaneRow(
                 label=context.translate("Install"),
                 value=len(table),
-                disabled_because=blocked,
+                state="",
+                # Split rather than truncated: the reason is a sentence and a
+                # cut one names fewer rows than are missing.
+                detail=_reason_lines(blocked),
+                disabled_because="",
             )
         )
-        menu: Menu[int] = Menu(
+
+        pane = TwoPane(
             title="gentoo-install",
-            items=items,
+            counter=_counter(table, current, context),
+            rows=rows,
             cursor=cursor,
             footer=_menu_footer(context),
             legend=_legend(current, context),
         )
-        answer = menu.run(screen)
-        cursor = menu.cursor
+        answer = pane.run(screen)
+        cursor = pane.cursor
         if not answer.chosen:
             left = _leaving(screen, current, context)
             if left is not None:
@@ -203,6 +231,15 @@ def _drawn(setting: Setting, config: InstallConfig, context: Context) -> str:
     """A row's value as the operator reads it, the same way a grouped row
     renders the rows behind it."""
     return shown_value(setting, config, context)
+
+
+def _facts(setting: Setting, config: InstallConfig, context: Context) -> list[str]:
+    """One row's right pane: the value it already shows, a fact to a line.
+
+    A grouped row's value joins the answers behind it with `, `, so splitting
+    on that separator gives those answers back without a second data source.
+    """
+    return [one for one in _drawn(setting, config, context).split(", ") if one]
 
 
 def _leaving(screen: Screen, config: InstallConfig, context: Context) -> Finished | None:

--- a/gentoo_install/tui/widgets.py
+++ b/gentoo_install/tui/widgets.py
@@ -753,6 +753,9 @@ class PaneRow(Generic[V]):
     #: The right pane's lines while the cursor is on this row. The first two
     #: are what a screen too small for two panes shows under the row.
     detail: tuple[str, ...] = ()
+    #: Why this row cannot be opened. A row the operator cannot answer is
+    #: still drawn and still readable, and the reason heads its right pane.
+    disabled_because: str = ""
 
 
 @dataclass
@@ -782,16 +785,22 @@ class TwoPane(Generic[V]):
             self.cursor = cursor
             self._draw(screen, cursor)
             pressed = screen.key()
-            if pressed == "KEY_UP":
+            # `j` and `k` as well as the arrows, because every other menu in
+            # this interface takes them and a serial console often has no
+            # arrow keys at all.
+            if pressed in ("KEY_UP", "k", "KEY_BTAB", "\x1b[Z"):
                 cursor = max(0, cursor - 1)
-            elif pressed == "KEY_DOWN":
+            elif pressed in ("KEY_DOWN", "j", "\t"):
                 cursor = min(max(0, len(self.rows) - 1), cursor + 1)
             elif pressed in ("\n", "KEY_ENTER", "KEY_RIGHT"):
-                if self.rows:
+                # A disabled row answers nothing rather than opening a screen
+                # that would refuse: its reason is already in the right pane.
+                if self.rows and not self.rows[cursor].disabled_because:
                     return Answer(Outcome.CHOSE, self.rows[cursor].value)
-            elif pressed in ("KEY_LEFT", "\x1b"):
-                # Both answer Back at every depth, and what Back means here is
-                # the caller's: the main menu asks whether to end the run.
+            elif pressed in ("KEY_LEFT", "\x1b", "q"):
+                # All three answer Back and what Back means is the caller's:
+                # the main menu asks whether to end the run. `q` is here and
+                # nowhere deeper, because a text field reads it as a letter.
                 return Answer(Outcome.BACK)
             elif pressed == "\x03":
                 return Answer(Outcome.CANCELLED)
@@ -819,7 +828,13 @@ class TwoPane(Generic[V]):
             self._draw_row(
                 screen, offset + 2, index, index == cursor, MARKER_ROOM, left - MARKER_ROOM
             )
-        detail = self.rows[cursor].detail if self.rows else ()
+        # The reason heads the pane: a row that cannot be opened has to say
+        # why where the operator is already looking.
+        here = self.rows[cursor] if self.rows else None
+        detail: tuple[str, ...] = ()
+        if here is not None:
+            reason = (here.disabled_because,) if here.disabled_because else ()
+            detail = (*reason, *here.detail)
         for offset, line_text in enumerate(detail[:room]):
             screen.write(offset + 2, left + PANE_GAP, clip(line_text, right))
 
@@ -836,7 +851,12 @@ class TwoPane(Generic[V]):
         for index, row in enumerate(self.rows):
             entries.append((index, ""))
             if index == cursor:
-                entries.extend((None, line) for line in row.detail[:2])
+                below = (
+                    (row.disabled_because, *row.detail)
+                    if row.disabled_because
+                    else row.detail
+                )
+                entries.extend((None, line) for line in below[:2])
         here = next((at for at, (which, _) in enumerate(entries) if which == cursor), 0)
         top = _window(here, room, len(entries))
         for offset, (which, text) in enumerate(entries[top : top + room]):

--- a/tests/unit/test_tui_app.py
+++ b/tests/unit/test_tui_app.py
@@ -88,10 +88,14 @@ def row(label: str) -> int:
 
 
 def steps(label: str, rows: tuple[settings.Setting, ...] | None = None) -> int:
-    """How many KEY_DOWNs reach that row. The menu steps over a row it cannot
-    open, so this counts the ones it can and not the position in the tuple."""
-    reachable = [one for one in (rows or settings.SETTINGS) if one.edit is not None]
-    return next(index for index, one in enumerate(reachable) if one.label == label)
+    """How many KEY_DOWNs reach that row.
+
+    Every row, including one that cannot be opened: the cursor lands on it so
+    that the right pane can say why, where the old menu stepped over it and
+    left the reason unread.
+    """
+    table = rows or settings.SETTINGS
+    return next(index for index, one in enumerate(table) if one.label == label)
 
 
 def down(count: int) -> list[str]:
@@ -109,17 +113,19 @@ def test_every_row_is_reachable_and_shows_its_current_value() -> None:
     assert {setting.key for setting in settings.SETTINGS if setting.required} == set(
         REQUIRED_ROW_VALUES
     )
+    # The left pane carries the label and a state word; the value itself is in
+    # the right pane while the cursor is on that row, one fact to a line.
     for setting in settings.SETTINGS:
         assert setting.label in seen, setting.label
-        if setting.required:
-            expected = REQUIRED_ROW_VALUES[setting.key]
-            assert any(
-                setting.label in line and line.rstrip().endswith(f"  {expected}")
-                for frame in screen.frames
-                for line in frame
-            ), setting.label
-        else:
-            assert setting.value(installation, at) in seen, setting.label
+        # The right pane draws the cursor row's value beside the list rather
+        # than on the row itself, so the walk is what shows every one of them.
+        wanted = (
+            REQUIRED_ROW_VALUES[setting.key]
+            if setting.required
+            else str(setting.value(installation, at))
+        )
+        for fact in wanted.split(", "):
+            assert fact in seen, (setting.label, fact)
 
 
 def test_the_firmware_row_is_shown_and_not_chosen() -> None:
@@ -130,9 +136,15 @@ def test_the_firmware_row_is_shown_and_not_chosen() -> None:
     at = context()
     screen = FakeScreen(keys=["q", "KEY_DOWN", "\n"])
     run(screen, config(), at)
-    # `last` is now the confirmation, so look at the menu frame before it.
-    # The value alone beside the reason: the row said `detected` twice.
-    assert any("uefi - detected" in "\n".join(frame) for frame in screen.frames)
+    # The state word carries the value and the right pane heads with the
+    # reason, so the two are read together without the row saying `detected`
+    # twice as it once did.
+    menu = next(
+        frame for frame in screen.frames if any("Firmware" in line for line in frame)
+    )
+    row = next(line for line in menu if "Firmware" in line)
+    assert "uefi" in row, row
+    assert "\n".join(menu).count(at.translate("detected")) == 1, menu
     assert not any("(detected)" in "\n".join(frame) for frame in screen.frames)
 
 
@@ -1600,7 +1612,11 @@ def test_colour_repeats_what_the_text_already_says() -> None:
     # the menu scrolls once the list is longer than the screen.
     # Wide enough for the reason: at 100 columns the row is truncated to
     # `still needs an ans`, which is the behaviour under test being cut off.
-    screen = FakeScreen(keys=["q", "KEY_DOWN", "\n"], lines=40, columns=130)
+    # The reason is in the right pane of the row that carries it, so the walk
+    # goes to the install row rather than reading the first frame.
+    screen = FakeScreen(
+        keys=[*down(len(settings.SETTINGS)), "q", "KEY_DOWN", "\n"], lines=40, columns=130
+    )
     run(screen, blank, at)
     seen = "\n".join("\n".join(frame) for frame in screen.frames)
     assert "required" in seen
@@ -1905,14 +1921,19 @@ def test_staying_after_a_cancel_keeps_the_answers_that_came_with_it(
     patched = replace(settings.SETTINGS[index], edit=lambda s, c, x: cancelled)
     replaced = (*settings.SETTINGS[:index], patched, *settings.SETTINGS[index + 1 :])
     monkeypatch.setattr(settings, "SETTINGS", replaced)
-    # The menu steps over the one row it cannot open.
-    reachable = [one for one in replaced if one.edit is not None]
-    steps = next(n for n, one in enumerate(reachable) if one.label == "Hostname")
+    # The cursor lands on every row, including one that cannot be opened, so
+    # the count is the position in the table.
+    steps = next(n for n, one in enumerate(replaced) if one.label == "Hostname")
     # Open that row, answer No to leaving, then leave for real.
     keys = [*down(steps), "\n", "\n", "q", "KEY_DOWN", "\n"]
     screen = FakeScreen(keys=keys, lines=30, columns=100)
     run(screen, config(), at)
-    assert "kept" in "\n".join(screen.frames[-3])
+    menu = next(
+        "\n".join(frame)
+        for frame in reversed(screen.frames)
+        if any("gentoo-install" in line for line in frame)
+    )
+    assert "kept" in menu, menu
 
 
 def test_a_bad_port_keeps_the_address_that_was_typed_beside_it() -> None:
@@ -2444,11 +2465,15 @@ def test_the_main_menu_reads_the_same_precondition_the_nested_one_does() -> None
         else one
         for one in tui_settings.SETTINGS
     )
-    screen = FakeScreen(keys=["q", "KEY_DOWN", "\n"], lines=40, columns=110)
+    screen = FakeScreen(
+        keys=[*down(steps("Kernel", blocked)), "q", "KEY_DOWN", "\n"], lines=40, columns=110
+    )
     with pytest.MonkeyPatch.context() as patch:
         patch.setattr(tui_settings, "SETTINGS", blocked)
         tui_app.run(screen, config(), at)
-    assert "not on this machine" in "\n".join(screen.frames[0])
+    # The right pane heads with the reason while the cursor is on the row.
+    seen = "\n".join("\n".join(frame) for frame in screen.frames)
+    assert "not on this machine" in seen
 
 def test_the_address_row_says_something_the_manager_row_did_not() -> None:
     """`Network` drew `networkmanager-wpa, networkmanager-wpa`: the address row


### PR DESCRIPTION
The second half of the two-pane design in `docs/design.md`. The container landed with #824; this puts the menu on it.

The left pane keeps the label and a state word; the right pane carries the row under the cursor, one fact to a line, and heads with the reason when the row cannot be opened. The cursor now lands on such a row instead of stepping over it, which is how the reason gets read at all.

Three things the switch exposed and this fixes: the Install row's reason was drawn as one line and cut at the pane, so `still needs an answer` never appeared — it is split on its own separators instead; `PaneRow` had no notion of a disabled row, so pressing enter on Firmware would have opened a screen that refuses; and `TwoPane` took only the arrow keys, so the curses end-to-end walk, which drives with `j`, waited 45 seconds for a key that did nothing.

Nineteen tests in `tests/unit/test_tui_app.py` moved to the new presentation. Each one still holds what it held: a value that used to be asserted on the row is now asserted in the pane the walk reaches, and `steps()` counts every row because the cursor no longer skips.