### PR TITLE
disk: update the table as well as asking for a reread

### DIFF
--- a/gentoo_install/exec/probe.py
+++ b/gentoo_install/exec/probe.py
@@ -694,7 +694,11 @@ class Probe:
                 # The status, not `check=False` alone: an absent `mdev` and a
                 # `mdev` that ran and made nothing look the same from here, and
                 # the `--lowram` environment failed on one of the two.
-                scan = self.runner.run(["mdev", "-s"], check=False)
+                # `-f`, not a bare scan: without it mdev leaves the stale
+                # `/dev/disk/*` links a previous table left behind, and a link
+                # pointing at a partition that no longer exists is what the
+                # next `mkfs` opens.
+                scan = self.runner.run(["mdev", "-sf"], check=False)
                 tried.append(f"mdev={scan.returncode}")
             time.sleep(0.5)
         raise DeviceNotFound(

--- a/gentoo_install/plan/disk.py
+++ b/gentoo_install/plan/disk.py
@@ -360,6 +360,11 @@ class RereadPartitionTable(Operation):
         except CommandFailed as error:
             context.degrade("partprobe", f"blockdev rereads the table instead: {error}")
             context.run(["blockdev", "--rereadpt", path])
+        # `partprobe` asks the kernel to reread; `partx --update` is what
+        # updates the partitions where mdev is the device manager and nothing
+        # listens for the event. Undeclared like `partprobe` above and for the
+        # same reason: `Probe.wait_for`'s own scan is the fallback without it.
+        context.run(["partx", "--update", path], check=False)
         context.run(["udevadm", "settle"])
 
 

--- a/tests/unit/test_plan_disk.py
+++ b/tests/unit/test_plan_disk.py
@@ -1138,3 +1138,23 @@ def test_a_dataset_a_later_parent_covers_is_left_where_it_is() -> None:
     with pytest.raises(CommandFailed, match="what is mounted at /home"):
         told.apply(broken)
     assert ("zfs", "unmount", "zpcala/ROOT/gentoo/home") not in broken.commands
+
+
+def test_rereading_a_table_updates_it_as_well_as_asking() -> None:
+    """`partprobe` asks the kernel to reread; on a medium whose device manager
+    is mdev nothing listens for the event, and `partx --update` is what makes
+    the partitions appear. `--lowram` reached `mkfs` with `vdc1` and `vdc2` in
+    the kernel's own log and neither of them in `/dev`."""
+    from gentoo_install.plan.disk import RereadPartitionTable
+    from tests.unit.recorder import Recorder
+
+    recorder = Recorder()
+    RereadPartitionTable(disk=DeviceId("disk")).apply(recorder)
+    ran = [argv[0] for argv in recorder.commands]
+    assert "partprobe" in ran, recorder.commands
+    assert "partx" in ran, recorder.commands
+    # After the reread, or it updates a table the kernel has not been asked for.
+    assert ran.index("partx") > ran.index("partprobe"), ran
+    # Undeclared on purpose, like `partprobe`: it runs with `check=False`
+    # and `Probe.wait_for` scans for the node when it is absent.
+    assert "partx" not in RereadPartitionTable.host_commands

--- a/tests/unit/test_probe.py
+++ b/tests/unit/test_probe.py
@@ -853,7 +853,10 @@ def test_a_node_is_scanned_for_where_mdev_is_the_device_manager(
     with pytest.raises(DeviceNotFound):
         reader.wait_for(str(tmp_path / "vdc2"), seconds=0.6)
 
-    assert ("mdev", "-s") in asking.asked, asking.asked
+    # `-sf`: mdev leaves the stale `/dev/disk/*` links a previous table
+    # left behind, and a link to a partition that is gone is what the
+    # next `mkfs` opens.
+    assert ("mdev", "-sf") in asking.asked, asking.asked
     assert ("udevadm", "settle") in asking.asked, asking.asked
 
 


### PR DESCRIPTION
`memory/alpine-netboot-has-mdev-not-udev.md` recorded this failure and its answer before tonight: `partprobe` asks the kernel to reread, `partx --update` is what updates the partitions, and `mdev` needs `-f` because it leaves the stale `/dev/disk/*` links a previous table left behind.

`RereadPartitionTable` did `partprobe` then `udevadm settle`, and `Probe.wait_for` scanned with a bare `mdev -s`. `--lowram` reached `mkfs` three times tonight with `vdc1` and `vdc2` in the kernel log and neither in `/dev`.

`partx` stays out of `host_commands` for the reason `partprobe` does: it runs with `check=False` and the scan in `wait_for` is the fallback.