### PR TITLE
harness: correct three things the commit review found

### DIFF
--- a/tests/unit/test_harness.py
+++ b/tests/unit/test_harness.py
@@ -5021,7 +5021,11 @@ def test_the_installed_login_answers_the_disk_before_it_answers_the_login() -> N
     import re
 
     from tests.vm import cluster
-    from tests.vm.console import DISK_PASSPHRASE, ConsoleTimeout
+    from tests.vm.console import (
+        DISK_PASSPHRASE,
+        PASSPHRASE_ATTEMPTS,
+        ConsoleTimeout,
+    )
     from tests.vm.proxmox import ProxmoxError
 
     class Booting:
@@ -5072,10 +5076,10 @@ def test_the_installed_login_answers_the_disk_before_it_answers_the_login() -> N
 
     # A prompt that never stops is the passphrase being wrong, not a layout
     # with many devices: it is raised, not answered until the ceiling.
-    forever = Booting(cluster.PASSPHRASE_ATTEMPTS + 1)
+    forever = Booting(PASSPHRASE_ATTEMPTS + 1)
     with pytest.raises(ProxmoxError, match="never offered a login"):
         cluster.reach_the_login_past_any_passphrase(forever)
-    assert len(forever.sent) == cluster.PASSPHRASE_ATTEMPTS, forever.sent
+    assert len(forever.sent) == PASSPHRASE_ATTEMPTS, forever.sent
 
 
 def test_the_pool_scan_is_bounded_and_outlives_its_own_window() -> None:
@@ -5096,11 +5100,18 @@ def test_the_pool_scan_is_bounded_and_outlives_its_own_window() -> None:
     )
     assert "timeout " in scan, scan
 
-    # The window has to outlast the bound, or the expect gives up while the
-    # command it is waiting for is still allowed to run.
+    # The window the caller passes has to outlast the bound the shell gets,
+    # or the expect gives up while the command is still allowed to run. Read
+    # off the call, not restated: `POOL_SCAN_PATIENCE + 60 > POOL_SCAN_PATIENCE`
+    # is true of every number and holds nothing.
+    called = next(
+        one for one in source.splitlines() if "timeout=POOL_SCAN_PATIENCE" in one
+    )
+    added = re.search(r"timeout=POOL_SCAN_PATIENCE \+ ([0-9.]+)", called)
+    assert added is not None, called
+    assert float(added.group(1)) > 0, called
     signature = inspect.signature(cluster.Reconnecting.expect_output)
     default = signature.parameters["timeout"].default
-    assert cluster.POOL_SCAN_PATIENCE + 60.0 > cluster.POOL_SCAN_PATIENCE
     assert cluster.POOL_SCAN_PATIENCE > default, (cluster.POOL_SCAN_PATIENCE, default)
 
 
@@ -5187,3 +5198,57 @@ def test_the_lookup_budget_outlasts_every_resolver_in_the_list() -> None:
         * int(settings["timeout"])
     )
     assert cluster.LOOKUP_PATIENCE > worst, (cluster.LOOKUP_PATIENCE, worst)
+
+
+def test_both_runners_answer_the_same_number_of_passphrase_prompts() -> None:
+    """The cluster bounded it at four and the local runner at five, so a fifth
+    valid dracut prompt passed one and failed the other. The bound is one
+    constant in `tests/vm/console.py`, which both already import."""
+    import inspect
+
+    from tests.vm import cluster, console, run
+
+    assert inspect.getsource(cluster).count("PASSPHRASE_ATTEMPTS: Final") == 0
+    assert inspect.getsource(run).count("PASSPHRASE_ATTEMPTS: Final") == 0
+    assert console.PASSPHRASE_ATTEMPTS >= 2
+    # And neither loop counts to a literal of its own.
+    for module in (cluster, run):
+        source = inspect.getsource(module)
+        assert "for _ in range(5):" not in source, module.__name__
+        assert "for _ in range(4):" not in source, module.__name__
+
+
+def test_the_unlock_key_count_refuses_a_digit_from_the_command_itself() -> None:
+    """`zbm unlock key` counts authorised keys in the EFI image. `[1-9]` was
+    an unanchored search, so the `2` of the command's own `2>/dev/null` would
+    satisfy it and an image that authenticates nobody would be accepted. The
+    test that came with the anchoring never exercised the pattern: an anchored
+    pattern is not a substring of its command, so it fell outside that scan."""
+    import re
+
+    from dataclasses import replace
+
+    from gentoo_install.model.config import Bootloader, DiskMode
+    from tests.vm import installed
+
+    from .layouts import config, ext4_on_gpt
+
+    unlocking = config(ext4_on_gpt())
+    unlocking = replace(
+        unlocking,
+        bootloader=replace(unlocking.bootloader, kind=Bootloader.ZFSBOOTMENU),
+        kernel=replace(
+            unlocking.kernel,
+            remote_unlock=replace(unlocking.kernel.remote_unlock, enabled=True),
+        ),
+    )
+    check = next(
+        one for one in installed.checks(unlocking) if one.name == "zbm unlock key"
+    )
+    matcher = re.compile(check.pattern)
+    # What the machine answers when the image carries no key at all.
+    assert not matcher.search("0"), check.pattern
+    # And what a digit borrowed from the command's own redirection looks like.
+    assert not matcher.search(check.command), check.pattern
+    # A real count still passes.
+    assert matcher.search("2"), check.pattern

