### PR TITLE
tui: cut the profile paths to what differs and let a pane follow a resize

### DIFF
--- a/gentoo_install/tui/screens.py
+++ b/gentoo_install/tui/screens.py
@@ -1630,9 +1630,17 @@ def _profile_screen(screen: Screen, config: InstallConfig, context: Context) -> 
         for profile in choices
         if ("systemd" in profile.split("/")) is (config.system.init is InitSystem.SYSTEMD)
     ]
+    # Without the part every row shares. The whole path is 44 cells and the
+    # pane is narrower than that, so a row wrapped onto a second line and the
+    # list stopped reading as a list; the prefix is named once above instead.
+    shared = f"{BASE_PROFILE}/"
     menu: Menu[str] = Menu(
         title=context.translate("Portage"),
-        items=[Item(label=profile, value=profile) for profile in wanted],
+        preamble=(f"{shared}\u2026",),
+        items=[
+            Item(label=profile.removeprefix(shared), value=profile)
+            for profile in wanted
+        ],
         footer=footer(context.translate),
         current=config.portage.profile,
     )

--- a/gentoo_install/tui/screens.py
+++ b/gentoo_install/tui/screens.py
@@ -1636,7 +1636,7 @@ def _profile_screen(screen: Screen, config: InstallConfig, context: Context) -> 
     shared = f"{BASE_PROFILE}/"
     menu: Menu[str] = Menu(
         title=context.translate("Portage"),
-        preamble=(f"{shared}\u2026",),
+        preamble=(shared,),
         items=[
             Item(label=profile.removeprefix(shared), value=profile)
             for profile in wanted

--- a/gentoo_install/tui/settings.py
+++ b/gentoo_install/tui/settings.py
@@ -16,6 +16,7 @@ from dataclasses import dataclass
 from typing import Callable, Final
 
 from ..model.config import (
+    BASE_PROFILE,
     Bootloader,
     DiskMode,
     Firewall,
@@ -1002,10 +1003,12 @@ SETTINGS: Final[tuple[Setting, ...]] = (
     Setting(
         'profile',
         'Profile',
-        # Without the `default/linux/` every profile starts with. The last
-        # component alone is not enough: `desktop/systemd` and `systemd` both
-        # end in the same word and they are different profiles.
-        lambda c, x: c.portage.profile.removeprefix("default/linux/"),
+        # Without the `default/linux/amd64/<release>/` every profile in the
+        # list shares. The last component alone is not enough, because
+        # `desktop/systemd` and `systemd` both end in the same word; the whole
+        # path is too long for the pane, and a value that does not fit is
+        # dropped rather than cut, so `no-multilib/systemd` left the row blank.
+        lambda c, x: c.portage.profile.removeprefix(f"{BASE_PROFILE}/"),
         screens._profile_screen,
         describes="The Portage profile, which sets the default USE flags and package set.",
         section="System",

--- a/gentoo_install/tui/widgets.py
+++ b/gentoo_install/tui/widgets.py
@@ -223,11 +223,24 @@ class Region:
     #: it while the frame around it was redrawn for the new one, and the screen
     #: held half of each layout.
     cut: Callable[[int, int], tuple[int, int, int, int]] | None = None
+    #: Draws the frame around this rectangle again. The editor inside redraws
+    #: itself when the terminal changes size; nothing else did, so the list
+    #: beside it and the box around it were gone and the screen held one pane
+    #: of an interface.
+    redraw: Callable[[], None] | None = None
+    _seen: tuple[int, int] = (0, 0)
 
     def _rectangle(self) -> tuple[int, int, int, int]:
         if self.cut is None:
             return self.line, self.column, self.lines, self.columns
-        return self.cut(*self.screen.size())
+        size = self.screen.size()
+        if size != self._seen:
+            # Before the arithmetic, so the rectangle answered is the one the
+            # frame just drew rather than the one it is about to replace.
+            self._seen = size
+            if self.redraw is not None:
+                self.redraw()
+        return self.cut(*size)
 
     def size(self) -> tuple[int, int]:
         _, _, lines, columns = self._rectangle()
@@ -1182,6 +1195,15 @@ class TwoPane(Generic[V]):
                 region.write(offset, 0, line_text)
         screen.show()
 
+    def _frame_only(self, screen: Screen, cursor: int, *, dimmed: bool) -> None:
+        """Draw the frame without answering with a rectangle.
+
+        Named so the redraw a resize needs cannot build a second `Region`: one
+        of those would carry its own callback and the two would take turns
+        drawing each other.
+        """
+        self.frame(screen, cursor, dimmed=dimmed)
+
     def frame(self, screen: Screen, cursor: int, *, dimmed: bool) -> Region | None:
         """Draw the list, the separator and the status line, and answer with
         the rectangle beside them.
@@ -1250,7 +1272,14 @@ class TwoPane(Generic[V]):
         # redrawn at the new size after a resize and the rectangle has to move
         # with it.
         return Region(
-            screen, 3, left + 2, room - 2, max(1, columns - left - 4), cut=self._pane
+            screen,
+            3,
+            left + 2,
+            room - 2,
+            max(1, columns - left - 4),
+            cut=self._pane,
+            redraw=lambda: self._frame_only(screen, cursor, dimmed=dimmed),
+            _seen=(lines, columns),
         )
 
     def _pane(self, lines: int, columns: int) -> tuple[int, int, int, int]:

--- a/gentoo_install/tui/widgets.py
+++ b/gentoo_install/tui/widgets.py
@@ -217,13 +217,26 @@ class Region:
     column: int
     lines: int
     columns: int
+    #: How the rectangle is cut from the screen, asked again on every write so
+    #: a terminal that changes size takes the rectangle with it. Measured once
+    #: and kept, an editor went on writing into the rectangle the old size gave
+    #: it while the frame around it was redrawn for the new one, and the screen
+    #: held half of each layout.
+    cut: Callable[[int, int], tuple[int, int, int, int]] | None = None
+
+    def _rectangle(self) -> tuple[int, int, int, int]:
+        if self.cut is None:
+            return self.line, self.column, self.lines, self.columns
+        return self.cut(*self.screen.size())
 
     def size(self) -> tuple[int, int]:
-        return self.lines, self.columns
+        _, _, lines, columns = self._rectangle()
+        return lines, columns
 
     def clear(self) -> None:
-        for offset in range(self.lines):
-            self.screen.write(self.line + offset, self.column, " " * self.columns)
+        line, column, lines, columns = self._rectangle()
+        for offset in range(lines):
+            self.screen.write(line + offset, column, " " * columns)
 
     def write(
         self,
@@ -233,12 +246,13 @@ class Region:
         highlight: bool = False,
         style: Style = Style.PLAIN,
     ) -> None:
-        if not 0 <= line < self.lines or column >= self.columns:
+        top, left, lines, columns = self._rectangle()
+        if not 0 <= line < lines or column >= columns:
             return
         self.screen.write(
-            self.line + line,
-            self.column + column,
-            clip(text, self.columns - column),
+            top + line,
+            left + column,
+            clip(text, columns - column),
             highlight=highlight,
             style=style,
         )
@@ -1232,7 +1246,17 @@ class TwoPane(Generic[V]):
             )
         if lines > 1 and (self.footer or self.legend):
             screen.write(lines - 1, 0, spread(self.footer, self.legend, columns))
-        return Region(screen, 3, left + 2, room - 2, max(1, columns - left - 4))
+        # The same arithmetic, handed over rather than its result: the pane is
+        # redrawn at the new size after a resize and the rectangle has to move
+        # with it.
+        return Region(
+            screen, 3, left + 2, room - 2, max(1, columns - left - 4), cut=self._pane
+        )
+
+    def _pane(self, lines: int, columns: int) -> tuple[int, int, int, int]:
+        """Where the right pane sits on a screen this size."""
+        left = left_pane_width(((row.label, row.state) for row in self.rows), columns)
+        return 3, left + 2, max(1, lines - 3 - 2), max(1, columns - left - 4)
 
     def _draw_one_pane(self, screen: Screen, cursor: int, lines: int, columns: int) -> None:
         """One pane, and the row under the cursor carries two of its lines.

--- a/tests/unit/test_tui_app.py
+++ b/tests/unit/test_tui_app.py
@@ -380,7 +380,11 @@ def test_only_profiles_matching_the_init_are_offered() -> None:
     screen = FakeScreen(keys=["q", "KEY_DOWN", "\n"])
     screens._profile_screen(screen, config(), context())
     drawn = screen.last
-    assert "23.0/systemd" in drawn
+    # The rows carry what differs; the part every one of them shares is named
+    # once above, because the whole path does not fit the pane.
+    assert "\n  systemd" in drawn, drawn
+    assert "default/linux/amd64/" in drawn, drawn
+    assert "default/linux/amd64/23.0/systemd" not in drawn, drawn
     openrc = replace(config(), system=replace(config().system, init=InitSystem.OPENRC))
     plain = FakeScreen(keys=["q", "KEY_DOWN", "\n"])
     screens._profile_screen(plain, openrc, context())
@@ -3680,8 +3684,9 @@ def test_two_profiles_ending_in_the_same_word_read_differently() -> None:
         portage=replace(plain.portage, profile="default/linux/amd64/23.0/desktop/systemd"),
     )
     assert row.value(plain, at) != row.value(desktop, at), row.value(plain, at)
-    assert row.value(desktop, at) == "amd64/23.0/desktop/systemd"
+    assert row.value(desktop, at) == "desktop/systemd"
 
     # Negative control: the shared prefix is still dropped, or the pane widens
     # for a word that is the same on every profile.
     assert not row.value(plain, at).startswith("default/linux/")
+    assert row.value(plain, at) == "systemd"

--- a/tests/unit/test_tui_curses.py
+++ b/tests/unit/test_tui_curses.py
@@ -714,6 +714,8 @@ def main(window: object) -> None:
     answer["outcome"] = chosen.outcome.value
     answer["size"] = [lines, columns]
     answer["region"] = list(inside.size()) if inside is not None else None
+    answer["left"] = window.instr(3, 0, 12).decode().rstrip()
+    answer["title"] = window.instr(0, 0, 20).decode().strip()
 
 
 curses.wrapper(main)
@@ -738,3 +740,8 @@ def test_a_row_opened_before_a_resize_draws_inside_the_new_frame() -> None:
     # The region has to follow the screen it is cut from, or the editor draws
     # into a rectangle the frame no longer occupies.
     assert lines >= grown[0] - 5, result
+    # And the frame itself has to be back on the screen: the editor redraws
+    # itself on a resize and nothing else did, so the list beside it and the
+    # box around it were gone.
+    assert result["left"].strip().startswith("row"), result
+    assert result["title"].startswith("gentoo-install"), result

--- a/tests/unit/test_tui_curses.py
+++ b/tests/unit/test_tui_curses.py
@@ -653,3 +653,88 @@ def test_every_key_the_session_sends_is_the_one_terminfo_names() -> None:
     # whatever the table happens to hold.
     assert curses.tigetstr("khome") != b"\x1b[H"
     assert curses.tigetstr("kcud1") != b"\x1b[B"
+
+
+RESIZE_PANE = r"""
+import curses
+
+from gentoo_install.tui.curses_screen import CursesScreen
+from gentoo_install.tui.widgets import PaneRow, TwoPane
+
+
+def main(window: object) -> None:
+    screen = CursesScreen(window)
+    rows = [
+        PaneRow(label=f"row {at}", value=at, state=f"value {at}", detail=("what it is",))
+        for at in range(6)
+    ]
+    chosen = TwoPane(title="gentoo-install", rows=rows).run(screen)
+    lines, columns = screen.size()
+    answer["outcome"] = chosen.outcome.value
+    answer["size"] = [lines, columns]
+    answer["drawn"] = window.instr(0, 0, 30).decode().rstrip()
+
+
+curses.wrapper(main)
+"""
+
+
+def test_the_two_pane_list_redraws_at_the_size_the_terminal_became() -> None:
+    """A resize must leave the frame drawn for the new size, not the old one.
+
+    The whole interface is this widget, so a resize that leaves it drawn for
+    the previous dimensions is the interface breaking rather than one screen.
+    """
+    grown = (46, 130)
+    actions: list[ResizeAction] = [(30, 100), grown, "\n"]
+    result, _ = drive_resizes(actions, RESIZE_PANE)
+    assert result.get("error") is None, result.get("error")
+    assert result["size"] == list(grown), result
+    assert result["drawn"].strip().startswith("gentoo-install"), result
+    assert result["outcome"] == "chose", result
+
+
+RESIZE_REGION = r"""
+import curses
+
+from gentoo_install.tui.curses_screen import CursesScreen
+from gentoo_install.tui.widgets import Item, Menu, PaneRow, TwoPane
+
+
+def main(window: object) -> None:
+    screen = CursesScreen(window)
+    rows = [PaneRow(label=f"row {at}", value=at, state="value") for at in range(6)]
+    pane = TwoPane(title="gentoo-install", rows=rows)
+    inside = pane.frame(screen, 0, dimmed=True)
+    chosen = Menu(
+        title="Portage",
+        items=[Item(label=f"choice {at}", value=at) for at in range(4)],
+    ).run(inside if inside is not None else screen)
+    lines, columns = screen.size()
+    answer["outcome"] = chosen.outcome.value
+    answer["size"] = [lines, columns]
+    answer["region"] = list(inside.size()) if inside is not None else None
+
+
+curses.wrapper(main)
+"""
+
+
+def test_a_row_opened_before_a_resize_draws_inside_the_new_frame() -> None:
+    """The rectangle an editor draws into is measured when the row is opened.
+
+    Resize while it is open and the editor keeps writing into the rectangle
+    the old size gave it: the frame around it moved and the screen holds two
+    layouts. The whole interface is one opened row most of the time.
+    """
+    grown = (46, 130)
+    actions: list[ResizeAction] = [(30, 100), grown, "\n"]
+    result, _ = drive_resizes(actions, RESIZE_REGION)
+    assert result.get("error") is None, result.get("error")
+    assert result["size"] == list(grown), result
+    lines, columns = result["region"]
+    assert columns < grown[1], "the region is not narrower than the screen"
+    assert lines <= grown[0], result
+    # The region has to follow the screen it is cut from, or the editor draws
+    # into a rectangle the frame no longer occupies.
+    assert lines >= grown[0] - 5, result


### PR DESCRIPTION
The whole profile path is 44 cells and the pane is narrower, so a row in the
picker wrapped onto a second line and the list stopped reading as one; in the
menu a value that does not fit is dropped rather than cut, so a `no-multilib`
profile left the row blank. The shared part is named once above instead.

An editor draws into a rectangle measured when its row was opened. Resized
while it is open, it kept writing into the old rectangle while the frame
around it was redrawn for the new size: a terminal at 46x130 with a pane still
35x86, and both layouts on the screen at once.