### PR TITLE
tui: plan the overview with the machine it converts

### DIFF
--- a/gentoo_install/tui/overview.py
+++ b/gentoo_install/tui/overview.py
@@ -45,7 +45,11 @@ def overview_screen(
     """Show the operation sequence and ask for final confirmation."""
     translate = context.translate
     try:
-        operations = plan_build(config, context.groups)
+        # With the machine's own layout, the way `app._blocked` plans: a
+        # conversion's graph is derived from it, and asked without one this
+        # screen answered `the running layout was not read` and cancelled,
+        # so no conversion could ever be started from the menu.
+        operations = plan_build(config, context.groups, layout=context.running_layout)
     except GentooInstallError as error:
         say(screen, context, str(error).splitlines()[-1].strip())
         return Answer(Outcome.CANCELLED)

--- a/tests/unit/test_automatic.py
+++ b/tests/unit/test_automatic.py
@@ -805,9 +805,9 @@ def test_the_overview_renders_an_unconverted_operation(monkeypatch: pytest.Monke
             raise AssertionError(operation_context)
 
     def only_unconverted(
-        installation: InstallConfig, groups: object
+        installation: InstallConfig, groups: object, *, layout: object = None
     ) -> list[Operation]:
-        del installation, groups
+        del installation, groups, layout
         return [UnconvertedOperation()]
 
     monkeypatch.setattr(overview, "plan_build", only_unconverted)

--- a/tests/unit/test_layers.py
+++ b/tests/unit/test_layers.py
@@ -1045,3 +1045,34 @@ def test_offering_a_conversion_and_reading_its_layout_are_one_answer() -> None:
         )
         offered += takes_it
     assert offered == 1, f"{offered} returns offer the conversion"
+
+
+def test_no_screen_plans_without_the_machine_it_is_planning_for() -> None:
+    """A conversion's graph comes from `context.running_layout`, so every
+    `plan.build` under `tui/` has to pass it. `#917` fixed `app._blocked` and
+    left `overview.py` planning without it, so pressing Install answered `the
+    running layout was not read` and cancelled: no conversion could be started
+    from the menu at all, while every `--config` run converted fine."""
+    import ast
+
+    from pathlib import Path as _Path
+
+    root = _Path(__file__).resolve().parents[2] / "gentoo_install" / "tui"
+    unplanned = []
+    for source in sorted(root.glob("*.py")):
+        tree = ast.parse(source.read_text())
+        for node in ast.walk(tree):
+            if not isinstance(node, ast.Call):
+                continue
+            name = node.func.id if isinstance(node.func, ast.Name) else ""
+            if name not in {"build", "plan_build"}:
+                continue
+            # `DeviceGraph.build` and the template builders are other calls of
+            # the same name; only the planner takes a catalog as its second
+            # argument, so the layout keyword is what identifies this one.
+            if len(node.args) < 2:
+                continue
+            if any(word.arg == "layout" for word in node.keywords):
+                continue
+            unplanned.append(f"{source.name}:{node.lineno}")
+    assert not unplanned, f"plans without the running layout: {unplanned}"


### PR DESCRIPTION
`overview.py` planned without `context.running_layout`, so in conversion mode the Install screen raised `the running layout was not read` and cancelled. No conversion could be started from the menu at all, while every `--config` run converted fine — that path never opens the overview.

`#917` fixed the same omission in `app._blocked`. The test walks every `build` call under `tui/` rather than pinning this one line, because the eighth site of a defect that had seven is not a surprise.