### PR TITLE
tui: narrow a long list to what the operator types

### DIFF
--- a/gentoo_install/data/locale/ja.toml
+++ b/gentoo_install/data/locale/ja.toml
@@ -670,3 +670,4 @@
 "Move the cursor one screen" = "カーソルを一画面分動かす"
 "Move the cursor to the first or last row" = "カーソルを先頭または末尾の行へ移す"
 "First or last row, in a list; a letter in a field" = "一覧では先頭または末尾の行へ移り、入力欄では一文字として扱う"
+"Narrow a list to the rows holding what is typed next" = "次に入力した文字を含む行だけに一覧を絞り込む"

--- a/gentoo_install/data/locale/ko.toml
+++ b/gentoo_install/data/locale/ko.toml
@@ -670,3 +670,4 @@
 "Move the cursor one screen" = "커서를 한 화면만큼 움직입니다"
 "Move the cursor to the first or last row" = "커서를 첫 줄이나 마지막 줄로 옮깁니다"
 "First or last row, in a list; a letter in a field" = "목록에서는 첫 줄이나 마지막 줄로 옮기고 입력란에서는 한 글자입니다"
+"Narrow a list to the rows holding what is typed next" = "이어서 입력한 글자가 들어간 줄만 목록에 남깁니다"

--- a/gentoo_install/data/locale/zh-CN.toml
+++ b/gentoo_install/data/locale/zh-CN.toml
@@ -671,3 +671,4 @@
 "Move the cursor one screen" = "光标移动一个屏幕"
 "Move the cursor to the first or last row" = "光标移到第一行或最后一行"
 "First or last row, in a list; a letter in a field" = "在列表里移到第一行或最后一行；在字段里是一个字符"
+"Narrow a list to the rows holding what is typed next" = "把列表缩小到含有接着输入的文字的那些行"

--- a/gentoo_install/data/locale/zh-TW.toml
+++ b/gentoo_install/data/locale/zh-TW.toml
@@ -671,3 +671,4 @@
 "Move the cursor one screen" = "游標移動一個畫面"
 "Move the cursor to the first or last row" = "游標移到第一列或最後一列"
 "First or last row, in a list; a letter in a field" = "在清單裡移到第一列或最後一列；在欄位裡是一個字元"
+"Narrow a list to the rows holding what is typed next" = "把清單縮小到含有接著輸入的文字的那些列"

--- a/gentoo_install/tui/widgets.py
+++ b/gentoo_install/tui/widgets.py
@@ -176,6 +176,7 @@ KEY_HELP: Final[tuple[KeyRow, ...]] = (
     KeyRow("page-up  page-down", "Move the cursor one screen"),
     KeyRow("home  end", "Move the cursor to the first or last row"),
     KeyRow("g  G", "First or last row, in a list; a letter in a field"),
+    KeyRow("/", "Narrow a list to the rows holding what is typed next"),
 )
 
 #: What opens the key page. A letter in a field, like `q`.
@@ -187,6 +188,9 @@ PAGE_BACKWARD: Final[tuple[str, ...]] = ("KEY_PPAGE",)
 PAGE_FORWARD: Final[tuple[str, ...]] = ("KEY_NPAGE",)
 FIRST: Final[tuple[str, ...]] = ("KEY_HOME", "g")
 LAST: Final[tuple[str, ...]] = ("KEY_END", "G")
+
+#: What narrows a list to the rows holding what was typed.
+FILTER_KEY: Final[str] = "/"
 
 
 def spread(left: str, right: str, columns: int) -> str:
@@ -276,6 +280,9 @@ class _Menu(Generic[V, A]):
     #: without this the first row won: encryption enabled became disabled, and
     #: a second disk became the first.
     current: V | None | _Missing = _MISSING
+    #: What `/` is narrowing the list to. `None` when no filter is open, which
+    #: is a different state from an open filter holding nothing typed yet.
+    _query: str | None = None
 
     _multiple: ClassVar[bool] = False
 
@@ -293,6 +300,12 @@ class _Menu(Generic[V, A]):
             self.cursor = cursor
             self._draw(screen, cursor)
             pressed = screen.key()
+            if self._query is not None and self._typed(pressed):
+                cursor = self._after_typing(cursor)
+                continue
+            if pressed == FILTER_KEY and self._query is None:
+                self._query = ""
+                continue
             if pressed in BACKWARD:
                 cursor = self._step(cursor, -1)
             elif pressed in FORWARD:
