### PR TITLE
vm: the terminal check has to name serial, not just the command

### DIFF
--- a/tests/unit/test_cluster.py
+++ b/tests/unit/test_cluster.py
@@ -3708,7 +3708,7 @@ def test_grub_is_moved_onto_the_serial_line_as_well() -> None:
             "blkid -t TYPE=vfat": "",
             "blkid -o export": "/dev/vda1:crypto_LUKS",
             "grub/grub.cfg": "/mnt/root/boot/grub/grub.cfg",
-            "grep -c '^terminal_output'": "0",
+            "grep -c '^terminal_output.*serial'": "0",
             "grep -c ttyS0": "0",
         }
     )
@@ -3734,10 +3734,51 @@ def test_a_grub_config_already_on_serial_is_left_alone() -> None:
             "blkid -t TYPE=vfat": "",
             "blkid -o export": "/dev/vda1:ext4",
             "grub/grub.cfg": "/mnt/root/boot/grub/grub.cfg",
-            "grep -c '^terminal_output'": "1",
+            "grep -c '^terminal_output.*serial'": "1",
             "grep -c ttyS0": "1",
         }
     )
     cluster.make_the_installed_system_speak(cast(Any, shell), "console=ttyS0,115200")
 
     assert not [one for one in shell.asked if one.startswith("sed -i '1i")]
+
+
+def test_a_gfxterm_only_config_is_still_moved_onto_the_serial_line() -> None:
+    """`00_header` writes `terminal_output gfxterm` on every machine that has
+    the graphics modules, so a check for the command alone answered 1 on
+    `gi-w2`, skipped the edit, and left the guest at an invisible passphrase
+    prompt for a second round. The check has to name `serial`."""
+    from tests.vm import cluster
+
+    def grub_cfg(command: str) -> str:
+        # What the machine computes, not what the test wants: the count comes
+        # from a real `grep` over a file that has gfxterm and nothing else.
+        lines = ["terminal_output gfxterm", "menuentry 'Gentoo' {", "  linux /boot/vmlinuz"]
+        pattern = command.split("'")[1]
+        assert pattern == "^terminal_output.*serial", pattern
+        import re as _re
+
+        return str(sum(1 for one in lines if _re.search(pattern, one)))
+
+    asked: list[str] = []
+
+    class Shell(ScriptedShell):
+        def expect_output(self, command: str, timeout: float = 120.0) -> bytes:
+            if "terminal_output" in command:
+                asked.append(command)
+                return grub_cfg(command).encode()
+            return super().expect_output(command, timeout)
+
+    shell = Shell(
+        {
+            "zpool import": "",
+            "blkid -t TYPE=vfat": "",
+            "blkid -o export": "/dev/vda1:ext4",
+            "grub/grub.cfg": "/mnt/root/boot/grub/grub.cfg",
+            "grep -c ttyS0": "1",
+        }
+    )
+    cluster.make_the_installed_system_speak(cast(Any, shell), "console=ttyS0,115200")
+
+    assert asked, "the terminal was never checked"
+    assert [one for one in shell.asked if one.startswith("sed -i '1i")], shell.asked

--- a/tests/vm/cluster.py
+++ b/tests/vm/cluster.py
@@ -3878,8 +3878,12 @@ def _grub_talks_on_the_serial_line(link: "Reconnecting") -> None:
     VGA console. `gi-w2` sent 49 bytes and stopped there.
     """
     config = "/mnt/root/boot/grub/grub.cfg"
+    # Naming `serial`, because `00_header` writes `terminal_output gfxterm`
+    # on every machine that has the graphics modules: a check for the command
+    # alone answered 1 on `gi-w2`, skipped the edit, and left the guest at an
+    # invisible passphrase prompt for a second round.
     already = link.expect_output(
-        f"grep -c '^terminal_output' {config} 2>/dev/null || echo 0"
+        f"grep -c '^terminal_output.*serial' {config} 2>/dev/null || echo 0"
     ).strip()
     if already not in (b"0", b""):
         return


### PR DESCRIPTION
`gi-w2` sent 49 bytes on the second round too. The medium's own transcript says why: `grep -c '^terminal_output' …/grub.cfg` answered **1**, so #886 read the config as already on serial and skipped it. `00_header` writes `terminal_output gfxterm` on every machine that has the graphics modules — the command was there and the serial terminal was not.

Fourth instance of a check that cannot fail: the string being searched for was already in the text being searched, and the machine never produced it. The test now runs a real `re.search` over a real `grub.cfg` body instead of letting the double answer the count.