### PR TITLE
plan: a conversion has no root in the graph to name

### DIFF
--- a/gentoo_install/plan/automatic.py
+++ b/gentoo_install/plan/automatic.py
@@ -79,7 +79,15 @@ def kernel_parameters(config: InstallConfig) -> tuple[Added, ...]:
         return ()
     kind = config.bootloader.kind
     added: list[Added] = []
-    if kind is Bootloader.SYSTEMD_BOOT:
+    # A conversion reads its layout from the running machine, so the graph here
+    # holds no root and nothing derived from one is known until
+    # `plan/convert.layout_graph` has read it. Asked anyway, the menu ended the
+    # session on `no node with id ''` one keypress after the confirmation, with
+    # the machine untouched and the operator looking at a shell.
+    from_the_graph = bool(config.disk.root)
+    if not from_the_graph:
+        pass
+    elif kind is Bootloader.SYSTEMD_BOOT:
         added.append(Added(value=_root_value(config), because=ROOT))
         added.append(Added(value="rw", because=WRITABLE))
         if _rootflags(config):
@@ -98,7 +106,7 @@ def kernel_parameters(config: InstallConfig) -> tuple[Added, ...]:
         added.append(
             Added(value=_root_value(config), because=ROOT_FROM_ZBM, written_here=False)
         )
-    if kind is not Bootloader.ZFSBOOTMENU:
+    if from_the_graph and kind is not Bootloader.ZFSBOOTMENU:
         containers, arrays = initramfs_devices(config)
         added += [Added(value="rd.luks.uuid=…", because=CONTAINER) for _ in containers]
         added += [Added(value="rd.md.uuid=…", because=ARRAY) for _ in arrays]

--- a/tests/unit/test_tui_app.py
+++ b/tests/unit/test_tui_app.py
@@ -3860,3 +3860,42 @@ def test_the_install_row_says_its_reason_once() -> None:
     for pane in carrying:
         for part in ("Install mode", "Drive", "Mirrors", "make.conf"):
             assert pane.count(part) == 1, f"{part} appears {pane.count(part)} times:\n{pane}"
+
+
+def test_every_row_answers_after_the_conversion_is_confirmed() -> None:
+    """A conversion reads its layout from the running machine, so the graph
+    holds no root. The bootloader row asked for one anyway and the session
+    ended on `no node with id ''` one keypress after the confirmation, with
+    the machine untouched and the operator looking at a shell."""
+    from dataclasses import replace
+
+    from gentoo_install.model.device import DeviceGraph, DeviceId
+    from gentoo_install.tui.settings import SETTINGS
+
+    offering = tui_context.Context(
+        translate=Catalog("en"),
+        disks=DISKS,
+        groups=load_catalog(),
+        hash_password=lambda password: f"$6$test${len(password)}",
+        conversion_refused=Refusal(""),
+        running_system="/dev/vda2 on btrfs",
+    )
+    built = config()
+    converted = replace(
+        built,
+        disk=replace(
+            built.disk,
+            mode=DiskMode.IN_PLACE,
+            graph=DeviceGraph.build([]),
+            root=DeviceId(""),
+        ),
+    )
+    for setting in SETTINGS:
+        list(app._facts(setting, converted, offering))
+
+    # Negative control: the same rows on a configuration that does carry a
+    # graph still name a root, so the rule above cannot be silence everywhere.
+    from gentoo_install.plan.automatic import kernel_parameters
+
+    assert any("root=" in one.value for one in kernel_parameters(built))
+    assert not any("root=" in one.value for one in kernel_parameters(converted))


### PR DESCRIPTION
Choosing the conversion drops the device graph, because the layout is read from the running machine at install time. `kernel_parameters` still asked the graph for a root, so the menu redraw one keypress after the confirmation ended the session on `no node with id ''` — machine untouched, operator at a shell, three measured rounds spent on it.

`dd` mode already carried the same guard for the same reason. This extends it to the mode that keeps a bootloader but not a graph.