### PR TITLE
tui: empty a field with ctrl-u

### DIFF
--- a/gentoo_install/data/locale/ja.toml
+++ b/gentoo_install/data/locale/ja.toml
@@ -718,3 +718,4 @@
 "names separated by commas, as on overlays.gentoo.org" = "overlays.gentoo.org に載っている名前をカンマ区切りで入力します"
 "no package this installer merges comes from these" = "インストーラーが導入するパッケージはこれらを使用しません"
 "enable the {} repository" = "{} リポジトリを有効にします"
+"Empty the field, which arrives with a value in it" = "フィールドを空にします。フィールドには最初から値が入っています"

--- a/gentoo_install/data/locale/ko.toml
+++ b/gentoo_install/data/locale/ko.toml
@@ -718,3 +718,4 @@
 "names separated by commas, as on overlays.gentoo.org" = "overlays.gentoo.org에 있는 이름을 쉼표로 구분하여 입력합니다"
 "no package this installer merges comes from these" = "설치 관리자가 병합하는 패키지는 이 오버레이를 사용하지 않습니다"
 "enable the {} repository" = "{} 저장소를 활성화합니다"
+"Empty the field, which arrives with a value in it" = "필드를 비웁니다. 필드에는 처음부터 값이 들어 있습니다"

--- a/gentoo_install/data/locale/zh-CN.toml
+++ b/gentoo_install/data/locale/zh-CN.toml
@@ -719,3 +719,4 @@
 "names separated by commas, as on overlays.gentoo.org" = "以逗号分隔的名称，取自 overlays.gentoo.org"
 "no package this installer merges comes from these" = "安装器合并的软件包都不会取自这些 overlay"
 "enable the {} repository" = "启用 {} 仓库"
+"Empty the field, which arrives with a value in it" = "清空字段，字段打开时本来就有值"

--- a/gentoo_install/data/locale/zh-TW.toml
+++ b/gentoo_install/data/locale/zh-TW.toml
@@ -719,3 +719,4 @@
 "names separated by commas, as on overlays.gentoo.org" = "以逗號分隔的名稱，取自 overlays.gentoo.org"
 "no package this installer merges comes from these" = "安裝器合併的套件都不會取自這些 overlay"
 "enable the {} repository" = "啟用 {} 儲存庫"
+"Empty the field, which arrives with a value in it" = "清空欄位，欄位開啟時本來就有值"

--- a/gentoo_install/tui/widgets.py
+++ b/gentoo_install/tui/widgets.py
@@ -180,10 +180,16 @@ KEY_HELP: Final[tuple[KeyRow, ...]] = (
     KeyRow("home  end", "Move the cursor to the first or last row"),
     KeyRow("g  G", "First or last row, in a list; a letter in a field"),
     KeyRow("/", "Narrow a list to the rows holding what is typed next"),
+    KeyRow("ctrl-u", "Empty the field, which arrives with a value in it"),
 )
 
 #: What opens the key page. A letter in a field, like `q`.
 HELP_KEY: Final[str] = "?"
+
+#: What empties a field. `ctrl-u` is what a shell's line editor uses, and a
+#: printable key cannot do this: every one of them is a character somebody
+#: types into one of these fields.
+CLEAR_KEY: Final[str] = "\x15"
 
 #: One screen at a time, and the ends. `America` holds 169 timezones, which is
 #: eight screens of `j` on a console 24 lines tall.
@@ -630,7 +636,14 @@ class TextField:
                 return Answer(Outcome.CHOSE, "".join(typed))
             if pressed in ("KEY_LEFT", "\x1b"):
                 return Answer(Outcome.BACK)
-            if pressed in ("\x7f", "KEY_BACKSPACE"):
+            if pressed == CLEAR_KEY:
+                # Every field here arrives with a value in it, and replacing
+                # one meant counting its characters and pressing backspace
+                # that many times: an operator asked for a 512 MiB partition
+                # and the field answered `1GiB512MiB`.
+                typed.clear()
+                touched = True
+            elif pressed in ("\x7f", "KEY_BACKSPACE"):
                 if typed:
                     typed.pop()
                     touched = True

--- a/tests/tui/brief.md
+++ b/tests/tui/brief.md
@@ -15,8 +15,9 @@ python3 -m tests.tui.session key <id> <keys...>   press keys
 ```
 
 Keys are named: `up`, `down`, `left`, `right`, `enter`, `esc`, `tab`, `space`,
-`home`, `end`, `pageup`, `pagedown`, `help`, `backspace`, and `type:<text>` to
-enter text. Several may be given at once: `key lab1 down down enter`.
+`home`, `end`, `pageup`, `pagedown`, `help`, `backspace`, `clear`, and
+`type:<text>` to enter text. A field arrives with a value in it, so `clear`
+before typing a replacement. Several may be given at once: `key lab1 down down enter`.
 
 ## What you may not do
 

--- a/tests/tui/session.py
+++ b/tests/tui/session.py
@@ -61,6 +61,7 @@ KEYS: Final[dict[str, str]] = {
     "pagedown": "\x1b[6~",
     "home": "\x1bOH",
     "end": "\x1bOF",
+    "clear": "\x15",
     "help": "?",
     "filter": "/",
 }

--- a/tests/unit/test_tui_widgets.py
+++ b/tests/unit/test_tui_widgets.py
@@ -1312,3 +1312,27 @@ def test_right_chooses_in_a_list_because_left_goes_back_from_one() -> None:
     )
     answer = several.run(FakeScreen(keys=["KEY_RIGHT", " ", "\n"]))
     assert answer.unwrap() == ("zh_TW",), answer
+
+
+def test_a_field_that_arrives_with_a_value_can_be_emptied() -> None:
+    """Replacing one meant counting its characters and pressing backspace.
+
+    Read off a guest: an agent asked for a 512 MiB partition, typed it into a
+    field already holding `1GiB`, and the field answered `1GiB512MiB`.
+    """
+    from gentoo_install.tui.widgets import CLEAR_KEY
+
+    screen = FakeScreen(keys=[CLEAR_KEY, "5", "1", "2", "M", "\n"])
+    answered = TextField(title="Size", value="1GiB").run(screen)
+    assert answered.unwrap() == "512M", answered
+
+    # Negative control: without it the same keys append, which is the value
+    # the operator saw.
+    appended = TextField(title="Size", value="1GiB").run(
+        FakeScreen(keys=["5", "1", "2", "M", "\n"])
+    )
+    assert appended.unwrap() == "1GiB512M"
+
+    # And the key is not a character: a field that took it as text would lose
+    # the one way out of a prefilled value.
+    assert not CLEAR_KEY.isprintable()


### PR DESCRIPTION
Every field arrives with a value in it, and replacing one meant counting its
characters and pressing backspace that many times.

Read off a guest: an operator asked for a 512 MiB partition, typed it into a
field already holding `1GiB`, and the field answered `1GiB512MiB`.