### PR TITLE
tests: read the screen the guest actually drew

### DIFF
--- a/tests/tui/screen.py
+++ b/tests/tui/screen.py
@@ -13,6 +13,7 @@ in the middle of a menu row is worse than a missing colour.
 
 from __future__ import annotations
 
+import codecs
 import re
 from dataclasses import dataclass, field
 from typing import Final
@@ -28,6 +29,19 @@ CSI: Final[re.Pattern[str]] = re.compile(r"\x1b\[([0-9;?]*)([A-Za-z])")
 SHORT: Final[re.Pattern[str]] = re.compile(r"\x1b[()][0-9A-B]|\x1b[=>]|\x1b\][^\x07]*\x07")
 
 
+#: The longest escape this reads, so a tail shorter than it may still grow
+#: into one. `\x1b]...\x07` can be longer, and is matched by its terminator.
+LONGEST: Final[int] = 12
+
+
+def _unfinished(text: str, at: int) -> bool:
+    """Whether the escape at `at` could still be completed by the next chunk."""
+    tail = text[at:]
+    if tail.startswith("\x1b]"):
+        return "\x07" not in tail
+    return len(tail) < LONGEST
+
+
 @dataclass
 class Screen:
     """A grid of cells and a cursor, filled by `feed`."""
@@ -39,10 +53,14 @@ class Screen:
     line: int = 0
     column: int = 0
     _reverse: bool = False
+    _decoder: codecs.IncrementalDecoder | None = None
+    #: An escape sequence the last chunk ended in the middle of.
+    _pending: str = ""
 
     def __post_init__(self) -> None:
         self._rows = [[" "] * self.columns for _ in range(self.lines)]
         self._reversed = [[False] * self.columns for _ in range(self.lines)]
+        self._decoder = codecs.getincrementaldecoder("utf-8")("replace")
 
     def text(self) -> str:
         """Every row, trailing spaces removed, as one string."""
@@ -57,7 +75,17 @@ class Screen:
         ]
 
     def feed(self, data: bytes) -> None:
-        text = data.decode("utf-8", "replace")
+        """Take a chunk of the console, which may end anywhere.
+
+        A read boundary falls wherever the network put it, so decoding each
+        chunk on its own turns one split character into three replacement
+        marks, and one split escape into a letter drawn into a row. Both are
+        carried over instead: the decoder keeps the bytes and `_pending` the
+        text of an escape that has not ended yet.
+        """
+        assert self._decoder is not None
+        text = self._pending + self._decoder.decode(data)
+        self._pending = ""
         at = 0
         while at < len(text):
             character = text[at]
@@ -68,6 +96,9 @@ class Screen:
                         self._control(found.group(1), found.group(2))
                     at = found.end()
                     continue
+                if _unfinished(text, at):
+                    self._pending = text[at:]
+                    return
                 # An escape this does not know: drop the escape alone, or the
                 # letter after it would be drawn into the middle of a row.
                 at += 1

--- a/tests/tui/screen.py
+++ b/tests/tui/screen.py
@@ -20,9 +20,10 @@ from typing import Final
 
 from gentoo_install.i18n import width
 
-#: `CSI ... final-byte`. The parameters are digits and semicolons, and every
-#: sequence `ncurses` emits ends in one letter.
-CSI: Final[re.Pattern[str]] = re.compile(r"\x1b\[([0-9;?]*)([A-Za-z])")
+#: `CSI ... final-byte`. The parameters are digits and semicolons; the final
+#: byte is anything in `@` to `~`, not a letter. Insert-character is `@`, and
+#: matching letters alone left it unrecognised in the middle of a row.
+CSI: Final[re.Pattern[str]] = re.compile(r"\x1b\[([0-9;?]*)([@-~])")
 
 #: Two-character escapes with no parameters, and the ones that take a string
 #: terminator. Neither draws anything.
@@ -146,6 +147,13 @@ class Screen:
                 self.column = max(0, self.column - step)
         elif final == "G":
             self.column = max(0, first - 1)
+        elif final == "d":
+            # ncurses moves down a column with this rather than a full `H`,
+            # 23 times in one menu draw. Ignored, every write after it landed
+            # a row too high and the pane read as two layouts at once.
+            self.line = max(0, min(self.lines - 1, (first or 1) - 1))
+        elif final == "@":
+            self._insert(first or 1)
         elif final == "J":
             self._erase_display(first)
         elif final == "K":
