### PR TITLE
model: refuse the disk keys a mode cannot use

### DIFF
--- a/gentoo_install/model/serialise.py
+++ b/gentoo_install/model/serialise.py
@@ -16,7 +16,7 @@ from pathlib import PurePosixPath
 from typing import Any, Final
 
 from . import config as model_config
-from .config import DiskMode, InstallConfig, ProxyConfig
+from .config import InstallConfig, ProxyConfig
 from .templates import Choice
 from .device import (
     Existing,
@@ -162,32 +162,19 @@ def _simple(choice: Choice) -> list[str]:
 def _disk(config: InstallConfig) -> list[str]:
     disk = config.disk
     lines = ["", "[disk]"]
-    if disk.layout_is_read_from_the_machine:
-        lines.append(f'mode = "{disk.mode.value}"')
-        return lines
-    if disk.mode is DiskMode.DD:
-        return [
-            *lines,
-            f'mode = "{disk.mode.value}"',
-            f"source = {_value(disk.source)}",
-            f"source_format = {_value(disk.source_format)}",
-            f"destination = {_value(disk.destination)}",
-        ]
-    if disk.mode is DiskMode.IMAGE:
-        lines += [
-            f'mode = "{disk.mode.value}"',
-            f'image = {_value(disk.image)}',
-            f"size = {_value(disk.size)}" if disk.size is not None else "",
-        ]
-        if disk.wipe:
-            lines.append("wipe = true")
-        lines = [line for line in lines if line]
+    for field in fields(disk):
+        if field.name in {"graph", "root", "simple"}:
+            continue
+        held = getattr(disk, field.name)
+        if held == field.default or held == _empty(field.default_factory):
+            continue
+        lines.append(f"{field.name} = {_value(held)}")
     if disk.simple is not None:
-        # The template it was expanded from, not the graph: a reader hand-edits
-        # eight lines instead of sixty, and `parse` expands it again with the
-        # one function the interface itself uses.
+        # `simple` reconstructs graph and root; writing both is a rejected duplicate.
+        # Its eight fields replace the graph's sixty for a hand-edited file.
         return [*lines, "", "[disk.simple]", *_simple(disk.simple)]
-    lines.append(f'root = "{disk.root}"')
+    if disk.root:
+        lines.append(f"root = {_value(disk.root)}")
     for node in disk.graph.nodes.values():
         kind = KINDS.get(type(node))
         if kind is None:

--- a/gentoo_install/model/validate.py
+++ b/gentoo_install/model/validate.py
@@ -11,7 +11,7 @@ import ipaddress
 
 import re
 from collections import Counter
-from dataclasses import dataclass
+from dataclasses import dataclass, fields
 from pathlib import PurePosixPath
 from typing import Collection, Final, Mapping
 
@@ -20,6 +20,7 @@ from . import compat
 from .config import (
     Bootloader,
     BootloaderConfig,
+    DiskConfig,
     DiskMode,
     InitSystem,
     InstallConfig,
@@ -69,6 +70,37 @@ _L10N_TAG: Final[re.Pattern[str]] = re.compile(
     r"^[a-z]{2,3}(?:-[A-Z][a-z]{3})?(?:-(?:[A-Z]{2}|[0-9]{3}))?"
     r"(?:-(?:[0-9][a-z0-9]{3}|[a-z][a-z0-9]{4,7}))*$"
 )
+
+#: `[disk]` keys valid after `mode` selects the operation. `mode` itself
+#: selects this table, so it is deliberately not a member of any row.
+DISK_MODE_FIELDS: Final[Mapping[DiskMode, frozenset[str]]] = {
+    DiskMode.PARTITION: frozenset({"devices", "root", "simple"}),
+    DiskMode.IN_PLACE: frozenset(),
+    DiskMode.IMAGE: frozenset({"devices", "root", "simple", "image", "size", "wipe"}),
+    DiskMode.DD: frozenset({"source", "source_format", "destination"}),
+}
+
+
+def _configured_disk_fields(disk: DiskConfig) -> frozenset[str]:
+    """The TOML keys represented by the disk configuration."""
+    if disk.simple is not None:
+        structural = frozenset({"simple"})
+    else:
+        structural = frozenset(
+            name
+            for name, present in (
+                ("devices", bool(disk.graph.nodes)),
+                ("root", bool(disk.root)),
+            )
+            if present
+        )
+    values = {
+        field.name
+        for field in fields(disk)
+        if field.name not in {"graph", "root", "simple", "mode"}
+        and getattr(disk, field.name) != field.default
+    }
+    return structural | frozenset(values)
 
 
 def parse_profile_list(
@@ -332,42 +364,31 @@ def _ignored_by_dd(config: InstallConfig) -> list[str]:
 
 def _disk_mode_problems(config: InstallConfig) -> list[str]:
     disk = config.disk
+    problems = [
+        f"disk.{field} is not allowed in {disk.mode.value} mode"
+        for field in sorted(_configured_disk_fields(disk) - DISK_MODE_FIELDS[disk.mode])
+    ]
     if disk.mode is DiskMode.PARTITION:
-        # The ordinary mode refused nothing, so a key belonging to another one
-        # was accepted and ignored: `disk.size` in a partition configuration
-        # even survived a save as `None`, because `serialise` writes it only
-        # for image mode. The dd branch below has had this table from the
-        # start.
-        elsewhere = (
-            ("disk.image", bool(disk.image)),
-            ("disk.size", disk.size is not None),
-            ("disk.source", bool(disk.source)),
-            ("disk.destination", bool(disk.destination)),
-        )
-        return [
-            f"{name} is not allowed in partition mode" for name, used in elsewhere if used
-        ]
+        return problems
     if disk.mode is DiskMode.IMAGE:
-        image_problems: list[str] = []
         if not disk.image:
-            image_problems.append("disk.image is required in image mode")
+            problems.append("disk.image is required in image mode")
         elif disk.image.startswith("/dev/"):
-            image_problems.append("disk.image must name a file rather than a physical disk")
+            problems.append("disk.image must name a file rather than a physical disk")
         if disk.size is None:
-            image_problems.append("disk.size is required in image mode")
+            problems.append("disk.size is required in image mode")
         for device in disk.graph.of_type(Existing):
             if device.selector.startswith("/dev/"):
-                image_problems.append(
+                problems.append(
                     f"disk.devices {device.id} selects a physical disk in image mode"
                 )
             elif device.selector != disk.image:
-                image_problems.append(
+                problems.append(
                     f"disk.devices {device.id} selects {device.selector!r} in image mode; "
                     "use disk.image rather than a physical disk"
                 )
-        return image_problems
+        return problems
     if disk.mode is DiskMode.DD:
-        problems: list[str] = []
         if not disk.source:
             problems.append("disk.source is required in dd mode")
         if not disk.destination:
@@ -376,23 +397,10 @@ def _disk_mode_problems(config: InstallConfig) -> list[str]:
             problems.append("disk.destination must name a device under /dev")
         if disk.source and disk.source == disk.destination:
             problems.append("disk.source and disk.destination must differ")
-        forbidden = (
-            ("disk.devices", bool(disk.graph.nodes)),
-            ("disk.root", bool(disk.root)),
-            ("disk.image", bool(disk.image)),
-            ("disk.size", disk.size is not None),
-            ("disk.wipe", disk.wipe),
-        )
-        problems.extend(f"{name} is not allowed in dd mode" for name, used in forbidden if used)
         return problems
-    in_place_problems: list[str] = []
-    if disk.graph.nodes:
-        in_place_problems.append("disk.devices is not allowed in in-place mode")
-    if disk.root:
-        in_place_problems.append("disk.root is not allowed in in-place mode")
     if config.bootloader.kind is Bootloader.ZFSBOOTMENU:
-        in_place_problems.append("disk.mode in-place cannot select ZFSBootMenu without a device graph")
-    return in_place_problems
+        problems.append("disk.mode in-place cannot select ZFSBootMenu without a device graph")
+    return problems
 
 
 def _proxy_problems(config: InstallConfig) -> list[str]:

--- a/tests/unit/test_validate.py
+++ b/tests/unit/test_validate.py
@@ -12,7 +12,9 @@ from gentoo_install.errors import ConfigError, ValidationFailed
 from gentoo_install.model import compat
 from gentoo_install.model.config import (
     BootloaderConfig,
+    DiskConfig,
     DiskMode,
+    ImageFormat,
     InitSystem,
     InstallConfig,
     KernelConfig,
@@ -37,10 +39,79 @@ from gentoo_install.model.device import (
 from gentoo_install.model.size import Size
 from gentoo_install.exec.config import load
 from gentoo_install.exec.probe import amd64_profiles, profiles_from_eselect
+from gentoo_install.model.templates import Choice
 from gentoo_install.model.validate import validate, validate_memory_launch, zfs_kernel_ceiling
 from gentoo_install.model.parse import parse
 
 from .layouts import encrypted_root, config, ext4_on_gpt, i, unlockable_root, zfs_root
+
+_DISK_MODE_FIELD_CASES: tuple[tuple[DiskMode, str], ...] = (
+    (DiskMode.PARTITION, "image"),
+    (DiskMode.PARTITION, "size"),
+    (DiskMode.PARTITION, "wipe"),
+    (DiskMode.PARTITION, "source"),
+    (DiskMode.PARTITION, "source_format"),
+    (DiskMode.PARTITION, "destination"),
+    (DiskMode.IN_PLACE, "devices"),
+    (DiskMode.IN_PLACE, "root"),
+    (DiskMode.IN_PLACE, "simple"),
+    (DiskMode.IN_PLACE, "image"),
+    (DiskMode.IN_PLACE, "size"),
+    (DiskMode.IN_PLACE, "wipe"),
+    (DiskMode.IN_PLACE, "source"),
+    (DiskMode.IN_PLACE, "source_format"),
+    (DiskMode.IN_PLACE, "destination"),
+    (DiskMode.IMAGE, "source"),
+    (DiskMode.IMAGE, "source_format"),
+    (DiskMode.IMAGE, "destination"),
+    (DiskMode.DD, "devices"),
+    (DiskMode.DD, "root"),
+    (DiskMode.DD, "simple"),
+    (DiskMode.DD, "image"),
+    (DiskMode.DD, "size"),
+    (DiskMode.DD, "wipe"),
+)
+
+
+def _mode_config(mode: DiskMode) -> InstallConfig:
+    if mode is DiskMode.PARTITION:
+        return config(ext4_on_gpt())
+    if mode is DiskMode.IMAGE:
+        return image_config()
+    if mode is DiskMode.DD:
+        return dd_config()
+    installation = config()
+    return replace(
+        installation,
+        disk=replace(
+            installation.disk,
+            graph=DeviceGraph.build(()),
+            root=i(""),
+            mode=DiskMode.IN_PLACE,
+        ),
+    )
+
+
+def _with_disk_field(disk: DiskConfig, field: str) -> DiskConfig:
+    if field == "devices":
+        return replace(disk, graph=DeviceGraph.build(ext4_on_gpt()))
+    if field == "root":
+        return replace(disk, root=i("mnt-root"))
+    if field == "simple":
+        return replace(disk, simple=Choice(disk="/dev/disk/by-id/virtio-target"))
+    if field == "image":
+        return replace(disk, image="/run/target.raw")
+    if field == "size":
+        return replace(disk, size=Size.parse("20GiB"))
+    if field == "wipe":
+        return replace(disk, wipe=True)
+    if field == "source":
+        return replace(disk, source="/run/source.raw")
+    if field == "source_format":
+        return replace(disk, source_format=ImageFormat.ZSTD)
+    if field == "destination":
+        return replace(disk, destination="/dev/disk/by-id/target")
+    raise AssertionError(f"no value for disk.{field}")
 
 FIXTURES = Path(__file__).resolve().parents[1] / "fixtures"
 
@@ -83,32 +154,28 @@ def dd_config() -> InstallConfig:
     )
 
 
-def test_partition_mode_refuses_the_keys_of_other_modes() -> None:
-    """The ordinary mode refused nothing, so a key belonging to another one
-    was accepted and ignored — and `disk.size` did not even survive a save,
-    because `serialise` writes it only in image mode.
-    """
-    from gentoo_install.model import parse as model_parse
-    from gentoo_install.model.serialise import to_toml
-    import tomllib
+@pytest.mark.parametrize(("mode", "field"), _DISK_MODE_FIELD_CASES)
+def test_every_disk_mode_refuses_other_fields(mode: DiskMode, field: str) -> None:
+    installation = _mode_config(mode)
 
-    sound = config(ext4_on_gpt())
-    validate(sound)
-
-    for field, wrong in (
-        ("image", replace(sound.disk, image="/run/image.raw")),
-        ("size", replace(sound.disk, size=Size.parse("20GiB"))),
-        ("source", replace(sound.disk, source="/run/source.raw")),
-        ("destination", replace(sound.disk, destination="/dev/disk/by-id/target")),
+    with pytest.raises(
+        ValidationFailed,
+        match=rf"disk\.{field} is not allowed in {mode.value} mode",
     ):
-        with pytest.raises(ValidationFailed, match=f"disk.{field} is not allowed"):
-            validate(replace(sound, disk=wrong))
+        validate(replace(installation, disk=_with_disk_field(installation.disk, field)))
 
-    # The save that lost it: a partition configuration carrying a size wrote
-    # TOML without one, so reloading changed the configuration.
-    carried = replace(sound, disk=replace(sound.disk, size=Size.parse("20GiB")))
-    again = model_parse.parse(tomllib.loads(to_toml(carried)))
-    assert again.disk.size is None, again.disk.size
+
+def test_disk_mode_field_cases_cover_the_table() -> None:
+    from gentoo_install.model.validate import DISK_MODE_FIELDS
+
+    assert set(DISK_MODE_FIELDS) == set(DiskMode)
+    all_fields = set().union(*DISK_MODE_FIELDS.values())
+    expected = {
+        (mode, field)
+        for mode, allowed in DISK_MODE_FIELDS.items()
+        for field in all_fields - allowed
+    }
+    assert set(_DISK_MODE_FIELD_CASES) == expected
 
 
 def test_every_port_is_judged_against_one_range() -> None:
@@ -257,25 +324,6 @@ def test_dd_mode_refuses_its_source_as_the_destination() -> None:
         )
 
 
-def test_dd_mode_refuses_target_layout_fields() -> None:
-    installation = dd_config()
-    with pytest.raises(ValidationFailed) as refused:
-        validate(
-            replace(
-                installation,
-                disk=replace(
-                    installation.disk,
-                    graph=DeviceGraph.build(ext4_on_gpt()),
-                    root=i("mnt-root"),
-                    image="/run/target.raw",
-                    size=Size.parse("20GiB"),
-                    wipe=True,
-                ),
-            )
-        )
-    said = str(refused.value)
-    for field in ("disk.devices", "disk.root", "disk.image", "disk.size", "disk.wipe"):
-        assert f"{field} is not allowed in dd mode" in said
 
 
 def test_image_mode_requires_an_image_file() -> None:


### PR DESCRIPTION
Partition mode rejected four keys by hand and accepted `wipe` and `source_format`; the writer then dropped them, so a configuration file could appear to ask for an overwrite or for image streaming, be accepted, and have the plan never receive it. Saving the configuration silently discarded what the operator wrote.

One table names the keys each mode permits, and the writer derives its keys from the dataclass rather than listing them per mode, which makes the existing round trip over every fixture total.