### PR TITLE
vm: name the case where the passphrase precedes grub.cfg

### DIFF
--- a/tests/unit/test_cluster.py
+++ b/tests/unit/test_cluster.py
@@ -3610,6 +3610,7 @@ def test_a_luks_root_is_unlocked_before_its_config_is_read() -> None:
             "blkid -t TYPE=vfat": "",
             "blkid -o export": "/dev/vda1:crypto_LUKS",
             "grub/grub.cfg": "/mnt/root/boot/grub/grub.cfg",
+            "GRUB_ENABLE_CRYPTODISK": "0",
         }
     )
     route = cluster.make_the_installed_system_speak(cast(Any, shell), "console=ttyS0,115200")
@@ -3808,3 +3809,33 @@ def test_a_grep_that_counts_none_is_read_as_none() -> None:
     shell = TwoZeroes()
     assert cluster._counted(cast(Any, shell), "ttyS0", "/mnt/root/etc/inittab") == 0
     assert "| head -1" in shell.asked[0], shell.asked
+
+
+def test_a_bios_cryptodisk_root_says_the_prompt_comes_first() -> None:
+    """`GRUB_ENABLE_CRYPTODISK=y` with `/boot` inside the encrypted root means
+    the core image asks for the passphrase before it can read `grub.cfg` at
+    all: `gi-w2` has the serial lines on lines 1 to 3 and `cryptomount` on
+    line 92, and it stayed quiet through four rounds. Everything is still
+    written, and the caller is told why the console says nothing."""
+    from tests.vm import cluster
+
+    shell = ScriptedShell(
+        {
+            "zpool import": "",
+            "blkid -t TYPE=vfat": "",
+            "blkid -o export": "/dev/vdb1:crypto_LUKS",
+            "grub/grub.cfg": "/mnt/root/boot/grub/grub.cfg",
+            "grep -c '^terminal_output.*serial'": "0",
+            "grep -c 'ttyS0'": "0",
+            "GRUB_ENABLE_CRYPTODISK": "1",
+        }
+    )
+    route = cluster.make_the_installed_system_speak(cast(Any, shell), "console=ttyS0,115200")
+
+    assert route is cluster.SerialRoute.CRYPTODISK_CORE
+    # The edits still happen: they work once the passphrase is answered.
+    assert [one for one in shell.asked if one.startswith("sed -i '1i")], shell.asked
+    assert [one for one in shell.asked if "inittab" in one and "printf" in one], shell.asked
+    # Asked while the root is mounted, or the answer cannot be read at all.
+    crypt = next(one for one in shell.asked if "GRUB_ENABLE_CRYPTODISK" in one)
+    assert shell.asked.index(crypt) < shell.asked.index("umount /mnt/root")

--- a/tests/vm/cluster.py
+++ b/tests/vm/cluster.py
@@ -3763,6 +3763,11 @@ class SerialRoute(Enum):
     LOADER_ENTRIES = "loader-entries"
     ZFSBOOTMENU = "zfsbootmenu"
     GRUB_CONFIG = "grub-config"
+    #: Everything was written, and the serial line stays quiet until the
+    #: passphrase is answered: GRUB's core image asks for it before it can
+    #: read `grub.cfg` at all. Held apart so a silent console is not read as
+    #: an install that failed.
+    CRYPTODISK_CORE = "cryptodisk-core"
     NOTHING_FOUND = "nothing-found"
 
 
@@ -3811,8 +3816,9 @@ def make_the_installed_system_speak(
             link.run("umount /mnt/esp")
             return SerialRoute.LOADER_ENTRIES
         link.run("umount /mnt/esp")
-    if _grub_config_edited(link, extra):
-        return SerialRoute.GRUB_CONFIG
+    edited = _grub_config_edited(link, extra)
+    if edited is not None:
+        return edited
     return SerialRoute.NOTHING_FOUND
 
 
@@ -3824,7 +3830,7 @@ def _boot_environments(link: "Reconnecting", pool: str) -> list[str]:
     return [one for one in named if one != f"{pool}/ROOT"]
 
 
-def _grub_config_edited(link: "Reconnecting", extra: str) -> bool:
+def _grub_config_edited(link: "Reconnecting", extra: str) -> SerialRoute | None:
     """Put the parameters in `grub.cfg` itself, for a menu nobody can type into.
 
     A BIOS GRUB draws its menu on the VGA console, so `append_to_cmdline` has
@@ -3855,14 +3861,17 @@ def _grub_config_edited(link: "Reconnecting", extra: str) -> bool:
                 )
                 _grub_talks_on_the_serial_line(link)
                 _open_a_serial_login(link)
+                # Read while the root is still mounted, because the answer
+                # decides what a silent console afterwards means.
+                core = _counted(link, "^GRUB_ENABLE_CRYPTODISK=y", "/mnt/root/etc/default/grub")
                 link.run("umount /mnt/root")
                 if opened != device:
                     link.run("cryptsetup close speak")
-                return True
+                return SerialRoute.CRYPTODISK_CORE if core else SerialRoute.GRUB_CONFIG
             link.run("umount /mnt/root 2>/dev/null; true")
         if opened != device:
             link.run("cryptsetup close speak")
-    return False
+    return None
 
 
 #: Every spec uses one password, so the harness knows it without being told.


### PR DESCRIPTION
`gi-w2` stayed quiet through four rounds with every fix in place. Reading the installed file settles it: the serial commands are on lines 1 to 3, `cryptomount` is on line 92, and `/etc/default/grub` carries `GRUB_ENABLE_CRYPTODISK=y` — `/boot` is inside the encrypted root, so GRUB's core image has to unlock the disk before it can read `grub.cfg` at all. It asks for the passphrase before line 1 exists to it.

No post-hoc edit reaches that. Embedding `serial` into the core image is a `grub-install` argument, which belongs to the installer and not to a verification tool. `SerialRoute.CRYPTODISK_CORE` says so: everything is still written, because it works once the passphrase is answered, and the caller no longer reads a quiet console as a failed install. The decision is in `docs/design.md` first.