### PR TITLE
tui: fit a row's value to the room that row has

### DIFF
--- a/gentoo_install/tui/app.py
+++ b/gentoo_install/tui/app.py
@@ -23,7 +23,18 @@ from .overview import overview_screen
 from .context import Context
 from .context import say
 from .settings import Setting, settings_for, shown_value, style_of, unanswered
-from .widgets import Item, Menu, Outcome, PaneRow, Screen, Style, TextField, TwoPane
+from .widgets import (
+    MARKER_ROOM,
+    Item,
+    Menu,
+    Outcome,
+    PaneRow,
+    Screen,
+    Style,
+    TextField,
+    TwoPane,
+    left_pane_width,
+)
 
 
 #: The default name for a saved configuration, offered as the field's example.
@@ -113,11 +124,18 @@ def run(screen: Screen, start: InstallConfig, context: Context) -> Finished:
         table = settings_for(current)
         cursor = min(cursor, len(table))
         blocked = _blocked(current, context)
+        labels = [context.translate(setting.label) for setting in table]
+        # The room a value gets is what its own label leaves in the left pane,
+        # not the width of the terminal: eleven English rows were fitted to the
+        # screen and then dropped whole by `spread`.
+        pane_width = left_pane_width(labels)
         rows: list[PaneRow[int]] = [
             PaneRow(
-                label=context.translate(setting.label),
+                label=label,
                 value=index,
-                state=shown_value(setting, current, context),
+                state=shown_value(
+                    setting, current, context, pane_width - MARKER_ROOM - width(label) - 1
+                ),
                 style=style_of(setting, current, context),
                 detail=tuple(_facts(setting, current, context)),
                 # `unavailable` first: `nested()` reads it and this loop did
@@ -126,7 +144,7 @@ def run(screen: Screen, start: InstallConfig, context: Context) -> Finished:
                 disabled_because=setting.unavailable(current, context)
                 or ("" if setting.edit else context.translate("detected")),
             )
-            for index, setting in enumerate(table)
+            for index, (setting, label) in enumerate(zip(table, labels))
         ]
         # The Install row stands for no setting, so what it shows is why the
         # install cannot start: one reason to a line.

--- a/gentoo_install/tui/settings.py
+++ b/gentoo_install/tui/settings.py
@@ -55,7 +55,7 @@ from .packages import (
 )
 from .partitions import partitions_screen
 from .context import Context, Step, ValueKind, ValueSource, footer
-from ..i18n import width
+from ..i18n import clip, width
 from .widgets import Answer, Item, Menu, Outcome, Screen, Style
 
 #: Shown for a row the operator has not visited and that has no usable default.
