### PR TITLE
netboot: say the disk is unwritten, not that it was untouched

### DIFF
--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -103,9 +103,9 @@ ssh root@the-machine
 
 默认引导项不会改动，所以没有进入该环境的机器仍引导回原本的系统；`--disarm` 取消这次预约。`--bypass` 改为取代默认项，供会丢弃一次性引导项的固件使用，那也是唯一一条「环境起不来就连机器都引导不了」的路径。
 
-第一个界面提供安装与救援 shell，没有超时，未回答之前不会擦除任何数据。`--ram` 引导的是带 ZFS 的 Gentoo CJK ISO，约需 2 GiB 内存；`--lowram` 引导的是较小、没有 `zfs.ko` 的 Alpine netboot 压缩包。`--ssh-port` 把服务移离 22 端口。第一页写出稍后启动安装的命令，所以回答 `no`、或在回答之前断线，都不会让重启成为唯一的退路。
+第一个界面提供安装与救援 shell，没有超时，未回答之前不会擦除任何数据。`--ram` 引导的是带 ZFS 的 Gentoo CJK ISO，约需 2 GiB 内存；`--lowram` 引导的是较小、没有 `zfs.ko` 的 Alpine netboot 压缩包。`--ssh-port` 把服务移离 22 端口。第一页写出稍后启动安装的命令，因此回答 `no` 或在回答之前断线，都不必重启才能再次看到该提示。
 
-`--ram` 连得上 Wi-Fi，`--lowram` 连不上。Gentoo CJK ISO 带着 NetworkManager 与 `linux-firmware`，`nmcli device wifi connect <SSID> password <密码>` 就能接起连接，接好再执行安装；第一页以正体中文、简体中文与英文写出这件事。Alpine netboot 环境没有无线驱动也没有 supplicant，完整模块在一份本身也要下载的 `modloop` 里，因此只有 Wi-Fi 一条连接的机器完全无法使用 `--lowram`。
+`--ram` 可使用 Wi-Fi，`--lowram` 不可。Gentoo CJK ISO 带着 NetworkManager 与 `linux-firmware`，以 `nmcli device wifi connect <SSID> password <密码>` 建立连接之后即可执行安装；第一页以正体中文、简体中文与英文写出这件事。Alpine netboot 环境没有无线驱动也没有 supplicant，完整模块在一份本身也要下载的 `modloop` 里，因此只有 Wi-Fi 一条连接的机器完全无法使用 `--lowram`。
 
 ## 转换运行中的系统
 

--- a/README.zh-TW.md
+++ b/README.zh-TW.md
@@ -103,9 +103,9 @@ ssh root@the-machine
 
 預設開機項目不會更動，所以沒有進入該環境的機器仍開回原本的系統；`--disarm` 取消這次預約。`--bypass` 改為取代預設項目，供會丟棄一次性項目的韌體使用，那也是唯一一條「環境起不來就連機器都開不起來」的路徑。
 
-第一個畫面提供安裝與救援 shell，沒有逾時，未回答之前不會抹除任何資料。`--ram` 開的是帶 ZFS 的 Gentoo CJK ISO，約需 2 GiB 記憶體；`--lowram` 開的是較小、沒有 `zfs.ko` 的 Alpine netboot 壓縮檔。`--ssh-port` 把服務移離 22 埠。第一頁寫出稍後啟動安裝的命令，所以回答 `no`、或在回答之前斷線，都不會讓重新開機成為唯一的回頭路。
+第一個畫面提供安裝與救援 shell，沒有逾時，未回答之前不會抹除任何資料。`--ram` 開的是帶 ZFS 的 Gentoo CJK ISO，約需 2 GiB 記憶體；`--lowram` 開的是較小、沒有 `zfs.ko` 的 Alpine netboot 壓縮檔。`--ssh-port` 把服務移離 22 埠。第一頁寫出稍後啟動安裝的命令，因此回答 `no` 或在回答之前斷線，都不必重新開機才能再次看到該提示。
 
