### PR TITLE
tests: drive the interface itself on a cluster guest

### DIFF
--- a/tests/tui/__init__.py
+++ b/tests/tui/__init__.py
@@ -1,0 +1,2 @@
+# SPDX-License-Identifier: GPL-2.0-or-later
+"""Driving the interface the way an operator does, so the interface is tested."""

--- a/tests/tui/brief.md
+++ b/tests/tui/brief.md
@@ -1,0 +1,65 @@
+<!-- SPDX-License-Identifier: GPL-2.0-or-later -->
+# Installing a machine through the interface
+
+You are the operator of a machine that is booted from the installer's medium
+and showing its interface. Build the machine described in your spec by using
+that interface, and nothing else.
+
+## What you may run
+
+One command, with these subcommands:
+
+```
+python3 -m tests.tui.session screen <id>          what is on the screen now
+python3 -m tests.tui.session key <id> <keys...>   press keys
+python3 -m tests.tui.session plan <id>            what the installer would do
+```
+
+Keys are named: `up`, `down`, `left`, `right`, `enter`, `esc`, `tab`, `space`,
+`home`, `end`, `pageup`, `pagedown`, `help`, `backspace`, and `type:<text>` to
+enter text. Several may be given at once: `key lab1 down down enter`.
+
+## What you may not do
+
+- Do not read `gentoo_install/`, `tests/fixtures/`, or any other file in this
+  repository. The question is whether the screen says enough on its own; a
+  source file answers it for you and destroys the measurement.
+- Do not pass `--config`, edit a configuration file, or start the installer
+  yourself. The session is already running.
+- Do not run any command other than the three above.
+- Do not answer from what a Gentoo install usually needs. If the screen does
+  not say which row sets something, that is the finding.
+
+## How to work
+
+Read the screen, decide which row answers the next part of your spec, open it,
+set it, and go back. Take the spec in whatever order the interface makes
+natural, not the order it is written in. When a screen refuses what you typed,
+read what it says and correct it.
+
+When you cannot tell what a row is for, or cannot find the row that sets
+something your spec names, press `help` once and read what it says. If that
+does not answer it, record the row's name under `unclear` and move on — do not
+guess, and do not brute-force the screen.
+
+Stop when the plan the installer would run matches your spec, or when you
+cannot make further progress.
+
+## What to answer
+
+One JSON object, and nothing else:
+
+```json
+{
+  "finished": true,
+  "installed": ["the root filesystem is btrfs", "hostname is lab1"],
+  "stuck": ["Kernel"],
+  "unclear": ["Firmware: could not tell whether it detects or sets"]
+}
+```
+
+`installed` lists the lines of your spec's proof that the plan shows were
+answered. `stuck` names a screen you could not leave or could not set.
+`unclear` names a row whose purpose the screen did not convey, one line each,
+saying what was missing. Your answer is read as a claim about the interface,
+not as the result of the run: the run is counted from the keys you pressed.

