### PR TITLE
session: drive the installer inside an installed guest

### DIFF
--- a/tests/tui/session.py
+++ b/tests/tui/session.py
@@ -176,12 +176,19 @@ def ask(
 
 
 
-def start(name: str, spec: int, node: str = "", vmid: int = 0) -> str:
+def start(
+    name: str, spec: int, node: str = "", vmid: int = 0, convert: int = 0
+) -> str:
     """Build a guest and leave the installer at its first screen.
 
     The same path an install fixture takes as far as the driver CD, and then
     the other half: `install.sh` with no `--config`, which is the interface
     this exists to exercise.
+
+    `convert` names a machine this harness already installed, and the
+    installer is started inside it instead: the interface answers that a live
+    medium has no system to replace, so the conversion spec cannot be reached
+    from a guest that just booted one.
     """
     from tests.vm import cluster
     from tests.vm.proxmox import Api
@@ -192,7 +199,12 @@ def start(name: str, spec: int, node: str = "", vmid: int = 0) -> str:
     session.screens.write_text("", encoding="utf-8")
     (session.directory / "spec.txt").write_text(str(spec), encoding="utf-8")
     api = Api()
-    held = cluster.tui_execution(api, node, name, spec, session.directory, vmid)
+    if convert:
+        if not node:
+            raise SessionError("--convert names a machine, so --node names where it is")
+        held = cluster.tui_conversion(api, node, name, convert, session.directory, spec)
+    else:
+        held = cluster.tui_execution(api, node, name, spec, session.directory, vmid)
     if os.fork() != 0:
         return name
     # The child holds the console; the parent's caller gets the name back and
@@ -327,6 +339,12 @@ def main(argv: list[str] | None = None) -> int:
     opened.add_argument("--spec", type=int, required=True)
     opened.add_argument("--node", default="")
     opened.add_argument("--vmid", type=int, default=0)
+    opened.add_argument(
+        "--convert",
+        type=int,
+        default=0,
+        help="drive the installer inside this already-installed guest",
+    )
     typed = commands.add_parser("key", help="press keys, in order")
     typed.add_argument("session")
     typed.add_argument("keys", nargs="+")
@@ -340,7 +358,15 @@ def main(argv: list[str] | None = None) -> int:
 
     session = Session(arguments.session)
     if arguments.command == "start":
-        print(start(arguments.session, arguments.spec, arguments.node, arguments.vmid))
+        print(
+            start(
+                arguments.session,
+                arguments.spec,
+                arguments.node,
+                arguments.vmid,
+                arguments.convert,
+            )
+        )
         return 0
     if arguments.command == "key":
         sent = keys_from(arguments.keys)

--- a/tests/unit/test_tui_session.py
+++ b/tests/unit/test_tui_session.py
@@ -4,6 +4,7 @@
 from __future__ import annotations
 
 import json
+import os
 import socket
 import struct
 import threading
@@ -113,3 +114,52 @@ def test_a_client_that_hangs_up_does_not_end_the_session(
     assert json.loads(answers[0].decode()) == {"sent": "yes"}
     assert console.sent == ["x"], console.sent
     assert not session.ended.exists(), session.ended.read_text(encoding="utf-8")
+
+
+def test_convert_drives_the_installer_inside_an_installed_guest(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The interface answers that a live medium has no system to replace, so
+    the conversion spec is reached through a machine this harness already
+    installed rather than through a guest of its own."""
+    from tests.vm import cluster
+
+    asked: list[tuple[str, object]] = []
+    monkeypatch.setattr(tui_session, "SESSIONS", tmp_path)
+    monkeypatch.setattr(
+        cluster,
+        "tui_conversion",
+        lambda api, node, name, vmid, workdir, spec=3: asked.append(("convert", vmid)),
+    )
+    monkeypatch.setattr(
+        cluster,
+        "tui_execution",
+        lambda api, node, name, spec, workdir, vmid=0: asked.append(("execution", vmid)),
+    )
+    monkeypatch.setattr(tui_session, "Api", lambda: None, raising=False)
+    # `os` itself, not the name the module re-exports: mypy refuses the
+    # attribute on a module that does not export it.
+    monkeypatch.setattr(os, "fork", lambda: 1)
+
+    tui_session.start("conv", spec=3, node="infra-node3", convert=9300)
+
+    assert asked == [("convert", 9300)], asked
+
+
+def test_a_conversion_without_a_node_is_refused_before_anything_is_built(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The guest already exists, so the harness cannot choose where it lives
+    the way it does for a guest it is about to create."""
+    from tests.vm import cluster
+
+    monkeypatch.setattr(tui_session, "SESSIONS", tmp_path)
+    monkeypatch.setattr(
+        cluster,
+        "tui_conversion",
+        lambda *a, **k: pytest.fail("a refused conversion must not reach the cluster"),
+    )
+    monkeypatch.setattr(tui_session, "Api", lambda: None, raising=False)
+
+    with pytest.raises(tui_session.SessionError, match="--node names where it is"):
+        tui_session.start("conv", spec=3, convert=9300)


### PR DESCRIPTION
`session start --convert <vmid>` takes the `tui_conversion` path instead of building a guest of its own, which is the last stretch that kept spec 3 out of reach from the command line. A conversion without `--node` is refused before anything is built: the guest already exists, so the harness cannot pick where it lives the way it does for one it is about to create.