### PR TITLE
vm: ask a machine that booted what its stub holds

### DIFF
--- a/tests/unit/test_cluster.py
+++ b/tests/unit/test_cluster.py
@@ -2984,13 +2984,24 @@ def test_a_cluster_conversion_writes_and_reads_the_home_marker() -> None:
 def test_the_extra_checks_reach_the_installed_reader() -> None:
     """`boot_and_check` grew a parameter, and a parameter nothing forwards is
     a check that never runs."""
+    import ast
     import inspect
+    import textwrap
 
     from tests.vm import cluster
 
-    source = inspect.getsource(cluster.boot_and_check)
-    asked = source.index("_asked_for(installation)")
-    assert "extra" in source[asked : asked + 200], source[asked : asked + 200]
+    # The list `boot_and_check` iterates, read from the tree: a window of
+    # characters after `_asked_for` moved when a comment was added between
+    # the two, and what this holds is that both reach the same reader.
+    asked = ast.parse(textwrap.dedent(inspect.getsource(cluster.boot_and_check)))
+    names = {
+        node.id
+        for loop in ast.walk(asked)
+        if isinstance(loop, ast.For)
+        for node in ast.walk(loop.iter)
+        if isinstance(node, ast.Name)
+    }
+    assert {"_asked_for", "extra"} <= names, sorted(names)
 
 
 def test_a_binhost_fixture_that_compiled_everything_is_not_a_pass() -> None:
