### PR TITLE
vm: set the ZFSBootMenu property on each boot environment

### DIFF
--- a/tests/unit/test_cluster.py
+++ b/tests/unit/test_cluster.py
@@ -3504,14 +3504,19 @@ def test_a_zfs_root_is_told_to_speak_through_the_pool() -> None:
     a menu editor to hold, so the parameters go on the pool it reads."""
     from tests.vm import cluster
 
-    shell = ScriptedShell({"zpool import": "rpool"})
+    shell = ScriptedShell(
+        {"zpool import": "rpool", "zfs list": "rpool/ROOT\nrpool/ROOT/gentoo"}
+    )
     route = cluster.make_the_installed_system_speak(cast(Any, shell), "console=ttyS0,115200")
 
     assert route is cluster.SerialRoute.ZFSBOOTMENU
     assert "zpool import -N -f rpool" in shell.asked
-    assert (
-        "zfs set org.zfsbootmenu:commandline='console=ttyS0,115200' rpool/ROOT" in shell.asked
-    )
+    # On the boot environment, not on `rpool/ROOT`: the installer writes an
+    # empty value on the environment itself, and `zfs get -o source` reads
+    # that back as `local`, so nothing is inherited from the parent.
+    assert [one for one in shell.asked if one.startswith("zfs set")] == [
+        "zfs set org.zfsbootmenu:commandline='console=ttyS0,115200' rpool/ROOT/gentoo"
+    ], shell.asked
     assert "zpool export rpool" in shell.asked
     # No esp is looked for once the pool answered: mounting one would be a
     # second bootloader's route taken on a machine that has the first.

--- a/tests/vm/cluster.py
+++ b/tests/vm/cluster.py
@@ -3760,7 +3760,14 @@ def make_the_installed_system_speak(
         # `-N` leaves the datasets unmounted: the property is on the pool, and
         # mounting a root over the live one is what the export then fights.
         link.run(f"zpool import -N -f {name}")
-        link.run(f"zfs set org.zfsbootmenu:commandline='{extra}' {name}/ROOT")
+        # On each boot environment, not on the dataset above them: the
+        # installer writes an empty `org.zfsbootmenu:commandline` on
+        # `<pool>/ROOT/<name>` itself, and `zfs get -o source` reads that back
+        # as `local`, so a value set on the parent is never inherited. Read on
+        # `gi-u7`, where the parent carried the parameters and the guest was
+        # silent through three boots.
+        for environment in _boot_environments(link, name):
+            link.run(f"zfs set org.zfsbootmenu:commandline='{extra}' {environment}")
         link.run(f"zpool export {name}")
         return SerialRoute.ZFSBOOTMENU
     esp = link.expect_output(
@@ -3784,6 +3791,14 @@ def make_the_installed_system_speak(
     if _grub_config_edited(link, extra):
         return SerialRoute.GRUB_CONFIG
     return SerialRoute.NOTHING_FOUND
+
+
+def _boot_environments(link: "Reconnecting", pool: str) -> list[str]:
+    """Every dataset directly under `<pool>/ROOT`, which is what ZFSBootMenu
+    offers and reads its properties from."""
+    said = link.expect_output(f"zfs list -H -o name -d 1 -r {pool}/ROOT 2>/dev/null")
+    named = [one.strip() for one in said.decode(errors="replace").split("\n") if one.strip()]
+    return [one for one in named if one != f"{pool}/ROOT"]
 
 
 def _grub_config_edited(link: "Reconnecting", extra: str) -> bool:


### PR DESCRIPTION
`gi-u7` was silent through three boots with `org.zfsbootmenu:commandline` set on `rpool/ROOT`. One `zfs get -r -o name,value,source` answered why: `rpool/ROOT` carried the parameters as `local`, and `rpool/ROOT/gentoo` carried an empty value, also `local` — the installer writes it there, and a local value is never inherited from a parent. Set on the environments instead, the same machine reached `lab7 login:` and `zpool status` on the running system reads `mirror-0 ONLINE` over `vda2` and `vdb1`.