### PR TITLE
vm: open the guest a conversion drives, do not adopt its console

### DIFF
--- a/tests/unit/test_tui_report.py
+++ b/tests/unit/test_tui_report.py
@@ -419,18 +419,23 @@ def test_a_conversion_runs_inside_the_machine_it_replaces(
         cluster, "edit_the_menu_if_that_is_the_only_route", lambda *a: done.append("menu")
     )
     monkeypatch.setattr(cluster, "reach_prompt", lambda one: done.append("prompt"))
+    monkeypatch.setattr(cluster, "_edit_uefi_cmdline", lambda *a: done.append("uefi"))
+    monkeypatch.setattr(cluster, "_edit_bios_cmdline", lambda *a: done.append("bios"))
     running = cluster.tui_conversion(
         cast(Any, Cluster()), "infra-node3", "conv", 9300, Path("/tmp")
     )
 
-    # The shell is cleared before anything is asked of it: this guest was
-    # driven by something else, and half a line left in its buffer turns every
-    # command after it into continuation text.
-    assert done[0] == f"send:{cluster.INTERRUPT}", done
+    # The guest is opened from firmware first, so the shell everything below
+    # talks to is one this call made rather than one it inherited.
+    assert done[0] == "stop", done
+    assert done.index("prompt") < done.index("speak"), done
     # The parameters go in while a live shell is still there, and only then is
     # the guest pointed at its own disk.
-    assert done.index("speak") < done.index("stop"), done
-    assert done.index("stop") < done.index("boot_from_disk") < done.index("start")
+    assert done.index("speak") < done.index("boot_from_disk"), done
+    # `start` happens twice — once for the medium and once for the disk — so
+    # the second cycle is asserted as a sequence rather than by first index.
+    at = done.index("boot_from_disk")
+    assert done[at - 1] == "stop" and done[at + 1] == "start", done
     assert "expect:login:" in done, done
     assert f"send:{cluster.TUI_PASSWORD}" in done, done
     # No `--config`: the menu is the subject here as much as anywhere else.

--- a/tests/vm/cluster.py
+++ b/tests/vm/cluster.py
@@ -2023,13 +2023,22 @@ def tui_conversion(
         spec=GuestSpec(name=named, iso="", nonce=nonce, target_gib=disks or (TARGET_GIB,)),
     )
     log = guest_log(workdir, name, vmid, "conversion")
+    # From firmware, not from whatever console the guest already had. Three
+    # runs died on different leftovers — half a `printf` inside a quote, an
+    # interrupt landing in a nested ssh — because this path had no grounds for
+    # any belief about what it was attaching to. The shell below is one this
+    # call made.
+    guest.stop()
+    api.call("PUT", f"/nodes/{node}/qemu/{vmid}/config", boot=f"order={MEDIUM_FIRST}")
+    guest.start()
     link = Reconnecting.to(guest, log)
-    # This guest was driven by something else before this call, and whatever
-    # it left behind is still in the shell: `gi-x1` was attached with half a
-    # `printf` in its buffer and answered `> ` to four commands in a row. The
-    # first open is not a reopen, so nothing else clears it.
-    link.console.send_raw(INTERRUPT)
-    link.console.send("")
+    guest.reset()
+    if _is_uefi(config):
+        _edit_uefi_cmdline(guest, link)
+    else:
+        _edit_bios_cmdline(guest, link)
+    print(f"{name}: waiting for the live medium", flush=True)
+    reach_prompt(link)
     # On the medium, while a live shell is still there: the installed system
     # has no `console=` of its own, so without this the machine boots to a
     # serial line nobody can log in on.
@@ -2068,6 +2077,17 @@ def tui_conversion(
 #: What a `virtio<N>` disk key looks like, so the count comes from the guest
 #: rather than from a caller who might name a different number.
 _VIRTIO_DISK: Final[re.Pattern[str]] = re.compile(r"virtio\d+")
+
+
+#: What points the firmware at the medium rather than the installed disk.
+MEDIUM_FIRST: Final[str] = "ide2"
+
+
+def _is_uefi(config: Mapping[str, object]) -> bool:
+    """Whether this guest boots UEFI, read from the guest rather than assumed:
+    the medium's menu is on the serial line for one and on the VGA console for
+    the other, and the wrong editor waits two minutes for a menu never drawn."""
+    return any(str(key).startswith("efidisk") for key in config)
 
 
 def _log_into_the_installed_system(link: "Reconnecting") -> None:


### PR DESCRIPTION
Three runs of `tui_conversion` on `gi-x1` died on three different leftovers — half a `printf` inside a quote, an interrupt landing in a nested ssh, `Connection to 10.31.0.202 closed.` — and two cleanups (#894, #895) did not help, because the problem was never that the shell had not been cleared. This path had no grounds for any belief about what it was attaching to: the guest had been driven by four other things, and which layer its shell was on was decided by that history.

It now takes the same shape as `tui_execution`: `stop`, point the firmware at the medium, `start`, edit the medium's command line, wait for a prompt. That shell is one this call made. A conversion costs one more boot, about a minute, and buys that a failure is a failure of the conversion.

The firmware kind is read from the guest's own config rather than assumed — the medium's menu is on the serial line for UEFI and on the VGA console for BIOS, and the wrong editor waits two minutes for a menu never drawn. Third time that lesson has landed: #875 assumed one disk, #887 assumed `terminal_output` was absent.