@@ -162,6 +170,18 @@ class Screen:
                     self._reverse = True
                 elif one == 27:
                     self._reverse = False
+
+    def _insert(self, count: int) -> None:
+        """Push the rest of the row right, which is how a value is corrected."""
+        row = self._rows[self.line]
+        marks = self._reversed[self.line]
+        keep = self.columns - self.column - count
+        if keep <= 0:
+            self._blank(self.line, self.column, self.columns)
+            return
+        row[self.column + count :] = row[self.column : self.column + keep]
+        marks[self.column + count :] = marks[self.column : self.column + keep]
+        self._blank(self.line, self.column, self.column + count)
 
     def _erase_display(self, kind: int) -> None:
         if kind == 2:

--- a/tests/tui/session.py
+++ b/tests/tui/session.py
@@ -26,6 +26,13 @@ from typing import Final
 
 from tests.tui.screen import Screen
 
+#: How long the console must stay quiet before the page counts as drawn, and
+#: how long to keep waiting for that. A redraw at 120x40 arrives in a few
+#: chunks a few milliseconds apart; a running install writes continuously and
+#: must not hold the answer for ever.
+SETTLE_QUIET: Final[float] = 0.25
+SETTLE_LIMIT: Final[float] = 5.0
+
 #: Where a session keeps its socket, its log and what it was asked to build.
 #: Beside the cluster's own work directory, in the workspace rather than the
 #: repository: a session leaves a driver CD and a screen transcript, and a
@@ -159,6 +166,24 @@ def start(name: str, spec: int, node: str = "", vmid: int = 0) -> str:
     os._exit(0)
 
 
