### PR TITLE
portage: enable overlays the operator names, by name alone

### DIFF
--- a/gentoo_install/data/locale/ja.toml
+++ b/gentoo_install/data/locale/ja.toml
@@ -714,3 +714,7 @@
 "Which licences Portage may merge: free software only, firmware as well, or every licence including proprietary software." = "Portage が導入してよい授権の範囲。自由ソフトウェアのみ、ファームウェアも含む、あるいは専有ソフトウェアを含む全部。"
 "Sources" = "取得元"
 "make.conf" = "make.conf"
+"Other overlays" = "その他のオーバーレイ"
+"names separated by commas, as on overlays.gentoo.org" = "overlays.gentoo.org に載っている名前をカンマ区切りで入力します"
+"no package this installer merges comes from these" = "インストーラーが導入するパッケージはこれらを使用しません"
+"enable the {} repository" = "{} リポジトリを有効にします"

--- a/gentoo_install/data/locale/ko.toml
+++ b/gentoo_install/data/locale/ko.toml
@@ -714,3 +714,7 @@
 "Which licences Portage may merge: free software only, firmware as well, or every licence including proprietary software." = "Portage 가 병합할 수 있는 라이선스 범위. 자유 소프트웨어만, 펌웨어까지, 또는 독점 소프트웨어를 포함한 전부."
 "Sources" = "패키지 출처"
 "make.conf" = "make.conf"
+"Other overlays" = "기타 오버레이"
+"names separated by commas, as on overlays.gentoo.org" = "overlays.gentoo.org에 있는 이름을 쉼표로 구분하여 입력합니다"
+"no package this installer merges comes from these" = "설치 관리자가 병합하는 패키지는 이 오버레이를 사용하지 않습니다"
+"enable the {} repository" = "{} 저장소를 활성화합니다"

--- a/gentoo_install/data/locale/zh-CN.toml
+++ b/gentoo_install/data/locale/zh-CN.toml
@@ -715,3 +715,7 @@
 "Which licences Portage may merge: free software only, firmware as well, or every licence including proprietary software." = "Portage 可以合并哪些许可的软件包：仅自由软件、另含固件，或全部许可含专有软件。"
 "Sources" = "软件包来源"
 "make.conf" = "make.conf"
+"Other overlays" = "其他 overlay"
+"names separated by commas, as on overlays.gentoo.org" = "以逗号分隔的名称，取自 overlays.gentoo.org"
+"no package this installer merges comes from these" = "安装器合并的软件包都不会取自这些 overlay"
+"enable the {} repository" = "启用 {} 仓库"

--- a/gentoo_install/data/locale/zh-TW.toml
+++ b/gentoo_install/data/locale/zh-TW.toml
@@ -715,3 +715,7 @@
 "Which licences Portage may merge: free software only, firmware as well, or every licence including proprietary software." = "Portage 可以合併哪些授權的套件：僅自由軟體、另含韌體，或全部授權含專有軟體。"
 "Sources" = "套件來源"
 "make.conf" = "make.conf"
+"Other overlays" = "其他 overlay"
+"names separated by commas, as on overlays.gentoo.org" = "以逗號分隔的名稱，取自 overlays.gentoo.org"
+"no package this installer merges comes from these" = "安裝器合併的套件都不會取自這些 overlay"
+"enable the {} repository" = "啟用 {} 儲存庫"

--- a/gentoo_install/model/config.py
+++ b/gentoo_install/model/config.py
@@ -441,6 +441,11 @@ class PortageConfig:
     mirrors: MirrorConfig = field(default_factory=MirrorConfig)
     binhost: Binhost = field(default_factory=Binhost)
     overlays: tuple[Overlay, ...] = ()
+    #: Names the operator asked for, enabled with `eselect repository`. Kept
+    #: apart from `overlays`: those carry a `sync_uri` this installer ships
+    #: because a package group names them, and these are the operator's own,
+    #: whose address `eselect` looks up in the current `repositories.xml`.
+    repositories: tuple[str, ...] = ()
 
 
 @dataclass(frozen=True)

