### PR TITLE
vm: name every target disk in the boot order

### DIFF
--- a/tests/unit/test_proxmox.py
+++ b/tests/unit/test_proxmox.py
@@ -4525,3 +4525,27 @@ def test_the_checksum_fields_precede_the_file_in_the_upload_body() -> None:
     # 128 characters as the default and refuses the upload it already took.
     assert 'name="checksum-algorithm"' in head and "sha512" in head
     assert head.count("--Xbound") == 4, head
+
+
+def test_the_boot_order_names_every_target_disk() -> None:
+    """`gi-s7a` mirrored its pool across `vda1` and `vdb2` and put the esp on
+    `vdb1`. `order=virtio0` pointed the firmware at a disk that is entirely a
+    pool member, so it fell through to the medium still attached and the run
+    read a live shell back as the installed system."""
+    asked: list[dict[str, object]] = []
+
+    class Recording:
+        def call(self, method: str, path: str, **form: object) -> object:
+            asked.append({"method": method, "path": path, **form})
+            return None
+
+    for disks, expected in (((40,), "order=virtio0"), ((40, 40), "order=virtio0;virtio1")):
+        asked.clear()
+        guest = Guest(
+            api=cast(Api, Recording()),
+            node="n",
+            vmid=9300,
+            spec=GuestSpec(name="gi-test", iso="x.iso", target_gib=disks),
+        )
+        guest.boot_from_disk()
+        assert [one["boot"] for one in asked] == [expected], disks

--- a/tests/vm/proxmox.py
+++ b/tests/vm/proxmox.py
@@ -668,11 +668,15 @@ class Guest:
 
         The install is only half the question: the other half is whether the
         machine it produced comes up and carries the settings that were asked
-        for. `order=virtio0` is what makes the firmware try the target rather
-        than the CD it was built with.
+        for. Every target disk is named, in order, because the esp does not
+        always land on the first: `gi-s7a` mirrored its pool across `vda1` and
+        `vdb2` and put the esp on `vdb1`, so `order=virtio0` sent the firmware
+        at a disk that is entirely a pool member and it fell through to the
+        medium still attached.
         """
+        order = ";".join(f"virtio{index}" for index in range(len(self.spec.target_gib)))
         upid = self.api.call(
-            "PUT", f"/nodes/{self.node}/qemu/{self.vmid}/config", boot="order=virtio0"
+            "PUT", f"/nodes/{self.node}/qemu/{self.vmid}/config", boot=f"order={order}"
         )
         # A config change the API applies then and there answers `data: null`;
         # only a deferred one comes back as a task. Waiting on the empty answer


### PR DESCRIPTION
`gi-s7a` mirrored its pool across `vda1` and `vdb2` and put the esp on `vdb1`. `boot_from_disk` set `order=virtio0`, which is a disk that is entirely a pool member, so the firmware fell through to the medium still attached and the boot check read a live shell back as the installed system. The order now lists every target disk, taking the count from `spec.target_gib`.