--- a/tests/tui/report.py
+++ b/tests/tui/report.py
@@ -1,0 +1,146 @@
+# SPDX-License-Identifier: GPL-2.0-or-later
+"""What a session cost the operator, counted rather than reported.
+
+An agent's own account of a run is a claim: it says it understood the screen
+because it believes it did. These five numbers come from the keys it pressed
+and the screens it was shown, so they say the same thing whatever it writes
+in its report, and each one names a screen rather than a feeling.
+"""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Final
+
+from gentoo_install.i18n import Catalog
+
+#: A screen the cursor entered and left with nothing changed. Named because
+#: it is the one count that means the row's own name failed: the operator
+#: opened it to find out what it was.
+LOST: Final[str] = "lost"
+
+#: The languages the interface offers, so a screen is matched in the one it
+#: was drawn in.
+TAGS: Final[tuple[str, ...]] = ("en", "zh-TW", "zh-CN", "ja", "ko")
+
+#: How many keys on one screen before it counts as stuck. Twelve is four rows
+#: of movement and a mistake; a screen that takes more is one the operator
+#: cannot answer.
+STUCK_AFTER: Final[int] = 12
+
+
+@dataclass(frozen=True)
+class Report:
+    """One session, in five numbers and the screens behind them."""
+
+    finished: bool
+    lost: tuple[str, ...]
+    helped: int
+    stuck: tuple[str, ...]
+    refused: int
+
+    def as_dict(self) -> dict[str, object]:
+        return {
+            "finished": self.finished,
+            "lost": list(self.lost),
+            "helped": self.helped,
+            "stuck": list(self.stuck),
+            "refused": self.refused,
+        }
+
+
+def title_of(screen: str) -> str:
+    """The framed pane's own heading, which names the row that is open.
+
+    The title bar says `gentoo-install` on every screen, so it identifies
+    nothing; the frame names what the operator is looking at.
+    """
+    found = re.search(r"\+-\s+(.+?)\s+-{2,}", screen)
+    if found:
+        return found.group(1).strip()
+    first = screen.splitlines()[0].strip() if screen.splitlines() else ""
+    return first
+
+
+def read(session: Path) -> Report:
+    """Count one session from what it left behind."""
+    keys = _lines(session / "keys.txt")
+    screens = _screens(session / "screens.txt")
+    return Report(
+        finished=any(_says("Install", one) for one in screens[-1:]),
+        lost=tuple(_lost(keys, screens)),
+        helped=sum(one.split().count("help") for one in keys),
+        stuck=tuple(_stuck(screens)),
+        refused=sum(1 for one in screens if _refusal(one)),
+    )
+
+
+def _lines(path: Path) -> list[str]:
+    if not path.is_file():
+        return []
+    return [one for one in path.read_text(encoding="utf-8").splitlines() if one.strip()]
+
+
+def _screens(path: Path) -> list[str]:
+    if not path.is_file():
+        return []
+    return [one for one in path.read_text(encoding="utf-8").split("\f") if one.strip()]
+
+
+def _lost(keys: list[str], screens: list[str]) -> list[str]:
+    """A screen entered and left with the same values on it."""
+    lost: list[str] = []
+    for at in range(1, len(screens) - 1):
+        before, inside, after = screens[at - 1], screens[at], screens[at + 1]
+        entered = "enter" in keys[at - 1] if at - 1 < len(keys) else False
+        left = at < len(keys) and ("esc" in keys[at] or "left" in keys[at])
+        if entered and left and _values(before) == _values(after):
+            lost.append(title_of(inside))
+    return lost
+
+
+def _stuck(screens: list[str]) -> list[str]:
+    """The same screen for more keys than answering one takes."""
+    stuck: list[str] = []
+    run = 1
+    for before, after in zip(screens, screens[1:]):
+        if title_of(before) == title_of(after):
+            run += 1
+            if run == STUCK_AFTER:
+                stuck.append(title_of(after))
+        else:
+            run = 1
+    return stuck
+
+
+def _values(screen: str) -> tuple[str, ...]:
+    """Every row as drawn, label and value together.
+
+    The value is what an edit changes, so comparing the labels answers that
+    nothing changed on every screen and makes every visit a lost one.
+    """
+    return tuple(
+        line.rstrip()
+        for line in screen.splitlines()
+        if "|" in line and line[:1] in {"*", "~", " "}
+    )
+
+
+def _refusal(screen: str) -> bool:
+    """A field that would not take what was typed."""
+    return _says("Not a package name", screen)
+
+
+def _says(source: str, screen: str) -> bool:
+    """Whether a screen carries a string, in whatever language it is drawn in.
+
+    Written against the catalogs rather than as a literal: a session runs in
+    the language its spec is in, and a translated word pasted into a test goes
+    stale the next time the wording is corrected.
+    """
+    for tag in TAGS:
+        if Catalog(tag)(source) in screen:
+            return True
+    return False

