### PR TITLE
vm: give an OpenRC root a getty on the serial line

### DIFF
--- a/tests/unit/test_cluster.py
+++ b/tests/unit/test_cluster.py
@@ -3643,3 +3643,47 @@ def test_the_menu_editor_is_asked_for_only_where_nothing_else_was_written() -> N
             assert bool(held) is expected, route
     finally:
         cluster._edit_uefi_cmdline = original
+
+
+def test_an_openrc_root_gets_a_getty_on_the_serial_line() -> None:
+    """`lab8` printed its whole boot and then nothing: systemd spawns a getty
+    on whatever `console=` names, and OpenRC's `/etc/inittab` only starts one
+    on tty1, so the check that reads the machine back had nowhere to log in."""
+    from tests.vm import cluster
+
+    shell = ScriptedShell(
+        {
+            "zpool import": "",
+            "blkid -t TYPE=vfat": "",
+            "blkid -o export": "/dev/vda1:ext4",
+            "grub/grub.cfg": "/mnt/root/boot/grub/grub.cfg",
+            "grep -c ttyS0": "0",
+        }
+    )
+    route = cluster.make_the_installed_system_speak(cast(Any, shell), "console=ttyS0,115200")
+
+    assert route is cluster.SerialRoute.GRUB_CONFIG
+    written = [one for one in shell.asked if "inittab" in one and "printf" in one]
+    assert written, shell.asked
+    assert cluster.SERIAL_GETTY in written[0]
+    # Written before the root is unmounted, or it lands on the live medium.
+    assert shell.asked.index(written[0]) < shell.asked.index("umount /mnt/root")
+
+
+def test_a_root_that_already_has_a_serial_getty_is_left_alone() -> None:
+    """A second line would give the machine two agettys on one device, and
+    they take turns losing the terminal."""
+    from tests.vm import cluster
+
+    shell = ScriptedShell(
+        {
+            "zpool import": "",
+            "blkid -t TYPE=vfat": "",
+            "blkid -o export": "/dev/vda1:ext4",
+            "grub/grub.cfg": "/mnt/root/boot/grub/grub.cfg",
+            "grep -c ttyS0": "1",
+        }
+    )
+    cluster.make_the_installed_system_speak(cast(Any, shell), "console=ttyS0,115200")
+
+    assert not [one for one in shell.asked if "inittab" in one and "printf" in one]

--- a/tests/vm/cluster.py
+++ b/tests/vm/cluster.py
@@ -3853,6 +3853,7 @@ def _grub_config_edited(link: "Reconnecting", extra: str) -> bool:
                     "sed -i '/^[[:space:]]*linux/ s|$| " + extra + "|' "
                     "/mnt/root/boot/grub/grub.cfg"
                 )
+                _open_a_serial_login(link)
                 link.run("umount /mnt/root")
                 if opened != device:
                     link.run("cryptsetup close speak")
@@ -3865,6 +3866,29 @@ def _grub_config_edited(link: "Reconnecting", extra: str) -> bool:
 
 #: Every spec uses one password, so the harness knows it without being told.
 TUI_PASSWORD: Final[str] = "testtest"
+
+
+def _open_a_serial_login(link: "Reconnecting") -> None:
+    """Give an OpenRC root a getty on the serial line, if it has none.
+
+    `lab8` printed its whole boot and then nothing: systemd spawns a getty on
+    whatever `console=` names, and OpenRC's `/etc/inittab` only starts one on
+    tty1. Written where the root is already mounted, so the check that reads
+    the machine back has somewhere to log in.
+    """
+    inittab = "/mnt/root/etc/inittab"
+    already = link.expect_output(f"grep -c ttyS0 {inittab} 2>/dev/null || echo 0").strip()
+    if already not in (b"0", b""):
+        return
+    link.run(
+        f"test -f {inittab} && printf '%s\\n' "
+        f"'{SERIAL_GETTY}' >> {inittab} || true"
+    )
+
+
+#: What OpenRC's `/etc/inittab` needs for a login on the serial line. The
+#: runlevels are the ones the medium's own autoconfig uses for tty1.
+SERIAL_GETTY: Final[str] = "s0:12345:respawn:/sbin/agetty 115200 ttyS0 vt100"
 
 
 def _rootish_devices(link: "Reconnecting") -> list[str]:


### PR DESCRIPTION
`lab8` printed its whole boot — `Setting hostname to lab8`, `INIT: Entering runlevel: 3`, cronie, dhcpcd — and then nothing, so the check that reads the machine back had nowhere to log in. systemd spawns a getty on whatever `console=` names; OpenRC's `/etc/inittab` only starts one on tty1. The line is added where the root is already mounted and only when `grep -c ttyS0` finds none, because two agettys on one device take turns losing the terminal.