### PR TITLE
tui: let the mirror be typed as an address

### DIFF
--- a/gentoo_install/data/locale/ja.toml
+++ b/gentoo_install/data/locale/ja.toml
@@ -209,6 +209,11 @@
 # Mirrors and compiler
 "Mirrors" = "ミラー"
 "Region" = "地域"
+"Distfiles address" = "distfiles のアドレス"
+"http://10.0.0.1/gentoo, separated by commas" = "http://10.0.0.1/gentoo、カンマ区切り"
+"empty leaves the chosen mirror in place" = "空欄なら選択したミラーをそのまま使います"
+"the chosen mirror" = "選択したミラー"
+"replaced by a typed address" = "入力したアドレスで置き換えます"
 "Gentoo mirror" = "Gentoo のミラー"
 "Measure them" = "速度で並べ替え"
 "yes" = "はい"

--- a/gentoo_install/data/locale/ko.toml
+++ b/gentoo_install/data/locale/ko.toml
@@ -209,6 +209,11 @@
 # Mirrors and compiler
 "Mirrors" = "미러"
 "Region" = "지역"
+"Distfiles address" = "distfiles 주소"
+"http://10.0.0.1/gentoo, separated by commas" = "http://10.0.0.1/gentoo, 쉼표로 구분"
+"empty leaves the chosen mirror in place" = "비워 두면 선택한 미러를 그대로 사용합니다"
+"the chosen mirror" = "선택한 미러"
+"replaced by a typed address" = "입력한 주소로 대체합니다"
 "Gentoo mirror" = "Gentoo 미러"
 "Measure them" = "속도로 정렬"
 "yes" = "예"

--- a/gentoo_install/data/locale/zh-CN.toml
+++ b/gentoo_install/data/locale/zh-CN.toml
@@ -209,6 +209,11 @@
 # 镜像与编译
 "Mirrors" = "镜像"
 "Region" = "地区"
+"Distfiles address" = "distfiles 地址"
+"http://10.0.0.1/gentoo, separated by commas" = "http://10.0.0.1/gentoo，以逗号分隔"
+"empty leaves the chosen mirror in place" = "留空则沿用选定的镜像"
+"the chosen mirror" = "选定的镜像"
+"replaced by a typed address" = "已由输入的地址取代"
 "Gentoo mirror" = "Gentoo 镜像"
 "Measure them" = "测速排序"
 "yes" = "是"

--- a/gentoo_install/data/locale/zh-TW.toml
+++ b/gentoo_install/data/locale/zh-TW.toml
@@ -209,6 +209,11 @@
 # 鏡像與編譯
 "Mirrors" = "鏡像"
 "Region" = "地區"
+"Distfiles address" = "distfiles 位址"
+"http://10.0.0.1/gentoo, separated by commas" = "http://10.0.0.1/gentoo，以逗號分隔"
+"empty leaves the chosen mirror in place" = "留空則沿用選定的鏡像"
+"the chosen mirror" = "選定的鏡像"
+"replaced by a typed address" = "已由輸入的位址取代"
 "Gentoo mirror" = "Gentoo 鏡像"
 "Measure them" = "測速排序"
 "yes" = "是"

--- a/gentoo_install/tui/mirror.py
+++ b/gentoo_install/tui/mirror.py
@@ -37,6 +37,7 @@ _REGION: Final[str] = "region"
 _SITE: Final[str] = "site"
 _MEASURE: Final[str] = "measure"
 _DISTFILES: Final[str] = "distfiles"
+_CUSTOM_DISTFILES: Final[str] = "custom-distfiles"
 _SYNC: Final[str] = "sync"
 _BINHOST: Final[str] = "binhost"
 _ZH_BINHOST: Final[str] = "zh-binhost"
@@ -217,7 +218,51 @@ def _mirror_site_row(config: InstallConfig, translate: Catalog) -> Item[str]:
     detail = _site_name(chosen.region, site, translate) if chosen.site else (
         f"{_default_site(chosen.region, translate)} ({translate('default')})"
     )
+    # The override, where the site would otherwise be read as what packages
+    # come from: a screen naming a site that nothing fetches from contradicts
+    # itself.
+    if chosen.distfiles:
+        detail = translate("replaced by a typed address")
     return Item(label=translate("Gentoo mirror"), value=_SITE, detail=detail)
