### PR TITLE
plan: a subvolume the conversion reuses is checked, not created

### DIFF
--- a/gentoo_install/model/device.py
+++ b/gentoo_install/model/device.py
@@ -342,6 +342,10 @@ class Filesystem(Node):
 class Subvolume(Node):
     filesystem: DeviceId
     name: str
+    #: False when the subvolume is already there, the way `Filesystem.create`
+    #: reads: a conversion mounts the running machine's own `@` and creating
+    #: it again ends the run on `target path already exists`.
+    create: bool = True
 
     @property
     def inputs(self) -> tuple[DeviceId, ...]:

--- a/gentoo_install/plan/convert.py
+++ b/gentoo_install/plan/convert.py
@@ -401,7 +401,10 @@ def layout_graph(layout: StorageLayout) -> DiskConfig:
     if layout.root_subvolume:
         nodes.append(
             Subvolume(
-                id=ROOT_SUBVOLUME, filesystem=ROOT_FILESYSTEM, name=layout.root_subvolume
+                id=ROOT_SUBVOLUME,
+                filesystem=ROOT_FILESYSTEM,
+                name=layout.root_subvolume,
+                create=False,
             )
         )
     nodes.append(

--- a/gentoo_install/plan/disk.py
+++ b/gentoo_install/plan/disk.py
@@ -609,6 +609,46 @@ SCRATCH_MOUNT: Final[str] = "btrfs-top"
 
 
 @dataclass(frozen=True, kw_only=True)
+class VerifySubvolume(Operation):
+    """A subvolume the configuration reuses rather than makes.
+
+    A conversion mounts the running machine's own layout, so `@` is already
+    there and `btrfs subvolume create` answers `target path already exists`.
+    Checked rather than skipped: a name that is not there is a layout this
+    plan cannot mount, and finding that out at the mount is too late.
+    """
+
+    stage: Stage = Stage.FORMAT
+    host_commands = ("mkdir", "mount", "btrfs", "umount")
+    subvolume: DeviceId
+    device: DeviceId
+    name: str
+
+    def describe(self) -> str:
+        return f"check {self.device} already holds the btrfs subvolume {self.name}"
+
+    def apply(self, context: Context) -> None:
+        scratch = context.target.parent / SCRATCH_MOUNT
+        path = context.device_path(self.device)
+        context.run(["mkdir", "--parents", str(scratch)])
+        context.run(["mount", "--types", "btrfs", path, str(scratch)])
+        # `btrfs subvolume list`, not a directory test: a plain directory of
+        # the same name is not a subvolume and mounting `subvol=` on it fails
+        # at the mount rather than here.
+        listed = context.run(["btrfs", "subvolume", "list", str(scratch)], check=False)
+        wanted = self.name.lstrip("/")
+        missing = not any(
+            line.rsplit(" path ", 1)[-1].strip() == wanted for line in listed.splitlines()
+        )
+        context.run(["umount", str(scratch)])
+        if missing:
+            raise InvalidLayout(
+                f"{self.device} has no btrfs subvolume {self.name}, and the "
+                "configuration reuses it"
+            )
+
+
+@dataclass(frozen=True, kw_only=True)
 class CreateSubvolume(Operation):
     """btrfs subvolumes live inside the filesystem, so the top level has to be
     mounted to create one and unmounted again before the layout is mounted."""
@@ -1176,6 +1216,10 @@ def _operations_for(
         ]
     if isinstance(node, Subvolume):
         filesystem = _expect(graph, node.filesystem, Filesystem)
+        if not node.create:
+            return [
+                VerifySubvolume(subvolume=node.id, device=filesystem.device, name=node.name)
+            ]
         return [CreateSubvolume(subvolume=node.id, device=filesystem.device, name=node.name)]
     if isinstance(node, Swap):
         return [MakeSwap(swap=node.id, device=node.device)]

--- a/tests/unit/test_plan_convert.py
+++ b/tests/unit/test_plan_convert.py
@@ -975,3 +975,27 @@ def test_an_ordinary_install_does_not_carry_that_operation() -> None:
     operations = build(config(), CATALOG)
 
     assert not [one for one in operations if isinstance(one, convert.FlushToDisk)]
+
+
+def test_a_conversion_checks_its_subvolume_rather_than_making_it() -> None:
+    """The running machine's own `@` is already there. Planned as a creation,
+    `btrfs subvolume create` answers `target path already exists` and the
+    conversion stops before it has staged anything."""
+    from gentoo_install.model.device import StorageFacts
+    from gentoo_install.plan import disk
+
+    graph = convert.layout_graph(replace(_layout(), root_subvolume="@")).graph
+    made = [
+        one
+        for node in graph.nodes.values()
+        for one in disk._operations_for(graph, node, StorageFacts())
+        if isinstance(one, (disk.CreateSubvolume, disk.VerifySubvolume))
+    ]
+    assert [type(one).__name__ for one in made] == ["VerifySubvolume"], made
+
+    # Negative control: a layout that asks for a new subvolume still gets one,
+    # so the rule above is not "never create a subvolume".
+    from gentoo_install.model.device import Subvolume
+
+    fresh = Subvolume(id=DeviceId("sub"), filesystem=DeviceId("rootfs"), name="@")
+    assert fresh.create


### PR DESCRIPTION
`Filesystem` carries `create`, and the plan answers it with `VerifyFilesystem` rather than `MakeFilesystem`. `Subvolume` had no such field, so every subvolume in a graph was planned as a creation — including the one a conversion derives from the running machine, where `@` or `root` is already there and `btrfs subvolume create` answers `target path already exists`.

The check reads `btrfs subvolume list` rather than testing for a directory: a plain directory of the same name is not a subvolume, and mounting `subvol=` on it fails at the mount instead of here.