### PR TITLE
tui: escape goes back at every depth below the main menu

### DIFF
--- a/gentoo_install/tui/context.py
+++ b/gentoo_install/tui/context.py
@@ -321,10 +321,11 @@ def footer(translate: Catalog, enter: str = "Continue") -> str:
             # back out of the hostname screen.
             f"[\u2190] {translate('Back')}",
             f"[backspace] {translate('Back')}",
-            # `esc`, not `q`: this footer is drawn over text fields as well
-            # as menus, and a field takes `q` as the letter. An operator who
-            # read `[q] Cancel` on the hostname screen typed one into it.
-            f"[esc] {translate('Cancel')}",
+            # Back, not Cancel: escape steps back one screen at every depth
+            # below the main menu, where it asks whether to end the run. It
+            # said `Cancel` while doing that, and `[q] Cancel` before it,
+            # which a field takes as the letter.
+            f"[esc] {translate('Back')}",
         )
     )
 

--- a/gentoo_install/tui/widgets.py
+++ b/gentoo_install/tui/widgets.py
@@ -36,7 +36,15 @@ U = TypeVar("U")
 
 #: What asks to leave. ctrl-c is here rather than a signal because raw mode
 #: delivers it as a byte, so it is answered rather than obeyed.
-CANCEL: Final[frozenset[str]] = frozenset({"\x1b", "\x03"})
+#: Ending the run. Escape is not here: it meant "end the install" on one
+#: screen and "go back one" on the next inside a single feature, and the key
+#: table in `docs/design.md` gives it one meaning below the main menu.
+CANCEL: Final[frozenset[str]] = frozenset({"\x03"})
+
+#: Leaving a screen without answering it. Every widget takes all three, and
+#: the status line names the arrow, which is the one that works in a field
+#: already holding a value.
+BACK_KEYS: Final[frozenset[str]] = frozenset({"KEY_LEFT", "\x1b", "\x7f", "KEY_BACKSPACE"})
 
 #: A menu takes `q` as well; a text field cannot, because `q` is a character
 #: someone is entitled to type into a hostname.
@@ -249,7 +257,7 @@ class _Menu(Generic[V, A]):
                 answer = self._accept(cursor)
                 if answer is not None:
                     return answer
-            elif pressed in ("KEY_LEFT", "\x7f", "KEY_BACKSPACE"):
+            elif pressed in BACK_KEYS:
                 return Answer(Outcome.BACK)
             elif pressed in CANCEL_IN_A_MENU:
                 return Answer(Outcome.CANCELLED)
@@ -424,7 +432,7 @@ class TextField:
             pressed = screen.key()
             if pressed in ("\n", "KEY_ENTER"):
                 return Answer(Outcome.CHOSE, "".join(typed))
-            if pressed == "KEY_LEFT":
+            if pressed in ("KEY_LEFT", "\x1b"):
                 return Answer(Outcome.BACK)
             if pressed in ("\x7f", "KEY_BACKSPACE"):
                 if typed:
@@ -632,7 +640,7 @@ class Form:
             elif pressed == " " and cursor < len(self.fields) and self.fields[cursor].toggle:
                 typed[cursor] = [] if typed[cursor] else ["x"]
                 touched = True
-            elif pressed == "KEY_LEFT":
+            elif pressed in ("KEY_LEFT", "\x1b"):
                 return Answer(Outcome.BACK)
             elif pressed in ("\x7f", "KEY_BACKSPACE"):
                 if cursor < len(self.fields) and typed[cursor] and not self.fields[cursor].toggle:

--- a/tests/unit/test_tui_app.py
+++ b/tests/unit/test_tui_app.py
@@ -316,15 +316,19 @@ def test_invalid_extra_package_dialog_cancellation_reaches_caller() -> None:
     assert answer.outcome is Outcome.CANCELLED
 
 
-def test_timezone_back_reopens_area_and_cancel_exits_city() -> None:
+def test_timezone_back_reopens_area_and_escape_leaves_both() -> None:
     changed = screens.timezone_screen(
         FakeScreen(keys=["\n", "KEY_LEFT", "KEY_DOWN", "\n", "\n"]),
         config(),
         context(),
     )
     assert changed.unwrap().system.timezone == "Europe/London"
-    cancelled = screens.timezone_screen(FakeScreen(keys=["\n", "\x1b"]), config(), context())
-    assert cancelled.outcome is Outcome.CANCELLED
+    # Escape leaves the city menu the same way the arrow does: one meaning at
+    # every depth below the main menu.
+    left = screens.timezone_screen(
+        FakeScreen(keys=["\n", "\x1b", "\x1b"]), config(), context()
+    )
+    assert left.outcome is Outcome.BACK
 
 
 def test_reopening_the_timezone_and_accepting_keeps_it() -> None:
