### PR TITLE
tui: a row behind a refused group asks for nothing either

### DIFF
--- a/gentoo_install/tui/app.py
+++ b/gentoo_install/tui/app.py
@@ -265,8 +265,12 @@ def _facts(setting: Setting, config: InstallConfig, context: Context) -> list[st
     if setting.rows:
         # A group answers with its own rows, so each value is named by the row
         # it came from rather than joined into a sentence with no subject.
+        refused = bool(setting.unavailable(config, context))
         for row in setting.rows:
-            lines.append(f"{context.translate(row.label)}: {shown_value(row, config, context)}")
+            lines.append(
+                f"{context.translate(row.label)}: "
+                f"{shown_value(row, config, context, within_refused=refused)}"
+            )
     else:
         value = _drawn(setting, config, context)
         lines.extend(

--- a/gentoo_install/tui/settings.py
+++ b/gentoo_install/tui/settings.py
@@ -212,7 +212,12 @@ QUIET: Final[tuple[str, ...]] = (
 
 
 def shown_value(
-    setting: Setting, config: InstallConfig, context: Context, room: int | None = None
+    setting: Setting,
+    config: InstallConfig,
+    context: Context,
+    room: int | None = None,
+    *,
+    within_refused: bool = False,
 ) -> str:
     """A row's value as the operator reads it.
 
@@ -223,7 +228,10 @@ def shown_value(
     """
     value = setting.value(config, context)
     if value == UNSET:
-        refused = bool(setting.unavailable(config, context))
+        # The group's refusal counts as this row's: a row behind a screen that
+        # will not open cannot be answered either, and the right pane went on
+        # reading `required` beside a row the operator could not reach.
+        refused = within_refused or bool(setting.unavailable(config, context))
         value = context.translate(
             "required" if setting.required and not refused else UNSET
         )

--- a/tests/unit/test_tui_app.py
+++ b/tests/unit/test_tui_app.py
@@ -3984,6 +3984,11 @@ def test_a_refused_row_is_not_drawn_as_an_answer_somebody_owes() -> None:
     assert style_of(disk, converted, offering) is Style.PLAIN
     assert shown_value(disk, converted, offering) != "required"
 
+    # And the rows behind it, which the right pane draws: they cannot be
+    # answered either, and one of them went on reading `required` beside a
+    # screen the operator could not open.
+    assert "required" not in "\n".join(app._facts(disk, converted, offering))
+
     # Negative control: the same row on a partition install with no disk chosen
     # is still red and still says so.
     empty = replace(built, disk=replace(built.disk, graph=DeviceGraph.build([])))


### PR DESCRIPTION
#912 stopped a refused row being drawn as an answer somebody owes, by asking the row's own refusal. A row behind a group carries none: the group holds the reason. The right pane draws those rows by name, so a conversion still showed `disk device: required` in the pane beside a row whose screen would not open, and a seventh agent reported it in those words.

`shown_value` takes the group's refusal from the one place that iterates a group's rows. Seventh place tonight where something asked a conversion for an answer the machine supplies later: #904, #910, #912, #915, #917, #919.