### PR TITLE
i18n: give Drive a word of its own in every catalog

### DIFF
--- a/gentoo_install/data/locale/ja.toml
+++ b/gentoo_install/data/locale/ja.toml
@@ -100,7 +100,7 @@
 "raid array member" = "raid アレイメンバー"
 "bios-boot" = "bios-boot"
 "other" = "その他"
-"Drive" = "ディスク"
+"Drive" = "ディスク装置"
 "Encryption" = "暗号化"
 "Kernel" = "カーネル"
 "Profile" = "プロファイル"

--- a/gentoo_install/data/locale/ko.toml
+++ b/gentoo_install/data/locale/ko.toml
@@ -100,7 +100,7 @@
 "raid array member" = "raid 어레이 멤버"
 "bios-boot" = "bios-boot"
 "other" = "기타"
-"Drive" = "디스크"
+"Drive" = "디스크 장치"
 "Encryption" = "암호화"
 "Kernel" = "커널"
 "Profile" = "프로파일"

--- a/gentoo_install/data/locale/zh-CN.toml
+++ b/gentoo_install/data/locale/zh-CN.toml
@@ -100,7 +100,7 @@
 "raid array member" = "raid 阵列成员"
 "bios-boot" = "bios-boot"
 "other" = "其他"
-"Drive" = "磁盘"
+"Drive" = "磁盘设备"
 "Encryption" = "加密"
 "Kernel" = "内核"
 "Profile" = "profile"

--- a/gentoo_install/data/locale/zh-TW.toml
+++ b/gentoo_install/data/locale/zh-TW.toml
@@ -100,7 +100,7 @@
 "raid array member" = "raid 陣列成員"
 "bios-boot" = "bios-boot"
 "other" = "其他"
-"Drive" = "磁碟"
+"Drive" = "磁碟裝置"
 "Encryption" = "加密"
 "Kernel" = "核心"
 "Profile" = "profile"

--- a/tests/unit/test_i18n.py
+++ b/tests/unit/test_i18n.py
@@ -597,3 +597,26 @@ def test_every_widget_that_shows_a_value_cuts_through_clip() -> None:
                 module,
                 node.lineno,
             )
+
+
+def test_no_two_rows_on_one_screen_translate_to_the_same_word() -> None:
+    """`Disk` names the group and `Drive` names the device inside it; every
+    catalog gave both the same word, so `Drive: still needs an answer` was read
+    in front of a `Disk` row already showing `/dev/vda`. An agent driving
+    spec 5 stalled there."""
+    from tests.unit.layouts import config
+
+    from gentoo_install.tui.settings import settings_for
+
+    table = settings_for(config())
+    for tag in sorted(path.stem for path in LOCALES.glob("*.toml")):
+        catalog = Catalog(tag)
+        for group in table:
+            said: dict[str, str] = {}
+            for label in [group.label, *(row.label for row in group.rows)]:
+                drawn = catalog(label)
+                assert said.get(drawn, label) == label, (
+                    f"{tag}: {said.get(drawn)!r} and {label!r} are both {drawn!r} "
+                    f"in {group.label!r}"
+                )
+                said[drawn] = label


### PR DESCRIPTION
`Disk` names the settings group and `Drive` names the device inside it. Every one of the four catalogs translated both to the same word, so the install row's blocking reason read `Disk: still needs an answer` while the row above it showed `Disk /dev/vda`. An agent driving spec 5 stalled in front of exactly that. The test asserts no two labels on one screen collapse to one word in any catalog, and goes red when `Drive` is put back.