--- a/tests/tui/screen.py
+++ b/tests/tui/screen.py
@@ -1,0 +1,160 @@
+# SPDX-License-Identifier: GPL-2.0-or-later
+"""What a terminal would be showing, rebuilt from what was written to it.
+
+An agent driving the interface has to read the screen, not the byte stream:
+`ncurses` repaints by moving the cursor and overwriting cells, so the same
+line appears many times in the stream and only the last write is on screen.
+
+Only what `ncurses` emits is understood, which is a small part of the
+standard: absolute cursor moves, the three erases, and the attributes. An
+escape this does not know is dropped rather than drawn, because a stray `[`
+in the middle of a menu row is worse than a missing colour.
+"""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass, field
+from typing import Final
+
+from gentoo_install.i18n import width
+
+#: `CSI ... final-byte`. The parameters are digits and semicolons, and every
+#: sequence `ncurses` emits ends in one letter.
+CSI: Final[re.Pattern[str]] = re.compile(r"\x1b\[([0-9;?]*)([A-Za-z])")
+
+#: Two-character escapes with no parameters, and the ones that take a string
+#: terminator. Neither draws anything.
+SHORT: Final[re.Pattern[str]] = re.compile(r"\x1b[()][0-9A-B]|\x1b[=>]|\x1b\][^\x07]*\x07")
+
+
+@dataclass
+class Screen:
+    """A grid of cells and a cursor, filled by `feed`."""
+
+    lines: int = 40
+    columns: int = 120
+    _rows: list[list[str]] = field(default_factory=list)
+    _reversed: list[list[bool]] = field(default_factory=list)
+    line: int = 0
+    column: int = 0
+    _reverse: bool = False
+
+    def __post_init__(self) -> None:
+        self._rows = [[" "] * self.columns for _ in range(self.lines)]
+        self._reversed = [[False] * self.columns for _ in range(self.lines)]
+
+    def text(self) -> str:
+        """Every row, trailing spaces removed, as one string."""
+        return "\n".join("".join(row).rstrip() for row in self._rows)
+
+    def banded(self) -> list[str]:
+        """The rows drawn in reverse video, which is what a heading is."""
+        return [
+            "".join(row).strip()
+            for row, marks in zip(self._rows, self._reversed)
+            if all(marks) and "".join(row).strip()
+        ]
+
+    def feed(self, data: bytes) -> None:
+        text = data.decode("utf-8", "replace")
+        at = 0
+        while at < len(text):
+            character = text[at]
+            if character == "\x1b":
+                found = CSI.match(text, at) or SHORT.match(text, at)
+                if found:
+                    if found.re is CSI:
+                        self._control(found.group(1), found.group(2))
+                    at = found.end()
+                    continue
+                # An escape this does not know: drop the escape alone, or the
+                # letter after it would be drawn into the middle of a row.
+                at += 1
+                continue
+            if character == "\r":
+                self.column = 0
+            elif character == "\n":
+                self.line = min(self.lines - 1, self.line + 1)
+                self.column = 0
+            elif character == "\b":
+                self.column = max(0, self.column - 1)
+            elif character >= " ":
+                self._put(character)
+            at += 1
+
+    def _put(self, character: str) -> None:
+        # A wide character owns two cells and the second is empty, the way the
+        # terminal itself lays it out: counting it as one put every column
+        # after a Chinese label one cell to the left.
+        cells = max(1, width(character))
+        if 0 <= self.line < self.lines and 0 <= self.column < self.columns:
+            self._rows[self.line][self.column] = character
+            self._reversed[self.line][self.column] = self._reverse
+            for offset in range(1, cells):
+                if self.column + offset < self.columns:
+                    self._rows[self.line][self.column + offset] = ""
+                    self._reversed[self.line][self.column + offset] = self._reverse
+        self.column += cells
+
+    def _control(self, parameters: str, final: str) -> None:
+        numbers = [int(one) for one in parameters.split(";") if one.isdigit()]
+        first = numbers[0] if numbers else 0
+        if final == "H":
+            self.line = max(0, (numbers[0] if numbers else 1) - 1)
+            self.column = max(0, (numbers[1] if len(numbers) > 1 else 1) - 1)
+        elif final in "ABCD":
+            step = first or 1
+            if final == "A":
+                self.line = max(0, self.line - step)
+            elif final == "B":
+                self.line = min(self.lines - 1, self.line + step)
+            elif final == "C":
+                self.column = min(self.columns - 1, self.column + step)
+            else:
+                self.column = max(0, self.column - step)
+        elif final == "G":
+            self.column = max(0, first - 1)
+        elif final == "J":
+            self._erase_display(first)
+        elif final == "K":
+            self._erase_line(first)
+        elif final == "X":
+            for offset in range(first or 1):
+                if self.column + offset < self.columns:
+                    self._rows[self.line][self.column + offset] = " "
+        elif final == "m":
+            for one in numbers or [0]:
+                if one == 0:
+                    self._reverse = False
+                elif one == 7:
+                    self._reverse = True
+                elif one == 27:
+                    self._reverse = False
+
+    def _erase_display(self, kind: int) -> None:
+        if kind == 2:
+            for line in range(self.lines):
+                self._blank(line, 0, self.columns)
+            return
+        if kind == 0:
+            self._blank(self.line, self.column, self.columns)
+            for line in range(self.line + 1, self.lines):
+                self._blank(line, 0, self.columns)
+        else:
+            for line in range(self.line):
+                self._blank(line, 0, self.columns)
+            self._blank(self.line, 0, self.column + 1)
+
+    def _erase_line(self, kind: int) -> None:
+        if kind == 1:
+            self._blank(self.line, 0, self.column + 1)
+        elif kind == 2:
+            self._blank(self.line, 0, self.columns)
+        else:
+            self._blank(self.line, self.column, self.columns)
+
+    def _blank(self, line: int, start: int, end: int) -> None:
+        for column in range(start, min(end, self.columns)):
+            self._rows[line][column] = " "
+            self._reversed[line][column] = False

