### PR TITLE
tui: refuse sizes larger than the disk where they are typed, and keep back at the top harmless

### DIFF
--- a/gentoo_install/data/locale/ja.toml
+++ b/gentoo_install/data/locale/ja.toml
@@ -719,3 +719,4 @@
 "no package this installer merges comes from these" = "インストーラーが導入するパッケージはこれらを使用しません"
 "enable the {} repository" = "{} リポジトリを有効にします"
 "Empty the field, which arrives with a value in it" = "フィールドを空にします。フィールドには最初から値が入っています"
+"{disk} can hand out {usable} and these sizes come to {claimed}" = "{disk} が割り当てられるのは {usable} ですが、指定された合計は {claimed} です"

--- a/gentoo_install/data/locale/ko.toml
+++ b/gentoo_install/data/locale/ko.toml
@@ -719,3 +719,4 @@
 "no package this installer merges comes from these" = "설치 관리자가 병합하는 패키지는 이 오버레이를 사용하지 않습니다"
 "enable the {} repository" = "{} 저장소를 활성화합니다"
 "Empty the field, which arrives with a value in it" = "필드를 비웁니다. 필드에는 처음부터 값이 들어 있습니다"
+"{disk} can hand out {usable} and these sizes come to {claimed}" = "디스크 {disk}: 배정 가능한 용량 {usable}, 지정한 합계 {claimed}"

--- a/gentoo_install/data/locale/zh-CN.toml
+++ b/gentoo_install/data/locale/zh-CN.toml
@@ -720,3 +720,4 @@
 "no package this installer merges comes from these" = "安装器合并的软件包都不会取自这些 overlay"
 "enable the {} repository" = "启用 {} 仓库"
 "Empty the field, which arrives with a value in it" = "清空字段，字段打开时本来就有值"
+"{disk} can hand out {usable} and these sizes come to {claimed}" = "{disk} 能分出 {usable}，这些大小加起来是 {claimed}"

--- a/gentoo_install/data/locale/zh-TW.toml
+++ b/gentoo_install/data/locale/zh-TW.toml
@@ -720,3 +720,4 @@
 "no package this installer merges comes from these" = "安裝器合併的套件都不會取自這些 overlay"
 "enable the {} repository" = "啟用 {} 儲存庫"
 "Empty the field, which arrives with a value in it" = "清空欄位，欄位開啟時本來就有值"
+"{disk} can hand out {usable} and these sizes come to {claimed}" = "{disk} 能配出 {usable}，這些大小加起來是 {claimed}"

--- a/gentoo_install/exec/preflight.py
+++ b/gentoo_install/exec/preflight.py
@@ -30,7 +30,7 @@ from ..model.device import (
     VolumeGroup,
     ZfsPool,
 )
-from ..model.size import DEFAULT_ALIGNMENT, SectorSize, Size
+from ..model.size import SectorSize, Size
 from ..model.validate import root_size_problems
 from ..plan.disk import MKFS
 from ..plan.operations import Operation
@@ -414,11 +414,9 @@ def _capacity_problems(config: InstallConfig, probe: Probe) -> list[str]:
             claimed += sum(
                 size for number, size in present.items() if number not in table.remove
             )
-        usable = Size(capacity)
-        if table.table is TableType.GPT:
-            usable = usable.gpt_last_usable(SectorSize(512))
-        # The first partition starts at the alignment boundary, not at zero.
-        usable = Size(max(0, usable.bytes - DEFAULT_ALIGNMENT))
+        usable = Size(capacity).usable_for_partitions(
+            table.table is TableType.GPT, SectorSize(512)
+        )
         supplied_root_sizes[table.id] = usable
         if claimed > usable.bytes:
             problems.append(

--- a/gentoo_install/model/size.py
+++ b/gentoo_install/model/size.py
@@ -184,6 +184,18 @@ class Size:
             raise InvalidSize(f"{self} is too small to hold a GPT")
         return Size(self.bytes - reserved.bytes)
 
+    def usable_for_partitions(self, gpt: bool, sector: SectorSize) -> Size:
+        """How much of a device this size a table may hand to partitions.
+
+        One function because two callers must agree: the check that runs
+        before the disk is written and the one the operator reads while
+        typing sizes. Answered separately, an operator was told their sizes
+        fitted and the install refused them an hour later.
+        """
+        usable = self.gpt_last_usable(sector) if gpt else self
+        # The first partition starts at the alignment boundary, not at zero.
+        return Size(max(0, usable.bytes - DEFAULT_ALIGNMENT))
+
     def fits_in_gpt(self, device: Size, sector: SectorSize) -> bool:
         """Whether a partition ending here clears the trailing GPT copy."""
         return self <= device.gpt_last_usable(sector)

--- a/gentoo_install/tui/app.py
+++ b/gentoo_install/tui/app.py
@@ -166,6 +166,13 @@ def run(screen: Screen, start: InstallConfig, context: Context) -> Finished:
         )
         answer = pane.run(screen)
         cursor = pane.cursor
