### PR TITLE
plan: reach the converter through the Context seam

### DIFF
--- a/gentoo_install/exec/apply.py
+++ b/gentoo_install/exec/apply.py
@@ -223,6 +223,21 @@ class Machine:
     def is_mounted(self, path: str) -> bool:
         return self.runner.run(["findmnt", "--mountpoint", path], check=False).returncode == 0
 
+    def swap_directories(
+        self,
+        staging: PurePosixPath,
+        names: Sequence[str],
+        copy: Callable[[Path, Path], None],
+    ) -> None:
+        from . import convert as converting
+
+        converting.convert(Path(str(staging)), names, copy=copy)
+
+    def populate_boot(self, staging: PurePosixPath) -> None:
+        from . import convert as converting
+
+        converting.populate_boot(Path(str(staging)))
+
     def containing_disk(self, device: DeviceId) -> str:
         """The whole disk a device sits on, which is what a bootloader wants.
 

--- a/gentoo_install/plan/convert.py
+++ b/gentoo_install/plan/convert.py
@@ -3,10 +3,9 @@
 
 from __future__ import annotations
 
-import importlib
 from dataclasses import dataclass, replace
 from pathlib import Path, PurePosixPath
-from typing import Any, Callable, Final, Protocol, Sequence, cast
+from typing import Any, Final, Sequence, cast
 
 from ..errors import ConversionFailed, ConversionUnsupported
 from ..model.config import DiskConfig, DiskMode
@@ -37,17 +36,6 @@ REPLACED_DIRECTORIES: tuple[str, ...] = (
     "usr",
     "var",
 )
-
-
-class _Converter(Protocol):
-    def convert(
-        self,
-        staging: Path,
-        names: Sequence[str],
-        *,
-        copy: Callable[[Path, Path], None],
-        root: Path = Path("/"),
-    ) -> None: ...
 
 
 @dataclass(frozen=True, kw_only=True)
@@ -132,9 +120,6 @@ class SwapDirectories(Operation):
         return f"atomically swap {', '.join('/' + name for name in self.names)} from {self.staging}"
 
     def apply(self, context: Context) -> None:
-        module = importlib.import_module("gentoo_install.exec.convert")
-        converter = cast(_Converter, module)
-
         def copy(source: Path, destination: Path) -> None:
             # `cp --archive`, not `shutil.copytree`: a stage3 carries file
             # capabilities and xattrs that Python's copy does not restore.
@@ -142,7 +127,7 @@ class SwapDirectories(Operation):
                 ["cp", "--archive", "--one-file-system", str(source), str(destination)]
             )
 
-        converter.convert(Path(str(self.staging)), self.names, copy=copy)
+        context.swap_directories(self.staging, self.names, copy)
 
 
 FSTAB: Final[PurePosixPath] = PurePosixPath("/etc/fstab")
@@ -321,10 +306,6 @@ class LeaveStaging(Operation):
         context.run(["rm", "--recursive", "--force", str(self.staging)])
 
 
-class _BootPopulator(Protocol):
-    def populate_boot(self, staging: Path, *, root: Path = Path("/")) -> None: ...
-
-
 @dataclass(frozen=True, kw_only=True)
 class PopulateBoot(Operation):
     """Put the staged kernel into the machine's own `/boot`, after the swap.
@@ -342,8 +323,7 @@ class PopulateBoot(Operation):
         return f"put the kernel from {self.staging}/boot into /boot and drop the old images"
 
     def apply(self, context: Context) -> None:
-        module = importlib.import_module("gentoo_install.exec.convert")
-        cast(_BootPopulator, module).populate_boot(Path(str(self.staging)))
+        context.populate_boot(self.staging)
 
 
 #: The synthetic ids. Fixed rather than derived from the device name so that a

--- a/gentoo_install/plan/operations.py
+++ b/gentoo_install/plan/operations.py
@@ -17,8 +17,9 @@ import signal
 from abc import ABC, abstractmethod
 from dataclasses import dataclass
 from enum import Enum
-from pathlib import PurePosixPath
+from pathlib import Path, PurePosixPath
 import re
+from collections.abc import Callable
 from typing import ClassVar, Final, Protocol, Sequence
 
 from ..errors import CommandFailed
@@ -158,6 +159,23 @@ class Context(Protocol):
         A path on the installing system, not inside the target: it is passed to
         `cryptsetup`, which runs outside the chroot.
         """
+
+    def swap_directories(
+        self,
+        staging: PurePosixPath,
+        names: Sequence[str],
+        copy: Callable[[Path, Path], None],
+    ) -> None:
+        """Replace each named directory of the running system from `staging`.
+
+        Here rather than imported: `plan/convert.py` reached
+        `gentoo_install.exec.convert` through `importlib` for as long as this
+        seam has existed, and the guard that forbids that edge walks `import`
+        statements, which never see one.
+        """
+
+    def populate_boot(self, staging: PurePosixPath) -> None:
+        """Fill the staged `/boot` from the running system's own."""
 
     def containing_disk(self, device: DeviceId) -> str:
         """The whole disk a device sits on, such as `/dev/sda`."""

--- a/tests/unit/recorder.py
+++ b/tests/unit/recorder.py
@@ -11,7 +11,7 @@ from gentoo_install.errors import CommandFailed, DownloadFailed
 from gentoo_install.plan.operations import CommandOutput
 from collections.abc import Callable
 from dataclasses import dataclass, field
-from pathlib import PurePosixPath
+from pathlib import Path, PurePosixPath
 from typing import Sequence
 
 from gentoo_install.model.device import DeviceId
@@ -42,6 +42,9 @@ class Recorder:
     #: Commands whose first word is here raise instead of returning.
     failures: set[str] = field(default_factory=set)
     given_up: set[str] = field(default_factory=set)
