### PR TITLE
docs: the hand-writable disk section in every README

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -345,6 +345,37 @@ mode = "in-place"
 
 設定ファイルは TOML 形式です。トップレベルの `config_version` フィールドがスキーマバージョンを指定します。ストレージはデバイスグラフで表します。各デバイスは `id` を持ち、ほかのデバイスを `id` で参照します。セレクタは実際のインストール時にのみ解決されます。
 
+<!-- fact: config-simple -->
+
+単一ディスクのレイアウトはデバイスグラフではなく `[disk.simple]` として記述します。パーサーはメニューが用いるものと同じテンプレートで展開するため、両方の記法は同一のグラフを生成します。グラフ記法は LUKS、ZFS、RAID、手書きのパーティションテーブルのために残されています。
+
+```toml
+config_version = 1
+
+[system]
+hostname = "workstation"
+timezone = "UTC"
+locales = ["en_US.UTF-8"]
+locale = "en_US.UTF-8"
+init = "systemd"
+root_password_hash = "$6$gentooinst$IR3GrdJ862XljQYDqocr4tKniIRDIT.jQNFzIrHE3U75H6B6YSWZoSYoVd5edSHpqaYBdiNfXHCoIPRVgb9lT/"
+
+[portage]
+profile = "default/linux/amd64/23.0/systemd"
+makeopts = "-j4"
+
+[bootloader]
+kind = "grub"
+firmware = "uefi"
+
+[disk.simple]
+disk = "/dev/disk/by-id/virtio-target0"
+filesystem = "ext4"
+swap = "2GiB"
+```
+
+上のハッシュは例であり、実行前に置き換える必要があります。必須は `disk` のみです。省略された鍵はインストーラーの既定値を取ります。`whole-disk`、`uefi`、ファームウェアが決めるパーティションテーブル、`xfs`、スワップなし、暗号化なしです。同一のファイルに `[disk.simple]` と `[[disk.devices]]` を同時に書くことはできません。
+
 <!-- fact: config-fixtures -->
 
 [`tests/fixtures/vm-binpkg.toml`](tests/fixtures/vm-binpkg.toml) は、UEFI と Ext4 を使用する完全なスキーマ参照です。ほかの [`tests/fixtures/`](tests/fixtures/) ファイルは BIOS、LUKS2、LVM、mdraid、ZFS、Btrfs subvolume、デスクトップを扱います。これらのファイルには仮想マシン用のディスクセレクタとテスト用パスワードが含まれているため、内容を変更せずに実機のインストールに使用してはなりません。

--- a/README.ko.md
+++ b/README.ko.md
@@ -345,6 +345,37 @@ mode = "in-place"
 
 설정 파일은 TOML 형식이다. 최상위 `config_version` 필드가 스키마 버전을 지정한다. 저장 장치는 장치 그래프로 표현된다. 각 장치에는 `id`가 있으며, 장치는 다른 장치를 `id`로 참조한다. 선택자는 실제 설치 중에만 해석된다.
 
+<!-- fact: config-simple -->
+
+디스크가 하나인 배치는 장치 그래프 대신 `[disk.simple]` 로 작성합니다. 파서는 메뉴가 사용하는 것과 같은 템플릿으로 전개하므로 두 표기는 동일한 그래프를 만듭니다. 그래프 표기는 LUKS, ZFS, RAID, 손으로 만든 파티션 테이블을 위해 남아 있습니다.
+
+```toml
+config_version = 1
+
+[system]
+hostname = "workstation"
+timezone = "UTC"
+locales = ["en_US.UTF-8"]
+locale = "en_US.UTF-8"
+init = "systemd"
+root_password_hash = "$6$gentooinst$IR3GrdJ862XljQYDqocr4tKniIRDIT.jQNFzIrHE3U75H6B6YSWZoSYoVd5edSHpqaYBdiNfXHCoIPRVgb9lT/"
+
+[portage]
+profile = "default/linux/amd64/23.0/systemd"
+makeopts = "-j4"
+
+[bootloader]
+kind = "grub"
+firmware = "uefi"
+
+[disk.simple]
+disk = "/dev/disk/by-id/virtio-target0"
+filesystem = "ext4"
+swap = "2GiB"
+```
+
+위 해시는 예시이며 실행 전에 교체해야 합니다. 필수 항목은 `disk` 하나입니다. 생략한 키는 설치기 기본값을 따릅니다: `whole-disk`, `uefi`, 펌웨어가 정하는 파티션 테이블, `xfs`, 스왑 없음, 암호화 없음. 한 파일에 `[disk.simple]` 과 `[[disk.devices]]` 를 함께 쓸 수 없습니다.
+
 <!-- fact: config-fixtures -->
 
 [`tests/fixtures/vm-binpkg.toml`](tests/fixtures/vm-binpkg.toml)은 UEFI와 Ext4 구성을 모두 포함한 완전한 스키마 참조 파일이다. [`tests/fixtures/`](tests/fixtures/)의 다른 파일은 BIOS, LUKS2, LVM, mdraid, ZFS, Btrfs subvolume, 데스크톱을 다룬다. 이 설정 파일들에는 가상 머신 디스크 선택자와 테스트용 암호가 포함되어 있으므로, 내용을 수정하지 않은 채 실제 머신 설치에 사용해서는 안 된다.

