### PR TITLE
kernel: install Intel microcode on physical hardware

### DIFF
--- a/gentoo_install/cli.py
+++ b/gentoo_install/cli.py
@@ -38,6 +38,7 @@ from .exec.probe import (
 from .exec.runner import Runner
 from .log import Journal
 from .model.device import DeviceGraph, DeviceId, StorageFacts, StorageLayout, ZfsPool
+from .model.hardware import HardwareFacts
 from .model.size import Size
 from .tui import app, screens
 from .tui import context as tui_context
@@ -466,6 +467,10 @@ def _once(arguments: argparse.Namespace, state: RunState, refused: str) -> int |
         storage_facts = StorageFacts()
         loader_v3: bool | None = None
         layout: StorageLayout | None = None
+        hardware = HardwareFacts()
+        if config.disk.mode is not DiskMode.DD:
+            reading = Probe(runner=Runner(log=lambda line: None), work=arguments.work)
+            hardware = reading.hardware()
         if config.disk.layout_is_read_from_the_machine:
             # Even for a dry run: a conversion's whole plan is derived from the
             # running machine, so without this there is nothing to print.
@@ -473,13 +478,9 @@ def _once(arguments: argparse.Namespace, state: RunState, refused: str) -> int |
                 runner=Runner(log=lambda line: None), work=arguments.work
             ).storage_layout()
         if not arguments.dry_run and config.disk.mode is not DiskMode.DD:
-            # Before the plan is derived, because `build` validates: a reused
-            # esp needs runtime metadata. A dry run remains independent of the
-            # selected hardware.
-            reading = Probe(runner=Runner(log=lambda line: None), work=arguments.work)
+            # Storage metadata is only required before a real install.
             storage_facts = probe_storage_facts(config, reading)
-            # `ld.so --help`, the loader's own answer about this machine: a dry
-            # run stays independent of the hardware, so it is not read there.
+            # `ld.so --help`, the loader's own answer about this machine.
             loader_v3 = reading.supports_v3()
         operations = build(
             config,
@@ -488,6 +489,7 @@ def _once(arguments: argparse.Namespace, state: RunState, refused: str) -> int |
             storage_facts=storage_facts,
             layout=layout,
             supports_v3=loader_v3,
+            hardware=hardware,
         )
         if arguments.dry_run:
             print(render(operations), end="")

--- a/gentoo_install/exec/probe.py
+++ b/gentoo_install/exec/probe.py
@@ -21,6 +21,7 @@ from typing import ClassVar, Final, Iterable, Mapping
 
 from ..errors import CommandFailed, DeviceNotFound
 from ..model.config import DiskMode, InstallConfig
+from ..model.hardware import CpuVendor, HardwareFacts
 # Declared in `model/` because `plan/netboot.py` derives operations from it
 # and `plan/` may not import `exec/`; re-exported here so every caller that
 # asks the probe for the method reads the enum from the same place.
@@ -929,6 +930,38 @@ class Probe:
         # exists, both tables are missing and there is nothing under it, so
         # every branch above answered nothing and the menu offered `UTC` alone.
         return ("UTC", *found) if found else _carried_timezones()
