### PR TITLE
tui: split the layout floor from the floor that refuses

### DIFF
--- a/gentoo_install/tui/widgets.py
+++ b/gentoo_install/tui/widgets.py
@@ -50,10 +50,10 @@ BACK_KEYS: Final[frozenset[str]] = frozenset({"KEY_LEFT", "\x1b", "\x7f", "KEY_B
 #: someone is entitled to type into a hostname.
 CANCEL_IN_A_MENU: Final[frozenset[str]] = CANCEL | {"q"}
 
-#: 80x24 is the floor every screen has to work in, and a serial console is
-#: often exactly that.
-MINIMUM_COLUMNS = 80
-MINIMUM_LINES = 24
+#: What the two panes need. A serial console is often exactly this, and below
+#: it `TwoPane` draws one pane: the floor for the layout, not for the run.
+TWO_PANE_COLUMNS: Final[int] = 80
+TWO_PANE_LINES: Final[int] = 24
 
 
 class Style(Enum):
@@ -728,6 +728,14 @@ LEFT_PANE_MAXIMUM: Final[int] = 34
 #: The marker column and the space after it, before every label.
 MARKER_ROOM: Final[int] = 2
 
+#: Below this the interface draws nothing and says so. One pane needs a label
+#: it does not have to cut, which is what `LEFT_PANE_MINIMUM` stands for, and
+#: a title, the cursor's row, the two summary lines under it and a footer.
+#: Measured against every widget on 2026-08-21: the narrowest any of them can
+#: still put its content on is 7x5, so this floor is above all of them.
+MINIMUM_COLUMNS: Final[int] = LEFT_PANE_MINIMUM
+MINIMUM_LINES: Final[int] = 6
+
 #: The separator column and the space after it, between the two panes.
 PANE_GAP: Final[int] = 2
 
@@ -821,7 +829,7 @@ class TwoPane(Generic[V]):
         lines, columns = screen.size()
         screen.clear()
         screen.write(0, 0, spread(self.title, self.counter, columns))
-        if columns < MINIMUM_COLUMNS or lines < MINIMUM_LINES:
+        if columns < TWO_PANE_COLUMNS or lines < TWO_PANE_LINES:
             self._draw_one_pane(screen, cursor, lines, columns)
         else:
             self._draw_two_panes(screen, cursor, lines, columns)

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -380,13 +380,22 @@ def test_a_terminal_too_small_for_the_interface_says_so_rather_than_drawing(
         def size(self) -> tuple[int, int]:
             return self.lines, self.columns
 
-    cramped = too_small(Sized(20, 60))
-    assert "60x20" in cramped and f"{MINIMUM_COLUMNS}x{MINIMUM_LINES}" in cramped
+    cramped = too_small(Sized(4, 16))
+    assert "16x4" in cramped and f"{MINIMUM_COLUMNS}x{MINIMUM_LINES}" in cramped
     assert too_small(Sized(MINIMUM_LINES, MINIMUM_COLUMNS)) == ""
+
+    # 60x20 is served rather than refused: it is under the two-pane floor and
+    # over the one this refuses at, so `TwoPane` draws one pane there. The two
+    # numbers are separate because a terminal the layout cannot use in full is
+    # not a terminal the interface cannot use at all.
+    from gentoo_install.tui.widgets import TWO_PANE_COLUMNS, TWO_PANE_LINES
+
+    assert too_small(Sized(20, 60)) == ""
+    assert MINIMUM_COLUMNS < TWO_PANE_COLUMNS and MINIMUM_LINES < TWO_PANE_LINES
 
     # The call and its effect, not the substring: `cramped = too_small(display)`
     # with the `raise` deleted keeps the text in `cli.py` and puts the menu on
-    # a 60x20 console again, which is the defect this test is named after.
+    # a console it cannot draw on, which is the defect this test is named after.
     import ast
     import inspect
 

--- a/tests/unit/test_tui_curses.py
+++ b/tests/unit/test_tui_curses.py
@@ -474,12 +474,15 @@ curses.wrapper(main)
 
 
 def test_a_form_that_no_longer_fits_says_how_to_leave() -> None:
-    result, drawing = drive_resizes([(10, 60), "\x1b"], RESIZE_FORM)
+    # Five lines is under the floor the interface refuses at, and sixty
+    # columns keeps the message on one row: a wrapped one matches no
+    # substring. 60x10 is over the floor now and is drawn rather than refused.
+    result, drawing = drive_resizes([(5, 60), "\x1b"], RESIZE_FORM)
     assert result.get("error") is None, result.get("error")
     # Back, not cancelled: a terminal that shrank below the floor still lets
     # escape leave the screen, and leaving is what the message offers.
     assert result["outcome"] == "back"
-    assert b"the interface needs 80x24" in drawing
+    assert b"the interface needs 20x6" in drawing
     assert b"Escape after translation" in drawing
 
 

--- a/tests/unit/test_tui_widgets.py
+++ b/tests/unit/test_tui_widgets.py
@@ -953,3 +953,60 @@ def test_a_terminal_narrower_than_the_brackets_still_redraws() -> None:
     assert _tail_that_fits("gentoo", -1) == ""
     screen = FakeScreen(keys=["g", "\x1b"], lines=24, columns=8)
     assert TextField(title="hostname").run(screen).outcome is Outcome.BACK
+
+
+def test_every_widget_draws_at_the_floor_the_interface_refuses_below() -> None:
+    """The floor is measured, not chosen: below it a widget drops content off
+    the screen, and the operator gets a wrecked menu instead of a message."""
+    from gentoo_install.tui.widgets import (
+        MINIMUM_COLUMNS,
+        MINIMUM_LINES,
+        Accepts,
+        Confirm,
+        Field,
+        Form,
+        Menu,
+        MultipleChoiceMenu,
+        TextField,
+        TwoPane,
+    )
+
+    items = [Item(label=f"choice {index}", value=index, detail="what it means") for index in range(6)]
+    field = Field(label="Address", accepts=Accepts.NO_SPACE)
+    drawn = (
+        lambda screen: Menu(title="gentoo-install", items=items, footer="[enter] pick").run(screen),
+        lambda screen: MultipleChoiceMenu(title="t", items=items).run(screen),
+        lambda screen: TextField(title="hostname", value="gentoo", detail="the name").run(screen),
+        lambda screen: Confirm(title="erase", phrase="vda", detail="type it").run(screen),
+        lambda screen: TwoPane(title="gentoo-install", rows=pane_rows(), footer="[enter]").run(screen),
+        lambda screen: Form(title="net", fields=[field]).run(screen),
+    )
+    for widget in drawn:
+        screen = FakeScreen(keys=["\x1b"] * 8, lines=MINIMUM_LINES, columns=MINIMUM_COLUMNS)
+        assert widget(screen).outcome is Outcome.BACK
+
+    # 7x5 is the narrowest any of them can still put its content on, measured
+    # on 2026-08-21. The floor stands above that, so nothing is drawing off
+    # the edge at the size the interface agrees to run in.
+    assert MINIMUM_COLUMNS >= 7 and MINIMUM_LINES >= 5
+
+
+def test_one_pane_below_the_two_pane_floor_and_two_at_it() -> None:
+    """The boundary the interface actually crosses, not a constant compared
+    with itself: 79 columns is one pane and 80 is two."""
+    from gentoo_install.tui.widgets import (
+        SEPARATOR,
+        TWO_PANE_COLUMNS,
+        TWO_PANE_LINES,
+        TwoPane,
+    )
+
+    wide = Recording(keys=["\x1b"], lines=TWO_PANE_LINES, columns=TWO_PANE_COLUMNS)
+    TwoPane(title="gentoo-install", rows=pane_rows()).run(wide)
+    assert SEPARATOR in wide.last
+
+    for lines, columns in ((TWO_PANE_LINES, TWO_PANE_COLUMNS - 1), (TWO_PANE_LINES - 1, TWO_PANE_COLUMNS)):
+        narrow = Recording(keys=["\x1b"], lines=lines, columns=columns)
+        TwoPane(title="gentoo-install", rows=pane_rows()).run(narrow)
+        assert SEPARATOR not in narrow.last
+        assert "Mirrors0" in narrow.drawn(2)


### PR DESCRIPTION
`MINIMUM_COLUMNS`/`MINIMUM_LINES` did two jobs with one number: `TwoPane._draw` chose two panes or one by it, and `cli.py` raised `PreflightFailed` below it. Set to 80x24 both readings cannot hold — `_draw_one_pane` existed but no real terminal ever reached it, because the run was refused first.

`TWO_PANE_COLUMNS`/`TWO_PANE_LINES` stay 80x24 and choose the layout. The refusal floor becomes `LEFT_PANE_MINIMUM` by six lines — a label that is not cut, and a title, the cursor's row, its two summary lines and a footer. Drawing all six widgets on the cell-grid screen at descending sizes measured 7x5 as the narrowest any of them can still put content on, so 20x6 stands above all of them.