### PR TITLE
exec: redact credentials in failed configuration URLs

### DIFF
--- a/gentoo_install/exec/config.py
+++ b/gentoo_install/exec/config.py
@@ -13,6 +13,7 @@ import tomllib
 from pathlib import Path
 
 from ..errors import ConfigError, GentooInstallError
+from ..redact import scrub
 from ..model.config import InstallConfig
 from ..model.parse import parse
 
@@ -58,9 +59,9 @@ def load_source(source: str) -> InstallConfig:
     try:
         body = fetch.read_text(source, ceiling=URL_CEILING)
     except GentooInstallError as error:
-        raise ConfigError(f"{source}: {error}") from error
+        raise ConfigError(scrub(f"{source}: {error}")) from error
     try:
         raw = tomllib.loads(body)
     except tomllib.TOMLDecodeError as error:
-        raise ConfigError(f"{source}: {error}") from error
+        raise ConfigError(scrub(f"{source}: {error}")) from error
     return parse(raw)

--- a/gentoo_install/exec/fetch.py
+++ b/gentoo_install/exec/fetch.py
@@ -35,6 +35,7 @@ from ..errors import (
     PreflightFailed,
     UploadFailed,
 )
+from ..redact import scrub
 from ..model import paste
 from ..model.validate import KernelCeiling
 from ..model.config import ProxyConfig
@@ -909,9 +910,11 @@ def read_text(url: str, *, ceiling: int) -> str:
         with _urlopen(_asked(url), _CURRENT_PROXY.get(), TIMEOUT) as response:
             body = response.read(ceiling + 1)
     except (urllib.error.URLError, TimeoutError, OSError, http.client.HTTPException) as error:
-        raise DownloadFailed(f"{url} could not be read: {error}{_resolver_state(url)}") from error
+        raise DownloadFailed(
+            scrub(f"{url} could not be read: {error}{_resolver_state(url)}")
+        ) from error
     if len(body) > ceiling:
-        raise DownloadFailed(f"{url} is larger than {ceiling} bytes")
+        raise DownloadFailed(scrub(f"{url} is larger than {ceiling} bytes"))
     return str(body.decode("utf-8", "replace"))
 
 
@@ -920,7 +923,9 @@ def _read_once(url: str, proxy: ProxyConfig | None = None) -> str:
         with _urlopen(_asked(url), proxy, TIMEOUT) as response:
             return str(response.read().decode("utf-8", "replace"))
     except (urllib.error.URLError, TimeoutError, OSError, http.client.HTTPException) as error:
-        raise DownloadFailed(f"{url} could not be read: {error}{_resolver_state(url)}") from error
+        raise DownloadFailed(
+            scrub(f"{url} could not be read: {error}{_resolver_state(url)}")
+        ) from error
 
 
 #: A stage3 is a quarter of a gigabyte over whatever link the operator has, so
