### PR TITLE
vm: put the parameters in grub.cfg for a menu on the VGA console

### DIFF
--- a/tests/unit/test_cluster.py
+++ b/tests/unit/test_cluster.py
@@ -3540,15 +3540,71 @@ def test_systemd_boot_is_told_to_speak_through_its_loader_entry() -> None:
     assert shell.asked[-1] == "umount /mnt/esp"
 
 
-def test_a_grub_only_machine_is_left_to_its_menu() -> None:
-    """An esp with no loader entries is GRUB's, and its entry is already
-    written: the menu editor is the only way in, so nothing is changed here and
-    the esp is unmounted rather than left over the next mount."""
+def test_a_machine_with_nothing_to_edit_is_left_to_the_menu() -> None:
+    """An esp with no loader entries and no partition carrying a `grub.cfg`
+    leaves the menu editor as the only way in. The esp is unmounted rather
+    than left over the next mount."""
     from tests.vm import cluster
 
-    shell = ScriptedShell({"zpool import": "", "blkid": "/dev/vda1", "loader/entries": ""})
+    shell = ScriptedShell(
+        {
+            "zpool import": "",
+            "blkid -t TYPE=vfat": "/dev/vda1",
+            "loader/entries": "",
+            "blkid -o export": "",
+        }
+    )
     route = cluster.make_the_installed_system_speak(cast(Any, shell), "console=ttyS0,115200")
 
     assert route is cluster.SerialRoute.NOTHING_FOUND
     assert not [one for one in shell.asked if one.startswith("sed -i")]
-    assert shell.asked[-1] == "umount /mnt/esp"
+    assert "umount /mnt/esp" in shell.asked
+    # Nothing was mounted looking for a config, because nothing was named.
+    assert not [one for one in shell.asked if "/mnt/root" in one]
+
+
+def test_a_bios_grub_machine_is_told_to_speak_through_its_config() -> None:
+    """A BIOS GRUB draws its menu on the VGA console, so the menu editor has
+    nothing to hold: `gi-s2a` answered zero bytes where `gi-t1b` answered a
+    whole boot. The kernel still writes wherever `console=` sends it."""
+    from tests.vm import cluster
+
+    shell = ScriptedShell(
+        {
+            "zpool import": "",
+            "blkid -t TYPE=vfat": "",
+            "blkid -o export": "/dev/vda1:ext4",
+            "grub/grub.cfg": "/mnt/root/boot/grub/grub.cfg",
+        }
+    )
+    route = cluster.make_the_installed_system_speak(cast(Any, shell), "console=ttyS0,115200")
+
+    assert route is cluster.SerialRoute.GRUB_CONFIG
+    assert [one for one in shell.asked if one.startswith("sed -i '/^[[:space:]]*linux/")] == [
+        "sed -i '/^[[:space:]]*linux/ s|$| console=ttyS0,115200|' /mnt/root/boot/grub/grub.cfg"
+    ]
+    assert "umount /mnt/root" in shell.asked
+
+
+def test_a_luks_root_is_unlocked_before_its_config_is_read() -> None:
+    """Spec 2's root is a LUKS container, and nothing under it can be mounted
+    until it is opened. Every spec uses one password, so the harness knows it
+    without being told."""
+    from tests.vm import cluster
+
+    shell = ScriptedShell(
+        {
+            "zpool import": "",
+            "blkid -t TYPE=vfat": "",
+            "blkid -o export": "/dev/vda1:crypto_LUKS",
+            "grub/grub.cfg": "/mnt/root/boot/grub/grub.cfg",
+        }
+    )
+    route = cluster.make_the_installed_system_speak(cast(Any, shell), "console=ttyS0,115200")
+
+    assert route is cluster.SerialRoute.GRUB_CONFIG
+    assert (
+        "printf '%s' testtest | cryptsetup open /dev/vda1 speak" in shell.asked
+    ), shell.asked
+    assert any("mount /dev/mapper/speak /mnt/root" in one for one in shell.asked), shell.asked
+    assert "cryptsetup close speak" in shell.asked