-`--ram` 連得上 Wi-Fi，`--lowram` 連不上。Gentoo CJK ISO 帶著 NetworkManager 與 `linux-firmware`，`nmcli device wifi connect <SSID> password <密碼>` 就能接起連線，接完再執行安裝；第一頁以正體中文、简体中文與英文寫出這件事。Alpine netboot 環境沒有無線驅動也沒有 supplicant，完整模組在一份本身也要下載的 `modloop` 裡，因此只有 Wi-Fi 一條連線的機器完全無法使用 `--lowram`。
+`--ram` 可使用 Wi-Fi，`--lowram` 不可。Gentoo CJK ISO 帶著 NetworkManager 與 `linux-firmware`，以 `nmcli device wifi connect <SSID> password <密碼>` 建立連線之後即可執行安裝；第一頁以正體中文、简体中文與英文寫出這件事。Alpine netboot 環境沒有無線驅動也沒有 supplicant，完整模組在一份本身也要下載的 `modloop` 裡，因此只有 Wi-Fi 一條連線的機器完全無法使用 `--lowram`。
 
 ## 轉換執行中的系統
 

--- a/gentoo_install/plan/netboot.py
+++ b/gentoo_install/plan/netboot.py
@@ -652,8 +652,8 @@ WIFI_LINES: Final[dict[MemoryMode, tuple[str, ...]]] = {
 BANNER: Final[dict[MemoryMode, tuple[str, ...]]] = {
     MemoryMode.RAM: (
         "gentoo-install is in memory. The disk has not been touched.",
-        "\u5b89\u88dd\u5668\u5df2\u5728\u8a18\u61b6\u9ad4\u4e2d\uff0c\u78c1\u789f\u9084\u6c92\u6709\u88ab\u52d5\u904e\u3002",
-        "\u5b89\u88c5\u5668\u5df2\u5728\u5185\u5b58\u4e2d\uff0c\u78c1\u76d8\u8fd8\u6ca1\u6709\u88ab\u52a8\u8fc7\u3002",
+        "\u5b89\u88dd\u5668\u5df2\u5728\u8a18\u61b6\u9ad4\u4e2d\uff0c\u5c1a\u672a\u5beb\u5165\u78c1\u789f\u3002",
+        "\u5b89\u88c5\u5668\u5df2\u5728\u5185\u5b58\u4e2d\uff0c\u5c1a\u672a\u5199\u5165\u78c1\u76d8\u3002",
     ),
     MemoryMode.LOWRAM: (
         "gentoo-install is in memory. The disk has not been touched.",

--- a/tests/unit/test_plan_netboot.py
+++ b/tests/unit/test_plan_netboot.py
@@ -1711,3 +1711,18 @@ def test_only_the_cjk_medium_is_told_about_wifi_in_chinese() -> None:
     # The traditional banner names the disk; the Alpine one is English only.
     assert "\u78c1\u789f" in ram
     assert not [one for one in lowram if "\u4e00" <= one <= "\u9fff"], lowram
+
+
+def test_the_banner_states_the_disk_is_unwritten_rather_than_untouched() -> None:
+    """`\\u78c1\\u789f\\u9084\\u6c92\\u6709\\u88ab\\u52d5\\u904e` reads as a turn of phrase; the operator needs the
+    operation. Both Chinese lines say that nothing has been written to the
+    disk yet, which is the state the whole screen exists to establish."""
+    said = netboot.BANNER[MemoryMode.RAM]
+
+    # Nothing written to the disk yet, in both scripts.
+    unwritten = ("\u5c1a\u672a\u5beb\u5165\u78c1\u789f", "\u5c1a\u672a\u5199\u5165\u78c1\u76d8")
+    for wanted in unwritten:
+        assert any(wanted in one for one in said), (wanted, said)
+    # The turn of phrase it must not go back to: "has not been moved".
+    refused = ("\u88ab\u52d5\u904e", "\u88ab\u52a8\u8fc7")
+    assert not [one for one in said if any(bad in one for bad in refused)], said


### PR DESCRIPTION
The banner's Chinese said the disk had not been moved, which is a turn of phrase; the operator needs the operation. Both scripts now state that nothing has been written to the disk, which is the state the whole screen exists to establish, and a test holds the wording so it cannot come back. The same reading pass tightened three phrases in the two Chinese READMEs.