### PR TITLE
tui: wrap a text field's detail instead of clipping it

### DIFF
--- a/gentoo_install/tui/widgets.py
+++ b/gentoo_install/tui/widgets.py
@@ -699,8 +699,16 @@ class TextField:
         shown = _tail_that_fits(shown, room - 1)
         row = 2
         if self.detail:
-            screen.write(row, 0, clip(self.detail, columns))
-            row += 2
+            # Wrapped, not clipped: the exact string to type is the last thing
+            # in this line and the first thing a clip removes. An operator
+            # whose screen cut the line short typed the row's own name instead.
+            # Bounded so the field and the footer keep their rows: a detail
+            # long enough to fill the screen would otherwise push the box off
+            # the bottom and leave nowhere to type.
+            for one in wrap_to_cells(self.detail, columns)[: max(1, lines - 5)]:
+                screen.write(row, 0, one)
+                row += 1
+            row += 1
         # The caret in both states, so an empty field never reads as a full
         # one. A placeholder is a hint about the shape of the answer and is
         # drawn only when there is no `detail` naming the exact string.

--- a/tests/unit/test_tui_widgets.py
+++ b/tests/unit/test_tui_widgets.py
@@ -1386,3 +1386,22 @@ def test_the_box_names_the_row_only_while_it_is_closed() -> None:
     TwoPane(title="gentoo-install", rows=rows).frame(opened, 0, dimmed=True)
     ajar = "\n".join(opened.drawn(line) for line in range(24))
     assert "Install mode" not in ajar.split("+-", 1)[1].split("\n", 1)[0], ajar
+
+
+def test_a_detail_too_long_for_one_row_keeps_its_end() -> None:
+    """The exact string to type is the last thing in the line and the first
+    thing a clip removes: an operator whose screen cut the line short typed the
+    row's own name into the field instead of the word it was asking for."""
+    screen = FakeScreen(keys=["\n"], lines=24, columns=40)
+    TextField(
+        title="replace the running system",
+        detail="Replaced: /bin, /sbin, /etc, /lib, /usr, /var. Type convert to confirm.",
+    ).run(screen)
+    assert "convert" in screen.last, screen.last
+
+    # Negative control: a detail that fits is drawn on one row, so the rule
+    # cannot be adding a row to every screen.
+    short = FakeScreen(keys=["\n"], lines=24, columns=40)
+    TextField(title="name", detail="convert").run(short)
+    assert short.frames[-1][2].strip() == "convert", short.frames[-1][:5]
+    assert short.frames[-1][3].strip() == "", short.frames[-1][:5]


### PR DESCRIPTION
The swap confirmation names the word to type at the end of a line that also lists what is replaced and what is kept. Drawn with `clip`, the line ended before the word: an operator reading the screen on a 120-column console typed the row's own name into the field instead.

The detail is where the exact string belongs, by the widget's own contract. Wrapping it with `wrap_to_cells` keeps that true at any width, bounded so the field and footer keep their rows.