### PR TITLE
vm: build and attach the driver CD the conversion measures

### DIFF
--- a/tests/unit/test_tui_report.py
+++ b/tests/unit/test_tui_report.py
@@ -399,6 +399,9 @@ def test_a_conversion_runs_inside_the_machine_it_replaces(
 
     class Cluster:
         def call(self, method: str, path: str, **form: object) -> object:
+            if method == "PUT":
+                done.append(f"put:{sorted(form)}")
+                done.append(f"cd:{form.get('ide3', '')}")
             return {"name": "gi-x1", "tags": "abc;gentoo-install-test", "virtio0": "disk"}
 
         def node_load(self, name: str) -> float | None:
@@ -419,6 +422,9 @@ def test_a_conversion_runs_inside_the_machine_it_replaces(
         cluster, "edit_the_menu_if_that_is_the_only_route", lambda *a: done.append("menu")
     )
     monkeypatch.setattr(cluster, "reach_prompt", lambda one: done.append("prompt"))
+    monkeypatch.setattr(cluster, "build_driver", lambda where, packed=False: where)
+    monkeypatch.setattr(cluster, "retain_driver", lambda workdir, built: Path("gi-driver-new.iso"))
+    monkeypatch.setattr(cluster, "place_driver", lambda *a: done.append("place_driver"))
     monkeypatch.setattr(cluster, "_edit_uefi_cmdline", lambda *a: done.append("uefi"))
     monkeypatch.setattr(cluster, "_edit_bios_cmdline", lambda *a: done.append("bios"))
     running = cluster.tui_conversion(
@@ -448,6 +454,18 @@ def test_a_conversion_runs_inside_the_machine_it_replaces(
     started = [one for one in done if "install.sh" in one]
     assert started and "--config" not in started[0], done
     assert running.console is link.console
+
+    # The driver CD is built and attached by this call. The guest keeps the one
+    # it was created with otherwise, so three rounds measured an installer older
+    # than the tree and read a fix made between them as absent from the screen.
+    assert "place_driver" in done, done
+    assert "cd:local:iso/gi-driver-new.iso,media=cdrom" in done, done
+    assert done.index("place_driver") < done.index("start"), done
+
+    # Negative control: the slot is named in the same request as the boot order,
+    # so a config edit that carried only one of them would leave the guest
+    # booting the medium off a CD it had already replaced, or the reverse.
+    assert "put:['boot', 'ide3']" in done, done
 
 
 def test_a_disk_spec_is_not_sent_through_the_conversion_path() -> None:

--- a/tests/vm/cluster.py
+++ b/tests/vm/cluster.py
@@ -2034,7 +2034,18 @@ def tui_conversion(
     # any belief about what it was attaching to. The shell below is one this
     # call made.
     guest.stop()
-    api.call("PUT", f"/nodes/{node}/qemu/{vmid}/config", boot=f"order={MEDIUM_FIRST}")
+    # Built and attached here, not reused: the guest carries whatever driver CD
+    # it was created with, so three rounds measured an installer older than the
+    # tree and a fix made between them was invisible on the screen.
+    print(f"{name}: building the driver CD", flush=True)
+    driver_path = retain_driver(workdir, build_driver(workdir / "driver.iso", packed=True))
+    place_driver(api, node, MEDIUM_TRUST, driver_path, driver_path.name)
+    api.call(
+        "PUT",
+        f"/nodes/{node}/qemu/{vmid}/config",
+        boot=f"order={MEDIUM_FIRST}",
+        **{DRIVER_SLOT: f"local:iso/{driver_path.name},media=cdrom"},
+    )
     guest.start()
     link = Reconnecting.to(guest, log)
     guest.reset()
@@ -2086,6 +2097,10 @@ _VIRTIO_DISK: Final[re.Pattern[str]] = re.compile(r"virtio\d+")
 
 #: What points the firmware at the medium rather than the installed disk.
 MEDIUM_FIRST: Final[str] = "ide2"
+
+#: Where `_created_on_a_free_vmid` puts the driver CD, so a conversion replaces
+#: that one rather than adding a second the guest would have to choose between.
+DRIVER_SLOT: Final[str] = "ide3"
 
 
 def _is_uefi(config: Mapping[str, object]) -> bool:

--- a/tests/vm/cluster.py
+++ b/tests/vm/cluster.py
@@ -825,6 +825,11 @@ def prepare(
         _place(api, node, medium, urls, sha512, local)
         stamp.parent.mkdir(parents=True, exist_ok=True)
         stamp.write_text(sha512)
+    place_driver(api, node, trust, driver_path, driver)
+
+
+def place_driver(api: Api, node: str, trust: Path, driver_path: Path, driver: str) -> None:
+    """Put one driver CD on a node's `local` storage, replacing a stale copy."""
     for stale in api.stale_drivers(node, driver, DRIVER_KEPT_SECONDS):
         reason = api.remove_iso(node, stale)
         if reason:


### PR DESCRIPTION
`tui_conversion` mounted `/mnt/driver` from whatever CD the guest was created with. Re-pinning the frozen worktree changed nothing the guest could see: three rounds measured an installer older than the tree, and a fix made between them read on the screen as absent. `tui_execution` builds, uploads and attaches its own; the conversion now does the same in the config edit that already sets the boot order.

The upload half of `prepare` moves to `place_driver` first, with no behaviour change, so the two commits bisect apart.