### PR TITLE
tui: the session holds a console that reconnects

### DIFF
--- a/tests/unit/test_tui_report.py
+++ b/tests/unit/test_tui_report.py
@@ -456,7 +456,10 @@ def test_a_conversion_runs_inside_the_machine_it_replaces(
     # No `--config`: the menu is the subject here as much as anywhere else.
     started = [one for one in done if "install.sh" in one]
     assert started and "--config" not in started[0], done
-    assert running.console is link.console
+    # The link, not the console inside it: the daemon that holds this outlives
+    # a drop only if what it reads through reconnects, and one `Broken pipe`
+    # ended a round with the interface still running inside the guest.
+    assert running.console is link
 
     # The driver CD is built and attached by this call. The guest keeps the one
     # it was created with otherwise, so three rounds measured an installer older

--- a/tests/unit/test_tui_session.py
+++ b/tests/unit/test_tui_session.py
@@ -163,3 +163,53 @@ def test_a_conversion_without_a_node_is_refused_before_anything_is_built(
 
     with pytest.raises(tui_session.SessionError, match="--node names where it is"):
         tui_session.start("conv", spec=3, convert=9300)
+
+
+def test_the_session_holds_a_console_that_reconnects() -> None:
+    """The daemon read through the raw console, so one `Broken pipe` ended a
+    round with the interface still running inside the guest. It holds the link
+    instead, which reopens under the read and never solicits: a line sent to
+    ask for a prompt is an answer to whatever prompt is on the screen."""
+    from typing import Any, cast
+
+    from tests.tui.session import Held
+    from tests.vm import cluster
+    from tests.vm.console import ConsoleClosed
+
+    opened: list[object] = []
+
+    class Console:
+        closed = False
+
+        def __init__(self, dies: bool) -> None:
+            self.dies = dies
+            self.sent: list[str] = []
+
+        def read_available(self, seconds: float) -> bytes:
+            if self.dies:
+                raise ConsoleClosed("the connection broke")
+            return b"drawn"
+
+        def send_raw(self, keys: str) -> None:
+            self.sent.append(keys)
+
+        def send(self, line: str) -> None:
+            self.sent.append(line)
+
+        def close(self) -> None:
+            return None
+
+    def open_console() -> object:
+        made = Console(dies=not opened)
+        opened.append(made)
+        return made
+
+    link = cluster.Reconnecting(cast(Any, open_console))
+    assert isinstance(link, Held), "the daemon accepts only what it can read"
+    assert link.read_available(0.1) == b"", "the dropped read answers empty"
+    assert link.read_available(0.1) == b"drawn", opened
+    assert len(opened) == 2, opened
+
+    # Negative control: the reopen must not write, or the empty line it would
+    # send answers a password prompt on the screen it is being read from.
+    assert cast(Any, opened[-1]).sent == [], cast(Any, opened[-1]).sent

--- a/tests/vm/cluster.py
+++ b/tests/vm/cluster.py
@@ -1994,7 +1994,7 @@ def tui_execution(
         f"TERM=xterm LINES={TUI_LINES} COLUMNS={TUI_COLUMNS} "
         "sh /mnt/driver/install.sh --lang zh-TW"
     )
-    held.console = link.console
+    held.console = link
     return held
 
 
@@ -2104,7 +2104,9 @@ def tui_conversion(
         ),
         reservation_bytes=0,
         created=False,
-        console=link.console,
+        # The link, not the console it holds: the daemon outlives drops only
+        # if what it reads through reconnects.
+        console=link,
     )
 
 
@@ -3198,6 +3200,20 @@ class Reconnecting:
     def send_raw(self, keys: str) -> None:
         self._reopen_if_closed()
         self.console.send_raw(keys)
+
+    def read_available(self, seconds: float) -> bytes:
+        """Whatever has arrived, reopening a dropped console under the read.
+
+        Never solicits, because the caller is drawing a screen and a line sent
+        to ask for a prompt is an answer to whatever prompt is on it. The
+        session daemon held the raw console instead and one `Broken pipe` ended
+        a round with the interface still running inside the guest.
+        """
+        try:
+            return cast(SerialConsole, self.console).read_available(seconds)
+        except (ConsoleClosed, OSError):
+            self.reopen(solicit_prompt=False)
+            return b""
 
     def _reopen_if_closed(self) -> None:
         """A write to a dropped connection is silently discarded.


### PR DESCRIPTION
`tui_execution` and `tui_conversion` handed the session daemon `link.console` — the raw serial console, with no reconnection under it. One `ConsoleClosed: the connection broke: [Errno 32] Broken pipe` ended a measured round while the interface was still running inside the guest and every answer it held was still on the screen.

They hand it the link instead. `Reconnecting` gains the read the daemon needs, which reopens on a drop and never solicits: the caller is drawing a screen, and a line sent to ask for a prompt is an answer to whatever prompt is on it.