+
+    def hardware(self) -> HardwareFacts:
+        """Facts that choose CPU microcode without becoming configuration."""
+        return HardwareFacts(
+            cpu_vendor=self.cpu_vendor(),
+            virtual_machine=self.virtual_machine(),
+        )
+
+    def cpu_vendor(self) -> CpuVendor:
+        """The CPU vendor reported by the kernel, or an unknown value."""
+        try:
+            text = CPUINFO.read_text()
+        except OSError:
+            return CpuVendor.UNKNOWN
+        for line in text.splitlines():
+            name, _, value = line.partition(":")
+            if name.strip() != "vendor_id":
+                continue
+            try:
+                return CpuVendor(value.strip())
+            except ValueError:
+                return CpuVendor.UNKNOWN
+        return CpuVendor.UNKNOWN
+
+    def virtual_machine(self) -> bool | None:
+        """Whether systemd identifies the installer as a virtual machine."""
+        result = self.runner.run(["systemd-detect-virt", "--quiet"], check=False)
+        if result.returncode == 0:
+            return True
+        if result.returncode == 1:
+            return False
+        return None
 
     def cpu_flags(self) -> tuple[str, ...]:
         """`CPU_FLAGS_X86` for this machine.

--- a/gentoo_install/model/hardware.py
+++ b/gentoo_install/model/hardware.py
@@ -1,0 +1,25 @@
+# SPDX-License-Identifier: GPL-2.0-or-later
+"""Hardware facts that select target packages."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from enum import Enum
+
+
+class CpuVendor(Enum):
+    AMD = "AuthenticAMD"
+    INTEL = "GenuineIntel"
+    UNKNOWN = ""
+
+
+@dataclass(frozen=True)
+class HardwareFacts:
+    """Machine facts read before the operation list is derived."""
+
+    cpu_vendor: CpuVendor = CpuVendor.UNKNOWN
+    virtual_machine: bool | None = None
+
+    @property
+    def needs_intel_microcode(self) -> bool:
+        return self.cpu_vendor is CpuVendor.INTEL and self.virtual_machine is False

--- a/gentoo_install/plan/build.py
+++ b/gentoo_install/plan/build.py
@@ -14,6 +14,7 @@ from typing import Final, Sequence
 from ..model import mirrors
 from ..errors import ConversionUnsupported
 from ..model.config import DiskMode, InstallConfig
+from ..model.hardware import HardwareFacts
 from ..model.device import StorageFacts, StorageLayout
 from ..model.validate import validate
 from . import bootloader, convert, dd, disk, fonts, kernel, packages, portage, system
