### PR TITLE
model: a conversion is not judged on a graph it has not read

### DIFF
--- a/gentoo_install/model/compat.py
+++ b/gentoo_install/model/compat.py
@@ -439,7 +439,12 @@ def traits_of(
     else:
         found.add(Trait.BIOS_BOOT)
 
-    if esp_mount(graph) is None:
+    # Not asked of a conversion: its layout is read from the running machine by
+    # `plan/convert.layout_graph`, which builds the esp when the machine booted
+    # through UEFI, and the graph here is empty until then. Asked anyway, the
+    # menu refused every UEFI machine with `uefi boot` against `no mounted esp`
+    # and the operator had no row that could answer it.
+    if config.disk.mode is not DiskMode.IN_PLACE and esp_mount(graph) is None:
         found.add(Trait.NO_MOUNTED_ESP)
     # GRUB alone, and for two different reasons. systemd-boot reads the kernel
     # off the esp, which is never in the container. ZFSBootMenu does keep the

--- a/tests/unit/test_compat.py
+++ b/tests/unit/test_compat.py
@@ -1078,3 +1078,30 @@ def test_a_configuration_rule_survives_the_loss_of_the_graph() -> None:
     ), [rule.describe() for rule in kept]
     for rule in kept:
         assert not {rule.when, rule.excludes} & FROM_THE_DEVICE_GRAPH, rule.describe()
+
+
+def test_a_conversion_is_not_refused_for_an_esp_it_has_not_read_yet() -> None:
+    """`plan/convert.layout_graph` builds the esp from the running machine, and
+    the graph the menu holds is empty until then. Asked for one anyway, every
+    UEFI machine was refused with `uefi boot` against `no mounted esp` and no
+    row could answer it."""
+    from dataclasses import replace
+
+    from gentoo_install.model import compat
+    from gentoo_install.model.config import DiskMode
+    from gentoo_install.model.device import DeviceGraph, DeviceId
+
+    built = config()
+    converted = replace(
+        built,
+        disk=replace(
+            built.disk, mode=DiskMode.IN_PLACE, graph=DeviceGraph.build([]), root=DeviceId("")
+        ),
+    )
+    assert compat.Trait.NO_MOUNTED_ESP not in compat.traits_of(converted)
+    assert not compat.violations(converted)
+
+    # Negative control: the same empty graph on a partition install is still
+    # refused, so the rule above is not "never ask for an esp".
+    partitioned = replace(built, disk=replace(built.disk, graph=DeviceGraph.build([])))
+    assert compat.Trait.NO_MOUNTED_ESP in compat.traits_of(partitioned)


### PR DESCRIPTION
Choosing the conversion drops the device graph: the layout is read from the running machine at install time, and `plan/convert.layout_graph` builds the esp there when the machine booted through UEFI. `traits_of` asked the empty graph for a mounted esp anyway, so a UEFI machine was refused with `uefi boot` against `no mounted esp` — a compatibility violation no row in the interface could answer.

An operator driving spec 3 reported it in those words. This is the third place the same assumption was written: #904 for the kernel command line, #910 and #912 for the rows, and now the compatibility table.