### PR TITLE
vm: send the interrupt only when a write was in flight

### DIFF
--- a/tests/unit/test_cluster.py
+++ b/tests/unit/test_cluster.py
@@ -2371,9 +2371,11 @@ def test_a_reopen_that_is_waiting_for_a_shell_still_asks_for_one() -> None:
     link = cluster.Reconnecting(cast("Any", open_console))
     link.reopen()
 
-    # The interrupt clears whatever half a line the drop left behind, and
-    # the empty one is the request for a prompt.
-    assert opened[-1].sent == [cluster.INTERRUPT, ""], opened[-1].sent
+    # The empty line is the request for a prompt, and it is the whole of it:
+    # the interrupt clears a half-written line, so a reopen with no write in
+    # flight has nothing to clear. Sent anyway it killed what the guest was
+    # running, and four finished installs in one round were recorded as errors.
+    assert opened[-1].sent == [""], opened[-1].sent
 
 
 def test_the_first_password_is_sent_the_moment_the_prompt_is_read(
@@ -3861,10 +3863,13 @@ def test_a_reopened_console_clears_whatever_the_shell_was_holding() -> None:
     else. The interrupt goes first, before the prompt is solicited, or the
     empty line only lengthens the quote."""
     from tests.vm import cluster
+    from tests.vm.console import ConsoleClosed
 
     sent: list[str] = []
 
     class Console:
+        closed = False
+
         def send(self, line: str) -> None:
             sent.append(f"send:{line}")
 
@@ -3874,8 +3879,29 @@ def test_a_reopened_console_clears_whatever_the_shell_was_holding() -> None:
         def close(self) -> None:
             sent.append("close")
 
-    link = cluster.Reconnecting(lambda: cast(Any, Console()))
+    class Dropping(Console):
+        closed = False
+
+        def send(self, line: str) -> None:
+            sent.append(f"send:{line}")
+            raise ConsoleClosed("dropped mid-send")
+
+    made: list[object] = []
+
+    def open_console() -> object:
+        one = Dropping() if not made else Console()
+        made.append(one)
+        return one
+
+    link = cluster.Reconnecting(cast(Any, open_console))
     sent.clear()
+    # A write that drops is what leaves the half line, and what the interrupt
+    # is for. Reopened after one, the interrupt goes first or the empty line
+    # only lengthens the quote.
+    try:
+        link.send("zpool import")
+    except ConsoleClosed:
+        pass
     link.reopen()
 
     assert sent.index(f"raw:{cluster.INTERRUPT}") < sent.index("send:"), sent

--- a/tests/vm/cluster.py
+++ b/tests/vm/cluster.py
@@ -2923,6 +2923,9 @@ class Reconnecting:
         self._tries = tries
         self._marks = itertools.count(1)
         self._reopens = 0
+        #: Whether a `send` is in flight. The interrupt on reopen exists to
+        #: clear the half line a dropped one leaves, and nothing else.
+        self._writing = False
         self.console: Line = open_console()
 
     @classmethod
@@ -2948,19 +2951,21 @@ class Reconnecting:
             pass
         self.console = self._open()
         if solicit_prompt:
-            # An interrupt before the prompt is asked for: a drop in the middle
-            # of a `send` leaves the shell holding half a line, and an unclosed
-            # quote turns every command after it into continuation text.
-            # `gi-x1` answered `> ` to three `zpool import` retries and nothing
-            # else. Only here, because the other path is used where the console
-            # is at a `login:` or a passphrase prompt and anything sent there is
-            # an answer to it.
-            try:
-                self.console.send_raw(INTERRUPT)
-            except (ConsoleClosed, OSError):
-                # A convenience, not a step: a console that will not take it is
-                # one the caller's own write will fail on and report properly.
-                pass
+            if self._writing:
+                # Only when a write was in flight: an interrupt clears the half
+                # line a dropped `send` left, where an unclosed quote turns
+                # every command after it into continuation text. Sent on every
+                # reopen instead it reached guests whose console had dropped
+                # while a command ran, and killed the command: `vm-luks` was at
+                # operation 56 of 56 with `grub-install` on the screen when
+                # `OK^C` ended it, and four fixtures in one round were finished
+                # installs recorded as errors.
+                try:
+                    self.console.send_raw(INTERRUPT)
+                except (ConsoleClosed, OSError):
+                    # A convenience, not a step: a console that will not take it
+                    # is one the caller's own write will fail on and report.
+                    pass
             # The reopened console shows nothing until the shell is asked for
             # a prompt, and ordinary shell waits below are looking for text.
             self.console.send("")
@@ -3157,7 +3162,11 @@ class Reconnecting:
 
     def send(self, line: str) -> None:
         self._reopen_if_closed()
+        # Cleared on success only: a `send` that raised is the one that left
+        # half a line, and that is the state the interrupt on reopen is for.
+        self._writing = True
         self.console.send(line)
+        self._writing = False
 
     def respond(self, line: str) -> None:
         """Answer an observed boot prompt once.


### PR DESCRIPTION
The interrupt on reopen exists to clear the half line a dropped `send` leaves, where an unclosed quote turns every command after it into continuation text. It was sent on every solicited reopen, including ones where the console dropped while the guest was running something — and there it killed what was running.

Four fixtures in round 44 were finished installs recorded as errors. `vm-luks` reached operation 56 of 56 with `grub-install` on the screen and ended on `OK^C`. A `send` that raised is now the only state that arms it, cleared on success only.