### PR TITLE
tui: mark every line the interface cuts

### DIFF
--- a/gentoo_install/tui/partitions.py
+++ b/gentoo_install/tui/partitions.py
@@ -16,7 +16,7 @@ from dataclasses import dataclass, replace
 from enum import Enum
 from typing import Callable, Final, Sequence
 
-from ..i18n import Catalog, truncate, width
+from ..i18n import CUT, Catalog, clip, width
 from ..model import manual
 from ..model.config import (
     Bootloader,
@@ -265,10 +265,6 @@ def partitions_screen(
 _GAP: Final[int] = 2
 
 
-#: What a shortened message ends with, so a cut one never reads as a whole one.
-_CUT: Final[str] = "…"
-
-
 def _status_line(problem: str, keys: str, columns: int) -> str:
     """The keys first, the validator's message in whatever room is left.
 
@@ -279,10 +275,9 @@ def _status_line(problem: str, keys: str, columns: int) -> str:
     if not problem:
         return keys
     room = columns - width(keys) - _GAP
-    if room <= width(_CUT):
+    if room <= width(CUT):
         return keys
-    shown = problem if width(problem) <= room else truncate(problem, room - width(_CUT)) + _CUT
-    return f"{keys}{' ' * _GAP}{shown}"
+    return f"{keys}{' ' * _GAP}{clip(problem, room)}"
 
 
 def _partitions_title(context: Context) -> str:

--- a/gentoo_install/tui/widgets.py
+++ b/gentoo_install/tui/widgets.py
@@ -24,7 +24,7 @@ from typing import (
     TypeVar,
 )
 
-from ..i18n import CUT, clip, truncate, width
+from ..i18n import CUT, clip, width
 
 #: Re-exported: every widget cuts through `clip`, and the mark it leaves is
 #: what tells a cut value from a whole one.
@@ -149,9 +149,10 @@ def spread(left: str, right: str, columns: int) -> str:
 
     `right` is dropped rather than truncated when the two cannot both fit: half
     a count reads as a different count, and half a legend explains a mark the
-    reader can no longer see named.
+    reader can no longer see named. `left` is cut with a mark, because a title
+    that lost its end and one that never had it read the same.
     """
-    head = truncate(left, columns)
+    head = clip(left, columns)
     room = columns - width(head) - 1
     tail = right if right and width(right) <= room else ""
     return f"{head}{' ' * (columns - width(head) - width(tail))}{tail}"

--- a/tests/unit/test_tui_widgets.py
+++ b/tests/unit/test_tui_widgets.py
@@ -1010,3 +1010,32 @@ def test_one_pane_below_the_two_pane_floor_and_two_at_it() -> None:
         TwoPane(title="gentoo-install", rows=pane_rows()).run(narrow)
         assert SEPARATOR not in narrow.last
         assert "Mirrors0" in narrow.drawn(2)
+
+
+def test_a_title_too_wide_for_the_row_is_cut_with_a_mark() -> None:
+    """`spread` cut the left side with no mark, so a mirror name that lost its
+    end read exactly like one that never had it."""
+    from gentoo_install.i18n import CUT, width
+    from gentoo_install.tui.widgets import spread
+
+    row = spread("Mirrors and the site every fetch goes to", "12/20", 20)
+    assert width(row) == 20
+    assert row.endswith(CUT), row
+    # Nothing is cut when it fits, and the right side still lands at the end.
+    assert spread("Mirrors", "12/20", 20) == "Mirrors" + " " * 8 + "12/20"
+
+
+def test_one_mark_says_a_line_was_cut() -> None:
+    """`partitions.py` carried its own mark and its own cut beside `clip`, so
+    one rule lived in two places and only one of them was measured."""
+    from pathlib import Path
+
+    from gentoo_install.i18n import CUT
+
+    carrying = sorted(
+        f"{path}:{number}"
+        for path in Path("gentoo_install/tui").rglob("*.py")
+        for number, line in enumerate(path.read_text(encoding="utf-8").splitlines(), 1)
+        if CUT in line
+    )
+    assert carrying == [], carrying


### PR DESCRIPTION
`spread` cut its left side through `truncate`, which leaves nothing behind: a mirror name that lost its end and one that never had it draw identically. `partitions.py` had the opposite problem — it did mark its cut, with its own `_CUT` and its own reimplementation of `clip`, so one rule lived in two places and only one of them had a test.

Both now go through `i18n.clip`, and a test asserts the mark appears nowhere under `gentoo_install/tui` except through that import. Removing the unused `truncate` import was forced by `test_no_module_imports_a_name_it_never_uses`.