### PR TITLE
model: name the layout a conversion has not read yet

### DIFF
--- a/gentoo_install/cli.py
+++ b/gentoo_install/cli.py
@@ -461,7 +461,7 @@ def _once(arguments: argparse.Namespace, state: RunState, refused: str) -> int |
         storage_facts = StorageFacts()
         loader_v3: bool | None = None
         layout: StorageLayout | None = None
-        if config.disk.mode is DiskMode.IN_PLACE:
+        if config.disk.layout_is_read_from_the_machine:
             # Even for a dry run: a conversion's whole plan is derived from the
             # running machine, so without this there is nothing to print.
             layout = Probe(

--- a/gentoo_install/model/compat.py
+++ b/gentoo_install/model/compat.py
@@ -444,7 +444,7 @@ def traits_of(
     # through UEFI, and the graph here is empty until then. Asked anyway, the
     # menu refused every UEFI machine with `uefi boot` against `no mounted esp`
     # and the operator had no row that could answer it.
-    if config.disk.mode is not DiskMode.IN_PLACE and esp_mount(graph) is None:
+    if not config.disk.layout_is_read_from_the_machine and esp_mount(graph) is None:
         found.add(Trait.NO_MOUNTED_ESP)
     # GRUB alone, and for two different reasons. systemd-boot reads the kernel
     # off the esp, which is never in the container. ZFSBootMenu does keep the

--- a/gentoo_install/model/config.py
+++ b/gentoo_install/model/config.py
@@ -516,6 +516,18 @@ class DiskConfig:
     source_format: ImageFormat = ImageFormat.RAW
     destination: str = ""
 
+    @property
+    def layout_is_read_from_the_machine(self) -> bool:
+        """Whether `graph` is a placeholder a conversion fills in later.
+
+        Not the mode alone: `plan/build._in_place()` derives a populated
+        configuration through `plan/convert.layout_graph()` and leaves the
+        mode as it found it, so a graph that has been read still answers
+        `IN_PLACE`. What every caller means is that `root` names nothing yet,
+        and seven of them each spelled that out before it had a name.
+        """
+        return self.mode is DiskMode.IN_PLACE and not self.root
+
 
 @dataclass(frozen=True)
 class PackagesConfig:

--- a/gentoo_install/model/serialise.py
+++ b/gentoo_install/model/serialise.py
@@ -162,7 +162,7 @@ def _simple(choice: Choice) -> list[str]:
 def _disk(config: InstallConfig) -> list[str]:
     disk = config.disk
     lines = ["", "[disk]"]
-    if disk.mode is DiskMode.IN_PLACE:
+    if disk.layout_is_read_from_the_machine:
         lines.append(f'mode = "{disk.mode.value}"')
         return lines
     if disk.mode is DiskMode.DD:

--- a/gentoo_install/model/validate.py
+++ b/gentoo_install/model/validate.py
@@ -241,7 +241,7 @@ def validate(
             *(rule.describe() for rule in compat.violations(config, storage_facts)),
         ]
     without_a_graph: list[str] = []
-    if config.disk.mode is DiskMode.IN_PLACE:
+    if config.disk.layout_is_read_from_the_machine:
         without_a_graph = [
             rule.describe() for rule in compat.violations_without_a_graph(config)
         ]

--- a/gentoo_install/plan/build.py
+++ b/gentoo_install/plan/build.py
@@ -91,7 +91,7 @@ def running_config(config: InstallConfig, layout: StorageLayout | None) -> Insta
     own configuration — `write /etc/fstab` stopped twenty-four operations in
     with `no node with id 'running-root-device'`.
     """
-    if config.disk.mode is not DiskMode.IN_PLACE:
+    if not config.disk.layout_is_read_from_the_machine:
         return config
     if layout is None:
         raise ConversionUnsupported("the running layout was not read")
@@ -109,7 +109,7 @@ def build(
 ) -> tuple[Operation, ...]:
     """Validate, then derive the whole install. Nothing here touches a machine."""
     facts = storage_facts if storage_facts is not None else StorageFacts()
-    if config.disk.mode is DiskMode.IN_PLACE:
+    if config.disk.layout_is_read_from_the_machine:
         return _in_place(config, catalog, mirror, layout, supports_v3)
     validate(config, storage_facts=facts, supports_v3=supports_v3)
     if config.disk.mode is DiskMode.DD:

--- a/gentoo_install/plan/kernel.py
+++ b/gentoo_install/plan/kernel.py
@@ -13,7 +13,7 @@ from pathlib import PurePosixPath
 from typing import Final
 
 from ..model.config import Bootloader, InitSystem, InstallConfig, KernelSource
-from ..errors import ConfigError, NothingToBoot, ValidationFailed
+from ..errors import ConfigError, ConversionUnsupported, NothingToBoot, ValidationFailed
 from ..model import compat
 from ..model.compat import CJK_KERNELS, KERNEL_PACKAGES
 from ..model.validate import zfs_kernel_version_problem
@@ -582,6 +582,12 @@ class RequestDistKernelModules(Operation):
 
 
 def build(config: InstallConfig) -> list[Operation]:
+    # The graph is empty until `plan/convert.layout_graph()` reads the machine,
+    # and every filesystem module and package here is derived from it: planning
+    # from the placeholder produces a system with no tools for its own root.
+    if config.disk.layout_is_read_from_the_machine:
+        raise ConversionUnsupported("the running layout was not read")
+
     graph = config.disk.graph
     modules = dracut_modules(config)
     entries = config.bootloader.kind is Bootloader.SYSTEMD_BOOT

--- a/gentoo_install/plan/system.py
+++ b/gentoo_install/plan/system.py
@@ -12,7 +12,7 @@ from pathlib import PurePosixPath
 from types import MappingProxyType
 from typing import Final, Mapping
 
-from ..errors import InvalidLayout, LocaleMissing
+from ..errors import ConversionUnsupported, InvalidLayout, LocaleMissing
 from ..model import compat
 from ..model.config import (
     ConsoleFontSize,
@@ -1047,6 +1047,12 @@ class EnableService(Operation):
 
 
 def build(config: InstallConfig) -> list[Operation]:
+    # The graph is empty until `plan/convert.layout_graph()` reads the machine,
+    # and every filesystem module and package here is derived from it: planning
+    # from the placeholder produces a system with no tools for its own root.
+    if config.disk.layout_is_read_from_the_machine:
+        raise ConversionUnsupported("the running layout was not read")
+
     system = config.system
     operations: list[Operation] = [
         *([WriteProxyEnvironment(proxy=config.proxy)] if config.proxy.enabled else []),

--- a/gentoo_install/tui/settings.py
+++ b/gentoo_install/tui/settings.py
@@ -750,7 +750,7 @@ def _the_conversion_writes_no_layout(config: InstallConfig, context: Context) ->
     it runs on, and `validate()` refuses one written by hand. The rows stay
     visible and say why rather than disappearing, or an operator who switched
     mode by accident sees a menu that lost a row and no reason."""
-    if config.disk.mode is DiskMode.IN_PLACE:
+    if config.disk.layout_is_read_from_the_machine:
         return context.translate("the conversion takes the layout from the running system")
     return ""
 

--- a/tests/unit/test_layers.py
+++ b/tests/unit/test_layers.py
@@ -15,6 +15,8 @@ from collections.abc import Iterator, Mapping
 from pathlib import Path
 from typing import Final
 
+import pytest
+
 PACKAGE = Path(__file__).resolve().parents[2] / "gentoo_install"
 HARNESS = Path(__file__).resolve().parents[1] / "vm"
 
@@ -934,3 +936,75 @@ def test_the_probe_offers_no_lookup_nothing_calls() -> None:
 
     assert not hasattr(Probe, "disk_of"), "nothing called it when it was deleted"
     assert hasattr(Probe, "disk_of_path"), "the one the production path uses"
+
+
+def test_every_builder_refuses_a_conversion_whose_layout_is_unread() -> None:
+    """A conversion's graph is empty until `plan/convert.layout_graph()` reads
+    the machine, and `plan/build._in_place()` is the only caller allowed to
+    derive a populated configuration from it. Seven callers each asked the
+    placeholder a question instead; the invariant that stops the eighth is
+    that a builder handed the unread configuration refuses rather than
+    inventing an answer for an empty graph."""
+    from dataclasses import replace
+
+    from gentoo_install.errors import GentooInstallError
+    from gentoo_install.model.config import DiskMode
+    from gentoo_install.model.device import DeviceGraph, DeviceId
+    from gentoo_install.plan import bootloader, kernel, system
+
+    from .layouts import config as a_config
+
+    unread = replace(
+        a_config(),
+        disk=replace(
+            a_config().disk,
+            mode=DiskMode.IN_PLACE,
+            graph=DeviceGraph.build([]),
+            root=DeviceId(""),
+        ),
+    )
+    assert unread.disk.layout_is_read_from_the_machine
+
+    # One entry per builder `plan/build._in_place()` hands the derived
+    # configuration to. A builder added there is added here, and the first
+    # thing this test asks of it is whether it can tell the two apart.
+    builders = (
+        ("bootloader.build", bootloader.build),
+        ("bootloader.boot_facts", bootloader.boot_facts),
+        ("kernel.build", kernel.build),
+        ("system.build", system.build),
+    )
+    answered = []
+    for name, builder in builders:
+        try:
+            builder(unread)
+        except (GentooInstallError, KeyError, LookupError):
+            continue
+        answered.append(name)
+    assert not answered, f"answered a question about an empty graph: {answered}"
+
+
+def test_the_planner_is_the_only_route_a_conversion_takes() -> None:
+    """`plan.build()` refuses without the layout rather than planning from the
+    placeholder, so the refusal above is never what a caller sees."""
+    from dataclasses import replace
+
+    from gentoo_install.data import load_catalog
+    from gentoo_install.errors import ConversionUnsupported
+    from gentoo_install.model.config import DiskMode
+    from gentoo_install.model.device import DeviceGraph, DeviceId
+    from gentoo_install.plan.build import build
+
+    from .layouts import config as a_config
+
+    unread = replace(
+        a_config(),
+        disk=replace(
+            a_config().disk,
+            mode=DiskMode.IN_PLACE,
+            graph=DeviceGraph.build([]),
+            root=DeviceId(""),
+        ),
+    )
+    with pytest.raises(ConversionUnsupported, match="running layout"):
+        build(unread, load_catalog())


### PR DESCRIPTION
Seven callers each spelled out that a conversion's graph is a placeholder until `plan/convert.layout_graph()` reads the machine. `DiskConfig.layout_is_read_from_the_machine` is that question once.

Only the callers asking about the graph changed; `cli.py:589`, `screens.py:158` and `preflight.py:514` ask about the mode itself and still compare the enum.

The test that enumerates the builders found two that planned from the placeholder rather than refusing: `kernel.build` and `system.build` derived no filesystem module or package for the running root.