+        if answer.outcome is Outcome.BACK:
+            # Back has nowhere to go from the top of the interface, and the
+            # key page says it keeps what the screen holds. Offering to leave
+            # instead made one stray escape the end of the run: an agent
+            # pressed it seven times reading it as one step back, and the
+            # third press landed on `Leave`.
+            continue
         if not answer.chosen:
             left = _leaving(screen, current, context)
             if left is not None:

--- a/gentoo_install/tui/partitions.py
+++ b/gentoo_install/tui/partitions.py
@@ -34,7 +34,7 @@ from ..model.device import (
     TableType,
     ZfsTopology,
 )
-from ..model.size import Size
+from ..model.size import SectorSize, Size
 from ..model.templates import Choice, Layout, build
 from ..model.validate import validate
 from ..errors import GentooInstallError, ValidationFailed
@@ -729,8 +729,40 @@ def _edit_pool_encryption(screen: Screen, context: Context) -> Answer[str]:
     return edited
 
 
+def _too_big_for_the_disk(context: Context) -> str:
+    """Sizes that come to more than the disk can hand out.
+
+    Checked while they are typed. Left to the check that runs before the disk
+    is written, an operator was told nothing for twenty rows and then refused
+    at the confirmation: `/efi 1GiB + / 35GiB + swap 4GiB` on a 40 GiB disk
+    is over by the trailing GPT copy and the first alignment boundary.
+    """
+    translate = context.translate
+    for disk in context.layout.disks:
+        total = context.contents(disk.selector)[1]
+        fresh = [one for one in disk.slices if one.status is manual.SliceStatus.CREATE]
+        claimed = sum(one.size.bytes for one in fresh if one.size is not None)
+        if not total or not claimed:
+            continue
+        try:
+            capacity = Size.parse(total)
+        except GentooInstallError:
+            continue
+        usable = capacity.usable_for_partitions(
+            disk.table is TableType.GPT, SectorSize(512)
+        )
+        if claimed > usable.bytes:
+            return translate(
+                "{disk} can hand out {usable} and these sizes come to {claimed}"
+            ).format(disk=disk.selector, usable=usable, claimed=Size(claimed))
+    return ""
+
+
 def _layout_problem(context: Context, config: InstallConfig) -> str:
     """What the validator says about the table as it stands."""
+    over = _too_big_for_the_disk(context)
+    if over:
+        return over
     try:
         graph, root = manual.build(context.layout)
     except GentooInstallError as error:

--- a/gentoo_install/tui/widgets.py
+++ b/gentoo_install/tui/widgets.py
@@ -1146,11 +1146,16 @@ class TwoPane(Generic[V]):
                 # that would refuse: its reason is already in the right pane.
                 if self.rows and not self.rows[cursor].disabled_because:
                     return Answer(Outcome.CHOSE, self.rows[cursor].value)
-            elif pressed in ("KEY_LEFT", "\x1b", "q"):
-                # All three answer Back and what Back means is the caller's:
-                # the main menu asks whether to end the run. `q` is here and
-                # nowhere deeper, because a text field reads it as a letter.
+            elif pressed in ("KEY_LEFT", "\x1b", "\x7f", "KEY_BACKSPACE"):
+                # Back, which at the top of the interface is nowhere to go.
+                # Held apart from `q` because they mean different things: an
+                # agent read the key page's `esc  Back` and pressed it seven
+                # times, and one of those presses offered to end the run.
                 return Answer(Outcome.BACK)
+            elif pressed == "q":
+                # Leaving, which is what the status line names it. Here and
+                # nowhere deeper, because a text field reads it as a letter.
+                return Answer(Outcome.CANCELLED)
             elif pressed == "\x03":
                 return Answer(Outcome.CANCELLED)
 