--- a/gentoo_install/model/parse.py
+++ b/gentoo_install/model/parse.py
@@ -203,7 +203,7 @@ def _portage(raw: Mapping[str, Any], at: str) -> PortageConfig:
             "profile", "keywords", "sync", "testing_packages", "makeopts",
             "common_flags", "use", "video_cards", "l10n", "accept_license",
             "cpu_flags", "build_in_ram", "input_devices", "mirrors", "binhost",
-            "overlays",
+            "overlays", "repositories",
         },
     )
     default = PortageConfig()
@@ -212,6 +212,7 @@ def _portage(raw: Mapping[str, Any], at: str) -> PortageConfig:
         keywords=_enum(raw, "keywords", at, Keywords, default.keywords),
         sync=_enum(raw, "sync", at, Sync, default.sync),
         testing_packages=_strings(raw, "testing_packages", at, default.testing_packages),
+        repositories=_strings(raw, "repositories", at, default.repositories),
         makeopts=_str(raw, "makeopts", at, default.makeopts),
         common_flags=_str(raw, "common_flags", at, default.common_flags),
         use=_strings(raw, "use", at, default.use),

--- a/gentoo_install/model/validate.py
+++ b/gentoo_install/model/validate.py
@@ -258,6 +258,7 @@ def validate(
         *_unlock_problems(config, address_facts.remote_unlock),
         *_locale_problems(config),
         *_l10n_problems(config),
+        *_repository_name_problems(config),
         *compat.binhost_subarch_problems(config, supports_v3),
     ]
     if problems:
@@ -439,6 +440,26 @@ def _numeric_version(version: str) -> tuple[int, ...]:
             break
         found.append(int(matched.group()))
     return tuple(found)
+
+
+#: What `eselect repository` accepts as a name, and what `repos.conf` accepts
+#: as a section. Checked here because `eselect` prints one line and exits 0
+#: for a name it does not know: the install continues and the overlay is not
+#: there.
+_REPOSITORY_NAME: Final[re.Pattern[str]] = re.compile(r"[A-Za-z0-9_][A-Za-z0-9_+.-]*")
+
+
+def _repository_name_problems(config: InstallConfig) -> list[str]:
+    problems = []
+    shipped = {overlay.name for overlay in config.portage.overlays} | {"gentoo"}
+    for name in config.portage.repositories:
+        if _REPOSITORY_NAME.fullmatch(name) is None:
+            problems.append(f"{name!r} is not a repository name")
+        elif name in shipped:
+            # Two `repos.conf` sections of the same name, and the later
+            # sync-uri replaces the earlier one.
+            problems.append(f"{name} is already configured with its own sync-uri")
+    return problems
 
 
 def _l10n_problems(config: InstallConfig) -> list[str]:

--- a/gentoo_install/plan/portage.py
+++ b/gentoo_install/plan/portage.py
@@ -845,6 +845,36 @@ class AcceptOverlayKeywords(Operation):
 
 
 @dataclass(frozen=True, kw_only=True)
+class EnableRepository(Operation):
+    """Turn on an overlay the operator named, by name alone.
+
+    `eselect repository` reads the current `repositories.xml` for the address,
+    so the list is whatever the project publishes today rather than whatever
+    this repository last copied. The exit status is checked because the tool
+    prints one line and exits 0 for a name it does not know, and the install
+    would carry on without the overlay.
+    """
+
+    stage: Stage = Stage.PORTAGE
+    repository: str
+
+    def describe_parts(self) -> tuple[str, tuple[str, ...]]:
+        return "enable the {} repository", (self.repository,)
+
+    def apply(self, context: Context) -> None:
+        said = context.run_in_target(
+            ["eselect", "repository", "enable", self.repository], check=False
+        )
+        failed = isinstance(said, CommandOutput) and said.returncode != 0
+        # The exit status is not enough: an unknown name prints one line and
+        # exits 0, and the install would carry on without the overlay.
+        if failed or "not found" in str(said):
+            raise CommandFailed(
+                f"{self.repository} was not enabled: {str(said).strip()[:200]}"
+            )
+
+
+@dataclass(frozen=True, kw_only=True)
 class Emerge(Operation):
     stage: Stage = Stage.PACKAGES
     packages: tuple[str, ...]