@@ -317,6 +330,37 @@ class _Menu(Generic[V, A]):
                 return Answer(Outcome.BACK)
             elif pressed in CANCEL_IN_A_MENU:
                 return Answer(Outcome.CANCELLED)
+
+    def _typed(self, pressed: str) -> bool:
+        """Whether this key belongs to the filter rather than to the list.
+
+        Arrows and the page keys keep navigating while a filter is open, so
+        the operator narrows and moves without leaving what they typed; `j`
+        and `k` are letters here, which is why they are not tested first.
+        """
+        if self._query is None:
+            return False
+        if pressed == "\x1b":
+            self._query = None
+            return True
+        if pressed in ("\x7f", "KEY_BACKSPACE"):
+            self._query = self._query[:-1] if self._query else None
+            return True
+        if len(pressed) == 1 and pressed.isprintable():
+            self._query += pressed
+            return True
+        return False
+
+    def _after_typing(self, cursor: int) -> int:
+        """Keep the cursor on a row the filter still shows."""
+        return cursor if self._shown(cursor) else self._first_enabled()
+
+    def _shown(self, index: int) -> bool:
+        """Case-insensitive, on the label alone: a row is found by the name the
+        operator reads, not by the reason printed beside it."""
+        if not self._query:
+            return True
+        return self._query.lower() in self.items[index].label.lower()
 
     def _accept(self, cursor: int) -> Answer[A] | None:
         raise NotImplementedError
@@ -353,12 +397,14 @@ class _Menu(Generic[V, A]):
 
     def _first_enabled(self) -> int:
         for index, item in enumerate(self.items):
-            if not item.disabled_because:
+            if self._shown(index) and not item.disabled_because:
                 return index
-        return 0
+        return next((index for index in range(len(self.items)) if self._shown(index)), 0)
 
     def _last_enabled(self) -> int:
         for index in range(len(self.items) - 1, -1, -1):
+            if not self._shown(index):
+                continue
             if not self.items[index].disabled_because or index in self.selected:
                 return index
         return len(self.items) - 1
@@ -384,6 +430,8 @@ class _Menu(Generic[V, A]):
             candidate += by
             # A selected row is reachable even when disabled, or the operator
             # cannot put the cursor on the choice they have to undo.
+            if not self._shown(candidate):
+                continue
             if not self.items[candidate].disabled_because or candidate in self.selected:
                 return candidate
         return cursor
@@ -400,8 +448,11 @@ class _Menu(Generic[V, A]):
         above = len(self.preamble)
         room = lines - 4 - above
         displayed = self._display_rows(columns)
