### PR TITLE
harness: announce the tree where the driver CD is built

### DIFF
--- a/tests/unit/test_harness.py
+++ b/tests/unit/test_harness.py
@@ -3282,7 +3282,6 @@ def test_local_runner_options_preserve_defaults_and_accept_none(
 
     monkeypatch.setattr(runner, "MEDIA", {"test": medium})
     monkeypatch.setattr(runner, "WORKROOT", tmp_path)
-    monkeypatch.setattr(runner, "_revision", lambda: "test-revision")
     monkeypatch.setattr(runner, "_perform", capture)
 
     assert runner.main(["--medium", "test"]) == 0
@@ -5252,3 +5251,35 @@ def test_the_unlock_key_count_refuses_a_digit_from_the_command_itself() -> None:
     assert not matcher.search(check.command), check.pattern
     # A real count still passes.
     assert matcher.search("2"), check.pattern
+
+
+def test_building_the_driver_names_the_tree_it_was_built_from(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    from tests.vm import driver
+
+    with pytest.raises(Exception):
+        driver.build(tmp_path / "nowhere" / "driver.iso", fixtures=tmp_path / "absent")
+    said = capsys.readouterr().out
+    assert "installer revision:" in said, said
+    assert driver.revision() in said, said
+
+
+def test_one_module_announces_the_revision_and_the_runners_do_not() -> None:
+    """A runner that prints its own copy is one the next edit can leave stale.
+
+    `run.py` announced the tree and the other three runners did not, so
+    `ram.py`, `dd.py` and `convert.py` each measured a snapshot their own logs
+    could not name.
+    """
+    room = Path(__file__).resolve().parents[2] / "tests" / "vm"
+    announcing = {
+        one.name for one in sorted(room.glob("*.py"))
+        if "installer revision:" in one.read_text()
+    }
+    # `cluster.py` writes it into each guest's own log rather than the
+    # campaign stream, and takes its value from `revision_identity`, which
+    # carries the driver digest a local run has no use for.
+    assert announcing == {"driver.py", "cluster.py"}, sorted(announcing)
+    runners = {"run.py", "ram.py", "dd.py", "convert.py"}
+    assert not announcing & runners, sorted(announcing & runners)

--- a/tests/vm/driver.py
+++ b/tests/vm/driver.py
@@ -111,6 +111,31 @@ exec sh ./bootstrap.sh --no-shell "$@"
 """
 
 
+def revision() -> str:
+    """What the driver CD is about to be built from.
+
+    A campaign that ran while its own tree was being committed to measured
+    twelve different snapshots and could name none of them, so every run says
+    this before it boots anything. `dirty` means the result proves nothing
+    about any commit.
+    """
+
+    def ask(command: list[str]) -> str:
+        try:
+            done = subprocess.run(
+                command, cwd=REPOSITORY, capture_output=True, text=True
+            )
+        except OSError:
+            return ""
+        return done.stdout if done.returncode == 0 else ""
+
+    described = ask(["git", "describe", "--always", "--dirty"]).strip()
+    if not described:
+        return "unknown, not a git checkout"
+    uncommitted = len(ask(["git", "status", "--short"]).splitlines())
+    return f"{described} ({uncommitted} uncommitted files)" if uncommitted else described
+
+
 def build(output: Path, packed: bool = False, fixtures: Path | None = None) -> Path:
     """Write an ISO holding the installer package and return its path.
 
@@ -121,6 +146,10 @@ def build(output: Path, packed: bool = False, fixtures: Path | None = None) -> P
     `fixtures` replaces the configurations the CD carries, which is how the
     cluster runs the same set against a different mirror region.
     """
+    # Here rather than in each runner: `run.py` announced the tree and `ram.py`,
+    # `dd.py` and `convert.py` did not, so three of the four measured a snapshot
+    # their own logs could not name. Every runner builds this CD.
+    print(f"installer revision: {revision()}", flush=True)
     if shutil.which("xorriso") is None:
         raise MediaError("xorriso is not installed, so the driver CD cannot be built")
     output.parent.mkdir(parents=True, exist_ok=True)

--- a/tests/vm/run.py
+++ b/tests/vm/run.py
@@ -769,7 +769,6 @@ def main(argv: list[str] | None = None) -> int:
     variant = Path(args.install).stem if args.install else "probe"
     workdir = WORKROOT / f"{medium.name}-{args.firmware}-{variant}"
     workdir.mkdir(parents=True, exist_ok=True)
-    print(f"installer revision: {_revision()}", flush=True)
     # The medium too: a rolling release keeps its filename, so a result
     # that names only the medium does not say which build it booted.
     print(f"medium: {medium.name} {medium.source_stamp()[:16]}", flush=True)
@@ -938,28 +937,6 @@ def power_off(console: SerialConsole, vm: Vm) -> None:
         except subprocess.TimeoutExpired:
             continue
     print("guest did not power off, killing it", file=sys.stderr)
-
-
-def _revision() -> str:
-    """What the driver CD is about to be built from.
-
-    A campaign that ran while its own tree was being committed to measured
-    twelve different snapshots and could name none of them, so every run says
-    this before it boots anything. `dirty` means the result proves nothing
-    about any commit.
-    """
-    def ask(command: list[str]) -> str:
-        try:
-            done = subprocess.run(command, cwd=REPOSITORY, capture_output=True, text=True)
-        except OSError:
-            return ""
-        return done.stdout if done.returncode == 0 else ""
-
-    described = ask(["git", "describe", "--always", "--dirty"]).strip()
-    if not described:
-        return "unknown, not a git checkout"
-    uncommitted = len(ask(["git", "status", "--short"]).splitlines())
-    return f"{described} ({uncommitted} uncommitted files)" if uncommitted else described
 
 
 def _discard(targets: Sequence[Path], *, keep: bool) -> None:


### PR DESCRIPTION
`run.py` printed the revision and `ram.py`, `dd.py` and `convert.py` did not, so three of the four runners measured a snapshot their own logs could not name.

Every runner builds the driver CD, so the identity is printed there rather than in each runner. A test holds that `driver.py` is the only module that announces it and that no runner carries its own copy.