### PR TITLE
cluster: replace the resolver file rather than write through it

### DIFF
--- a/tests/unit/test_harness.py
+++ b/tests/unit/test_harness.py
@@ -5144,3 +5144,24 @@ def _a_conversion() -> "InstallConfig":
     from tests.unit.layouts import config
 
     return config()
+
+
+def test_the_resolver_file_replaces_the_symlink_and_the_daemon_that_owns_it() -> None:
+    """On an installed systemd system `/etc/resolv.conf` points into
+    `/run/systemd/resolve/`, so writing through it lasts until the daemon
+    rewrites its own file. The eighth conversion's guest reached the gateway
+    and `223.5.5.5` and still answered `fail fail fail fail fail` to every
+    lookup of `mirrors.ustc.edu.cn`."""
+    from tests.vm import cluster
+
+    written = cluster.use_our_resolvers()
+    at = written.index("> /etc/resolv.conf")
+    before = written[:at]
+    assert "rm -f /etc/resolv.conf" in before, written
+    assert "systemd-resolved" in before, written
+    # The removal comes after the daemon is stopped, or the daemon puts a new
+    # symlink back between the two commands.
+    assert before.index("systemd-resolved") < before.index("rm -f"), written
+    # And every failure is tolerated: the medium runs neither init system's
+    # service manager and must not stop on that.
+    assert before.count("2>/dev/null") >= 2, written

--- a/tests/vm/cluster.py
+++ b/tests/vm/cluster.py
@@ -1080,7 +1080,17 @@ def use_our_resolvers() -> str:
     resolvers = f"options no-aaaa {RESOLVER_OPTIONS}\\n" + "".join(
         f"nameserver {one}\\n" for one in GUEST_RESOLVERS
     )
-    return f"printf '{resolvers}' > /etc/resolv.conf"
+    # The daemon first, and the symlink after it: on an installed systemd
+    # system `/etc/resolv.conf` points into `/run/systemd/resolve/`, so this
+    # printf wrote through the link and `systemd-resolved` put its own file
+    # back. The converted guest reached `10.31.0.254` and `223.5.5.5` and
+    # still answered `fail fail fail fail fail` to every lookup.
+    return (
+        "systemctl stop systemd-resolved 2>/dev/null; "
+        "rc-service systemd-resolved stop 2>/dev/null; "
+        "rm -f /etc/resolv.conf; "
+        f"printf '{resolvers}' > /etc/resolv.conf"
+    )
 
 
 #: Where the keeper records each time it had to put the address back. The


### PR DESCRIPTION
`use_our_resolvers()` wrote `/etc/resolv.conf` with a printf. On a live medium that is a plain file; on an installed systemd system it points into `/run/systemd/resolve/` and `systemd-resolved` owns what ends up there.

`#929` made the conversion path configure the installed system it starts the installer inside, which is the first time this function ran anywhere but a medium.

The daemon is stopped before the link is removed, or it puts a new one back between the two commands.