### PR TITLE
tui: say where the cursor is, and choose with right

### DIFF
--- a/gentoo_install/tui/widgets.py
+++ b/gentoo_install/tui/widgets.py
@@ -167,7 +167,7 @@ class KeyRow:
 #: find is a key that does not exist: `KEY_LEFT` went back from every screen
 #: for a year and no status line named it.
 KEY_HELP: Final[tuple[KeyRow, ...]] = (
-    KeyRow("enter", "Open the row under the cursor, or accept this screen"),
+    KeyRow("enter  \u2192", "Open the row under the cursor, or accept this screen"),
     KeyRow("\u2191  \u2193", "Move the cursor"),
     KeyRow("j  k", "Move the cursor, in a list; a letter in a field"),
     KeyRow("tab  shift-tab", "Move the cursor, in a list and between fields"),
@@ -376,7 +376,13 @@ class _Menu(Generic[V, A]):
                 screen.help()
             elif pressed == " " and self._multiple:
                 self._toggle(cursor)
-            elif pressed in ("\n", "KEY_ENTER"):
+            elif pressed in ("\n", "KEY_ENTER") or (
+                pressed == "KEY_RIGHT" and not self._multiple
+            ):
+                # Right chooses here as it opens a row in the list, because
+                # left goes back from both. It is left out where several rows
+                # are chosen at once: there right would accept the screen on
+                # the way to a row the operator meant to mark.
                 answer = self._accept(cursor)
                 if answer is not None:
                     return answer

--- a/tests/tui/screen.py
+++ b/tests/tui/screen.py
@@ -75,6 +75,20 @@ class Screen:
             if all(marks) and "".join(row).strip()
         ]
 
+    def highlighted(self) -> list[str]:
+        """The rows carrying a run of reverse video that is not a whole band.
+
+        Where the cursor is. The interface marks it by inverting the row and
+        nothing else, so `text` loses it entirely: an operator reading the
+        grid cannot tell which of twenty-four rows enter would open, and the
+        first agent to drive the interface spent five keys finding out.
+        """
+        found = []
+        for row, marks in zip(self._rows, self._reversed):
+            if any(marks) and not all(marks) and "".join(row).strip():
+                found.append("".join(row).rstrip())
+        return found
+
     def feed(self, data: bytes) -> None:
         """Take a chunk of the console, which may end anywhere.
 

--- a/tests/tui/session.py
+++ b/tests/tui/session.py
@@ -166,6 +166,20 @@ def start(name: str, spec: int, node: str = "", vmid: int = 0) -> str:
     os._exit(0)
 
 
+def _with_cursor(grid: "Screen") -> str:
+    """The grid, and under it the row the cursor is on.
+
+    The interface marks the cursor by inverting that row and nothing else, so
+    the grid alone does not carry it: every row reads the same and enter is a
+    guess. Named rather than drawn into the grid, because a marker in the
+    cells would be a character the operator's own screen does not show.
+    """
+    rows = grid.highlighted()
+    if not rows:
+        return grid.text()
+    return grid.text() + "\n\ncursor:\n" + "\n".join(rows)
+
+
 def _settled(grid: "Screen", console: object) -> str:
     """The screen once the guest has stopped drawing on it.
 
@@ -181,7 +195,7 @@ def _settled(grid: "Screen", console: object) -> str:
         if not arrived:
             break
         grid.feed(arrived)
-    return grid.text()
+    return _with_cursor(grid)
 
 
 def serve(session: Session, console: object, guest: object) -> None:

--- a/tests/unit/test_tui_screen.py
+++ b/tests/unit/test_tui_screen.py
@@ -161,3 +161,25 @@ def test_inserting_cells_pushes_the_rest_of_the_row_right() -> None:
     wide = Screen(lines=2, columns=10)
     wide.feed(b"abcdef\x1b[1;1H\x1b[20@")
     assert wide.text().splitlines()[0] == ""
+
+
+def test_the_row_under_the_cursor_is_named_beside_the_grid() -> None:
+    """The interface inverts that row and marks it no other way.
+
+    Read as text every row looks alike, so enter is a guess: the first agent
+    to drive the interface spent five keys working out where it was. A whole
+    inverted line is a section band and is not the cursor.
+    """
+    from tests.tui.screen import Screen
+
+    grid = Screen(lines=4, columns=12)
+    grid.feed(b"\x1b[1;1H\x1b[7m band       \x1b[27m")
+    grid.feed(b"\x1b[2;1H\x1b[7mrow one\x1b[27m   ")
+    grid.feed(b"\x1b[3;1Hrow two")
+    assert grid.highlighted() == ["row one"], grid.highlighted()
+
+    # Negative control: with nothing inverted but the band, there is no
+    # cursor to name, and the band must not be offered as one.
+    plain = Screen(lines=4, columns=12)
+    plain.feed(b"\x1b[1;1H\x1b[7m band       \x1b[27m\x1b[2;1Hrow one")
+    assert plain.highlighted() == []

--- a/tests/unit/test_tui_widgets.py
+++ b/tests/unit/test_tui_widgets.py
@@ -1290,3 +1290,22 @@ def test_the_box_closes_at_the_same_column_on_both_edges() -> None:
         top, bottom = edges[0].rstrip(), edges[-1].rstrip()
         assert top.endswith("+"), (title, top)
         assert width(top) == width(bottom), (title, top, bottom)
+
+
+def test_right_chooses_in_a_list_because_left_goes_back_from_one() -> None:
+    """The main list opened a row on right; a menu ignored it.
+
+    Watched on a guest: the first agent to drive the interface pressed right
+    twice inside a menu and nothing happened, because only the two-pane list
+    took it. Left is Back in both, so right is forward in both.
+    """
+    assert menu().run(FakeScreen(keys=["KEY_RIGHT"])).unwrap() == "vda"
+
+    # Negative control: where several rows are chosen at once, right would
+    # accept the screen on the way to a row the operator meant to mark.
+    several = MultipleChoiceMenu(
+        title="Locales",
+        items=[Item(label="zh_TW", value="zh_TW"), Item(label="en_US", value="en_US")],
+    )
+    answer = several.run(FakeScreen(keys=["KEY_RIGHT", " ", "\n"]))
+    assert answer.unwrap() == ("zh_TW",), answer


### PR DESCRIPTION
Both read off a guest while an agent drove the interface.

The cursor is marked by inverting its row and nothing else, so the screen read
as text carries no cursor: every row looks alike and enter is a guess. The
grid now names that row beside it.

Left is Back from every screen, so right is forward from every list; only the
two-pane one took it, and the agent pressed right twice inside a menu with
nothing happening.