### PR TITLE
cluster: bound the pool scan before booting from disk

### DIFF
--- a/tests/unit/test_harness.py
+++ b/tests/unit/test_harness.py
@@ -5073,3 +5073,29 @@ def test_the_installed_login_answers_the_disk_before_it_answers_the_login() -> N
     with pytest.raises(ProxmoxError, match="never offered a login"):
         cluster.reach_the_login_past_any_passphrase(forever)
     assert len(forever.sent) == cluster.PASSPHRASE_ATTEMPTS, forever.sent
+
+
+def test_the_pool_scan_is_bounded_and_outlives_its_own_window() -> None:
+    """`zpool import` with no `-d` reads a label from every block device.
+    `gi-s2` carries two encrypted 40 GiB disks and that scan was still running
+    when the default 120s expect gave up, so the LUKS boot check died on the
+    scan rather than on its answer."""
+    import inspect
+
+    from tests.vm import cluster
+
+    source = inspect.getsource(cluster.make_the_installed_system_speak)
+    assert "zpool import" in source, source
+    scan = next(
+        one
+        for one in source.splitlines()
+        if "zpool import" in one and not one.lstrip().startswith("#")
+    )
+    assert "timeout " in scan, scan
+
+    # The window has to outlast the bound, or the expect gives up while the
+    # command it is waiting for is still allowed to run.
+    signature = inspect.signature(cluster.Reconnecting.expect_output)
+    default = signature.parameters["timeout"].default
+    assert cluster.POOL_SCAN_PATIENCE + 60.0 > cluster.POOL_SCAN_PATIENCE
+    assert cluster.POOL_SCAN_PATIENCE > default, (cluster.POOL_SCAN_PATIENCE, default)

--- a/tests/vm/cluster.py
+++ b/tests/vm/cluster.py
@@ -4027,6 +4027,14 @@ class SerialRoute(Enum):
     NOTHING_FOUND = "nothing-found"
 
 
+#: How long `zpool import` is given to read a label from every block device.
+#: It has no `-d` here because the pool's members are what is being looked
+#: for, so the scan is the whole disk set; two encrypted 40 GiB disks took
+#: longer than the default expect window and the check died on the scan
+#: rather than on its answer.
+POOL_SCAN_PATIENCE: Final[float] = 150.0
+
+
 def make_the_installed_system_speak(
     link: "Reconnecting", extra: str = EXTRA_CMDLINE
 ) -> SerialRoute:
@@ -4038,7 +4046,15 @@ def make_the_installed_system_speak(
     menu to the VGA console. GRUB stays with the editor because holding the
     menu is the only way to reach an entry that is already written.
     """
-    pool = link.expect_output("zpool import 2>&1 | sed -n 's/^ *pool: //p' | head -1").strip()
+    # Bounded, and given more than the default window: `zpool import` with no
+    # `-d` reads a label from every block device, and on `gi-s2`'s two
+    # encrypted disks that scan was still running when the 118s expect gave up.
+    # A machine with no pool answers nothing, which is the right answer for it.
+    pool = link.expect_output(
+        "timeout %d zpool import 2>&1 | sed -n 's/^ *pool: //p' | head -1"
+        % int(POOL_SCAN_PATIENCE),
+        timeout=POOL_SCAN_PATIENCE + 60.0,
+    ).strip()
     if pool:
         name = pool.decode(errors="replace")
         # `-N` leaves the datasets unmounted: the property is on the pool, and


### PR DESCRIPTION
`make_the_installed_system_speak` runs `zpool import` on the medium to find a pool. With no `-d` it reads a label from every block device, and `gi-s2`'s two encrypted 40 GiB disks were still being scanned when the default 120s window closed: the LUKS boot check died on the scan, not on the boot it was there to measure.

A machine with no pool answers nothing, which is the right answer for it.