@@ -1492,6 +1522,18 @@ def build(
                 ),
             ),
             AcceptOverlayKeywords(repository=overlay.name),
+        ]
+    if portage.repositories:
+        operations.append(
+            Emerge(
+                stage=Stage.PORTAGE,
+                packages=("app-eselect/eselect-repository",),
+                summary="install eselect-repository, which the named overlays are added with",
+                repository_bootstrap=True,
+            )
+        )
+        operations += [
+            EnableRepository(repository=name) for name in portage.repositories
         ]
     if portage.testing_packages:
         # Before the check below: an atom accepted as testing is one the

--- a/gentoo_install/tui/mirror.py
+++ b/gentoo_install/tui/mirror.py
@@ -31,7 +31,7 @@ from .context import (
     pick,
     with_gentoo_zh,
 )
-from .widgets import Answer, Item, Menu, Outcome, Screen
+from .widgets import Answer, Item, Menu, Outcome, Screen, TextField
 
 _REGION: Final[str] = "region"
 _SITE: Final[str] = "site"
@@ -297,6 +297,41 @@ def _overlay_descriptor(name: str) -> FieldDescriptor[InstallConfig]:
     return FieldDescriptor(name, row, edit)
 
 
+_REPOSITORIES: Final[str] = "repositories"
+
+
+def _repositories_row(config: InstallConfig, translate: Catalog) -> Item[str]:
+    named = config.portage.repositories
+    return Item(
+        label=translate("Other overlays"),
+        value=_REPOSITORIES,
+        detail=", ".join(named) if named else translate("none"),
+    )
+
+
+def _edit_repositories(
+    screen: Screen, context: Context, config: InstallConfig
+) -> InstallConfig | None:
+    """Names from `https://overlays.gentoo.org/`, typed rather than listed.
+
+    The list has over four hundred entries and every one of them can change
+    address; `eselect repository` reads the current `repositories.xml` at
+    install time, so a name is all this has to carry.
+    """
+    translate = context.translate
+    typed = TextField(
+        title=translate("Other overlays"),
+        value=", ".join(config.portage.repositories),
+        placeholder=translate("names separated by commas, as on overlays.gentoo.org"),
+        detail=translate("no package this installer merges comes from these"),
+        footer=footer(translate),
+    ).run(screen)
+    if not typed.chosen:
+        return None
+    names = tuple(one.strip() for one in typed.unwrap().split(",") if one.strip())
+    return replace(config, portage=replace(config.portage, repositories=names))
+
+
 _MIRROR_FIELDS: tuple[FieldDescriptor[InstallConfig], ...] = (
     FieldDescriptor(_REGION, _mirror_region_row, _edit_mirror_region),
     FieldDescriptor(_SITE, _mirror_site_row, _edit_mirror_site),
@@ -317,6 +352,7 @@ _ALL_MIRROR_FIELDS = _MIRROR_FIELDS + (
     FieldDescriptor(_ZH_SITE, lambda config, translate: Item(label=translate("gentoo-zh"), value=_ZH_SITE, detail=translate(mirrors.gentoozh(config.portage.mirrors.gentoo_zh).name) if "gentoo-zh" in {one.name for one in config.portage.overlays} else translate("not used")), lambda s, c, x: _edit_gentoozh(s, c, x)),
     *_ZH_MIRROR_FIELDS,
     *_OVERLAY_FIELDS,
+    FieldDescriptor(_REPOSITORIES, _repositories_row, _edit_repositories),
 )
 
 

--- a/tests/unit/test_plan_portage.py
+++ b/tests/unit/test_plan_portage.py
@@ -2674,3 +2674,40 @@ def test_the_recorded_reason_carries_portage_own_diagnosis() -> None:
     )
     assert alone is not None and "example.invalid" in alone, alone
 