--- a/tests/unit/test_tui_app.py
+++ b/tests/unit/test_tui_app.py
@@ -3723,3 +3723,33 @@ def test_every_profile_the_target_reports_is_offered() -> None:
     # and the hurd one is not an amd64 linux profile at all.
     assert "desktop/systemd" not in drawn, drawn
     assert "hurd" not in drawn, drawn
+
+
+def test_back_does_nothing_at_the_top_and_only_cancel_offers_to_leave() -> None:
+    """Back has nowhere to go from the main menu.
+
+    Offering to leave instead made one stray escape the end of the run: an
+    agent driving the interface pressed it seven times reading it as one step
+    back, and one of those presses ended the session with twenty rows filled.
+    """
+    at = context()
+    # Nothing but the three ways back. The menu is still asking for a key
+    # afterwards, which is the whole claim: none of them ended the run and
+    # none of them asked anything.
+    quiet = FakeScreen(keys=["\x1b", "KEY_LEFT", "KEY_BACKSPACE"])
+    with pytest.raises(AssertionError, match="asked for a key"):
+        run(quiet, config(), at)
+    drawn = "\n".join("\n".join(frame) for frame in quiet.frames)
+    # Not asked, not only unanswered: the question itself was never drawn.
+    assert "Leave without installing?" not in drawn, drawn[-300:]
+
+    # And the one the status line names does end it.
+    screen = FakeScreen(keys=["q", "KEY_DOWN", "\n"])
+    assert run(screen, config(), at).cancelled
+    seen = "\n".join("\n".join(frame) for frame in screen.frames)
+    assert "Leave without installing?" in seen
+
+    # Negative control: the same three keys with `q` in front do end it, so
+    # the widget is not simply ignoring every key it is given.
+    ended = FakeScreen(keys=["q", "KEY_DOWN", "\n", "\x1b", "KEY_LEFT"])
+    assert run(ended, config(), at).cancelled

--- a/tests/unit/test_tui_partitions.py
+++ b/tests/unit/test_tui_partitions.py
@@ -1582,3 +1582,48 @@ def test_no_door_of_this_module_answers_with_the_quit_prompt() -> None:
     }
     answered = {name: door() for name, door in doors.items()}
     assert set(answered.values()) == {Outcome.BACK}, answered
+
+
+def test_sizes_larger_than_the_disk_are_refused_where_they_are_typed() -> None:
+    """`/efi 1GiB + / 35GiB + swap 4GiB` on a 40 GiB disk is over.
+
+    The trailing GPT copy and the first alignment boundary are not free, and
+    the check that knew it ran after the confirmation: an operator answered
+    twenty rows and was refused at the last one with no way back.
+    """
+    from gentoo_install.model import manual
+    from gentoo_install.model.size import Size
+    from gentoo_install.tui.partitions import _too_big_for_the_disk
+
+    at = context()
+    selector = at.disks[0][0]
+    at._inspected[selector] = ((), "40G")
+    at.layout = manual.Layout(
+        disks=[
+            manual.Disk(
+                selector=selector,
+                slices=[
+                    manual.Slice(
+                        index=1, role=PartitionRole.ESP, size=Size.parse("1GiB"),
+                        mountpoint="/efi",
+                    ),
+                    manual.Slice(
+                        index=2, role=PartitionRole.DATA, size=Size.parse("35GiB"),
+                        mountpoint="/",
+                    ),
+                    manual.Slice(
+                        index=3, role=PartitionRole.SWAP, size=Size.parse("4GiB"),
+                    ),
+                ],
+            )
+        ]
+    )
+    said = _too_big_for_the_disk(at)
+    assert "40" in said and "GiB" in said, said
+
+    # Negative control: one gibibyte less fits, so the rule is not refusing
+    # every table that fills the disk.
+    at.layout.disks[0].slices[1] = manual.Slice(
+        index=2, role=PartitionRole.DATA, size=Size.parse("34GiB"), mountpoint="/"
+    )
+    assert _too_big_for_the_disk(at) == "", _too_big_for_the_disk(at)


### PR DESCRIPTION
The trailing GPT copy and the first alignment boundary are not free, and the
check that knew it ran after the confirmation: an operator asked for
`/efi 1GiB + / 35GiB + swap 4GiB` on a 40 GiB disk, answered twenty rows, and
was refused at the last one. One function now answers both callers.

The main list answered Back to all four keys, so one stray escape offered to
end the run. An agent read the key page's `esc  Back` and pressed it seven
times; one of those presses ended a session with twenty rows filled in.