@@ -930,31 +934,37 @@ def test_main_menu_enter_action_is_open() -> None:
     assert "[enter] Open" in app._menu_footer(context())
 
 
-def test_the_shared_footer_names_a_key_that_cancels_every_screen() -> None:
+def test_the_shared_footer_names_a_key_that_leaves_every_screen() -> None:
     """That footer is drawn over text fields as well as menus, and it said
     `[q] Cancel`. A menu takes `q`; a field takes it as the letter, so an
     operator who read the footer on the hostname screen typed one into it.
+
+    It then said `[esc] Cancel` while escape was ending the run on one screen
+    and going back one on the next. Escape has one meaning below the main
+    menu, and the footer says which.
     """
     from gentoo_install.tui import widgets as widget_module
     from gentoo_install.tui.context import footer
-    from tests.unit.fake_screen import FakeScreen
+
+    from .fake_screen import FakeScreen
 
     said = footer(context().translate)
     assert "[esc]" in said, said
     assert "[q]" not in said, said
+    assert context().translate("Cancel") not in said, said
 
-    # The key it names really cancels both, which is the reason it is that one.
+    # The key it names leaves both, which is the reason it is that one.
     escape = "\x1b"
-    assert escape in widget_module.CANCEL
+    assert escape not in widget_module.CANCEL
     field = widget_module.TextField(title="Hostname", footer=said)
-    assert field.run(FakeScreen(keys=[escape])).outcome is widget_module.Outcome.CANCELLED
+    assert field.run(FakeScreen(keys=[escape])).outcome is widget_module.Outcome.BACK
 
     menu: widget_module.Menu[str] = widget_module.Menu(
         title="Anything",
         items=[widget_module.Item(label="One", value="one")],
         footer=said,
     )
-    assert menu.run(FakeScreen(keys=[escape])).outcome is widget_module.Outcome.CANCELLED
+    assert menu.run(FakeScreen(keys=[escape])).outcome is widget_module.Outcome.BACK
 
 
 def test_the_footer_keys_and_the_legend_are_not_one_run_of_text() -> None:
@@ -2145,24 +2155,22 @@ def test_the_unlock_keyboard_offers_following_the_console() -> None:
     assert "the same as the console" in "\n".join(screen.frames[0])
 
 
-def test_cancelling_a_nested_prompt_reaches_the_screen_as_cancelled() -> None:
+def test_escape_leaves_a_nested_prompt_and_reaches_the_screen_as_back() -> None:
+    """Escape has one meaning below the main menu: it leaves the screen and
+    the caller decides what that means. It ended the whole run here."""
     at = context()
     assert screens.root_password_screen(
         FakeScreen(keys=["\x1b"]), config(), at
-    ).outcome is Outcome.CANCELLED
-    # Escape inside the encryption question reaches the passphrase prompts in
-    # `partitions.py`, which answer Back: the key table gives escape one
-    # meaning at depth, and the quit prompt only at the main menu. The screens
-    # around it follow in the commits that take the rest of the table.
+    ).outcome is Outcome.BACK
     assert screens.encryption_screen(
         FakeScreen(keys=["KEY_DOWN", "\n", "\x1b"]), config(), at
     ).outcome is Outcome.BACK
     assert screens.keymap_screen(
         FakeScreen(keys=["\x1b"]), config(), at
-    ).outcome is Outcome.CANCELLED
+    ).outcome is Outcome.BACK
     assert screens.initramfs_keymap_screen(
         FakeScreen(keys=["\x1b"]), config(), at
-    ).outcome is Outcome.CANCELLED
+    ).outcome is Outcome.BACK
 
 
 def test_selecting_gentoo_zh_turns_its_binary_host_on() -> None:

--- a/tests/unit/test_tui_curses.py
+++ b/tests/unit/test_tui_curses.py
@@ -282,8 +282,12 @@ def test_the_menu_runs_under_a_real_terminal() -> None:
     assert result["chosen"] == 4
 
 