--- a/tests/unit/test_plan_portage.py
+++ b/tests/unit/test_plan_portage.py
@@ -2736,7 +2736,11 @@ def test_the_gentoo_tree_is_offered_the_rest_of_its_region() -> None:
     tried = [one.sync_uri for one in syncing[0].alternates]
     assert tried, "the tree was left with one site"
     assert "https://mirrors.ustc.edu.cn/gentoo.git" not in tried, tried
-    assert set(tried) < set(mirrors.gentoo_sync_uris(MirrorRegion.CN))
+    # Every other site of the region, not merely some of them: a proper
+    # subset accepted an implementation that kept one alternate while the
+    # change claims to offer the rest of the region.
+    everything = set(mirrors.gentoo_sync_uris(MirrorRegion.CN))
+    assert set(tried) == everything - {"https://mirrors.ustc.edu.cn/gentoo.git"}
 
     # Every alternate still verifies: they mirror the same signed history, and
     # a fallback that quietly stopped checking would be worse than stopping.

--- a/tests/vm/cluster.py
+++ b/tests/vm/cluster.py
@@ -66,6 +66,7 @@ from gentoo_install.plan.portage import BINARY_PACKAGES, KEY_SERVER
 
 from .console import (
     DISK_PASSPHRASE,
+    PASSPHRASE_ATTEMPTS,
     PASSPHRASE_PROMPT,
     PASSWORD_PROMPT,
     ConsoleClosed,
@@ -2242,13 +2243,6 @@ def _log_into_the_installed_system(link: "Reconnecting") -> None:
     link.console.expect(PASSWORD_PROMPT, INSTALLED_LOGIN_PATIENCE)
     link.console.send(TUI_PASSWORD)
     reach_prompt(link)
-
-
-#: How many passphrase prompts are answered before the boot is called stuck.
-#: A layout can hold more than one encrypted device, and dracut asks once per
-#: device; a prompt that keeps returning means the passphrase is wrong, and
-#: answering it for ever would hide that behind the patience ceiling.
-PASSPHRASE_ATTEMPTS: Final[int] = 4
 
 
 #: A machine booting its own disk answers sooner than a medium does, and a

--- a/tests/vm/console.py
+++ b/tests/vm/console.py
@@ -9,7 +9,7 @@ import socket
 import time
 from pathlib import Path
 from types import TracebackType
-from typing import IO, Iterator, Protocol, Self
+from typing import IO, Final, Iterator, Protocol, Self
 
 _ANSI = re.compile(
     rb"\x1b\[[0-9;?]*[a-zA-Z]"
@@ -83,6 +83,15 @@ PASSPHRASE_PROMPT = r"[Ee]nter passphrase|Please enter passphrase|password for"
 #: the other. Here rather than in each runner, so the local runs and the
 #: cluster runs cannot install one and answer with another.
 DISK_PASSPHRASE = "install-disk"
+
+
+#: How many passphrase prompts are answered before the boot is called stuck.
+#: A layout can hold more than one encrypted device and dracut asks once per
+#: device; a prompt that keeps returning means the passphrase is wrong, and
+#: answering it for ever would hide that behind the patience ceiling. Here
+#: rather than in either runner: the cluster bounded it at four and the local
+#: runner at five, so a fifth valid prompt passed one and failed the other.
+PASSPHRASE_ATTEMPTS: Final[int] = 5
 
 
 class Channel(Protocol):

--- a/tests/vm/run.py
+++ b/tests/vm/run.py
@@ -43,7 +43,13 @@ from gentoo_install.exec.config import load
 from gentoo_install.model.serialise import to_toml
 from gentoo_install.model.manual import dataset_for
 
-from .console import DISK_PASSPHRASE, PASSPHRASE_PROMPT, PASSWORD_PROMPT, SerialConsole
+from .console import (
+    DISK_PASSPHRASE,
+    PASSPHRASE_ATTEMPTS,
+    PASSPHRASE_PROMPT,
+    PASSWORD_PROMPT,
+    SerialConsole,
+)
 from .monitor import type_text
 from .driver import FIND_DRIVER, REPOSITORY, build as build_driver
 from .media import MEDIA, Medium
@@ -468,7 +474,7 @@ def unlock_and_login(
         # prompt, which is on the serial port and is waited for below.
         time.sleep(GRUB_PROMPT_SECONDS)
         type_text(monitor, DISK_PASSPHRASE)
-    for _ in range(5):
+    for _ in range(PASSPHRASE_ATTEMPTS):
         seen = console.expect(rf"{PASSPHRASE_PROMPT}|login:", timeout=300.0)
         if b"login:" in seen:
             console.send("root")


### PR DESCRIPTION
A reviewer read every commit merged tonight. Three findings held.

`PASSPHRASE_ATTEMPTS` was defined in `cluster.py` at four while `run.py` counted to five, so a fifth valid dracut prompt passed one runner and failed the other — the same rule in two places, added by `#928` on the same night as a memory entry about that exact defect.

Two of the tests written tonight did not hold what they claimed. The `zbm unlock key` anchoring had no test that a revert would redden: an anchored pattern is not a substring of its own command, so it fell outside the scan that was supposed to cover it. And `POOL_SCAN_PATIENCE + 60 > POOL_SCAN_PATIENCE` is true of every finite number.