### PR TITLE
tests: erase both halves of a wide character, and record what is counted

### DIFF
--- a/tests/tui/brief.md
+++ b/tests/tui/brief.md
@@ -12,7 +12,6 @@ One command, with these subcommands:
 ```
 python3 -m tests.tui.session screen <id>          what is on the screen now
 python3 -m tests.tui.session key <id> <keys...>   press keys
-python3 -m tests.tui.session plan <id>            what the installer would do
 ```
 
 Keys are named: `up`, `down`, `left`, `right`, `enter`, `esc`, `tab`, `space`,
@@ -42,8 +41,9 @@ something your spec names, press `help` once and read what it says. If that
 does not answer it, record the row's name under `unclear` and move on — do not
 guess, and do not brute-force the screen.
 
-Stop when the plan the installer would run matches your spec, or when you
-cannot make further progress.
+Stop when every part of your spec is answered by a row of the list, which the
+list itself shows: each row carries its current value beside its name. Stop
+early if you cannot make further progress.
 
 ## What to answer
 
@@ -58,8 +58,8 @@ One JSON object, and nothing else:
 }
 ```
 
-`installed` lists the lines of your spec's proof that the plan shows were
-answered. `stuck` names a screen you could not leave or could not set.
+`installed` lists the lines of your spec's proof that the list shows were
+answered, each with the row that answered it. `stuck` names a screen you could not leave or could not set.
 `unclear` names a row whose purpose the screen did not convey, one line each,
 saying what was missing. Your answer is read as a claim about the interface,
 not as the result of the run: the run is counted from the keys you pressed.

--- a/tests/tui/screen.py
+++ b/tests/tui/screen.py
@@ -173,9 +173,7 @@ class Screen:
         elif final == "K":
             self._erase_line(first)
         elif final == "X":
-            for offset in range(first or 1):
-                if self.column + offset < self.columns:
-                    self._rows[self.line][self.column + offset] = " "
+            self._blank(self.line, self.column, self.column + (first or 1))
         elif final == "m":
             for one in numbers or [0]:
                 if one == 0:
@@ -220,6 +218,20 @@ class Screen:
             self._blank(self.line, self.column, self.columns)
 
     def _blank(self, line: int, start: int, end: int) -> None:
-        for column in range(start, min(end, self.columns)):
+        """Erase a run, taking both halves of any wide character it touches.
+
+        A wide character is one cell holding it and one holding the empty
+        string. Erasing only one of them leaves a row whose cells no longer
+        add up to its columns, and every column after it moves: a menu row
+        lost the ten spaces between its label and its value, and the two read
+        as one word.
+        """
+        first = max(0, start)
+        last = min(end, self.columns)
+        if 0 < first < self.columns and self._rows[line][first] == "":
+            first -= 1
+        while last < self.columns and self._rows[line][last] == "":
+            last += 1
+        for column in range(first, last):
             self._rows[line][column] = " "
             self._reversed[line][column] = False

--- a/tests/tui/session.py
+++ b/tests/tui/session.py
@@ -91,6 +91,11 @@ class Session:
         return self.directory / "control"
 
     @property
+    def screens(self) -> Path:
+        """Every screen answered, separated by a form feed, in order."""
+        return self.directory / "screens.txt"
+
+    @property
     def transcript(self) -> Path:
         """Every key sent, one per line, so the counts a report is judged on
         are read off the session rather than taken from the agent."""
@@ -154,6 +159,7 @@ def start(name: str, spec: int, node: str = "", vmid: int = 0) -> str:
     session = Session(name)
     session.directory.mkdir(parents=True, exist_ok=True)
     session.transcript.write_text("", encoding="utf-8")
+    session.screens.write_text("", encoding="utf-8")
     (session.directory / "spec.txt").write_text(str(spec), encoding="utf-8")
     api = Api()
     held = cluster.tui_execution(api, node, name, spec, session.directory, vmid)
@@ -228,7 +234,13 @@ def serve(session: Session, console: object, guest: object) -> None:
             message = json.loads(asked.decode())
             answer: dict[str, str] = {}
             if message["do"] == "screen":
-                answer = {"screen": _settled(grid, console)}
+                shown = _settled(grid, console)
+                # Kept as it is answered, because the counts are computed from
+                # the screens the operator was actually shown: a report that
+                # reads a file nobody writes answers zero for every one of them.
+                with session.screens.open("a", encoding="utf-8") as log:
+                    log.write(shown + "\f")
+                answer = {"screen": shown}
             elif message["do"] == "key":
                 console.send_raw(str(message["text"]))
                 answer = {"sent": "yes"}

--- a/tests/tui/session.py
+++ b/tests/tui/session.py
@@ -232,8 +232,6 @@ def serve(session: Session, console: object, guest: object) -> None:
             elif message["do"] == "key":
                 console.send_raw(str(message["text"]))
                 answer = {"sent": "yes"}
-            elif message["do"] == "plan":
-                answer = {"plan": session.transcript.read_text(encoding="utf-8")}
             elif message["do"] == "stop":
                 answer = {"stopped": "yes"}
             channel.sendall(json.dumps(answer).encode() + b"\n")
@@ -251,7 +249,6 @@ def main(argv: list[str] | None = None) -> int:
     commands = parser.add_subparsers(dest="command", required=True)
     for name, helped in (
         ("screen", "print what the terminal is showing"),
-        ("plan", "print what the run produced"),
         ("stop", "delete the guest"),
     ):
         one = commands.add_parser(name, help=helped)
@@ -286,9 +283,6 @@ def main(argv: list[str] | None = None) -> int:
         return 0
     if arguments.command == "screen":
         print(ask(session, {"do": "screen"})["screen"])
-        return 0
-    if arguments.command == "plan":
-        print(ask(session, {"do": "plan"})["plan"])
         return 0
     if arguments.command == "stop":
         ask(session, {"do": "stop"})

--- a/tests/unit/test_tui_report.py
+++ b/tests/unit/test_tui_report.py
@@ -131,3 +131,26 @@ def test_the_session_offers_no_subcommand_that_answers_with_its_own_input() -> N
     source = Path(session.__file__).read_text(encoding="utf-8")
     assert '"plan"' not in source, "plan is back and has to answer a real plan"
     assert '"screen"' in source and '"key"' in source
+
+
+def test_the_session_writes_the_file_the_report_counts_from(tmp_path: Path) -> None:
+    """The report read `screens.txt` and nothing wrote it.
+
+    Every count came back zero on a session that had been driven for half an
+    hour, and zero reads as a clean run rather than as a missing file.
+    """
+    import tests.tui.session as session
+
+    named = session.Session("probe")
+    assert named.screens.name == "screens.txt"
+    assert named.screens != named.transcript
+
+    source = Path(session.__file__).read_text(encoding="utf-8")
+    assert "session.screens.open" in source, "no screen is ever recorded"
+
+    # Negative control: the report on a directory holding only keys answers
+    # zero, which is what a session that never recorded a screen looks like.
+    (tmp_path / "keys.txt").write_text("enter\nesc\n", encoding="utf-8")
+    assert read(tmp_path) == Report(
+        finished=False, lost=(), helped=0, stuck=(), refused=0
+    )

--- a/tests/unit/test_tui_report.py
+++ b/tests/unit/test_tui_report.py
@@ -116,3 +116,18 @@ def test_a_translated_screen_is_counted_the_same_as_an_english_one(tmp_path: Pat
     # Negative control: a screen whose heading is a word no catalog maps
     # `Install` to must not be read as having reached it.
     assert not read(session(tmp_path / "no", [frame("Kernel", DISK)], ["enter"])).finished
+
+
+def test_the_session_offers_no_subcommand_that_answers_with_its_own_input() -> None:
+    """`plan` read the key log and called it the installer's plan.
+
+    An agent asked whether the plan matches its spec would have been comparing
+    the spec against its own keystrokes, which is the shape of check that
+    cannot fail. It is gone rather than stubbed: a subcommand that answers
+    something else under the right name is worse than an absent one.
+    """
+    import tests.tui.session as session
+
+    source = Path(session.__file__).read_text(encoding="utf-8")
+    assert '"plan"' not in source, "plan is back and has to answer a real plan"
+    assert '"screen"' in source and '"key"' in source

--- a/tests/unit/test_tui_screen.py
+++ b/tests/unit/test_tui_screen.py
@@ -183,3 +183,25 @@ def test_the_row_under_the_cursor_is_named_beside_the_grid() -> None:
     plain = Screen(lines=4, columns=12)
     plain.feed(b"\x1b[1;1H\x1b[7m band       \x1b[27m\x1b[2;1Hrow one")
     assert plain.highlighted() == []
+def test_erasing_half_a_wide_character_takes_the_other_half() -> None:
+    """A wide character is two cells: the character and an empty string.
+
+    Erasing one of them leaves a row whose cells no longer add up to its
+    columns, so every column after it moves. Read off a guest: a menu row
+    lost the ten spaces between its label and its value and the two ran
+    together as one word.
+    """
+    from tests.tui.screen import Screen
+
+    # `\u78c1\u789f` is four cells; the erase lands on the second half of the
+    # second character.
+    grid = Screen(lines=2, columns=10)
+    grid.feed("\u78c1\u789fabcd".encode())
+    grid.feed(b"\x1b[1;4H\x1b[1X")
+    assert grid.text().splitlines()[0] == "\u78c1  abcd", grid.text()
+
+    # Negative control: an erase that lands on no wide character takes one
+    # cell, so the count above cannot be the erase width alone.
+    plain = Screen(lines=2, columns=10)
+    plain.feed(b"abcdefghij\x1b[1;4H\x1b[1X")
+    assert width(plain.text().splitlines()[0]) == 10


### PR DESCRIPTION
The guest sends 821 erase-character sequences in one session and a wide
character is two cells; erasing one half left a row whose cells no longer add
up to its columns, and a menu row lost the ten spaces between its label and
its value.

`plan` read the key log and called it the installer's plan, so an agent asked
whether the plan matched its spec was comparing the spec against its own
keystrokes. `report.read` parsed a `screens.txt` nothing wrote, so every count
came back zero on a session driven for half an hour.