### PR TITLE
tui: the install row derives a conversion from the machine

### DIFF
--- a/gentoo_install/cli.py
+++ b/gentoo_install/cli.py
@@ -949,7 +949,9 @@ def _require_network() -> None:
     )
 
 
-def _conversion_offer(probe: Probe) -> tuple[str, refusals.Refusal]:
+def _conversion_offer(
+    probe: Probe,
+) -> tuple[str, refusals.Refusal, StorageLayout | None]:
     """What the running system is, and why it cannot be converted in place.
 
     The refusal is what the menu shows instead of the option. Everything that
@@ -960,18 +962,22 @@ def _conversion_offer(probe: Probe) -> tuple[str, refusals.Refusal]:
     """
     medium = probe.live_medium()
     if medium:
-        return "", refusals.Refusal(refusals.LIVE_MEDIUM, medium)
+        return "", refusals.Refusal(refusals.LIVE_MEDIUM, medium), None
     # Measured on an Alpine cloud image: without these the layout reads back
     # empty and the refusal blamed the root device rather than the package.
     lacking = report.absent(preflight.LAYOUT_COMMANDS, probe)
     if lacking:
-        return "", refusals.Refusal(refusals.CANNOT_READ_THE_SYSTEM, ", ".join(sorted(lacking)))
+        return (
+            "",
+            refusals.Refusal(refusals.CANNOT_READ_THE_SYSTEM, ", ".join(sorted(lacking))),
+            None,
+        )
     try:
         layout = probe.storage_layout()
     except GentooInstallError as error:
         # The message is the detail: English beside the translated reason, and
         # it names the device the reading failed on.
-        return "", refusals.Refusal(refusals.CANNOT_READ_THE_SYSTEM, str(error))
+        return "", refusals.Refusal(refusals.CANNOT_READ_THE_SYSTEM, str(error)), None
     described = f"{layout.root_device} on {layout.root_filesystem_type}"
     try:
         convert.layout_graph(layout)
@@ -979,10 +985,12 @@ def _conversion_offer(probe: Probe) -> tuple[str, refusals.Refusal]:
         # The exception says which filesystem, in English, for the log. The
         # menu already draws `Running system:` beside this, so the reason it
         # shows is a catalog key rather than the message.
