### PR TITLE
netboot: read the question from the module that writes it

### DIFF
--- a/tests/unit/test_plan_netboot.py
+++ b/tests/unit/test_plan_netboot.py
@@ -771,7 +771,7 @@ def test_the_live_system_asks_before_it_erases_anything() -> None:
         PurePosixPath(f"{ESP}/{netboot.PLACE}/payload{netboot.PAYLOAD}/start.sh")
     ]
     assert "read answer" in start, start
-    assert "install now? [yes/no]" in start, start
+    assert netboot.ASKS_TO_INSTALL in start, start
     # The banner names the command, because answering `no` must not make
     # rebooting the only way back to the offer.
     assert netboot.COMMAND in start, start
@@ -1291,7 +1291,7 @@ def test_the_first_screen_asks_and_leaves_the_login_shell_alive(
     where = _payload_at(tmp_path, monkeypatch)
 
     said = _sourced(where, "yes")
-    assert "install now? [yes/no]" in said, said
+    assert netboot.ASKS_TO_INSTALL in said, said
     assert "BOOTSTRAP" in said and "--config" in said, said
     assert "LOGIN-SHELL-ALIVE" in said, said
 


### PR DESCRIPTION
Two assertions in `tests/unit/test_plan_netboot.py` still held the profile's wording as a literal, so a deliberate reword fails in three unrelated places instead of one. `ASKS_TO_INSTALL` is already the single definition both `_start()` and `tests/vm/ram.py` read.