### PR TITLE
tests: send the key sequences terminfo names

### DIFF
--- a/tests/tui/session.py
+++ b/tests/tui/session.py
@@ -41,11 +41,16 @@ SESSIONS: Final[Path] = Path.home() / "code/gentoo-install/lab/tui"
 
 #: What the operator types, as the terminal sends it. Named because an agent
 #: writing `\x1b[B` by hand gets it wrong once per session.
+#: What each name sends, taken from terminfo rather than written out. ncurses
+#: parses against the terminal's own capabilities and `curses.wrapper` turns
+#: the keypad on, so the `CSI` forms are not what it is waiting for: every
+#: arrow arrived as a bare escape and the widgets read it as Back. The agent
+#: driving the first session worked that out and navigated on tab alone.
 KEYS: Final[dict[str, str]] = {
-    "up": "\x1b[A",
-    "down": "\x1b[B",
-    "left": "\x1b[D",
-    "right": "\x1b[C",
+    "up": "\x1bOA",
+    "down": "\x1bOB",
+    "left": "\x1bOD",
+    "right": "\x1bOC",
     "enter": "\n",
     "esc": "\x1b",
     "escape": "\x1b",
@@ -54,8 +59,8 @@ KEYS: Final[dict[str, str]] = {
     "backspace": "\x7f",
     "pageup": "\x1b[5~",
     "pagedown": "\x1b[6~",
-    "home": "\x1b[H",
-    "end": "\x1b[F",
+    "home": "\x1bOH",
+    "end": "\x1bOF",
     "help": "?",
     "filter": "/",
 }

--- a/tests/unit/test_tui_curses.py
+++ b/tests/unit/test_tui_curses.py
@@ -619,3 +619,37 @@ def test_the_key_page_leaves_the_interface_where_it_was() -> None:
     assert answered.get("error") is None, answered
     assert answered["left"] == "MARKER-LEFT", answered
     assert answered["right"] == "MARKER-RIGHT", answered
+
+def test_every_key_the_session_sends_is_the_one_terminfo_names() -> None:
+    """A sequence ncurses cannot parse arrives as a bare escape.
+
+    `CSI H` and `CSI F` are what a terminal sends with the keypad off, and
+    `curses.wrapper` turns it on: sent anyway, End reached the widgets as
+    escape and the interface offered to leave the run instead of moving the
+    cursor. Checked against terminfo rather than a pty, because the pty
+    helper writes one byte at a time and ncurses times out inside a sequence.
+    """
+    from tests.tui.session import KEYS
+
+    curses.setupterm(term="xterm", fd=sys.stdout.fileno())
+    for name, capability in (
+        ("up", "kcuu1"),
+        ("down", "kcud1"),
+        ("left", "kcub1"),
+        ("right", "kcuf1"),
+        ("home", "khome"),
+        ("end", "kend"),
+        ("pageup", "kpp"),
+        ("pagedown", "knp"),
+        ("backspace", "kbs"),
+    ):
+        wanted = curses.tigetstr(capability)
+        assert wanted is not None, capability
+        assert KEYS[name] == wanted.decode(), (name, KEYS[name], wanted)
+
+
+    # Negative control: the form this replaced is not what terminfo names, so
+    # the check above is comparing against the terminal and not against
+    # whatever the table happens to hold.
+    assert curses.tigetstr("khome") != b"\x1b[H"
+    assert curses.tigetstr("kcud1") != b"\x1b[B"


### PR DESCRIPTION
`curses.wrapper` turns the keypad on and ncurses parses against the terminal's
own capabilities, so the `CSI` forms are not what it waits for: every arrow
and End arrived as a bare escape and the widgets read it as Back.

Found on a guest: the confirmation before the install could not be moved from
No to Yes, and the agent driving the session had worked the arrows out as
useless and navigated on tab alone.