@@ -189,10 +189,6 @@ def nested(
     return open
 
 
-#: Room the label, the indent and the `+N` need, so the summary is measured
-#: against what is left of the line rather than against the whole width.
-_MARGIN: Final[int] = 34
-
 #: Values that say a row holds no answer. A summary of seven rows reads as a
 #: string of words with no subject when five of them are one of these, so the
 #: group names what is set and says so when nothing is.
@@ -202,7 +198,9 @@ QUIET: Final[tuple[str, ...]] = (
 )
 
 
-def shown_value(setting: Setting, config: InstallConfig, context: Context) -> str:
+def shown_value(
+    setting: Setting, config: InstallConfig, context: Context, room: int | None = None
+) -> str:
     """A row's value as the operator reads it.
 
     `UNSET` is the sentinel `style_of` compares against, so it is translated
@@ -211,9 +209,46 @@ def shown_value(setting: Setting, config: InstallConfig, context: Context) -> st
     left alone.
     """
     value = setting.value(config, context)
-    if value != UNSET:
+    if value == UNSET:
+        value = context.translate("required" if setting.required else UNSET)
+    if room is None:
         return value
-    return context.translate("required" if setting.required else UNSET)
+    # `required` is fitted too: the widest label in the catalog leaves its own
+    # row no room at all, and a word wider than the row is dropped whole.
+    return fit(value.split(", "), room)
+
+
+def fit(parts: list[str], room: int) -> str:
+    """As many of the values as the room holds, and how many did not.
+
+    One place, because the room a row's value gets is what the pane leaves
+    after its label and nothing else: fitting against the whole terminal drew
+    a summary eleven rows could not hold, and `spread` dropped every one of
+    them rather than showing a shorter answer.
+    """
+    said = [one for one in parts if one]
+    taken: list[str] = []
+    for value in said:
+        rest = len(said) - len(taken) - 1
+        if width(", ".join([*taken, value])) + (4 if rest else 0) > room:
+            break
+        taken.append(value)
+    # The first value is measured like the rest: taking it unchecked is what
+    # left five rows holding a value wider than their own pane, which `spread`
+    # then dropped whole rather than shortened.
+    if not taken:
+        if not said:
+            return ""
+        # The count still has to be said: one value clipped to look whole reads
+        # as the only answer, and four more were set.
+        rest = len(said) - 1
+        if not rest:
+            return clip(said[0], room)
+        counter = f" +{rest}"
+        return clip(said[0], max(1, room - width(counter))) + counter
+    left = len(said) - len(taken)
+    joined = ", ".join(taken)
+    return f"{joined} +{left}" if left else joined
 
 
 def _summary(rows: tuple[Setting, ...]) -> Callable[[InstallConfig, Context], str]:
@@ -227,16 +262,9 @@ def _summary(rows: tuple[Setting, ...]) -> Callable[[InstallConfig, Context], st
         said = [one for one in values if one not in quiet]
         if not said:
             return context.translate("nothing set")
-        room = max(20, context.columns - _MARGIN)
-        taken: list[str] = []
-        for value in said:
-            rest = len(said) - len(taken) - 1
-            if taken and width(", ".join([*taken, value])) + (4 if rest else 0) > room:
-                break
-            taken.append(value)
-        left = len(said) - len(taken)
-        joined = ", ".join(taken)
-        return f"{joined} +{left}" if left else joined
+        # Whole: `shown_value` fits it to the room its own row has, which the
+        # terminal's width is not.
+        return ", ".join(said)
 
     return shown
 

--- a/tests/unit/test_tui_app.py
+++ b/tests/unit/test_tui_app.py
@@ -7,7 +7,7 @@ import pytest
 
 from gentoo_install.data import load_catalog
 from gentoo_install.errors import ConfigError
-from gentoo_install.i18n import Catalog
+from gentoo_install.i18n import Catalog, width
 from gentoo_install.model.size import Size
 from gentoo_install.model.config import (
     Bootloader,
@@ -46,8 +46,10 @@ DISKS = [("/dev/disk/by-id/virtio-target0", "20 GiB"), ("/dev/disk/by-id/virtio-
 REQUIRED_ROW_VALUES: dict[str, str] = {
     "mirror": "required",
     "mode": "partition a disk and install onto it",
-    "storage": "virtio-target, gpt +2",
-    "compiler": "stage3 default, -O2 -pipe (stage3 default) +3",
+    "storage": "virtio-target, gpt, whole-disk (erases the disk), /efi 512MiB, / the rest",
+    "compiler": (
+        "stage3 default, -O2 -pipe (stage3 default), what the profile sets, @FREE, amd64"
+    ),
     "root": "set",
     "erase": "required",
 }
@@ -2194,9 +2196,9 @@ def test_selecting_gentoo_zh_turns_its_binary_host_on() -> None:
     assert tui_context.with_gentoo_zh(picked).binhost.community is BinhostChannel.UNSTABLE
 
 
-def test_a_grouped_row_uses_the_width_the_terminal_actually_has() -> None:
-    """It took two values whatever the terminal was, so a 160-column ssh window
-    still read `openrc, syslog-ng +1` with the rest of the line empty."""
+def test_a_grouped_row_answers_whole_and_the_pane_is_what_fits_it() -> None:
+    """The summary was cut against the terminal and then drawn into a pane a
+    fraction of that wide, so `spread` dropped eleven English rows whole."""
     at = context()
     disk = next(one for one in settings.SETTINGS if one.key == "storage")
 
@@ -2206,17 +2208,21 @@ def test_a_grouped_row_uses_the_width_the_terminal_actually_has() -> None:
     said = [one for one in (row.value(config(), at) for row in disk.rows) if one not in quiet]
     assert len(said) < len(disk.rows)
 
-    at.columns = 200
-    wide = disk.value(config(), at)
-    assert "+" not in wide
-    # Every field, not a comma count: one of them lists the partitions and
-    # carries commas of its own.
-    for one in said:
-        assert one in wide, one
+    # Whole, at any terminal width: the row does not know what room it gets.
+    for columns in (40, 200):
+        at.columns = columns
+        whole = disk.value(config(), at)
+        assert "+" not in whole
+        # Every field, not a comma count: one of them lists the partitions and
+        # carries commas of its own.
+        for one in said:
+            assert one in whole, one
 
-    at.columns = 40
-    narrow = disk.value(config(), at)
-    assert "+" in narrow and len(narrow) < 40
+    # The room decides, and the count is said whatever the room is.
+    assert settings.shown_value(disk, config(), at, 200) == disk.value(config(), at)
+    parts = disk.value(config(), at).split(", ")
+    narrow = settings.shown_value(disk, config(), at, 20)
+    assert width(narrow) <= 20 and narrow.endswith(f"+{len(parts) - 1}"), narrow
 
 
 def test_the_rows_say_not_set_in_the_language_the_menu_is_in() -> None:
@@ -3547,3 +3553,56 @@ def test_writing_an_image_asks_the_same_erase_confirmation_as_every_other_path()
     assert erase.value(written, at) == settings.UNSET
     at.confirmed.add(written.disk.destination)
     assert erase.value(written, at) == at.translate("confirmed")
+
+
+def test_the_first_value_is_measured_like_the_rest_and_the_count_is_said() -> None:
+    """Two defects in one loop: the first value was taken unchecked, so a row
+    held a value wider than its own pane; and when it was cut, the count of
+    what was left out went with it, so one answer read as the only answer."""
+    from gentoo_install.tui.settings import fit
+
+    assert fit(["systemd", "journald", "cronie"], 40) == "systemd, journald, cronie"
+    assert fit(["systemd", "journald", "cronie"], 13) == "systemd +2"
+    # Wider than the room on its own: cut, and the count still said.
+    cut = fit(["partition a disk and install onto it", "and one more"], 12)
+    assert width(cut) <= 12 and cut.endswith("+1"), cut
+    # One value and no room: cut with a mark, and no count invented.
+    only = fit(["default/linux/amd64/23.0/systemd"], 10)
+    assert width(only) <= 10 and "+" not in only and only != "default/linux/amd64/23.0/systemd"
+    assert fit([], 10) == ""
+
+
+def test_every_row_of_the_main_menu_carries_a_value() -> None:
+    """Measured on 2026-08-21: eleven English rows and ten Traditional Chinese
+    ones drew no value at all, because the summary was fitted to the terminal
+    and then dropped whole by the pane it was drawn into.
+
+    Read off the drawn rows rather than recomputed: a test that fits the value
+    itself passes whatever the menu hands the pane, which is the wiring this
+    is here to hold.
+    """
+    from gentoo_install.tui.widgets import SEPARATOR
+
+    for tag in ("en", "zh-TW", "zh-CN", "ja", "ko"):
+        at = context()
+        at.translate = Catalog(tag)
+        at.tag = tag
+        installation = config()
+        table = settings.settings_for(installation)
+        labels = [at.translate(setting.label) for setting in table]
+        screen = FakeScreen(keys=[*down(len(table)), "q", "KEY_DOWN", "\n"])
+        run(screen, installation, at)
+        blank = []
+        for frame in screen.frames:
+            for line in frame:
+                if SEPARATOR not in line:
+                    continue
+                left = line.split(SEPARATOR)[0][2:]
+                for label in labels:
+                    if left.startswith(label) and not left[len(label) :].strip():
+                        blank.append((label, line))
+        # One named exception: the pane is sized so no label is ever cut, so
+        # the widest label in the catalog fills its own row and its value is
+        # left to the right pane. Every other row carries one.
+        widest = max(labels, key=width)
+        assert {one for one, _ in blank} <= {widest}, (tag, sorted({one for one, _ in blank}))


### PR DESCRIPTION
Rendering the main menu in all five languages measured it: eleven English rows, ten Traditional Chinese and eight Japanese drew no value at all. `_summary` cut the value against `context.columns - 34` — 46 cells — and it was then drawn into the left pane, where `Language and fonts` has six. `spread` drops a right side that does not fit, by a rule that is right for a count and wrong for a value, so the whole thing vanished.

The row now answers whole and `shown_value` fits it to `pane - marker - label - 1`. Two defects in the old loop came out with it: the first value was never measured, so a 37-cell answer counted as fitting; and when it was cut the `+N` went with it, so `stage3 default` read as the only answer when four more were set. `app.py` and `settings.py` had a near-identical loop and a `_MARGIN` each; there is now one `fit()`.

One named exception, asserted: the pane is sized so no label is ever cut, so the catalog's widest label fills its own row and leaves its value to the right pane.