### PR TITLE
tui: draw a row's refusal once

### DIFF
--- a/gentoo_install/tui/app.py
+++ b/gentoo_install/tui/app.py
@@ -63,15 +63,6 @@ def _labelled(setting: Setting, current: InstallConfig, context: Context) -> str
     return f"{label} [{context.translate(named)}]" if named else label
 
 
-def _reason_lines(reason: str) -> tuple[str, ...]:
-    """One line per part, because the right pane cuts a line that overruns."""
-    if not reason:
-        return ()
-    head, separator, tail = reason.partition(": ")
-    parts = [one.strip() for one in head.split(",") if one.strip()]
-    return (*parts, tail.strip()) if separator else tuple(parts)
-
-
 def _counter(table: Sequence[Setting], current: InstallConfig, context: Context) -> str:
     """How many rows are answered, out of how many.
 
@@ -149,9 +140,6 @@ def run(screen: Screen, start: InstallConfig, context: Context) -> Finished:
                 label=context.translate("Install"),
                 value=len(table),
                 state="",
-                # Split rather than truncated: the reason is a sentence and a
-                # cut one names fewer rows than are missing.
-                detail=_reason_lines(blocked),
                 # Refused, not merely described. Left choosable, a ZFS mirror
                 # with one member reached the plan and ended the session on
                 # `no node with id ''` with every other row still answered.

--- a/gentoo_install/tui/widgets.py
+++ b/gentoo_install/tui/widgets.py
@@ -1075,6 +1075,21 @@ def right_pane_width(columns: int, left: int) -> int:
     return columns - left - PANE_GAP
 
 
+def reason_lines(reason: str) -> tuple[str, ...]:
+    """A refusal laid out one part to a line.
+
+    Wrapped instead, `Install mode, Drive, Mirrors: still needs an answer`
+    breaks wherever the pane happens to end and the operator reads `still
+    needs an` on one line. The parts are what the reason is made of, so the
+    line breaks go where they already are.
+    """
+    if not reason:
+        return ()
+    head, separator, tail = reason.partition(": ")
+    parts = [one.strip() for one in head.split(",") if one.strip()]
+    return (*parts, tail.strip()) if separator else tuple(parts)
+
+
 @dataclass(frozen=True)
 class PaneRow(Generic[V]):
     """One row of the left pane, and what the right pane says about it."""
@@ -1194,8 +1209,7 @@ class TwoPane(Generic[V]):
             here = self.rows[cursor] if self.rows else None
             detail: tuple[str, ...] = ()
             if here is not None:
-                reason = (here.disabled_because,) if here.disabled_because else ()
-                detail = (*reason, *here.detail)
+                detail = (*reason_lines(here.disabled_because), *here.detail)
             wrapped: list[str] = []
             for line_text in detail:
                 # Wrapped here and not by the caller: only the pane knows how
@@ -1310,11 +1324,7 @@ class TwoPane(Generic[V]):
         here_row = self.rows[cursor] if self.rows else None
         below: tuple[str, ...] = ()
         if here_row is not None:
-            below = (
-                (here_row.disabled_because, *here_row.detail)
-                if here_row.disabled_because
-                else here_row.detail
-            )
+            below = (*reason_lines(here_row.disabled_because), *here_row.detail)
         # A band of its own above the status line rather than lines pushed in
         # between the rows: inserting them moved every row under the cursor,
         # so walking the list made the interface jump and hid the next row.

--- a/tests/unit/test_tui_app.py
+++ b/tests/unit/test_tui_app.py
@@ -3814,3 +3814,26 @@ def test_the_install_row_refuses_while_something_required_is_missing() -> None:
     # And the overview behind that row was never opened: refused, not merely
     # described. Left choosable this is where the run reached the plan.
     assert "Overview" not in drawn, drawn[-300:]
+
+
+def test_the_install_row_says_its_reason_once() -> None:
+    """The pane headed itself with `disabled_because` and app.py passed the
+    same sentence again as the detail lines, so the right pane read `Install
+    mode, Drive, ...: still needs an answer` and then each of those parts
+    again underneath. Counted in the right pane only, because every part is
+    also a row label in the left one."""
+    at = context()
+    blank = replace(config(), system=replace(config().system, root_password_hash=""))
+    screen = FakeScreen(
+        keys=[*down(len(settings.SETTINGS)), "q", "KEY_DOWN", "\n"], lines=40, columns=130
+    )
+    run(screen, blank, at)
+    panes = [
+        "\n".join(line.split("|", 1)[1] for line in frame if "|" in line)
+        for frame in screen.frames
+    ]
+    carrying = [pane for pane in panes if "Install mode" in pane and "Mirrors" in pane]
+    assert carrying, "no right pane carried the install row's reason"
+    for pane in carrying:
+        for part in ("Install mode", "Drive", "Mirrors", "make.conf"):
+            assert pane.count(part) == 1, f"{part} appears {pane.count(part)} times:\n{pane}"


### PR DESCRIPTION
`TwoPane` heads the right pane with `disabled_because` and `app.py` passed the same sentence again as the detail lines, so the install row read `Install mode, Drive, Mirrors: still needs an answer` and then each of those parts again underneath. The split that kept the reason off a mid-phrase line break moves into the pane, where it applies to every refused row rather than to one caller.