### PR TITLE
vm: run a conversion inside the machine it replaces

### DIFF
--- a/tests/unit/test_tui_report.py
+++ b/tests/unit/test_tui_report.py
@@ -11,6 +11,8 @@ from __future__ import annotations
 from pathlib import Path
 from typing import Any, cast
 
+import pytest
+
 from tests.tui.report import STUCK_AFTER, Report, read, title_of
 
 #: A framed pane, as `TwoPane.frame` draws it. The heading names the open row.
@@ -337,3 +339,105 @@ def test_two_sessions_started_together_do_not_take_one_vmid() -> None:
             )
     finally:
         cluster._execution = original
+
+
+def test_a_conversion_runs_inside_the_machine_it_replaces(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """`refusals.LIVE_MEDIUM` is what the interface answers on a guest that
+    just booted a live image, so spec 3 cannot be measured the way the other
+    eight are. `tui_conversion` makes the installed system speak first, boots
+    it from its own disk, logs in, and runs the installer from the driver CD
+    inside it."""
+    import pytest
+
+    from tests.vm import cluster
+
+    done: list[str] = []
+
+    class Machine:
+        vmid = 9300
+        node = "infra-node3"
+
+        def stop(self) -> None:
+            done.append("stop")
+
+        def boot_from_disk(self) -> None:
+            done.append("boot_from_disk")
+
+        def start(self) -> None:
+            done.append("start")
+
+        def reset(self) -> None:
+            done.append("reset")
+
+        def transferred(self) -> tuple[int, int]:
+            return (0, 0)
+
+        def qmp_state(self) -> str:
+            return "running"
+
+    class Console:
+        def send(self, line: str) -> None:
+            done.append(f"send:{line}")
+
+        def expect(self, pattern: str, timeout: float, idle: float = 0.0) -> bytes:
+            done.append(f"expect:{pattern}")
+            return b""
+
+    class Link:
+        console = Console()
+
+        def reopen(self, *, solicit_prompt: bool = True) -> None:
+            done.append("reopen")
+
+        def run(self, command: str, timeout: float = 120.0, *, repeatable: bool = True) -> None:
+            done.append(f"run:{command[:20]}")
+
+    class Cluster:
+        def call(self, method: str, path: str, **form: object) -> object:
+            return {"name": "gi-x1", "tags": "abc;gentoo-install-test", "virtio0": "disk"}
+
+        def node_load(self, name: str) -> float | None:
+            return 0.0
+
+    machine, link = Machine(), Link()
+
+    def speak(one: object) -> object:
+        done.append("speak")
+        return cluster.SerialRoute.GRUB_CONFIG
+
+    monkeypatch.setattr(cluster, "Guest", lambda **kw: machine)
+    monkeypatch.setattr(
+        cluster, "Reconnecting", type("R", (), {"to": staticmethod(lambda *a: link)})
+    )
+    monkeypatch.setattr(cluster, "make_the_installed_system_speak", speak)
+    monkeypatch.setattr(
+        cluster, "edit_the_menu_if_that_is_the_only_route", lambda *a: done.append("menu")
+    )
+    monkeypatch.setattr(cluster, "reach_prompt", lambda one: done.append("prompt"))
+    running = cluster.tui_conversion(
+        cast(Any, Cluster()), "infra-node3", "conv", 9300, Path("/tmp")
+    )
+
+    # The parameters go in while a live shell is still there, and only then is
+    # the guest pointed at its own disk.
+    assert done.index("speak") < done.index("stop"), done
+    assert done.index("stop") < done.index("boot_from_disk") < done.index("start")
+    assert "expect:login:" in done, done
+    assert f"send:{cluster.TUI_PASSWORD}" in done, done
+    # No `--config`: the menu is the subject here as much as anywhere else.
+    started = [one for one in done if "install.sh" in one]
+    assert started and "--config" not in started[0], done
+    assert running.console is link.console
+
+
+def test_a_disk_spec_is_not_sent_through_the_conversion_path() -> None:
+    """The other eight build a new system and get a guest of their own; only
+    the conversion needs one that already boots."""
+    import pytest
+
+    from tests.vm import cluster
+
+    with pytest.raises(ValueError, match="goes through"):
+        cluster.tui_conversion(cast(Any, None), "n", "x", 9300, Path("/tmp"), spec=1)

--- a/tests/vm/cluster.py
+++ b/tests/vm/cluster.py
@@ -1937,8 +1937,9 @@ def tui_execution(
     if spec in TUI_NEEDS_A_SYSTEM:
         raise ValueError(
             f"spec {spec} replaces a running system, so it needs a guest that "
-            "already boots one; a fresh guest can only be told that conversion "
-            "is not offered"
+            "already boots one; hand `tui_conversion` the vmid of a machine "
+            "this harness installed, or a fresh guest can only be told that "
+            "conversion is not offered"
         )
     chosen = node or free_slots(api)[0].name
     # The medium and the driver CD are per node, and `local` is not shared:
@@ -1990,6 +1991,91 @@ def tui_execution(
     )
     held.console = link.console
     return held
+
+
+def tui_conversion(
+    api: Api, node: str, name: str, vmid: int, workdir: Path, spec: int = 3
+) -> Running:
+    """The installer running inside a machine this harness already installed.
+
+    `refusals.LIVE_MEDIUM` is what the interface answers on a guest that just
+    booted a live image, so the conversion spec cannot be measured the way the
+    other eight are: it needs the installer running *in* an installed system,
+    not on the medium beside it. The steps are settled in `docs/design.md`.
+    """
+    if spec not in TUI_NEEDS_A_SYSTEM:
+        raise ValueError(
+            f"spec {spec} builds a new system, so it goes through "
+            "`tui_execution` on a guest of its own"
+        )
+    config = api.call("GET", f"/nodes/{node}/qemu/{vmid}/config")
+    named = str(config.get("name", ""))
+    if not named.startswith("gi-"):
+        raise ForeignGuest(f"vm {vmid} on {node} is named {named!r}; not converting it")
+    nonce = str(config.get("tags") or "").split(";")[0]
+    disks = tuple(
+        TARGET_GIB for key in config if _VIRTIO_DISK.fullmatch(key)
+    )
+    guest = Guest(
+        api=api,
+        node=node,
+        vmid=vmid,
+        spec=GuestSpec(name=named, iso="", nonce=nonce, target_gib=disks or (TARGET_GIB,)),
+    )
+    log = guest_log(workdir, name, vmid, "conversion")
+    link = Reconnecting.to(guest, log)
+    # On the medium, while a live shell is still there: the installed system
+    # has no `console=` of its own, so without this the machine boots to a
+    # serial line nobody can log in on.
+    route = make_the_installed_system_speak(link)
+    print(f"{name}: {route.value}", flush=True)
+    guest.stop()
+    guest.boot_from_disk()
+    guest.start()
+    link.reopen(solicit_prompt=False)
+    guest.reset()
+    edit_the_menu_if_that_is_the_only_route(guest, link, route)
+    print(f"{name}: waiting for the installed system", flush=True)
+    _log_into_the_installed_system(link)
+    link.run(FIND_DRIVER)
+    link.run(f"mkdir -p {RESULT_DIR}")
+    link.run(f"stty rows {TUI_LINES} cols {TUI_COLUMNS}")
+    link.console.send(
+        f"TERM=xterm LINES={TUI_LINES} COLUMNS={TUI_COLUMNS} "
+        "sh /mnt/driver/install.sh --lang zh-TW"
+    )
+    return Running(
+        guest=guest,
+        watch=Watchdog(
+            log=log,
+            counters=lambda: guest.transferred(),
+            where=node,
+            load=lambda: api.node_load(node),
+            state=lambda: guest.qmp_state(),
+        ),
+        reservation_bytes=0,
+        created=False,
+        console=link.console,
+    )
+
+
+#: What a `virtio<N>` disk key looks like, so the count comes from the guest
+#: rather than from a caller who might name a different number.
+_VIRTIO_DISK: Final[re.Pattern[str]] = re.compile(r"virtio\d+")
+
+
+def _log_into_the_installed_system(link: "Reconnecting") -> None:
+    """Answer the login the installed system offers on its serial line."""
+    link.console.expect(r"login:", INSTALLED_LOGIN_PATIENCE)
+    link.console.send("root")
+    link.console.expect(r"assword", INSTALLED_LOGIN_PATIENCE)
+    link.console.send(TUI_PASSWORD)
+    reach_prompt(link)
+
+
+#: A machine booting its own disk answers sooner than a medium does, and a
+#: passphrase prompt on the way makes it slower again.
+INSTALLED_LOGIN_PATIENCE: Final[float] = 300.0
 
 
 def install_one(


### PR DESCRIPTION
`refusals.LIVE_MEDIUM` is what the interface answers on a guest that just booted a live image, so spec 3 cannot be measured the way the other eight are. `tui_conversion` takes a machine this harness already installed: it writes the serial parameters while a live shell is still there — the installed system has no `console=` of its own and would otherwise boot to a line nobody can log in on — then `stop`, `boot_from_disk`, `start`, logs in, mounts the driver CD and runs `install.sh --lang zh-TW` inside that system. The disk count comes from the guest's own `virtio<N>` keys rather than from the caller.

`TUI_NEEDS_A_SYSTEM` now names the entry point instead of only refusing. The control moves `make_the_installed_system_speak` after `stop` and goes red: the order is the one thing on this path that cannot be wrong.