### PR TITLE
model: a hand-writable disk section for the common layouts

### DIFF
--- a/gentoo_install/model/config.py
+++ b/gentoo_install/model/config.py
@@ -9,9 +9,14 @@ from __future__ import annotations
 
 from dataclasses import dataclass, field
 from enum import Enum
-from typing import Final
+from typing import Final, TYPE_CHECKING
 
 from .size import Size
+
+if TYPE_CHECKING:
+    # `model/templates.py` imports this module, so the reverse import exists
+    # only for the annotation.
+    from .templates import Choice
 from .device import DeviceGraph, DeviceId
 
 #: `parse.py` refuses a newer file and migrates an older one.
@@ -498,6 +503,11 @@ class DiskConfig:
     #: Empty means the running layout supplies the root.
     root: DeviceId
     mode: DiskMode = DiskMode.PARTITION
+    #: The template this graph was expanded from, when a `[disk.simple]`
+    #: section wrote it. Kept rather than derived: an explicit `table = "gpt"`
+    #: and an omitted one produce the same graph, so the writer cannot tell
+    #: the two apart by looking at it.
+    simple: "Choice | None" = None
     #: The sparse file attached as the graph's disk in image mode.
     image: str = ""
     size: Size | None = None

--- a/gentoo_install/model/parse.py
+++ b/gentoo_install/model/parse.py
@@ -15,6 +15,7 @@ from typing import Any, Mapping, Sequence, TypeVar
 from ..errors import ConfigError
 from . import config as model_config
 from . import sshkey
+from . import templates
 from .config import (
     CONFIG_VERSION,
     Binhost,
@@ -326,6 +327,7 @@ def _disk(raw: Mapping[str, Any], at: str) -> DiskConfig:
         {
             "root",
             "devices",
+            "simple",
             "mode",
             "image",
             "size",
@@ -336,6 +338,31 @@ def _disk(raw: Mapping[str, Any], at: str) -> DiskConfig:
         },
     )
     mode = _enum(raw, "mode", at, DiskMode, DiskMode.PARTITION)
+    simple = raw.get("simple")
+    if simple is not None:
+        # Refused rather than merged: with both written, one of them decides
+        # and nothing on the page says which.
+        if raw.get("devices"):
+            raise ConfigError(
+                f"{at} carries both `simple` and `devices`; a layout is written one way "
+                "or the other"
+            )
+        if raw.get("root"):
+            raise ConfigError(f"{at}.root is derived from `simple` and is not written beside it")
+        chosen = _choice(simple, f"{at}.simple")
+        graph, root = templates.build(chosen)
+        return DiskConfig(
+            graph=graph,
+            root=root,
+            mode=mode,
+            simple=chosen,
+            image=_str(raw, "image", at),
+            size=_size(raw, "size", at),
+            wipe=_bool(raw, "wipe", at, False),
+            source=_str(raw, "source", at),
+            source_format=_enum(raw, "source_format", at, ImageFormat, ImageFormat.RAW),
+            destination=_str(raw, "destination", at),
+        )
     devices = _tables(raw, "devices", at)
     nodes = [_node(entry, f"{at}.devices[{n}]") for n, entry in enumerate(devices)]
     if mode in (DiskMode.PARTITION, DiskMode.IMAGE) and not nodes:
@@ -351,6 +378,37 @@ def _disk(raw: Mapping[str, Any], at: str) -> DiskConfig:
         source_format=_enum(raw, "source_format", at, ImageFormat, ImageFormat.RAW),
         destination=_str(raw, "destination", at),
     )
