### PR TITLE
model: a refused public key is not quoted back

### DIFF
--- a/gentoo_install/model/sshkey.py
+++ b/gentoo_install/model/sshkey.py
@@ -23,6 +23,10 @@ KEY_TYPES: Final[frozenset[str]] = frozenset(
     }
 )
 
+#: Named in the refusal, so an operator learns what is accepted without the
+#: message having to quote what they typed.
+ACCEPTED: Final[str] = ", ".join(sorted(KEY_TYPES))
+
 
 def check(line: str) -> str:
     """The key with its whitespace normalised, or a named error.
@@ -30,19 +34,22 @@ def check(line: str) -> str:
     A key that reached the target truncated is discovered at the first login
     attempt, which is the moment the console is no longer available.
     """
+    # No message quotes what was read. This is the field a password or a
+    # private key is pasted into by mistake, and every error here reaches the
+    # log, `install.jsonl` and the paste an operator sends to somebody else.
     fields = line.split()
     if len(fields) < 2:
-        raise ConfigError(f"not a public key: {line[:40]!r}")
+        raise ConfigError("not a public key: a key is a type and a body")
     kind, blob = fields[0], fields[1]
     if kind not in KEY_TYPES:
-        raise ConfigError(f"unknown key type: {kind}")
+        raise ConfigError(f"unknown key type; the accepted ones are {ACCEPTED}")
     try:
         raw = base64.b64decode(blob, validate=True)
     except (binascii.Error, ValueError) as error:
-        raise ConfigError(f"the key body is not base64: {error}") from error
+        raise ConfigError("the key body is not base64") from error
     parts = _wire(raw)
     if len(parts) < 2 or parts[0] != kind.encode():
-        raise ConfigError(f"the key body does not declare {kind}")
+        raise ConfigError("the key body declares a different type from its first field")
     return " ".join(fields)
 
 

--- a/tests/unit/test_sshkey.py
+++ b/tests/unit/test_sshkey.py
@@ -49,7 +49,7 @@ def test_a_body_declaring_another_type_is_refused(tmp_path: Path) -> None:
     """`ssh-rsa` in front of an ed25519 body is what a hand-edited file looks
     like, and sshd ignores the line rather than saying so."""
     _, blob, comment = generated(tmp_path, "ed25519").split()
-    with pytest.raises(ConfigError, match="does not declare"):
+    with pytest.raises(ConfigError, match="declares a different type"):
         sshkey.check(f"ssh-rsa {blob} {comment}")
 
 
@@ -89,5 +89,26 @@ def test_a_key_that_decodes_but_holds_one_field_is_refused() -> None:
     body = base64.b64encode(
         len(b"ssh-ed25519").to_bytes(4, "big") + b"ssh-ed25519"
     ).decode()
-    with pytest.raises(ConfigError, match="does not declare"):
+    with pytest.raises(ConfigError, match="declares a different type"):
         sshkey.check(f"ssh-ed25519 {body}")
+
+
+def test_a_refused_key_is_not_quoted_back() -> None:
+    """This is the field a password or a private key is pasted into by mistake,
+    and every error here reaches the log, `install.jsonl` and the paste an
+    operator sends to somebody else."""
+    import pytest
+
+    from gentoo_install.errors import ConfigError
+    from gentoo_install.model import sshkey
+
+    secret = "correct-horse-battery-staple"
+    for line in (secret, f"{secret} body", f"ssh-ed25519 {secret}"):
+        with pytest.raises(ConfigError) as raised:
+            sshkey.check(line)
+        assert secret not in str(raised.value), str(raised.value)
+
+    # Negative control: a refusal still says which types are accepted, so the
+    # rule above cannot be met by a message that carries nothing at all.
+    with pytest.raises(ConfigError, match="ssh-ed25519"):
+        sshkey.check("ssh-rsa2 AAAA")


### PR DESCRIPTION
Every refusal in `sshkey.check` quoted what it had read: the first forty characters of the line, or the first field as the key type. That field is where a password or a private key gets pasted by mistake, and the error reaches the run log, `install.jsonl`, and the pastebin an operator sends to somebody else.

The refusals now carry no input. The one about the key type names the accepted types instead, so an operator still learns what to write.