### PR TITLE
tui: name the word the swap confirmation asks for

### DIFF
--- a/gentoo_install/data/locale/ja.toml
+++ b/gentoo_install/data/locale/ja.toml
@@ -575,7 +575,7 @@
 "This replaces the running system and cannot be undone." = "実行中のシステムを置き換えます。元には戻せません。"
 "Replaced: " = "置き換える対象: "
 "Kept: /home, /root and every other mount." = "残す対象: /home、/root、およびその他のマウント。"
-"Type the word to confirm." = "この語を入力して確認してください。"
+"Type {word} to confirm." = "{word} と入力して確認してください。"
 "keep proxy environment for {} in the installed system" = "インストール済みシステムで {} のプロキシ環境を保持"
 "generate and verify locales {}" = "ロケール {} を生成して検証"
 "set the system locale to {}" = "システムロケールを {} に設定"

--- a/gentoo_install/data/locale/ko.toml
+++ b/gentoo_install/data/locale/ko.toml
@@ -575,7 +575,7 @@
 "This replaces the running system and cannot be undone." = "실행 중인 시스템을 교체하며 되돌릴 수 없습니다."
 "Replaced: " = "교체 대상: "
 "Kept: /home, /root and every other mount." = "유지 대상: /home, /root 및 그 밖의 모든 마운트."
-"Type the word to confirm." = "이 단어를 입력하여 확인하십시오."
+"Type {word} to confirm." = "확인하려면 다음 단어를 입력하십시오: {word}"
 "keep proxy environment for {} in the installed system" = "설치된 시스템에 {} 프록시 환경 유지"
 "generate and verify locales {}" = "로캘 {} 생성 및 검증"
 "set the system locale to {}" = "시스템 로캘을 {}로 설정"

--- a/gentoo_install/data/locale/zh-CN.toml
+++ b/gentoo_install/data/locale/zh-CN.toml
@@ -576,7 +576,7 @@
 "This replaces the running system and cannot be undone." = "这会替换正在运行的系统，而且无法恢复。"
 "Replaced: " = "被替换："
 "Kept: /home, /root and every other mount." = "保留：/home、/root，以及其他每一个挂载点。"
-"Type the word to confirm." = "输入这个词确认。"
+"Type {word} to confirm." = "输入 {word} 确认。"
 "keep proxy environment for {} in the installed system" = "在已安装的系统中保留 {} 代理环境"
 "generate and verify locales {}" = "生成并验证语言环境 {}"
 "set the system locale to {}" = "将系统语言设为 {}"

--- a/gentoo_install/data/locale/zh-TW.toml
+++ b/gentoo_install/data/locale/zh-TW.toml
@@ -576,7 +576,7 @@
 "This replaces the running system and cannot be undone." = "取代執行中的系統（無法復原）"
 "Replaced: " = "被取代："
 "Kept: /home, /root and every other mount." = "保留：/home、/root，以及其他每一個掛載點。"
-"Type the word to confirm." = "輸入這個字確認。"
+"Type {word} to confirm." = "輸入 {word} 確認。"
 "keep proxy environment for {} in the installed system" = "在已安裝的系統中保留 {} 代理環境"
 "generate and verify locales {}" = "產生並驗證語系 {}"
 "set the system locale to {}" = "將系統語系設為 {}"

--- a/gentoo_install/tui/screens.py
+++ b/gentoo_install/tui/screens.py
@@ -325,10 +325,13 @@ def _confirm_the_swap(screen: Screen, context: Context) -> Answer[InstallConfig]
         **answers(translate),
         title=translate("This replaces the running system and cannot be undone."),
         phrase=SWAP_CONFIRMATION,
+        # The word itself, the way the erase screen shows the disk name: an
+        # operator reading `Type the word to confirm.` was left with an empty
+        # field and no word anywhere on the screen.
         detail=(
             f"{translate('Replaced: ')}{replaced}. "
             f"{translate('Kept: /home, /root and every other mount.')} "
-            f"{translate('Type the word to confirm.')}"
+            f"{translate('Type {word} to confirm.').format(word=SWAP_CONFIRMATION)}"
         ),
         footer=footer(translate),
     )

--- a/tests/unit/test_tui_app.py
+++ b/tests/unit/test_tui_app.py
@@ -3359,6 +3359,29 @@ def test_choosing_the_conversion_drops_the_device_graph() -> None:
     assert kept.disk.mode is DiskMode.PARTITION
     assert kept.disk.graph.nodes == built.disk.graph.nodes
 
+def test_the_swap_screen_names_the_word_it_asks_for() -> None:
+    """The field is empty and the word is the only way past it.
+
+    An operator driving the interface stopped here with `Type the word to
+    confirm.` and an empty `[ _ ]`: the word was in the code and on no screen.
+    """
+    from gentoo_install.plan import convert
+
+    offering = app.MainMenuContext(tui_context.Context(
+        translate=Catalog("en"),
+        disks=DISKS,
+        groups=load_catalog(),
+        hash_password=lambda password: f"$6$test${len(password)}",
+        conversion_refused=Refusal(""),
+        running_system="/dev/vda2 on ext4",
+    ))
+    screen = FakeScreen(keys=["KEY_DOWN", "\n", "\x1b"], lines=24, columns=110)
+    screens.install_mode_screen(screen, config(), offering)
+    asking = [one for one in screen.frames if "cannot be undone" in "\n".join(one)]
+    assert asking, screen.last
+    assert convert.SWAP_CONFIRMATION in "\n".join(asking[-1]), "\n".join(asking[-1])
+
+
 def test_dd_mode_is_offered_only_from_a_live_or_memory_environment() -> None:
     unsafe = app.MainMenuContext(
         tui_context.Context(


### PR DESCRIPTION
The screen that replaces the running system asks for a typed word rather than a keypress, and the field is the only way past it. Its detail read `Type the word to confirm.` and named no word: the string lived in `plan/convert.py` and appeared on no screen. An operator driving the interface stopped there with an empty field and reported it as unreadable.

The erase confirmation already shows the disk name on its own line. This shows the word the same way, in all four catalogs.