### PR TITLE
vm: read a count of none as none

### DIFF
--- a/tests/unit/test_cluster.py
+++ b/tests/unit/test_cluster.py
@@ -3664,7 +3664,7 @@ def test_an_openrc_root_gets_a_getty_on_the_serial_line() -> None:
             "blkid -t TYPE=vfat": "",
             "blkid -o export": "/dev/vda1:ext4",
             "grub/grub.cfg": "/mnt/root/boot/grub/grub.cfg",
-            "grep -c ttyS0": "0",
+            "grep -c 'ttyS0'": "0",
         }
     )
     route = cluster.make_the_installed_system_speak(cast(Any, shell), "console=ttyS0,115200")
@@ -3688,7 +3688,7 @@ def test_a_root_that_already_has_a_serial_getty_is_left_alone() -> None:
             "blkid -t TYPE=vfat": "",
             "blkid -o export": "/dev/vda1:ext4",
             "grub/grub.cfg": "/mnt/root/boot/grub/grub.cfg",
-            "grep -c ttyS0": "1",
+            "grep -c 'ttyS0'": "1",
         }
     )
     cluster.make_the_installed_system_speak(cast(Any, shell), "console=ttyS0,115200")
@@ -3709,7 +3709,7 @@ def test_grub_is_moved_onto_the_serial_line_as_well() -> None:
             "blkid -o export": "/dev/vda1:crypto_LUKS",
             "grub/grub.cfg": "/mnt/root/boot/grub/grub.cfg",
             "grep -c '^terminal_output.*serial'": "0",
-            "grep -c ttyS0": "0",
+            "grep -c 'ttyS0'": "0",
         }
     )
     cluster.make_the_installed_system_speak(cast(Any, shell), "console=ttyS0,115200")
@@ -3735,7 +3735,7 @@ def test_a_grub_config_already_on_serial_is_left_alone() -> None:
             "blkid -o export": "/dev/vda1:ext4",
             "grub/grub.cfg": "/mnt/root/boot/grub/grub.cfg",
             "grep -c '^terminal_output.*serial'": "1",
-            "grep -c ttyS0": "1",
+            "grep -c 'ttyS0'": "1",
         }
     )
     cluster.make_the_installed_system_speak(cast(Any, shell), "console=ttyS0,115200")
@@ -3775,10 +3775,36 @@ def test_a_gfxterm_only_config_is_still_moved_onto_the_serial_line() -> None:
             "blkid -t TYPE=vfat": "",
             "blkid -o export": "/dev/vda1:ext4",
             "grub/grub.cfg": "/mnt/root/boot/grub/grub.cfg",
-            "grep -c ttyS0": "1",
+            "grep -c 'ttyS0'": "1",
         }
     )
     cluster.make_the_installed_system_speak(cast(Any, shell), "console=ttyS0,115200")
 
     assert asked, "the terminal was never checked"
     assert [one for one in shell.asked if one.startswith("sed -i '1i")], shell.asked
+
+
+def test_a_grep_that_counts_none_is_read_as_none() -> None:
+    """`grep -c` exits 1 when it counts nothing, so `grep -c … || echo 0` ran
+    both halves and the console answered two lines. Compared against `"0"`
+    that read as a match, and `gi-w2` lost two rounds to an edit that was
+    skipped every time."""
+    from tests.vm import cluster
+
+    class TwoZeroes:
+        """What the shell really answered: the count and the fallback."""
+
+        def __init__(self) -> None:
+            self.asked: list[str] = []
+
+        def expect_output(self, command: str, timeout: float = 120.0) -> bytes:
+            self.asked.append(command)
+            # A pipeline takes grep's exit status out of play, so one line.
+            return b"0\n" if "| head -1" in command else b"0\n0\n"
+
+        def run(self, command: str, timeout: float = 120.0, *, repeatable: bool = True) -> None:
+            self.asked.append(command)
+
+    shell = TwoZeroes()
+    assert cluster._counted(cast(Any, shell), "ttyS0", "/mnt/root/etc/inittab") == 0
+    assert "| head -1" in shell.asked[0], shell.asked

--- a/tests/vm/cluster.py
+++ b/tests/vm/cluster.py
@@ -3869,6 +3869,20 @@ def _grub_config_edited(link: "Reconnecting", extra: str) -> bool:
 TUI_PASSWORD: Final[str] = "testtest"
 
 
+def _counted(link: "Reconnecting", pattern: str, path: str) -> int:
+    """How many lines of `path` match `pattern`, and zero when there are none.
+
+    `grep -c` exits 1 when it counts nothing, so `grep -c … || echo 0` runs
+    both halves and answers `0\\n0`: every caller comparing that to `"0"` read
+    it as a match and skipped its own edit. `gi-w2` lost two rounds to it.
+    """
+    said = link.expect_output(f"grep -c '{pattern}' {path} 2>/dev/null | head -1").strip()
+    try:
+        return int(said or b"0")
+    except ValueError:
+        return 0
+
+
 def _grub_talks_on_the_serial_line(link: "Reconnecting") -> None:
     """Move GRUB's own terminal onto the serial line as well as the screen.
 
@@ -3882,10 +3896,8 @@ def _grub_talks_on_the_serial_line(link: "Reconnecting") -> None:
     # on every machine that has the graphics modules: a check for the command
     # alone answered 1 on `gi-w2`, skipped the edit, and left the guest at an
     # invisible passphrase prompt for a second round.
-    already = link.expect_output(
-        f"grep -c '^terminal_output.*serial' {config} 2>/dev/null || echo 0"
-    ).strip()
-    if already not in (b"0", b""):
+    already = _counted(link, "^terminal_output.*serial", config)
+    if already:
         return
     # Prepended, because GRUB acts on these where it reads them and the
     # passphrase prompt is the first thing the file leads to.
@@ -3911,8 +3923,7 @@ def _open_a_serial_login(link: "Reconnecting") -> None:
     the machine back has somewhere to log in.
     """
     inittab = "/mnt/root/etc/inittab"
-    already = link.expect_output(f"grep -c ttyS0 {inittab} 2>/dev/null || echo 0").strip()
-    if already not in (b"0", b""):
+    if _counted(link, "ttyS0", inittab):
         return
     link.run(
         f"test -f {inittab} && printf '%s\\n' "


### PR DESCRIPTION
`grep -c '^terminal_output.*serial' … 2>/dev/null || echo 0` answered **two** lines of `0`: grep exits 1 when it counts nothing, so the fallback ran as well. Compared against `"0"` that read as a match, and both callers — GRUB's terminal and OpenRC's inittab — skipped their edit. `gi-w2` lost two rounds to it.

One `_counted()` now does the counting, with `| head -1` so the pipeline takes grep's exit status out of play, and returns an `int`. Third distinct cause behind one unchanging symptom on the same guest: VGA-only GRUB (#886), a check matching `terminal_output gfxterm` (#887), and this. All three were found by reading the medium's own transcript, and every guess in between was wrong.