+    #: What the conversion seam was asked to do, rather than doing it.
+    swapped: list[tuple[PurePosixPath, tuple[str, ...]]] = field(default_factory=list)
+    populated: list[PurePosixPath] = field(default_factory=list)
     #: Why each one was given up. The reason is what `install.jsonl` records
     #: and what an operator reads, so a double that drops it cannot hold it.
     degradations: dict[str, str] = field(default_factory=dict)
@@ -145,6 +148,19 @@ class Recorder:
 
     def key_file(self, device: DeviceId) -> PurePosixPath:
         return PurePosixPath(f"/run/gentoo-install/keys/{device}")
+
+    def swap_directories(
+        self,
+        staging: PurePosixPath,
+        names: Sequence[str],
+        copy: Callable[[Path, Path], None],
+    ) -> None:
+        # Recorded rather than performed: the real one renames the running
+        # system's directories, and a unit test must not.
+        self.swapped.append((staging, tuple(names)))
+
+    def populate_boot(self, staging: PurePosixPath) -> None:
+        self.populated.append(staging)
 
     def containing_disk(self, device: DeviceId) -> str:
         return "/dev/vda"

--- a/tests/unit/test_layers.py
+++ b/tests/unit/test_layers.py
@@ -43,6 +43,18 @@ def _imports(tree: ast.AST) -> set[str]:
                 imported.add(prefix + node.module)
             else:
                 imported.update(prefix + alias.name for alias in node.names)
+        # `importlib.import_module("gentoo_install.exec.convert")` is an
+        # import that `ast.Import` never sees, and `plan/convert.py` reached
+        # `exec/` through one for as long as this guard has existed.
+        elif (
+            isinstance(node, ast.Call)
+            and isinstance(node.func, ast.Attribute)
+            and node.func.attr == "import_module"
+            and node.args
+            and isinstance(node.args[0], ast.Constant)
+            and isinstance(node.args[0].value, str)
+        ):
+            imported.add(node.args[0].value)
     return imported
 
 

--- a/tests/unit/test_plan_convert.py
+++ b/tests/unit/test_plan_convert.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 from dataclasses import replace
 from pathlib import Path, PurePosixPath
 from types import SimpleNamespace
+from collections.abc import Callable
 from typing import Any, Sequence, cast
 
 import pytest
@@ -53,19 +54,17 @@ def test_partition_mode_keeps_the_ordinary_list() -> None:
     assert not any(isinstance(operation, plan_disk.CreatePartition) for operation in conversion)
 
 
-def test_conversion_operation_describes_and_applies(monkeypatch: pytest.MonkeyPatch) -> None:
-    called: list[tuple[Path, tuple[str, ...]]] = []
+def test_conversion_operation_describes_and_applies() -> None:
+    """Through the `Context` seam, not `gentoo_install.exec.convert`: the plan
+    layer does not import `exec`, and this test used to reach it by patching
+    `importlib.import_module`, which is how the crossing stayed invisible."""
+    from .recorder import Recorder
 
-    def convert(staging: Any, names: tuple[str, ...], *, copy: Any) -> None:
-        called.append((staging, names))
-
-    from gentoo_install.exec import convert as executor
-
-    monkeypatch.setattr(executor, "convert", convert)
+    recorder = Recorder()
     operation = SwapDirectories()
     assert operation.describe()
-    operation.apply(SimpleNamespace(target=PurePosixPath("/target")))
-    assert called == [(Path("/gentoo-install.new"), operation.names)]
+    operation.apply(recorder)
+    assert recorder.swapped == [(PurePosixPath("/gentoo-install.new"), operation.names)]
 
 
 def _layout(
@@ -870,35 +869,23 @@ def test_the_swap_copies_with_cp_archive_rather_than_a_python_copy() -> None:
 
     from .recorder import Recorder
 
-    recorder = Recorder()
     copied: list[tuple[str, str]] = []
 
-    class Module:
-        @staticmethod
-        def convert(
-            staging: Path,
-            names: object,
-            *,
-            copy: object,
-            root: Path = Path("/"),
+    class Crossing(Recorder):
+        """A seam that calls the copier, the way the real one does for a
+        directory a rename cannot cross."""
+
+        def swap_directories(
+            self,
+            staging: PurePosixPath,
+            names: Sequence[str],
+            copy: Callable[[Path, Path], None],
         ) -> None:
-            assert callable(copy)
             copy(Path("/gentoo-install.new/var/cache"), Path("/var/cache"))
-            copied.append((str(staging), str(root)))
+            copied.append((str(staging), str(tuple(names))))
 
-    import importlib
-
-    original = importlib.import_module
-
-    def importing(name: str, package: str | None = None) -> Any:
-        return Module if name == "gentoo_install.exec.convert" else original(name, package)
-
-    saved = importlib.import_module
-    importlib.import_module = importing
-    try:
-        SwapDirectories(names=("var",)).apply(recorder)
-    finally:
-        importlib.import_module = saved
+    recorder = Crossing()
+    SwapDirectories(names=("var",)).apply(recorder)
 
     assert copied, "the converter was never called"
     written = [argv for argv in recorder.commands if argv and argv[0] == "cp"]


### PR DESCRIPTION
`plan/operations.py:9` says the plan layer never imports `exec`. `plan/convert.py` did, twice, through `importlib.import_module("gentoo_install.exec.convert")` — and `tests/unit/test_layers.py` collects only `ast.Import` and `ast.ImportFrom`, so the edge was invisible to the guard written to forbid it.

The guard now sees a constant-string `import_module`, which turned it red on that file first; the fix is two methods on `Context`, implemented in `exec/apply.py`. The two tests that reached the converter by patching `importlib` go through the seam instead — patching the import was how the crossing stayed comfortable.