### PR TITLE
tui: keep an invalid partition size in the field

### DIFF
--- a/gentoo_install/data/locale/ja.toml
+++ b/gentoo_install/data/locale/ja.toml
@@ -124,6 +124,7 @@
 "Done" = "完了"
 "Size" = "サイズ"
 "512MiB, 20GiB, or empty for the remaining space" = "512MiB、20GiB、空欄なら残り全部"
+"{value} is not a valid size" = "{value} は有効なサイズではありません"
 "the remaining space" = "残り全部"
 "Purpose" = "用途"
 "What is this partition for?" = "このパーティションの用途"

--- a/gentoo_install/data/locale/ko.toml
+++ b/gentoo_install/data/locale/ko.toml
@@ -124,6 +124,7 @@
 "Done" = "완료"
 "Size" = "크기"
 "512MiB, 20GiB, or empty for the remaining space" = "512MiB, 20GiB, 비우면 남은 공간 전부"
+"{value} is not a valid size" = "{value} 값은 유효한 크기가 아닙니다"
 "the remaining space" = "남은 공간 전부"
 "Purpose" = "용도"
 "What is this partition for?" = "이 파티션의 용도"

--- a/gentoo_install/data/locale/zh-CN.toml
+++ b/gentoo_install/data/locale/zh-CN.toml
@@ -124,6 +124,7 @@
 "Done" = "完成"
 "Size" = "大小"
 "512MiB, 20GiB, or empty for the remaining space" = "512MiB、20GiB，留空表示剩余空间"
+"{value} is not a valid size" = "{value} 不是有效的大小"
 "the remaining space" = "剩余空间"
 "Purpose" = "用途"
 "What is this partition for?" = "分区用途"

--- a/gentoo_install/data/locale/zh-TW.toml
+++ b/gentoo_install/data/locale/zh-TW.toml
@@ -124,6 +124,7 @@
 "Done" = "完成"
 "Size" = "大小"
 "512MiB, 20GiB, or empty for the remaining space" = "512MiB、20GiB，留空表示剩餘空間"
+"{value} is not a valid size" = "{value} 不是有效的大小"
 "the remaining space" = "剩餘空間"
 "Purpose" = "用途"
 "What is this partition for?" = "分割區用途"