+
+def _choice(raw: Any, at: str) -> templates.Choice:
+    """The hand-written form of a whole-disk layout.
+
+    Every field is `templates.Choice`'s own, so nothing here decides what a
+    value means: `templates.build` is the one expansion and this only reads.
+    """
+    if not isinstance(raw, Mapping):
+        raise ConfigError(f"{at} is not a table")
+    _reject_unknown(
+        raw,
+        at,
+        {"disk", "layout", "firmware", "table", "filesystem", "swap", "passphrase_file", "pool"},
+    )
+    layout = _enum(raw, "layout", at, templates.Layout, templates.Layout.WHOLE_DISK)
+    if layout is templates.Layout.REUSE:
+        raise ConfigError(
+            f"{at}.layout is 'reuse', which names partitions that already exist; "
+            "write those as `devices`"
+        )
+    return templates.Choice(
+        disk=_str(raw, "disk", at, required=True),
+        layout=layout,
+        firmware=_enum(raw, "firmware", at, Firmware, Firmware.UEFI),
+        table=_enum(raw, "table", at, TableType, None) if raw.get("table") else None,
+        filesystem=_enum(raw, "filesystem", at, FilesystemType, FilesystemType.XFS),
+        swap=_size(raw, "swap", at),
+        passphrase_file=_str(raw, "passphrase_file", at),
+        pool=_str(raw, "pool", at) or "rpool",
+    )
+
 
 def _node(raw: Mapping[str, Any], at: str) -> Node:
     kind = _str(raw, "kind", at, required=True)

--- a/gentoo_install/model/serialise.py
+++ b/gentoo_install/model/serialise.py
@@ -17,6 +17,7 @@ from typing import Any, Final
 
 from . import config as model_config
 from .config import DiskMode, InstallConfig, ProxyConfig
