### PR TITLE
cli: a mirror that answers is enough to open the menu

### DIFF
--- a/gentoo_install/cli.py
+++ b/gentoo_install/cli.py
@@ -63,7 +63,13 @@ from .model.serialise import to_toml
 from .model.validate import validate_memory_launch
 from .plan import convert, netboot
 from .plan.convert import SWAP_CONFIRMATION
-from .plan.build import DEFAULT_MIRROR, build, running_config, stage3_mirror
+from .plan.build import (
+    DEFAULT_MIRROR,
+    DEFAULT_VARIANT,
+    build,
+    running_config,
+    stage3_mirror,
+)
 from .plan.operations import Context, Operation, Stage
 from .plan.portage import variant_of
 from .plan.render import render, summarise
@@ -917,17 +923,30 @@ def _check_the_clock() -> None:
 
 
 def _require_network() -> None:
-    """Stop at startup rather than halfway through the install.
+    """Stop at startup rather than halfway through, but only when nothing answers.
 
-    Every version the menu offers is read live, so that the installer runs on
-    Alpine or Debian as well as on a Gentoo medium, and no install of any kind
-    finishes without fetching a stage3.
+    The version rows are read from `packages.gentoo.org` and the install is
+    read from a mirror, so the package site being unreachable costs the pinned
+    versions and nothing else. `mirror_online` already carries the same lesson
+    from the configuration path, where requiring that site stopped five runs on
+    a network the mirror answered on; one cluster guest then resolved it to an
+    IPv6 address alone with no route to reach that, and was refused at the
+    first screen with a working mirror one row away.
     """
-    if refused := fetch.why_offline():
-        raise errors.PreflightFailed(
-            "this machine cannot reach packages.gentoo.org, so the version menu "
-            f"has nothing to read: {refused}"
+    refused = fetch.why_offline()
+    if not refused:
+        return
+    if fetch.mirror_online(DEFAULT_MIRROR, DEFAULT_VARIANT):
+        print(
+            "warning: packages.gentoo.org did not answer, so the version rows "
+            f"offer only what the keywords allow ({refused})",
+            file=sys.stderr,
         )
+        return
+    raise errors.PreflightFailed(
+        "this machine reaches neither packages.gentoo.org nor "
+        f"{DEFAULT_MIRROR}, so no install can fetch a stage3: {refused}"
+    )
 
 
 def _conversion_offer(probe: Probe) -> tuple[str, refusals.Refusal]:

--- a/gentoo_install/plan/build.py
+++ b/gentoo_install/plan/build.py
@@ -22,6 +22,11 @@ from .operations import Operation, Stage
 #: The mirror a stage3 is fetched from when the configuration names none.
 DEFAULT_MIRROR: Final[str] = "https://distfiles.gentoo.org"
 
+#: What `variant_of` returns for the default profile and init system, and the
+#: only variant a reachability check can name before the operator has answered
+#: anything. Every mirror publishes it.
+DEFAULT_VARIANT: Final[str] = "systemd"
+
 # These operations alter the resolver's inputs, so the complete-set check has
 # to see them before their package merges run in later stages.
 PORTAGE_PREREQUISITES: Final[tuple[type[Operation], ...]] = (

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -285,6 +285,10 @@ def online(monkeypatch: pytest.MonkeyPatch, answer: bool = True, said: str = "")
     monkeypatch.setattr(
         fetch, "why_offline", lambda: "" if answer else (said or "HTTP Error 503")
     )
+    # The mirror answers with the package site by default: a machine that
+    # reaches neither is the offline case, and a test that wants the mirror up
+    # while the site is down says so itself.
+    monkeypatch.setattr(fetch, "mirror_online", lambda *a, **k: answer)
 
 
 def test_the_menu_stops_when_the_machine_cannot_reach_the_package_site(
@@ -298,8 +302,40 @@ def test_the_menu_stops_when_the_machine_cannot_reach_the_package_site(
     said = capsys.readouterr().err
     # The site's own answer, not a guess about the machine: the url names one
     # atom, so a package rename upstream reads as a broken network.
-    assert "cannot reach packages.gentoo.org" in said, said
+    assert "neither packages.gentoo.org" in said, said
     assert "HTTP Error 404: Not Found" in said, said
+
+
+def test_a_mirror_that_answers_is_enough_to_open_the_menu(
+    capsys: pytest.CaptureFixture[str], monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The version rows are read from the package site and the install from a
+    mirror, so the site being unreachable costs the pinned versions and nothing
+    else. One guest resolved that site to an IPv6 address alone with no route
+    to reach it, and was refused at the first screen with a working mirror one
+    row away."""
+    monkeypatch.setattr(os, "geteuid", lambda: 0)
+    online(monkeypatch, False, said="Errno 101 Network is unreachable")
+    monkeypatch.setattr(fetch, "mirror_online", lambda *a, **k: True)
+
+    def reached(*args: object, **keywords: object) -> object:
+        raise errors.PreflightFailed("the menu was reached")
+
+    monkeypatch.setattr(cli, "_from_menu", reached)
+    assert main([]) == EXIT_PREFLIGHT
+    warned = capsys.readouterr().err
+    assert "the menu was reached" in warned, warned
+    assert "packages.gentoo.org did not answer" in warned, warned
+    assert "Errno 101" in warned, warned
+
+    # Negative control: with the mirror unreachable too, the same machine is
+    # refused before the menu, so the warning above is the degradation and not
+    # a check that stopped running.
+    online(monkeypatch, False, said="Errno 101 Network is unreachable")
+    assert main([]) == EXIT_PREFLIGHT
+    refused = capsys.readouterr().err
+    assert "the menu was reached" not in refused, refused
+    assert "neither packages.gentoo.org" in refused, refused
 
 
 def test_the_two_offline_answers_are_still_given_without_a_network(


### PR DESCRIPTION
`_require_network` refused to start whenever `packages.gentoo.org` did not answer. The version rows are read from that site; the install is read from a mirror. `mirror_online` already carries the same lesson from the configuration path, where requiring the package site stopped five runs on a network the mirror answered on.

A converted guest measured tonight resolved `packages.gentoo.org` to an IPv6 address alone, had no IPv6 default route, and was refused at the first screen with a working mirror one row away. The check now refuses only when neither answers, and warns that the version rows offer what the keywords allow.