### PR TITLE
tui: ask before writing an image discards the other answers

### DIFF
--- a/gentoo_install/data/locale/ja.toml
+++ b/gentoo_install/data/locale/ja.toml
@@ -720,3 +720,5 @@
 "enable the {} repository" = "{} リポジトリを有効にします"
 "Empty the field, which arrives with a value in it" = "フィールドを空にします。フィールドには最初から値が入っています"
 "{disk} can hand out {usable} and these sizes come to {claimed}" = "{disk} が割り当てられるのは {usable} ですが、指定された合計は {claimed} です"
+"Writing an image discards the rest of the answers." = "イメージを書き込むと、ほかの回答は破棄されます。"
+"{count} groups of answers are discarded." = "破棄される回答は {count} 組です。"

--- a/gentoo_install/data/locale/ko.toml
+++ b/gentoo_install/data/locale/ko.toml
@@ -720,3 +720,5 @@
 "enable the {} repository" = "{} 저장소를 활성화합니다"
 "Empty the field, which arrives with a value in it" = "필드를 비웁니다. 필드에는 처음부터 값이 들어 있습니다"
 "{disk} can hand out {usable} and these sizes come to {claimed}" = "디스크 {disk}: 배정 가능한 용량 {usable}, 지정한 합계 {claimed}"
+"Writing an image discards the rest of the answers." = "이미지를 쓰면 나머지 답변은 버려집니다."
+"{count} groups of answers are discarded." = "버려지는 답변은 {count}개 묶음입니다."

--- a/gentoo_install/data/locale/zh-CN.toml
+++ b/gentoo_install/data/locale/zh-CN.toml
@@ -721,3 +721,5 @@
 "enable the {} repository" = "启用 {} 仓库"
 "Empty the field, which arrives with a value in it" = "清空字段，字段打开时本来就有值"
 "{disk} can hand out {usable} and these sizes come to {claimed}" = "{disk} 能分出 {usable}，这些大小加起来是 {claimed}"
+"Writing an image discards the rest of the answers." = "写入映像会舍弃其余的答案。"
+"{count} groups of answers are discarded." = "有 {count} 组答案会被舍弃。"

--- a/gentoo_install/data/locale/zh-TW.toml
+++ b/gentoo_install/data/locale/zh-TW.toml
@@ -721,3 +721,5 @@
 "enable the {} repository" = "啟用 {} 儲存庫"
 "Empty the field, which arrives with a value in it" = "清空欄位，欄位開啟時本來就有值"
 "{disk} can hand out {usable} and these sizes come to {claimed}" = "{disk} 能配出 {usable}，這些大小加起來是 {claimed}"
+"Writing an image discards the rest of the answers." = "寫入映像檔會捨棄其餘的答案。"
+"{count} groups of answers are discarded." = "有 {count} 組答案會被捨棄。"

--- a/gentoo_install/tui/screens.py
+++ b/gentoo_install/tui/screens.py
@@ -172,6 +172,9 @@ def install_mode_screen(
         if agreed is not None:
             return agreed
     if mode is DiskMode.DD:
+        kept = _answers_this_mode_discards(config)
+        if kept and not _agrees_to_discard(screen, context, kept):
+            return Answer(Outcome.CHOSE, config)
         # Cleared with the disk keys: this mode writes the image as it is
         # and configures nothing in it, and `validate` refuses a configuration
         # that describes a machine it will not produce. Left standing they
@@ -273,6 +276,38 @@ def image_destination_screen(
         Outcome.CHOSE,
         replace(config, disk=replace(config.disk, destination=destination.unwrap())),
     )
+
+
+def _answers_this_mode_discards(config: InstallConfig) -> int:
+    """How many of the operator's answers writing an image would throw away.
+
+    Counted rather than guessed at: the row is the first in the list and one
+    keypress on it emptied twenty of them, silently. An agent that pressed it
+    went back and forth three times looking for what it had lost.
+    """
+    return sum(
+        1
+        for part, blank in (
+            ("system", SystemConfig()),
+            ("packages", PackagesConfig()),
+            ("portage", PortageConfig()),
+            ("kernel", KernelConfig()),
+            ("bootloader", BootloaderConfig()),
+        )
+        if getattr(config, part) != blank
+    )
+
+
+def _agrees_to_discard(screen: Screen, context: Context, kept: int) -> bool:
+    """Whether the operator wants those answers gone."""
+    translate = context.translate
+    asked = Confirm(
+        **answers(translate),
+        title=translate("Writing an image discards the rest of the answers."),
+        detail=translate("{count} groups of answers are discarded.").format(count=kept),
+        footer=footer(translate),
+    ).run(screen)
+    return bool(asked.chosen and asked.unwrap())
 
 
 def _confirm_the_swap(screen: Screen, context: Context) -> Answer[InstallConfig] | None:

--- a/tests/unit/test_tui_app.py
+++ b/tests/unit/test_tui_app.py
@@ -1566,15 +1566,17 @@ def test_what_still_asks_before_it_changes() -> None:
         "Use DHCP?",
         "Unlock the root over SSH from the initramfs?",
         "This replaces the running system and cannot be undone.",
+        "Writing an image discards the rest of the answers.",
         "Install",
     }
     for title in asked:
         assert title in source, title
