### PR TITLE
cluster: place a medium the nodes cannot download

### DIFF
--- a/tests/unit/test_cluster.py
+++ b/tests/unit/test_cluster.py
@@ -3,8 +3,11 @@ from __future__ import annotations
 
 from typing import Any, cast
 
+import hashlib
+import io
 import re
 import time
+import urllib.request
 from collections.abc import Callable
 from io import BytesIO
 from pathlib import Path
@@ -3385,3 +3388,88 @@ def test_a_machine_that_booted_is_asked_what_its_stub_holds() -> None:
         and node.func.id == "after_the_boot"
         for node in ast.walk(asked)
     ), "boot_and_check never asks what the stub holds"
+
+
+def test_a_local_copy_is_sent_and_the_node_is_never_asked_to_fetch(
+    tmp_path: Path,
+) -> None:
+    """The node reaches the Chinese Gentoo mirrors and nothing else.
+
+    Asked for a GitHub release it starts a download task that never
+    progresses, and `fetch_iso` waits an hour: one session sat fifteen minutes
+    with no output before its own timeout ended it.
+    """
+    from tests.vm import cluster
+
+    asked: list[str] = []
+    sent: list[Path] = []
+
+    class Placing:
+        def isos(self, node: str) -> list[str]:
+            return []
+
+        def fetch_iso(self, node: str, url: str, name: str, sha512: str) -> None:
+            asked.append(url)
+
+        def send_iso(self, node: str, path: Path, name: str, sha512: str) -> None:
+            sent.append(path)
+
+        def stale_drivers(self, node: str, keep: str, older_than: float) -> list[str]:
+            return []
+
+        def upload_iso(self, node: str, path: Path, name: str) -> str:
+            return name
+
+    copy = tmp_path / "medium.iso"
+    copy.write_bytes(b"medium")
+    driver = tmp_path / "driver.iso"
+    driver.write_bytes(b"driver")
+    api = cast(Any, Placing())
+    cluster.prepare(
+        api, "infra-node6", "medium.iso", ("https://github.example/medium.iso",),
+        "ab" * 64, tmp_path / "trust", driver, driver.name, local=copy,
+    )
+    assert sent == [copy] and asked == []
+
+    # Negative control: with no local copy the URLs are what is used, in order.
+    cluster.prepare(
+        api, "infra-node6", "medium.iso", ("https://one.example/m", "https://two.example/m"),
+        "ab" * 64, tmp_path / "trust", driver, driver.name,
+    )
+    assert asked == ["https://one.example/m"] and sent == [copy]
+
+
+def test_a_cached_medium_with_the_wrong_checksum_is_fetched_again(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A truncated download left behind reads as a medium until it is booted."""
+    from tests.vm import cluster
+
+    monkeypatch.setattr(cluster, "MEDIA_CACHE", tmp_path / "media")
+    body = b"the whole medium"
+    want = hashlib.sha512(body).hexdigest()
+
+    served: list[str] = []
+
+    class Answer(io.BytesIO):
+        def __enter__(self) -> Answer:
+            return self
+
+        def __exit__(self, *rest: object) -> None:
+            return None
+
+    def open_url(url: str, timeout: float = 0.0) -> Answer:
+        served.append(url)
+        return Answer(body)
+
+    monkeypatch.setattr(urllib.request, "urlopen", open_url)
+    stale = tmp_path / "media" / "medium.iso"
+    stale.parent.mkdir(parents=True)
+    stale.write_bytes(b"half of it")
+    got = cluster.cached_medium("medium.iso", ("https://one.example/m",), want)
+    assert got.read_bytes() == body and served == ["https://one.example/m"]
+
+    # Negative control: the same call against the now-correct file downloads
+    # nothing, or every session would re-fetch a gigabyte it already has.
+    again = cluster.cached_medium("medium.iso", ("https://one.example/m",), want)
+    assert again == got and served == ["https://one.example/m"]

--- a/tests/unit/test_proxmox.py
+++ b/tests/unit/test_proxmox.py
@@ -4506,3 +4506,22 @@ def test_a_guest_replaced_between_the_two_reads_is_not_deleted() -> None:
         guest.destroy(patience=5.0)
     assert not api.deleted, "the guest that replaced ours was deleted"
 
+
+
+def test_the_checksum_fields_precede_the_file_in_the_upload_body() -> None:
+    """The endpoint reads the form in order and ignores a checksum after it.
+
+    Sent the other way round the upload still succeeds, and the medium lands
+    unverified: the failure is a wrong file that every later check trusts.
+    """
+    from tests.vm.proxmox import _multipart_head
+
+    head = _multipart_head("Xbound", "medium.iso", "ab" * 64).decode()
+    checksum = head.index('name="checksum"')
+    filename = head.index('name="filename"')
+    assert checksum < filename, head
+
+    # Negative control: the algorithm has to be there too, or PVE reads the
+    # 128 characters as the default and refuses the upload it already took.
+    assert 'name="checksum-algorithm"' in head and "sha512" in head
+    assert head.count("--Xbound") == 4, head

--- a/tests/vm/cluster.py
+++ b/tests/vm/cluster.py
@@ -18,11 +18,13 @@ from __future__ import annotations
 
 import argparse
 import fcntl
+import hashlib
 import ipaddress
 import itertools
 import json
 import os
 import queue
+import shutil
 import signal
 import re
 import socket
@@ -33,6 +35,7 @@ import time
 import uuid
 
 from gentoo_install.plan.netboot import CJK_RELEASES
+import urllib.error
 import urllib.parse
 import urllib.request
 from dataclasses import dataclass, field, replace
@@ -128,6 +131,10 @@ ADDRESS_POOL_ROOT: Final[Path] = Path.home() / "code/gentoo-install/lab/vm/addre
 #: uploaded it. A fresh work directory otherwise met its own upload as
 #: `already exists on infra-node5 without its signed SHA-512 record`.
 MEDIUM_TRUST: Final[Path] = WORKROOT / "medium-trust"
+
+#: The workstation's own copy of a medium the cluster cannot download, kept
+#: outside a round for the same reason as the trust record above.
+MEDIA_CACHE: Final[Path] = WORKROOT / "media"
 
 #: Where the guest gathers what the run produced before it is read back.
 RESULT_DIR: Final[str] = "/tmp/gentoo-install-results"
@@ -655,7 +662,7 @@ def _medium_name(name: str, sha512: str) -> str:
 
 
 def current_cjk() -> tuple[str, tuple[str, ...], str]:
-    """The current CJK live CD, its download and its published SHA-256.
+    """The current CJK live CD, its download and its published SHA-512.
 
     Read from the release index rather than pinned: the asset name carries
     the build timestamp, and the one this was first written against was gone
@@ -679,6 +686,46 @@ def current_cjk() -> tuple[str, tuple[str, ...], str]:
         if digest:
             break
     return image, (assets[image],), digest
+
+
+
+def cached_medium(medium: str, urls: tuple[str, ...], sha512: str) -> Path:
+    """The workstation's own copy, downloaded once and kept.
+
+    The cluster reaches the Chinese Gentoo mirrors and nothing else: GitHub,
+    where the CJK live CD is published, answers a node with a closed
+    connection, so `fetch_iso` waits an hour for a task that never starts.
+    The workstation does reach it, and `send_iso` puts the file on the node
+    over the cluster's own certificate.
+    """
+    kept = MEDIA_CACHE / medium
+    if kept.is_file() and _sha512(kept) == sha512:
+        return kept
+    kept.parent.mkdir(parents=True, exist_ok=True)
+    partial = kept.with_suffix(kept.suffix + ".part")
+    last = ""
+    for url in urls:
+        try:
+            with urllib.request.urlopen(url, timeout=60.0) as answer, partial.open("wb") as out:
+                shutil.copyfileobj(answer, out)
+        except (urllib.error.URLError, TimeoutError, OSError) as error:
+            last = str(error)
+            continue
+        if _sha512(partial) != sha512:
+            last = f"{url} served {medium} with the wrong checksum"
+            continue
+        partial.replace(kept)
+        return kept
+    partial.unlink(missing_ok=True)
+    raise ProxmoxError(f"no source served {medium} to the workstation: {last}")
+
+
+def _sha512(path: Path) -> str:
+    digest = hashlib.sha512()
+    with path.open("rb") as handle:
+        for block in iter(lambda: handle.read(1 << 20), b""):
+            digest.update(block)
+    return digest.hexdigest()
 
 
 def current_minimal() -> tuple[str, tuple[str, ...], str]:
@@ -717,6 +764,33 @@ def current_minimal() -> tuple[str, tuple[str, ...], str]:
     raise SystemExit("no mirror named an install medium")
 
 
+def _place(
+    api: Api,
+    node: str,
+    medium: str,
+    urls: tuple[str, ...],
+    sha512: str,
+    local: Path | None,
+) -> None:
+    """Get one medium onto a node, by whichever route can reach it.
+
+    A local copy is sent rather than fetched: the node reaches the Chinese
+    Gentoo mirrors and nothing else, so asking it for a GitHub release starts
+    a download task that never progresses and `fetch_iso` waits an hour.
+    """
+    if local is not None:
+        api.send_iso(node, local, medium, sha512)
+        return
+    last = ""
+    for url in urls:
+        try:
+            api.fetch_iso(node, url, medium, sha512)
+            return
+        except ProxmoxError as error:
+            last = str(error)
+    raise ProxmoxError(f"no mirror served {medium} to {node}: {last}")
+
+
 def prepare(
     api: Api,
     node: str,
@@ -726,6 +800,7 @@ def prepare(
     trust: Path,
     driver_path: Path,
     driver: str,
+    local: Path | None = None,
 ) -> None:
     """Put the medium and the driver CD on one node's `local` storage.
 
@@ -743,27 +818,11 @@ def prepare(
             reason = api.remove_iso(node, medium)
             if reason:
                 raise ProxmoxError(f"{medium} could not be replaced on {node}: {reason}")
-            last = ""
-            for url in urls:
-                try:
-                    api.fetch_iso(node, url, medium, sha512)
-                    break
-                except ProxmoxError as error:
-                    last = str(error)
-            else:
-                raise ProxmoxError(f"no mirror served {medium} to {node}: {last}")
+            _place(api, node, medium, urls, sha512, local)
             stamp.parent.mkdir(parents=True, exist_ok=True)
             stamp.write_text(sha512)
     else:
-        last = ""
-        for url in urls:
-            try:
-                api.fetch_iso(node, url, medium, sha512)
-                break
-            except ProxmoxError as error:
-                last = str(error)
-        else:
-            raise ProxmoxError(f"no mirror served {medium} to {node}: {last}")
+        _place(api, node, medium, urls, sha512, local)
         stamp.parent.mkdir(parents=True, exist_ok=True)
         stamp.write_text(sha512)
     for stale in api.stale_drivers(node, driver, DRIVER_KEPT_SECONDS):
@@ -1834,13 +1893,13 @@ def tui_execution(
     # The CJK live CD for a session, because the interface is Chinese and the
     # official minimal ISO has no font for it: every label would read as a row
     # of empty boxes and the run would say nothing about the wording.
-    medium, urls, medium_sha512 = (
-        current_cjk() if TUI_GUESTS[spec][2] else current_minimal()
-    )
-    print(f"{name}: uploading {medium} to {chosen}", flush=True)
+    cjk = TUI_GUESTS[spec][2]
+    medium, urls, medium_sha512 = current_cjk() if cjk else current_minimal()
+    print(f"{name}: placing {medium} on {chosen}", flush=True)
     prepare(
         api, chosen, medium, urls, medium_sha512, MEDIUM_TRUST,
         driver_path, driver_path.name,
+        local=cached_medium(medium, urls, medium_sha512) if cjk else None,
     )
     job = replace(tui_job(name, spec), iso=medium)
     held = _execution(

--- a/tests/vm/proxmox.py
+++ b/tests/vm/proxmox.py
@@ -18,6 +18,7 @@ VMID.
 
 from __future__ import annotations
 
+import http.client
 import json
 import re
 import ssl
@@ -66,6 +67,18 @@ CREATE_PAUSE: Final[float] = 10.0
 
 DISK_STORAGE: Final[str] = "ceph-pve"
 ISO_STORAGE: Final[str] = "local"
+
+#: Where a node's own API answers, and the bridge its address is read from.
+#: Used only for a medium too large for the proxy in front of the cluster.
+NODE_PORT: Final[int] = 8006
+NODE_BRIDGE: Final[str] = "vmbr0"
+
+#: A gigabyte over the workstation's link, plus the node's own checksum pass.
+MEDIUM_PATIENCE: Final[float] = 3600.0
+
+#: How much of the file each TLS record carries. The default 8 KiB turns a
+#: 989 MB medium into 120000 records and took five times as long as `curl`.
+MEDIUM_BLOCK: Final[int] = 1 << 20
 
 #: Long enough for a stage3 to extract over a slow mirror, short enough that a
 #: node that stopped answering does not hold the whole campaign.
@@ -163,6 +176,27 @@ def _http_exception(method: str, path: str, error: urllib.error.HTTPError) -> Pr
     if error.code in (429, 502, 503, 504, 595) or retryable_500:
         return ProxmoxTransientError(message)
     return ProxmoxError(message)
+
+
+def _multipart_head(boundary: str, name: str, sha512: str) -> bytes:
+    """Everything of the body that comes before the file's own bytes.
+
+    Separated so a test can read it without a node: the field order is what
+    the endpoint checks, and it rejects a checksum sent after the file.
+    """
+    parts = [("content", "iso"), ("checksum-algorithm", "sha512"), ("checksum", sha512)]
+    body = b""
+    for field, value in parts:
+        body += (
+            f"--{boundary}\r\n"
+            f'Content-Disposition: form-data; name="{field}"\r\n\r\n{value}\r\n'
+        ).encode()
+    body += (
+        f"--{boundary}\r\n"
+        f'Content-Disposition: form-data; name="filename"; filename="{name}"\r\n'
+        "Content-Type: application/octet-stream\r\n\r\n"
+    ).encode()
+    return body
 
 
 def _certificates() -> ssl.SSLContext:
@@ -412,6 +446,82 @@ class Api:
         if isinstance(upid, str) and upid.startswith("UPID"):
             self.wait(node, upid, patience=600.0)
         return name
+
+    def node_certificate(self, node: str) -> str:
+        """The cluster CA, read over the connection that is already verified.
+
+        A node's own address serves a certificate that CA signed and the public
+        trust store does not carry, so a direct connection needs this as its
+        root. Asked of the proxy rather than of the node, because trusting a
+        root the unverified peer handed over verifies nothing.
+        """
+        for one in self.call("GET", f"/nodes/{node}/certificates/info"):
+            if str(one.get("filename")) == "pve-root-ca.pem":
+                return str(one.get("pem", ""))
+        raise ProxmoxError(f"{node} did not report its cluster CA")
+
+    def node_address(self, node: str) -> str:
+        """The address the node answers its own API on."""
+        for one in self.call("GET", f"/nodes/{node}/network"):
+            if str(one.get("iface")) == NODE_BRIDGE and one.get("address"):
+                return str(one["address"])
+        raise ProxmoxError(f"{node} has no address on {NODE_BRIDGE}")
+
+    def send_iso(self, node: str, path: Path, name: str, sha512: str) -> None:
+        """Upload a medium to the node itself, streaming it from disk.
+
+        Two reasons this does not go through `upload_iso`. The proxy in front
+        of the cluster answers `413 Request Entity Too Large` to a 989 MB body
+        within seconds, and `upload_iso` reads the whole file into memory,
+        which a medium does not fit in beside a campaign.
+
+        The node's certificate carries its address in `subjectAltName` and the
+        cluster CA signs it, so this verifies exactly as strictly as every
+        other call: the token still only goes to a peer holding a certificate
+        the trusted proxy vouched for.
+        """
+        context = ssl.create_default_context(cadata=self.node_certificate(node))
+        # The chain and the hostname are still checked against that CA; only
+        # RFC 5280's optional-extension rules are not. Python 3.13 turned
+        # VERIFY_X509_STRICT on by default and PVE's own CA carries no
+        # keyUsage, so the strict flag refuses every node in the cluster.
+        context.verify_flags &= ~ssl.VERIFY_X509_STRICT
+        boundary = "----" + uuid.uuid4().hex
+        head = _multipart_head(boundary, name, sha512)
+        tail = f"\r\n--{boundary}--\r\n".encode()
+        size = path.stat().st_size
+        connection = http.client.HTTPSConnection(
+            self.node_address(node),
+            NODE_PORT,
+            context=context,
+            timeout=MEDIUM_PATIENCE,
+            blocksize=MEDIUM_BLOCK,
+        )
+        try:
+            connection.putrequest(
+                "POST", f"/api2/json/nodes/{node}/storage/{ISO_STORAGE}/upload"
+            )
+            connection.putheader("Authorization", f"PVEAPIToken={TOKEN_ID}={_secret()}")
+            connection.putheader(
+                "Content-Type", f"multipart/form-data; boundary={boundary}"
+            )
+            connection.putheader("Content-Length", str(len(head) + size + len(tail)))
+            connection.endheaders()
+            connection.send(head)
+            with path.open("rb") as handle:
+                connection.send(handle)
+            connection.send(tail)
+            answer = connection.getresponse()
+            said = answer.read().decode("utf-8", "replace")
+            if answer.status != 200:
+                raise ProxmoxError(f"{name} was not uploaded: {answer.status} {said[:300]}")
+        except (OSError, ssl.SSLError, http.client.HTTPException) as error:
+            raise ProxmoxError(f"{name} was not uploaded to {node}: {error}") from error
+        finally:
+            connection.close()
+        upid = json.loads(said).get("data")
+        if isinstance(upid, str) and upid.startswith("UPID"):
+            self.wait(node, upid, patience=MEDIUM_PATIENCE)
 
     def remove_iso(self, node: str, name: str) -> str:
         """Drop an uploaded file, and answer why if it stayed.


### PR DESCRIPTION
The nodes reach `10.31.0.2` and the Chinese Gentoo mirrors and nothing else:
`distfiles.gentoo.org` resets the connection and GitHub, where the CJK live CD
is published, closes without answering. `fetch_iso` therefore started a
download task that never progressed and waited an hour for it.

The workstation keeps its own copy and sends it to the node's own address, in
megabyte records. Verification is not relaxed: the node's certificate carries
its address and the cluster CA signs it, and that CA is read over the already
verified connection. Only `VERIFY_X509_STRICT` is cleared, because PVE's CA
carries no `keyUsage` and Python 3.13 refuses every node in the cluster for it.