### PR TITLE
tui: record why a session's reader stopped holding the console

### DIFF
--- a/tests/tui/session.py
+++ b/tests/tui/session.py
@@ -22,9 +22,19 @@ import sys
 import time
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Final
+from typing import Final, Protocol, runtime_checkable
 
 from tests.tui.screen import Screen
+
+
+@runtime_checkable
+class Held(Protocol):
+    """What `serve` needs of the console it holds. A protocol rather than
+    `SerialConsole`, so a test can hand it one that dies."""
+
+    def read_available(self, seconds: float) -> bytes: ...
+
+    def send_raw(self, keys: str) -> None: ...
 
 #: How long the console must stay quiet before the page counts as drawn, and
 #: how long to keep waiting for that. A redraw at 120x40 arrives in a few
@@ -102,6 +112,14 @@ class Session:
         return self.directory / "screens.txt"
 
     @property
+    def ended(self) -> Path:
+        """Why the daemon stopped holding the console.
+
+        Two readers died mid-install and the guests kept going; with nothing
+        written, a stale `screens.txt` reads as a run still in progress."""
+        return self.directory / "ended.txt"
+
+    @property
     def transcript(self) -> Path:
         """Every key sent, one per line, so the counts a report is judged on
         are read off the session rather than taken from the agent."""
@@ -174,7 +192,9 @@ def start(name: str, spec: int, node: str = "", vmid: int = 0) -> str:
     # The child holds the console; the parent's caller gets the name back and
     # every other subcommand reaches this process through the socket.
     os.setsid()
-    serve(session, held.console, held.guest)
+    console = held.console
+    assert isinstance(console, Held), f"{type(console).__name__} cannot be held"
+    serve(session, console, held.guest)
     os._exit(0)
 
 
@@ -210,21 +230,33 @@ def _settled(grid: "Screen", console: object) -> str:
     return _with_cursor(grid)
 
 
-def serve(session: Session, console: object, guest: object) -> None:
+def serve(session: Session, console: Held, guest: object) -> None:
     """Hold the console and answer the other subcommands.
 
     A websocket cannot be handed to a second process, so the process that
     opened it stays and everything else talks to it here.
     """
-    from tests.vm.console import SerialConsole
-
-    assert isinstance(console, SerialConsole)
     grid = Screen(lines=SCREEN_LINES, columns=SCREEN_COLUMNS)
     session.control.unlink(missing_ok=True)
     listener = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
     listener.bind(str(session.control))
     listener.listen(4)
     listener.settimeout(1.0)
+    try:
+        _answer_until_stopped(session, console, guest, grid, listener)
+    except BaseException as error:
+        session.ended.write_text(f"{type(error).__name__}: {error}\n", encoding="utf-8")
+        raise
+
+
+def _answer_until_stopped(
+    session: Session,
+    console: Held,
+    guest: object,
+    grid: Screen,
+    listener: socket.socket,
+) -> None:
+    """The loop `serve` wraps, so one `except` covers every way it can end."""
     while True:
         # Drain first, always: the guest writes whether or not anyone asked,
         # and a screen read without draining is the previous page.

--- a/tests/unit/test_tui_session.py
+++ b/tests/unit/test_tui_session.py
@@ -1,0 +1,46 @@
+# SPDX-License-Identifier: GPL-2.0-or-later
+"""The daemon that holds one session's console."""
+
+from __future__ import annotations
+
+import socket
+from pathlib import Path
+
+import pytest
+
+from tests.tui import session as tui_session
+from tests.tui.screen import Screen
+
+
+class DeadConsole:
+    """A console that stops answering, the way a dropped websocket does."""
+
+    def read_available(self, seconds: float) -> bytes:
+        raise OSError("the guest closed the serial connection")
+
+    def send_raw(self, keys: str) -> None:
+        raise AssertionError("nothing is sent to a console that died")
+
+
+def test_a_reader_that_dies_says_so_beside_the_session(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Two readers died mid-install on 2026-08-22 and both guests carried on
+    installing. Nothing was written, so a `screens.txt` frozen at 03:14 read
+    as a run still in progress; only the cluster's byte counters said
+    otherwise."""
+    monkeypatch.setattr(tui_session, "SESSIONS", tmp_path)
+    session = tui_session.Session(name="dead")
+    session.directory.mkdir(parents=True)
+    listener = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+    listener.bind(str(session.control))
+    listener.listen(1)
+    listener.settimeout(0.05)
+    try:
+        with pytest.raises(OSError):
+            tui_session.serve(session, DeadConsole(), None)
+    finally:
+        listener.close()
+    assert session.ended.read_text(encoding="utf-8") == (
+        "OSError: the guest closed the serial connection\n"
+    )


### PR DESCRIPTION
Two session daemons died mid-install on 2026-08-22 and both guests carried on installing to completion. Nothing was written anywhere, so a `screens.txt` frozen at 03:14 read as a run still in progress; only the cluster's byte counters said otherwise. `serve` now writes the reason to `ended.txt` beside the session before the exception leaves it, and takes a protocol so a console that dies can be handed to it in a test.