+from .templates import Choice
 from .device import (
     Existing,
     Filesystem,
@@ -143,6 +144,21 @@ class _Nothing:
 _NOTHING: Final[_Nothing] = _Nothing()
 
 
+def _simple(choice: Choice) -> list[str]:
+    """A whole-disk template, with every field the default already covers left
+    out: an omitted key reads as `whatever this installer does by default`."""
+    against = Choice(disk=choice.disk)
+    lines = [f"disk = {_value(choice.disk)}"]
+    for field in fields(choice):
+        if field.name == "disk":
+            continue
+        held = getattr(choice, field.name)
+        if held == getattr(against, field.name):
+            continue
+        lines.append(f"{field.name} = {_value(held)}")
+    return lines
+
+
 def _disk(config: InstallConfig) -> list[str]:
     disk = config.disk
     lines = ["", "[disk]"]
@@ -166,6 +182,11 @@ def _disk(config: InstallConfig) -> list[str]:
         if disk.wipe:
             lines.append("wipe = true")
         lines = [line for line in lines if line]
+    if disk.simple is not None:
+        # The template it was expanded from, not the graph: a reader hand-edits
+        # eight lines instead of sixty, and `parse` expands it again with the
+        # one function the interface itself uses.
+        return [*lines, "", "[disk.simple]", *_simple(disk.simple)]
     lines.append(f'root = "{disk.root}"')
     for node in disk.graph.nodes.values():
         kind = KINDS.get(type(node))

--- a/tests/unit/test_parse.py
+++ b/tests/unit/test_parse.py
@@ -454,3 +454,71 @@ def test_an_ordinary_mountpoint_is_still_taken() -> None:
     config = parse(raw)
 
     assert any(str(one.path) == "/home/zakk" for one in config.disk.graph.of_type(Mountpoint))
+
+
+def _simple_disk() -> dict[str, Any]:
+    """The fixture with its device graph replaced by the hand-written form."""
+    raw = fixture()
+    raw["disk"] = {"simple": {"disk": "/dev/disk/by-id/virtio-target0"}}
+    return raw
+
+
+def test_a_simple_disk_expands_to_the_graph_the_template_builds() -> None:
+    """The surface is `templates.Choice` written down, and `templates.build` is
+    the one expansion: a hand-written file and the interface produce the same
+    graph or the two forms mean different things."""
+    from gentoo_install.model import templates
+
+    parsed = parse(_simple_disk())
+    graph, root = templates.build(templates.Choice(disk="/dev/disk/by-id/virtio-target0"))
+
+    assert parsed.disk.graph == graph
+    assert parsed.disk.root == root
+    assert parsed.disk.simple == templates.Choice(disk="/dev/disk/by-id/virtio-target0")
+
+    # Negative control: a different template is a different graph, so the
+    # comparison above is not satisfied by any two whole-disk layouts.
+    other, _ = templates.build(
+        templates.Choice(disk="/dev/disk/by-id/virtio-target0", filesystem=FilesystemType.EXT4)
+    )
+    assert parsed.disk.graph != other
+
+
+def test_a_layout_is_written_one_way_or_the_other() -> None:
+    """With both forms present one of them decides and nothing on the page says
+    which, so neither is taken."""
+    raw = fixture()
+    raw["disk"]["simple"] = {"disk": "/dev/disk/by-id/virtio-target0"}
+
+    with pytest.raises(ConfigError, match="both"):
+        parse(raw)
+
+
+def test_a_simple_disk_does_not_carry_a_root_of_its_own() -> None:
+    """`templates.build` answers with the mount point it made, so a `root`
+    beside it is either the same value written twice or a contradiction."""
+    raw = _simple_disk()
+    raw["disk"]["root"] = "mnt-root"
+
+    with pytest.raises(ConfigError, match="derived"):
+        parse(raw)
+
+
+def test_the_reuse_layout_is_not_a_template() -> None:
+    """It names partitions that already exist and a template has none of them;
+    `templates.build` refuses it for the same reason."""
+    raw = _simple_disk()
+    raw["disk"]["simple"]["layout"] = "reuse"
+
+    with pytest.raises(ConfigError, match="reuse"):
+        parse(raw)
+
+
+def test_a_simple_disk_refuses_a_key_it_does_not_know() -> None:
+    """A misspelled key that is quietly ignored is a layout the operator did
+    not ask for, written to a disk that is then erased."""
+    raw = _simple_disk()
+    raw["disk"]["simple"]["filesystems"] = "ext4"
+
+    with pytest.raises(ConfigError, match="filesystems"):
+        parse(raw)

--- a/tests/unit/test_serialise.py
+++ b/tests/unit/test_serialise.py
@@ -236,3 +236,44 @@ def test_a_control_character_survives_the_round_trip(said: str) -> None:
 
     held = replace(config(), system=replace(config().system, hostname=said))
     assert _round_trip(held).system.hostname == said
+
+
+def test_a_simple_disk_is_written_back_as_the_template() -> None:
+    """Sixty lines of graph become the eight the operator typed, and reading
+    them again expands to the same graph through the same function."""
+    import tomllib
+
+    from gentoo_install.model import templates
+    from gentoo_install.model.config import DiskConfig
+    from gentoo_install.model.device import FilesystemType
+    from gentoo_install.model.parse import parse
+    from gentoo_install.model.size import Size
+
+    chosen = templates.Choice(
+        disk="/dev/disk/by-id/virtio-target0",
+        filesystem=FilesystemType.EXT4,
+        swap=Size.parse("2GiB"),
+    )
+    graph, root = templates.build(chosen)
+    fixtures = Path(__file__).resolve().parents[1] / "fixtures"
+    config = replace(
+        parse(tomllib.loads((fixtures / "btrfs-luks.toml").read_text())),
+        disk=DiskConfig(graph=graph, root=root, simple=chosen),
+    )
+
+    written = to_toml(config)
+    assert "[disk.simple]" in written
+    assert "[[disk.devices]]" not in written
+    # Only what differs from the default: an omitted key reads as whatever this
+    # installer does on its own.
+    assert "pool" not in written
+    assert 'firmware = "uefi"' not in written
+
+    again = parse(tomllib.loads(written))
+    assert again.disk.simple == chosen
+    assert again.disk.graph == graph
+
+    # Negative control: a configuration that carries no template still writes
+    # its graph, so the rule above is not "never write devices".
+    plain = replace(config, disk=DiskConfig(graph=graph, root=root))
+    assert "[[disk.devices]]" in to_toml(plain)


### PR DESCRIPTION
Twenty-two of the thirty-nine fixtures describe one disk, one table, an esp, an optional swap, a root and its mount. `vm-bios.toml` spends sixty of its seventy-five lines saying that as a device graph.

`[disk.simple]` writes `templates.Choice` instead, and the parser expands it with `templates.build` — the function the interface itself uses. No second expansion exists to disagree with the first. The graph form stays for LUKS, ZFS, RAID and hand-made tables.

`DiskConfig` keeps the `Choice` because the form cannot be recovered from the graph: an explicit `table = "gpt"` and an omitted one build the same nodes. Four configurations are refused: both forms present, a `root` beside the template, `layout = "reuse"`, and a key the section does not know.