### PR TITLE
vm: take the next free VMID when a session's choice is gone

### DIFF
--- a/tests/unit/test_tui_report.py
+++ b/tests/unit/test_tui_report.py
@@ -280,3 +280,60 @@ def test_a_spec_the_interface_has_no_row_for_is_refused_before_a_guest() -> None
     assert cluster.TUI_HAS_NO_ROW == frozenset({4}), cluster.TUI_HAS_NO_ROW
     assert not cluster.TUI_HAS_NO_ROW & cluster.TUI_NEEDS_A_SYSTEM
     assert set(cluster.TUI_GUESTS) - cluster.TUI_HAS_NO_ROW - cluster.TUI_NEEDS_A_SYSTEM
+
+
+def test_two_sessions_started_together_do_not_take_one_vmid() -> None:
+    """`v2` and `v8` were started four seconds apart, both read 9300 as free,
+    and the second answered `VM 9300 already exists on node 'infra-node5'`.
+    Nothing between two `session start` calls allocates, so the collision is
+    found only by the create."""
+    import pytest
+
+    from tests.vm import cluster
+    from tests.vm.proxmox import CreateConflict
+
+    taken = {9300}
+    built: list[int] = []
+
+    class Machine:
+        def __init__(self, vmid: int) -> None:
+            self.vmid = vmid
+
+        def create(self) -> None:
+            built.append(self.vmid)
+            if self.vmid in taken:
+                raise CreateConflict(f"VM {self.vmid} already exists")
+            taken.add(self.vmid)
+
+    class Cluster:
+        def free_vmid(self, held: frozenset[int] = frozenset()) -> int:
+            return next(one for one in range(9300, 9400) if one not in held)
+
+    def execution(
+        api: object, node: str, job: object, driver: str, workdir: object, vmid: int, nonce: str
+    ) -> object:
+        return type("Held", (), {"guest": Machine(vmid)})()
+
+    original = cluster._execution
+    cluster._execution = cast(Any, execution)
+    try:
+        _, guest = cluster._created_on_a_free_vmid(
+            cast(Any, Cluster()), "n", cast(Any, None), "d", Path("/x"), 0, "v2"
+        )
+    finally:
+        cluster._execution = original
+
+    assert built == [9300, 9301], built
+    assert guest.vmid == 9301
+
+    # A VMID the caller named is not swapped for another: the operator asked
+    # for that machine, and quietly building a different one hides the clash.
+    taken.add(9302)
+    cluster._execution = cast(Any, execution)
+    try:
+        with pytest.raises(CreateConflict):
+            cluster._created_on_a_free_vmid(
+                cast(Any, Cluster()), "n", cast(Any, None), "d", Path("/x"), 9302, "v2"
+            )
+    finally:
+        cluster._execution = original

--- a/tests/vm/cluster.py
+++ b/tests/vm/cluster.py
@@ -1892,6 +1892,30 @@ def tui_job(name: str, spec: int) -> Job:
     return Job(name=name, fixture=Path(), disks=disks, uefi=uefi)
 
 
+def _created_on_a_free_vmid(
+    api: Api, node: str, job: Job, driver: str, workdir: Path, vmid: int, name: str
+) -> tuple[Running, Guest]:
+    """Build the guest, taking the next free VMID when the chosen one is gone."""
+    excluded: set[int] = set()
+    conflict: CreateConflict | None = None
+    for _ in range(RESERVATION_TRIES):
+        chosen = vmid or api.free_vmid(frozenset(excluded))
+        held = _execution(api, node, job, driver, workdir, vmid=chosen, nonce=uuid.uuid4().hex)
+        guest = cast(Guest, held.guest)
+        print(f"{name}: booting {guest.vmid} on {node}", flush=True)
+        try:
+            guest.create()
+        except CreateConflict as error:
+            if vmid:
+                raise
+            excluded.add(chosen)
+            conflict = error
+            continue
+        return held, guest
+    assert conflict is not None
+    raise conflict
+
+
 def tui_execution(
     api: Api, node: str, name: str, spec: int, workdir: Path, vmid: int = 0
 ) -> Running:
@@ -1937,12 +1961,11 @@ def tui_execution(
         local=cached_medium(medium, urls, medium_sha512) if cjk else None,
     )
     job = replace(tui_job(name, spec), iso=medium)
-    held = _execution(
-        api, chosen, job, driver_path.name, workdir, vmid=vmid, nonce=uuid.uuid4().hex
-    )
-    guest = cast(Guest, held.guest)
-    print(f"{name}: booting {guest.vmid} on {chosen}", flush=True)
-    guest.create()
+    # Retried on a taken VMID, the same way `_reserve` does it: two sessions
+    # started four seconds apart both read 9300 as free and the second answered
+    # `VM 9300 already exists on node 'infra-node5'`. Nothing between them
+    # allocates, so the collision is found only by the create.
+    held, guest = _created_on_a_free_vmid(api, chosen, job, driver_path.name, workdir, vmid, name)
     guest.start()
     link = Reconnecting.to(guest, held.watch.log)
     guest.reset()


### PR DESCRIPTION
`v2` and `v8` were started four seconds apart, both read 9300 as free, and the second answered `VM 9300 already exists on node 'infra-node5'` — the whole session died there. `_reserve` already retries on a taken VMID; `tui_execution` did not. A VMID the caller named is still not swapped for another: the operator asked for that machine, and quietly building a different one hides the clash.