### PR TITLE
tui: three interface defects in the screens module

### DIFF
--- a/gentoo_install/data/locale/ja.toml
+++ b/gentoo_install/data/locale/ja.toml
@@ -61,6 +61,8 @@
 "Back to the menu" = "メニューに戻る"
 "Leave" = "終了する"
 "Esc leaves; resize the terminal" = "Esc で終了するか、端末のサイズを変更してください"
+"The terminal is {columns}x{lines} and the interface needs {minimum_columns}x{minimum_lines}" = "端末は {columns}x{lines} で、インターフェースには {minimum_columns}x{minimum_lines} が必要です"
+"[enter] select" = "[enter] 選択"
 "Save the configuration and leave" = "設定を保存して終了する"
 "Send the configuration to the pastebin and leave" = "設定を paste に投稿して終了"
 "public, without the password hashes" = "公開（パスワードハッシュを除去）"

--- a/gentoo_install/data/locale/ko.toml
+++ b/gentoo_install/data/locale/ko.toml
@@ -61,6 +61,8 @@
 "Back to the menu" = "메뉴로 돌아가기"
 "Leave" = "나가기"
 "Esc leaves; resize the terminal" = "Esc 키로 나가거나 터미널 크기를 조정하십시오"
+"The terminal is {columns}x{lines} and the interface needs {minimum_columns}x{minimum_lines}" = "터미널은 {columns}x{lines}이며 인터페이스에는 {minimum_columns}x{minimum_lines}이 필요합니다"
+"[enter] select" = "[enter] 선택"
 "Save the configuration and leave" = "설정을 저장하고 나가기"
 "Send the configuration to the pastebin and leave" = "설정을 paste에 올리고 나가기"
 "public, without the password hashes" = "공개(비밀번호 해시 제거)"

--- a/gentoo_install/data/locale/zh-CN.toml
+++ b/gentoo_install/data/locale/zh-CN.toml
@@ -61,6 +61,8 @@
 "Back to the menu" = "回到菜单"
 "Leave" = "离开"
 "Esc leaves; resize the terminal" = "按 Esc 离开，或调整终端大小"
+"The terminal is {columns}x{lines} and the interface needs {minimum_columns}x{minimum_lines}" = "终端为 {columns}x{lines}，界面需要 {minimum_columns}x{minimum_lines}"
+"[enter] select" = "[enter] 选择"
 "Save the configuration and leave" = "保存配置后离开"
 "Send the configuration to the pastebin and leave" = "上传配置到 pastebin 后离开"
 "public, without the password hashes" = "公开（去除密码哈希）"

--- a/gentoo_install/data/locale/zh-TW.toml
+++ b/gentoo_install/data/locale/zh-TW.toml
@@ -61,6 +61,8 @@
 "Back to the menu" = "回到選單"
 "Leave" = "離開"
 "Esc leaves; resize the terminal" = "按 Esc 離開，或調整終端機大小"
+"The terminal is {columns}x{lines} and the interface needs {minimum_columns}x{minimum_lines}" = "終端機為 {columns}x{lines}，介面需要 {minimum_columns}x{minimum_lines}"
+"[enter] select" = "[enter] 選取"
 "Save the configuration and leave" = "儲存設定後離開"
 "Send the configuration to the pastebin and leave" = "上傳設定到 pastebin 後離開"
 "public, without the password hashes" = "公開（去除密碼雜湊）"

--- a/gentoo_install/tui/curses_screen.py
+++ b/gentoo_install/tui/curses_screen.py
@@ -166,7 +166,7 @@ class CursesScreen:
         """Draw the required size and the two ways out of the wait."""
         self.clear()
         self.write(0, 0, self._translate("Esc leaves; resize the terminal"))
-        self.write(2, 0, too_small(self))
+        self.write(2, 0, too_small(self, self._translate))
         self.show()
 
 
@@ -177,11 +177,18 @@ class Sized(Protocol):
     def size(self) -> tuple[int, int]: ...
 
 
-def too_small(screen: Sized) -> str:
+def too_small(
+    screen: Sized, translate: Callable[[str], str] = lambda source: source
+) -> str:
     lines, columns = screen.size()
     if lines >= MINIMUM_LINES and columns >= MINIMUM_COLUMNS:
         return ""