--- a/tests/tui/session.py
+++ b/tests/tui/session.py
@@ -1,0 +1,258 @@
+# SPDX-License-Identifier: GPL-2.0-or-later
+"""A guest an operator can drive one keystroke at a time.
+
+The install fixtures hand the installer a configuration file, so the whole
+interface is skipped: a menu nobody can read still passes every one of them.
+This is the other half. A session boots a guest, leaves the installer at its
+first screen, and answers three questions from the command line: what is on
+the screen, what happens when this key is pressed, and what the run produced.
+
+The console is a websocket to the node, which no second process can inherit,
+so `start` leaves a daemon holding it and the other subcommands speak to that
+daemon over a unix socket beside the session's own directory.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import socket
+import sys
+import time
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Final
+
+from tests.tui.screen import Screen
+
+#: Where a session keeps its socket, its log and what it was asked to build.
+SESSIONS: Final[Path] = Path("lab/tui")
+
+#: What the operator types, as the terminal sends it. Named because an agent
+#: writing `\x1b[B` by hand gets it wrong once per session.
+KEYS: Final[dict[str, str]] = {
+    "up": "\x1b[A",
+    "down": "\x1b[B",
+    "left": "\x1b[D",
+    "right": "\x1b[C",
+    "enter": "\n",
+    "esc": "\x1b",
+    "escape": "\x1b",
+    "tab": "\t",
+    "space": " ",
+    "backspace": "\x7f",
+    "pageup": "\x1b[5~",
+    "pagedown": "\x1b[6~",
+    "home": "\x1b[H",
+    "end": "\x1b[F",
+    "help": "?",
+    "filter": "/",
+}
+
+#: The terminal the guest is given. Wide enough for two panes, tall enough
+#: that the whole list fits without the agent having to scroll to see it.
+from tests.vm.cluster import TUI_COLUMNS as SCREEN_COLUMNS
+from tests.vm.cluster import TUI_LINES as SCREEN_LINES
+
+#: How long the screen is allowed to keep changing before it is read. A menu
+#: redraws in one frame; a screen that fetches answers after a keystroke may
+#: take several, and reading too early shows the operator the previous page.
+SETTLE: Final[float] = 0.6
+
+
+class SessionError(Exception):
+    """Anything the operator can act on: a session that is not there, a key
+    with no name, a guest that stopped answering."""
+
+
+@dataclass(frozen=True)
+class Session:
+    """Where one session keeps its things."""
+
+    name: str
+
+    @property
+    def directory(self) -> Path:
+        return SESSIONS / self.name
+
+    @property
+    def control(self) -> Path:
+        return self.directory / "control"
+
+    @property
+    def transcript(self) -> Path:
+        """Every key sent, one per line, so the counts a report is judged on
+        are read off the session rather than taken from the agent."""
+        return self.directory / "keys.txt"
+
+
+def keys_from(words: list[str]) -> str:
+    """`down down enter` or a literal string, never a raw escape.
+
+    An agent that has to spell `\\x1b[B` spells it wrong, and a run lost to
+    that is a run that says nothing about the interface.
+    """
+    typed: list[str] = []
+    for word in words:
+        if word in KEYS:
+            typed.append(KEYS[word])
+        elif word.startswith("type:"):
+            typed.append(word[len("type:") :])
+        else:
+            raise SessionError(
+                f"{word} is not a key; use one of {', '.join(sorted(KEYS))} "
+                "or type:<text>"
+            )
+    return "".join(typed)
+
+
+def ask(
+    session: Session, message: dict[str, object], patience: float = 120.0
+) -> dict[str, str]:
+    """One request to the daemon holding the console."""
+    if not session.control.exists():
+        raise SessionError(f"no session named {session.name}")
+    with socket.socket(socket.AF_UNIX, socket.SOCK_STREAM) as channel:
+        channel.settimeout(patience)
+        channel.connect(str(session.control))
+        channel.sendall(json.dumps(message).encode() + b"\n")
+        answer = bytearray()
+        while not answer.endswith(b"\n"):
+            chunk = channel.recv(65536)
+            if not chunk:
+                break
+            answer.extend(chunk)
+    if not answer:
+        raise SessionError(f"the session {session.name} stopped answering")
+    answered: dict[str, str] = json.loads(answer.decode())
+    return answered
+
+
+
+
+def start(name: str, spec: int, node: str = "", vmid: int = 0) -> str:
+    """Build a guest and leave the installer at its first screen.
+
+    The same path an install fixture takes as far as the driver CD, and then
+    the other half: `install.sh` with no `--config`, which is the interface
+    this exists to exercise.
+    """
+    from tests.vm import cluster
+    from tests.vm.proxmox import Api
+
+    session = Session(name)
+    session.directory.mkdir(parents=True, exist_ok=True)
+    session.transcript.write_text("", encoding="utf-8")
+    (session.directory / "spec.txt").write_text(str(spec), encoding="utf-8")
+    api = Api()
+    held = cluster.tui_execution(api, node, name, spec, session.directory, vmid)
+    if os.fork() != 0:
+        return name
+    # The child holds the console; the parent's caller gets the name back and
+    # every other subcommand reaches this process through the socket.
+    os.setsid()
+    serve(session, held.console, held.guest)
+    os._exit(0)
+
+
+def serve(session: Session, console: object, guest: object) -> None:
+    """Hold the console and answer the other subcommands.
+
+    A websocket cannot be handed to a second process, so the process that
+    opened it stays and everything else talks to it here.
+    """
+    from tests.vm.console import SerialConsole
+
+    assert isinstance(console, SerialConsole)
+    grid = Screen(lines=SCREEN_LINES, columns=SCREEN_COLUMNS)
+    session.control.unlink(missing_ok=True)
+    listener = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+    listener.bind(str(session.control))
+    listener.listen(4)
+    listener.settimeout(1.0)
+    while True:
+        # Drain first, always: the guest writes whether or not anyone asked,
+        # and a screen read without draining is the previous page.
+        grid.feed(console.read_available(0.2))
+        try:
+            channel, _ = listener.accept()
+        except TimeoutError:
+            continue
+        with channel:
+            asked = channel.makefile("rb").readline()
+            if not asked:
+                continue
+            message = json.loads(asked.decode())
+            answer: dict[str, str] = {}
+            if message["do"] == "screen":
+                answer = {"screen": grid.text()}
+            elif message["do"] == "key":
+                console.send_raw(str(message["text"]))
+                answer = {"sent": "yes"}
+            elif message["do"] == "plan":
+                answer = {"plan": session.transcript.read_text(encoding="utf-8")}
+            elif message["do"] == "stop":
+                answer = {"stopped": "yes"}
+            channel.sendall(json.dumps(answer).encode() + b"\n")
+            if message["do"] == "stop":
+                break
+    listener.close()
+    session.control.unlink(missing_ok=True)
+    stop = getattr(guest, "destroy", None)
+    if stop is not None:
+        stop()
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    commands = parser.add_subparsers(dest="command", required=True)
+    for name, helped in (
+        ("screen", "print what the terminal is showing"),
+        ("plan", "print what the run produced"),
+        ("stop", "delete the guest"),
+    ):
+        one = commands.add_parser(name, help=helped)
+        one.add_argument("session")
+    opened = commands.add_parser("start", help="build a guest and open the menu")
+    opened.add_argument("session")
+    opened.add_argument("--spec", type=int, required=True)
+    opened.add_argument("--node", default="")
+    opened.add_argument("--vmid", type=int, default=0)
+    typed = commands.add_parser("key", help="press keys, in order")
+    typed.add_argument("session")
+    typed.add_argument("keys", nargs="+")
+    commands.add_parser("list", help="every session on this machine")
+    arguments = parser.parse_args(argv)
+
+    if arguments.command == "list":
+        for found in sorted(SESSIONS.glob("*/control")):
+            print(found.parent.name)
+        return 0
+
+    session = Session(arguments.session)
+    if arguments.command == "start":
+        print(start(arguments.session, arguments.spec, arguments.node, arguments.vmid))
+        return 0
+    if arguments.command == "key":
+        sent = keys_from(arguments.keys)
+        with session.transcript.open("a", encoding="utf-8") as log:
+            log.write(" ".join(arguments.keys) + "\n")
+        ask(session, {"do": "key", "text": sent})
+        time.sleep(SETTLE)
+        print(ask(session, {"do": "screen"})["screen"])
+        return 0
+    if arguments.command == "screen":
+        print(ask(session, {"do": "screen"})["screen"])
+        return 0
+    if arguments.command == "plan":
+        print(ask(session, {"do": "plan"})["plan"])
+        return 0
+    if arguments.command == "stop":
+        ask(session, {"do": "stop"})
+        return 0
+    return 2
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/tui/specs.py
+++ b/tests/tui/specs.py
@@ -1,0 +1,93 @@
+# SPDX-License-Identifier: GPL-2.0-or-later
+"""What each session is asked to build, in the words an operator would use.
+
+Not a configuration file. Every install fixture hands the installer a `.toml`
+and the interface is never read; these are sentences, and finding the rows
+that answer them is the whole test. A spec that named `disk.filesystem` would
+be telling the agent where to look, which is the question being asked.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Final
+
+
+@dataclass(frozen=True)
+class Spec:
+    """One machine to build, and how to tell whether it was."""
+
+    number: int
+    #: What the operator wants, as they would say it.
+    wanted: str
+    #: What the installed machine must show for the run to have answered the
+    #: spec. Read off the machine after it boots, never from the agent.
+    proof: tuple[str, ...]
+
+
+#: Every password in every spec. One value, because a test that fails on a
+#: mistyped password says nothing about the interface.
+PASSWORD: Final[str] = "testtest"
+
+SPECS: Final[dict[int, Spec]] = {
+    1: Spec(
+        number=1,
+        wanted=(
+            "Install Gentoo onto the whole 40 GiB disk. The machine boots with "
+            "UEFI and should use GRUB. Use btrfs for the root filesystem. The "
+            "system should come up in Traditional Chinese with a CJK font, in "
+            "the Asia/Taipei timezone, and be called lab1. Set the root "
+            f"password to {PASSWORD}. Add a user called zakk with the same "
+            "password who can use sudo. No desktop environment."
+        ),
+        proof=(
+            "hostname is lab1",
+            "the root filesystem is btrfs",
+            "the bootloader is grub and the firmware is uefi",
+            "/etc/localtime points at Asia/Taipei",
+            "zh_TW.UTF-8 is in /etc/locale.gen",
+            "zakk exists and is in the wheel group",
+        ),
+    ),
+    2: Spec(
+        number=2,
+        wanted=(
+            "This machine has two disks. Install onto them with the root "
+            f"filesystem encrypted, using the passphrase {PASSWORD}. Give "
+            "/home a partition of its own. Use ext4. The machine boots with "
+            "BIOS, not UEFI. Use OpenRC rather than systemd. The system should "
+            "come up in Simplified Chinese, timezone Asia/Shanghai. Set the "
+            f"root password to {PASSWORD}."
+        ),
+        proof=(
+            "the root filesystem sits on a LUKS container",
+            "/home is a separate filesystem",
+            "the root filesystem is ext4",
+            "the init system is openrc",
+            "zh_CN.UTF-8 is in /etc/locale.gen",
+        ),
+    ),
+    3: Spec(
+        number=3,
+        wanted=(
+            "This machine is already running a system. Replace it with Gentoo "
+            "in place, keeping everything under /home. Set the root password "
+            f"to {PASSWORD}."
+        ),
+        proof=(
+            "the machine boots into Gentoo",
+            "the files that were under /home are still there",
+        ),
+    ),
+    4: Spec(
+        number=4,
+        wanted=(
+            "Move the installer into memory first, then install onto the disk "
+            f"from there. Set the root password to {PASSWORD}."
+        ),
+        proof=(
+            "the installer ran from a memory-held medium",
+            "the machine boots into Gentoo",
+        ),
+    ),
+}