-        return described, refusals.Refusal(
-            refusals.CANNOT_DESCRIBE_THE_ROOT, layout.root_filesystem_type or ""
+        return (
+            described,
+            refusals.Refusal(refusals.CANNOT_DESCRIBE_THE_ROOT, layout.root_filesystem_type or ""),
+            None,
         )
-    return described, refusals.OFFERED
+    return described, refusals.OFFERED, layout
 
 def _image_write_offer(probe: Probe) -> refusals.Refusal:
     """Why the whole-disk image writer must stay unavailable on this machine."""
@@ -1074,7 +1082,7 @@ def _from_menu(
     lacking = report.absent(preflight.MENU_ONLY)
     if lacking:
         raise errors.PreflightFailed(f"the menu needs {', '.join(sorted(lacking))}")
-    running_system, conversion_refused = _conversion_offer(probe)
+    running_system, conversion_refused, running_layout = _conversion_offer(probe)
     image_write_refused = _image_write_offer(probe)
     context = tui_context.Context(
         translate=Catalog(tag_for(override=arguments.lang)),
@@ -1103,6 +1111,7 @@ def _from_menu(
         zfs_unavailable=probe.zfs_support(),
         configs_here=report.configs_here(app.SAVE_AS),
         running_system=running_system,
+        running_layout=running_layout,
         conversion_refused=conversion_refused,
         image_write_refused=image_write_refused,
         load_config=load_source,

--- a/gentoo_install/tui/app.py
+++ b/gentoo_install/tui/app.py
@@ -385,7 +385,10 @@ def _blocked(config: InstallConfig, context: Context) -> str:
         # an overlay nobody selected raises from `plan.build`, and the row that
         # blocks the install is the only place that can say so before the
         # operator presses it and loses every answer to a traceback.
-        build(config, context.groups)
+        # With the machine's own layout: a conversion's graph is derived from
+        # it, and asked without one this raised `the running layout was not
+        # read` into the Install row, where no answer could clear it.
+        build(config, context.groups, layout=context.running_layout)
     except GentooInstallError as error:
         return str(error).splitlines()[-1].strip()
     return ""

--- a/gentoo_install/tui/context.py
+++ b/gentoo_install/tui/context.py
@@ -17,6 +17,7 @@ from ..errors import ConfigError, GentooInstallError
 from ..exec.preflight import ZFS_PASSPHRASE_MINIMUM
 from ..i18n import Catalog, clip
 from ..model import manual, mirrors, qr, refusals
+from ..model.device import StorageLayout
 from ..model.config import (
     BinhostChannel,
     Firmware,
@@ -127,11 +128,16 @@ class Context:
         #: because this layer reads no machine. A machine that could not be
         #: read refuses the conversion rather than offering one blind.
         running_system: str = "",
+        #: What `exec/probe.py` read of the running machine, for the rows that
+        #: have to derive the plan before the operator presses Install. A
+        #: conversion's graph is built from this and from nothing else.
+        running_layout: StorageLayout | None = None,
         conversion_refused: refusals.Refusal = refusals.Refusal(refusals.SYSTEM_NOT_READ),
         image_write_refused: refusals.Refusal = refusals.Refusal(refusals.MEMORY_NOT_READ),
     ) -> None:
         self.translate = translate
         self.running_system = running_system
+        self.running_layout = running_layout
         self.conversion_refused = conversion_refused
         self.image_write_refused = image_write_refused
         self.ipv4 = ipv4

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -1560,7 +1560,10 @@ def test_the_conversion_offer_names_the_command_the_reading_needs(
     absent: set[str] = {"findmnt", "lsblk"}
     monkeypatch.setattr(report, "absent", lambda wanted, probe=None: set(absent))
 
-    running, refused = cli._conversion_offer(cast(RealProbe, Probe()))
+    # The layout comes back too: the Install row derives a conversion's plan
+    # from it before the operator presses it.
+    running, refused, layout = cli._conversion_offer(cast(RealProbe, Probe()))
+    assert layout is None, layout
     assert running == ""
     # The reason is a catalog key and the commands are the detail beside it:
     # a translated screen cannot hold `findmnt` and the operator still needs it.

--- a/tests/unit/test_no_english_on_a_translated_screen.py
+++ b/tests/unit/test_no_english_on_a_translated_screen.py
@@ -93,8 +93,13 @@ def test_every_refusal_the_entry_point_can_answer_is_a_catalog_key() -> None:
             if not isinstance(node, ast.Return) or node.value is None:
                 continue
             parts = node.value.elts if isinstance(node.value, ast.Tuple) else [node.value]
-            # The reason is the last element; the first is what was measured.
-            answer = parts[-1]
+            # The `Refusal` itself, wherever it sits: the tuple also carries
+            # what was measured and, since the Install row began deriving a
+            # conversion's plan, the layout it was read from.
+            refusal = [
+                one for one in parts if ast.unparse(one).startswith("refusals.")
+            ]
+            answer = refusal[0] if refusal else parts[-1]
             # `Refusal(REASON, detail)`: the reason is what a catalog holds and
             # the detail is a device or a command, which none does.
             if isinstance(answer, ast.Call) and answer.args:

--- a/tests/unit/test_tui_app.py
+++ b/tests/unit/test_tui_app.py
@@ -3989,3 +3989,67 @@ def test_a_refused_row_is_not_drawn_as_an_answer_somebody_owes() -> None:
     empty = replace(built, disk=replace(built.disk, graph=DeviceGraph.build([])))
     assert style_of(disk, empty, offering) is Style.REQUIRED
     assert shown_value(disk, empty, offering) == "required"
+
+
+def test_the_install_row_derives_a_conversion_from_the_machine(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A conversion's plan is built from the running layout and from nothing
+    else. The row that blocks the install derived it without one and reported
+    `the running layout was not read` as the reason, which no answer in the
+    interface could clear."""
+    from dataclasses import replace
+
+    from gentoo_install.model.device import DeviceGraph, DeviceId
+
+    from .test_plan_convert import _layout
+
+    reading = _layout()
+    offering = app.MainMenuContext(tui_context.Context(
+        translate=Catalog("en"),
+        disks=DISKS,
+        groups=load_catalog(),
+        hash_password=lambda password: f"$6$test${len(password)}",
+        conversion_refused=Refusal(""),
+        running_system="/dev/vda2 on xfs",
+        running_layout=reading,
+    ))
+    built = config()
+    converted = replace(
+        built,
+        disk=replace(
+            built.disk, mode=DiskMode.IN_PLACE, graph=DeviceGraph.build([]), root=DeviceId("")
+        ),
+    )
+
+    # Every row answered and opened, or `_blocked` names one of those instead
+    # and never reaches the plan.
+    converted = replace(
+        converted,
+        system=replace(converted.system, root_password_hash="$6$test$x"),
+        # A mirror chosen rather than detected, the way `Mirrors` is answered.
+        portage=replace(
+            converted.portage, mirrors=replace(converted.portage.mirrors, site="tuna")
+        ),
+    )
+    offering.visited.update(one.key for one in settings.SETTINGS)
+    for group in settings.SETTINGS:
+        offering.visited.update(one.key for one in group.rows)
+
+    handed: list[object] = []
+
+    def watching(one: object, groups: object, *, layout: object = None) -> tuple[object, ...]:
+        handed.append(layout)
+        return ()
+
+    monkeypatch.setattr(app, "build", watching)
+    app._blocked(converted, offering)
+    assert handed == [reading], handed
+
+    # Negative control: without the layout the plan cannot be derived at all,
+    # which is the refusal the row used to show.
+    from gentoo_install.errors import ConversionUnsupported
+    from gentoo_install.plan.build import build as real_build
+
+    with pytest.raises(ConversionUnsupported, match="layout was not read"):
+        real_build(converted, load_catalog())


### PR DESCRIPTION
The Install row derives the whole plan before the operator presses it, so a group whose packages live in an unselected overlay is named there rather than raising a traceback. It called `plan.build` without the running layout, and a conversion's graph is built from that and nothing else: the row showed `the running layout was not read` and no answer in the interface could clear it.

`_conversion_offer` already reads the layout to decide whether to offer the mode at all. It hands it back now, the context carries it, and the row passes it through.

Sixth place tonight where something asked for a conversion's graph before the machine had been read: #904, #910, #912, #915 and now this.