### PR TITLE
cluster: derive the probe's budgets from what it waits for

### DIFF
--- a/tests/unit/test_cluster.py
+++ b/tests/unit/test_cluster.py
@@ -2040,9 +2040,13 @@ def test_the_probe_costs_less_than_its_own_budget() -> None:
         + 3 * 2
         + cluster.KEYSERVER_PATIENCE
     )
-    # Against the 120s the three call sites give it, with room for the `ip`
-    # and `dmesg` reads that follow.
-    assert worst < 90, worst
+    # Against what the call site actually gives it, with room for the `ip` and
+    # `dmesg` reads that follow. Both numbers are derived from the same
+    # `LOOKUP_PATIENCE`, so an absolute ceiling is what keeps the probe from
+    # growing: it is read three times per install and once ended every run it
+    # was measuring.
+    assert worst + 20 < cluster.PROBE_PATIENCE, (worst, cluster.PROBE_PATIENCE)
+    assert cluster.PROBE_PATIENCE <= 180.0, cluster.PROBE_PATIENCE
     assert subprocess.run(["bash", "-n", "-c", probe], capture_output=True).returncode == 0
 
 

--- a/tests/unit/test_harness.py
+++ b/tests/unit/test_harness.py
@@ -5165,3 +5165,25 @@ def test_the_resolver_file_replaces_the_symlink_and_the_daemon_that_owns_it() ->
     # And every failure is tolerated: the medium runs neither init system's
     # service manager and must not stop on that.
     assert before.count("2>/dev/null") >= 2, written
+
+
+def test_the_lookup_budget_outlasts_every_resolver_in_the_list() -> None:
+    """`RESOLVER_OPTIONS` gives each resolver `attempts` tries of `timeout`
+    seconds, so a list whose first entries are down costs that much before the
+    working one is reached. At 3 seconds the probe could not outlast one dead
+    resolver: the eighth conversion's guest answered `fail fail fail fail fail`
+    while it held a route to `10.31.0.254` and `223.5.5.5`, and reading that as
+    a broken resolver sent the diagnosis after the wrong thing."""
+    from tests.vm import cluster
+
+    settings = dict(
+        one.split(":", 1)
+        for one in cluster.RESOLVER_OPTIONS.split()
+        if ":" in one
+    )
+    worst = (
+        len(cluster.GUEST_RESOLVERS)
+        * int(settings["attempts"])
+        * int(settings["timeout"])
+    )
+    assert cluster.LOOKUP_PATIENCE > worst, (cluster.LOOKUP_PATIENCE, worst)

--- a/tests/vm/cluster.py
+++ b/tests/vm/cluster.py
@@ -943,11 +943,30 @@ KEY_SERVER_HOST: Final[str] = urllib.parse.urlparse(KEY_SERVER).hostname or KEY_
 #: and their installs never started.
 RESOLVER_OPTIONS: Final[str] = "timeout:1 attempts:2"
 
+
+def _resolver_worst_case() -> int:
+    """How long every resolver in the list can take before one of them answers.
+
+    Read out of `RESOLVER_OPTIONS` rather than restated, so raising `attempts`
+    cannot quietly make the probe's budget too small again.
+    """
+    settings = dict(
+        one.split(":", 1) for one in RESOLVER_OPTIONS.split() if ":" in one
+    )
+    return len(GUEST_RESOLVERS) * int(settings["attempts"]) * int(settings["timeout"])
+
 #: What each lookup in the probe is given. A resolver that has stopped
 #: answering makes `getent` wait for its own timeout, and ten of them cost more
 #: than the probe's whole budget: five guests of run61 were ended at three
 #: minutes with `LOOKUPS_ANY ok fail` as the last line and no install started.
-LOOKUP_PATIENCE: Final[int] = 3
+#:
+#: Derived rather than chosen: `RESOLVER_OPTIONS` gives each resolver
+#: `attempts` tries of `timeout` seconds, so a list whose first entries are
+#: down costs that much before the working one is reached. At 3 seconds the
+#: probe could not outlast one dead resolver, and the eighth conversion's
+#: guest answered `fail fail fail fail fail` while it held a route to
+#: `10.31.0.254` and `223.5.5.5`.
+LOOKUP_PATIENCE: Final[int] = _resolver_worst_case() + 2
 
 #: Asked once the network is up, because every round so far has failed at the
 #: stage3 while `/etc/resolv.conf` named a resolver nobody had proved the guest
@@ -1836,6 +1855,15 @@ def _reserve_job(
     raise conflict
 
 
+#: What the whole probe is given, derived from what it can wait for rather
+#: than chosen: twelve bounded lookups, three pings and one keyserver connect.
+#: A fixed 120 held while `LOOKUP_PATIENCE` was too small to outlast a dead
+#: resolver, and raising that made the two numbers disagree.
+PROBE_PATIENCE: Final[float] = float(
+    12 * LOOKUP_PATIENCE + 3 * 2 + KEYSERVER_PATIENCE + 30
+)
+
+
 def _note_the_probe(link: Reconnecting, when: str) -> None:
     """Measure the network, and never make the measurement the verdict.
 
@@ -1846,7 +1874,7 @@ def _note_the_probe(link: Reconnecting, when: str) -> None:
     on a resolver that had stopped answering.
     """
     try:
-        link.run(REACHABILITY_PROBE, timeout=120.0)
+        link.run(REACHABILITY_PROBE, timeout=PROBE_PATIENCE)
     except (ConsoleTimeout, ConsoleClosed) as error:
         print(f"the {when} reachability probe did not answer: {error}", flush=True)
 


### PR DESCRIPTION
`LOOKUP_PATIENCE` was 3 while `RESOLVER_OPTIONS` gives each of three resolvers two one-second tries: a list whose first entry is down costs six seconds, so `timeout 3 getent` reported `fail` on a guest holding a route to `10.31.0.254` and `223.5.5.5`. The eighth conversion's diagnosis went after that reading.

Raising it broke the opposite bound, which exists because the probe once ended every run it was measuring. Both are now computed from the same numbers, and the test keeps an absolute ceiling as well — two figures derived from one constant would otherwise only ever agree with themselves.