### PR TITLE
tui: say where in a list the cursor is when it scrolls

### DIFF
--- a/gentoo_install/tui/widgets.py
+++ b/gentoo_install/tui/widgets.py
@@ -532,7 +532,6 @@ class _Menu(Generic[V, A]):
     def _draw(self, screen: Screen, cursor: int) -> None:
         lines, columns = screen.size()
         screen.clear()
-        screen.write(0, 0, clip(self.title, columns))
         # One line each, under the title. A question whose subject is a list
         # crammed the list into the title, and the title is truncated to the
         # width: the profile a desktop moves to fell off the end of it.
@@ -548,6 +547,13 @@ class _Menu(Generic[V, A]):
             (row for row, (index, _) in enumerate(displayed) if index == cursor), 0
         )
         top = max(0, min(cursor_row - room // 2, len(displayed) - room))
+        # On the title row, and only when a row is off the screen: a list that
+        # scrolls with nothing to say so reads as the whole list, and the
+        # profile screen was read as offering thirteen of its fourteen.
+        counted = (
+            f"{cursor_row + 1}/{len(displayed)}" if len(displayed) > room else ""
+        )
+        screen.write(0, 0, spread(clip(self.title, columns), counted, columns))
         for row, (index, text) in enumerate(displayed[top : top + room]):
             if index is None:
                 screen.write(row + 2 + above, 2, clip(text, columns - 4))

--- a/tests/unit/test_tui_app.py
+++ b/tests/unit/test_tui_app.py
@@ -3690,3 +3690,36 @@ def test_two_profiles_ending_in_the_same_word_read_differently() -> None:
     # for a word that is the same on every profile.
     assert not row.value(plain, at).startswith("default/linux/")
     assert row.value(plain, at) == "systemd"
+
+
+def test_every_profile_the_target_reports_is_offered() -> None:
+    """Read off a live machine: `eselect profile list` names fourteen systemd
+    profiles and the screen showed thirteen. The parser reads them all, so the
+    screen has to offer them all."""
+    from gentoo_install.exec.probe import profiles_from_eselect
+
+    listed = "\n".join(
+        [
+            "Available profile symlink targets:",
+            "  [2]   default/linux/amd64/23.0/systemd (stable)",
+            "  [20]  default/linux/amd64/23.0/llvm/systemd (exp)",
+            "  [41]  default/linux/amd64/23.0/x32/systemd (exp)",
+            "  [44]  default/linux/amd64/23.0/musl (dev)",
+            "  [45]  default/linux/amd64/23.0/musl/systemd (dev)",
+            "  [47]  default/linux/amd64/23.0/musl/llvm/systemd (exp)",
+            "  [43]  default/hurd/amd64/23.0 (exp)",
+        ]
+    )
+    paths = tuple(one.path for one in profiles_from_eselect(listed))
+    at = context()
+    at.profile_paths = paths
+    screen = FakeScreen(keys=["q", "\n"], lines=40, columns=110)
+    screens._profile_screen(screen, config(), at)
+    drawn = screen.last
+    for offered in ("systemd", "llvm/systemd", "x32/systemd", "musl/systemd", "musl/llvm/systemd"):
+        assert f"\n  {offered}" in drawn, (offered, drawn)
+
+    # Negative control: a profile the machine did not report is not invented,
+    # and the hurd one is not an amd64 linux profile at all.
+    assert "desktop/systemd" not in drawn, drawn
+    assert "hurd" not in drawn, drawn

--- a/tests/unit/test_tui_widgets.py
+++ b/tests/unit/test_tui_widgets.py
@@ -1336,3 +1336,29 @@ def test_a_field_that_arrives_with_a_value_can_be_emptied() -> None:
     # And the key is not a character: a field that took it as text would lose
     # the one way out of a prefilled value.
     assert not CLEAR_KEY.isprintable()
+
+
+def test_a_list_that_scrolls_says_where_in_it_the_cursor_is() -> None:
+    """A list with a row off the screen read as the whole list.
+
+    Fourteen profiles in thirteen rows of room showed thirteen and nothing
+    said the fourteenth existed, so the screen answered a question about
+    completeness with a wrong answer.
+    """
+    items = [Item(label=f"row {at}", value=at) for at in range(14)]
+
+    tight = FakeScreen(keys=["\n"], lines=17, columns=40)
+    Menu(title="Portage", items=items).run(tight)
+    assert tight.last.splitlines()[0].rstrip().endswith("1/14"), tight.last
+
+    # Negative control: a screen with room for every row says nothing, or the
+    # count becomes noise on every list in the interface.
+    roomy = FakeScreen(keys=["\n"], lines=30, columns=40)
+    Menu(title="Portage", items=items).run(roomy)
+    assert roomy.last.splitlines()[0].strip() == "Portage", roomy.last
+
+    # And it follows the cursor, so it says where in the list the operator is
+    # rather than only that there is more of it.
+    moved = FakeScreen(keys=["KEY_DOWN", "KEY_DOWN", "\n"], lines=17, columns=40)
+    Menu(title="Portage", items=items).run(moved)
+    assert moved.last.splitlines()[0].rstrip().endswith("3/14"), moved.last


### PR DESCRIPTION
A list with a row off the screen read as the whole list. `eselect profile list`
names fourteen systemd profiles and the screen showed thirteen with nothing to
say the fourteenth existed, so a question about whether the list was complete
got a wrong answer from the screen itself.

The count appears only when a row is off the screen, or it is noise on every
list in the interface.