### PR TITLE
cli: classify a declined conversion as an abort

### DIFF
--- a/gentoo_install/cli.py
+++ b/gentoo_install/cli.py
@@ -374,7 +374,12 @@ def _reboot_or_disarm(
 
 
 def main(argv: Sequence[str] | None = None) -> int:
-    arguments = parser().parse_args(argv)
+    try:
+        arguments = parser().parse_args(argv)
+    except SystemExit as error:
+        if error.code == 2:
+            return EXIT_CONFIG
+        raise
     state = RunState(disk_was_written=bool(arguments.resume))
     # Why the previous walk's answers were turned down, carried back into the
     # menu. A refusal that reaches the operator as a line on a dead terminal
@@ -602,7 +607,7 @@ def install(
                 record(f"warning: {warning}")
             preflight_report.raise_if_fatal()
         if config.disk.mode is DiskMode.IN_PLACE and not _confirmed_swap(arguments, record):
-            return EXIT_CONFIG
+            return EXIT_ABORTED
         machine = Machine(
             config=running if running is not None else config,
             runner=runner,
@@ -731,7 +736,10 @@ def _confirmed_swap(
     print("Everything else, including /home and /root, is left alone.")
     print(SESSION_IS_THE_LIFELINE)
     print(f"Type {SWAP_CONFIRMATION} to continue, anything else to stop.")
-    answer = input("> ").strip()
+    try:
+        answer = input("> ").strip()
+    except EOFError:
+        answer = ""
     if answer == SWAP_CONFIRMATION:
         return True
     record("in-place conversion was not confirmed")

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -2,8 +2,10 @@
 from __future__ import annotations
 
 import argparse
+import io
 import os
 import shutil
+import sys
 import time
 from typing import Sequence, cast
 import re
@@ -237,6 +239,13 @@ def test_a_dry_run_names_devices_by_id_rather_than_by_path(
     gone looking for a node under `/dev` to print."""
     main(["--config", str(FIXTURES / "ext4-bios.toml"), "--dry-run"])
     assert "/dev/" not in capsys.readouterr().out
+
+
+def test_an_unknown_option_is_a_configuration_error(
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    assert main(["--not-an-option"]) == EXIT_CONFIG
+    assert "unrecognized arguments" in capsys.readouterr().err
 
 
 def test_a_missing_file_is_a_configuration_error(capsys: pytest.CaptureFixture[str]) -> None:
@@ -1395,6 +1404,43 @@ def test_the_swap_is_confirmed_before_it_runs(
     assert any("not confirmed" in one for one in said)
 
 
+def test_an_eof_at_the_conversion_prompt_declines_the_swap(
+    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    def closed_stdin(*_: object) -> str:
+        raise EOFError
+
+    said: list[str] = []
+    monkeypatch.setattr(cli, "_unattended", lambda arguments: False)
+    monkeypatch.setattr("builtins.input", closed_stdin)
+
+    assert not cli._confirmed_swap(_conversion_arguments(False), said.append)
+    assert any("not confirmed" in line for line in said)
+    assert "nothing was changed" in capsys.readouterr().err
+
+
+def test_a_declined_conversion_exits_as_a_user_abort(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    from .layouts import config
+
+    converted = replace(
+        config(),
+        disk=DiskConfig(graph=DeviceGraph.build([]), root=DeviceId(""), mode=DiskMode.IN_PLACE),
+    )
+    monkeypatch.setattr(cli, "_confirmed_swap", lambda arguments, record: False)
+    arguments = argparse.Namespace(
+        work=tmp_path / "work",
+        target=Path("/mnt/gentoo"),
+        skip_preflight=True,
+        resume=False,
+        no_shell=True,
+        dry_run=False,
+    )
+
+    assert cli.install(converted, (), arguments, cli.RunState()) == cli.EXIT_ABORTED
+
+
 def test_an_unattended_conversion_is_not_asked_but_is_recorded(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -1405,10 +1451,21 @@ def test_an_unattended_conversion_is_not_asked_but_is_recorded(
         raise AssertionError("an unattended run must not be asked")
 
     monkeypatch.setattr("builtins.input", refuse)
-    monkeypatch.setattr(cli, "_unattended", lambda arguments: True)
     said: list[str] = []
     assert cli._confirmed_swap(_conversion_arguments(True), said.append)
     assert any("/usr" in one for one in said)
+
+
+def test_a_conversion_with_nonterminal_stdin_is_not_asked(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    def refuse(*_: object) -> str:
+        raise AssertionError("a nonterminal run must not be asked")
+
+    monkeypatch.setattr(sys, "stdin", io.StringIO())
+    monkeypatch.setattr("builtins.input", refuse)
+
+    assert cli._confirmed_swap(_conversion_arguments(False), lambda line: None)
 
 
 def test_a_layout_that_cannot_be_converted_exits_as_a_preflight_failure(

--- a/tests/unit/test_layers.py
+++ b/tests/unit/test_layers.py
@@ -215,14 +215,15 @@ def test_every_source_file_states_the_licence() -> None:
     read: list[Path] = []
     for pattern, line in (("*.py", 0), ("*.sh", 1)):
         for one in sorted(root.rglob(pattern)):
-            if not one.is_file() or ".git" in one.parts or "lab" in one.parts:
+            relative = one.relative_to(root)
+            if not one.is_file() or ".git" in relative.parts or "lab" in relative.parts:
                 continue
-            read.append(one.relative_to(root))
+            read.append(relative)
             # A shell script's first line is its interpreter, so the identifier
             # is on the second; Python has no such line and uses the first.
             head = one.read_text(encoding="utf-8").splitlines()[: line + 1]
             if head[line : line + 1] != [SPDX]:
-                silent.append(one.relative_to(root))
+                silent.append(relative)
 
     assert not silent, f"no licence on the first line of: {silent}"
     # Not vacuous: the shell scripts have to be among the files examined, or


### PR DESCRIPTION
Three exit codes did not match the table in `docs/design.md`. A conversion the operator declined returned `1`, a configuration error, so automation could not tell a deliberate stop from a bad file; EOF at that prompt travelled through `except BaseException` and printed `unexpected EOFError`; and an unknown option left `argparse` with `SystemExit(2)`, which the table calls a failed preflight.

The second commit is not part of that finding but was found by it: `test_layers.py` filtered `lab` out of **absolute** paths, so inside any worktree under `lab/` the licence scan read no files at all.