### PR TITLE
tui: say on the overview that no disk has been written yet

### DIFF
--- a/gentoo_install/data/locale/ja.toml
+++ b/gentoo_install/data/locale/ja.toml
@@ -512,7 +512,7 @@
 "packages" = "パッケージ"
 "finish" = "仕上げ"
 "Start the installation" = "インストールを開始"
-"everything below is what it will do" = "以下がこれから行う内容です"
+"nothing has been written to the disks yet" = "ディスクにはまだ何も書き込まれていない"
 "Choose a row" = "行を選ぶ"
 "Start writing to the disks" = "ディスクへの書き込みを開始"
 "Firewall" = "ファイアウォール"

--- a/gentoo_install/data/locale/ko.toml
+++ b/gentoo_install/data/locale/ko.toml
@@ -512,7 +512,7 @@
 "packages" = "패키지"
 "finish" = "마무리"
 "Start the installation" = "설치 시작"
-"everything below is what it will do" = "아래가 수행할 작업입니다"
+"nothing has been written to the disks yet" = "디스크에 아직 아무것도 쓰지 않음"
 "Choose a row" = "항목 선택"
 "Start writing to the disks" = "디스크 쓰기 시작"
 "Firewall" = "방화벽"

--- a/gentoo_install/data/locale/zh-CN.toml
+++ b/gentoo_install/data/locale/zh-CN.toml
@@ -513,7 +513,7 @@
 "packages" = "软件包"
 "finish" = "收尾"
 "Start the installation" = "开始安装"
-"everything below is what it will do" = "以下是计划执行的操作"
+"nothing has been written to the disks yet" = "还没有写入任何磁盘"
 "Choose a row" = "选择一行"
 "Start writing to the disks" = "开始写入磁盘"
 "Firewall" = "防火墙"

--- a/gentoo_install/data/locale/zh-TW.toml
+++ b/gentoo_install/data/locale/zh-TW.toml
@@ -513,7 +513,7 @@
 "packages" = "套件"
 "finish" = "完成"
 "Start the installation" = "開始安裝"
-"everything below is what it will do" = "以下為預定操作"
+"nothing has been written to the disks yet" = "還沒有寫入任何磁碟"
 "Choose a row" = "選擇一列"
 "Start writing to the disks" = "開始寫入磁碟"
 "Firewall" = "防火牆"

--- a/gentoo_install/tui/overview.py
+++ b/gentoo_install/tui/overview.py
@@ -99,7 +99,7 @@ def overview_screen(
         Item(
             label=translate("Start the installation"),
             value=_INSTALL,
-            detail=translate("everything below is what it will do"),
+            detail=translate("nothing has been written to the disks yet"),
         ),
     )
     while True:

--- a/tests/unit/test_automatic.py
+++ b/tests/unit/test_automatic.py
@@ -1500,3 +1500,16 @@ def test_the_greetd_check_passes_the_file_the_installer_leaves_behind() -> None:
     # And it still refuses the file before the installer touched it, which is
     # the machine where tuigreet was installed and never reached.
     assert re.search(pattern, EBUILD_GREETD_CONFIG) is None
+
+
+def test_the_overview_says_no_disk_has_been_written_yet() -> None:
+    """An agent driving spec 5 reached this screen, reported `started: yes`
+    and finished; the guest had written zero bytes an hour later. The row it
+    was looking at carries the same label as the row that opened the screen,
+    so the only thing that can tell the two apart is what the row says."""
+    from tests.unit.fake_screen import FakeScreen
+    from tests.unit.test_tui_app import context
+
+    drawn = FakeScreen(keys=["q"], lines=120, columns=130)
+    overview_screen(drawn, config(ext4_on_gpt()), context())
+    assert "nothing has been written to the disks yet" in drawn.last


### PR DESCRIPTION
An agent driving spec 5 reached the overview, reported `started: yes` and finished; the guest had written zero bytes an hour later. The row that opens the overview and the overview's own first row are both labelled `Start the installation`, and the latter's detail described the rest of the screen rather than the row. It now states the fact the operator got wrong.