+
+
+def _custom_distfiles_row(config: InstallConfig, translate: Catalog) -> Item[str]:
+    typed = config.portage.mirrors.distfiles
+    return Item(
+        label=translate("Distfiles address"),
+        value=_CUSTOM_DISTFILES,
+        detail=", ".join(typed) if typed else translate("the chosen mirror"),
+    )
+
+
+def _edit_custom_distfiles(
+    screen: Screen, context: Context, config: InstallConfig
+) -> InstallConfig | None:
+    """Where packages are fetched from, typed rather than chosen.
+
+    A machine whose resolver is down reaches a cache on its own segment by
+    address and nothing else: the eighth interface conversion stopped here
+    with every listed mirror unreachable and no way to say so.
+    """
+    translate = context.translate
+    typed = TextField(
+        title=translate("Distfiles address"),
+        value=", ".join(config.portage.mirrors.distfiles),
+        # An address, not a name: this row exists for the machine that cannot
+        # resolve one.
+        placeholder=translate("http://10.0.0.1/gentoo, separated by commas"),
+        detail=translate("empty leaves the chosen mirror in place"),
+        footer=footer(translate),
+    ).run(screen)
+    if not typed.chosen:
+        return None
+    given = tuple(one.strip() for one in typed.unwrap().split(",") if one.strip())
+    return replace(
+        config,
+        portage=replace(
+            config.portage, mirrors=replace(config.portage.mirrors, distfiles=given)
+        ),
+    )
 
 
 def _mirror_measure_row(config: InstallConfig, translate: Catalog) -> Item[str]:
@@ -335,6 +380,7 @@ def _edit_repositories(
 _MIRROR_FIELDS: tuple[FieldDescriptor[InstallConfig], ...] = (
     FieldDescriptor(_REGION, _mirror_region_row, _edit_mirror_region),
     FieldDescriptor(_SITE, _mirror_site_row, _edit_mirror_site),
+    FieldDescriptor(_CUSTOM_DISTFILES, _custom_distfiles_row, _edit_custom_distfiles),
     FieldDescriptor(_DISTFILES, _mirror_distfiles_row, lambda s, c, x: _toggle_mirror_distfiles(s, c, x)),
     FieldDescriptor(_MEASURE, _mirror_measure_row, lambda s, c, x: _toggle_mirror_measure(s, c, x)),
     FieldDescriptor(_SYNC, _mirror_sync_row, _edit_mirror_sync),

--- a/tests/unit/test_automatic.py
+++ b/tests/unit/test_automatic.py
@@ -911,6 +911,41 @@ def test_the_mirror_screen_shows_the_site_it_would_adopt() -> None:
     assert "(default)" in line
 
 
+def test_a_typed_distfiles_address_replaces_the_chosen_mirror() -> None:
+    """A machine whose resolver is down reaches a cache on its own segment by
+    address and nothing else. `--config` could say so through
+    `portage.mirrors.distfiles`; the menu had no row for it at all, and the
+    eighth interface conversion stopped with every listed mirror unreachable."""
+    from dataclasses import replace as _replace
+
+    from tests.unit.fake_screen import FakeScreen
+    from tests.unit.test_tui_app import context
+
+    started = config(ext4_on_gpt())
+    drawn = FakeScreen(keys=["q"], lines=30, columns=110)
+    mirror.mirror_screen(drawn, started, context())
+    row = next(one for one in drawn.last.splitlines() if "Distfiles address" in one)
+    assert "the chosen mirror" in row, row
+
+    # And with one typed, the site row says so rather than naming a mirror
+    # nothing fetches from.
+    typed = _replace(
+        started,
+        portage=_replace(
+            started.portage,
+            mirrors=_replace(
+                started.portage.mirrors, distfiles=("http://10.31.0.2/gentoo",)
+            ),
+        ),
+    )
+    again = FakeScreen(keys=["q"], lines=30, columns=110)
+    mirror.mirror_screen(again, typed, context())
+    shown = next(one for one in again.last.splitlines() if "Distfiles address" in one)
+    assert "10.31.0.2" in shown, shown
+    site = next(one for one in again.last.splitlines() if "Gentoo mirror" in one)
+    assert "replaced by a typed address" in site, site
+
+
 def test_password_login_does_not_let_root_in_by_itself() -> None:
     """The row said `root included` and the installer wrote
     `PermitRootLogin no`: root is a second row, and it starts off."""

--- a/tests/unit/test_tui_app.py
+++ b/tests/unit/test_tui_app.py
@@ -188,6 +188,7 @@ def test_a_group_is_a_list_and_never_a_wizard() -> None:
 def test_field_editors_have_one_descriptor_for_each_editable_row() -> None:
     at = context()
     mirror_expected = {mirror._REGION, mirror._SITE, mirror._DISTFILES,
+                       mirror._CUSTOM_DISTFILES,
                        mirror._MEASURE, mirror._SYNC, mirror._BINHOST,
                        mirror._ZH_SITE, mirror._ZH_DISTFILES,
                        mirror._ZH_BINHOST, mirror._REPOSITORIES, "gig", "guru"}


### PR DESCRIPTION
The eighth interface conversion stopped with every listed mirror unreachable: the cluster's resolver was down, so the guest could resolve no name at all. `--config` can say `portage.mirrors.distfiles = ["http://10.31.0.2/gentoo"]`; the menu had no row for it, so that path had nowhere to go.

The model already carries the field, parses it and writes it back — only the screen was missing. The site row now says it has been replaced rather than naming a mirror nothing fetches from, and the placeholder is an address because the row exists for the machine that cannot resolve a name.