--- a/tests/vm/cluster.py
+++ b/tests/vm/cluster.py
@@ -3739,6 +3739,7 @@ class SerialRoute(Enum):
     GRUB_MENU = "grub-menu"
     LOADER_ENTRIES = "loader-entries"
     ZFSBOOTMENU = "zfsbootmenu"
+    GRUB_CONFIG = "grub-config"
     NOTHING_FOUND = "nothing-found"
 
 
@@ -3780,7 +3781,66 @@ def make_the_installed_system_speak(
             link.run("umount /mnt/esp")
             return SerialRoute.LOADER_ENTRIES
         link.run("umount /mnt/esp")
+    if _grub_config_edited(link, extra):
+        return SerialRoute.GRUB_CONFIG
     return SerialRoute.NOTHING_FOUND
+
+
+def _grub_config_edited(link: "Reconnecting", extra: str) -> bool:
+    """Put the parameters in `grub.cfg` itself, for a menu nobody can type into.
+
+    A BIOS GRUB draws its menu on the VGA console, so `append_to_cmdline` has
+    nothing to hold: `gi-s2a` answered zero bytes where `gi-t1b` answered a
+    whole boot. The kernel still writes wherever `console=` sends it, and that
+    comes from the `linux` lines the installer already generated.
+    """
+    for named in _rootish_devices(link):
+        device, _, kind = named.rpartition(":")
+        if not device:
+            continue
+        opened = device
+        if kind == "crypto_LUKS":
+            opened = "/dev/mapper/speak"
+            link.run(f"printf '%s' {TUI_PASSWORD} | cryptsetup open {device} speak")
+        for options in ("", "-o subvol=@"):
+            where = f"{options} {opened}".strip()
+            link.run(f"mkdir -p /mnt/root && mount {where} /mnt/root 2>/dev/null; true")
+            found = link.expect_output(
+                "ls /mnt/root/boot/grub/grub.cfg 2>/dev/null | head -1"
+            ).strip()
+            if found:
+                # Every `linux` line, because GRUB writes one per kernel and
+                # the operator boots whichever the menu defaults to.
+                link.run(
+                    "sed -i '/^[[:space:]]*linux/ s|$| " + extra + "|' "
+                    "/mnt/root/boot/grub/grub.cfg"
+                )
+                link.run("umount /mnt/root")
+                if opened != device:
+                    link.run("cryptsetup close speak")
+                return True
+            link.run("umount /mnt/root 2>/dev/null; true")
+        if opened != device:
+            link.run("cryptsetup close speak")
+    return False
+
+
+#: Every spec uses one password, so the harness knows it without being told.
+TUI_PASSWORD: Final[str] = "testtest"
+
+
+def _rootish_devices(link: "Reconnecting") -> list[str]:
+    """Partitions that could hold a root, newest-looking first.
+
+    `blkid` names the type as well, because a LUKS container has to be
+    unlocked before anything can be mounted from it and the two cases cannot
+    be told apart from the device name.
+    """
+    said = link.expect_output(
+        "blkid -o export 2>/dev/null | awk -F= '/^DEVNAME=/{d=$2} /^TYPE=/{print d\":\"$2}' "
+        "| grep -Ev ':(vfat|swap|iso9660|squashfs|zfs_member)$'"
+    )
+    return [one for one in said.decode(errors="replace").split("\n") if one.strip()]
 
 
 def _edit_uefi_cmdline(guest: Guest, link: "Reconnecting") -> None:


### PR DESCRIPTION
`gi-s2a` answered zero bytes to the menu editor where `gi-t1b` answered a whole boot: a BIOS GRUB draws its menu on the VGA console and `append_to_cmdline` has nothing to hold. The kernel still writes wherever `console=` sends it, and that comes from the `linux` lines the installer already generated, so the fourth route mounts each partition that could hold a root and edits them. A LUKS container is opened with the one password every spec uses, and btrfs is tried again with `subvol=@`; both are put back.

Specs 2, 6 and 8 had no way to be boot-verified at all before this.