@@ -32,6 +33,7 @@ DEFAULT_VARIANT: Final[str] = "systemd"
 PORTAGE_PREREQUISITES: Final[tuple[type[Operation], ...]] = (
     kernel.ConfigureInstallKernel,
     kernel.AcceptFirmwareLicence,
+    kernel.ConfigureIntelMicrocode,
     kernel.ConfigureRemoteUnlock,
     kernel.UnmaskCjkDistKernel,
     kernel.AcceptKernelVersion,
@@ -106,11 +108,12 @@ def build(
     storage_facts: StorageFacts | None = None,
     layout: StorageLayout | None = None,
     supports_v3: bool | None = None,
+    hardware: HardwareFacts = HardwareFacts(),
 ) -> tuple[Operation, ...]:
     """Validate, then derive the whole install. Nothing here touches a machine."""
     facts = storage_facts if storage_facts is not None else StorageFacts()
     if config.disk.layout_is_read_from_the_machine:
-        return _in_place(config, catalog, mirror, layout, supports_v3)
+        return _in_place(config, catalog, mirror, layout, supports_v3, hardware)
     validate(config, storage_facts=facts, supports_v3=supports_v3)
     if config.disk.mode is DiskMode.DD:
         return dd.build(config)
@@ -124,7 +127,7 @@ def build(
             packages._required_video_cards(config, chosen),
         ),
         *system.build(config),
-        *kernel.build(config),
+        *kernel.build(config, hardware),
         *bootloader.build(config),
         *packages._build(config, catalog, chosen),
         *fonts.build(config, catalog),
@@ -176,6 +179,7 @@ def _in_place(
     mirror: str,
     layout: StorageLayout | None,
     supports_v3: bool | None = None,
+    hardware: HardwareFacts = HardwareFacts(),
 ) -> tuple[Operation, ...]:
     """Derive the conversion of a running system, in the order it must run.
 
@@ -212,7 +216,7 @@ def _in_place(
         # After `WriteFstab`, which is in the same stage and earlier in this
         # list: the file has to exist before its other mounts are appended.
         convert.CarryFstabEntries(lines=layout.carried_fstab),
-        *kernel.build(derived),
+        *kernel.build(derived, hardware),
         *(one for one in boot if not isinstance(one, AFTER_THE_SWAP)),
         *packages._build(derived, catalog, chosen),
         *fonts.build(derived, catalog),

--- a/gentoo_install/plan/kernel.py
+++ b/gentoo_install/plan/kernel.py
@@ -16,6 +16,7 @@ from ..model.config import Bootloader, InitSystem, InstallConfig, KernelSource
 from ..errors import ConfigError, ConversionUnsupported, NothingToBoot, ValidationFailed
 from ..model import compat
 from ..model.compat import CJK_KERNELS, KERNEL_PACKAGES
+from ..model.hardware import HardwareFacts
 from ..model.validate import zfs_kernel_version_problem
 from ..model.device import (
     DeviceId,
@@ -348,6 +349,39 @@ class AcceptFirmwareLicence(Operation):
             lines=("sys-kernel/linux-firmware linux-fw-redistributable no-source-code",),
         ).apply(context)
 
+INTEL_MICROCODE: Final[str] = "sys-firmware/intel-microcode"
+
+
+@dataclass(frozen=True, kw_only=True)
+class ConfigureIntelMicrocode(Operation):
+    """Enable Intel microcode and its dist-kernel initramfs integration."""
+
+    stage: Stage = Stage.KERNEL
+
+    def describe(self) -> str:
+        return (
+            f"accept {INTEL_MICROCODE} as testing, enable its dist-kernel initramfs hooks, "
+            "and accept its licence"
+        )
+
+    def apply(self, context: Context) -> None:
+        VerifyPackageUse(atom=INTEL_MICROCODE, flags=("dist-kernel", "initramfs")).apply(context)
+        WritePortageConfig(
+            kind=PortageConfigKind.USE,
+            name="intel-microcode",
+            lines=(f"{INTEL_MICROCODE} dist-kernel initramfs",),
+        ).apply(context)
+        WritePortageConfig(
+            kind=PortageConfigKind.KEYWORDS,
+            name="intel-microcode",
+            lines=(f"{INTEL_MICROCODE} ~amd64",),
+        ).apply(context)
+        WritePortageConfig(
+            kind=PortageConfigKind.LICENSE,
+            name="intel-microcode",
+            lines=(f"{INTEL_MICROCODE} intel-ucode",),
+        ).apply(context)
+
 
 @dataclass(frozen=True, kw_only=True)
 class ConfigureRemoteUnlock(Operation):
@@ -581,7 +615,7 @@ class RequestDistKernelModules(Operation):
         ).apply(context)
 
 
-def build(config: InstallConfig) -> list[Operation]:
+def build(config: InstallConfig, hardware: HardwareFacts = HardwareFacts()) -> list[Operation]:
     # The graph is empty until `plan/convert.layout_graph()` reads the machine,
     # and every filesystem module and package here is derived from it: planning
     # from the placeholder produces a system with no tools for its own root.
@@ -643,6 +677,8 @@ def build(config: InstallConfig) -> list[Operation]:
             summary="install the initramfs builder and firmware",
         ),
     ]
+    if hardware.needs_intel_microcode:
+        operations.append(ConfigureIntelMicrocode())
     flagged = storage_use(modules)
     if flagged:
         operations.insert(0, RequestStorageUse(entries=flagged))
@@ -651,6 +687,7 @@ def build(config: InstallConfig) -> list[Operation]:
     # `=atom-version` rather than a range: the operator chose one version off a
     # list this machine read, so anything else is not what they picked.
     atom = f"={package}-{version}" if version else package
+    microcode = (INTEL_MICROCODE,) if hardware.needs_intel_microcode else ()
     if version:
         operations.append(AcceptKernelVersion(package=package, version=version))
     if config.kernel.remote_unlock.enabled:
@@ -723,8 +760,12 @@ def build(config: InstallConfig) -> list[Operation]:
         operations.append(
             Emerge(
                 stage=Stage.KERNEL,
-                packages=(atom, *sorted(building)),
-                summary="install the kernel and the tools that build a module for it",
+                packages=(atom, *sorted(building), *microcode),
+                summary=(
+                    "install the kernel, Intel microcode, and the tools that build a module for it"
+                    if microcode
+                    else "install the kernel and the tools that build a module for it"
+                ),
                 source=(
                     SourcePolicy.build_subset(tuple(sorted(building)))
                     if prebuilt
@@ -736,8 +777,8 @@ def build(config: InstallConfig) -> list[Operation]:
         operations.append(
             Emerge(
                 stage=Stage.KERNEL,
-                packages=(atom,),
-                summary="install the kernel",
+                packages=(atom, *microcode),
+                summary="install the kernel and Intel microcode" if microcode else "install the kernel",
                 source=(
                     SourcePolicy.binaries_allowed()
                     if prebuilt

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -22,6 +22,7 @@ from gentoo_install.exec.runner import Runner
 from gentoo_install.cli import EXIT_CONFIG, EXIT_INTEGRITY, EXIT_OK, EXIT_PREFLIGHT, main
 from gentoo_install.errors import CommandFailed, ConfigError, IntegrityError
 from gentoo_install.model.config import DiskConfig, DiskMode, ImageFormat, MemoryLaunch, MemoryMode
+from gentoo_install.model.hardware import CpuVendor, HardwareFacts
 from gentoo_install.model.device import DeviceGraph, DeviceId, StorageFacts, StorageLayout
 from gentoo_install.plan.build import DEFAULT_MIRROR
 from gentoo_install.exec.config import load
@@ -225,11 +226,46 @@ def test_a_dry_run_touches_nothing(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setattr(
         cli,
         "build",
-        lambda chosen, catalog, *, mirror, storage_facts, layout, supports_v3: (operation,),
+        lambda chosen, catalog, *, mirror, storage_facts, layout, supports_v3, hardware: (operation,),
     )
     code = main(["--config", str(FIXTURES / "ext4-bios.toml"), "--dry-run"])
     assert code == EXIT_OK
     assert executed == []
+
+
+def test_a_dry_run_passes_probed_hardware_to_the_plan(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from gentoo_install.plan.operations import Operation
+
+    expected = HardwareFacts(cpu_vendor=CpuVendor.INTEL, virtual_machine=False)
+    planned: list[HardwareFacts] = []
+
+    class HardwareProbe:
+        def __init__(self, **_: object) -> None:
+            pass
+
+        def hardware(self) -> HardwareFacts:
+            return expected
+
+    def build_with_hardware(
+        chosen: object,
+        catalog: object,
+        *,
+        mirror: str,
+        storage_facts: StorageFacts,
+        layout: StorageLayout | None,
+        supports_v3: bool | None,
+        hardware: HardwareFacts,
+    ) -> tuple[Operation, ...]:
+        planned.append(hardware)
+        return ()
+
+    monkeypatch.setattr(cli, "Probe", HardwareProbe)
+    monkeypatch.setattr(cli, "build", build_with_hardware)
+
+    assert main(["--config", str(FIXTURES / "ext4-bios.toml"), "--dry-run"]) == EXIT_OK
+    assert planned == [expected]
 
 
 def test_a_dry_run_names_devices_by_id_rather_than_by_path(
@@ -1028,7 +1064,7 @@ def test_a_finish_failure_releases_the_machine_and_keeps_its_exit_code(
     monkeypatch.setattr(
         cli,
         "build",
-        lambda chosen, catalog, *, mirror, storage_facts, layout, supports_v3: (
+        lambda chosen, catalog, *, mirror, storage_facts, layout, supports_v3, hardware: (
             Partition(),
             FailFinish(),
             FailRelease(),
@@ -1080,7 +1116,7 @@ def test_a_failure_after_partitioning_says_the_disk_may_not_boot(
     monkeypatch.setattr(
         cli,
         "build",
-        lambda chosen, catalog, *, mirror, storage_facts, layout, supports_v3: (FailPartition(),),
+        lambda chosen, catalog, *, mirror, storage_facts, layout, supports_v3, hardware: (FailPartition(),),
     )
     monkeypatch.setattr(report, "keep_log", lambda work, target, record: None)
 
@@ -1158,7 +1194,7 @@ def test_a_body_failure_before_partitioning_says_nothing_was_written(
     monkeypatch.setattr(
         cli,
         "build",
-        lambda chosen, catalog, *, mirror, storage_facts, layout, supports_v3: (
+        lambda chosen, catalog, *, mirror, storage_facts, layout, supports_v3, hardware: (
             FailBeforePartition(),
             Partition(),
         ),
@@ -1341,6 +1377,9 @@ def test_a_conversion_reads_the_running_layout_even_for_a_dry_run(
         def __init__(self, **_: object) -> None:
             pass
 
+        def hardware(self) -> HardwareFacts:
+            return HardwareFacts()
+
         def storage_layout(self) -> StorageLayout:
             read.append("layout")
             return StorageLayout(
@@ -1480,6 +1519,9 @@ def test_a_layout_that_cannot_be_converted_exits_as_a_preflight_failure(
     class OnZfs:
         def __init__(self, **_: object) -> None:
             pass
+
+        def hardware(self) -> HardwareFacts:
+            return HardwareFacts()
 
         def storage_layout(self) -> StorageLayout:
             return StorageLayout(

--- a/tests/unit/test_exec.py
+++ b/tests/unit/test_exec.py
@@ -22,12 +22,14 @@ from gentoo_install.errors import (
     PreflightFailed,
 )
 from gentoo_install.exec import apply, fetch, preflight, report as exec_report
+from gentoo_install.exec import probe as probe_module
 from gentoo_install.exec.config import load
 from gentoo_install.log import Journal
 from gentoo_install.exec.probe import Machine as ProbedMachine
 from gentoo_install.exec.probe import Probe, probe_storage_facts
 from gentoo_install.exec.runner import Result, Runner, under
 from gentoo_install.model.config import Bootloader, BootloaderConfig, DiskMode, Firmware, InstallConfig
+from gentoo_install.model.hardware import CpuVendor
 from gentoo_install.model.device import DeviceId, Existing, Luks, Node
 from gentoo_install.model.size import Size
 from gentoo_install.plan.operations import CommandOutput
@@ -1335,6 +1337,40 @@ def test_a_cpu_flag_is_renamed_and_never_swapped_for_another(tmp_path: Path) -> 
     # One kernel name per portage name: two keys sharing a value is a swap.
     values = [portage for portage in CPU_FLAGS.values()]
     assert len(values) == len(set(values))
+
+
+@pytest.mark.parametrize(
+    ("returncode", "virtual_machine"),
+    ((0, True), (1, False), (127, None)),
+)
+def test_hardware_facts_read_cpu_vendor_and_virtualization(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    returncode: int,
+    virtual_machine: bool | None,
+) -> None:
+    cpuinfo = tmp_path / "cpuinfo"
+    cpuinfo.write_text("vendor_id : GenuineIntel\n", encoding="utf-8")
+    monkeypatch.setattr(probe_module, "CPUINFO", cpuinfo)
+    probed = Probe(runner=runner(tmp_path), work=tmp_path)
+
+    def detect(
+        argv: Sequence[str],
+        *,
+        check: bool = True,
+        input_text: str | None = None,
+        timeout: float | None = None,
+    ) -> Result:
+        assert argv == ["systemd-detect-virt", "--quiet"]
+        assert check is False
+        assert input_text is None and timeout is None
+        return Result(tuple(argv), returncode, "", "", 0.0)
+
+    monkeypatch.setattr(probed.runner, "run", detect)
+    facts = probed.hardware()
+
+    assert facts.cpu_vendor is CpuVendor.INTEL
+    assert facts.virtual_machine is virtual_machine
 
 
 def test_every_request_names_the_installer(monkeypatch: pytest.MonkeyPatch) -> None:

--- a/tests/unit/test_plan_kernel.py
+++ b/tests/unit/test_plan_kernel.py
@@ -3,12 +3,16 @@ from __future__ import annotations
 
 from dataclasses import replace
 from pathlib import Path, PurePosixPath
+from typing import Sequence
 
 import pytest
 
+from gentoo_install.data import load_catalog
 from gentoo_install.exec.config import load
 from gentoo_install.model.config import InstallConfig, KernelSource
+from gentoo_install.model.hardware import CpuVendor, HardwareFacts
 from gentoo_install.plan import bootloader, kernel
+from gentoo_install.plan.build import build as build_plan
 from gentoo_install.plan.portage import (
     BINPKG_EXCLUDED,
     BINPKG_OPTIONS,
@@ -21,6 +25,71 @@ from gentoo_install.errors import ValidationFailed
 from gentoo_install.model.validate import KernelCeiling
 
 from .recorder import Recorder
+from .layouts import config
+from gentoo_install.plan.operations import Stage
+
+
+def test_physical_intel_gets_microcode_before_its_kernel_merges() -> None:
+    """The package needs testing, licence, and USE configuration before it
+    enters the kernel transaction."""
+    operations = build_plan(
+        config(),
+        load_catalog(),
+        hardware=HardwareFacts(cpu_vendor=CpuVendor.INTEL, virtual_machine=False),
+    )
+    configured = next(
+        operation for operation in operations if isinstance(operation, kernel.ConfigureIntelMicrocode)
+    )
+    merged = next(
+        operation
+        for operation in operations
+        if isinstance(operation, Emerge) and kernel.INTEL_MICROCODE in operation.packages
+    )
+
+    def iuse(argv: Sequence[str]) -> str | None:
+        if tuple(argv[:4]) == ("portageq", "metadata", "/", "ebuild") and argv[-1] == "IUSE":
+            return "+dist-kernel +initramfs"
+        return None
+
+    recorder = Recorder(answering=iuse)
+    configured.apply(recorder)
+
+    assert configured.stage is Stage.PORTAGE
+    assert operations.index(configured) < operations.index(merged)
+    assert merged.packages[-1] == kernel.INTEL_MICROCODE
+    assert merged.summary == "install the kernel and Intel microcode"
+    assert recorder.files[PurePosixPath("/etc/portage/package.use/intel-microcode")] == (
+        f"{kernel.INTEL_MICROCODE} dist-kernel initramfs\n"
+    )
+    assert recorder.files[PurePosixPath("/etc/portage/package.accept_keywords/intel-microcode")] == (
+        f"{kernel.INTEL_MICROCODE} ~amd64\n"
+    )
+    assert recorder.files[PurePosixPath("/etc/portage/package.license/intel-microcode")] == (
+        f"{kernel.INTEL_MICROCODE} intel-ucode\n"
+    )
+
+
+@pytest.mark.parametrize(
+    "hardware",
+    (
+        HardwareFacts(cpu_vendor=CpuVendor.AMD, virtual_machine=False),
+        HardwareFacts(cpu_vendor=CpuVendor.INTEL, virtual_machine=True),
+        HardwareFacts(cpu_vendor=CpuVendor.INTEL, virtual_machine=None),
+        HardwareFacts(),
+    ),
+)
+def test_only_a_confirmed_physical_intel_needs_the_intel_microcode_package(
+    hardware: HardwareFacts,
+) -> None:
+    operations = kernel.build(config(), hardware)
+
+    assert not any(
+        isinstance(operation, kernel.ConfigureIntelMicrocode) for operation in operations
+    )
+    assert not any(
+        isinstance(operation, Emerge) and kernel.INTEL_MICROCODE in operation.packages
+        for operation in operations
+    )
 
 
 def test_no_dracut_config_this_installer_writes_is_a_file_a_package_owns() -> None:


### PR DESCRIPTION
`archinstall` picks `amd-ucode` or `intel-ucode` by CPU vendor and skips it inside a virtual machine; this installer merged only `linux-firmware`, which carries device firmware and not the microcode Gentoo ships as `sys-firmware/intel-microcode`. A physical Intel machine therefore booted without the errata and security fixes newer microcode carries.

`HardwareFacts` lives in `model/` and does no I/O of its own. The package is merged when the vendor is Intel **and** the machine is known not to be virtual, so an unread machine gets nothing rather than a guess. dracut 112 already defaults `early_microcode=yes`, so no second setting was added.

The LUKS header backup from the same audit was declined with a reason: the work directory is volatile, the target may be inside the container, and on BIOS there is no ESP mounted when `luksFormat` runs. No destination is both durable and reachable, so that belongs to the operator.

The physical path cannot be measured on a VM by construction.