--- a/README.md
+++ b/README.md
@@ -345,6 +345,37 @@ A source-built kernel and binary-package degradation have runner-level tests onl
 
 Configuration files use TOML. The top-level `config_version` field selects the schema version. Storage is a device graph: every device has an `id`, devices refer to other devices by `id`, and selectors are resolved only during a real run.
 
+<!-- fact: config-simple -->
+
+A single-disk layout is written as `[disk.simple]` instead of a device graph. The parser expands it with the same template the menu uses, so both forms produce the same graph. The graph form remains for LUKS, ZFS, RAID and hand-made partition tables.
+
+```toml
+config_version = 1
+
+[system]
+hostname = "workstation"
+timezone = "UTC"
+locales = ["en_US.UTF-8"]
+locale = "en_US.UTF-8"
+init = "systemd"
+root_password_hash = "$6$gentooinst$IR3GrdJ862XljQYDqocr4tKniIRDIT.jQNFzIrHE3U75H6B6YSWZoSYoVd5edSHpqaYBdiNfXHCoIPRVgb9lT/"
+
+[portage]
+profile = "default/linux/amd64/23.0/systemd"
+makeopts = "-j4"
+
+[bootloader]
+kind = "grub"
+firmware = "uefi"
+
+[disk.simple]
+disk = "/dev/disk/by-id/virtio-target0"
+filesystem = "ext4"
+swap = "2GiB"
+```
+
+The hash above is an example and must be replaced before execution. Only `disk` is required. An omitted key takes the installer default: `whole-disk`, `uefi`, a partition table chosen by the firmware, `xfs`, no swap, no encryption. A file must not carry both `[disk.simple]` and `[[disk.devices]]`.
+
 <!-- fact: config-fixtures -->
 
 [`tests/fixtures/vm-binpkg.toml`](tests/fixtures/vm-binpkg.toml) is a complete UEFI and ext4 schema reference. Other files under [`tests/fixtures/`](tests/fixtures/) cover BIOS, LUKS2, LVM, mdraid, ZFS, btrfs subvolumes and desktops. They contain virtual-machine disk selectors and test credentials, so they must not be installed unchanged on a real machine.

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -345,6 +345,37 @@ mode = "in-place"
 
 配置文件使用 TOML。顶层 `config_version` 字段指定结构版本。存储设备以设备图表示：每个设备都有 `id`，设备通过其他设备的 `id` 建立引用，选择器仅在实际安装时解析。
 