-    # Six call sites, nine titles: one encryption editor serves three titles,
+    # Seven call sites, ten titles: one encryption editor serves three titles,
     # and the slice screen words its title for a pool or for a partition. The
     # sixth is the in-place swap, which takes a typed word for the same reason
-    # the erase screen does — it cannot be undone.
-    assert source.count("Confirm(") == 6
+    # the erase screen does — it cannot be undone. The seventh is writing an
+    # image, which empties five groups of answers on one keypress.
+    assert source.count("Confirm(") == 7
     # `settle` asks the same kind of question with three answers rather than
     # two, because the third opens the row the values land on.
     assert "This choice also sets" in source
@@ -3382,7 +3384,8 @@ def test_dd_mode_is_offered_only_from_a_live_or_memory_environment() -> None:
         )
     )
     chosen = screens.install_mode_screen(
-        FakeScreen(keys=["KEY_DOWN", "\n"], lines=24, columns=110),
+        # The last two answer Yes to the question about discarding the rest.
+        FakeScreen(keys=["KEY_DOWN", "\n", "KEY_DOWN", "\n"], lines=24, columns=110),
         config(),
         safe,
     ).unwrap()
@@ -3753,3 +3756,36 @@ def test_back_does_nothing_at_the_top_and_only_cancel_offers_to_leave() -> None:
     # the widget is not simply ignoring every key it is given.
     ended = FakeScreen(keys=["q", "KEY_DOWN", "\n", "\x1b", "KEY_LEFT"])
     assert run(ended, config(), at).cancelled
+
+
+def test_writing_an_image_asks_before_discarding_the_other_answers() -> None:
+    """One keypress on the first row emptied twenty rows, silently.
+
+    An agent that pressed it went in and out of that row three times looking
+    for what it had lost, then left the installer without installing.
+    """
+    from dataclasses import replace
+
+    from gentoo_install.model.config import DiskMode
+
+    at = context()
+    # The row is only offered on a medium that can write one, which is what
+    # this test is about.
+    at.image_write_refused = Refusal("")
+    at.conversion_refused = Refusal("")
+    answered = replace(config(), system=replace(config().system, hostname="lab5"))
+
+    # Down twice to `write a prepared image`, enter, then No to the question.
+    kept = screens.install_mode_screen(
+        FakeScreen(keys=["KEY_DOWN", "KEY_DOWN", "\n", "\n"]), answered, at
+    )
+    assert kept.unwrap().system.hostname == "lab5", kept.unwrap().system
+    assert kept.unwrap().disk.mode is not DiskMode.DD
+
+    # Negative control: answering Yes does discard them, so the question is
+    # the only thing between the operator and an empty list.
+    gone = screens.install_mode_screen(
+        FakeScreen(keys=["KEY_DOWN", "KEY_DOWN", "\n", "KEY_DOWN", "\n"]), answered, at
+    )
+    assert gone.unwrap().disk.mode is DiskMode.DD
+    assert gone.unwrap().system.hostname != "lab5"


### PR DESCRIPTION
The first row of the list emptied five groups of answers on one keypress and
said nothing. An agent that pressed it went in and out of that row three times
looking for what it had lost, then left without installing.

The in-place swap on the same screen has asked for a typed word since it was
written, for the same reason: it cannot be undone by going back.