### PR TITLE
tui: say on the layout row where a second disk goes

### DIFF
--- a/gentoo_install/data/locale/ja.toml
+++ b/gentoo_install/data/locale/ja.toml
@@ -381,7 +381,7 @@
 "removed from the table, data and all" = "表から削除。データも消える"
 "not on the disk yet" = "ディスクにまだない"
 "Take this row off the table" = "この行を表から外す"
-"one table: keep, format, delete or add each partition" = "パーティションごとに処置を指定"
+"each partition, and a second disk for a pool or array" = "パーティションごとの処置と、2 台目のディスクの追加"
 
 "Kernel command line" = "カーネルコマンドライン"
 "Parameters to append, separated by spaces" = "追加するパラメータ、空白区切り"

--- a/gentoo_install/data/locale/ko.toml
+++ b/gentoo_install/data/locale/ko.toml
@@ -381,7 +381,7 @@
 "removed from the table, data and all" = "표에서 제거하며 데이터도 사라짐"
 "not on the disk yet" = "디스크에 아직 없음"
 "Take this row off the table" = "이 행을 표에서 제외"
-"one table: keep, format, delete or add each partition" = "파티션마다 처리 방식 지정"
+"each partition, and a second disk for a pool or array" = "파티션마다 처리 방식 지정, 두 번째 디스크 추가"
 
 "Kernel command line" = "커널 명령줄"
 "Parameters to append, separated by spaces" = "추가할 매개변수, 공백으로 구분"

--- a/gentoo_install/data/locale/zh-CN.toml
+++ b/gentoo_install/data/locale/zh-CN.toml
@@ -381,7 +381,7 @@
 "removed from the table, data and all" = "从分区表移除，数据一并消失"
 "not on the disk yet" = "尚未创建"
 "Take this row off the table" = "移除此行"
-"one table: keep, format, delete or add each partition" = "每个分区各自处置"
+"each partition, and a second disk for a pool or array" = "每个分区各自处置，也在这里加第二块磁盘"
 
 # 内核命令行与 USE：面板同时显示手动输入与安装器自动加入的值
 "Kernel command line" = "内核命令行"

--- a/gentoo_install/data/locale/zh-TW.toml
+++ b/gentoo_install/data/locale/zh-TW.toml
@@ -381,7 +381,7 @@
 "removed from the table, data and all" = "從分割表移除，資料一併消失"
 "not on the disk yet" = "尚未建立"
 "Take this row off the table" = "移除此列"
-"one table: keep, format, delete or add each partition" = "每個分割區各自處置"
+"each partition, and a second disk for a pool or array" = "每個分割區各自處置，也在這裡加第二顆磁碟"
 
 # 核心命令列與 USE：面板同時顯示手動輸入與安裝器自動加入的值
 "Kernel command line" = "核心命令列"

--- a/gentoo_install/tui/screens.py
+++ b/gentoo_install/tui/screens.py
@@ -398,7 +398,7 @@ def layout_screen(screen: Screen, config: InstallConfig, context: Context) -> An
             Item(
                 label=translate("manual"),
                 value=True,
-                detail=translate("one table: keep, format, delete or add each partition"),
+                detail=translate("each partition, and a second disk for a pool or array"),
             ),
         ],
         footer=footer(translate),

--- a/tests/unit/test_tui_partitions.py
+++ b/tests/unit/test_tui_partitions.py
@@ -1627,3 +1627,14 @@ def test_sizes_larger_than_the_disk_are_refused_where_they_are_typed() -> None:
         index=2, role=PartitionRole.DATA, size=Size.parse("34GiB"), mountpoint="/"
     )
     assert _too_big_for_the_disk(at) == "", _too_big_for_the_disk(at)
+
+
+def test_the_manual_row_says_where_a_second_disk_goes() -> None:
+    """A pool across two disks is only reachable from the manual editor, and
+    `r6-7` ended with a single-device `rpool` because nothing on this screen
+    said so: the agent filled the one disk row twice and never found
+    `_RowKind.ADD_DISK`."""
+    screen = FakeScreen(keys=["q"], lines=24, columns=100)
+    screens.layout_screen(screen, config(), opened())
+    drawn = "\n".join(screen.frames[0])
+    assert "second disk" in drawn


### PR DESCRIPTION
A pool across two disks is only reachable from the manual editor. An agent asked for a two-disk ZFS mirror produced a single-device `rpool` on `vda2` with `vdb` untouched: it filled the one disk row twice and never found `_RowKind.ADD_DISK`. The manual row's detail now names the second disk.