--- a/gentoo_install/tui/partitions.py
+++ b/gentoo_install/tui/partitions.py
@@ -37,7 +37,7 @@ from ..model.device import (
 from ..model.size import SectorSize, Size
 from ..model.templates import Choice, Layout, build
 from ..model.validate import validate
-from ..errors import GentooInstallError, ValidationFailed
+from ..errors import GentooInstallError, InvalidSize, ValidationFailed
 from .context import (
     Context,
     answers,
@@ -59,6 +59,7 @@ from .widgets import (
     Outcome,
     Screen,
     TextField,
+    TextFieldRejected,
 )
 
 def _known(kind: str) -> FilesystemType | None:
@@ -1040,16 +1041,26 @@ def _edit_field_legacy(
             return None
         return replace(entry, status=chosen_status.unwrap())
     if field == _SIZE:
+        def parse_size(text: str) -> Answer[Size | None] | TextFieldRejected:
+            literal = text.strip()
+            if not literal:
+                return Answer(Outcome.CHOSE, None)
+            try:
+                return Answer(Outcome.CHOSE, Size.parse(literal))
+            except InvalidSize:
+                return TextFieldRejected(
+                    translate("{value} is not a valid size").format(value=text), text
+                )
+
         typed = TextField(
             title=translate("Size"),
             value="" if entry.size is None else str(entry.size),
             placeholder=translate("512MiB, 20GiB, or empty for the remaining space"),
             footer=footer(translate),
-        ).run(screen)
+        ).run_validated(screen, parse_size)
         if not typed.chosen:
             return None
-        text = typed.unwrap().strip()
-        return replace(entry, size=Size.parse(text) if text else None)
+        return replace(entry, size=typed.unwrap())
     if field == _PURPOSE:
         picked = current_menu(
             screen,

--- a/gentoo_install/tui/widgets.py
+++ b/gentoo_install/tui/widgets.py
@@ -654,7 +654,16 @@ class TextField:
     detail: str = ""
 
     def run(self, screen: Screen) -> Answer[str]:
+        return self.run_validated(screen, lambda value: Answer(Outcome.CHOSE, value))
+
+    def run_validated(
+        self,
+        screen: Screen,
+        validator: Callable[[str], Answer[V] | TextFieldRejected],
+    ) -> Answer[V]:
+        """Retry rejected entries while restoring the submitted text."""
         typed = list(self.value)
+        message = ""
         # Backspace leaves the screen only while the field is untouched: a
         # field that had content could not be cleared otherwise, and several
         # of them mean something by empty. Left always leaves, because a
@@ -663,13 +672,18 @@ class TextField:
         # the run.
         touched = False
         while True:
-            self._draw(screen, typed)
+            self._draw(screen, typed, message)
             pressed = screen.key()
             if pressed in ("\n", "KEY_ENTER"):
-                return Answer(Outcome.CHOSE, "".join(typed))
-            if pressed in ("KEY_LEFT", "\x1b"):
+                checked = validator("".join(typed))
+                if not isinstance(checked, TextFieldRejected):
+                    return checked
+                typed = list(checked.correction)
+                message = checked.message
+                touched = False
+            elif pressed in ("KEY_LEFT", "\x1b"):
                 return Answer(Outcome.BACK)
-            if pressed == CLEAR_KEY:
+            elif pressed == CLEAR_KEY:
                 # Every field here arrives with a value in it, and replacing
                 # one meant counting its characters and pressing backspace
                 # that many times: an operator asked for a 512 MiB partition
@@ -688,16 +702,19 @@ class TextField:
                 typed.append(pressed)
                 touched = True
 
-    def _draw(self, screen: Screen, typed: list[str]) -> None:
+    def _draw(self, screen: Screen, typed: list[str], message: str = "") -> None:
         lines, columns = screen.size()
         screen.clear()
         screen.write(0, 0, clip(self.title, columns))
+        row = 2
+        if message:
+            screen.write(1, 2, clip(message, columns - 2), style=Style.REQUIRED)
+            row = 3
         # Brackets and a caret, drawn highlighted: a bare string at the top of
         # an empty screen does not read as somewhere to type.
         room = columns - 8
         shown = "*" * len(typed) if self.masked else "".join(typed)
         shown = _tail_that_fits(shown, room - 1)
-        row = 2
         if self.detail:
             # Wrapped, not clipped: the exact string to type is the last thing
             # in this line and the first thing a clip removes. An operator
@@ -705,10 +722,11 @@ class TextField:
             # Bounded so the field and the footer keep their rows: a detail
             # long enough to fill the screen would otherwise push the box off
             # the bottom and leave nowhere to type.
-            for one in wrap_to_cells(self.detail, columns)[: max(1, lines - 5)]:
+            for one in wrap_to_cells(self.detail, columns)[: max(0, lines - row - 2)]:
                 screen.write(row, 0, one)
                 row += 1
-            row += 1
+            if row < lines - 2:
+                row += 1
         # The caret in both states, so an empty field never reads as a full
         # one. A placeholder is a hint about the shape of the answer and is
         # drawn only when there is no `detail` naming the exact string.
@@ -732,6 +750,14 @@ def _tail_that_fits(text: str, room: int) -> str:
     while text and width(text) > room:
         text = text[1:]
     return text
+
+
+@dataclass(frozen=True)
+class TextFieldRejected:
+    """A submitted text field that must be redrawn with an explanation."""
+
+    message: str
+    correction: str
 
 
 @dataclass

--- a/tests/unit/test_tui_partitions.py
+++ b/tests/unit/test_tui_partitions.py
@@ -1533,6 +1533,26 @@ def test_a_relative_mount_point_typed_into_the_editor_never_reaches_the_table() 
     assert kept is not None and kept.mountpoint == "/srv", kept
 
 
+@pytest.mark.parametrize("invalid", ("abc", "-1GiB", "20ZiB"))
+def test_an_invalid_size_stays_in_the_partition_field(invalid: str) -> None:
+    at = opened()
+    entry = replace(GOOD, size=None)
+    screen = FakeScreen(
+        keys=[*invalid, "\n", *(["\x7f"] * len(invalid)), *"20GiB", "\n"]
+    )
+
+    changed = partitions._edit_field(
+        screen, at, entry, manual.purpose_of(entry), partitions._SIZE
+    )
+    retry = next(
+        frame
+        for frame in screen.frames
+        if f"{invalid} is not a valid size" in "\n".join(frame)
+    )
+    assert f"{invalid}_" in "\n".join(retry)
+    assert changed is not None and changed.size == Size.parse("20GiB")
+    assert screen.keys == []
+
 def test_backing_out_of_a_partition_nobody_filled_in_adds_nothing() -> None:
     """`Add a partition` then `←`: keeping what was typed must not turn an
     editor nobody typed into into a row on the disk."""

--- a/tests/unit/test_tui_widgets.py
+++ b/tests/unit/test_tui_widgets.py
@@ -17,6 +17,7 @@ from gentoo_install.tui.widgets import (
     SEPARATOR,
     Style,
     TextField,
+    TextFieldRejected,
 )
 
 from gentoo_install.i18n import width
@@ -382,6 +383,23 @@ def test_a_validated_form_retains_values_and_draws_the_error_inline() -> None:
     retry = next(frame for frame in screen.frames if "That value is not valid." in "\n".join(frame))
     assert "kept" in "\n".join(retry)
 
+
+def test_a_validated_text_field_retains_the_rejected_value_and_error() -> None:
+    submitted: list[str] = []
+
+    def validate(value: str) -> Answer[str] | TextFieldRejected:
+        submitted.append(value)
+        if value == "wrong":
+            return TextFieldRejected("That value is not valid.", value)
+        return Answer(Outcome.CHOSE, value)
+
+    screen = FakeScreen(keys=[*"wrong", "\n", *(["\x7f"] * 5), *"right", "\n"])
+    answer = TextField(title="Size").run_validated(screen, validate)
+
+    assert answer.unwrap() == "right"
+    assert submitted == ["wrong", "right"]
+    retry = next(frame for frame in screen.frames if "That value is not valid." in "\n".join(frame))
+    assert "wrong_" in "\n".join(retry)
 
 def test_a_validator_can_correct_one_field_without_losing_the_others() -> None:
     submitted: list[list[str]] = []


### PR DESCRIPTION
`Size.parse` raised through the partition editor, so typing `abc`, `-1GiB` or an unknown unit left it through an exception and the operator lost the table they were editing instead of being told which value is wrong.

`TextField.run_validated` retries with the submitted text restored and the reason drawn above the field; `run()` is the same loop with a validator that accepts everything, so there is one loop rather than two.