### PR TITLE
probe: delete the disk lookup nothing calls

### DIFF
--- a/gentoo_install/exec/probe.py
+++ b/gentoo_install/exec/probe.py
@@ -648,10 +648,6 @@ class Probe:
             raise DeviceNotFound(f"{device} has no UUID; was it formatted?")
         return uuid
 
-    def disk_of(self, device: DeviceId) -> str:
-        """The whole disk a partition sits on, which is what a bootloader wants."""
-        return self.disk_of_path(self.path_of(device))
-
     def disk_of_path(self, path: str) -> str:
         """The same answer for a path already in hand.
 

--- a/tests/unit/test_exec.py
+++ b/tests/unit/test_exec.py
@@ -1475,7 +1475,7 @@ def test_the_bootloader_disk_of_a_reused_partition_is_the_disk(tmp_path: Path) -
         base(), disk=DiskConfig(graph=DeviceGraph.build(nodes), root=DeviceId("root"))
     )
     # A real Probe over a runner that answers `lsblk`, not a monkeypatched
-    # `disk_of`: patching the method under test hid that the production path
+    # lookup: patching the method under test hid that the production path
     # asked for a cached path `resolve()` never writes.
     asked: list[list[str]] = []
 

--- a/tests/unit/test_layers.py
+++ b/tests/unit/test_layers.py
@@ -924,3 +924,13 @@ def test_no_test_writes_its_artifacts_inside_the_checkout() -> None:
             if first.value.startswith("lab/"):
                 written.append(f"{one.relative_to(root)}:{node.lineno}")
     assert not written, f"an artifact path relative to the checkout: {written}"
+
+
+def test_the_probe_offers_no_lookup_nothing_calls() -> None:
+    """`Probe.disk_of` wrapped `disk_of_path` and had no caller: the
+    bootloader route calls `disk_of_path` directly. A second spelling of one
+    lookup is a second place for a device-graph question to be asked."""
+    from gentoo_install.exec.probe import Probe
+
+    assert not hasattr(Probe, "disk_of"), "nothing called it when it was deleted"
+    assert hasattr(Probe, "disk_of_path"), "the one the production path uses"


### PR DESCRIPTION
`Probe.disk_of` wrapped `disk_of_path` and had no caller; the bootloader route at `exec/apply.py:247` calls `disk_of_path` directly. A second spelling of one lookup is a second place for a device-graph question to be asked.