### PR TITLE
exec: restore copied directories after cp failure

### DIFF
--- a/gentoo_install/exec/convert.py
+++ b/gentoo_install/exec/convert.py
@@ -79,8 +79,13 @@ def _replace_contents(destination: Path, staged: Path, copy: Copier) -> None:
             except OSError as error:
                 if error.errno != errno.EXDEV:
                     raise
-                copy(staged / name, destination / name)
+                # Recorded before the copy, not after: `cp --archive` can
+                # write part of a tree and then fail, and an entry the
+                # rollback never hears about leaves that part in place beside
+                # the restored original. `_remove` tolerates a path that was
+                # never created.
                 arrived.append((name, Arrival.COPIED))
+                copy(staged / name, destination / name)
                 continue
             arrived.append((name, Arrival.RENAMED))
     except Exception as error:

--- a/gentoo_install/exec/convert.py
+++ b/gentoo_install/exec/convert.py
@@ -83,7 +83,7 @@ def _replace_contents(destination: Path, staged: Path, copy: Copier) -> None:
                 arrived.append((name, Arrival.COPIED))
                 continue
             arrived.append((name, Arrival.RENAMED))
-    except OSError as error:
+    except Exception as error:
         for name, how in reversed(arrived):
             try:
                 if how is Arrival.RENAMED:
@@ -97,6 +97,10 @@ def _replace_contents(destination: Path, staged: Path, copy: Copier) -> None:
                 os.rename(aside / name, destination / name)
             except OSError as rollback_error:
                 error.add_note(f"could not restore {destination / name}: {rollback_error}")
+        try:
+            os.rmdir(aside)
+        except OSError as rollback_error:
+            error.add_note(f"could not remove {aside}: {rollback_error}")
         raise ConversionFailed(
             f"{destination} could not be replaced by content: {error}"
         ) from error
