### PR TITLE
vm: ask for the menu editor only where nothing else was written

### DIFF
--- a/tests/unit/test_cluster.py
+++ b/tests/unit/test_cluster.py
@@ -3608,3 +3608,33 @@ def test_a_luks_root_is_unlocked_before_its_config_is_read() -> None:
     ), shell.asked
     assert any("mount /dev/mapper/speak /mnt/root" in one for one in shell.asked), shell.asked
     assert "cryptsetup close speak" in shell.asked
+
+
+def test_the_menu_editor_is_asked_for_only_where_nothing_else_was_written() -> None:
+    """Asked unconditionally it waits 120 seconds twice for a menu that never
+    comes: `gi-u7` boots ZFSBootMenu and `gi-u5` draws systemd-boot's own menu,
+    and the 90 KB that guest sent were that menu redrawing."""
+    from tests.vm import cluster
+
+    held: list[str] = []
+
+    def editor(guest: object, link: object) -> None:
+        held.append("asked")
+
+    original = cluster._edit_uefi_cmdline
+    cluster._edit_uefi_cmdline = cast(Any, editor)
+    try:
+        for route, expected in (
+            (cluster.SerialRoute.ZFSBOOTMENU, False),
+            (cluster.SerialRoute.LOADER_ENTRIES, False),
+            (cluster.SerialRoute.GRUB_CONFIG, False),
+            (cluster.SerialRoute.NOTHING_FOUND, True),
+        ):
+            held.clear()
+            answered = cluster.edit_the_menu_if_that_is_the_only_route(
+                cast(Any, None), cast(Any, None), route
+            )
+            assert answered is expected, route
+            assert bool(held) is expected, route
+    finally:
+        cluster._edit_uefi_cmdline = original

--- a/tests/vm/cluster.py
+++ b/tests/vm/cluster.py
@@ -3843,6 +3843,22 @@ def _rootish_devices(link: "Reconnecting") -> list[str]:
     return [one for one in said.decode(errors="replace").split("\n") if one.strip()]
 
 
+def edit_the_menu_if_that_is_the_only_route(
+    guest: Guest, link: "Reconnecting", route: SerialRoute
+) -> bool:
+    """Hold the bootloader's menu only where nothing else could be written.
+
+    Asked unconditionally, the editor waits 120 seconds twice for a menu that
+    will never come: `gi-u7` boots ZFSBootMenu and `gi-u5` draws systemd-boot's
+    own menu, and the 90 KB that guest sent were that menu redrawing. Answers
+    whether the menu was edited.
+    """
+    if route is not SerialRoute.NOTHING_FOUND:
+        return False
+    _edit_uefi_cmdline(guest, link)
+    return True
+
+
 def _edit_uefi_cmdline(guest: Guest, link: "Reconnecting") -> None:
     """Add the serial parameters to the medium's entry, once more if the
     console said nothing at all.


### PR DESCRIPTION
`gi-u7` boots ZFSBootMenu and `gi-u5` draws systemd-boot's own menu — the 90 KB that guest sent were that menu redrawing while the editor waited. Once `make_the_installed_system_speak` has written the parameters, holding a GRUB menu costs 120 seconds twice and finds nothing. The decision moves out of a scratch script and into the harness beside the routes it depends on.