### PR TITLE
cluster: have the probe print what it looked up with

### DIFF
--- a/tests/unit/test_cluster.py
+++ b/tests/unit/test_cluster.py
@@ -3967,3 +3967,21 @@ def test_a_commented_getty_does_not_count_as_a_login() -> None:
     # The control for this rule is
     # `test_a_root_that_already_has_a_serial_getty_is_left_alone`, which feeds
     # the same check an uncommented entry and asserts nothing is appended.
+
+
+def test_the_probe_records_what_the_lookups_were_asked_with() -> None:
+    """A converted guest answered `fail` to five lookups while it held a route
+    to the gateway and to `223.5.5.5`, and neither the resolver list nor the
+    order glibc consults was anywhere in the log. `nsswitch.conf` matters as
+    much as `resolv.conf`: a `hosts:` line that returns before `dns` makes a
+    correct resolver file irrelevant, and three rounds were spent guessing
+    which of the two it was."""
+    probe = cluster.REACHABILITY_PROBE
+    assert "/etc/resolv.conf" in probe, probe
+    assert "/etc/nsswitch.conf" in probe, probe
+    # Read, not only named: a probe that mentions the file without printing it
+    # leaves the reader exactly where they were.
+    assert "RESOLVCONF " in probe and "NSSWITCH " in probe, probe
+    # Absent is an answer too. A guest with no resolver file at all is the
+    # case the lookups cannot distinguish from a resolver that says nothing.
+    assert probe.count("printf 'absent'") >= 2, probe

--- a/tests/vm/cluster.py
+++ b/tests/vm/cluster.py
@@ -998,6 +998,16 @@ REACHABILITY_PROBE: Final[str] = (
     f"timeout {KEYSERVER_PATIENCE} bash -c '</dev/tcp/{KEY_SERVER_HOST}/443' 2>/dev/null "
     "&& printf 'open' || printf 'refused'; "
     "printf '\\nLIBC '; getconf GNU_LIBC_VERSION; "
+    # What the lookups were asked with, not only whether they worked: a
+    # converted guest answered `fail` five times with a route to the gateway
+    # and to `223.5.5.5`, and neither the resolver list nor the order glibc
+    # consults was anywhere in the log. `nsswitch.conf` matters as much as
+    # `resolv.conf`: a `hosts:` line that returns before `dns` makes a correct
+    # resolver file irrelevant.
+    "printf '\\nRESOLVCONF '; tr '\\n' ';' < /etc/resolv.conf 2>/dev/null "
+    "|| printf 'absent'; "
+    "printf '\\nNSSWITCH '; sed -n 's/^hosts: *//p' /etc/nsswitch.conf 2>/dev/null "
+    "|| printf 'absent'; "
     # The state itself, not only whether it worked: sixty-one lookups answered
     # `ENETUNREACH` from a guest that had passed this probe a minute earlier,
     # and only the addresses and routes at each moment say what went.


### PR DESCRIPTION
A converted guest answered `fail fail fail fail fail` while `REACH` said `10.31.0.254=up 223.5.5.5=up`. The log held no resolver list and no `hosts:` line, so the reading could not separate a resolver that says nothing from a `nsswitch.conf` that returns before `dns` — a correct `resolv.conf` is irrelevant against the second.

`absent` is one of the answers, because a guest with no resolver file at all looks identical on the lookups line.