### PR TITLE
vm: clear the shell a conversion attaches to

### DIFF
--- a/tests/unit/test_tui_report.py
+++ b/tests/unit/test_tui_report.py
@@ -381,6 +381,9 @@ def test_a_conversion_runs_inside_the_machine_it_replaces(
         def send(self, line: str) -> None:
             done.append(f"send:{line}")
 
+        def send_raw(self, keys: str) -> None:
+            done.append(f"send:{keys}")
+
         def expect(self, pattern: str, timeout: float, idle: float = 0.0) -> bytes:
             done.append(f"expect:{pattern}")
             return b""
@@ -420,6 +423,10 @@ def test_a_conversion_runs_inside_the_machine_it_replaces(
         cast(Any, Cluster()), "infra-node3", "conv", 9300, Path("/tmp")
     )
 
+    # The shell is cleared before anything is asked of it: this guest was
+    # driven by something else, and half a line left in its buffer turns every
+    # command after it into continuation text.
+    assert done[0] == f"send:{cluster.INTERRUPT}", done
     # The parameters go in while a live shell is still there, and only then is
     # the guest pointed at its own disk.
     assert done.index("speak") < done.index("stop"), done

--- a/tests/vm/cluster.py
+++ b/tests/vm/cluster.py
@@ -2024,6 +2024,12 @@ def tui_conversion(
     )
     log = guest_log(workdir, name, vmid, "conversion")
     link = Reconnecting.to(guest, log)
+    # This guest was driven by something else before this call, and whatever
+    # it left behind is still in the shell: `gi-x1` was attached with half a
+    # `printf` in its buffer and answered `> ` to four commands in a row. The
+    # first open is not a reopen, so nothing else clears it.
+    link.console.send_raw(INTERRUPT)
+    link.console.send("")
     # On the medium, while a live shell is still there: the installed system
     # has no `console=` of its own, so without this the machine boots to a
     # serial line nobody can log in on.


### PR DESCRIPTION
With #894 in place `gi-x1` still answered `> ` to four commands: the leftover from the previous run was already in its shell, and `Reconnecting.__init__` opens the console rather than reopening it, so nothing cleared the line. `tui_conversion` sends the interrupt before it asks anything — this path takes over a guest something else was driving, and its shell state is not decided by this call. `tui_execution` is unchanged: it creates its guest and attaches while the machine is still in firmware.