### PR TITLE
tui: the footer names the key that always goes back

### DIFF
--- a/gentoo_install/tui/context.py
+++ b/gentoo_install/tui/context.py
@@ -315,6 +315,11 @@ def footer(translate: Catalog, enter: str = "Continue") -> str:
     return "  ".join(
         (
             f"[enter] {translate(enter)}",
+            # Left as well as backspace: left is the only Back that works in
+            # every widget, and a field with a value in it takes backspace as
+            # a deletion, so an operator reading this footer alone had no way
+            # back out of the hostname screen.
+            f"[\u2190] {translate('Back')}",
             f"[backspace] {translate('Back')}",
             # `esc`, not `q`: this footer is drawn over text fields as well
             # as menus, and a field takes `q` as the letter. An operator who

--- a/tests/unit/test_tui_widgets.py
+++ b/tests/unit/test_tui_widgets.py
@@ -903,3 +903,26 @@ def test_a_list_longer_than_the_pane_scrolls_to_keep_the_cursor_on_screen() -> N
     screen = Recording(keys=["KEY_DOWN"] * 30 + ["\n"])
     assert TwoPane(title="gentoo-install", rows=rows).run(screen).unwrap() == 30
     assert "row30" in screen.last
+
+
+def test_the_footer_names_the_key_that_always_goes_back() -> None:
+    """Left is the only Back every widget takes: backspace deletes a character
+    in a field that has one, and escape ends the run. A footer that named
+    neither left it to the operator to guess, and the walk that found this
+    spent eighteen rows deleting the hostname one letter at a time."""
+    from gentoo_install.i18n import Catalog
+    from gentoo_install.tui.context import footer
+    from gentoo_install.tui.widgets import Field, Form, TextField
+
+    for tag in ("en", "zh-TW", "zh-CN", "ja", "ko"):
+        translate = Catalog(tag)
+        drawn = footer(translate)
+        assert "[←]" in drawn, (tag, drawn)
+        assert drawn.count(translate("Back")) == 2, (tag, drawn)
+
+    # And the key the footer names is the key the widgets answer Back to,
+    # with a value already in the field.
+    typed = TextField(title="Hostname", value="gentoo")
+    assert typed.run(FakeScreen(keys=["KEY_LEFT"])).outcome is Outcome.BACK
+    form = Form(title="User", fields=[Field(label="Name", value="zakk")])
+    assert form.run(FakeScreen(keys=["KEY_LEFT"])).outcome is Outcome.BACK


### PR DESCRIPTION
`docs/design.md`'s key table, first step. The status line named `[backspace] Back` and `[esc] Cancel`, and neither is a way out of a field that already holds a value: backspace deletes a character there, and escape ends the run. Left is the one key every widget answers Back to, and nothing said so — the interface walk that found it spent eighteen rows deleting `gentoo` one letter at a time.

The test reads the footer in all five catalogs and then drives a `TextField` and a `Form` that both hold a value, requiring Back from the key the footer names. Dropping the new entry from the footer turns it red.

The rest of the table — escape as Back at every depth below the main menu, `q` only at the main menu — is a separate change: 126 tests pin today's meaning of escape, and moving them is a review of each one rather than a sed.