### PR TITLE
vm: clear a half-typed line when the console is reopened

### DIFF
--- a/tests/unit/test_cluster.py
+++ b/tests/unit/test_cluster.py
@@ -1449,6 +1449,11 @@ def test_the_login_wait_asks_again_after_the_console_is_reopened() -> None:
         def send(self, line: str) -> None:
             self.asked = True
 
+        def send_raw(self, keys: str) -> None:
+            # The protocol has it, so the double does: a reopen clears the
+            # line before it asks for a prompt.
+            self.asked = True
+
         def close(self) -> None:
             return None
 
@@ -1842,6 +1847,10 @@ def test_a_dropped_console_does_not_end_a_guest_that_is_still_working(
             raise ConsoleClosed("the connection broke: [Errno 104] Connection reset by peer")
 
         def send(self, line: str) -> None:
+            return None
+
+        def send_raw(self, keys: str) -> None:
+            # The protocol has it, so the double does.
             return None
 
         def close(self) -> None:
@@ -2344,6 +2353,8 @@ def test_a_reopen_before_a_write_sends_no_empty_line() -> None:
     assert len(opened) == 2, opened
     assert opened[1].sent == ["root"], opened[1].sent
     assert "" not in opened[1].sent, opened[1].sent
+    # Nor an interrupt: at a `login:` prompt that is an answer too.
+    assert cluster.INTERRUPT not in opened[1].sent, opened[1].sent
 
 
 def test_a_reopen_that_is_waiting_for_a_shell_still_asks_for_one() -> None:
@@ -2360,7 +2371,9 @@ def test_a_reopen_that_is_waiting_for_a_shell_still_asks_for_one() -> None:
     link = cluster.Reconnecting(cast("Any", open_console))
     link.reopen()
 
-    assert opened[-1].sent == [""], opened[-1].sent
+    # The interrupt clears whatever half a line the drop left behind, and
+    # the empty one is the request for a prompt.
+    assert opened[-1].sent == [cluster.INTERRUPT, ""], opened[-1].sent
 
 
 def test_the_first_password_is_sent_the_moment_the_prompt_is_read(
@@ -3839,3 +3852,58 @@ def test_a_bios_cryptodisk_root_says_the_prompt_comes_first() -> None:
     # Asked while the root is mounted, or the answer cannot be read at all.
     crypt = next(one for one in shell.asked if "GRUB_ENABLE_CRYPTODISK" in one)
     assert shell.asked.index(crypt) < shell.asked.index("umount /mnt/root")
+
+
+def test_a_reopened_console_clears_whatever_the_shell_was_holding() -> None:
+    """A drop in the middle of a `send` leaves the shell holding half a line,
+    and an unclosed quote turns every command after it into continuation text:
+    `gi-x1` answered `> ` to three `zpool import` retries in a row and nothing
+    else. The interrupt goes first, before the prompt is solicited, or the
+    empty line only lengthens the quote."""
+    from tests.vm import cluster
+
+    sent: list[str] = []
+
+    class Console:
+        def send(self, line: str) -> None:
+            sent.append(f"send:{line}")
+
+        def send_raw(self, keys: str) -> None:
+            sent.append(f"raw:{keys}")
+
+        def close(self) -> None:
+            sent.append("close")
+
+    link = cluster.Reconnecting(lambda: cast(Any, Console()))
+    sent.clear()
+    link.reopen()
+
+    assert sent.index(f"raw:{cluster.INTERRUPT}") < sent.index("send:"), sent
+
+
+def test_no_interrupt_reaches_a_console_that_may_be_at_a_login_prompt() -> None:
+    """`solicit_prompt=False` is used where the console may be at `login:`, a
+    GRUB menu or a passphrase prompt, and anything sent there is an answer to
+    it: `vm-lvm` and `openrc-sdboot` failed three rounds to one empty line at
+    a login prompt. The interrupt clears a shell and belongs only where one is
+    known to be there."""
+    from tests.vm import cluster
+
+    sent: list[str] = []
+
+    class Console:
+        def send(self, line: str) -> None:
+            sent.append(f"send:{line}")
+
+        def send_raw(self, keys: str) -> None:
+            sent.append(f"raw:{keys}")
+
+        def close(self) -> None:
+            sent.append("close")
+
+    link = cluster.Reconnecting(lambda: cast(Any, Console()))
+    sent.clear()
+    link.reopen(solicit_prompt=False)
+
+    assert f"raw:{cluster.INTERRUPT}" not in sent, sent
+    assert not [one for one in sent if one.startswith("send:")], sent

--- a/tests/unit/test_proxmox.py
+++ b/tests/unit/test_proxmox.py
@@ -986,7 +986,10 @@ def test_wait_for_does_not_resend_after_an_ambiguous_write_failure() -> None:
                 )
 
         def send_raw(self, keys: str) -> None:
-            raise AssertionError("this test sends a line")
+            # The reopen clears whatever half a line the drop left; an
+            # interrupt cancels and cannot start a second install, which is
+            # the thing this test exists to prevent.
+            raw.append(keys)
 
         def snapshot(self, seconds: float) -> bytes:
             return b""
@@ -1001,12 +1004,16 @@ def test_wait_for_does_not_resend_after_an_ambiguous_write_failure() -> None:
         def close(self) -> None:
             pass
 
+    raw: list[str] = []
     consoles = [Console(fail_write=True), Console(fail_write=False)]
     link = Reconnecting(lambda: consoles.pop(0), tries=2)
     link.wait_for("sh install.sh", timeout=5.0)
 
     commands = [one for one in sent if "install.sh" in one]
     assert len(commands) == 1, commands
+    # Nothing raw carries the command either: a second install is what the
+    # ambiguous write might already have started.
+    assert not [one for one in raw if "install.sh" in one], raw
 
 
 def test_a_short_command_is_sent_again_after_a_reconnect() -> None:

--- a/tests/vm/cluster.py
+++ b/tests/vm/cluster.py
@@ -2833,6 +2833,10 @@ def _naming(command: str) -> Iterator[None]:
         raise ConsoleTimeout(f"{error} while running {_shortened(command)!r}") from error
 
 
+#: What clears a half-typed line, including one inside an unclosed quote.
+INTERRUPT: Final[str] = "\x03"
+
+
 class Reconnecting:
     """A console that opens another one when the cluster drops it.
 
@@ -2876,6 +2880,19 @@ class Reconnecting:
             pass
         self.console = self._open()
         if solicit_prompt:
+            # An interrupt before the prompt is asked for: a drop in the middle
+            # of a `send` leaves the shell holding half a line, and an unclosed
+            # quote turns every command after it into continuation text.
+            # `gi-x1` answered `> ` to three `zpool import` retries and nothing
+            # else. Only here, because the other path is used where the console
+            # is at a `login:` or a passphrase prompt and anything sent there is
+            # an answer to it.
+            try:
+                self.console.send_raw(INTERRUPT)
+            except (ConsoleClosed, OSError):
+                # A convenience, not a step: a console that will not take it is
+                # one the caller's own write will fail on and report properly.
+                pass
             # The reopened console shows nothing until the shell is asked for
             # a prompt, and ordinary shell waits below are looking for text.
             self.console.send("")


### PR DESCRIPTION
`gi-x1` answered `> ` to three `zpool import` retries and nothing else: the console dropped in the middle of a send, the shell kept half a line, and the unclosed quote turned every command after it into continuation text. `reopen` now sends an interrupt before it asks for a prompt.

Only on that path. `solicit_prompt=False` is used where the console may be at `login:`, a GRUB menu or a passphrase prompt, and anything sent there is an answer to it — `vm-lvm` and `openrc-sdboot` lost three rounds to one empty line at a login prompt. The interrupt is also wrapped: it is a convenience, not a step, and a console that will not take it is one the caller's own write will fail on and report properly.

Three console doubles had no `send_raw` although the `Line` protocol declares one, so the new call reached them as an `AttributeError`. The ambiguous-write test now records raw sends instead of refusing them, and still asserts that nothing carrying the command goes out twice — an interrupt cancels and cannot start a second install.