### PR TITLE
tests: move the cursor on a tab instead of drawing one

### DIFF
--- a/tests/tui/screen.py
+++ b/tests/tui/screen.py
@@ -123,6 +123,13 @@ class Screen:
             elif character == "\n":
                 self.line = min(self.lines - 1, self.line + 1)
                 self.column = 0
+            elif character == "\t":
+                # ncurses moves the cursor with tabs rather than a position
+                # sequence when the distance is right, 34 times in one menu
+                # draw. Drawn as a character instead, every cell after it on
+                # that row was one column out and the row kept the text the
+                # screen before it had left there.
+                self.column = min(self.columns - 1, (self.column // 8 + 1) * 8)
             elif character == "\b":
                 self.column = max(0, self.column - 1)
             elif character >= " ":

--- a/tests/unit/test_tui_screen.py
+++ b/tests/unit/test_tui_screen.py
@@ -205,3 +205,22 @@ def test_erasing_half_a_wide_character_takes_the_other_half() -> None:
     plain = Screen(lines=2, columns=10)
     plain.feed(b"abcdefghij\x1b[1;4H\x1b[1X")
     assert width(plain.text().splitlines()[0]) == 10
+def test_a_tab_moves_the_cursor_rather_than_drawing_something() -> None:
+    """ncurses moves the cursor with tabs when the distance suits it.
+
+    Drawn as a character instead, every cell after it on that row was one
+    column out, and the row kept whatever the screen before it had left
+    there: the overview read `root password set` followed by three
+    characters of the network row.
+    """
+    from tests.tui.screen import Screen
+
+    grid = Screen(lines=2, columns=20)
+    grid.feed(b"ab\tcd")
+    assert grid.text().splitlines()[0] == "ab      cd", grid.text()
+
+    # Negative control: a tab already on a stop still advances a whole one,
+    # so a rule that only rounded up would leave the cursor where it was.
+    stop = Screen(lines=2, columns=20)
+    stop.feed(b"abcdefgh\tx")
+    assert stop.text().splitlines()[0] == "abcdefgh        x", stop.text()


### PR DESCRIPTION
ncurses moves the cursor with tabs when the distance suits it, thirty-four
times in one menu draw. Drawn as a character, every cell after it on that row
was one column out and the row kept what the screen before it had left there:
the overview read `root password set` followed by three characters of the
network row.