### PR TITLE
packaging: the installer enters the Live ISO beside Calamares

### DIFF
--- a/packaging/gig/app-admin/gentoo-install/gentoo-install-9999.ebuild
+++ b/packaging/gig/app-admin/gentoo-install/gentoo-install-9999.ebuild
@@ -1,0 +1,36 @@
+# Copyright 2026 Zakk
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=8
+
+PYTHON_COMPAT=( python3_{11..14} )
+inherit git-r3 python-single-r1
+
+DESCRIPTION="Interactive Gentoo installer for the Gig-OS Live ISO"
+HOMEPAGE="https://github.com/Zakkaus/gentoo-install"
+EGIT_REPO_URI="https://github.com/Zakkaus/gentoo-install.git"
+
+LICENSE="GPL-2+"
+SLOT="0"
+KEYWORDS=""
+REQUIRED_USE="${PYTHON_REQUIRED_USE}"
+
+# Standard library only: the installer takes no runtime dependency the medium
+# does not already carry.
+RDEPEND="${PYTHON_DEPS}"
+
+src_install() {
+	python_moduleinto gentoo_install
+	python_domodule gentoo_install/.
+
+	# The one path `plan/netboot.py` names in its banner, so the command an
+	# operator is told about is the command the medium has.
+	exeinto /usr/local/sbin
+	doexe packaging/launcher/gentoo-install
+
+	# Beside the Calamares entry rather than instead of it.
+	insinto /usr/share/applications
+	doins packaging/launcher/gentoo-install.desktop
+
+	dodoc README.md TESTED.md
+}

--- a/packaging/launcher/gentoo-install
+++ b/packaging/launcher/gentoo-install
@@ -1,0 +1,6 @@
+#!/bin/sh
+# SPDX-License-Identifier: GPL-2.0-or-later
+# The installer as a command on the Live ISO. No `--config`: the operator on a
+# live desktop wants the menu, and the memory environment's own launcher is the
+# one that carries a prepared file.
+exec python3 -m gentoo_install "$@"

--- a/packaging/launcher/gentoo-install.desktop
+++ b/packaging/launcher/gentoo-install.desktop
@@ -1,0 +1,18 @@
+[Desktop Entry]
+Type=Application
+Version=1.0
+Name=Install System (text)
+Name[zh_CN]=安装系统（文字界面）
+Name[zh_TW]=安裝系統（文字介面）
+Name[ja]=システムをインストール（テキスト）
+Name[ko]=시스템 설치 (텍스트)
+GenericName=System Installer
+Comment=Install this system to disk from a terminal
+Comment[zh_CN]=在终端中把本系统安装到硬盘
+Comment[zh_TW]=在終端機中把本系統安裝到硬碟
+Comment[ja]=端末からこのシステムをディスクにインストールします
+Comment[ko]=터미널에서 이 시스템을 디스크에 설치합니다
+Exec=/usr/local/sbin/gentoo-install
+Icon=utilities-terminal
+Terminal=true
+Categories=System;

--- a/tests/unit/test_packaging.py
+++ b/tests/unit/test_packaging.py
@@ -1,0 +1,66 @@
+# SPDX-License-Identifier: GPL-2.0-or-later
+"""What the Live ISO installs, checked against what the installer says it is."""
+
+from __future__ import annotations
+
+import configparser
+import stat
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]
+LAUNCHER = ROOT / "packaging" / "launcher" / "gentoo-install"
+ENTRY = ROOT / "packaging" / "launcher" / "gentoo-install.desktop"
+EBUILD = ROOT / "packaging" / "gig" / "app-admin" / "gentoo-install" / "gentoo-install-9999.ebuild"
+
+
+def test_the_command_the_banner_names_is_the_command_the_medium_has() -> None:
+    """`plan/netboot.py` prints where the installer can be started from, and the
+    Live ISO has to put it there. Two places naming the path is one place too
+    many for them to agree by themselves."""
+    from gentoo_install.plan.netboot import COMMAND
+
+    desktop = configparser.ConfigParser(interpolation=None)
+    desktop.read_string(ENTRY.read_text())
+    assert desktop["Desktop Entry"]["Exec"] == COMMAND
+
+    # The ebuild puts the launcher in the directory that path names.
+    assert f"exeinto {COMMAND.rsplit('/', 1)[0]}" in EBUILD.read_text()
+
+    # Negative control: the path is not the empty string, so the comparison
+    # above cannot be satisfied by two things that were both never set.
+    assert COMMAND.startswith("/") and COMMAND.endswith("gentoo-install")
+
+
+def test_the_live_launcher_opens_the_menu() -> None:
+    """The memory environment's launcher carries `--config`, because the file
+    arrives with it. On a live desktop the operator wants the menu, and a
+    launcher that answered from a file would install without asking."""
+    # The line that runs, not the comment above it.
+    running = [
+        line for line in LAUNCHER.read_text().splitlines() if line.startswith("exec ")
+    ]
+    assert running == ['exec python3 -m gentoo_install "$@"'], running
+    assert LAUNCHER.stat().st_mode & stat.S_IXUSR
+
+    # Negative control: the memory launcher does carry one, so the rule above
+    # is about this file rather than about the installer having no such option.
+    from gentoo_install.plan.netboot import _command
+
+    assert "--config" in _command()
+
+
+def test_the_desktop_entry_says_it_is_the_text_installer() -> None:
+    """It appears beside the Calamares entry on the same desktop, and two rows
+    both reading `Install System` tell the operator nothing about which is
+    which."""
+    desktop = configparser.ConfigParser(interpolation=None)
+    desktop.read_string(ENTRY.read_text())
+    section = desktop["Desktop Entry"]
+
+    assert section["Type"] == "Application"
+    assert section["Terminal"] == "true"
+    assert "text" in section["Name"].lower()
+    # Every language the interface offers, so no locale falls back to a name
+    # that does not say which installer it is.
+    for tag in ("zh_CN", "zh_TW", "ja", "ko"):
+        assert f"Name[{tag}]" in section, tag


### PR DESCRIPTION
`Live-ISO/config` merges Calamares through `EXTRA_PKGS`; this takes the same route with a live ebuild, and adds the two files a live desktop needs: the command at `/usr/local/sbin/gentoo-install` and a desktop entry beside the Calamares one rather than instead of it.

Three things are held by tests. The path is named in `plan/netboot.py` as well — the memory environment's banner prints it — so the ebuild, the launcher and the entry's `Exec` are compared against that constant. The live launcher must not carry `--config`, whose control is that the memory launcher does. And the entry names itself the text installer in all five interface languages, because it appears beside a graphical installer on the same desktop.