### PR TITLE
vm: wait for the prompt the installed system actually prints

### DIFF
--- a/tests/unit/test_tui_report.py
+++ b/tests/unit/test_tui_report.py
@@ -437,6 +437,12 @@ def test_a_conversion_runs_inside_the_machine_it_replaces(
     at = done.index("boot_from_disk")
     assert done[at - 1] == "stop" and done[at + 1] == "start", done
     assert "expect:login:" in done, done
+    # The prompt that covers all three spellings: the installed system comes
+    # up in Chinese and asks in Chinese, and an `assword` of its own matched
+    # nothing while the password sat unsent.
+    from tests.vm.console import PASSWORD_PROMPT
+
+    assert f"expect:{PASSWORD_PROMPT}" in done, done
     assert f"send:{cluster.TUI_PASSWORD}" in done, done
     # No `--config`: the menu is the subject here as much as anywhere else.
     started = [one for one in done if "install.sh" in one]

--- a/tests/vm/cluster.py
+++ b/tests/vm/cluster.py
@@ -2094,7 +2094,11 @@ def _log_into_the_installed_system(link: "Reconnecting") -> None:
     """Answer the login the installed system offers on its serial line."""
     link.console.expect(r"login:", INSTALLED_LOGIN_PATIENCE)
     link.console.send("root")
-    link.console.expect(r"assword", INSTALLED_LOGIN_PATIENCE)
+    # The system this drives was built to come up in Chinese, so its own
+    # prompt is `\u5bc6\u78bc\uff1a`: an `assword` of its own matched nothing and
+    # `gi-x1` answered `\u767b\u5165\u903e\u6642\uff0c\u5df2\u904e 60 \u79d2\u3002` while the password sat unsent.
+    # `PASSWORD_PROMPT` already carries all three spellings.
+    link.console.expect(PASSWORD_PROMPT, INSTALLED_LOGIN_PATIENCE)
     link.console.send(TUI_PASSWORD)
     reach_prompt(link)
 


### PR DESCRIPTION
#896's shape works: the conversion reached the medium, wrote the serial parameters, booted the disk and got to `lab1 login:`. Then it sent `root`, the machine asked for a password in Chinese, and the run timed out after sixty seconds with the password never sent — the pattern it waited on was one I wrote for this call, and it matched nothing.

`tests/vm/console.py` already carries `PASSWORD_PROMPT` with all three spellings, for exactly this reason. Fifth instance today of the same defect: assuming a fact the machine will state.