+        # A filter can hide every row, and then there is no cursor to keep on
+        # screen: an empty list with a count of nothing is the answer, not a
+        # traceback out of `next`.
         cursor_row = next(
-            row for row, (index, _) in enumerate(displayed) if index == cursor
+            (row for row, (index, _) in enumerate(displayed) if index == cursor), 0
         )
         top = max(0, min(cursor_row - room // 2, len(displayed) - room))
         for row, (index, text) in enumerate(displayed[top : top + room]):
@@ -422,7 +473,15 @@ class _Menu(Generic[V, A]):
                 highlight=index == cursor,
                 style=item.style,
             )
-        if self.footer or self.legend:
+        if self._query is not None:
+            # The filter replaces the keys while it is open: what was typed
+            # and how many rows are left are what the operator needs, and a
+            # count they cannot see makes an empty list read as a broken menu.
+            left = sum(1 for index in range(len(self.items)) if self._shown(index))
+            screen.write(
+                lines - 1, 0, spread(f"{FILTER_KEY}{self._query}", str(left), columns)
+            )
+        elif self.footer or self.legend:
             # Held apart rather than run together: the keys and what the marks
             # mean are two things to read, and one line of `[enter] open
             # [q] cancel * required ~ never opened` reads as neither.
@@ -433,6 +492,8 @@ class _Menu(Generic[V, A]):
         rows: list[tuple[int | None, str]] = []
         heading = ""
         for index, item in enumerate(self.items):
+            if not self._shown(index):
+                continue
             if item.heading and item.heading != heading:
                 heading = item.heading
                 rows.append((None, heading))

--- a/tests/unit/test_tui_widgets.py
+++ b/tests/unit/test_tui_widgets.py
@@ -1132,3 +1132,54 @@ def test_the_main_menu_pages_the_same_way() -> None:
     assert TwoPane(title="gentoo-install", rows=rows).run(paged).unwrap() == 21
     ended = Recording(keys=["KEY_END", "\n"], lines=24, columns=80)
     assert TwoPane(title="gentoo-install", rows=rows).run(ended).unwrap() == 59
+
+
+def test_typing_after_the_filter_key_narrows_a_long_list() -> None:
+    """169 timezones under `America`, and the operator knows the name: `/` and
+    three letters beat eight screens of paging."""
+    from gentoo_install.tui.widgets import FILTER_KEY, Menu
+
+    zones = ["Asia/Shanghai", "Asia/Taipei", "Europe/Berlin", "America/Shanghai_Falls"]
+    items = [Item(label=zone, value=zone) for zone in zones]
+
+    # Two rows hold `sha`, and the cursor lands on the first of them.
+    screen = Recording(keys=[FILTER_KEY, "s", "h", "a", "\n"], lines=24, columns=80)
+    assert Menu(title="Timezone", items=items).run(screen).unwrap() == "Asia/Shanghai"
+    assert "Europe/Berlin" not in screen.last
+    assert "Asia/Taipei" not in screen.last
+    # What was typed and how many rows are left, where the keys usually are.
+    assert f"{FILTER_KEY}sha" in screen.last and "2" in screen.drawn(23)
+
+    # Case does not matter: the label is read, not matched.
+    upper = Recording(keys=[FILTER_KEY, "B", "E", "R", "\n"], lines=24, columns=80)
+    assert Menu(title="Timezone", items=items).run(upper).unwrap() == "Europe/Berlin"
+
+    # Backspace widens it again and the rows it had hidden come back, while
+    # the cursor stays on the row the operator had narrowed down to.
+    wider = Recording(keys=[FILTER_KEY, "t", "a", "i", "\x7f", "\x7f", "\x7f", "\n"],
+                      lines=24, columns=80)
+    assert Menu(title="Timezone", items=items).run(wider).unwrap() == "Asia/Taipei"
+    assert "Europe/Berlin" in wider.last
+
+
+def test_escape_closes_the_filter_before_it_goes_back() -> None:
+    """`esc` is Back everywhere else, so the first one has to be spent on the
+    filter or an operator who mistyped cannot get the whole list back."""
+    from gentoo_install.tui.widgets import FILTER_KEY, Menu
+
+    items = [Item(label=name, value=name) for name in ("nju", "tuna", "ustc")]
+    screen = Recording(keys=[FILTER_KEY, "n", "j", "\x1b", "\n"], lines=24, columns=80)
+    assert Menu(title="Mirrors", items=items).run(screen).unwrap() == "nju"
+    assert "ustc" in screen.last, screen.last
+
+    # And the second one leaves.
+    away = Recording(keys=[FILTER_KEY, "n", "\x1b", "\x1b"], lines=24, columns=80)
+    assert Menu(title="Mirrors", items=items).run(away).outcome is Outcome.BACK
+
+
+def test_a_filter_that_matches_nothing_says_so_rather_than_drawing_nothing() -> None:
+    from gentoo_install.tui.widgets import FILTER_KEY, Menu
+
+    items = [Item(label=name, value=name) for name in ("nju", "tuna")]
+    screen = Recording(keys=[FILTER_KEY, "z", "z", "\x1b", "\x1b"], lines=24, columns=80)
+    assert Menu(title="Mirrors", items=items).run(screen).outcome is Outcome.BACK


### PR DESCRIPTION
The last of the three key gaps measured against archinstall's binding table. Its menus bind `/` on both the single and multi lists (`components.py:185`, `:418`) and match a label case-insensitively (`menu_item.py:252`); here the only way through 169 timezones was the cursor.

`/` opens a filter, typing narrows it, and the status line carries what was typed and how many rows are left — a count matters because a filter matching nothing otherwise looks like a broken menu. The first `esc` closes the filter and restores the list, the second goes back: without that an operator who mistyped cannot get the whole list again, and the open filter is visible on the status line while it applies.

Writing the tests found a real defect: with nothing matching, `_draw` raised `StopIteration` out of `next`. Both halves were broken to check the tests hold them — a case-sensitive match and an escape that no longer closes the filter each turn one red.