+
+
+def test_a_named_repository_is_enabled_after_its_tool_is_merged() -> None:
+    """`eselect repository` is not in a stage3.
+
+    Ordered rather than assumed: the enable runs in the Portage stage and the
+    package it needs is merged in the same stage, so a plan that put them the
+    other way round would fail at the first name the operator typed.
+    """
+    from gentoo_install.plan.portage import EnableRepository
+
+    installation = config()
+    asked = replace(
+        installation,
+        portage=replace(installation.portage, repositories=("science", "libressl")),
+    )
+    operations = portage.build(asked, MIRROR)
+    enabled = [one for one in operations if isinstance(one, EnableRepository)]
+    assert [one.repository for one in enabled] == ["science", "libressl"], enabled
+
+    merged = [
+        at
+        for at, one in enumerate(operations)
+        if getattr(one, "packages", ()) == ("app-eselect/eselect-repository",)
+    ]
+    assert merged, "the tool is never merged"
+    assert merged[0] < operations.index(enabled[0]), "enabled before the tool exists"
+
+    # Negative control: with no names asked for, neither the tool nor an
+    # enable is planned, so a machine pays nothing for a feature it did not use.
+    plain = portage.build(installation, MIRROR)
+    assert not [one for one in plain if isinstance(one, EnableRepository)]
+    assert not [
+        one
+        for one in plain
+        if getattr(one, "packages", ()) == ("app-eselect/eselect-repository",)
+    ]

--- a/tests/unit/test_tui_app.py
+++ b/tests/unit/test_tui_app.py
@@ -190,7 +190,7 @@ def test_field_editors_have_one_descriptor_for_each_editable_row() -> None:
     mirror_expected = {mirror._REGION, mirror._SITE, mirror._DISTFILES,
                        mirror._MEASURE, mirror._SYNC, mirror._BINHOST,
                        mirror._ZH_SITE, mirror._ZH_DISTFILES,
-                       mirror._ZH_BINHOST, "gig", "guru"}
+                       mirror._ZH_BINHOST, mirror._REPOSITORIES, "gig", "guru"}
     mirror_rows = {item.value for item in mirror._mirror_fields(config(), at.translate)
                    if item.value not in ("", tui_context.DONE)}
     assert mirror_rows <= mirror_expected

--- a/tests/unit/test_validate.py
+++ b/tests/unit/test_validate.py
@@ -1275,3 +1275,38 @@ def test_a_profile_whose_stage3_is_not_fetched_is_refused() -> None:
         )
         validate(served)
         assert variant_of(served) == f"{expected}-openrc", variant_of(served)
+
+
+def test_a_repository_name_is_checked_before_it_reaches_eselect() -> None:
+    """`eselect repository` prints one line and exits 0 for a name it does not
+    know, so the install carries on and the overlay is not there. The name is
+    refused here instead, before a disk has been written."""
+    from dataclasses import replace
+
+    installation = config()
+    for refused in ("not a name", "-leading-dash", "", "science/extra"):
+        asked = replace(
+            installation,
+            portage=replace(installation.portage, repositories=(refused,)),
+        )
+        with pytest.raises(ValidationFailed):
+            validate(asked)
+
+    # A name this installer already ships is refused too: two `repos.conf`
+    # sections of one name, and the later sync-uri replaces the earlier.
+    shipped = installation.portage.overlays[0].name if installation.portage.overlays else "gentoo"
+    with pytest.raises(ValidationFailed):
+        validate(
+            replace(
+                installation,
+                portage=replace(installation.portage, repositories=(shipped,)),
+            )
+        )
+
+    # Negative control: a name that is neither malformed nor already shipped
+    # passes, so the rule is not refusing everything.
+    validate(
+        replace(
+            installation, portage=replace(installation.portage, repositories=("science",))
+        )
+    )


### PR DESCRIPTION
`overlays.gentoo.org` lists over four hundred, and shipping that list means
maintaining it: any address that moves fails an install after the disk is
written. `eselect repository` reads the current `repositories.xml` instead,
so the configuration carries a name and nothing else.

A name is checked before it is sent, because `eselect` prints one line and
exits 0 for a name it does not know: the install would carry on without the
overlay. No package group may take a package from one of these.