--- a/tests/unit/test_tui_report.py
+++ b/tests/unit/test_tui_report.py
@@ -1,0 +1,118 @@
+# SPDX-License-Identifier: GPL-2.0-or-later
+"""The five counts, each against a session that produces it and one that does not.
+
+Every count here has a negative control in the same test: a session whose
+screens differ only in the thing being counted. A count that answers the same
+number for both is measuring the session's length, not the interface.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from tests.tui.report import STUCK_AFTER, Report, read, title_of
+
+#: A framed pane, as `TwoPane.frame` draws it. The heading names the open row.
+def frame(name: str, rows: tuple[tuple[str, str], ...]) -> str:
+    lines = [f"+- {name} " + "-" * 20 + "+"]
+    lines += [f"{one.ljust(20)}| {other}" for one, other in rows]
+    return "\n".join(lines)
+
+
+def session(directory: Path, screens: list[str], keys: list[str]) -> Path:
+    directory.mkdir(parents=True, exist_ok=True)
+    (directory / "screens.txt").write_text("\f".join(screens), encoding="utf-8")
+    (directory / "keys.txt").write_text("\n".join(keys) + "\n", encoding="utf-8")
+    return directory
+
+
+DISK = (("* Disk", "/dev/sda"), ("  Hostname", "lab1"))
+CHANGED = (("* Disk", "/dev/sdb"), ("  Hostname", "lab1"))
+
+
+def test_the_frame_names_the_open_row_not_the_title_bar() -> None:
+    """`gentoo-install` is on every screen, so it identifies none of them."""
+    assert title_of(frame("Partitioning", DISK)) == "Partitioning"
+    # Negative control: a screen with no frame falls back to its first line,
+    # and must not answer with the box drawing of a screen that has one.
+    assert title_of("Mirrors\n  gentoo") == "Mirrors"
+
+
+def test_a_row_opened_and_left_unchanged_counts_as_lost(tmp_path: Path) -> None:
+    """The count that says a row's own name failed to say what it was."""
+    inside = frame("Disk", DISK)
+    lost = read(
+        session(
+            tmp_path / "lost",
+            [frame("Partitioning", DISK), inside, frame("Partitioning", DISK)],
+            ["enter", "esc", "down"],
+        )
+    )
+    assert lost.lost == ("Disk",), lost
+
+    # Negative control: the same three screens and the same two keys, with one
+    # value different on the way out. Nothing was lost; something was set.
+    found = read(
+        session(
+            tmp_path / "found",
+            [frame("Partitioning", DISK), inside, frame("Partitioning", CHANGED)],
+            ["enter", "esc", "down"],
+        )
+    )
+    assert found.lost == (), found
+
+
+def test_a_screen_that_outlasts_answering_it_counts_as_stuck(tmp_path: Path) -> None:
+    same = frame("Mirrors", DISK)
+    stuck = read(session(tmp_path / "stuck", [same] * (STUCK_AFTER + 2), ["down"]))
+    assert stuck.stuck == ("Mirrors",), stuck
+
+    # Negative control: the same number of screens, moving through rows. Length
+    # alone must not produce the count.
+    moving = [frame(f"Row {at}", DISK) for at in range(STUCK_AFTER + 2)]
+    assert read(session(tmp_path / "moving", moving, ["down"])).stuck == ()
+
+
+def test_asking_for_help_and_being_refused_are_counted(tmp_path: Path) -> None:
+    refused = frame("Extra packages", (("Not a package name: code", ""),))
+    one = read(
+        session(tmp_path / "asked", [frame("Disk", DISK), refused], ["help", "type:code"])
+    )
+    assert one.helped == 1 and one.refused == 1, one
+
+    # Negative control: the same length of session with neither.
+    quiet = read(
+        session(tmp_path / "quiet", [frame("Disk", DISK)] * 2, ["down", "type:code"])
+    )
+    assert quiet.helped == 0 and quiet.refused == 0, quiet
+
+
+def test_a_session_that_never_reached_the_install_row_is_unfinished(tmp_path: Path) -> None:
+    assert not read(session(tmp_path / "part", [frame("Disk", DISK)], ["down"])).finished
+    done = read(session(tmp_path / "done", [frame("Install", DISK)], ["enter"]))
+    assert done.finished, done
+
+
+def test_reading_a_session_that_left_nothing_behind_answers_zero(tmp_path: Path) -> None:
+    """A guest killed before its first screen must not read as a finished run."""
+    empty = read(tmp_path / "never-ran")
+    assert empty == Report(finished=False, lost=(), helped=0, stuck=(), refused=0)
+
+
+def test_a_translated_screen_is_counted_the_same_as_an_english_one(tmp_path: Path) -> None:
+    """A session runs in its spec's language, so the counts read the catalogs.
+
+    The words come from the catalog rather than from a literal in this file:
+    a translated string pasted here goes stale the next time the wording is
+    corrected, and passes while measuring nothing.
+    """
+    from gentoo_install.i18n import Catalog
+
+    done = Catalog("zh-TW")("Install")
+    assert done != "Install", "the catalog has no translation to test against"
+    reached = read(session(tmp_path / "zh", [frame(done, DISK)], ["enter"]))
+    assert reached.finished, reached
+
+    # Negative control: a screen whose heading is a word no catalog maps
+    # `Install` to must not be read as having reached it.
+    assert not read(session(tmp_path / "no", [frame("Kernel", DISK)], ["enter"])).finished

