### PR TITLE
exec: keep password hashes out of the log that gets published

### DIFF
--- a/gentoo_install/exec/report.py
+++ b/gentoo_install/exec/report.py
@@ -22,6 +22,7 @@ from ..model import config as model_config
 from ..model import paste
 from ..model.config import InstallConfig
 from ..model.serialise import to_toml
+from ..redact import holds_a_secret
 from . import fetch, preflight
 from .probe import Probe
 from .runner import open_in_target, write_file
@@ -133,6 +134,12 @@ def offer_paste(
         body = source.read_text()
     except OSError as error:
         record(f"warning: {source} could not be read: {error}")
+        return
+    if holds_a_secret(body):
+        # A second guard, because the first one only reaches command lines: a
+        # log carries what commands printed as well as how they were called.
+        record(f"the log holds a password hash and was not sent to {paste.HOST}")
+        record(f"the log to publish by hand is {source}")
         return
     try:
         url = fetch.upload(body, paste.export_for(PasteKind.LOG.value))

--- a/gentoo_install/exec/runner.py
+++ b/gentoo_install/exec/runner.py
@@ -21,6 +21,7 @@ from pathlib import Path, PurePosixPath
 from typing import Callable, Sequence, TextIO
 
 from ..errors import CommandFailed, TargetEscape
+from ..redact import scrub
 from ..log import Journal
 from ..model.config import ProxyConfig
 from ..plan.operations import ending, worth_reading
@@ -326,7 +327,11 @@ def _pretending(argv: Sequence[str]) -> bool:
 
 
 def _display_argv(argv: Sequence[str]) -> tuple[str, ...]:
-    """Redact URL user information before a command reaches logs or journals."""
+    """Redact secrets before a command reaches logs or journals.
+
+    `usermod --password` takes the hash as an argument, and this run's log is
+    what `offer_paste` uploads to a public pastebin.
+    """
     shown: list[str] = []
     for value in argv:
         try:
@@ -343,6 +348,7 @@ def _display_argv(argv: Sequence[str]) -> tuple[str, ...]:
             value = urllib.parse.urlunsplit(
                 (parts.scheme, host, parts.path, parts.query, parts.fragment)
             )
+        value = scrub(value)
         shown.append(value)
     return tuple(shown)
 

--- a/gentoo_install/redact.py
+++ b/gentoo_install/redact.py
@@ -1,0 +1,36 @@
+# SPDX-License-Identifier: GPL-2.0-or-later
+"""Take crypt hashes out of text that is about to be logged or published.
+
+Two callers, and both are needed: `exec/runner.py` scrubs the argv of every
+command, and `exec/report.py` refuses to publish a log that still holds one,
+because a log carries command output as well as command lines.
+"""
+
+from __future__ import annotations
+
+import re
+from typing import Final
+
+#: A modular crypt hash: `$id$` and then the rest of it. The identifier is
+#: kept and everything after it replaced, so `$6$` still says which scheme
+#: produced it. One expression covers `$6$salt$hash`, bcrypt's
+#: `$2b$rounds$…`, yescrypt's `$y$j9T$salt$hash` and `$argon2id$v=19$…`,
+#: which differ in how many fields follow the identifier.
+CRYPT_HASH: Final[re.Pattern[str]] = re.compile(r"\$[0-9A-Za-z-]{1,12}\$\S{10,}")
+
+HIDDEN: Final[str] = "[redacted]"
+
+
+def _hide(found: re.Match[str]) -> str:
+    scheme = found.group(0).split("$")[1]
+    return f"${scheme}${HIDDEN}"
+
+
+def scrub(value: str) -> str:
+    """`value` with every crypt hash in it replaced by its scheme."""
+    return CRYPT_HASH.sub(_hide, value)
+
+
+def holds_a_secret(text: str) -> bool:
+    """Whether publishing `text` would hand out offline-cracking material."""
+    return CRYPT_HASH.search(text) is not None

--- a/tests/unit/test_proxy.py
+++ b/tests/unit/test_proxy.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 import json
 import socket
 import urllib.request
+from pathlib import Path
 from typing import Any
 from typing import cast
 
@@ -142,3 +143,44 @@ def test_fetch_paths_accept_the_same_proxy_setting(monkeypatch: pytest.MonkeyPat
     assert fetch.zfs_kernel_max(PROXY).maximum == "7.0"
     assert seen and all(proxy is PROXY for proxy in seen)
     assert opened == [PROXY]
+
+
+def test_a_password_hash_never_reaches_the_log_or_the_journal() -> None:
+    """`usermod --password` takes the hash as an argument, and this run's log
+    is what `offer_paste` offers to upload to a public pastebin."""
+    secret = "$6$rQ8n2YeKp$T7xLmQvBc3ZdWnRfHjKgPsAeUyIoNbXcVmZlQwErTyUi"
+    lines: list[str] = []
+    runner = Runner(log=lines.append, dry_run=True)
+    result = runner.run(["usermod", "--password", secret, "root"])
+    assert all(secret not in line for line in lines), lines
+    assert secret not in result.command, result.command
+    assert any("$6$" in line for line in lines), "the scheme still names itself"
+
+
+def test_a_log_that_still_holds_a_hash_is_not_published(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The argv scrub cannot reach what a command printed, so the last thing
+    before the upload reads the body it is about to hand out."""
+    from gentoo_install.exec import fetch as fetch_module
+    from gentoo_install.exec import report
+    from gentoo_install.exec.report import RunFile
+
+    body = (
+        "run: usermod --password '$6$[redacted]' root\n"
+        "root:$6$AbCdEf$0123456789abcdefghij:20000:\n"
+    )
+    (tmp_path / RunFile.LOG.value).write_text(body)
+    said: list[str] = []
+    sent: list[str] = []
+
+    def upload(text: str, export: object) -> str:
+        sent.append(text)
+        return "https://paste.example/1"
+
+    monkeypatch.setattr(fetch_module, "upload", upload)
+    report.offer_paste(
+        tmp_path, said.append, False, False, lambda question: True, lambda address: None
+    )
+    assert sent == [], sent
+    assert any("password hash" in line for line in said), said


### PR DESCRIPTION
`_display_argv` redacted URL user information only, so the hash `usermod --password` takes as an argument reached `install.log` and the command journal, and `offer_paste` uploads that log to a public pastebin.

Two layers, because the second is not a copy of the first: `redact.scrub` takes the hash out of every command line, and `offer_paste` reads the body it is about to hand out, because a log carries what commands printed as well as how they were called. One expression covers `$6$`, bcrypt, yescrypt and argon2, which differ in how many fields follow the identifier.