### PR TITLE
fetch: keep the threaded probe away from the resolver override

### DIFF
--- a/gentoo_install/exec/fetch.py
+++ b/gentoo_install/exec/fetch.py
@@ -720,6 +720,9 @@ def _over(family: int) -> Iterator[None]:
     Both directions, not only a fall back to IPv4. An IPv6-only machine has no
     IPv4 route at all, and retrying the family that just failed is no retry.
     """
+    # One thread at a time: this replaces the process-global resolver and
+    # restores what it captured, so two overlapping calls leave the second
+    # one's override installed for the rest of the run.
     real = socket.getaddrinfo
 
     def only_this(

--- a/tests/unit/test_proxy.py
+++ b/tests/unit/test_proxy.py
@@ -184,3 +184,19 @@ def test_a_log_that_still_holds_a_hash_is_not_published(
     )
     assert sent == [], sent
     assert any("password hash" in line for line in said), said
+def test_the_threaded_mirror_probe_does_not_force_an_address_family() -> None:
+    """`_over` replaces the process-global resolver and restores the value it
+    captured, so two overlapping calls leave the second override installed."""
+    import ast
+    import inspect
+
+    from gentoo_install.exec import fetch as fetch_module
+
+    reached = {"_read", "_read_patiently", "_download", "_over"}
+    tree = ast.parse(inspect.getsource(fetch_module._probe))
+    called = {
+        node.func.id
+        for node in ast.walk(tree)
+        if isinstance(node, ast.Call) and isinstance(node.func, ast.Name)
+    }
+    assert not called & reached, sorted(called & reached)


### PR DESCRIPTION
`_over` replaces the process-global `socket.getaddrinfo` and restores the value it captured, so two overlapping calls leave the second one's override installed for the rest of the run and every later fetch stays pinned to one address family.

`_probe` is the only worker `rank_mirrors` runs in threads, and it reaches `_over` through no call today, so the hazard is latent rather than live. A test holds that it stays that way, since giving `_probe` the retry behaviour of `_read` is a natural change to want.