+<!-- fact: config-simple -->
+
+单一磁盘的布局写成 `[disk.simple]`，不必写设备图。解析时以菜单所用的同一份模板展开，因此两种写法产生相同的图。设备图的写法保留给 LUKS、ZFS、RAID 与手动分区表。
+
+```toml
+config_version = 1
+
+[system]
+hostname = "workstation"
+timezone = "UTC"
+locales = ["en_US.UTF-8"]
+locale = "en_US.UTF-8"
+init = "systemd"
+root_password_hash = "$6$gentooinst$IR3GrdJ862XljQYDqocr4tKniIRDIT.jQNFzIrHE3U75H6B6YSWZoSYoVd5edSHpqaYBdiNfXHCoIPRVgb9lT/"
+
+[portage]
+profile = "default/linux/amd64/23.0/systemd"
+makeopts = "-j4"
+
+[bootloader]
+kind = "grub"
+firmware = "uefi"
+
+[disk.simple]
+disk = "/dev/disk/by-id/virtio-target0"
+filesystem = "ext4"
+swap = "2GiB"
+```
+
+上面的哈希值是示例，执行前必须替换。只有 `disk` 必填。省略的键取安装器默认值：`whole-disk`、`uefi`、由固件决定的分区表、`xfs`、无交换空间、不加密。同一份文件不得同时写 `[disk.simple]` 与 `[[disk.devices]]`。
+
 <!-- fact: config-fixtures -->
 
 [`tests/fixtures/vm-binpkg.toml`](tests/fixtures/vm-binpkg.toml) 是完整的 UEFI 和 ext4 结构参考。其他 [`tests/fixtures/`](tests/fixtures/) 文件覆盖 BIOS、LUKS2、LVM、mdraid、ZFS、btrfs subvolume 和桌面。这些文件使用虚拟机磁盘选择器和测试密码，不得原样用于实际机器的安装。

--- a/README.zh-TW.md
+++ b/README.zh-TW.md
@@ -345,6 +345,37 @@ mode = "in-place"
 
 設定檔使用 TOML。頂層的 `config_version` 欄位指定結構版本。儲存裝置以裝置圖表示：每個裝置都有 `id`，裝置以其他裝置的 `id` 建立引用，選擇器只在實際安裝時解析。
 
+<!-- fact: config-simple -->
+
+單一磁碟的版面寫成 `[disk.simple]`，不必寫裝置圖。解析時以選單所用的同一份樣板展開，因此兩種寫法產生相同的圖。裝置圖的寫法保留給 LUKS、ZFS、RAID 與手動分割表。
+
+```toml
+config_version = 1
+
+[system]
+hostname = "workstation"
+timezone = "UTC"
+locales = ["en_US.UTF-8"]
+locale = "en_US.UTF-8"
+init = "systemd"
+root_password_hash = "$6$gentooinst$IR3GrdJ862XljQYDqocr4tKniIRDIT.jQNFzIrHE3U75H6B6YSWZoSYoVd5edSHpqaYBdiNfXHCoIPRVgb9lT/"
+
+[portage]
+profile = "default/linux/amd64/23.0/systemd"
+makeopts = "-j4"
+
+[bootloader]
+kind = "grub"
+firmware = "uefi"
+
+[disk.simple]
+disk = "/dev/disk/by-id/virtio-target0"
+filesystem = "ext4"
+swap = "2GiB"
+```
+
+上面的雜湊值是範例，執行前必須替換。只有 `disk` 必填。省略的鍵取安裝器預設值：`whole-disk`、`uefi`、由韌體決定的分割表、`xfs`、無交換空間、不加密。同一份檔案不得同時寫 `[disk.simple]` 與 `[[disk.devices]]`。
+
 <!-- fact: config-fixtures -->
 
 [`tests/fixtures/vm-binpkg.toml`](tests/fixtures/vm-binpkg.toml) 是完整的 UEFI 與 ext4 結構參考。其他 [`tests/fixtures/`](tests/fixtures/) 檔案涵蓋 BIOS、LUKS2、LVM、mdraid、ZFS、btrfs subvolume 與桌面。這些檔案使用虛擬機磁碟選擇器與測試密碼，不得原樣用於實機安裝。

--- a/tests/unit/test_readme.py
+++ b/tests/unit/test_readme.py
@@ -106,7 +106,8 @@ FACT_UNITS = (
     "desktop-language", "portage", "proxy",
     "memory-environment", "memory-environment-access",
     "plan-records", "verification-scope",
-    "config-model", "config-fixtures", "config-dry-run", "binary-packages", "exit-codes",
+    "config-model", "config-simple", "config-fixtures", "config-dry-run",
+    "binary-packages", "exit-codes",
     "faq-customisation", "contributing", "license",
 )
 


### PR DESCRIPTION
`[disk.simple]` landed in #921 and the READMEs still showed only the device graph. Each of the five now carries the same complete example, in the same place, with the same warning that the hash must be replaced.

The example is a whole file rather than a fragment, because `test_every_configuration_a_readme_prints_can_produce_a_plan` parses and validates every TOML block a README prints — a reader who copies one gets a plan or the test fails.