### PR TITLE
tui: move a long list by the screen and to its ends

### DIFF
--- a/gentoo_install/data/locale/ja.toml
+++ b/gentoo_install/data/locale/ja.toml
@@ -667,3 +667,6 @@
 "Ask whether to leave, in a list; a letter in a field" = "一覧では終了するか尋ね、入力欄では一文字として扱う"
 "Ask whether to leave, anywhere" = "どの画面でも終了するか尋ねる"
 "This page, in a list; a letter in a field" = "このページを開く。入力欄では一文字として扱う"
+"Move the cursor one screen" = "カーソルを一画面分動かす"
+"Move the cursor to the first or last row" = "カーソルを先頭または末尾の行へ移す"
+"First or last row, in a list; a letter in a field" = "一覧では先頭または末尾の行へ移り、入力欄では一文字として扱う"

--- a/gentoo_install/data/locale/ko.toml
+++ b/gentoo_install/data/locale/ko.toml
@@ -667,3 +667,6 @@
 "Ask whether to leave, in a list; a letter in a field" = "목록에서는 나갈지 묻고 입력란에서는 한 글자입니다"
 "Ask whether to leave, anywhere" = "어느 화면에서든 나갈지 묻습니다"
 "This page, in a list; a letter in a field" = "이 쪽을 엽니다. 입력란에서는 한 글자입니다"
+"Move the cursor one screen" = "커서를 한 화면만큼 움직입니다"
+"Move the cursor to the first or last row" = "커서를 첫 줄이나 마지막 줄로 옮깁니다"
+"First or last row, in a list; a letter in a field" = "목록에서는 첫 줄이나 마지막 줄로 옮기고 입력란에서는 한 글자입니다"

--- a/gentoo_install/data/locale/zh-CN.toml
+++ b/gentoo_install/data/locale/zh-CN.toml
@@ -668,3 +668,6 @@
 "Ask whether to leave, in a list; a letter in a field" = "在列表里询问是否离开；在字段里是一个字符"
 "Ask whether to leave, anywhere" = "在任何界面询问是否离开"
 "This page, in a list; a letter in a field" = "打开这一页；在字段里是一个字符"
+"Move the cursor one screen" = "光标移动一个屏幕"
+"Move the cursor to the first or last row" = "光标移到第一行或最后一行"
+"First or last row, in a list; a letter in a field" = "在列表里移到第一行或最后一行；在字段里是一个字符"

--- a/gentoo_install/data/locale/zh-TW.toml
+++ b/gentoo_install/data/locale/zh-TW.toml
@@ -668,3 +668,6 @@
 "Ask whether to leave, in a list; a letter in a field" = "在清單裡詢問是否離開；在欄位裡是一個字元"
 "Ask whether to leave, anywhere" = "在任何畫面詢問是否離開"
 "This page, in a list; a letter in a field" = "開啟這一頁；在欄位裡是一個字元"
+"Move the cursor one screen" = "游標移動一個畫面"
+"Move the cursor to the first or last row" = "游標移到第一列或最後一列"
+"First or last row, in a list; a letter in a field" = "在清單裡移到第一列或最後一列；在欄位裡是一個字元"

--- a/gentoo_install/tui/widgets.py
+++ b/gentoo_install/tui/widgets.py
@@ -173,10 +173,20 @@ KEY_HELP: Final[tuple[KeyRow, ...]] = (
     KeyRow("q", "Ask whether to leave, in a list; a letter in a field"),
     KeyRow("ctrl-c", "Ask whether to leave, anywhere"),
     KeyRow("?", "This page, in a list; a letter in a field"),
+    KeyRow("page-up  page-down", "Move the cursor one screen"),
+    KeyRow("home  end", "Move the cursor to the first or last row"),
+    KeyRow("g  G", "First or last row, in a list; a letter in a field"),
 )
 
 #: What opens the key page. A letter in a field, like `q`.
 HELP_KEY: Final[str] = "?"
+
+#: One screen at a time, and the ends. `America` holds 169 timezones, which is
+#: eight screens of `j` on a console 24 lines tall.
+PAGE_BACKWARD: Final[tuple[str, ...]] = ("KEY_PPAGE",)
+PAGE_FORWARD: Final[tuple[str, ...]] = ("KEY_NPAGE",)
+FIRST: Final[tuple[str, ...]] = ("KEY_HOME", "g")
+LAST: Final[tuple[str, ...]] = ("KEY_END", "G")
 
 
 def spread(left: str, right: str, columns: int) -> str:
@@ -287,6 +297,14 @@ class _Menu(Generic[V, A]):
                 cursor = self._step(cursor, -1)
             elif pressed in FORWARD:
                 cursor = self._step(cursor, 1)
+            elif pressed in PAGE_BACKWARD:
+                cursor = self._page(cursor, -1, screen)
+            elif pressed in PAGE_FORWARD:
+                cursor = self._page(cursor, 1, screen)
+            elif pressed in FIRST:
+                cursor = self._first_enabled()
+            elif pressed in LAST:
+                cursor = self._last_enabled()
             elif pressed == HELP_KEY:
                 screen.help()
             elif pressed == " " and self._multiple:
@@ -338,6 +356,25 @@ class _Menu(Generic[V, A]):
             if not item.disabled_because:
                 return index
         return 0