--- a/tests/unit/test_tui_screen.py
+++ b/tests/unit/test_tui_screen.py
@@ -1,0 +1,53 @@
+# SPDX-License-Identifier: GPL-2.0-or-later
+"""The screen an agent reads, rebuilt from what the interface wrote."""
+
+from __future__ import annotations
+
+from gentoo_install.i18n import width
+
+from tests.tui.screen import Screen
+
+
+def test_the_last_write_to_a_cell_is_what_is_on_screen() -> None:
+    """`ncurses` repaints by moving the cursor and writing over cells, so the
+    same row appears many times in the stream. Reading the stream instead of
+    the screen shows every draft of the menu at once."""
+    grid = Screen(lines=4, columns=20)
+    grid.feed(b"\x1b[1;1Hfirst\x1b[1;1Hsecond")
+    assert grid.text().splitlines()[0] == "second"
+
+
+def test_a_wide_character_owns_two_cells() -> None:
+    """Counting it as one put every column after a Chinese label one cell to
+    the left, and the pane's right edge landed inside the text."""
+    grid = Screen(lines=2, columns=12)
+    # Two wide characters fill cells 0 to 3, so the escape that names column
+    # 7 lands two cells further on. Counting them as one puts it four on.
+    grid.feed("\u5206\u5340\x1b[1;7H|".encode())
+    row = grid.text().splitlines()[0]
+    assert row == "\u5206\u5340  |", repr(row)
+    assert width(row) == 7
+
+
+def test_a_band_is_the_row_drawn_in_reverse_video() -> None:
+    """What a section heading is: the agent finds them without knowing what
+    the interface calls its sections."""
+    grid = Screen(lines=3, columns=10)
+    grid.feed(b"\x1b[1;1H\x1b[7m   Disks  \x1b[m\x1b[2;1Hplain")
+    assert grid.banded() == ["Disks"]
+
+
+def test_an_erase_clears_what_it_names_and_no_more() -> None:
+    grid = Screen(lines=3, columns=8)
+    grid.feed(b"\x1b[1;1Habcdefgh\x1b[2;1Hijkl\x1b[1;4H\x1b[K")
+    rows = grid.text().splitlines()
+    assert rows[0] == "abc"
+    assert rows[1] == "ijkl"
+
+
+def test_an_escape_it_does_not_know_draws_nothing() -> None:
+    """A stray `[` in the middle of a menu row is worse than a missing
+    colour, so an unknown escape is dropped rather than printed."""
+    grid = Screen(lines=2, columns=12)
+    grid.feed(b"\x1b(B\x1b=ok\x1b>\x1b]0;title\x07!")
+    assert grid.text().splitlines()[0] == "ok!"