@@ -169,7 +173,7 @@ def convert(
                     os.rename(destination, old)
                     moved_old = True
                 os.rename(staged, destination)
-        except OSError as error:
+        except Exception as error:
             if moved_old:
                 try:
                     os.rename(old, destination)

--- a/tests/unit/test_convert.py
+++ b/tests/unit/test_convert.py
@@ -420,3 +420,42 @@ def test_a_merged_usr_symlink_is_removed_rather_than_left_beside_the_new_one(
     assert (root / "bin").is_dir() and not (root / "bin").is_symlink()
     left = [one.name for one in root.iterdir() if one.name.endswith(convert.KEPT_ASIDE)]
     assert left == [], left
+
+
+def test_a_copy_that_writes_part_of_a_tree_then_fails_leaves_none_of_it(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """`cp --archive` can create destination content and then return non-zero.
+    The entry is recorded before the copy runs, or the rollback never hears
+    about it and restores the original beside the half-written copy."""
+    root = tmp_path / "root"
+    staging = root / "new"
+    (root / "var").mkdir(parents=True)
+    (staging / "var").mkdir(parents=True)
+    (root / "var" / "old-log").write_text("old var")
+    (staging / "var" / "cache").mkdir()
+
+    real_mount = os.path.ismount
+    monkeypatch.setattr(
+        "os.path.ismount", lambda path: str(path).endswith("/var") or real_mount(path)
+    )
+    real_rename = os.rename
+
+    def cross_device_rename(source: Path | str, destination: Path | str) -> None:
+        if Path(source) == staging / "var" / "cache":
+            raise OSError(errno.EXDEV, "Invalid cross-device link")
+        real_rename(source, destination)
+
+    def half_written(source: Path, destination: Path) -> None:
+        destination.mkdir(parents=True)
+        (destination / "arrived-first").write_text("half of it")
+        raise CommandFailed("cp --archive ended with exit status 1")
+
+    monkeypatch.setattr(os, "rename", cross_device_rename)
+    with pytest.raises(ConversionFailed):
+        convert.convert(staging, ("var",), copy=half_written, root=root)
+
+    assert (root / "var" / "old-log").read_text() == "old var", "the original is back"
+    assert not (root / "var" / "cache").exists(), sorted(
+        one.name for one in (root / "var").iterdir()
+    )

--- a/tests/unit/test_convert.py
+++ b/tests/unit/test_convert.py
@@ -1,12 +1,13 @@
 # SPDX-License-Identifier: GPL-2.0-or-later
 from __future__ import annotations
 
+import errno
 import os
 from pathlib import Path
 
 import pytest
 
-from gentoo_install.errors import ConversionFailed
+from gentoo_install.errors import CommandFailed, ConversionFailed
 from gentoo_install.exec import convert
 
 
@@ -314,8 +315,6 @@ def test_a_mounted_directory_is_filled_by_copy_when_rename_cannot_cross(
     the staging root's and `rename(2)` cannot reach it. Everything before this
     had succeeded: the whole userland was built and the swap was the last step.
     """
-    import errno
-
     root = tmp_path / "root"
     staging = root / "new"
     for name in ("usr", "var"):
@@ -355,6 +354,52 @@ def test_a_mounted_directory_is_filled_by_copy_when_rename_cannot_cross(
     assert not (root / "var" / "old-log").exists(), "replaced, not merged"
     assert not (root / "var" / convert.KEPT_ASIDE).exists(), "the kept set is removed"
     assert (root / "usr" / "new.txt").read_text() == "new", "an ordinary directory renames"
+
+
+def test_a_failed_cross_device_copy_restores_all_replaced_directories(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    root = tmp_path / "root"
+    staging = root / "new"
+    (root / "usr").mkdir(parents=True)
+    (staging / "usr").mkdir(parents=True)
+    (root / "usr" / "content").write_text("old usr")
+    (staging / "usr" / "content").write_text("new usr")
+    (root / "var").mkdir()
+    (staging / "var").mkdir()
+    (root / "var" / "old-log").write_text("old var")
+    (staging / "var" / "cache").mkdir()
+
+    real_mount = os.path.ismount
+    monkeypatch.setattr(
+        "os.path.ismount", lambda path: str(path).endswith("/var") or real_mount(path)
+    )
+    real_rename = os.rename
+
+    def cross_device_rename(source: Path | str, destination: Path | str) -> None:
+        if Path(source) == staging / "var" / "cache":
+            raise OSError(errno.EXDEV, "Invalid cross-device link")
+        real_rename(source, destination)
+
+    copy_failure = CommandFailed("cp --archive ended with exit status 1")
+
+    def failing_copy(source: Path, destination: Path) -> None:
+        raise copy_failure
+
+    monkeypatch.setattr("os.rename", cross_device_rename)
+
+    with pytest.raises(ConversionFailed, match="cp --archive") as failure:
+        convert.convert(staging, ("usr", "var"), copy=failing_copy, root=root)
+
+    assert (root / "usr" / "content").read_text() == "old usr"
+    assert (staging / "usr" / "content").read_text() == "new usr"
+    assert (root / "var" / "old-log").read_text() == "old var"
+    assert (staging / "var" / "cache").is_dir()
+    assert not (root / "var" / "cache").exists()
+    assert not (root / "var" / convert.KEPT_ASIDE).exists()
+    inner_failure = failure.value.__cause__
+    assert isinstance(inner_failure, ConversionFailed)
+    assert inner_failure.__cause__ is copy_failure
 
 
 def test_a_merged_usr_symlink_is_removed_rather_than_left_beside_the_new_one(


### PR DESCRIPTION
The conversion moves each named directory of the running system aside, then either renames or copies the replacement into place. Both the copy attempt and the rollback caught only `OSError`, and the copier the plan supplies is `context.run(["cp", "--archive", ...])`, which raises `CommandFailed`.

So the one case the copy path exists for — a directory a rename cannot cross — skipped both rollbacks with `/usr` or `/var` already moved aside, leaving a working machine incomplete.

The test builds that case: `/var` a mount point, `EXDEV` from the rename, `CommandFailed` from the copier.