### PR TITLE
tui: a refused row is not drawn as an answer somebody owes

### DIFF
--- a/gentoo_install/tui/settings.py
+++ b/gentoo_install/tui/settings.py
@@ -125,6 +125,11 @@ def style_of(setting: Setting, config: InstallConfig, context: Context) -> Style
     """Red for a required row with no answer, yellow for an optional row the
     operator has not opened. Colour repeats what the value already says: a
     console without it loses nothing."""
+    # A row the configuration refuses is not an answer anybody owes: a
+    # conversion takes its layout from the running machine, and `Drive` was
+    # drawn red and read `required` beside a screen that would not open.
+    if setting.unavailable(config, context):
+        return Style.PLAIN
     if setting.required and not settled(setting, config, context):
         return Style.REQUIRED
     if not setting.required and setting.edit is not None and setting.key not in context.visited:
@@ -218,7 +223,10 @@ def shown_value(
     """
     value = setting.value(config, context)
     if value == UNSET:
-        value = context.translate("required" if setting.required else UNSET)
+        refused = bool(setting.unavailable(config, context))
+        value = context.translate(
+            "required" if setting.required and not refused else UNSET
+        )
     if room is None:
         return value
     # `required` is fitted too: the widest label in the catalog leaves its own

--- a/tests/unit/test_tui_app.py
+++ b/tests/unit/test_tui_app.py
@@ -3952,3 +3952,40 @@ def test_a_conversion_can_reach_its_install_row() -> None:
     # so the rule above cannot be dropping every required row.
     empty = replace(built, disk=replace(built.disk, graph=DeviceGraph.build([])))
     assert "disk" in [one.key for one in unanswered(empty, offering)]
+
+
+def test_a_refused_row_is_not_drawn_as_an_answer_somebody_owes() -> None:
+    """A conversion takes its layout from the running machine, so the screen
+    behind `Drive` will not open. Drawn red and reading `required` beside it,
+    two operators in a row reported the interface as stuck on a row they could
+    not answer."""
+    from dataclasses import replace
+
+    from gentoo_install.model.device import DeviceGraph, DeviceId
+    from gentoo_install.tui.settings import SETTINGS, shown_value, style_of
+    from gentoo_install.tui.widgets import Style
+
+    offering = app.MainMenuContext(tui_context.Context(
+        translate=Catalog("en"),
+        disks=DISKS,
+        groups=load_catalog(),
+        hash_password=lambda password: f"$6$test${len(password)}",
+        conversion_refused=Refusal(""),
+        running_system="/dev/vda2 on btrfs",
+    ))
+    built = config()
+    converted = replace(
+        built,
+        disk=replace(
+            built.disk, mode=DiskMode.IN_PLACE, graph=DeviceGraph.build([]), root=DeviceId("")
+        ),
+    )
+    disk = next(one for one in SETTINGS if one.key == "storage")
+    assert style_of(disk, converted, offering) is Style.PLAIN
+    assert shown_value(disk, converted, offering) != "required"
+
+    # Negative control: the same row on a partition install with no disk chosen
+    # is still red and still says so.
+    empty = replace(built, disk=replace(built.disk, graph=DeviceGraph.build([])))
+    assert style_of(disk, empty, offering) is Style.REQUIRED
+    assert shown_value(disk, empty, offering) == "required"


### PR DESCRIPTION
#910 stopped a refused row from blocking the install. It was still drawn red and still read `required`, so the operator was told to answer a row whose screen refuses to open. Two agents driving spec 3 reported exactly that, one before the fix and one after: `disk device: required; Enter did not open a disk selector`.

`style_of` and `shown_value` ask the same question `unanswered` now asks. A row the configuration refuses is plain and shows no value, with the reason already on the row.