@@ -1060,7 +1065,7 @@ def _download_once(
     # the install instead of reaching the next mirror.
     except (urllib.error.URLError, TimeoutError, OSError, http.client.HTTPException) as error:
         partial.unlink(missing_ok=True)
-        raise DownloadFailed(f"{url} could not be fetched: {error}") from error
+        raise DownloadFailed(scrub(f"{url} could not be fetched: {error}")) from error
 
 
 def _verify_signature(digests: Path, fingerprint: str, runner: Runner) -> None:

--- a/gentoo_install/exec/runner.py
+++ b/gentoo_install/exec/runner.py
@@ -15,7 +15,6 @@ import signal
 import subprocess
 import threading
 import time
-import urllib.parse
 from dataclasses import dataclass, field
 from pathlib import Path, PurePosixPath
 from typing import Callable, Sequence, TextIO
@@ -332,25 +331,9 @@ def _display_argv(argv: Sequence[str]) -> tuple[str, ...]:
     `usermod --password` takes the hash as an argument, and this run's log is
     what `offer_paste` uploads to a public pastebin.
     """
-    shown: list[str] = []
-    for value in argv:
-        try:
-            parts = urllib.parse.urlsplit(value)
-        except ValueError:
-            shown.append(value)
-            continue
-        if parts.scheme and parts.hostname and parts.username is not None:
-            host = parts.hostname
-            if ":" in host and not host.startswith("["):
-                host = f"[{host}]"
-            if parts.port is not None:
-                host = f"{host}:{parts.port}"
-            value = urllib.parse.urlunsplit(
-                (parts.scheme, host, parts.path, parts.query, parts.fragment)
-            )
-        value = scrub(value)
-        shown.append(value)
-    return tuple(shown)
+    # `scrub` owns every rule: a second copy of the URL handling lived here
+    # and did not know about the secret query parameters.
+    return tuple(scrub(value) for value in argv)
 
 
 def write_file(path: Path, content: str, mode: int = 0o644) -> None:

--- a/gentoo_install/redact.py
+++ b/gentoo_install/redact.py
@@ -1,14 +1,14 @@
 # SPDX-License-Identifier: GPL-2.0-or-later
-"""Take crypt hashes out of text that is about to be logged or published.
+"""Take secrets out of text that is about to be logged or published.
 
-Two callers, and both are needed: `exec/runner.py` scrubs the argv of every
-command, and `exec/report.py` refuses to publish a log that still holds one,
-because a log carries command output as well as command lines.
+`exec/runner.py` scrubs command arguments, fetch errors scrub their source,
+and `exec/report.py` refuses to publish a log that still holds a secret.
 """
 
 from __future__ import annotations
 
 import re
+import urllib.parse
 from typing import Final
 
 #: A modular crypt hash: `$id$` and then the rest of it. The identifier is
@@ -20,17 +20,57 @@ CRYPT_HASH: Final[re.Pattern[str]] = re.compile(r"\$[0-9A-Za-z-]{1,12}\$\S{10,}"
 
 HIDDEN: Final[str] = "[redacted]"
 
+SECRET_QUERY_PARAMETERS: Final[frozenset[str]] = frozenset(
+    ("token", "key", "password", "secret", "access_token")
+)
+_URL: Final[re.Pattern[str]] = re.compile(r"https?://[^\s'\"`<>]+", re.IGNORECASE)
 
 def _hide(found: re.Match[str]) -> str:
     scheme = found.group(0).split("$")[1]
     return f"${scheme}${HIDDEN}"
 
 
+def _hide_url(found: re.Match[str]) -> str:
+    return _scrub_url(found.group(0))
+
+
+def _scrub_url(value: str) -> str:
+    try:
+        parts = urllib.parse.urlsplit(value)
+        host = parts.hostname
+        port = parts.port
+    except ValueError:
+        return value
+    if not parts.scheme or host is None:
+        return value
+    netloc = parts.netloc
+    if parts.username is not None:
+        if ":" in host and not host.startswith("["):
+            host = f"[{host}]"
+        netloc = f"{host}:{port}" if port is not None else host
+    query = _scrub_query(parts.query)
+    if netloc == parts.netloc and query == parts.query:
+        return value
+    return urllib.parse.urlunsplit((parts.scheme, netloc, parts.path, query, parts.fragment))
+
+
+def _scrub_query(query: str) -> str:
+    pairs = urllib.parse.parse_qsl(query, keep_blank_values=True)
+    if not any(name.casefold() in SECRET_QUERY_PARAMETERS for name, _ in pairs):
+        return query
+    return urllib.parse.urlencode(
+        [
+            (name, HIDDEN if name.casefold() in SECRET_QUERY_PARAMETERS else value)
+            for name, value in pairs
+        ]
+    )
+
+
 def scrub(value: str) -> str:
-    """`value` with every crypt hash in it replaced by its scheme."""
-    return CRYPT_HASH.sub(_hide, value)
+    """`value` with password hashes and URL credentials replaced."""
+    return CRYPT_HASH.sub(_hide, _URL.sub(_hide_url, value))
 
 
 def holds_a_secret(text: str) -> bool:
-    """Whether publishing `text` would hand out offline-cracking material."""
-    return CRYPT_HASH.search(text) is not None
+    """Whether publishing `text` would disclose password material."""
+    return scrub(text) != text

--- a/tests/unit/test_redact.py
+++ b/tests/unit/test_redact.py
@@ -1,0 +1,84 @@
+# SPDX-License-Identifier: GPL-2.0-or-later
+from __future__ import annotations
+
+from typing import Final
+
+import pytest
+
+from gentoo_install.errors import ConfigError, DownloadFailed
+from gentoo_install.exec import config as config_loader
+from gentoo_install.exec import fetch
+from gentoo_install.exec.runner import Runner
+from gentoo_install.redact import SECRET_QUERY_PARAMETERS, holds_a_secret
+
+
+QUERY_SECRET_CASES: Final[tuple[str, ...]] = (
+    "token",
+    "key",
+    "password",
+    "secret",
+    "access_token",
+)
+
+
+def test_query_secret_cases_cover_the_redaction_rule_table() -> None:
+    assert frozenset(QUERY_SECRET_CASES) == SECRET_QUERY_PARAMETERS
+
+
+@pytest.mark.parametrize("parameter", QUERY_SECRET_CASES)
+def test_fetch_failure_redacts_each_secret_query_parameter(
+    parameter: str, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    secret = f"{parameter}-credential"
+    source = f"https://example.invalid/install.toml?{parameter}={secret}&mode=dry-run"
+
+    def refuse(*args: object, **kwargs: object) -> object:
+        raise OSError("network unreachable")
+
+    def resolver_state(url: str) -> str:
+        return ""
+
+    monkeypatch.setattr(fetch, "_urlopen", refuse)
+    monkeypatch.setattr(fetch, "_resolver_state", resolver_state)
+
+    with pytest.raises(DownloadFailed) as caught:
+        fetch.read_text(source, ceiling=1024)
+
+    message = str(caught.value)
+    assert secret not in message and parameter in message and "mode=dry-run" in message
+    assert not holds_a_secret(message)
+
+
+def test_config_error_redacts_user_information_and_query_credentials(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    source = (
+        "https://operator:network-password@example.invalid/install.toml"
+        "?token=query-credential"
+    )
+
+    def refuse(url: str, *, ceiling: int) -> str:
+        raise DownloadFailed(f"{url} could not be read")
+
+    monkeypatch.setattr(fetch, "read_text", refuse)
+
+    with pytest.raises(ConfigError) as caught:
+        config_loader.load_source(source)
+
+    message = str(caught.value)
+    assert not any(
+        secret in message
+        for secret in ("operator", "network-password", "query-credential")
+    )
+    assert not holds_a_secret(message)
+
+
+def test_runner_redacts_query_credentials_with_the_shared_scrubber() -> None:
+    secret = "runner-credential"
+    source = f"https://example.invalid/file?access_token={secret}"
+    lines: list[str] = []
+    result = Runner(log=lines.append, dry_run=True).run(["curl", source])
+    shown = "\n".join((*lines, result.command))
+
+    assert secret not in shown
+    assert not holds_a_secret(shown)


### PR DESCRIPTION
`--config https://user:password@host/install.toml`, or a URL carrying a token in its query, put the credential on the terminal and into the captured log the moment the fetch failed: `fetch.py` and `config.py` each formatted the raw URL into an exception and `cli.py` printed it.

`redact.scrub` now takes URL credentials as well as password hashes, and `_display_argv` drops its own copy of the URL handling — that copy did not know about the secret query parameters, which is how one rule in two places goes wrong.