+def _settled(grid: "Screen", console: object) -> str:
+    """The screen once the guest has stopped drawing on it.
+
+    Read while `ncurses` is repainting, the grid holds a page half of one
+    layout and half of the next: a real read at 120x40 showed three rows
+    twice and no section headings at all, which is a screen the interface
+    never drew and an operator would call broken.
+    """
+    read = getattr(console, "read_available")
+    deadline = time.monotonic() + SETTLE_LIMIT
+    while time.monotonic() < deadline:
+        arrived = read(SETTLE_QUIET)
+        if not arrived:
+            break
+        grid.feed(arrived)
+    return grid.text()
+
+
 def serve(session: Session, console: object, guest: object) -> None:
     """Hold the console and answer the other subcommands.
 
@@ -189,7 +214,7 @@ def serve(session: Session, console: object, guest: object) -> None:
             message = json.loads(asked.decode())
             answer: dict[str, str] = {}
             if message["do"] == "screen":
-                answer = {"screen": grid.text()}
+                answer = {"screen": _settled(grid, console)}
             elif message["do"] == "key":
                 console.send_raw(str(message["text"]))
                 answer = {"sent": "yes"}

--- a/tests/unit/test_tui_screen.py
+++ b/tests/unit/test_tui_screen.py
@@ -124,3 +124,40 @@ def test_a_screen_is_answered_only_once_the_guest_stops_drawing() -> None:
     console = Repainting()
     torn.feed(console.read_available(0.25))
     assert torn.text().splitlines()[0] == "first"
+
+
+def test_a_row_is_moved_to_by_the_sequence_ncurses_actually_uses() -> None:
+    """`CSI n d` sets the row, and one menu draw sends it twenty-three times.
+
+    Ignored, the row stayed where the last `H` left it and every write after
+    it landed a line too high: the pane read as two layouts at once, with
+    three labels drawn twice and no section headings at all.
+    """
+    from tests.tui.screen import Screen
+
+    # The column is left where it was, which is what the sequence means.
+    grid = Screen(lines=6, columns=10)
+    grid.feed(b"\x1b[1;1Hfirst\x1b[4d\x1b[1Gfourth")
+    assert grid.text().splitlines()[3] == "fourth", grid.text()
+    assert grid.text().splitlines()[0] == "first"
+
+    # Negative control: without the row move the same text overwrites line
+    # one, which is the two-layouts-at-once page this exists to prevent.
+    stuck = Screen(lines=6, columns=10)
+    stuck.feed(b"\x1b[1;1Hfirst\x1b[1Gfourth")
+    assert stuck.text().splitlines()[0] == "fourth"
+
+
+def test_inserting_cells_pushes_the_rest_of_the_row_right() -> None:
+    """`CSI n @` is how a corrected value keeps the text after it."""
+    from tests.tui.screen import Screen
+
+    grid = Screen(lines=2, columns=10)
+    grid.feed(b"abcdef\x1b[1;1H\x1b[2@")
+    assert grid.text().splitlines()[0] == "  abcdef", grid.text()
+
+    # Negative control: an insert wider than the row leaves it blank rather
+    # than wrapping the pushed text onto the next line.
+    wide = Screen(lines=2, columns=10)
+    wide.feed(b"abcdef\x1b[1;1H\x1b[20@")
+    assert wide.text().splitlines()[0] == ""

--- a/tests/unit/test_tui_screen.py
+++ b/tests/unit/test_tui_screen.py
@@ -51,3 +51,76 @@ def test_an_escape_it_does_not_know_draws_nothing() -> None:
     grid = Screen(lines=2, columns=12)
     grid.feed(b"\x1b(B\x1b=ok\x1b>\x1b]0;title\x07!")
     assert grid.text().splitlines()[0] == "ok!"
+
+
+def test_a_character_split_across_two_reads_is_one_character() -> None:
+    """A read boundary falls wherever the network put it.
+
+    Decoding each chunk on its own turned one three-byte character into three
+    replacement marks, and the guest at 120x40 drew three of them where the
+    interface had written the second half of a word.
+    """
+    from tests.tui.screen import Screen
+
+    # `\u53d6\u4ee3`: a literal here would be unreadable to a contributor who
+    # does not read Chinese, and the tree carries none.
+    wide = "\u53d6\u4ee3".encode()
+    grid = Screen(lines=4, columns=20)
+    grid.feed(wide[:4])
+    grid.feed(wide[4:])
+    assert grid.text().splitlines()[0] == "\u53d6\u4ee3", grid.text()
+
+    # Negative control: the same bytes in one chunk, so a test that only ever
+    # sees whole characters cannot be what is passing above.
+    whole = Screen(lines=4, columns=20)
+    whole.feed(wide)
+    assert whole.text().splitlines()[0] == "\u53d6\u4ee3"
+
+
+def test_an_escape_split_across_two_reads_does_not_reach_a_row() -> None:
+    """The letter that ends a sequence is drawn as text when the escape is cut.
+
+    `\\x1b[2` and `J` arriving separately used to clear nothing and put a `J`
+    into the row, which reads as a value the operator never typed.
+    """
+    from tests.tui.screen import Screen
+
+    grid = Screen(lines=4, columns=20)
+    grid.feed(b"ab\x1b[")
+    grid.feed(b"2J")
+    assert "J" not in grid.text(), grid.text()
+
+    # Negative control: a `J` that is not part of an escape still lands.
+    plain = Screen(lines=4, columns=20)
+    plain.feed(b"aJ")
+    assert plain.text().splitlines()[0] == "aJ"
+
+
+def test_a_screen_is_answered_only_once_the_guest_stops_drawing() -> None:
+    """Read during a repaint the grid holds half of each of two layouts.
+
+    A real read at 120x40 showed three rows twice and no section headings:
+    a page the interface never drew, which an operator reports as a defect
+    in the interface rather than in the harness.
+    """
+    from tests.tui.screen import Screen
+    from tests.tui.session import _settled
+
+    class Repainting:
+        """A console that delivers one redraw across three reads."""
+
+        def __init__(self) -> None:
+            self.chunks = [b"\x1b[2Jfirst", b" second", b" third", b""]
+
+        def read_available(self, seconds: float) -> bytes:
+            return self.chunks.pop(0) if self.chunks else b""
+
+    grid = Screen(lines=4, columns=40)
+    assert _settled(grid, Repainting()).splitlines()[0] == "first second third"
+
+    # Negative control: one read of the same console stops at the first chunk,
+    # which is the torn page this exists to prevent.
+    torn = Screen(lines=4, columns=40)
+    console = Repainting()
+    torn.feed(console.read_available(0.25))
+    assert torn.text().splitlines()[0] == "first"


### PR DESCRIPTION
Three defects a fixture could never see, all read off a guest at 120x40.

`CSI n d` appears twenty-three times in one menu draw and `CSI n @` five, and
the final-byte class matched letters only, so the pane held two layouts at
once: three labels drawn twice and no section headings at all. A character
split across two reads became three replacement marks, and a split escape put
its closing letter into a row. A screen read during a repaint was half of each
of two pages, which an operator reports as a defect in the interface.