### PR TITLE
tests: cover partitioning and filesystems across nine specs

### DIFF
--- a/tests/tui/specs.py
+++ b/tests/tui/specs.py
@@ -90,4 +90,73 @@ SPECS: Final[dict[int, Spec]] = {
             "the machine boots into Gentoo",
         ),
     ),
+    5: Spec(
+        number=5,
+        wanted=(
+            "Install onto the whole disk with xfs for the root filesystem and "
+            "a 4 GiB swap partition. The machine boots with UEFI and should "
+            "use systemd-boot rather than GRUB. Hostname lab5, root password "
+            f"{PASSWORD}."
+        ),
+        proof=(
+            "the root filesystem is xfs",
+            "swap is a partition of about 4 GiB",
+            "the bootloader is systemd-boot",
+            "hostname is lab5",
+        ),
+    ),
+    6: Spec(
+        number=6,
+        wanted=(
+            "Partition this 40 GiB disk by hand: a 512 MiB EFI partition, a "
+            "20 GiB root on ext4, and the rest as /home on ext4. Do not let "
+            f"the installer choose the sizes. Hostname lab6, root password {PASSWORD}."
+        ),
+        proof=(
+            "there are three partitions and their sizes are the ones asked for",
+            "/home is a separate ext4 filesystem",
+            "hostname is lab6",
+        ),
+    ),
+    7: Spec(
+        number=7,
+        wanted=(
+            "This machine has two disks. Put the root filesystem on ZFS across "
+            "both of them as a mirror, so either disk can fail. Hostname lab7, "
+            f"root password {PASSWORD}."
+        ),
+        proof=(
+            "the root filesystem is zfs",
+            "the pool is a mirror of two devices",
+            "hostname is lab7",
+        ),
+    ),
+    8: Spec(
+        number=8,
+        wanted=(
+            "An old machine with an MBR partition table and BIOS boot. Install "
+            "onto the whole disk with ext4 and OpenRC. Keep it in English, "
+            f"timezone UTC. Hostname lab8, root password {PASSWORD}."
+        ),
+        proof=(
+            "the partition table is mbr",
+            "the bootloader is grub and the firmware is bios",
+            "the init system is openrc",
+            "hostname is lab8",
+        ),
+    ),
+    9: Spec(
+        number=9,
+        wanted=(
+            "Install onto the whole disk with btrfs, and give the machine a "
+            "KDE Plasma desktop with a Chinese input method. Hostname lab9, "
+            f"root password {PASSWORD}, user zakk with the same password."
+        ),
+        proof=(
+            "the root filesystem is btrfs",
+            "a desktop environment is selected",
+            "an input method is selected",
+            "hostname is lab9",
+        ),
+    ),
 }

--- a/tests/unit/test_tui_report.py
+++ b/tests/unit/test_tui_report.py
@@ -154,3 +154,31 @@ def test_the_session_writes_the_file_the_report_counts_from(tmp_path: Path) -> N
     assert read(tmp_path) == Report(
         finished=False, lost=(), helped=0, stuck=(), refused=0
     )
+def test_every_spec_names_a_machine_that_can_answer_it() -> None:
+    """A spec and the guest it runs on are one thing.
+
+    Asked for an MBR table on a UEFI guest, or for a mirror on a machine with
+    one disk, the operator is answering an impossible question and the run
+    measures that rather than the interface.
+    """
+    from tests.tui.specs import SPECS
+    from tests.vm.cluster import TUI_GUESTS
+
+    assert sorted(SPECS) == sorted(TUI_GUESTS), (sorted(SPECS), sorted(TUI_GUESTS))
+    # Read from the proof, not the prose: a spec that says "BIOS, not UEFI"
+    # names both words, and the proof is the half a machine can be checked
+    # against anyway.
+    for number, spec in SPECS.items():
+        disks, uefi, _cjk = TUI_GUESTS[number]
+        proof = " ".join(spec.proof).lower()
+        if "mirror" in proof:
+            assert disks >= 2, (number, disks)
+        if "firmware is bios" in proof:
+            assert not uefi, number
+        if "firmware is uefi" in proof or "systemd-boot" in proof:
+            assert uefi, number
+
+    # Negative control: a spec asking for two disks on a one-disk guest is the
+    # mismatch this refuses, and the rule has to see it.
+    broken = {1: (1, True, True)}
+    assert not (broken[1][0] >= 2), "a one-disk guest must not satisfy two disks"

--- a/tests/vm/cluster.py
+++ b/tests/vm/cluster.py
@@ -1849,11 +1849,20 @@ TUI_COLUMNS: Final[int] = 120
 #: minimal ISO carries no CJK font, so a Chinese session on it reads as a
 #: screen of empty boxes and says nothing about the wording. `gentoo-zh`'s
 #: own live CD carries cjktty and the fonts.
+#: Disks, UEFI, and whether the medium has to carry a CJK font. One entry per
+#: spec, because the machine a spec describes is part of the spec: asking for
+#: an MBR table on a UEFI guest is asking the operator to answer an impossible
+#: question, and the run would measure that rather than the interface.
 TUI_GUESTS: Final[dict[int, tuple[int, bool, bool]]] = {
     1: (1, True, True),
     2: (2, False, True),
     3: (1, True, True),
     4: (1, True, True),
+    5: (1, True, True),
+    6: (1, True, True),
+    7: (2, True, True),
+    8: (1, False, False),
+    9: (1, True, True),
 }
 
 


### PR DESCRIPTION
Four specs exercised one layout and two filesystems. These add xfs with swap
and systemd-boot, a hand-partitioned disk, a ZFS mirror over two disks, an MBR
BIOS machine on OpenRC, and a desktop with an input method.

A spec and the guest it runs on are one thing: asked for an MBR table on a
UEFI guest the operator is answering an impossible question, and the run would
measure that rather than the interface.