### PR TITLE
tui: a row behind a refused group does not block the install

### DIFF
--- a/gentoo_install/tui/settings.py
+++ b/gentoo_install/tui/settings.py
@@ -1178,8 +1178,19 @@ def unanswered(config: InstallConfig, context: Context) -> tuple[Setting, ...]:
     """
     named: list[Setting] = []
     for group in settings_for(config):
+        # A row behind a group the configuration refuses has no screen to open
+        # and no value to gain: a conversion left `Drive` required with the
+        # screen behind it refusing to open, and the install could never start
+        # from the interface. The group itself is left alone, because a group
+        # that cannot be opened still shows the value it holds.
+        refused = bool(group.unavailable(config, context))
         behind = [
-            row for row in group.rows if row.required and not settled(row, config, context)
+            row
+            for row in group.rows
+            if row.required
+            and not refused
+            and not row.unavailable(config, context)
+            and not settled(row, config, context)
         ]
         if any(row.required for row in group.rows):
             # The rows carry the requirement, so the group is not named as

--- a/tests/unit/test_tui_app.py
+++ b/tests/unit/test_tui_app.py
@@ -3918,3 +3918,37 @@ def test_every_row_answers_after_the_conversion_is_confirmed() -> None:
 
     assert any("root=" in one.value for one in kernel_parameters(built))
     assert not any("root=" in one.value for one in kernel_parameters(converted))
+
+
+def test_a_conversion_can_reach_its_install_row() -> None:
+    """`Drive` is required and the conversion refuses the screen behind it: the
+    layout comes from the running machine. Counted as missing anyway, the row
+    that starts the install stayed blocked on an answer nothing could give,
+    and spec 3 could not be started from the interface at all."""
+    from dataclasses import replace
+
+    from gentoo_install.model.device import DeviceGraph, DeviceId
+    from gentoo_install.tui.settings import unanswered
+
+    offering = app.MainMenuContext(tui_context.Context(
+        translate=Catalog("en"),
+        disks=DISKS,
+        groups=load_catalog(),
+        hash_password=lambda password: f"$6$test${len(password)}",
+        conversion_refused=Refusal(""),
+        running_system="/dev/vda2 on btrfs",
+    ))
+    built = config()
+    converted = replace(
+        built,
+        disk=replace(
+            built.disk, mode=DiskMode.IN_PLACE, graph=DeviceGraph.build([]), root=DeviceId("")
+        ),
+    )
+    still = [one.key for one in unanswered(converted, offering)]
+    assert "disk" not in still, still
+
+    # Negative control: a partition install with no disk chosen still names it,
+    # so the rule above cannot be dropping every required row.
+    empty = replace(built, disk=replace(built.disk, graph=DeviceGraph.build([])))
+    assert "disk" in [one.key for one in unanswered(empty, offering)]


### PR DESCRIPTION
`unanswered` counted every required row with no value, without asking whether the configuration would open it. A conversion takes its layout from the running machine, so the group refuses the screen behind `Drive` — and `Drive` is required and empty. The Install row therefore reported an answer that nothing could give, and spec 3 could not be started from the interface at all. An operator driving it reported the row as 必填 with enter doing nothing.

Only rows behind a refused group are skipped. A group that is itself the row still shows the value it holds, so it is left as it was.