@@ -3296,3 +3307,49 @@ def test_each_schedule_rewrites_its_fixtures_into_its_own_directory(tmp_path: Pa
     assert "_fixture_dir(workdir)" in source, source[:200]
     assert 'workdir / "fixtures"' not in source, source[:200]
 
+
+
+def test_a_machine_that_booted_is_asked_what_its_stub_holds() -> None:
+    """`#828` refused every UEFI install by assuming what a bootable stub
+    carries. Nothing had measured it: the prefix checks run only for a
+    conversion. This one reports and judges nothing, so the answer arrives
+    without a rule written ahead of it."""
+    import re
+
+    from gentoo_install.exec.config import load
+    from tests.vm.convert import GRUB_PREFIX_CHECK, GRUB_PREFIX_REPORT, after_the_boot
+
+    uefi = load(Path("tests/fixtures/vm-xfs.toml"))
+    assert after_the_boot(uefi) == (GRUB_PREFIX_REPORT,)
+    # BIOS asks none of it: the stub and the module directory are UEFI's.
+    assert after_the_boot(load(Path("tests/fixtures/ext4-bios.toml"))) == ()
+
+    # The same command as the conversion, so the two answers are comparable.
+    assert GRUB_PREFIX_REPORT.command == GRUB_PREFIX_CHECK.command
+
+    # Every field, no value: the failing conversion's own answer passes here,
+    # which is the point — it is a measurement and not a refusal.
+    failed = (
+        "grubstub=163840 grubprefix=0 boot=642038bc esp=99F1-0F9A stub= "
+        "embedded=(,gpt2)/boot/grub drive=(hostdisk//dev/vda,gpt2) fs=xfs\n"
+    )
+    assert re.search(GRUB_PREFIX_REPORT.pattern, failed)
+    assert re.search(GRUB_PREFIX_CHECK.pattern, failed) is None
+    # A line that lost a field is still refused: an absent answer is not one.
+    assert re.search(GRUB_PREFIX_REPORT.pattern, failed.replace(" fs=xfs", "")) is None
+
+    # And somebody asks it. A check nothing calls is the shape this repository
+    # has shipped before: declared, never read, and read as coverage.
+    import ast
+    import inspect
+    import textwrap
+
+    from tests.vm import cluster as cluster_module
+
+    asked = ast.parse(textwrap.dedent(inspect.getsource(cluster_module.boot_and_check)))
+    assert any(
+        isinstance(node, ast.Call)
+        and isinstance(node.func, ast.Name)
+        and node.func.id == "after_the_boot"
+        for node in ast.walk(asked)
+    ), "boot_and_check never asks what the stub holds"

--- a/tests/unit/test_proxmox.py
+++ b/tests/unit/test_proxmox.py
@@ -1701,6 +1701,7 @@ def test_installed_login_uses_the_login_observed_by_unlock(
     from gentoo_install.exec.config import load
     from tests.vm import cluster
     from tests.vm.console import PASSWORD_PROMPT
+    from tests.vm.convert import after_the_boot
 
     events: list[str] = []
 
@@ -1731,11 +1732,18 @@ def test_installed_login_uses_the_login_observed_by_unlock(
             events.append(f"respond:{line}")
 
         def expect_output(self, command: str, timeout: float = 120.0) -> bytes:
-            for _, expected_command, wanted in cluster._asked_for(
-                load(Path("tests/fixtures/vm-luks.toml"))
-            ):
+            installation = load(Path("tests/fixtures/vm-luks.toml"))
+            for _, expected_command, wanted in cluster._asked_for(installation):
                 if command == expected_command:
                     return wanted.encode()
+            # The prefix report a booted machine is asked. It judges nothing,
+            # so any complete line answers it.
+            for one in after_the_boot(installation):
+                if command == one.command:
+                    return (
+                        b"grubstub=163840 grubprefix=1 boot=aaaa esp=1234-ABCD stub=aaaa "
+                        b"embedded=(hd0,gpt2)/boot/grub drive=hd0,gpt2 fs=ext2\n"
+                    )
             raise AssertionError(command)
 
     monkeypatch.setattr(

--- a/tests/vm/cluster.py
+++ b/tests/vm/cluster.py
@@ -111,6 +111,7 @@ from .convert import (
     HOME_MARKER,
     HOME_MARKER_CHECK,
     HOME_MARKER_PATH,
+    after_the_boot,
     before_the_reboot,
 )
 from .installed import InstalledCheck, checks, stage_passphrase_commands
@@ -3341,6 +3342,10 @@ def boot_and_check(
 
     for name, command, wanted in [
         *_asked_for(installation),
+        # What a stub on a machine that booted holds, asked of every UEFI
+        # GRUB install: the conversion is the only path that ever asked, and
+        # a rule written without the healthy answer refused all of them.
+        *((one.name, one.command, one.pattern) for one in after_the_boot(installation)),
         *((one.name, one.command, one.pattern) for one in extra),
     ]:
         said = link.expect_output(command, timeout=120.0)

--- a/tests/vm/convert.py
+++ b/tests/vm/convert.py
@@ -136,6 +136,31 @@ GRUB_PREFIX_CHECK: Final[InstalledCheck] = InstalledCheck(
 )
 
 
+#: The same fields the conversion is asked, with nothing judged. What a stub
+#: on a machine that boots holds has never been measured: `before_the_reboot`
+#: runs only for a conversion, and `#828` refused every UEFI install by
+#: assuming the answer. The pattern requires the fields and not their values.
+GRUB_PREFIX_REPORT: Final[InstalledCheck] = InstalledCheck(
+    "grub's prefix on a machine that booted",
+    GRUB_PREFIX_CHECK.command,
+    r"(?m)^grubstub=\S* grubprefix=\S* boot=\S* esp=\S* stub=\S* "
+    r"embedded=\S* drive=\S* fs=\S*$",
+)
+
+
+def after_the_boot(installation: InstallConfig) -> tuple[InstalledCheck, ...]:
+    """What a machine that booted is asked, to find out what healthy is.
+
+    Reporting rather than judging: the values a bootable stub carries are the
+    open question, and a rule written before they are known is the one that
+    refused every UEFI install.
+    """
+    bootloader = installation.bootloader
+    if bootloader.kind.value != "grub" or bootloader.firmware.value != "uefi":
+        return ()
+    return (GRUB_PREFIX_REPORT,)
+
+
 def before_the_reboot(installation: InstallConfig) -> tuple[InstalledCheck, ...]:
     """What a conversion is asked while it still answers.
 


### PR DESCRIPTION
Row 238, restarted from the measurement rather than from a rule.

`before_the_reboot` asks `grubprefix`, `embedded`, `drive` and `fs`, and it runs only on the conversion path. So the failing conversion's `drive=(hostdisk//dev/vda,gpt2)`, `embedded=(,gpt2)/boot/grub`, `grubprefix=0` has never had anything to be compared against — and #828 filled that gap by assuming the healthy answer, which refused every UEFI install until #829 took it back.

`after_the_boot` asks the same command of every UEFI GRUB install once the disk it wrote has booted, with a pattern that requires the fields and none of their values. The failing conversion's own line passes it, which is the point: a measurement, not a refusal.

The first control did not fail, and that is in the commit too — the test asserted what `after_the_boot` returns and never that anything calls it, which is the declared-but-unread shape this repository has shipped before. It now walks `boot_and_check` for the call. The neighbouring `extra` test moved from a 200-character window after `_asked_for` to the same AST walk, because a comment between the two broke it.