-    return (
-        f"the terminal is {columns}x{lines} and the interface needs "
-        f"{MINIMUM_COLUMNS}x{MINIMUM_LINES}"
+    return translate(
+        "The terminal is {columns}x{lines} and the interface needs "
+        "{minimum_columns}x{minimum_lines}"
+    ).format(
+        columns=columns,
+        lines=lines,
+        minimum_columns=MINIMUM_COLUMNS,
+        minimum_lines=MINIMUM_LINES,
     )

--- a/gentoo_install/tui/screens.py
+++ b/gentoo_install/tui/screens.py
@@ -11,6 +11,7 @@ from __future__ import annotations
 
 import re
 from dataclasses import dataclass, replace
+from enum import Enum
 from itertools import takewhile
 from typing import Callable, Final, Sequence
 
@@ -548,6 +549,14 @@ def system_screen(screen: Screen, config: InstallConfig, context: Context) -> An
     )
 
 
+class _ProxyField(Enum):
+    HOST = "host"
+    PORT = "port"
+    USERNAME = "username"
+    PASSWORD = "password"
+    BYPASS = "bypass"
+
+
 def proxy_screen(screen: Screen, config: InstallConfig, context: Context) -> Answer[InstallConfig]:
     """Set the session proxy before any network-derived setting is read."""
     translate = context.translate
@@ -562,16 +571,63 @@ def proxy_screen(screen: Screen, config: InstallConfig, context: Context) -> Ans
     if not kind_answer.chosen:
         return Answer(kind_answer.outcome)
     selected_kind = kind_answer.unwrap()
+    proxy_fields = [
+        (
+            _ProxyField.HOST,
+            Field(
+                label=translate("Proxy host"),
+                value=current.host,
+                accepts=Accepts.NO_SPACE,
+                placeholder="proxy.example.com",
+            ),
+        ),
+        (
+            _ProxyField.PORT,
+            Field(
+                label=translate("Proxy port"),
+                value=str(current.port) if current.port else "",
+                accepts=Accepts.DIGITS,
+                placeholder="3128",
+            ),
+        ),
+        (
+            _ProxyField.USERNAME,
+            Field(
+                label=translate("Proxy username"),
+                value=current.username,
+                accepts=Accepts.NO_SPACE,
+                placeholder=translate("empty when the proxy needs no login"),
+            ),
+        ),
+        (_ProxyField.PASSWORD, Field(label=translate("Proxy password"), value=current.password, secret=True)),
+        (
+            _ProxyField.BYPASS,
+            Field(
+                label=translate("Bypass hosts"),
+                value=", ".join(current.bypass),
+                accepts=Accepts.NO_SPACE,
+                placeholder=translate("comma-separated host names"),
+            ),
+        ),
+    ]
+    positions = {name: index for index, (name, _) in enumerate(proxy_fields)}
 
     def validated(values: list[str]) -> Answer[InstallConfig] | FormRejected:
-        host, port, username, password, hosts = (one.strip() for one in values)
+        host = values[positions[_ProxyField.HOST]].strip()
+        port = values[positions[_ProxyField.PORT]].strip()
+        username = values[positions[_ProxyField.USERNAME]].strip()
+        password = values[positions[_ProxyField.PASSWORD]].strip()
+        hosts = values[positions[_ProxyField.BYPASS]].strip()
         if not host and (port or username or password or hosts):
             return FormRejected(translate("Proxy host is required when proxy fields are set"), {0: host})
         if port and (not port.isdecimal() or not 1 <= int(port) <= 65535):
             return FormRejected(translate("Proxy port must be between 1 and 65535"), {1: port})
         bypass = tuple(one for one in (item.strip() for item in hosts.split(",")) if one)
         if any(any(char.isspace() for char in item) for item in bypass):
