### PR TITLE
exec: preserve failed command state

### DIFF
--- a/gentoo_install/exec/runner.py
+++ b/gentoo_install/exec/runner.py
@@ -104,7 +104,7 @@ class Runner:
         self.history.append(result)
         if self.journal is not None:
             self.journal.command(_display_argv(result.argv), result.returncode, result.seconds)
-            if "emerge" in full and not _pretending(full):
+            if result.returncode == 0 and "emerge" in full and not _pretending(full):
                 self.journal.packages(result.stdout)
         if check and result.returncode != 0:
             raise CommandFailed(
@@ -149,10 +149,14 @@ class Runner:
                 env=self._environment(),
                 start_new_session=True,
             )
-        except FileNotFoundError as error:
+        except OSError as error:
+            if source_process.stdout is not None:
+                source_process.stdout.close()
             _kill_group(source_process)
             source_process.wait()
-            raise CommandFailed(f"{sink[0]} is not installed") from error
+            if isinstance(error, FileNotFoundError):
+                raise CommandFailed(f"{sink[0]} is not installed") from error
+            raise
         if source_process.stdout is not None:
             source_process.stdout.close()
         source_lines: list[str] = []

--- a/tests/unit/test_exec.py
+++ b/tests/unit/test_exec.py
@@ -2,6 +2,8 @@
 from __future__ import annotations
 
 import os
+import signal
+import subprocess
 
 from dataclasses import replace
 from pathlib import Path, PurePosixPath
@@ -190,6 +192,51 @@ def test_a_pipeline_keeps_binary_bytes_out_of_python(tmp_path: Path) -> None:
 def test_a_pipeline_source_failure_is_not_hidden_by_dd_success(tmp_path: Path) -> None:
     with pytest.raises(CommandFailed, match="exit 7"):
         runner(tmp_path).pipe(["sh", "-c", "exit 7"], ["cat"])
+
+
+def test_a_pipeline_cleans_the_source_when_the_sink_cannot_start(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    from io import StringIO
+
+    from gentoo_install.exec import runner as exec_runner
+
+    class Source:
+        def __init__(self) -> None:
+            self.pid = 0
+            self.stdout = StringIO()
+            self.waited = False
+
+        def poll(self) -> int | None:
+            return None
+
+        def wait(self) -> int:
+            self.waited = True
+            return -signal.SIGKILL
+
+    source = Source()
+    killed: list[object] = []
+    launches = 0
+
+    def launch(*args: object, **kwargs: object) -> Source:
+        nonlocal launches
+        launches += 1
+        if launches == 1:
+            return source
+        raise PermissionError("sink is not executable")
+
+    def remember_kill(process: object) -> None:
+        killed.append(process)
+
+    monkeypatch.setattr(subprocess, "Popen", launch)
+    monkeypatch.setattr(exec_runner, "_kill_group", remember_kill)
+
+    with pytest.raises(PermissionError, match="not executable"):
+        runner(tmp_path).pipe(["source"], ["sink"])
+
+    assert killed == [source]
+    assert source.stdout.closed
+    assert source.waited
 
 
 def test_a_failure_can_be_asked_for_rather_than_raised(tmp_path: Path) -> None:

--- a/tests/unit/test_log.py
+++ b/tests/unit/test_log.py
@@ -4,6 +4,9 @@ from __future__ import annotations
 import json
 from pathlib import Path
 
+import pytest
+
+from gentoo_install.errors import CommandFailed
 from gentoo_install.exec.runner import Runner
 from gentoo_install.log import Journal, Source, merged
 
@@ -102,4 +105,14 @@ def test_a_pretend_is_not_a_merge(tmp_path: Path) -> None:
     # recorded, so this is a rule about the flag rather than about `sh`.
     runner.run(["sh", "-c", "cat", "emerge", "--verbose"], input_text=EMERGE_OUTPUT)
     assert journal.counts() == {"binary": 2, "compiled": 1}, journal.counts()
+
+
+def test_a_failed_emerge_does_not_record_packages(tmp_path: Path) -> None:
+    journal = Journal(path=tmp_path / "install.jsonl")
+    runner = Runner(log=lambda line: None, journal=journal)
+
+    with pytest.raises(CommandFailed):
+        runner.run(["sh", "-c", "cat; exit 1", "emerge"], input_text=EMERGE_OUTPUT)
+
+    assert journal.counts() == {}, journal.counts()
 


### PR DESCRIPTION
`runner.py` called `journal.packages(result.stdout)` before checking the exit status, and those lines are what emerge prints when it is *about to* merge. An emerge that announced packages and then failed recorded them as installed, in the file this project uses to say where each package came from.

A pipeline whose sink could not start caught only `FileNotFoundError`; a `PermissionError` left the source running with its stdout open.

The audit's third finding — a race on the global `getaddrinfo` override — was checked and rejected: the concurrent probe calls `_urlopen` directly and never enters `_over`.