### PR TITLE
portage: give the gentoo tree the rest of its region

### DIFF
--- a/gentoo_install/model/mirrors.py
+++ b/gentoo_install/model/mirrors.py
@@ -221,6 +221,15 @@ def gentoo_sync_uri(region: MirrorRegion, preferred: str = "") -> str:
     return next(site.git for site in gentoo_sites(region) if site.git)
 
 
+def gentoo_sync_uris(region: MirrorRegion) -> tuple[str, ...]:
+    """Every git tree the region carries, in the order the menu lists them.
+
+    The chosen site is one of these; a sync that cannot reach it has the rest
+    to try, and each one is a mirror of the same signed history.
+    """
+    return tuple(site.git for site in gentoo_sites(region) if site.git)
+
+
 def gentoo_rsync_uri(region: MirrorRegion, preferred: str = "") -> str:
     """The chosen site's rsync module, then any in the region, then the official
     pool. Never empty: most mirrors carry the files and not an rsync module, and

--- a/gentoo_install/plan/netboot.py
+++ b/gentoo_install/plan/netboot.py
@@ -625,6 +625,16 @@ def _ready_the_environment() -> str:
     )
 
 
+#: The question the delivered profile ends on. `tests/vm/ram.py` waits for
+#: this exact text to decide the configuration arrived, so it is defined here
+#: and imported there: changing the wording in one place alone made every
+#: `--ram` and `--lowram` run time out for a day without anyone noticing.
+ASKS_TO_INSTALL: Final[str] = "install now? [yes/no]"
+
+#: An answer outside `yes|y|install`, which the profile reads as a decline.
+DECLINES: Final[str] = "no"
+
+
 #: Where the command lands, because it is on `PATH` in both environments and
 #: is not part of either distribution's own package set.
 COMMAND: Final[str] = "/usr/local/sbin/gentoo-install"
@@ -702,7 +712,7 @@ def _start(mode: MemoryMode) -> str:
         + wifi
         + f"printf '%s\\n' 'start it later with: {COMMAND}'\n"
         "printf '\\n'\n"
-        "printf 'install now? [yes/no] '\n"
+        f"printf '%s' '{ASKS_TO_INSTALL} '\n"
         "read answer\n"
         'case "$answer" in\n'
         "yes|y|install)\n"

--- a/gentoo_install/plan/portage.py
+++ b/gentoo_install/plan/portage.py
@@ -1457,7 +1457,24 @@ def build(
                 sync_uri=_repo_sync_uri(portage),
                 verify_commits=True,
             ),
-            SyncRepository(name="gentoo", location=gentoo),
+            SyncRepository(
+                name="gentoo",
+                location=gentoo,
+                # The rest of the region, the way an overlay already gets it.
+                # Without them one unreachable host ended the install on
+                # `none of the 1 sites for gentoo could be synced from`, an
+                # hour in, with four more mirrors carrying the same tree.
+                alternates=tuple(
+                    ConfigureRepository(
+                        name="gentoo",
+                        location=gentoo,
+                        sync_uri=uri,
+                        verify_commits=True,
+                    )
+                    for uri in mirrors.gentoo_sync_uris(portage.mirrors.region)
+                    if uri != _repo_sync_uri(portage)
+                ),
+            ),
         ]
     elif portage.sync is Sync.RSYNC:
         # No `dev-vcs/git`: rsync needs none, and the stage3 already has the

--- a/tests/golden/btrfs-luks.txt
+++ b/tests/golden/btrfs-luks.txt
@@ -38,7 +38,7 @@
   select profile default/linux/amd64/23.0/desktop/systemd
   install git, which every later repository sync needs: emerge dev-vcs/git
   point repository gentoo at https://mirrors.ustc.edu.cn/gentoo.git, commit signatures verified
-  sync repository gentoo
+  sync repository gentoo, 4 other sites to fall back on
   point repository gentoo-zh at https://mirrors.cernet.edu.cn/gentoo-zh.git
   sync repository gentoo-zh, 4 other sites to fall back on
   accept ~amd64 for packages from gentoo-zh only

--- a/tests/unit/test_harness.py
+++ b/tests/unit/test_harness.py
@@ -4385,7 +4385,9 @@ def test_the_bypass_runner_reaches_a_shell_before_it_sends_a_command() -> None:
     assert source.index('console.run("reboot"') < left, source
     assert 'for boot in ("first", "second")' in source, source
     answered = inspect.getsource(ram.leave_the_first_screen)
-    assert 'console.send("shell")' in answered, answered
+    # What it sends, not the word it used to send: the profile stopped
+    # accepting `shell` and no test noticed, because this one held the literal.
+    assert "console.send(netboot.DECLINES)" in answered, answered
 
 
 def test_a_conversion_reads_its_exit_code_and_not_the_echo() -> None:

--- a/tests/unit/test_plan_netboot.py
+++ b/tests/unit/test_plan_netboot.py
@@ -1726,3 +1726,22 @@ def test_the_banner_states_the_disk_is_unwritten_rather_than_untouched() -> None
     # The turn of phrase it must not go back to: "has not been moved".
     refused = ("\u88ab\u52d5\u904e", "\u88ab\u52a8\u8fc7")
     assert not [one for one in said if any(bad in one for bad in refused)], said
+
+
+def test_the_question_the_profile_asks_is_the_one_the_harness_waits_for() -> None:
+    """`tests/vm/ram.py` decides the payload arrived by matching the profile's
+    last line. `9e88ecda73ea9` reworded that line and left the harness matching
+    the old text, so every `--ram` and `--lowram` run timed out for a day on a
+    machine that had in fact booted correctly."""
+    import re
+
+    from tests.vm import ram
+
+    for mode in MemoryMode:
+        written = netboot._start(mode)
+        assert netboot.ASKS_TO_INSTALL in written, (mode, written[-300:])
+        assert re.search(ram.PAYLOAD_SPEAKS, written), (mode, ram.PAYLOAD_SPEAKS)
+
+    # The decline the harness types has to miss `yes|y|install`, or answering
+    # it would erase the disk the run is still measuring.
+    assert not re.fullmatch(r"yes|y|install", netboot.DECLINES)

--- a/tests/unit/test_plan_portage.py
+++ b/tests/unit/test_plan_portage.py
@@ -1763,7 +1763,7 @@ def test_an_rsync_install_does_not_fetch_the_tree_twice() -> None:
     synced = [
         one
         for one in operations
-        if isinstance(one, plan_portage.SyncRepository) and one.name == "gentoo"
+        if isinstance(one, portage.SyncRepository) and one.name == "gentoo"
     ]
     assert not synced, [one.describe() for one in operations]
     pointed = [one for one in operations if isinstance(one, plan_portage.ConfigureRepository)]
@@ -2711,3 +2711,49 @@ def test_a_named_repository_is_enabled_after_its_tool_is_merged() -> None:
         for one in plain
         if getattr(one, "packages", ()) == ("app-eselect/eselect-repository",)
     ]
+
+
+def test_the_gentoo_tree_is_offered_the_rest_of_its_region() -> None:
+    """An overlay already gets every mirror the region carries; the tree itself
+    got none. `s1` stopped an hour in on `none of the 1 sites for gentoo could
+    be synced from` with four more mirrors serving the same history."""
+    from gentoo_install.model import mirrors
+
+    built = replace(
+        config(),
+        portage=replace(
+            config().portage,
+            sync=Sync.GIT,
+            mirrors=replace(config().portage.mirrors, region=MirrorRegion.CN, site="ustc"),
+        ),
+    )
+    syncing = [
+        one
+        for one in portage.build(built, MIRROR)
+        if isinstance(one, portage.SyncRepository) and one.name == "gentoo"
+    ]
+    assert len(syncing) == 1, syncing
+    tried = [one.sync_uri for one in syncing[0].alternates]
+    assert tried, "the tree was left with one site"
+    assert "https://mirrors.ustc.edu.cn/gentoo.git" not in tried, tried
+    assert set(tried) < set(mirrors.gentoo_sync_uris(MirrorRegion.CN))
+
+    # Every alternate still verifies: they mirror the same signed history, and
+    # a fallback that quietly stopped checking would be worse than stopping.
+    assert all(one.verify_commits for one in syncing[0].alternates)
+
+    # Negative control: a region with one git tree has no alternate to offer,
+    # so the rule above is not "always at least one".
+    worldwide = replace(
+        built,
+        portage=replace(
+            built.portage,
+            mirrors=replace(built.portage.mirrors, region=MirrorRegion.GLOBAL, site="gentoo"),
+        ),
+    )
+    alone = [
+        one
+        for one in portage.build(worldwide, MIRROR)
+        if isinstance(one, portage.SyncRepository) and one.name == "gentoo"
+    ]
+    assert alone[0].alternates == ()

--- a/tests/vm/cluster.py
+++ b/tests/vm/cluster.py
@@ -4478,7 +4478,7 @@ def main(argv: list[str] | None = None) -> int:
         "--sync",
         choices=[one.value for one in Sync],
         default=Sync.RSYNC.value,
-        help="how every fixture syncs the tree; git needs github, which this network lacks",
+        help="how every fixture syncs the tree; git falls back through the region's mirrors",
     )
     args = parser.parse_args(argv)
 

--- a/tests/vm/ram.py
+++ b/tests/vm/ram.py
@@ -21,6 +21,7 @@ from typing import Final
 
 from gentoo_install.exec.config import load
 from gentoo_install.model.config import InstallConfig
+from gentoo_install.plan import netboot
 from gentoo_install.plan.netboot import ENTRY_LABEL
 
 from .console import ConsoleClosed, ConsoleTimeout, SerialConsole
@@ -52,8 +53,11 @@ CJK_SPEAKS: Final[str] = r"livecd login:|Gentoo Linux Minimal Installation CD"
 ALPINE_SPEAKS: Final[str] = r"Welcome to Alpine Linux|localhost login:"
 
 #: What the delivered payload's own first screen prints. It is the proof the
-#: configuration arrived, not merely that a live medium booted.
-PAYLOAD_SPEAKS: Final[str] = r"install or shell>"
+#: configuration arrived, not merely that a live medium booted. Taken from the
+#: module that writes the profile, never copied: the two drifted apart for a
+#: day and every run in between timed out on text the installer had stopped
+#: printing.
+PAYLOAD_SPEAKS: Final[str] = re.escape(netboot.ASKS_TO_INSTALL)
 
 #: How long the login prompt is given after the medium's banner.
 LOGIN_PATIENCE: Final[float] = 300.0
@@ -289,12 +293,12 @@ def came_up(console: SerialConsole, mode: str) -> str:
 def leave_the_first_screen(console: SerialConsole) -> None:
     """Answer the delivered screen so the console is at a shell again.
 
-    `run()` sends a marked command, and typed at `install or shell>` the whole
-    line is read as the answer: the screen printed `nothing was changed` and
-    the marker never came back, so the second reboot of a `--bypass` run
+    `run()` sends a marked command, and typed at the delivered question the
+    whole line is read as the answer: the screen printed `nothing was changed`
+    and the marker never came back, so the second reboot of a `--bypass` run
     failed at `never matched 'MARK_14_DONE'`.
     """
-    console.send("shell")
+    console.send(netboot.DECLINES)
     console.expect(r"# ", timeout=POST_INSTALL_PATIENCE)
 
 


### PR DESCRIPTION
An overlay already syncs through every mirror the region carries; the tree itself was built with none, so one unreachable host ended the install an hour in on `none of the 1 sites for gentoo could be synced from`. Measured: `s5` synced from USTC with commit signatures verified, so verification does not pin github.

`9e88ecda73ea9` also reworded the memory profile's prompt and left `tests/vm/ram.py` matching the old text, so every `--ram` and `--lowram` run timed out on a machine that had booted correctly. The question now has one definition both sides read.