### PR TITLE
tui: a zone that is its own area is choosable on the way back

### DIFF
--- a/gentoo_install/tui/screens.py
+++ b/gentoo_install/tui/screens.py
@@ -1241,6 +1241,20 @@ def additional_locales_screen(
     )
 
 
+def _zones_under(area: str, zones: Sequence[str]) -> list[str]:
+    """The zones of one area, each named once, in the order the machine gave."""
+    seen: dict[str, None] = {}
+    for zone in zones:
+        if zone.split("/", 1)[0] == area:
+            seen[zone] = None
+    return list(seen)
+
+
+def _under(zone: str) -> str:
+    """What to label a zone inside its area's list."""
+    return zone.split("/", 1)[1] if "/" in zone else zone
+
+
 def timezone_screen(screen: Screen, config: InstallConfig, context: Context) -> Answer[InstallConfig]:
     """Every zone the machine knows, area first.
 
@@ -1290,15 +1304,19 @@ def timezone_screen(screen: Screen, config: InstallConfig, context: Context) -> 
             Outcome.CHOSE,
             replace(config, system=replace(config.system, timezone=context.timezone_here)),
         )
-    within = [zone for zone in zones if zone.split("/", 1)[0] == area]
-    if within == [area]:
-        return Answer(
-            Outcome.CHOSE, replace(config, system=replace(config.system, timezone=area))
-        )
     while True:
+        within = _zones_under(area, zones)
+        # An area that is one whole zone has no city to pick: `UTC` is the
+        # only row under `UTC`. Checked on every pass, not once before the
+        # loop: an operator who opened `Asia`, went back and chose `UTC` ended
+        # the run on `list index out of range` and was left at a shell.
+        if within == [area]:
+            return Answer(
+                Outcome.CHOSE, replace(config, system=replace(config.system, timezone=area))
+            )
         city: Menu[str] = Menu(
             title=area,
-            items=[Item(label=zone.split("/", 1)[1], value=zone) for zone in within],
+            items=[Item(label=_under(zone), value=zone) for zone in within],
             footer=footer(translate),
             current=config.system.timezone,
         )
@@ -1312,7 +1330,11 @@ def timezone_screen(screen: Screen, config: InstallConfig, context: Context) -> 
             if not picked.chosen:
                 return Answer(picked.outcome)
             area = picked.unwrap()
-            within = [zone for zone in zones if zone.split("/", 1)[0] == area]
+            if not area:
+                return Answer(
+                    Outcome.CHOSE,
+                    replace(config, system=replace(config.system, timezone=context.timezone_here)),
+                )
             continue
         return Answer(answer.outcome)
 

--- a/tests/unit/test_tui_app.py
+++ b/tests/unit/test_tui_app.py
@@ -326,6 +326,25 @@ def test_the_timezone_list_is_every_zone_the_machine_knows() -> None:
     assert answer.unwrap().system.timezone == "Asia/Taipei"
 
 
+def test_a_zone_that_is_its_own_area_is_still_choosable_after_going_back() -> None:
+    """`UTC` is the only row under `UTC`, so there is no city to pick. The
+    check for that ran once before the loop and not on the way back through it:
+    an operator who opened `Asia`, went back and chose `UTC` ended the run on
+    `list index out of range` and was left at a shell."""
+    # Areas in the order the machine gives them: `UTC` first, `Asia` second,
+    # and the menu opens on `Asia` because that is what the configuration holds.
+    screen = FakeScreen(keys=["\n", "KEY_LEFT", "KEY_UP", "\n"])
+    answer = screens.timezone_screen(screen, config(), context())
+    assert answer.outcome is Outcome.CHOSE, answer.outcome
+    assert answer.unwrap().system.timezone == "UTC", answer.unwrap().system.timezone
+
+    # Negative control: an area that does have cities still opens its list, so
+    # the rule above cannot be answering every area with the area itself.
+    asia = FakeScreen(keys=["\n", "KEY_DOWN", "\n"])
+    picked = screens.timezone_screen(asia, config(), context())
+    assert picked.unwrap().system.timezone == "Asia/Taipei", picked.unwrap().system.timezone
+
+
 @pytest.mark.parametrize("leaving", ["KEY_LEFT", "q"])
 def test_firewall_dialog_leaving_does_not_commit(leaving: str) -> None:
     start = config()


### PR DESCRIPTION
`UTC` is the only zone under the area `UTC`, so there is no city to pick. That check ran once before the city loop and not on the path back through it: an operator who opened `Asia`, pressed back and chose `UTC` reached a list built from the part after a slash the zone does not have, and the run ended on `unexpected IndexError: list index out of range` at a shell prompt.

Measured on a guest driving spec 8 through the interface, which is where the console recorded the area list and the two keypresses. The back path also answers the BIOS row now, which it read as an area name.