### PR TITLE
vm: refuse a spec the interface has no row for

### DIFF
--- a/tests/unit/test_tui_report.py
+++ b/tests/unit/test_tui_report.py
@@ -254,3 +254,29 @@ def test_a_spec_that_replaces_a_system_is_refused_on_a_fresh_guest() -> None:
     assert cluster.TUI_NEEDS_A_SYSTEM == frozenset({3}), cluster.TUI_NEEDS_A_SYSTEM
     for number in sorted(set(cluster.TUI_GUESTS) - cluster.TUI_NEEDS_A_SYSTEM):
         assert number not in cluster.TUI_NEEDS_A_SYSTEM
+
+
+def test_a_spec_the_interface_has_no_row_for_is_refused_before_a_guest() -> None:
+    """`--ram` and `--lowram` arm a one-shot boot entry and reboot into a
+    memory-held environment, and they exist only on the command line. An agent
+    sent at spec 4 found `Build in RAM`, which is Portage's build directory,
+    was refused for too little memory, and reported being stuck having spent a
+    guest and an hour."""
+    import pytest
+
+    from tests.vm import cluster
+
+    class Nothing:
+        def isos(self, node: str) -> list[str]:
+            raise AssertionError("a refused spec must not reach the cluster")
+
+    with pytest.raises(ValueError, match="has no row in the interface"):
+        cluster.tui_execution(
+            cast(Any, Nothing()), "infra-node1", "ram", 4, Path("/nonexistent")
+        )
+
+    # The two refusals are about different things, so a spec in one is never
+    # in the other and neither set has quietly grown to cover the whole table.
+    assert cluster.TUI_HAS_NO_ROW == frozenset({4}), cluster.TUI_HAS_NO_ROW
+    assert not cluster.TUI_HAS_NO_ROW & cluster.TUI_NEEDS_A_SYSTEM
+    assert set(cluster.TUI_GUESTS) - cluster.TUI_HAS_NO_ROW - cluster.TUI_NEEDS_A_SYSTEM

--- a/tests/vm/cluster.py
+++ b/tests/vm/cluster.py
@@ -1859,6 +1859,14 @@ TUI_COLUMNS: Final[int] = 120
 #: replace` — and an agent sent at one spends its whole run finding that out.
 TUI_NEEDS_A_SYSTEM: Final[frozenset[int]] = frozenset({3})
 
+#: Specs the interface has no row for. `--ram` and `--lowram` arm a one-shot
+#: boot entry and reboot into a memory-held environment, and they exist only
+#: as command-line options: an agent sent at spec 4 found `Build in RAM`,
+#: which is Portage's build directory and a different thing, was refused for
+#: too little memory, and reported being stuck. Held apart from
+#: `TUI_NEEDS_A_SYSTEM` because the guest is not what is missing.
+TUI_HAS_NO_ROW: Final[frozenset[int]] = frozenset({4})
+
 TUI_GUESTS: Final[dict[int, tuple[int, bool, bool]]] = {
     1: (1, True, True),
     2: (2, False, True),
@@ -1896,6 +1904,12 @@ def tui_execution(
     # Most free node first, the same order the schedule uses. The node is
     # chosen here rather than by the caller so two sessions started at once
     # cannot both take the last slot on one node.
+    if spec in TUI_HAS_NO_ROW:
+        raise ValueError(
+            f"spec {spec} names a memory-held launch, which is --ram and "
+            "--lowram on the command line and has no row in the interface; "
+            "an agent sent at it can only report being stuck"
+        )
     if spec in TUI_NEEDS_A_SYSTEM:
         raise ValueError(
             f"spec {spec} replaces a running system, so it needs a guest that "


### PR DESCRIPTION
Spec 4 asks for the installer to be moved into memory first. `--ram` and `--lowram` arm a one-shot boot entry and reboot into a memory-held environment, and they exist only as command-line options. The agent sent at it found `Build in RAM`, which is Portage's build directory and a different thing, was refused for too little memory, and reported that it could not go on — having spent a guest and an hour. The refusal is held apart from `TUI_NEEDS_A_SYSTEM` because the guest is not what is missing.