### PR TITLE
tui: name the three ways back in one footer entry

### DIFF
--- a/gentoo_install/tui/context.py
+++ b/gentoo_install/tui/context.py
@@ -315,17 +315,16 @@ def footer(translate: Catalog, enter: str = "Continue") -> str:
     return "  ".join(
         (
             f"[enter] {translate(enter)}",
-            # Left as well as backspace: left is the only Back that works in
-            # every widget, and a field with a value in it takes backspace as
-            # a deletion, so an operator reading this footer alone had no way
-            # back out of the hostname screen.
-            f"[\u2190] {translate('Back')}",
-            f"[backspace] {translate('Back')}",
+            # One entry, three keys. Left as well as backspace because left is
+            # the only Back that works in every widget and a field with a value
+            # in it takes backspace as a deletion; listed separately they read
+            # as three different things and filled half the line.
+            #
             # Back, not Cancel: escape steps back one screen at every depth
             # below the main menu, where it asks whether to end the run. It
             # said `Cancel` while doing that, and `[q] Cancel` before it,
             # which a field takes as the letter.
-            f"[esc] {translate('Back')}",
+            f"[\u2190 backspace esc] {translate('Back')}",
             # The page names the six this line has no room for. A key nothing
             # writes down is a key nobody finds: `j`, `k`, `tab`, `shift-tab`
             # and `q` all worked here with no status line naming one of them.

--- a/tests/unit/test_tui_app.py
+++ b/tests/unit/test_tui_app.py
@@ -977,7 +977,7 @@ def test_the_shared_footer_names_a_key_that_leaves_every_screen() -> None:
     from .fake_screen import FakeScreen
 
     said = footer(context().translate)
-    assert "[esc]" in said, said
+    assert "esc]" in said, said
     assert "[q]" not in said, said
     assert context().translate("Cancel") not in said, said
 

--- a/tests/unit/test_tui_partitions.py
+++ b/tests/unit/test_tui_partitions.py
@@ -1444,7 +1444,9 @@ def test_a_long_validator_message_leaves_the_keys_on_the_status_line() -> None:
     screen = FakeScreen(keys=["\x1b"], columns=80, lines=24)
     partitions.partitions_screen(screen, config(), at)
     line = screen.frames[-1][-1]
-    assert "[enter]" in line and "[backspace]" in line and "[esc]" in line, line
+    assert "[enter]" in line, line
+    for key in ("\u2190", "backspace", "esc"):
+        assert key in line, (key, line)
     assert problem not in line and "\u2026" in line, line
     assert width(line) <= 80
 

--- a/tests/unit/test_tui_widgets.py
+++ b/tests/unit/test_tui_widgets.py
@@ -948,10 +948,13 @@ def test_the_footer_names_the_key_that_always_goes_back() -> None:
     for tag in ("en", "zh-TW", "zh-CN", "ja", "ko"):
         translate = Catalog(tag)
         drawn = footer(translate)
-        assert "[←]" in drawn, (tag, drawn)
-        # Three ways back and no Cancel: escape steps back below the main
-        # menu, which is where ending the run is asked about.
-        assert drawn.count(translate("Back")) == 3, (tag, drawn)
+        # Three keys and no Cancel, in one entry: three entries reading the
+        # same word filled half the line and read as three different things.
+        # Escape steps back below the main menu, which is where ending the run
+        # is asked about.
+        for key in ("\u2190", "backspace", "esc"):
+            assert key in drawn, (tag, key, drawn)
+        assert drawn.count(translate("Back")) == 1, (tag, drawn)
         assert translate("Cancel") not in drawn, (tag, drawn)
 
     # And the key the footer names is the key the widgets answer Back to,


### PR DESCRIPTION
`[←] Back  [backspace] Back  [esc] Back` filled half the status line and read
as three different actions. One entry names all three keys.