### PR TITLE
tests: refuse the in-place spec on a guest with nothing to replace

### DIFF
--- a/tests/unit/test_tui_report.py
+++ b/tests/unit/test_tui_report.py
@@ -9,6 +9,7 @@ number for both is measuring the session's length, not the interface.
 from __future__ import annotations
 
 from pathlib import Path
+from typing import Any, cast
 
 from tests.tui.report import STUCK_AFTER, Report, read, title_of
 
@@ -226,3 +227,30 @@ def test_the_open_row_is_named_when_the_box_carries_no_name() -> None:
     # closed row is what the box is there to label.
     named = frame("Mirrors", DISK) + "\n\ncursor:\n* Disk  /dev/vda"
     assert title_of(named) == "Mirrors", title_of(named)
+
+
+def test_a_spec_that_replaces_a_system_is_refused_on_a_fresh_guest() -> None:
+    """The interface says so on its first screen, after ten minutes of boot.
+
+    `conversion is not offered: this medium has no installed system to
+    replace` is what an agent sent at the in-place spec would read, having
+    spent a guest and a round to get there.
+    """
+    import pytest
+
+    from tests.vm import cluster
+
+    class Nothing:
+        def isos(self, node: str) -> list[str]:
+            raise AssertionError("a refused spec must not reach the cluster")
+
+    with pytest.raises(ValueError, match="already boots one"):
+        cluster.tui_execution(
+            cast(Any, Nothing()), "infra-node1", "conv", 3, Path("/nonexistent")
+        )
+
+    # Negative control: every other spec is answerable on a fresh guest, so
+    # the refusal is about this one and not about the check being on at all.
+    assert cluster.TUI_NEEDS_A_SYSTEM == frozenset({3}), cluster.TUI_NEEDS_A_SYSTEM
+    for number in sorted(set(cluster.TUI_GUESTS) - cluster.TUI_NEEDS_A_SYSTEM):
+        assert number not in cluster.TUI_NEEDS_A_SYSTEM

--- a/tests/vm/cluster.py
+++ b/tests/vm/cluster.py
@@ -1853,6 +1853,12 @@ TUI_COLUMNS: Final[int] = 120
 #: spec, because the machine a spec describes is part of the spec: asking for
 #: an MBR table on a UEFI guest is asking the operator to answer an impossible
 #: question, and the run would measure that rather than the interface.
+#: Specs that describe a machine already running something. A blank guest
+#: cannot answer them: the interface itself says so on its first screen —
+#: `conversion is not offered: this medium has no installed system to
+#: replace` — and an agent sent at one spends its whole run finding that out.
+TUI_NEEDS_A_SYSTEM: Final[frozenset[int]] = frozenset({3})
+
 TUI_GUESTS: Final[dict[int, tuple[int, bool, bool]]] = {
     1: (1, True, True),
     2: (2, False, True),
@@ -1890,6 +1896,12 @@ def tui_execution(
     # Most free node first, the same order the schedule uses. The node is
     # chosen here rather than by the caller so two sessions started at once
     # cannot both take the last slot on one node.
+    if spec in TUI_NEEDS_A_SYSTEM:
+        raise ValueError(
+            f"spec {spec} replaces a running system, so it needs a guest that "
+            "already boots one; a fresh guest can only be told that conversion "
+            "is not offered"
+        )
     chosen = node or free_slots(api)[0].name
     # The medium and the driver CD are per node, and `local` is not shared:
     # a session that skipped this asked the node for `iso/minimal`, which is


### PR DESCRIPTION
The interface says so on its first screen, ten minutes of boot later:
`conversion is not offered: this medium has no installed system to replace`.
An agent sent at it spends a guest and a round to read that.