### PR TITLE
i18n: translate the font screen's own title

### DIFF
--- a/gentoo_install/data/locale/ja.toml
+++ b/gentoo_install/data/locale/ja.toml
@@ -545,6 +545,7 @@
 "Write /etc/xdg/kwinrc and the Fcitx profile for: {engines}." = "/etc/xdg/kwinrc と Fcitx の設定を書き込み、{engines} を指定します。"
 "Write the Fcitx profile and input environment for: {engines}." = "Fcitx の設定と入力環境を書き込み、{engines} を指定します。"
 "Write the IBus input environment." = "IBus の入力環境を書き込みます。"
+"Font configuration" = "フォント設定"
 "Write {path}; {face} will lead sans-serif." = "{path} を書き込み、sans-serif は {face} を先頭にします。"
 "installed" = "インストール"
 "installed and preferred" = "インストールして優先"

--- a/gentoo_install/data/locale/ko.toml
+++ b/gentoo_install/data/locale/ko.toml
@@ -545,6 +545,7 @@
 "Write /etc/xdg/kwinrc and the Fcitx profile for: {engines}." = "/etc/xdg/kwinrc 와 Fcitx 설정을 작성하고 {engines} 를 지정합니다."
 "Write the Fcitx profile and input environment for: {engines}." = "Fcitx 설정과 입력 환경을 작성하고 {engines} 를 지정합니다."
 "Write the IBus input environment." = "IBus 입력 환경을 작성합니다."
+"Font configuration" = "글꼴 설정"
 "Write {path}; {face} will lead sans-serif." = "{path} 를 작성하며 sans-serif 는 {face} 가 이끕니다."
 "installed" = "설치"
 "installed and preferred" = "설치하고 기본으로 지정"

--- a/gentoo_install/data/locale/zh-CN.toml
+++ b/gentoo_install/data/locale/zh-CN.toml
@@ -546,6 +546,7 @@
 "Write /etc/xdg/kwinrc and the Fcitx profile for: {engines}." = "写入 /etc/xdg/kwinrc 与 Fcitx 配置文件，指定：{engines}。"
 "Write the Fcitx profile and input environment for: {engines}." = "写入 Fcitx 配置文件与输入环境，指定：{engines}。"
 "Write the IBus input environment." = "写入 IBus 的输入环境。"
+"Font configuration" = "字体设置"
 "Write {path}; {face} will lead sans-serif." = "写入 {path}；sans-serif 由 {face} 领头。"
 "installed" = "已安装"
 "installed and preferred" = "已安装并设为首选"

--- a/gentoo_install/data/locale/zh-TW.toml
+++ b/gentoo_install/data/locale/zh-TW.toml
@@ -546,6 +546,7 @@
 "Write /etc/xdg/kwinrc and the Fcitx profile for: {engines}." = "寫入 /etc/xdg/kwinrc 與 Fcitx 設定檔，指定：{engines}。"
 "Write the Fcitx profile and input environment for: {engines}." = "寫入 Fcitx 設定檔與輸入環境，指定：{engines}。"
 "Write the IBus input environment." = "寫入 IBus 的輸入環境。"
+"Font configuration" = "字型設定"
 "Write {path}; {face} will lead sans-serif." = "寫入 {path}；sans-serif 由 {face} 領頭。"
 "installed" = "已安裝"
 "installed and preferred" = "已安裝並設為首選"

--- a/tests/unit/test_i18n.py
+++ b/tests/unit/test_i18n.py
@@ -278,6 +278,14 @@ def displayed() -> set[str]:
             if called == "footer" and len(node.args) > 1:
                 if isinstance(node.args[1], ast.Constant):
                     found.add(str(node.args[1].value))
+            # `_consent_screen(screen, config, context, "Font configuration",
+            # summary)`: its fourth argument is the title and it calls
+            # `translate(title)` itself. Without this the collector could not
+            # see that title at all, so `Font configuration` drew in English
+            # on four translated screens and this test stayed green.
+            if called == "_consent_screen" and len(node.args) > 3:
+                if isinstance(node.args[3], ast.Constant):
+                    found.add(str(node.args[3].value))
     return found
 
 


### PR DESCRIPTION
`Font configuration` reached four translated screens in English. The test that exists to catch exactly that could not see it: `displayed()` collects `translate(...)`, `Setting(...)` and `footer(...)`, and `_consent_screen` is a fourth wrapper that translates its title itself.

Adding the key alone would have made the test fail the other way, as a key nothing shows. The collector had to learn the wrapper first.