### PR TITLE
tui: read a console that a systemd boot has written

### DIFF
--- a/tests/tui/screen.py
+++ b/tests/tui/screen.py
@@ -154,8 +154,13 @@ class Screen:
         numbers = [int(one) for one in parameters.split(";") if one.isdigit()]
         first = numbers[0] if numbers else 0
         if final == "H":
-            self.line = max(0, (numbers[0] if numbers else 1) - 1)
-            self.column = max(0, (numbers[1] if len(numbers) > 1 else 1) - 1)
+            # Clamped like every other branch: the guest sizes its own terminal
+            # and a taller one addresses a row this grid does not have, which
+            # raised `IndexError` out of the next erase rather than drawing.
+            self.line = self._within(self.lines, numbers[0] if numbers else 1)
+            self.column = self._within(
+                self.columns, numbers[1] if len(numbers) > 1 else 1
+            )
         elif final in "ABCD":
             step = first or 1
             if final == "A":
@@ -167,7 +172,7 @@ class Screen:
             else:
                 self.column = max(0, self.column - step)
         elif final == "G":
-            self.column = max(0, first - 1)
+            self.column = self._within(self.columns, first)
         elif final == "d":
             # ncurses moves down a column with this rather than a full `H`,
             # 23 times in one menu draw. Ignored, every write after it landed
@@ -189,6 +194,11 @@ class Screen:
                     self._reverse = True
                 elif one == 27:
                     self._reverse = False
+
+    @staticmethod
+    def _within(size: int, position: int) -> int:
+        """A one-based position as an index this grid holds."""
+        return max(0, min(size - 1, position - 1))
 
     def _insert(self, count: int) -> None:
         """Push the rest of the row right, which is how a value is corrected."""

--- a/tests/tui/screen.py
+++ b/tests/tui/screen.py
@@ -26,8 +26,13 @@ from gentoo_install.i18n import width
 CSI: Final[re.Pattern[str]] = re.compile(r"\x1b\[([0-9;?]*)([@-~])")
 
 #: Two-character escapes with no parameters, and the ones that take a string
-#: terminator. Neither draws anything.
-SHORT: Final[re.Pattern[str]] = re.compile(r"\x1b[()][0-9A-B]|\x1b[=>]|\x1b\][^\x07]*\x07")
+#: terminator. Neither draws anything. An OSC ends at BEL or at ST, and
+#: `systemd` resets the palette with the latter: matching BEL alone parked the
+#: parser 2.7 seconds into one conversion's boot, and the 250 KB after it that
+#: held the interface was never read.
+SHORT: Final[re.Pattern[str]] = re.compile(
+    r"\x1b[()][0-9A-B]|\x1b[=>]|\x1b\][^\x07\x1b]*(?:\x07|\x1b\\)"
+)
 
 
 #: The longest escape this reads, so a tail shorter than it may still grow

--- a/tests/unit/test_tui_screen.py
+++ b/tests/unit/test_tui_screen.py
@@ -239,3 +239,29 @@ def test_a_position_outside_the_grid_lands_on_its_edge() -> None:
     inside = Screen(lines=4, columns=20)
     inside.feed(b"\x1b[2;3Hx")
     assert inside.text().splitlines()[1].rstrip() == "  x"
+
+
+def test_an_operating_system_command_ends_at_either_terminator() -> None:
+    """`systemd` resets the palette with `OSC 104 ST` early in every boot.
+
+    Read as if only BEL ended one, the parser waited for a byte that never
+    came: a conversion's console stopped 2.7 seconds into the boot and the
+    250 KB that held the interface was never read.
+    """
+    whole = Screen(lines=2, columns=20)
+    whole.feed(b"\x1b]104\x1b\\menu")
+    assert whole.text().splitlines()[0].rstrip() == "menu"
+
+    # A read boundary falls wherever the network put it, and the sequence held
+    # over is the one `_unfinished` decides about. Split, it is the only form
+    # that asks whether an unterminated OSC could still grow.
+    split = Screen(lines=2, columns=20)
+    split.feed(b"\x1b]104")
+    split.feed(b"\x1b\\menu")
+    assert split.text().splitlines()[0].rstrip() == "menu"
+
+    # Negative control: the sequence's own text is not drawn either way, so
+    # neither row above can be the parser reading an OSC as characters.
+    bell = Screen(lines=2, columns=20)
+    bell.feed(b"\x1b]0;title\x07menu")
+    assert bell.text().splitlines()[0].rstrip() == "menu"

--- a/tests/unit/test_tui_screen.py
+++ b/tests/unit/test_tui_screen.py
@@ -224,3 +224,18 @@ def test_a_tab_moves_the_cursor_rather_than_drawing_something() -> None:
     stop = Screen(lines=2, columns=20)
     stop.feed(b"abcdefgh\tx")
     assert stop.text().splitlines()[0] == "abcdefgh        x", stop.text()
+
+
+def test_a_position_outside_the_grid_lands_on_its_edge() -> None:
+    """The guest sizes its own terminal, so it addresses rows this grid has not
+    got. Unclamped, the cursor sat outside `_rows` and the next erase raised
+    `IndexError` out of the middle of a conversion's console."""
+    grid = Screen(lines=4, columns=20)
+    grid.feed(b"\x1b[9;40Hx\x1b[0J")
+    assert grid.text().splitlines()[3].rstrip() == " " * 19 + "x"
+
+    # Negative control: a position the grid does hold is not moved to the edge,
+    # so the rule cannot be reading every position as the last cell.
+    inside = Screen(lines=4, columns=20)
+    inside.feed(b"\x1b[2;3Hx")
+    assert inside.text().splitlines()[1].rstrip() == "  x"


### PR DESCRIPTION
`systemd` resets the palette with `OSC 104 ST` early in every boot, and the screen matched an operating system command only at BEL, so the parser waited for a byte that never came. One conversion's console stopped 2.7 seconds into the boot with 250 KB unread, and its grid drew the kernel messages under a menu it never reached.

Clamping came out of the same log: `H` was the only branch with no upper bound, so a guest whose terminal is taller than the grid put the cursor outside it and the next erase raised `IndexError`.