-            return FormRejected(translate("Bypass hosts must not contain spaces"), {1: hosts})
+            return FormRejected(
+                translate("Bypass hosts must not contain spaces"),
+                {positions[_ProxyField.BYPASS]: hosts},
+            )
         selected = replace(config, proxy=ProxyConfig(
             kind=selected_kind, host=host, port=int(port or "0"), username=username,
             password=password, bypass=bypass,
@@ -581,33 +637,7 @@ def proxy_screen(screen: Screen, config: InstallConfig, context: Context) -> Ans
 
     return Form(
         title=translate("Proxy"),
-        fields=[
-            Field(
-                label=translate("Proxy host"),
-                value=current.host,
-                accepts=Accepts.NO_SPACE,
-                placeholder="proxy.example.com",
-            ),
-            Field(
-                label=translate("Proxy port"),
-                value=str(current.port) if current.port else "",
-                accepts=Accepts.DIGITS,
-                placeholder="3128",
-            ),
-            Field(
-                label=translate("Proxy username"),
-                value=current.username,
-                accepts=Accepts.NO_SPACE,
-                placeholder=translate("empty when the proxy needs no login"),
-            ),
-            Field(label=translate("Proxy password"), value=current.password, secret=True),
-            Field(
-                label=translate("Bypass hosts"),
-                value=", ".join(current.bypass),
-                accepts=Accepts.NO_SPACE,
-                placeholder=translate("comma-separated host names"),
-            ),
-        ],
+        fields=[field for _, field in proxy_fields],
         footer=footer(translate),
         done=translate("Done"),
     ).run_validated(screen, validated)

--- a/gentoo_install/tui/screens.py
+++ b/gentoo_install/tui/screens.py
@@ -2217,10 +2217,11 @@ def language_screen(screen: Screen, context: Context) -> str:
         (index for index, (tag, _, _) in enumerate(INTERFACE_LANGUAGES) if tag == context.tag), 0
     )
     menu: Menu[str] = Menu(
+        # This screen precedes the language choice, so each script identifies it.
         title="Language / \u8a9e\u8a00 / \uc5b8\uc5b4",
         items=items,
         cursor=start,
-        footer="[enter] select",
+        footer=context.translate("[enter] select"),
     )
     answer = menu.run(screen)
     return answer.unwrap() if answer.chosen else context.tag

--- a/gentoo_install/tui/screens.py
+++ b/gentoo_install/tui/screens.py
@@ -1747,11 +1747,16 @@ def table_screen(screen: Screen, config: InstallConfig, context: Context) -> Ans
     refuses BIOS booting a GPT disk with no bios-boot partition."""
     translate = context.translate
     items = [Item(label=table.value, value=table) for table in TableType]
+    current = (
+        context.layout.disks[0].table
+        if context.manual and context.layout.disks
+        else context.choice.table
+    )
     menu: Menu[TableType] = Menu(
         title=translate("Partition table"),
         preamble=(translate("The table format controls how firmware and the kernel identify partitions."),),
         items=items,
-        current=context.choice.table,
+        current=current,
         footer=footer(translate),
     )
     answer = menu.run(screen)

--- a/tests/unit/test_tui_app.py
+++ b/tests/unit/test_tui_app.py
@@ -1,6 +1,7 @@
 # SPDX-License-Identifier: GPL-2.0-or-later
 from __future__ import annotations
 
+from collections.abc import Callable
 from dataclasses import replace
 
 import pytest
@@ -2771,6 +2772,29 @@ def test_cancelled_manual_layout_restores_the_opening_table(
     monkeypatch.setattr(partitions, "_act_on", mutate)
     partitions.partitions_screen(FakeScreen(keys=["\n", "q"], lines=30), config(), at)
     assert at.layout == before
+
+
+def test_proxy_bypass_rejection_corrects_the_named_field(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The correction follows the bypass field when the form order changes."""
+    def capture(
+        form: widgets.Form,
+        _screen: widgets.Screen,
+        validator: Callable[
+            [list[str]], widgets.Answer[InstallConfig] | widgets.FormRejected
+        ],
+    ) -> widgets.Answer[InstallConfig]:
+        values = ["proxy.example", "3128", "", "", "outside host"]
+        rejected = validator(values)
+        assert isinstance(rejected, widgets.FormRejected)
+        index, corrected = next(iter(rejected.corrections.items()))
+        assert form.fields[index].label == "Bypass hosts"
+        assert corrected == values[index]
+        return widgets.Answer(Outcome.BACK)
+
+    monkeypatch.setattr(widgets.Form, "run_validated", capture)
+    screens.proxy_screen(FakeScreen(keys=["\n"], lines=24), config(), context())
 
 
 def test_loaded_configuration_remains_the_disk_target_after_an_edit() -> None:

--- a/tests/unit/test_tui_app.py
+++ b/tests/unit/test_tui_app.py
@@ -2823,6 +2823,20 @@ def test_loaded_configuration_remains_the_disk_target_after_an_edit() -> None:
     assert edited.disk.graph.of_type(Existing)[0].selector == "/dev/loaded"
 
 
+def test_manual_table_screen_reopens_on_the_selected_disk_table() -> None:
+    """Enter keeps the table the manual disk already carries."""
+    from gentoo_install.model.device import TableType
+
+    at = context()
+    at.manual = True
+    at.layout = manual.suggest(at.choice.disk, at.firmware)
+    at.layout.disks[0].table = TableType.MBR
+
+    screens.table_screen(FakeScreen(keys=["\n"], lines=24), config(), at)
+
+    assert at.layout.disks[0].table is TableType.MBR
+
+
 def test_the_zfs_bootloader_prompt_returns_only_installable_answers() -> None:
     """It changed the bootloader and left the esp at `/efi`, so choosing
     systemd-boot returned a configuration `validate` refuses -- from the very

--- a/tests/unit/test_tui_app.py
+++ b/tests/unit/test_tui_app.py
@@ -838,6 +838,17 @@ def test_choosing_the_traditional_catalog_moves_the_defaults_with_it() -> None:
     assert china.portage.mirrors.region is taiwan.portage.mirrors.region
 
 
+def test_language_selector_translates_its_footer() -> None:
+    """The selected catalog is available before the language menu opens."""
+    at = context()
+    at.translate = Catalog("zh-TW")
+    screen = FakeScreen(keys=["\x1b"], lines=24)
+
+    screens.language_screen(screen, at)
+
+    assert at.translate("[enter] select") in "\n".join(screen.frames[0])
+
+
 def test_every_interface_language_has_defaults_of_its_own() -> None:
     """A language offered on the first screen and missing from the table leaves
     the operator on someone else's timezone."""

--- a/tests/unit/test_tui_curses.py
+++ b/tests/unit/test_tui_curses.py
@@ -255,6 +255,27 @@ with os.fdopen({write_end}, "w") as handle:
     return result, bytes(drawing)
 
 
+def test_a_too_small_screen_uses_the_catalog() -> None:
+    """The constrained terminal message follows the interface language."""
+    from gentoo_install.i18n import Catalog
+    from gentoo_install.tui.curses_screen import too_small
+    from gentoo_install.tui.widgets import MINIMUM_COLUMNS, MINIMUM_LINES
+
+    class Sized:
+        def size(self) -> tuple[int, int]:
+            return 4, 16
+
+    translate = Catalog("zh-TW")
+    assert too_small(Sized(), translate) == translate(
+        "The terminal is {columns}x{lines} and the interface needs "
+        "{minimum_columns}x{minimum_lines}"
+    ).format(
+        columns=16,
+        lines=4,
+        minimum_columns=MINIMUM_COLUMNS,
+        minimum_lines=MINIMUM_LINES,
+    )
+
 #: Walk to the bottom of the menu and leave. The exact rows do not matter: what
 #: is under test is that a real terminal draws them and hands keys back.
 WALK = r"""
@@ -498,8 +519,7 @@ def test_a_form_that_no_longer_fits_says_how_to_leave() -> None:
     # Back, not cancelled: a terminal that shrank below the floor still lets
     # escape leave the screen, and leaving is what the message offers.
     assert result["outcome"] == "back"
-    assert b"the interface needs 20x6" in drawing
-    assert b"Escape after translation" in drawing
+    assert drawing.count(b"Escape after translation") >= 2
 
 
 #: What a terminal does with a wide glyph, asked of ncurses rather than of the


### PR DESCRIPTION
A bypass list containing whitespace was rejected into field index 1, which is the proxy port, so the invalid list stayed and the port was overwritten; the next submission then named the wrong field. Fields are now identified by a `_ProxyField` enum rather than counted, so reordering them cannot repeat this.

Reopening `Partition table` restored its highlight from the template choice rather than the manual disk, so accepting the highlighted row replaced a table the operator had chosen.

`too_small()` and the language selector's footer drew English in a translated interface. The selector's own title stays multilingual and untranslated, because it is drawn before a language has been chosen; a comment records that.