### PR TITLE
tui: a client hanging up ends its request, not the session

### DIFF
--- a/tests/tui/session.py
+++ b/tests/tui/session.py
@@ -120,6 +120,12 @@ class Session:
         return self.directory / "ended.txt"
 
     @property
+    def hangups(self) -> Path:
+        """The last request that ended without an answer. A client going away
+        is not a failure of the session, and used to end it."""
+        return self.directory / "hangups.txt"
+
+    @property
     def transcript(self) -> Path:
         """Every key sent, one per line, so the counts a report is judged on
         are read off the session rather than taken from the agent."""
@@ -266,25 +272,38 @@ def _answer_until_stopped(
         except TimeoutError:
             continue
         with channel:
-            asked = channel.makefile("rb").readline()
-            if not asked:
+            # A client that goes away takes its own request with it and
+            # nothing else: two agents lost their guests to one
+            # `BrokenPipeError` raised writing an answer nobody was left to
+            # read, both while the 38-row font screen was settling.
+            try:
+                asked = channel.makefile("rb").readline()
+                if not asked:
+                    continue
+                message = json.loads(asked.decode())
+                answer: dict[str, str] = {}
+                if message["do"] == "screen":
+                    shown = _settled(grid, console)
+                    # Kept as it is answered, because the counts are computed
+                    # from the screens the operator was actually shown: a
+                    # report that reads a file nobody writes answers zero for
+                    # every one of them.
+                    with session.screens.open("a", encoding="utf-8") as log:
+                        log.write(shown + "\f")
+                    answer = {"screen": shown}
+                elif message["do"] == "key":
+                    console.send_raw(str(message["text"]))
+                    answer = {"sent": "yes"}
+                elif message["do"] == "stop":
+                    answer = {"stopped": "yes"}
+                channel.sendall(json.dumps(answer).encode() + b"\n")
+            except (OSError, ValueError) as error:
+                # `OSError` covers the hang-ups; `ValueError` covers a request
+                # that arrived truncated and will not parse.
+                session.hangups.write_text(
+                    f"{type(error).__name__}: {error}\n", encoding="utf-8"
+                )
                 continue
-            message = json.loads(asked.decode())
-            answer: dict[str, str] = {}
-            if message["do"] == "screen":
-                shown = _settled(grid, console)
-                # Kept as it is answered, because the counts are computed from
-                # the screens the operator was actually shown: a report that
-                # reads a file nobody writes answers zero for every one of them.
-                with session.screens.open("a", encoding="utf-8") as log:
-                    log.write(shown + "\f")
-                answer = {"screen": shown}
-            elif message["do"] == "key":
-                console.send_raw(str(message["text"]))
-                answer = {"sent": "yes"}
-            elif message["do"] == "stop":
-                answer = {"stopped": "yes"}
-            channel.sendall(json.dumps(answer).encode() + b"\n")
             if message["do"] == "stop":
                 break
     listener.close()

--- a/tests/unit/test_tui_session.py
+++ b/tests/unit/test_tui_session.py
@@ -3,7 +3,11 @@
 
 from __future__ import annotations
 
+import json
 import socket
+import struct
+import threading
+import time
 from pathlib import Path
 
 import pytest
@@ -44,3 +48,68 @@ def test_a_reader_that_dies_says_so_beside_the_session(
     assert session.ended.read_text(encoding="utf-8") == (
         "OSError: the guest closed the serial connection\n"
     )
+
+
+class OneScreen:
+    """A console with something to show and nothing after it."""
+
+    def __init__(self) -> None:
+        self.sent: list[str] = []
+        self.reads = 0
+
+    def read_available(self, seconds: float) -> bytes:
+        self.reads += 1
+        return b"hello" if self.reads == 1 else b""
+
+    def send_raw(self, keys: str) -> None:
+        self.sent.append(keys)
+
+
+def test_a_client_that_hangs_up_does_not_end_the_session(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Two agents lost their guests to one `BrokenPipeError` raised writing an
+    answer nobody was left to read, both while the 38-row font screen was
+    settling. The request ends; the session goes on."""
+    monkeypatch.setattr(tui_session, "SESSIONS", tmp_path)
+    session = tui_session.Session(name="hangup")
+    session.directory.mkdir(parents=True)
+    session.screens.write_text("", encoding="utf-8")
+    console = OneScreen()
+
+    def ask(message: dict[str, str], *, read_the_answer: bool) -> bytes:
+        client = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+        # A dead daemon leaves a socket that still accepts and never answers,
+        # so without this the control for this test hangs instead of failing.
+        client.settimeout(15.0)
+        client.connect(str(session.control))
+        client.sendall(json.dumps(message).encode() + b"\n")
+        if not read_the_answer:
+            # What an interrupted `session screen` leaves behind.
+            client.setsockopt(socket.SOL_SOCKET, socket.SO_LINGER, struct.pack("ii", 1, 0))
+            client.close()
+            return b""
+        got = client.makefile("rb").readline()
+        client.close()
+        return got
+
+    gone = threading.Thread(target=ask, args=({"do": "screen"},), kwargs={"read_the_answer": False})
+    answers: list[bytes] = []
+    served = threading.Thread(
+        target=tui_session.serve, args=(session, console, None), daemon=True
+    )
+    served.start()
+    for _ in range(200):
+        if session.control.exists():
+            break
+        time.sleep(0.02)
+    gone.start()
+    gone.join()
+    answers.append(ask({"do": "key", "text": "x"}, read_the_answer=True))
+    ask({"do": "stop"}, read_the_answer=True)
+    served.join(timeout=10)
+
+    assert not served.is_alive(), "the session outlived its own stop"
+    assert json.loads(answers[0].decode()) == {"sent": "yes"}
+    assert console.sent == ["x"], console.sent
+    assert not session.ended.exists(), session.ended.read_text(encoding="utf-8")


### PR DESCRIPTION
`t1` and `t9` both hit `ConnectionRefusedError` on the 38-row font screen, and both sessions' `ended.txt` read `BrokenPipeError: [Errno 32] Broken pipe` — raised by `channel.sendall` writing to a client that had already gone. The exception left the loop and took the daemon with it, so two guests became unreachable. One request now ends instead, recorded in `hangups.txt`. This is the first defect `ended.txt` explained.