### PR TITLE
cluster: answer the disk passphrase before the login

### DIFF
--- a/tests/unit/test_harness.py
+++ b/tests/unit/test_harness.py
@@ -5009,3 +5009,67 @@ def test_a_dd_fixture_names_the_runner_that_can_run_it(
     assert "tests.vm.dd" not in also.err, also
     assert "--firmware says uefi" in also.err, also
 
+
+
+def test_the_installed_login_answers_the_disk_before_it_answers_the_login() -> None:
+    """An encrypted root asks dracut's passphrase prompt before anything
+    offers a login. Waiting for `login:` alone spent the whole patience at
+    that prompt and reported `s2` as a machine that never booted."""
+    import re
+
+    from tests.vm import cluster
+    from tests.vm.console import DISK_PASSPHRASE, ConsoleTimeout
+    from tests.vm.proxmox import ProxmoxError
+
+    class Booting:
+        """A console that asks for the passphrase, then offers a login.
+
+        It matches the caller's pattern against what the machine is printing,
+        the way the real one does. A double that answers whatever is asked
+        cannot fail: the first version of this test stayed green with the
+        passphrase alternative taken back out.
+        """
+
+        def __init__(self, prompts: int) -> None:
+            self.left = prompts
+            self.sent: list[str] = []
+
+        def expect(self, pattern: str, timeout: float, idle: float = 0.0) -> bytes:
+            printing = (
+                b"Please enter passphrase for disk vda2:"
+                if self.left
+                else b"localhost login:"
+            )
+            if re.search(pattern.encode(), printing) is None:
+                raise ConsoleTimeout(f"never matched {pattern!r}: {printing!r}")
+            if self.left:
+                self.left -= 1
+            return printing
+
+        def send(self, text: str) -> None:
+            self.sent.append(text)
+
+        def send_raw(self, keys: str) -> None:
+            raise AssertionError("this path types no raw keys")
+
+        def snapshot(self, seconds: float) -> bytes:
+            raise AssertionError("this path reads through expect only")
+
+        def close(self) -> None:
+            return None
+
+        @property
+        def closed(self) -> bool:
+            return False
+
+    for prompts in (0, 1, 3):
+        console = Booting(prompts)
+        cluster.reach_the_login_past_any_passphrase(console)
+        assert console.sent == [DISK_PASSPHRASE] * prompts, console.sent
+
+    # A prompt that never stops is the passphrase being wrong, not a layout
+    # with many devices: it is raised, not answered until the ceiling.
+    forever = Booting(cluster.PASSPHRASE_ATTEMPTS + 1)
+    with pytest.raises(ProxmoxError, match="never offered a login"):
+        cluster.reach_the_login_past_any_passphrase(forever)
+    assert len(forever.sent) == cluster.PASSPHRASE_ATTEMPTS, forever.sent

--- a/tests/unit/test_tui_report.py
+++ b/tests/unit/test_tui_report.py
@@ -445,7 +445,12 @@ def test_a_conversion_runs_inside_the_machine_it_replaces(
     # the second cycle is asserted as a sequence rather than by first index.
     at = done.index("boot_from_disk")
     assert done[at - 1] == "stop" and done[at + 1] == "start", done
-    assert "expect:login:" in done, done
+    # It waits for a login on the installed system, whatever else the same
+    # pattern also covers: an encrypted root asks for its passphrase first,
+    # so the alternation grew and pinning the whole string went stale.
+    assert any(
+        one.startswith("expect:") and one.endswith("login:") for one in done
+    ), done
     # The prompt that covers all three spellings: the installed system comes
     # up in Chinese and asks in Chinese, and an `assword` of its own matched
     # nothing while the password sat unsent.

--- a/tests/vm/cluster.py
+++ b/tests/vm/cluster.py
@@ -2157,9 +2157,30 @@ def _is_uefi(config: Mapping[str, object]) -> bool:
     return any(str(key).startswith("efidisk") for key in config)
 
 
+def reach_the_login_past_any_passphrase(console: Line) -> None:
+    """Wait for `login:`, answering dracut on the way.
+
+    An encrypted root asks for its passphrase before anything offers a login,
+    so waiting for `login:` alone spent the whole patience at dracut's prompt
+    and reported `s2` as a machine that never booted.
+    """
+    for _ in range(PASSPHRASE_ATTEMPTS):
+        seen = console.expect(f"{PASSPHRASE_PROMPT}|login:", INSTALLED_LOGIN_PATIENCE)
+        # What arrived shows a passphrase prompt, rather than what it does not
+        # end in: a console that answers the pattern without echoing the text
+        # would otherwise be read as an endless passphrase.
+        if re.search(PASSPHRASE_PROMPT.encode(), seen) is None:
+            return
+        console.send(DISK_PASSPHRASE)
+    raise ProxmoxError(
+        f"the installed system asked for a passphrase {PASSPHRASE_ATTEMPTS} "
+        "times and never offered a login"
+    )
+
+
 def _log_into_the_installed_system(link: "Reconnecting") -> None:
     """Answer the login the installed system offers on its serial line."""
-    link.console.expect(r"login:", INSTALLED_LOGIN_PATIENCE)
+    reach_the_login_past_any_passphrase(link.console)
     link.console.send("root")
     # The system this drives was built to come up in Chinese, so its own
     # prompt is `\u5bc6\u78bc\uff1a`: an `assword` of its own matched nothing and
@@ -2168,6 +2189,13 @@ def _log_into_the_installed_system(link: "Reconnecting") -> None:
     link.console.expect(PASSWORD_PROMPT, INSTALLED_LOGIN_PATIENCE)
     link.console.send(TUI_PASSWORD)
     reach_prompt(link)
+
+
+#: How many passphrase prompts are answered before the boot is called stuck.
+#: A layout can hold more than one encrypted device, and dracut asks once per
+#: device; a prompt that keeps returning means the passphrase is wrong, and
+#: answering it for ever would hide that behind the patience ceiling.
+PASSPHRASE_ATTEMPTS: Final[int] = 4
 
 
 #: A machine booting its own disk answers sooner than a medium does, and a


### PR DESCRIPTION
An encrypted root asks dracut for its passphrase before anything offers a login, so waiting for `login:` alone spent the whole patience at that prompt and recorded `s2` as a machine that never booted.

The double in the new test matches the pattern its caller passes, the way the real console does; the first version answered whatever was asked and stayed green with the fix taken back out.