-@pytest.mark.parametrize("key", ["q", "\x1b", "\x03"], ids=["q", "escape", "ctrl-c"])
-def test_cancelling_reaches_the_widgets_as_an_answer(key: str) -> None:
+@pytest.mark.parametrize(
+    ("key", "outcome"),
+    [("q", "cancelled"), ("\x1b", "back"), ("\x03", "cancelled")],
+    ids=["q", "escape", "ctrl-c"],
+)
+def test_a_key_that_leaves_reaches_the_widgets_as_an_answer(key: str, outcome: str) -> None:
     """`raw()` is what makes ctrl-c a byte rather than a signal, so the menu
     answers it the way it answers an escape instead of the run ending.
 
@@ -294,7 +298,9 @@ def test_cancelling_reaches_the_widgets_as_an_answer(key: str) -> None:
     result = drive(f"k{key}", WALK)
     assert result.get("error") is None, result.get("error")
     assert result["chosen"] is None
-    assert result["outcome"] == "cancelled"
+    # Escape answers Back below the main menu and the other two end the run,
+    # which is the key table in `docs/design.md` reaching a real terminal.
+    assert result["outcome"] == outcome
 
 
 #: The whole menu, from the configuration `cli.py` starts it with, driven to the
@@ -470,7 +476,9 @@ curses.wrapper(main)
 def test_a_form_that_no_longer_fits_says_how_to_leave() -> None:
     result, drawing = drive_resizes([(10, 60), "\x1b"], RESIZE_FORM)
     assert result.get("error") is None, result.get("error")
-    assert result["outcome"] == "cancelled"
+    # Back, not cancelled: a terminal that shrank below the floor still lets
+    # escape leave the screen, and leaving is what the message offers.
+    assert result["outcome"] == "back"
     assert b"the interface needs 80x24" in drawing
     assert b"Escape after translation" in drawing
 

--- a/tests/unit/test_tui_widgets.py
+++ b/tests/unit/test_tui_widgets.py
@@ -316,8 +316,10 @@ def test_a_form_with_an_overlong_wide_label_still_accepts_input() -> None:
 
 
 def test_escape_leaves_a_form_without_an_answer() -> None:
+    """Back rather than Cancel: escape has one meaning at every depth below
+    the main menu, and it had two inside one feature."""
     form = Form(title="t", fields=[Field(label="a")])
-    assert form.run(FakeScreen(keys=["\x1b"])).outcome is Outcome.CANCELLED
+    assert form.run(FakeScreen(keys=["\x1b"])).outcome is Outcome.BACK
 
 
 def test_a_field_that_had_content_can_be_cleared() -> None:
@@ -402,7 +404,7 @@ def test_a_validator_can_correct_one_field_without_losing_the_others() -> None:
 
 @pytest.mark.parametrize(
     ("pressed", "outcome"),
-    [("KEY_BACKSPACE", Outcome.BACK), ("\x1b", Outcome.CANCELLED)],
+    [("KEY_BACKSPACE", Outcome.BACK), ("\x1b", Outcome.BACK)],
 )
 def test_a_rejected_form_can_still_go_back_or_cancel(pressed: str, outcome: Outcome) -> None:
     def reject(values: list[str]) -> Answer[str] | FormRejected:
@@ -918,7 +920,10 @@ def test_the_footer_names_the_key_that_always_goes_back() -> None:
         translate = Catalog(tag)
         drawn = footer(translate)
         assert "[←]" in drawn, (tag, drawn)
-        assert drawn.count(translate("Back")) == 2, (tag, drawn)
+        # Three ways back and no Cancel: escape steps back below the main
+        # menu, which is where ending the run is asked about.
+        assert drawn.count(translate("Back")) == 3, (tag, drawn)
+        assert translate("Cancel") not in drawn, (tag, drawn)
 
     # And the key the footer names is the key the widgets answer Back to,
     # with a value already in the field.


### PR DESCRIPTION
The key table in `docs/design.md`. Escape ended the whole install on one screen and went back one screen on the next, inside `partitions.py` alone, and the footer every screen shares called it `Cancel` while it did both.

Finding the mechanism took an instrumented run rather than a reading: with escape removed from `CANCEL`, the `keymap` row drew the same screen seven times for six presses, and `_Menu.run` was never entered — that path builds a `TextField` when the medium lists no keymap, and a field dropped escape as an unprintable character. Adding it to the field's and the form's Back keys took the failures from 71 to 7.

Those seven are here, each read before it moved: five asserted the outcome of leaving a screen and now assert `BACK`; one is the footer, which now reads `[esc] Back` and no longer offers a Cancel that does not exist below the main menu; and the curses end-to-end walk keeps `q` and ctrl-c as the two that end a run and moves escape to Back, which is the table reaching a real terminal.

Nothing asserted escape as an operator-facing promise to end the install. The main menu is unchanged: escape and `q` there still ask.