### PR TITLE
log: isolate journal attempts

### DIFF
--- a/gentoo_install/cli.py
+++ b/gentoo_install/cli.py
@@ -617,8 +617,12 @@ def install(
         )
         identity = _run_identity(config)
         if arguments.resume:
+            resuming = journal.resume()
             _refuse_a_different_run(journal, identity, record)
-        journal.started(**identity)
+            if not resuming:
+                journal.started(**identity)
+        else:
+            journal.started(**identity)
         finished = completed(journal) if arguments.resume else frozenset()
         if arguments.resume:
             # Replayed before anything runs. The operation that recorded an

--- a/gentoo_install/exec/apply.py
+++ b/gentoo_install/exec/apply.py
@@ -366,7 +366,7 @@ def already_degraded(journal: Journal | None) -> set[str]:
         return set()
     return {
         str(entry["what"])
-        for entry in journal.replay()
+        for entry in journal.resume_entries()
         if entry.get("event") == "degraded" and entry.get("what")
     }
 
@@ -384,7 +384,7 @@ def completed(journal: Journal | None) -> frozenset[tuple[int, str]]:
     if journal is None:
         return frozenset()
     done: set[tuple[int, str]] = set()
-    for entry in journal.replay():
+    for entry in journal.resume_entries():
         if entry.get("event") != "operation" or entry.get("status") != "done":
             continue
         position = entry.get("position")

--- a/gentoo_install/log.py
+++ b/gentoo_install/log.py
@@ -12,6 +12,7 @@ from __future__ import annotations
 
 import json
 import re
+import uuid
 from dataclasses import dataclass, field
 from enum import Enum
 from pathlib import Path
@@ -33,9 +34,13 @@ class Journal:
     path: Path
     #: Kept in memory as well, so a caller can assert on a run without parsing.
     entries: list[dict[str, Any]] = field(default_factory=list)
+    attempt_id: str | None = field(default=None, init=False, repr=False)
+    _resume_selected: bool = field(default=False, init=False, repr=False)
 
     def write(self, kind: str, **fields: Any) -> None:
         entry: dict[str, Any] = {"event": kind, **fields}
+        if self.attempt_id is not None:
+            entry.setdefault("attempt", self.attempt_id)
         self.entries.append(entry)
         self.path.parent.mkdir(parents=True, exist_ok=True)
         with self.path.open("a") as handle:
@@ -64,18 +69,47 @@ class Journal:
         the first run left, or against an installer that numbers them
         differently.
         """
+        self.attempt_id = uuid.uuid4().hex
+        self._resume_selected = True
         self.write(
-            "started", configuration=configuration, session=session, installer=installer
+            "started",
+            configuration=configuration,
+            session=session,
+            installer=installer,
+            attempt=self.attempt_id,
         )
 
+    def resume(self) -> bool:
+        """Select the newest attempt and report whether the journal has entries."""
+        self.attempt_id = None
+        found = False
+        for entry in self.replay():
+            found = True
+            attempt = entry.get("attempt")
+            if entry.get("event") == "started" and isinstance(attempt, str):
+                self.attempt_id = attempt
+        self._resume_selected = True
+        return found
+
+    def resume_entries(self) -> Iterator[dict[str, Any]]:
+        """Entries belonging to the attempt selected for `--resume`."""
+        if not self._resume_selected:
+            self.resume()
+        for entry in self.replay():
+            if self.attempt_id is None:
+                if "attempt" not in entry:
+                    yield entry
+            elif entry.get("attempt") == self.attempt_id:
+                yield entry
+
     def identity(self) -> dict[str, str] | None:
-        """What the first run recorded, or None for a journal without one.
+        """What the selected run recorded, or None for a journal without one.
 
         Every field or none: a partial entry is what a run killed mid-write
         leaves, and half an identity that happens to match is worse than no
         identity at all.
         """
-        for entry in self.replay():
+        for entry in self.resume_entries():
             if entry.get("event") != "started":
                 continue
             held = {name: entry.get(name) for name in self.IDENTITY}

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -2001,6 +2001,30 @@ def test_a_resume_refuses_a_journal_from_another_run(tmp_path: Path) -> None:
     assert said and "records no identity" in said[-1], said
 
 
