### PR TITLE
tui: end the field's trim on the string, not on the width

### DIFF
--- a/gentoo_install/tui/widgets.py
+++ b/gentoo_install/tui/widgets.py
@@ -454,8 +454,7 @@ class TextField:
         # an empty screen does not read as somewhere to type.
         room = columns - 8
         shown = "*" * len(typed) if self.masked else "".join(typed)
-        while width(shown) > room - 1:
-            shown = shown[1:]
+        shown = _tail_that_fits(shown, room - 1)
         row = 2
         if self.detail:
             screen.write(row, 0, clip(self.detail, columns))
@@ -471,6 +470,18 @@ class TextField:
             # [q] cancel * required ~ never opened` reads as neither.
             screen.write(lines - 1, 0, spread(self.footer, self.legend, columns))
         screen.show()
+
+
+def _tail_that_fits(text: str, room: int) -> str:
+    """The end of what was typed, because that is where the caret is.
+
+    `room` is negative on a terminal narrower than the brackets, and dropping
+    a character off an empty string never makes it shorter: the loop ends on
+    the string rather than on the width, or an 8-column terminal never redraws.
+    """
+    while text and width(text) > room:
+        text = text[1:]
+    return text
 
 
 @dataclass

--- a/tests/unit/test_tui_widgets.py
+++ b/tests/unit/test_tui_widgets.py
@@ -931,3 +931,25 @@ def test_the_footer_names_the_key_that_always_goes_back() -> None:
     assert typed.run(FakeScreen(keys=["KEY_LEFT"])).outcome is Outcome.BACK
     form = Form(title="User", fields=[Field(label="Name", value="zakk")])
     assert form.run(FakeScreen(keys=["KEY_LEFT"])).outcome is Outcome.BACK
+
+
+def test_the_field_keeps_the_end_of_what_was_typed_where_the_caret_is() -> None:
+    from gentoo_install.tui.widgets import _tail_that_fits
+
+    assert _tail_that_fits("gentoo", 6) == "gentoo"
+    assert _tail_that_fits("gentoo", 3) == "too"
+    # A wide character owns two cells, so three cells hold one of them and not
+    # a half of the other.
+    assert _tail_that_fits("\u4e2d\u6587", 3) == "\u6587"
+
+
+def test_a_terminal_narrower_than_the_brackets_still_redraws() -> None:
+    """8 columns leaves the field no room at all, and dropping a character off
+    an empty string never makes it shorter: the trim has to end on the string.
+    """
+    from gentoo_install.tui.widgets import TextField, _tail_that_fits
+
+    assert _tail_that_fits("gentoo", 0) == ""
+    assert _tail_that_fits("gentoo", -1) == ""
+    screen = FakeScreen(keys=["g", "\x1b"], lines=24, columns=8)
+    assert TextField(title="hostname").run(screen).outcome is Outcome.BACK


### PR DESCRIPTION
Drawing every widget on the cell-grid `FakeScreen` at descending sizes measured a floor no test had asked about: `Menu`, `MultipleChoiceMenu` and `TwoPane` draw from 80x24 down to 12x4, while `TextField` and the `Confirm` that delegates to it never return at eight columns or fewer, at any height.

`room = columns - 8` is `0` there, so the loop compares against `-1`; an empty string is width `0`, and `""[1:]` is still empty. `cli.py` refuses that terminal today, so nothing reaches it — but `docs/design.md` promises a single-pane fallback below 80x24, and this loop sits directly behind it.