### PR TITLE
model: drop the mount list nothing reads

### DIFF
--- a/gentoo_install/exec/probe.py
+++ b/gentoo_install/exec/probe.py
@@ -1034,18 +1034,6 @@ class Probe:
             uefi=uefi,
             root_free_bytes=_entry_int(root, "avail") if root is not None else None,
             root_subvolume=root_subvolume,
-            separate_mounts=tuple(
-                sorted(
-                    {
-                        target
-                        for entry in mounts
-                        if (target := _entry_text(entry, "target"))
-                        and target.startswith("/")
-                        and target.count("/") == 1
-                        and target != "/"
-                    }
-                )
-            ),
             carried_fstab=_fstab_we_do_not_manage(
                 esp_mountpoint if uefi else None,
                 _entry_text(boot, "target") if boot is not None else None,

--- a/gentoo_install/model/device.py
+++ b/gentoo_install/model/device.py
@@ -163,10 +163,6 @@ class StorageLayout:
     #: level. `findmnt` writes it into the source as `/dev/sda2[/@]` and into
     #: the options as `subvol=/@`, and a root read without it names no device.
     root_subvolume: str | None = None
-    #: Top-level directories that are their own mount, `/var` and `/home` on a
-    #: Fedora cloud image. A conversion renames the directories it replaces,
-    #: and rename cannot replace a mount point.
-    separate_mounts: tuple[str, ...] = ()
 
 
 @dataclass(frozen=True, init=False)

--- a/tests/unit/test_plan_convert.py
+++ b/tests/unit/test_plan_convert.py
@@ -787,11 +787,16 @@ def test_a_failed_conversion_still_unmounts_the_staging_root() -> None:
 
 def test_a_replaced_directory_that_is_its_own_mount_no_longer_refuses() -> None:
     """A Fedora 41 cloud image mounts `/var` and `/home` as their own btrfs
-    subvolumes. Refusing that kept the whole RPM family out; `exec/convert.py`
-    replaces a mount point's contents instead, every move a rename on the one
-    filesystem, so the graph has nothing to object to.
+    subvolumes, with the root on `/root`. Refusing that kept the whole RPM
+    family out; `exec/convert.py` replaces a mount point's contents instead,
+    every move a rename on the one filesystem, so the graph has nothing to
+    object to.
+
+    The layout named those mounts in a field of its own until the refusal that
+    read it was removed. Nothing read the field after that, so the case is
+    written from the subvolume, which the fstab and `rootflags=` still need.
     """
-    fedora = replace(_layout(), separate_mounts=("/boot", "/home", "/proc", "/var"))
+    fedora = replace(_layout(), root_subvolume="root")
     assert convert.layout_graph(fedora).mode is DiskMode.IN_PLACE
 
     # Negative control: the layers the graph genuinely cannot describe are


### PR DESCRIPTION
`StorageLayout.separate_mounts` was read by the refusal that kept the RPM family out. That refusal was removed when `exec/convert.py` started replacing a mount point's contents rather than renaming the directory, and the field stayed: the probe still walked `findmnt` to build it and nothing anywhere read it back.

The test that named it set the field and asserted the graph was accepted, which it would have been either way. It is written from `root_subvolume` instead — a field the new fstab and `rootflags=` both still need.