+
+    def _last_enabled(self) -> int:
+        for index in range(len(self.items) - 1, -1, -1):
+            if not self.items[index].disabled_because or index in self.selected:
+                return index
+        return len(self.items) - 1
+
+    def _page(self, cursor: int, by: int, screen: Screen) -> int:
+        """One screen, measured from the screen rather than a constant: the
+        rows a page holds is what this terminal draws, and a fixed number is
+        wrong on every terminal but one."""
+        lines, _ = screen.size()
+        room = max(1, lines - 4 - len(self.preamble))
+        for _ in range(room):
+            moved = self._step(cursor, by)
+            if moved == cursor:
+                break
+            cursor = moved
+        return cursor
 
     def _step(self, cursor: int, by: int) -> int:
         """Skip disabled rows, and stop rather than wrap: wrapping past the end
@@ -850,6 +887,14 @@ class TwoPane(Generic[V]):
                 cursor = max(0, cursor - 1)
             elif pressed in ("KEY_DOWN", "j", "\t"):
                 cursor = min(max(0, len(self.rows) - 1), cursor + 1)
+            elif pressed in PAGE_BACKWARD:
+                cursor = max(0, cursor - self._page(screen))
+            elif pressed in PAGE_FORWARD:
+                cursor = min(max(0, len(self.rows) - 1), cursor + self._page(screen))
+            elif pressed in FIRST:
+                cursor = 0
+            elif pressed in LAST:
+                cursor = max(0, len(self.rows) - 1)
             elif pressed == HELP_KEY:
                 screen.help()
             elif pressed in ("\n", "KEY_ENTER", "KEY_RIGHT"):
@@ -864,6 +909,13 @@ class TwoPane(Generic[V]):
                 return Answer(Outcome.BACK)
             elif pressed == "\x03":
                 return Answer(Outcome.CANCELLED)
+
+    @staticmethod
+    def _page(screen: Screen) -> int:
+        """The rows one screen holds, which is what both layouts draw between
+        the title row and the status line."""
+        lines, _ = screen.size()
+        return max(1, lines - 3)
 
     def _draw(self, screen: Screen, cursor: int) -> None:
         lines, columns = screen.size()

--- a/tests/unit/test_tui_widgets.py
+++ b/tests/unit/test_tui_widgets.py
@@ -1093,3 +1093,42 @@ def test_the_help_page_names_every_key_a_widget_answers() -> None:
     }
     for key in answered:
         assert written.get(key, key) in listed, key
+
+
+def test_a_long_list_moves_one_screen_and_to_its_ends() -> None:
+    """169 timezones live under `America`, which is eight screens of `j` on a
+    console 24 lines tall."""
+    from gentoo_install.tui.widgets import Menu
+
+    items = [Item(label=f"zone {index}", value=index) for index in range(169)]
+
+    # A page is what this screen draws, not a constant: the title, a blank, the
+    # rows and the status line.
+    for lines, page in ((24, 20), (12, 8)):
+        screen = FakeScreen(keys=["KEY_NPAGE", "\n"], lines=lines, columns=80)
+        assert Menu(title="Timezone", items=items).run(screen).unwrap() == page
+
+    down = FakeScreen(keys=["KEY_NPAGE", "KEY_NPAGE", "KEY_PPAGE", "\n"], lines=24, columns=80)
+    assert Menu(title="Timezone", items=items).run(down).unwrap() == 20
+
+    # The ends, and neither runs off: paging past the last row stops on it.
+    assert Menu(title="Timezone", items=items).run(
+        FakeScreen(keys=["KEY_END", "\n"], lines=24, columns=80)
+    ).unwrap() == 168
+    assert Menu(title="Timezone", items=items).run(
+        FakeScreen(keys=["G", "g", "\n"], lines=24, columns=80)
+    ).unwrap() == 0
+    assert Menu(title="Timezone", items=items).run(
+        FakeScreen(keys=[*(["KEY_NPAGE"] * 20), "\n"], lines=24, columns=80)
+    ).unwrap() == 168
+
+
+def test_the_main_menu_pages_the_same_way() -> None:
+    """One key table, so the two-pane list answers what a menu answers."""
+    from gentoo_install.tui.widgets import TwoPane
+
+    rows = pane_rows(count=60)
+    paged = Recording(keys=["KEY_NPAGE", "\n"], lines=24, columns=80)
+    assert TwoPane(title="gentoo-install", rows=rows).run(paged).unwrap() == 21
+    ended = Recording(keys=["KEY_END", "\n"], lines=24, columns=80)
+    assert TwoPane(title="gentoo-install", rows=rows).run(ended).unwrap() == 59


### PR DESCRIPTION
The longest menu in the interface is 169 rows — the timezones under `America` — and the only way through it was `j`, eight screens of it on a console 24 lines tall. `page-up`/`page-down`, `home`/`end` and `g`/`G` now move it, in both the menu and the two-pane list.

A page is the rows that screen actually draws, not a constant: `lines - 4 - len(preamble)` for a menu and `lines - 3` for the two-pane. The test measures two heights, 24 lines and 12, so replacing it with a fixed number fails rather than passing on the one terminal it was tuned for.

The new keys go in `KEY_HELP` in the same commit, which `test_the_help_page_names_every_key_a_widget_answers` requires — that test exists so a key can no longer be added without being written down.