--- a/tests/vm/cluster.py
+++ b/tests/vm/cluster.py
@@ -31,6 +31,8 @@ import sys
 import threading
 import time
 import uuid
+
+from gentoo_install.plan.netboot import CJK_RELEASES
 import urllib.parse
 import urllib.request
 from dataclasses import dataclass, field, replace
@@ -650,6 +652,33 @@ def _expected_sha512(digests: Path, name: str) -> str:
 
 def _medium_name(name: str, sha512: str) -> str:
     return f"{Path(name).stem}-{sha512[:20]}.iso"
+
+
+def current_cjk() -> tuple[str, tuple[str, ...], str]:
+    """The current CJK live CD, its download and its published SHA-256.
+
+    Read from the release index rather than pinned: the asset name carries
+    the build timestamp, and the one this was first written against was gone
+    from the index within the week.
+    """
+    with urllib.request.urlopen(CJK_RELEASES, timeout=30.0) as answer:
+        release = json.loads(answer.read().decode("utf-8", "replace"))
+    assets = {one["name"]: one["browser_download_url"] for one in release["assets"]}
+    image = next((name for name in assets if name.endswith(".iso")), "")
+    if not image:
+        raise RuntimeError(f"no iso among {sorted(assets)} in {release.get('tag_name')}")
+    digest = ""
+    for name, url in assets.items():
+        if name == f"{image}.sha256" or name.endswith("DIGESTS"):
+            with urllib.request.urlopen(url, timeout=30.0) as answer:
+                said = answer.read().decode("utf-8", "replace")
+            for line in said.splitlines():
+                if image in line or len(line.split()) == 2:
+                    digest = line.split()[0]
+                    break
+        if digest:
+            break
+    return image, (assets[image],), digest
 
 
 def current_minimal() -> tuple[str, tuple[str, ...], str]:
@@ -1505,6 +1534,9 @@ class Running:
     reservation_bytes: int
     address: str = ""
     created: bool = False
+    #: Held open by a session so the operator's keys reach the same terminal
+    #: the screen was read from.
+    console: object | None = None
 
 
 #: What a guest needs beyond its install: the boots either side of it and the
@@ -1743,6 +1775,104 @@ def _note_the_probe(link: Reconnecting, when: str) -> None:
         link.run(REACHABILITY_PROBE, timeout=120.0)
     except (ConsoleTimeout, ConsoleClosed) as error:
         print(f"the {when} reachability probe did not answer: {error}", flush=True)