+def test_a_resume_checks_the_newest_journal_attempt(tmp_path: Path) -> None:
+    from gentoo_install.errors import ResumeRefused
+    from gentoo_install.log import Journal
+
+    path = tmp_path / "install.jsonl"
+    earlier = {
+        "configuration": "first",
+        "session": "boot",
+        "installer": "tree",
+    }
+    resumed = {
+        "configuration": "second",
+        "session": "boot",
+        "installer": "tree",
+    }
+    journal = Journal(path=path)
+    journal.started(**earlier)
+    Journal(path=path).started(**resumed)
+
+    cli._refuse_a_different_run(Journal(path=path), resumed, lambda line: None)
+    with pytest.raises(ResumeRefused, match="different configuration"):
+        cli._refuse_a_different_run(Journal(path=path), earlier, lambda line: None)
+
+
 def test_every_refusal_names_a_field_the_identity_carries() -> None:
     """A refusal for a field the journal does not record is one no run can
     trigger, and a field with no refusal is one no run is refused for."""

--- a/tests/unit/test_resume.py
+++ b/tests/unit/test_resume.py
@@ -96,6 +96,54 @@ def test_a_second_resume_does_not_redo_what_the_first_one_finished(tmp_path: Pat
     assert completed(Journal(path=path)) == {(n, f"op{n}") for n in range(7)}
 
 
+def test_a_new_run_does_not_inherit_an_earlier_runs_checkpoints(tmp_path: Path) -> None:
+    path = tmp_path / "install.jsonl"
+    earlier = Journal(path=path)
+    earlier.started(configuration="first", session="boot", installer="tree")
+    earlier.write(
+        "operation",
+        stage="partition",
+        describe="partition",
+        identity="partition",
+        seconds=0.1,
+        status="done",
+        position=0,
+    )
+
+    Journal(path=path).started(configuration="second", session="boot", installer="tree")
+
+    assert completed(Journal(path=path)) == frozenset()
+
+
+def test_a_resume_keeps_its_earlier_checkpoints(tmp_path: Path) -> None:
+    path = tmp_path / "install.jsonl"
+    initial = Journal(path=path)
+    initial.started(configuration="config", session="boot", installer="tree")
+    initial.write(
+        "operation",
+        stage="partition",
+        describe="partition",
+        identity="partition",
+        seconds=0.1,
+        status="done",
+        position=0,
+    )
+
+    resumed = Journal(path=path)
+    assert resumed.resume()
+    resumed.write(
+        "operation",
+        stage="partition",
+        describe="format",
+        identity="format",
+        seconds=0.1,
+        status="done",
+        position=1,
+    )
+
+    assert completed(Journal(path=path)) == {(0, "partition"), (1, "format")}
+
+
 def test_an_entry_from_before_positions_were_recorded_is_ignored(tmp_path: Path) -> None:
     """It says nothing reliable about where it sat, and redoing work is safer
     than skipping the wrong operation."""
@@ -268,6 +316,19 @@ def test_a_resume_gives_up_on_what_the_first_run_gave_up_on(tmp_path: Path) -> N
 
     assert already_degraded(journal) == {"binary packages"}
     assert already_degraded(None) == set()
+
+
+def test_a_new_run_does_not_inherit_an_earlier_runs_degradation(tmp_path: Path) -> None:
+    from gentoo_install.exec.apply import already_degraded
+
+    path = tmp_path / "install.jsonl"
+    earlier = Journal(path=path)
+    earlier.started(configuration="first", session="boot", installer="tree")
+    earlier.degraded("binary packages", "the host answered no signature")
+
+    Journal(path=path).started(configuration="second", session="boot", installer="tree")
+
+    assert already_degraded(Journal(path=path)) == set()
 
 
 def test_an_emerge_after_a_resume_still_builds_from_source(tmp_path: Path) -> None:


### PR DESCRIPTION
An append-only journal let a new run inherit an earlier run's checkpoints: `identity()` read the first `started` event and `completed()` collected every done operation from any attempt, so a later `--resume` could skip work the current run never did.

Each `started` takes an attempt identifier and every later event carries it; `--resume` continues the selected attempt. A journal with no attempt field keeps its whole-file reading, since it has no boundary to use.