+
+
+#: What each session's guest is built as. The spec is a sentence the agent
+#: is given; the shape here is only what the machine needs to exist, and it
+#: is deliberately the same for all four so a difference in the report is a
+#: difference in the interface rather than in the hardware.
+#: The grid the session reads and the guest draws on. One number, so the two
+#: cannot drift: a serial line carries no size and ncurses guesses 80x24.
+TUI_LINES: Final[int] = 40
+TUI_COLUMNS: Final[int] = 120
+
+#: Disks, firmware, and whether the guest needs the CJK medium. The official
+#: minimal ISO carries no CJK font, so a Chinese session on it reads as a
+#: screen of empty boxes and says nothing about the wording. `gentoo-zh`'s
+#: own live CD carries cjktty and the fonts.
+TUI_GUESTS: Final[dict[int, tuple[int, bool, bool]]] = {
+    1: (1, True, True),
+    2: (2, False, True),
+    3: (1, True, True),
+    4: (1, True, True),
+}
+
+
+def tui_job(name: str, spec: int) -> Job:
+    """A job that carries no fixture, because there is nothing to hand over.
+
+    Every other job names a configuration file. This one names none: what the
+    installer is asked to build is typed into it by the operator.
+    """
+    if spec not in TUI_GUESTS:
+        raise ValueError(f"no spec {spec}; there are {sorted(TUI_GUESTS)}")
+    disks, uefi, _cjk = TUI_GUESTS[spec]
+    return Job(name=name, fixture=Path(), disks=disks, uefi=uefi)
+
+
+def tui_execution(
+    api: Api, node: str, name: str, spec: int, workdir: Path, vmid: int = 0
+) -> Running:
+    """A guest with the installer at its first screen and nothing answered.
+
+    Every fixture hands the installer a configuration file, so the interface
+    is never exercised: a menu nobody can read passes all forty of them. This
+    is the other half, and it takes the same path as far as the driver CD.
+    """
+    # Most free node first, the same order the schedule uses. The node is
+    # chosen here rather than by the caller so two sessions started at once
+    # cannot both take the last slot on one node.
+    chosen = node or free_slots(api)[0].name
+    # The medium and the driver CD are per node, and `local` is not shared:
+    # a session that skipped this asked the node for `iso/minimal`, which is
+    # the name before it is uploaded and not a volume the node has.
+    # `build` names the ISO it writes, so this is a file and not a directory
+    # to write into; `retain_driver` then moves it to its content-derived name.
+    print(f"{name}: building the driver CD", flush=True)
+    written = workdir / "driver.iso"
+    driver_path = retain_driver(workdir, build_driver(written, packed=True))
+    # The CJK live CD for a session, because the interface is Chinese and the
+    # official minimal ISO has no font for it: every label would read as a row
+    # of empty boxes and the run would say nothing about the wording.
+    medium, urls, medium_sha512 = (
+        current_cjk() if TUI_GUESTS[spec][2] else current_minimal()
+    )
+    print(f"{name}: uploading {medium} to {chosen}", flush=True)
+    prepare(
+        api, chosen, medium, urls, medium_sha512, MEDIUM_TRUST,
+        driver_path, driver_path.name,
+    )
+    job = replace(tui_job(name, spec), iso=medium)
+    held = _execution(
+        api, chosen, job, driver_path.name, workdir, vmid=vmid, nonce=uuid.uuid4().hex
+    )
+    guest = cast(Guest, held.guest)
+    print(f"{name}: booting {guest.vmid} on {chosen}", flush=True)
+    guest.create()
+    guest.start()
+    link = Reconnecting.to(guest, held.watch.log)
+    guest.reset()
+    if job.uefi:
+        _edit_uefi_cmdline(guest, link)
+    else:
+        _edit_bios_cmdline(guest, link)
+    print(f"{name}: waiting for the live medium", flush=True)
+    reach_prompt(link)
+    wait_for_network(link, guest.vmid, held.address)
+    link.run(FIND_DRIVER)
+    link.run(f"mkdir -p {RESULT_DIR}")
+    # Both ends have to agree on the size or the interface draws for one grid
+    # and is read on another: a serial line reports nothing, so ncurses fell
+    # back to 80x24 while the screen was rebuilt at 120x40 and every row past
+    # column 80 was read from the wrong cells.
+    link.run(f"stty rows {TUI_LINES} cols {TUI_COLUMNS}")
+    # No `--config`: the menu is the subject.
+    link.console.send(
+        f"TERM=xterm LINES={TUI_LINES} COLUMNS={TUI_COLUMNS} "
+        "sh /mnt/driver/install.sh --lang zh-TW"
+    )
+    held.console = link.console
+    return held
 
 
 def install_one(

--- a/tests/vm/console.py
+++ b/tests/vm/console.py
@@ -359,6 +359,25 @@ class SerialConsole:
         self._buffer = b""
         return bytes(got)
 
+    def read_available(self, seconds: float) -> bytes:
+        """What arrived, escapes and all.
+
+        `drain` discards and `expect` strips the escapes to match a pattern.
+        Rebuilding the screen needs them: the cursor moves are how `ncurses`
+        says which cell it is overwriting, and text with them removed is every
+        draft of the menu run together.
+        """
+        got = bytearray()
+        deadline = time.monotonic() + seconds
+        while time.monotonic() < deadline:
+            try:
+                self._read_once()
+            except ConsoleClosed:
+                break
+            got += self._last_chunk
+        self._buffer = b""
+        return bytes(got)
+
     def drain(self, seconds: float) -> None:
         """Read and discard for a while.
 


### PR DESCRIPTION
Every fixture hands the installer a `--config` file, so no run has ever read
the interface: a menu nobody can read passes all forty. These five commits
boot a guest into `install.sh --lang zh-TW` with no configuration, rebuild
its screen from the console's own escapes, and count what a session cost from
the keys pressed rather than from the operator's account of it.