### PR TITLE
docs: cut the README set and move the reference material out

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -4,45 +4,52 @@
 
 <!-- fact: identity -->
 
-gentoo-install は Linux ライブ環境で動作し、amd64 アーキテクチャの Gentoo システムをインストールするシステムインストーラです。インストール内容は、対話式メニューまたは TOML 設定ファイルで指定できます。プログラムのインターフェイスは、英語、繁体字中国語、簡体字中国語、日本語、韓国語に対応しています。
+gentoo-install は Linux ライブ環境で動作し、amd64 アーキテクチャの Gentoo システムをインストールするシステムインストーラです。インストール内容は対話式メニューまたは TOML 設定ファイルで指定します。プログラムのインターフェイスは英語、繁体字中国語、簡体字中国語、日本語、韓国語に対応しています。
 
 ![インストール内容の各項目を表示するメニュー](screenshot-ja.png)
 
-![簡体字中国語、繁体字中国語、日本語、韓国語を表示する cjktty コンソール](cjk-console.png)
+## 機能の概要
+
+<!-- fact: capability-summary -->
+
+実装範囲には、通常のディスクインストール、ストレージと起動の設定、デスクトップと言語の profile、特殊モードが含まれます。
+
+- **ストレージ。**デバイスグラフはパーティションテーブル、ファイルシステム、LUKS2、LVM、mdraid、ZFS を扱います。
+- **起動とシステム。**GRUB、systemd-boot、ZFSBootMenu は設定に応じて UEFI または BIOS の起動を構成します。
+- **デスクトップと言語。**GNOME、KDE Plasma、Xfce、CJK フォント、入力メソッドは設定項目です。
+- **特殊モード。**メモリ環境、インプレース変換、スパースイメージ、`dd` には個別の制約があります。
+
+[リファレンス](REFERENCE.md#capabilities)はモデル、制限、特殊モードの手順を定義します。
+
+## 検証状況
+
+<!-- fact: verification-scope -->
+
+[`TESTED.md`](TESTED.md)は、実行した各経路、インストーラのリビジョン、実行環境を記録します。記録したリビジョンがインストーラと一致し、インストールが `0` で終了し、インストール済みシステムが起動し、起動後の設定検査が通過した実行だけが記録に計上されます。
+
+単体、計画、fixture coverage は実装動作を示しますが、インストール済みシステムの起動を証明しません。[`tests/fixtures/`](tests/fixtures/)は設定モデルを検証するものであり、インストール済みのマシンではありません。記録は未検証の組み合わせを示します。
 
 ## 要件
 
 <!-- fact: requirements-runtime -->
 
-実際のインストールには root 権限、amd64 アーキテクチャ、Python 3.11 以降が必要です。設定ファイルを使用する dry run には root 権限が必要ありません。インストーラには Python 標準ライブラリ以外の実行時依存関係がありません。
-
-<!-- fact: requirements-version-sources -->
-
-メニューは、Gentoo メインツリーのパッケージバージョンを `packages.gentoo.org` から、gentoo-zh のパッチ適用済みカーネルのバージョンを `api.github.com/repos/gentoo-zh/overlay/contents` から読み取ります。`sys-fs/zfs` が受け入れる最大カーネルバージョンは `gitweb.gentoo.org` から読み取ります。設定ファイルからのインストールでは、その設定が指定するミラーへの接続が必要です。`--missing-commands` と `--config FILE --dry-run` は、これらのバージョン取得先への接続を必要としません。
-
-<!-- fact: requirements-network-filter -->
-
-ライブ環境に IPv6 があり IPv4 がない場合、メニューは記録上 IPv4 専用の Gentoo ミラーを無効にします。
-
-<!-- fact: requirements-bootstrap -->
-
-`bootstrap.sh` は `/etc/os-release` を読み、不足しているコマンドを報告し、候補となるパッケージマネージャのコマンドを表示します。識別するディストリビューション系統は、Debian と Ubuntu、Arch、openSUSE、Fedora、RHEL と CentOS、Gentoo、Alpine です。表示されたコマンドは実行前に確認する必要があります。
+実際のインストールには root 権限、amd64 ターゲット、Python 3.11 以降が必要です。設定ファイルによる dry run には root 権限が必要ありません。インストーラにはサードパーティーの Python 実行時依存関係がありません。
 
 ## 安全上の注意
 
 <!-- fact: safety-destructive -->
 
-実際のインストールでは、選択したディスクに書き込みます。設定ファイルを使用して実行する場合、ディスク消去の確認は再度行われません。`wipe = true`、パーティションの削除、ファイルシステムの作成は既存データを破壊する可能性があります。
+実際の実行は選択したディスクに書き込みます。設定ファイルによる実行では、消去確認を二度行いません。`wipe = true`、パーティションの削除、ファイルシステムの作成は既存データを破壊する可能性があります。
 
 <!-- fact: safety-review-backup -->
 
-実際のインストール前に、dry-run の出力でディスクセレクタとすべての破壊的操作を確認する必要があります。`/dev/sda` のような名前より、安定した `/dev/disk/by-id/` セレクタが望ましいです。保持する必要があるデータには、選択したディスクとは別のバックアップが必要です。
+実際の実行前に、dry-run の出力でディスクセレクタとすべての破壊的操作を確認する必要があります。`/dev/sda` のような名前より、安定した `/dev/disk/by-id/` セレクタが望ましいです。保持するデータには、選択したディスクとは別のバックアップが必要です。
 
 ## インストール
 
 <!-- fact: install-download -->
 
-次のコマンドを使用すると、現在の `master` アーカイブをダウンロードしてメニューを開けます。
+次のコマンドは現在の `master` アーカイブをダウンロードしてメニューを開きます。
 
 ```sh
 curl -fsSL https://github.com/Zakkaus/gentoo-install/archive/refs/heads/master.tar.gz | tar xz
@@ -52,601 +59,59 @@ cd gentoo-install-master
 
 <!-- fact: install-terminal -->
 
-メニューには、80 列 24 行以上の対話型端末が必要です。インストーラは起動時にインターフェイス言語の選択を一度求めます。`--lang ja` を使用すると、日本語を直接選択できます。
+メニューには 80 列 24 行以上の対話型端末が必要です。
 
 <!-- fact: install-config-workflow -->
 
-メニューでは、設定を `my-install.toml` という設定ファイルに保存して終了できます。次の設定ファイルによる操作手順では、最初に完全な設定計画を表示し、その後に実際のインストールを実行します。
+メニューは回答を `my-install.toml` に保存します。設定ファイルの手順は、保存、dry run、検査、インストールの順です。
 
 ```sh
 ./bootstrap.sh --config my-install.toml --dry-run
-# 続いて次のいずれか一方を実行します。どちらも選択したディスクに書き込みます。
+# 実際のコマンドを選ぶ前に、表示された計画を検査します。
 ./bootstrap.sh --config my-install.toml
-./bootstrap.sh --config my-install.toml --no-shell   # 同じ実行で、root シェルの確認をしません
+./bootstrap.sh --config my-install.toml --no-shell   # 同じ実行で root シェルの確認を省略します
 ```
 
 <!-- fact: install-root-shell -->
 
-対話型インストールでは、成功時と失敗時のどちらでも、アンマウント前にターゲットシステム内で root シェルを開く選択肢が提示されます。`--no-shell` を使用すると、この確認を省略できます。
-
-| オプション | 引数と既定値 | 効果 |
-| --- | --- | --- |
-| `--config` | file または URL; unset | メニューを開かずに、そのソースを読み込みます。 |
-| `--dry-run` | none; `false` | 派生した操作と概要を表示し、操作を適用せずに終了します。 |
-| `--mirror` | stage3 mirror string; installer default | 通常のインストールで使用する stage3 のソースを選択します。メモリ起動の設定では、地域を設定から導出します。 |
-| `--lang` | language tag; `""` | メニューが設定を作成する間、`LC_ALL`、`LC_MESSAGES`、`LANG` を上書きします。 |
-| `--target` | path; `/mnt/gentoo` | 通常のインストールのマウント先を選択します。変換とメモリ起動の設定では `/` を使用します。 |
-| `--work` | path; `/run/gentoo-install` | レポートとジャーナルを含む実行状態を保持します。 |
-| `--missing-commands` | none; `false` | 不足しているホストコマンドを一行に一つずつ表示して終了します。 |
-| `--resume` | none; `false` | 既存のジャーナルを使用して、互換性のある完了済み操作を省略します。 |
-| `--no-shell` | none; `false` | ターゲットの root シェルを提示しません。メモリ起動の設定も無人で行います。 |
-| `--skip-preflight` | none; `false` | 通常のインストールの事前検査を省略します。 |
-| `--ram` | none; unset memory mode | メモリ上に保持した Gentoo CJK ISO への一回の起動を設定します。`--lowram` とは競合します。 |
-| `--lowram` | none; unset memory mode | メモリ上に保持した Alpine netboot 環境への一回の起動を設定します。`--ram` とは競合します。 |
-| `--ssh-key` | key, file, HTTP(S) URL, or `github:`/`gitlab:` reference; `""` | メモリ環境で認証される公開鍵を設定します。メモリモードが必要です。 |
-| `--ssh-port` | integer; unset | メモリ環境の `sshd` ポートを設定します。メモリモードが必要です。 |
-| `--root-password` | string; `""` | メモリ環境の root パスワードを設定します。メモリモードが必要です。 |
-| `--bypass` | none; `false` | 一回限りの起動項目を設定する代わりに、既定の起動項目を置き換えます。メモリモードが必要です。 |
-| `--disarm` | none; `false` | 以前に設定されたメモリ起動と、設定の読み込み前に配置されたファイルを削除します。 |
-
-## メモリからのインストール
-
-<!-- fact: install-memory -->
-
-`--ram` と `--lowram` は、メモリ上のライブ環境への起動を一度だけ設定します。コンソールもレスキューイメージも持たないレンタルマシンが自分のディスクを上書きするには、これが必要です。インストーラ、選んだ設定、認証鍵は initramfs の中を運ばれるため、環境はそれを設定したリビジョンで起動します。
-
-```sh
-./bootstrap.sh --ram --ssh-key github:zakkaus --root-password 'replace this'
-reboot
-ssh root@the-machine
-```
-
-既定の起動項目は変更されないので、環境で起動しなかったマシンは以前と同じものを起動します。`--disarm` は設定を取り消します。`--bypass` は既定の項目自体を置き換えるもので、一度きりの項目を捨てるファームウェア向けです。環境が起動しなかったときにマシンがまったく起動しなくなるのは、この経路だけです。
-
-最初の画面は `install now? [yes/no]` と尋ね、タイムアウトはありません。答えるまで何も消去されません。`--ram` は ZFS を含む Gentoo CJK ISO を起動し、約 2 GiB のメモリを必要とします。`--lowram` はより小さく `zfs.ko` を持たない Alpine netboot 書庫を起動します。`--ssh-port` はデーモンを 22 番から動かします。最初の画面はインストールを後から開始するコマンドを示すため、`no` と答えても、答える前に接続が切れても、再起動だけが戻る道になることはありません。
-
-`--ram` は wifi に到達でき、`--lowram` は到達できません。Gentoo CJK ISO は NetworkManager と `linux-firmware` を持つため、`nmcli device wifi connect <SSID> password <パスワード>` で接続を確立してからインストールを実行できます。最初の画面は繁体字中国語、簡体字中国語、英語でこれを示します。Alpine netboot 環境には無線ドライバもサプリカントもなく、完全なモジュール群はそれ自体を取得する必要がある `modloop` にあるため、wifi しか接続を持たない機械は `--lowram` を使えません。
-
-## 稼働中のシステムの変換
-
-<!-- fact: install-in-place -->
-
-`[disk]` テーブルの `mode = "in-place"` は、ディスクをパーティション分割する代わりに、稼働中のディストリビューションのユーザ空間を置き換えます。レイアウトはマシンから読み取るため、このテーブルはデバイス一覧を持ちません。
-
-```toml
-config_version = 1
-
-[system]
-hostname = "converted"
-timezone = "UTC"
-locales = ["en_US.UTF-8"]
-locale = "en_US.UTF-8"
-init = "systemd"
-root_password_hash = "$6$gentooinst$IR3GrdJ862XljQYDqocr4tKniIRDIT.jQNFzIrHE3U75H6B6YSWZoSYoVd5edSHpqaYBdiNfXHCoIPRVgb9lT/"
-
-[portage]
-profile = "default/linux/amd64/23.0/systemd"
-makeopts = "-j4"
-
-[bootloader]
-kind = "grub"
-firmware = "uefi"
-
-[disk]
-mode = "in-place"
-```
-
-上のハッシュは例であり、実行前に置き換える必要があります。対話的な実行は変換が置き換えるディレクトリを表示し、何かを書き込む前に `convert` の入力を求めます。端末のない実行は尋ねられません。設定ファイルの `mode = "in-place"` が承認であり、そこで質問すればシリアルコンソールを永久に待たせることになるからです。
-
-**この実行を始めたセッションが生命線です。**`/usr` と `/etc` が新しいシステムのものになると新しい SSH ログインは成立しなくなり、実行を始めたセッションだけがすでに対応付けたバイナリを保持します。
-
-## 中断した実行の再開
-
-<!-- fact: resume-behavior -->
-
-`--resume` は、ジャーナル上の位置と識別子が現在の計画に一致し、再起動後も効果が残ると指定された完了済み操作だけを省略します。
-
-```sh
-./bootstrap.sh --config my-install.toml --resume
-```
-
-<!-- fact: resume-limits -->
-
-再開は同じライブセッション、同じインストーラー、同じ設定ファイルに限られ、それ以外の場合はインストーラーが拒否します。
-
-- ジャーナルの先頭には設定のダイジェスト、マシンの boot id、インストーラー自身のソースのダイジェストが記録されます。`--resume` はこの三つをすべて比較し、いずれかが一致しない場合は理由を示して停止します。カーネルが boot id を公開しないマシンでは、残りの二つだけを比較します。
-- 既定のジャーナルは `/run/gentoo-install/install.jsonl` にあるため、いずれにせよ再起動後には残りません。
-- 各操作記録には、その操作のクラスのソースとフィールド値から生成された識別子も含まれます。識別子が変わった操作は省略されずに再度実行されます。共有のヘルパーや定数の変更はその識別子の範囲外で、インストーラーのダイジェストが対象とします。
-
-## 機能
-
-<!-- fact: capability-scope -->
-
-検証状況により狭い範囲が示されている場合を除き、以下の経路は実装済みであり、自動化された単体テストまたは plan テストで検査されています。
-
-<!-- fact: storage-device-graph -->
-
-**ストレージ**
-- デバイスグラフは、GPT と MBR のパーティションテーブル、ext2、ext3、ext4、xfs、f2fs、vfat、subvolume を含む btrfs、swap、LUKS2 暗号化、LVM、mdraid を扱います。
-- ZFS も同じグラフに属します。プールは vdev の上で stripe、mirror、raidz1、raidz2、raidz3 のいずれかを取り、ネイティブ暗号化はプールの属性であり、各 dataset はそれぞれ独立したノードです。
-- 既存のパーティションテーブルを保持し、各パーティションに対して保持、フォーマット、削除のいずれかを個別に指定できます。
-
-| モデルノード | `id` 以外のフィールド | 結果 |
-| --- | --- | --- |
-| `Existing` | `selector`, `wipe` | 既存のデバイスを選択します。 |
-| `PartitionTable` | `disk`, `table`, `create`, `remove` | パーティションテーブルを作成または編集します。 |
-| `Partition` | `table`, `index`, `role`, `size`, `label` | パーティションを定義します。最後の `size` は残りの領域を消費できます。 |
-| `Luks` | `backing`, `name`, `passphrase_file` | LUKS コンテナを定義します。 |
-| `MdRaid` | `members`, `level`, `name`, `metadata` | mdraid アレイを定義します。 |
-| `VolumeGroup` | `members`, `name` | LVM ボリュームグループを定義します。 |
-| `LogicalVolume` | `group`, `name`, `size` | LVM 論理ボリュームを定義します。 |
-| `ZfsPool` | `vdevs`, `name`, `topology`, `encrypted`, `passphrase_file` | ZFS プールを定義します。 |
-| `ZfsDataset` | `pool`, `name` | ZFS dataset を定義します。 |
-| `Filesystem` | `device`, `kind`, `label`, `create` | デバイスをフォーマットします。`create = false` の場合は検証します。 |
-| `Subvolume` | `filesystem`, `name` | Btrfs subvolume を定義します。 |
-| `Swap` | `device` | 参照されたデバイス上の swap を定義します。 |
-| `Mountpoint` | `source`, `path`, `options` | ファイルシステム、Btrfs subvolume、または ZFS dataset をマウントします。 |
-
-| 選択肢 | 値 |
-| --- | --- |
-| パーティションテーブル | `gpt`, `mbr` |
-| パーティションの役割 | `esp`, `bios-boot`, `swap`, `raid`, `lvm`, `zfs`, `data` |
-| mdraid レベル | `raid0`, `raid1`, `raid5`, `raid6` |
-| mdraid メタデータ | `0.90`, `1.0`, `1.1`, `1.2` |
-| ファイルシステム | `ext2`, `ext3`, `ext4`, `btrfs`, `xfs`, `f2fs`, `vfat` |
-| ZFS トポロジ | `stripe`, `mirror`, `raidz1`, `raidz2`, `raidz3` |
-
-<!-- fact: zram-system -->
-
-システム設定では、デバイスグラフおよび swap パーティションとは別に zram を設定できます。
-
-<!-- fact: in-place-conversion -->
-
-**インプレース変換。**
-- `[disk]` テーブルで `mode = "in-place"` を設定すると、インストーラはディスクをパーティション分割する代わりに、稼働中のディストリビューションのユーザ空間を Gentoo で置き換えます。
-- レイアウトはマシンから読み取るため、このテーブルはデバイス一覧を持ちません。
-- `/bin`、`/sbin`、`/etc`、`/lib`、`/lib64`、`/usr`、`/var` が置き換えられ、`/home`、`/root`、`/srv`、`/opt` およびそれ以外のすべてのパスはそのまま残ります。`/etc` は統合ではなく置き換えです。
-
-- ステージングされたシステムは稼働中のシステムに触れずに `/gentoo-install.new` 以下で構築され、その後 `rename(2)` でディレクトリごとに交換されます。交換より後に実行されるのは、esp またはブートセクタへの書き込みだけです。
-- ルートが LUKS、LVM、mdraid の下にある場合、ルートファイルシステムがこのインストーラで記述できない種類である場合、ルートファイルシステムの空き容量が 10 GiB 未満の場合、ライブメディア上で実行された場合は、いずれも何も書き込む前に理由を挙げて拒否されます。
-
-<!-- fact: prepared-image -->
-
-**ディスクイメージ**
-- `mode = "image"` は、ディスクではなく `disk.image` が指定し `disk.size` が大きさを決めるスパースファイルにインストールします。成果物は他所へ複製して後から書き込めるファイルです。`mode = "dd"` はインストールを行いません。
-- `disk.source` のイメージを `disk.destination` のディスク全体へストリーム書き込みし、読み取りながら `raw`、`gz`、`xz`、`zst`、`tar` を展開し、そのイメージが持つレイアウトとブートローダーをそのまま残します。
-- 両モードは互いのキーを受け付けず、`partition` モードはどちらのキーも受け付けません。
-
-<!-- fact: boot-system -->
-
-**起動とシステム**
-- インストーラでは、ブートローダーとして GRUB、systemd-boot、ZFSBootMenu を選択できます。GRUB は UEFI と BIOS に対応し、systemd-boot は UEFI に対応しています。
-- ZFSBootMenu は UEFI で ZFS ルートを起動し、カーネルはプール内のブート環境自身の `/boot` から取得します。また、systemd または OpenRC、dracut、locale、キーボードレイアウト、タイムゾーン、ホスト名、DNS、静的アドレス、選択したネットワークマネージャを設定できます。
-
-<!-- fact: remote-unlock -->
-
-**暗号化されたルートを ssh で解除する**
-- `[kernel.remote_unlock]` は、パスフレーズの入力を求める画面の前に誰もいないマシンのために、起動経路へ ssh デーモンを配置します。`enabled` がこの経路を有効にします。
-- `port` の既定値は 22 ではなく 222 で、稼働中システムに対するクライアントの `known_hosts` 項目と initramfs の項目が衝突しないようにしています。`address`、`gateway`、`interface` はそのデーモンに静的アドレスを与え、アドレスが空の場合は DHCP を使います。
-- LUKS ルートはシステム initramfs 内の `sys-kernel/dracut-crypt-ssh` が開き、ZFS ルートは ZFSBootMenu が自身のイメージへ組み込む dropbear が開きます。
-- 認証鍵は `system.authorized_keys` のものです。この経路を有効にしながら鍵を一つも挙げていない設定は理由を挙げて拒否されます。誰もログインできないデーモンを記述しているためです。
-
-<!-- fact: desktop-language -->
-
-**デスクトップと言語対応**
-- GNOME、KDE Plasma、Xfce を選択し、GDM、SDDM、LightDM、または greetd とその tuigreet コンソールグリータのいずれかと組み合わせられます。
-- グラフィックス設定は AMD、Intel、NVIDIA、仮想マシンに対応しています。
-- パッケージカタログには Fcitx 5、Rime、Anthy、Mozc、Hangul、CJK フォントが含まれます。
-- カーネルの選択肢には、cjktty パッチを含む `sys-kernel/gentoo-cjk-kernel-bin` と `sys-kernel/gentoo-cjk-kernel` があります。
-
-<!-- fact: portage -->
-
-**Portage**
-- 設定項目には、profile、`MAKEOPTS`、`USE`、`ACCEPT_KEYWORDS`、`L10N`、ミラー、リポジトリ同期方式が含まれます。
-- gentoo-zh と gig の overlay は個別に選択できます。
-- インターフェイス言語として `zh-TW`、`zh-CN`、`ja`、`ko` のいずれかを選択すると、gentoo-zh のパッチ適用済みバイナリカーネルとその overlay も選択されます。
-- `en` を選択した場合は自動的に選択されません。公式と gentoo-zh のバイナリパッケージ取得元は、それぞれ独立した設定と鍵を使用します。
-
-<!-- fact: proxy -->
-
-**セッションプロキシ**
-- `[proxy]` テーブルは `kind`、`host`、`port`、任意の `username` と `password`、`bypass` を受け付けます。
-- `kind` は `http`、`https`、`socks5` のいずれかです。`host` が空の場合は直接接続となり、これが既定値です。
-- SOCKS5 は `socks5h://` を導出し、内部ホスト名をプロキシで解決します。
-- メインメニューには値ごとのフィールドとプロキシ種類のメニューがあります。
-- `bypass` はインターフェイスではコンマ区切りの値、TOML ではリストです。
-
-- プロキシを選択した後、設定したプロキシは stage3 と署名鍵、メインツリーおよび overlay のバージョン取得、`gitweb.gentoo.org` の ZFS ebuild 取得、`make.conf` と `FETCHCOMMAND`/`RESUMECOMMAND` を通る Portage のダウンロード、`wget`、`curl`、`git`、GnuPG、binhost、overlay、paste のアップロードに使用されます。
-- 時計、初期接続検査、メニュー前のミラー検査は設定を取得する前に実行されるため、この設定の対象外です。インストーラは dry-run の説明と公開設定から認証情報を除外します。
-- 公開設定とインストール済みシステムには、認証情報を含まないエンドポイントとバイパスリストだけが残ります。
-
-<!-- fact: memory-environment -->
-
-**メモリ環境。**
-- `--ram` と `--lowram` はメモリ上に常駐するライブ環境への起動を一度だけ仕掛け、続いて再起動するかどうかを尋ねる。
-- この経路に画面はない。対象となる計算機は SSH 接続が一本あるだけで、コンソールを持たないことが多いためである。`--ram` は Gentoo CJK ISO を用いる。ZFS を含み、約 2 GiB のメモリを要する。
-- その initramfs は、メモリから 824 MiB のライブイメージを差し引いた値が 1 GiB を下回ると緊急シェルで停止する。
-- `--lowram` は Alpine netboot 一式を用いる。より小さく、`zfs.ko` を持たない。いずれも版を固定しない。配布側が現在のイメージとチェックサムを公開しており、仕掛ける前に取得して検証する。
-
-- 既定の起動項目は変更しない。したがって環境が立ち上がらなくても計算機は起動する。`--bypass` はこれを置き換える。
-- 一度きりの起動項目を破棄するファームウェア向けであり、環境が立ち上がらなければ計算機が全く起動しなくなる唯一の経路であるため、自動的に選択されることはない。
-
-<!-- fact: memory-environment-access -->
-
-**SSH によるメモリ導入の観察。**
-- `--ssh-key` は公開鍵そのもの（`ssh-ed25519`、`ssh-rsa`、`ecdsa-sha2-nistp256`、`-384`、`-521`、および `sk-` 系）、パス、`http` または `https` の URL、および `github:user` と `gitlab:user` を受け付ける。
-- `--ssh-port` と `--root-password` が残りを定める。
-- 導入器、選択された構成、鍵はいずれも initramfs の内部を通るため、環境はその構成を書いた版を実行し、最初のログインより前に `authorized_keys` が置かれている。
-- 操作者は SSH で再接続して導入の経過を見ればよく、コンソールを開いたままにする必要はない。最初の画面に答えるまで何も消去しない。その画面は `install now? [yes/no]` と尋ね、時間切れを持たない。
-
-<!-- fact: plan-records -->
-
-**計画と記録**
-- dry run はストレージハードウェアを調査せずに操作計画を表示します。
-- 実際のインストールでは、再利用するデバイスから調査した mdraid メタデータを追加したうえで同じ planner を使用するため、ハードウェアに依存する検証結果が変わる場合があります。
-- `install.log` はコマンド出力を記録し、`install.jsonl` は操作、パッケージの取得元、バイナリパッケージのフォールバック理由を記録します。
-- メニューは設定を `paste.gentoozh.org` にアップロードする前に、`password_hash` と `root_password_hash` の値を `removed-before-publishing` に置き換え、プロキシの `username` と `password` は鍵ごと出力しません。
-- その他の設定値はアップロードに残ります。メニューはアップロード先ページのアドレスをテキストと QR コードで表示します。
-
-### 互換性規則
-
-検証では次の組み合わせを拒否します。
-
-| 拒否される組み合わせ |
-| --- |
-| パスワード認証するユーザーも、利用可能な SSH 鍵によるログインもない状態で、root ハッシュが空、ロック済み、または不正な形式である組み合わせ。 |
-| ZFS root と GRUB の組み合わせ。 |
-| GRUB を使用する ZFS 上の `/boot`。 |
-| BIOS 起動と ZFS root の組み合わせ。 |
-| LUKS root chain と ZFS root の組み合わせ。 |
-| ZFS ではない root と ZFSBootMenu の組み合わせ。 |
-| マウントされた ESP がない UEFI 起動。 |
-| 暗号化された ESP を使用する UEFI 起動。 |
-| BIOS 起動と systemd-boot の組み合わせ。 |
-| `/boot` が暗号化されているか vfat ではないため、ESP から kernel または initramfs にアクセスできない systemd-boot。 |
-| メタデータが `1.1` または `1.2` である mdraid 上の ESP。 |
-| `bios-boot` パーティションがない GPT ディスク上の BIOS 起動。 |
-| cjktty を欠く kernel での CJK コンソール描画。 |
-| 認証済み SSH 鍵がないリモート解除。 |
-| 暗号化された root コンテナまたはプールがないリモート解除。 |
-| initramfs SSH が開始する前に `/boot` を解除しなければならない GRUB を使用するリモート解除。 |
-| GRUB または systemd-boot のシステム initramfs によるネイティブ ZFS 暗号化のリモート解除。 |
-| `gentoo-zh` overlay がない CJK kernel。 |
-| `8x16` 以外のコンソールフォントによる CJK コンソール描画。 |
-| `gentoo-zh` overlay がない ZFSBootMenu。 |
-| `gentoo-zh` overlay がない gentoo-zh community binhost。 |
-
-## 検証状況
-
-<!-- fact: verification-scope -->
-
-[`TESTED.md`](TESTED.md) が検証記録です。実際に動かした経路ごとに 1 行あり、それが動作したインストーラのリビジョンと、動作した場所を記載します。実行が記録として数えられるのは、記録されたリビジョンがインストーラと一致し、インストールの終了コードが `0` で、導入されたシステムが起動し、起動後の設定チェックがすべて通った場合だけです。
-
-| 経路 | 記録 |
-| --- | --- |
-| ディスクへの導入 | ext4、ext2、ext3、xfs、btrfs、f2fs、ZFS、LVM、mdraid、LUKS2 を、両方のファームウェアと両方の init システムで |
-| ZFS プール | stripe、mirror、raidz、暗号化プール、そして ZFSBootMenu が起動したプール |
-| ssh による解除 | システム initramfs が開いた LUKS ルートと、ZFSBootMenu 自身のイメージが開いた ZFS プール |
-| 静的アドレスと greetd | それぞれにクラスタでの記録 |
-| 稼働中のシステムのインプレース変換 | QEMU での記録が 4 件。BIOS が 2 件、`/home` を保持した UEFI が 1 件、ルートが btrfs で `/home` と `/var` を subvolume として保持した UEFI が 1 件 |
-| この導入器自身が構築した計算機の変換 | 再起動まで到達したクラスタ変換 6 件のうち 5 件は起動し、1 件はモジュールが見つからず GRUB の救助シェルで停止したが変換自体の終了コードは `0` で、この経路はまだ信頼できない |
-| `--ram` と `--lowram` | Debian 12 の計算機が一度だけの起動を設定し、既定の起動項目を変えずに再起動し、渡された設定を保持したまま配信された環境で起動した。その画面で `install` と答えると Gentoo を導入し、書き込んだディスクから起動した |
-| `--bypass` | 既定の起動項目を置き換えた状態が電源再投入をまたいで残り、二回とも配信された環境で起動した |
-| 設定した起動が立ち上がらない場合 | 設定済み項目の initramfs を削除した計算機は配信された画面を出さず、続く二回の起動でいずれも元のクラウド系に到達した |
-| `dd` | 記録が一件。live 媒体から準備済みイメージをディスク全体へ書き込み、raw と gzip の両形式で 1 バイトずつ読み戻した |
-| ファイルへの導入 | 記録が一件。イメージを `losetup -Pf` で接続し、そのレイアウトが宣言する二つのファイルシステムとして読み戻したが、そのファイルから起動したマシンはまだない |
-| メニュー | 80x24 のシリアルコンソールで一行ずつ開かれ、英語、繁体字中国語、簡体字中国語、日本語、韓国語で端末より広い行はなかった |
-
-ソースからビルドするカーネルとバイナリパッケージのフォールバックには runner レベルの試験しかなく、runner レベルの試験はエンドツーエンドの記録ではありません。`tests/fixtures/` 以下のファイルが対象とするのは設定モデルであり、その存在は導入されたマシンについて何も示しません。
+対話型実行はアンマウント前にターゲットの root シェルを提示します。`--no-shell` はそのプロンプトを省略します。
 
 ## 設定ファイル
 
-<!-- fact: config-model -->
+<!-- fact: configuration-reference -->
 
-設定ファイルは TOML 形式です。トップレベルの `config_version` フィールドがスキーマバージョンを指定します。ストレージはデバイスグラフで表します。各デバイスは `id` を持ち、ほかのデバイスを `id` で参照します。セレクタは実際のインストール時にのみ解決されます。
+設定ファイルは TOML を使用し、`config_version` がスキーマバージョンを選択します。[設定リファレンス](REFERENCE.md#configuration-files)はすべての永続化キーと検証済みの例を示します。[`tests/fixtures/vm-binpkg.toml`](tests/fixtures/vm-binpkg.toml)はスキーマリファレンスです。この仮想マシン用ディスクセレクタとテスト用認証情報を実機でそのまま使用してはなりません。
 
-<!-- fact: config-simple -->
+## 中断した実行の再開
 
-単一ディスクのレイアウトはデバイスグラフではなく `[disk.simple]` として記述します。パーサーはメニューが用いるものと同じテンプレートで展開するため、両方の記法は同一のグラフを生成します。グラフ記法は LUKS、ZFS、RAID、手書きのパーティションテーブルのために残されています。
+<!-- fact: resume-limits -->
 
-```toml
-config_version = 1
+`--resume` は同じライブセッション、同じインストーラのリビジョン、同じ設定ファイルに限られます。インストーラは一致しない実行を拒否します。既定のジャーナルは `/run/gentoo-install/install.jsonl` にあるため、再起動後には残りません。
 
-[system]
-hostname = "workstation"
-timezone = "UTC"
-locales = ["en_US.UTF-8"]
-locale = "en_US.UTF-8"
-init = "systemd"
-root_password_hash = "$6$gentooinst$IR3GrdJ862XljQYDqocr4tKniIRDIT.jQNFzIrHE3U75H6B6YSWZoSYoVd5edSHpqaYBdiNfXHCoIPRVgb9lT/"
-
-[portage]
-profile = "default/linux/amd64/23.0/systemd"
-makeopts = "-j4"
-
-[bootloader]
-kind = "grub"
-firmware = "uefi"
-
-[disk.simple]
-disk = "/dev/disk/by-id/virtio-target0"
-filesystem = "ext4"
-swap = "2GiB"
-```
-
-上のハッシュは例であり、実行前に置き換える必要があります。必須は `disk` のみです。省略された鍵はインストーラーの既定値を取ります。`whole-disk`、`uefi`、ファームウェアが決めるパーティションテーブル、`xfs`、スワップなし、暗号化なしです。同一のファイルに `[disk.simple]` と `[[disk.devices]]` を同時に書くことはできません。
-
-<!-- fact: config-fixtures -->
-
-[`tests/fixtures/vm-binpkg.toml`](tests/fixtures/vm-binpkg.toml) は、UEFI と Ext4 を使用する完全なスキーマ参照です。ほかの [`tests/fixtures/`](tests/fixtures/) ファイルは BIOS、LUKS2、LVM、mdraid、ZFS、Btrfs subvolume、デスクトップを扱います。これらのファイルには仮想マシン用のディスクセレクタとテスト用パスワードが含まれているため、内容を変更せずに実機のインストールに使用してはなりません。
-
-<!-- fact: config-dry-run -->
-
-解析と計画ではストレージハードウェアを調査しないため、ターゲットディスクがないマシンでも `--dry-run` で設定を確認できます。
-
-次の参照は、永続化されるすべてのキーを挙げます。テーブルのパスは TOML テーブル記法であり、`[[disk.devices]]` にはグラフノードが格納されます。
-
-| キー | 意味と既定値または選択肢 |
-| --- | --- |
-| `config_version` | 永続化されるスキーマバージョン。`1`。 |
-| `proxy.kind` | プロキシスキーム。`http`、`https`、または `socks5`。既定値は `http` です。 |
-| `proxy.host` | プロキシホスト。`""` でプロキシを無効にします。 |
-| `proxy.port` | プロキシポート。`0`。 |
-| `proxy.username` | 任意のプロキシユーザー名。`""`。 |
-| `proxy.password` | 任意のプロキシパスワード。`""`。 |
-| `proxy.bypass` | プロキシをバイパスするホスト。`[]`。 |
-
-| `system` キー | 意味と既定値または選択肢 |
-| --- | --- |
-| `hostname` | ターゲットのホスト名。`gentoo`。 |
-| `timezone` | ターゲットのタイムゾーン。`Asia/Shanghai`。 |
-| `locales` | 生成する locale。`en_US.UTF-8`、`zh_CN.UTF-8`、`zh_TW.UTF-8`。 |
-| `locale` | 選択する locale。`zh_CN.UTF-8`。 |
-| `keymap` | インストール後のシステムのキーマップ。`us`。 |
-| `keymap_initramfs` | initramfs のキーマップ。`""` は `keymap` に従います。 |
-| `interface` | ネットワークインターフェースパターン。`""` は `en*` と `eth*` に一致します。 |
-| `addresses` | 静的 CIDR アドレス。`[]` は DHCP またはルーター広告を選択します。 |
-| `gateways` | ゲートウェイ。アドレスファミリーごとに最大一つです。`[]`。 |
-| `dns` | リゾルバーアドレス。`[]`。 |
-| `authorized_keys` | root および sudo ユーザー用の鍵。`[]`。 |
-| `console_cjk` | CJK コンソール描画を要求します。`false`。cjktty が必要です。 |
-| `console_font` | コンソールのセルサイズ。`8x8`、`8x16`、または `16x32`。既定値は `8x16` です。 |
-| `init` | init システム。`openrc` または `systemd`。既定値は `systemd` です。 |
-| `zram` | 圧縮 RAM の swap サイズ。unset では無効です。 |
-| `hardware_clock_utc` | RTC に UTC を保存します。`true`。 |
-| `users` | ユーザーレコード。`[]`。 |
-| `root_password_hash` | root の `crypt(3)` hash。`""` は root をロックします。 |
-| `logger` | logger。`none`、`sysklogd`、`syslog-ng`、または `metalog`。既定値は `sysklogd` です。 |
-| `cron` | `sys-process/cronie` をインストールします。`true`。 |
-| `sshd` | SSH デーモンのサポートをインストールして設定します。`false`。 |
-| `sshd_password_login` | SSH デーモンがパスワードを受け入れます。`false`。 |
-| `sshd_root_login` | root が SSH でログインできます。`false`。 |
-| `networking` | リンク管理。`builtin`、`networkmanager-wpa`、`networkmanager-iwd`、または `none`。既定値は `builtin` です。 |
-| `firewall` | パケットフィルターパッケージ。`none`、`nftables`、または `iptables`。既定値は `none` です。 |
-| `first_boot` | 初回起動レコード。既定では空のレコードです。 |
-
-| `system.users` 項目 | 意味と既定値 |
-| --- | --- |
-| `name` | ユーザー名。必須です。 |
-| `groups` | 補助グループ。`[]`。 |
-| `shell` | ログインシェル。`/bin/bash`。 |
-| `sudo` | ユーザーを sudo ユーザーにします。`false`。 |
-| `password_hash` | ユーザーの `crypt(3)` hash。`""` はアカウントをロックします。 |
-
-| `system.first_boot` キー | 意味と既定値 |
-| --- | --- |
-| `commands` | 取得したスクリプトの後に順番に実行するシェル行。`[]`。 |
-| `url` | スクリプト URL。`""` は取得したスクリプトを省略します。 |
-
-| `portage` キー | 意味と既定値または選択肢 |
-| --- | --- |
-| `profile` | Portage プロファイル。`default/linux/amd64/23.0/systemd`。 |
-| `keywords` | グローバルキーワードチャネル。`stable` または `testing`。既定値は `stable` です。 |
-| `sync` | 継続同期。`git`、`webrsync`、または `rsync`。既定値は `git` です。最初の同期では `webrsync` を使用します。 |
-| `testing_packages` | システムが stable のままで受け入れる testing の atom。`[]`。 |
-| `makeopts` | `MAKEOPTS`。`""`。 |
-| `common_flags` | 共通のコンパイラフラグ。`-O2 -pipe`。 |
-| `use` | `USE` フラグ。`[]`。 |
-| `video_cards` | `VIDEO_CARDS` の値。`[]`。 |
-| `l10n` | `L10N`。`[]` は生成する locale から値を導出します。 |
-| `input_devices` | `INPUT_DEVICES`。`["libinput"]`。 |
-| `accept_license` | 受諾するライセンス。`["@FREE"]`。 |
-| `cpu_flags` | CPU フラグ。`[]` はプロファイル値を保持します。 |
-| `build_in_ram` | `/var/tmp/portage` の tmpfs サイズ。unset ではディスク上でビルドします。 |
-| `mirrors` | ミラーレコード。既定値は下記です。 |
-| `binhost` | バイナリホストレコード。既定値は下記です。 |
-| `overlays` | overlay レコード。`[]`。 |
-
-| `portage.mirrors` キー | 意味と既定値または選択肢 |
-| --- | --- |
-| `region` | Gentoo ミラーの地域。`cn` または `global`。既定値は `global` です。 |
-| `speed_test` | 提示されたミラーの速度をテストします。`false`。 |
-| `distfiles` | カスタム distfile ベース。空でない一覧は組み込みの一覧を置き換えます。 |
-| `repo_sync_uri` | 明示的なリポジトリ同期 URI。`""`。 |
-| `site` | `region` 内のサイトキー。`""` は地域の最初のサイトを選択します。 |
-| `gentoo_distfiles` | `GENTOO_MIRRORS` を書き込みます。`true`。 |
-| `gentoo_zh` | gentoo-zh ミラー。`upstream`、`cernet`、`nju`、`nyist`、または `ha`。既定値は `upstream` です。 |
-| `gentoo_zh_distfiles` | gentoo-zh の distfile を `GENTOO_MIRRORS` に追加します。`true`。 |
-
-| ミラー地域 | サイトキー |
-| --- | --- |
-| `cn` | `ustc`, `nju`, `bfsu`, `tuna`, `zju`, `sdu`, `hust`, `sustech`, `hit`, `lzu`, `aliyun`, `netease`, `cernet`, `cicku-hk`, `planetunix-hk`, `xtom-hk`, `rackspace-hk`, `aditsu-hk`, `nchc-tw`, `cicku-tw`, `freedif-sg`, `cicku-sg`, `planetunix-sg` |
-| `global` | `gentoo`, `osuosl` |
-
-| `portage.binhost` キー | 意味と既定値または選択肢 |
-| --- | --- |
-| `official` | 公式バイナリホストを有効にします。`true`。 |
-| `subarch` | 公式バイナリホストのサブアーキテクチャ。`x86-64`。 |
-| `community` | gentoo-zh チャネル。`off`、`stable`、または `unstable`。既定値は `off` です。 |
-
-| `portage.overlays` 項目 | 意味 |
-| --- | --- |
-| `name` | overlay 名。必須です。 |
-| `sync_uri` | overlay の同期 URI。必須です。 |
-
-| `kernel` キー | 意味と既定値または選択肢 |
-| --- | --- |
-| `source` | kernel の選択肢。`dist-bin`、`dist-source`、`cjk-bin`、または `cjk`。既定値は `dist-bin` です。 |
-| `package` | `source` が暗黙に指定するパッケージを上書きします。`""`。 |
-| `version` | バージョン固定。`""` は Portage に最新のキーワード許可済みバージョンを選ばせます。 |
-| `dracut_modules` | ディスクレイアウトが必要とする dracut モジュールを追加します。`[]`。 |
-| `remote_unlock` | initramfs SSH 解除レコード。既定では空のレコードです。 |
-
-| `kernel.source` | パッケージと CJK の状態 |
-| --- | --- |
-| `dist-bin` | `sys-kernel/gentoo-kernel-bin`。CJK kernel ではありません。 |
-| `dist-source` | `sys-kernel/gentoo-kernel`。CJK kernel ではありません。 |
-| `cjk-bin` | `sys-kernel/gentoo-cjk-kernel-bin`。CJK kernel です。 |
-| `cjk` | `sys-kernel/gentoo-cjk-kernel`。CJK kernel です。 |
-
-| `kernel.remote_unlock` キー | 意味と既定値 |
-| --- | --- |
-| `enabled` | initramfs SSH 解除を有効にします。`false`。 |
-| `port` | initramfs の SSH ポート。`222`。 |
-| `address` | 静的 CIDR アドレス。`""` は DHCP を使用します。 |
-| `gateway` | 静的アドレスのゲートウェイ。`""`。 |
-| `interface` | initramfs のネットワークインターフェース。`""`。 |
-
-| `bootloader` キー | 意味と既定値または選択肢 |
-| --- | --- |
-| `kind` | ブートローダー。`grub`、`systemd-boot`、または `zfsbootmenu`。既定値は `grub` です。 |
-| `firmware` | ファームウェア。`uefi` または `bios`。既定値は `uefi` です。 |
-| `kernel_params` | 追加の kernel コマンドラインパラメーター。`[]`。 |
-
-| `packages` キー | 意味と既定値 |
-| --- | --- |
-| `desktop` | デスクトッププロファイル名。`""` はデスクトップを選択しません。 |
-| `applications` | パッケージグループ名。`[]`。 |
-| `graphics` | グラフィックスドライバーグループ名。`[]`。複数のグループがハイブリッドハードウェアに対応します。 |
-| `display_manager` | ディスプレイマネージャーグループ。`""` はコンソールログインを選択します。 |
-| `extra` | 他の選択後にマージするパッケージ atom。`[]`。 |
-
-| `disk` キー | 意味と既定値または選択肢 |
-| --- | --- |
-| `graph` | `[[disk.devices]]` で表すデバイスグラフ。必須です。 |
-| `root` | root グラフノード識別子。変換以外では必須です。`""` は変換時に稼働中のレイアウトを使用します。 |
-| `mode` | `partition`、`in-place`、`image`、または `dd`。既定値は `partition` です。 |
-| `image` | image モードでの疎なイメージパス。`""`。 |
-| `size` | image モードでの疎なイメージサイズ。unset。 |
-| `wipe` | ディスクレベルの消去設定。`false`。 |
-| `source` | `dd` モードでの準備済みイメージのソース。`""`。 |
-| `source_format` | ソースエンコーディング。`raw`、`gz`、`xz`、`zst`、または `tar`。既定値は `raw` です。 |
-| `destination` | ディスク全体への `dd` の宛先。`""`。 |
-
-| テンプレート入力 | 意味と既定値または選択肢 |
-| --- | --- |
-| `disk` | ディスク全体のセレクタ。必須です。 |
-| `layout` | `whole-disk`、`whole-disk-btrfs`、`whole-disk-zfs`、または `reuse`。既定値は `whole-disk` です。 |
-| `firmware` | テンプレートのファームウェア。`uefi`。 |
-| `table` | パーティションテーブルの上書き。unset では UEFI に GPT、BIOS に MBR を導出します。 |
-| `filesystem` | Btrfs および ZFS ではないディスク全体レイアウト用の root ファイルシステム。`xfs`。 |
-| `swap` | swap パーティションサイズ。unset。 |
-| `passphrase_file` | インストール側システムのパスフレーズファイルのパス。`""` はレイアウトを暗号化しません。 |
-| `pool` | ZFS プール名。`rpool`。 |
-
-次の完全な設定は、認証情報と 2 つのバイパスホストを持つプロキシを示します。認証情報は例であり、実行前に置き換える必要があります。
-
-```toml
-config_version = 1
-
-[proxy]
-kind = "socks5"
-host = "proxy.example"
-port = 1080
-username = "operator"
-password = "secret"
-bypass = ["localhost", "intranet.example"]
-
-[system]
-hostname = "proxy-target"
-timezone = "UTC"
-locales = ["en_US.UTF-8"]
-locale = "en_US.UTF-8"
-init = "openrc"
-root_password_hash = "$6$gentooinst$IR3GrdJ862XljQYDqocr4tKniIRDIT.jQNFzIrHE3U75H6B6YSWZoSYoVd5edSHpqaYBdiNfXHCoIPRVgb9lT/"
-
-[portage]
-profile = "default/linux/amd64/23.0"
-makeopts = "-j4"
-
-[portage.binhost]
-official = false
-
-[bootloader]
-firmware = "bios"
-
-[disk]
-root = "mnt-root"
-
-[[disk.devices]]
-kind = "existing"
-id = "disk"
-selector = "/dev/disk/by-id/virtio-target0"
-wipe = true
-
-[[disk.devices]]
-kind = "table"
-id = "table"
-disk = "disk"
-table = "mbr"
-
-[[disk.devices]]
-kind = "partition"
-id = "rootpart"
-table = "table"
-index = 1
-role = "data"
-
-[[disk.devices]]
-kind = "filesystem"
-id = "rootfs"
-device = "rootpart"
-type = "ext4"
-
-[[disk.devices]]
-kind = "mountpoint"
-id = "mnt-root"
-source = "rootfs"
-path = "/"
+```sh
+./bootstrap.sh --config my-install.toml --resume
 ```
 
 ## バイナリパッケージ
 
 <!-- fact: binary-packages -->
 
-バイナリパッケージは任意の機能です。無効にしてもソースからビルドできます。公式 binhost と gentoo-zh binhost は別々の選択肢であり、それぞれ異なる信頼設定を使用します。binhost に接続できない場合、署名がない場合、鍵が信頼されていない場合を対象とする現在のエンドツーエンド根拠はなく、これらのフォールバック経路は未検証です。
+バイナリパッケージは任意です。無効にしてもソースからのビルドは可能です。公式 binhost と gentoo-zh binhost には別々の信頼設定があります。到達不能な binhost、署名の欠落、信頼されない鍵については、現在エンドツーエンドの証拠がありません。これらの降格経路は未検証です。
 
-## 終了コード
+## リファレンス
 
-<!-- fact: exit-codes -->
+<!-- fact: reference -->
 
-| 終了コード | `gentoo-install` |
-| --- | --- |
-| `0` | 正常終了 |
-| `1` | 設定エラー |
-| `2` | `argparse` の使用方法エラーまたは preflight の失敗 |
-| `3` | 完全性検証の失敗 |
-| `4` | ダウンロード、外部コマンド、OS、未分類のインストーラの失敗 |
-| `5` | 操作者による中止 |
-
-Python CLI の起動前に Python、必須コマンド、root 権限の検査が失敗した場合、`bootstrap.sh` も `1` で終了することがあります。
-
-## よくある質問
-
-<!-- fact: faq-customisation -->
-
-**この種のインストーラーは Gentoo の自由な構成を損なうのか。**
-
-損なわない。基礎的なインストールだけを行って終わる。パーティション、stage3、Portage の設定、カーネル、ブートローダー、および任意のデスクトップである。その後の判断はすべて運用者のものであり、できあがるのは本プロジェクトの構成要素が何も残らない通常の Gentoo である。取り除かれるのは最初の一時間の手間であり、それが Gentoo の導入と、多数の機材や VPS への展開を難しくしている。
+[REFERENCE.md](REFERENCE.md)には、実行時要件、コマンドラインオプション、メモリ環境、インプレース変換、機能と検証の詳細、設定ファイル、バイナリパッケージの信頼、終了コードがあります。
 
 ## 開発への参加
 
 <!-- fact: contributing -->
 
-[CONTRIBUTING.md](CONTRIBUTING.md) では、開発環境、アーキテクチャ、必要な検査について説明しています。
+[CONTRIBUTING.md](CONTRIBUTING.md)は開発環境、アーキテクチャ、必要な検査を説明します。
 
 ## ライセンス
 
 <!-- fact: license -->
 
-本プロジェクトは GNU General Public License のバージョン 2、または受領者が選ぶそれ以降のバージョンのもとで配布される。バージョン 2 の全文は [LICENSE](LICENSE) にあり、各ソースファイルは `SPDX-License-Identifier: GPL-2.0-or-later` を持つ。
+gentoo-install は GNU General Public License のバージョン 2、または受領者が選ぶそれ以降のバージョンのもとで配布されます。バージョン 2 の全文は [LICENSE](LICENSE) にあり、各ソースファイルは `SPDX-License-Identifier: GPL-2.0-or-later` を持ちます。

--- a/README.ko.md
+++ b/README.ko.md
@@ -4,45 +4,52 @@
 
 <!-- fact: identity -->
 
-gentoo-install은 Linux 라이브 환경에서 실행되어 amd64 아키텍처의 Gentoo 시스템을 설치하는 시스템 설치 도구다. 설치 내용은 대화형 메뉴 또는 TOML 설정 파일로 지정할 수 있다. 프로그램 인터페이스는 영어, 번체 중국어, 간체 중국어, 일본어, 한국어를 제공한다.
+gentoo-install은 Linux 라이브 환경에서 실행되어 amd64 아키텍처의 Gentoo 시스템을 설치하는 시스템 설치 도구다. 설치 내용은 대화형 메뉴 또는 TOML 설정 파일로 지정한다. 프로그램 인터페이스는 영어, 번체 중국어, 간체 중국어, 일본어, 한국어를 제공한다.
 
 ![설치 과정의 선택 항목을 보여 주는 메뉴](screenshot-ko.png)
 
-![간체 중국어, 번체 중국어, 일본어, 한국어를 표시하는 cjktty 콘솔](cjk-console.png)
+## 기능 개요
+
+<!-- fact: capability-summary -->
+
+구현 범위에는 일반 디스크 설치, 스토리지와 부팅 구성, 데스크톱과 언어 profile, 특수 모드가 포함된다.
+
+- **스토리지.** 장치 그래프는 파티션 테이블, 파일 시스템, LUKS2, LVM, mdraid, ZFS를 다룬다.
+- **부팅과 시스템.** GRUB, systemd-boot, ZFSBootMenu는 구성에 따라 UEFI 또는 BIOS 부팅을 구성한다.
+- **데스크톱과 언어.** GNOME, KDE Plasma, Xfce, CJK 글꼴, 입력기는 구성 선택지다.
+- **특수 모드.** 메모리 환경, 인플레이스 변환, 스파스 이미지, `dd`에는 각각의 제약이 있다.
+
+[참조 문서](REFERENCE.md#capabilities)는 모델, 제한, 특수 모드 절차를 정의한다.
+
+## 검증 상태
+
+<!-- fact: verification-scope -->
+
+[`TESTED.md`](TESTED.md)는 실행한 각 경로, 설치 도구 리비전, 실행 환경을 기록한다. 기록한 리비전이 설치 도구와 일치하고, 설치가 `0`으로 끝나며, 설치된 시스템이 부팅되고, 부팅 후 구성 검사가 통과한 실행만 기록에 포함된다.
+
+단위, 계획, fixture coverage는 구현 동작을 설명하지만 설치된 시스템의 부팅을 증명하지 않는다.[`tests/fixtures/`](tests/fixtures/)는 구성 모델을 검증하며 설치된 시스템이 아니다. 기록은 미검증 조합을 표시한다.
 
 ## 요구 사항
 
 <!-- fact: requirements-runtime -->
 
-실제 설치에는 root 권한, amd64 아키텍처, Python 3.11 이상이 필요하다. 설정 파일로 dry run을 수행할 때는 root 권한이 필요하지 않다. 설치 도구에는 타사 Python 런타임 의존성이 없다.
-
-<!-- fact: requirements-version-sources -->
-
-메뉴는 Gentoo 메인 트리 패키지 버전을 `packages.gentoo.org`에서 읽고 gentoo-zh 패치 커널 버전을 `api.github.com/repos/gentoo-zh/overlay/contents`에서 읽는다. `sys-fs/zfs`가 허용하는 최대 커널 버전은 `gitweb.gentoo.org`에서 읽는다. 설정 파일로 설치할 때는 해당 설정이 지정한 미러에 연결해야 한다. `--missing-commands`와 `--config FILE --dry-run`은 이 버전 제공 지점에 연결하지 않는다.
-
-<!-- fact: requirements-network-filter -->
-
-라이브 환경에 IPv6가 있고 IPv4가 없으면 메뉴는 기록상 IPv4 전용인 Gentoo 미러를 비활성화한다.
-
-<!-- fact: requirements-bootstrap -->
-
-`bootstrap.sh`는 `/etc/os-release`를 읽고, 누락된 명령을 보고하며, 후보 패키지 관리자 명령을 표시한다. 인식하는 배포판 계열은 Debian과 Ubuntu, Arch, openSUSE, Fedora, RHEL과 CentOS, Gentoo, Alpine이다. 표시된 명령은 실행하기 전에 확인해야 한다.
+실제 설치에는 root 권한, amd64 대상, Python 3.11 이상이 필요하다. 설정 파일로 dry run을 실행할 때는 root 권한이 필요하지 않다. 설치 도구에는 타사 Python 런타임 의존성이 없다.
 
 ## 안전
 
 <!-- fact: safety-destructive -->
 
-실제 설치는 선택한 디스크에 데이터를 기록한다. 설정 파일로 실행할 때는 디스크 삭제 여부를 다시 확인하지 않는다. `wipe = true`, 파티션 삭제, 파일 시스템 생성은 기존 데이터를 파괴할 수 있다.
+실제 실행은 선택한 디스크에 기록한다. 설정 파일 실행에는 두 번째 삭제 확인이 없다. `wipe = true`, 파티션 삭제, 파일 시스템 생성은 기존 데이터를 파괴할 수 있다.
 
 <!-- fact: safety-review-backup -->
 
-실제 설치 전에 dry-run 출력에서 디스크 선택자와 모든 파괴적 작업을 확인해야 한다. `/dev/sda` 같은 이름보다 안정적인 `/dev/disk/by-id/` 선택자가 더 적합하다. 보존해야 하는 데이터는 선택한 디스크와 분리된 위치에 별도 백업이 있어야 한다.
+실제 실행 전에 dry-run 출력에서 디스크 선택자와 모든 파괴적 작업을 확인해야 한다. `/dev/sda` 같은 이름보다 안정적인 `/dev/disk/by-id/` 선택자가 더 적합하다. 보존할 데이터에는 선택한 디스크와 분리된 위치의 별도 백업이 필요하다.
 
 ## 설치
 
 <!-- fact: install-download -->
 
-다음 명령을 사용하여 현재 `master` 아카이브를 다운로드하고 메뉴를 열 수 있다.
+다음 명령은 현재 `master` 아카이브를 다운로드하고 메뉴를 연다.
 
 ```sh
 curl -fsSL https://github.com/Zakkaus/gentoo-install/archive/refs/heads/master.tar.gz | tar xz
@@ -52,601 +59,59 @@ cd gentoo-install-master
 
 <!-- fact: install-terminal -->
 
-메뉴에는 80열 24행 이상의 대화형 터미널이 필요하다. 설치 도구는 시작할 때 인터페이스 언어를 한 번 묻는다. `--lang ko`를 사용하면 한국어를 바로 선택할 수 있다.
+메뉴에는 80열 24행 이상의 대화형 터미널이 필요하다.
 
 <!-- fact: install-config-workflow -->
 
-메뉴는 설정을 `my-install.toml`이라는 설정 파일로 저장한 뒤 종료할 수 있다. 다음 설정 파일 작업 절차에서는 전체 설정 계획을 먼저 표시한 다음 실제 설치를 수행한다.
+메뉴는 응답을 `my-install.toml`로 저장한다. 설정 파일 작업 순서는 저장, dry run, 검사, 설치다.
 
 ```sh
 ./bootstrap.sh --config my-install.toml --dry-run
-# 이어서 아래 두 줄 가운데 하나만 실행한다. 둘 다 선택한 디스크에 쓴다.
+# 실제 명령을 선택하기 전에 렌더링된 계획을 검사한다.
 ./bootstrap.sh --config my-install.toml
-./bootstrap.sh --config my-install.toml --no-shell   # 같은 실행이며 root 셸을 묻지 않는다
+./bootstrap.sh --config my-install.toml --no-shell   # 같은 실행이며 root 셸 프롬프트를 생략한다
 ```
 
 <!-- fact: install-root-shell -->
 
-대화형 설치에서는 성공하거나 실패한 경우 모두 마운트를 해제하기 전에 대상 시스템 안에서 root 셸을 여는 선택지를 제공한다. `--no-shell`을 사용하면 이 확인을 생략할 수 있다.
-
-| 옵션 | 인수 및 기본값 | 효과 |
-| --- | --- | --- |
-| `--config` | 파일 또는 URL; 설정되지 않음 | 메뉴를 열지 않고 해당 소스를 불러온다. |
-| `--dry-run` | 없음; `false` | 파생된 작업과 요약을 렌더링한 뒤 작업을 적용하지 않고 종료한다. |
-| `--mirror` | stage3 미러 문자열; 설치 도구 기본값 | 일반 설치에 사용할 stage3 소스를 선택한다. 메모리 설정은 구성에서 해당 지역을 도출한다. |
-| `--lang` | 언어 태그; `""` | 메뉴가 구성을 만드는 동안 `LC_ALL`, `LC_MESSAGES`, `LANG`을 재정의한다. |
-| `--target` | 경로; `/mnt/gentoo` | 일반 설치의 마운트 대상을 선택한다. 변환과 메모리 설정에는 `/`을 사용한다. |
-| `--work` | 경로; `/run/gentoo-install` | 보고서와 저널을 포함한 실행 상태를 보관한다. |
-| `--missing-commands` | 없음; `false` | 누락된 호스트 명령을 한 줄에 하나씩 출력한 뒤 종료한다. |
-| `--resume` | 없음; `false` | 기존 저널을 사용하여 호환되는 완료 작업을 건너뛴다. |
-| `--no-shell` | 없음; `false` | 대상 root 셸 제안을 표시하지 않는다. 메모리 설정도 무인으로 만든다. |
-| `--skip-preflight` | 없음; `false` | 일반 설치의 사전 점검을 건너뛴다. |
-| `--ram` | 없음; 설정되지 않은 메모리 모드 | 메모리에 올린 Gentoo CJK ISO로 한 번 부팅하도록 설정한다. `--lowram`과 충돌한다. |
-| `--lowram` | 없음; 설정되지 않은 메모리 모드 | 메모리에 올린 Alpine netboot 환경으로 한 번 부팅하도록 설정한다. `--ram`과 충돌한다. |
-| `--ssh-key` | 키, 파일, HTTP(S) URL 또는 `github:`/`gitlab:` 참조; `""` | 메모리 환경의 인증된 공개 키를 설정한다. 메모리 모드가 필요하다. |
-| `--ssh-port` | 정수; 설정되지 않음 | 메모리 환경의 `sshd` 포트를 설정한다. 메모리 모드가 필요하다. |
-| `--root-password` | 문자열; `""` | 메모리 환경의 root 비밀번호를 설정한다. 메모리 모드가 필요하다. |
-| `--bypass` | 없음; `false` | 한 번만 부팅하는 항목을 설정하는 대신 기본 부팅 항목을 교체한다. 메모리 모드가 필요하다. |
-| `--disarm` | 없음; `false` | 구성 불러오기 전에 이전에 설정한 메모리 부팅과 그 부팅이 배치한 파일을 제거한다. |
-
-## 메모리에서 설치
-
-<!-- fact: install-memory -->
-
-`--ram`과 `--lowram`은 메모리에 올린 라이브 환경으로 한 번 부팅하도록 설정한다. 콘솔도 복구 이미지도 없는 임대 장비가 자기 디스크를 덮어쓰려면 이것이 필요하다. 설치 도구와 선택한 설정, 인가된 키는 initramfs 안에 실려 가므로 환경은 그것을 설정한 리비전으로 올라온다.
-
-```sh
-./bootstrap.sh --ram --ssh-key github:zakkaus --root-password 'replace this'
-reboot
-ssh root@the-machine
-```
-
-기본 부팅 항목은 바뀌지 않으므로 환경으로 올라오지 못한 장비는 이전과 같은 것을 부팅한다. `--disarm`은 설정을 되돌린다. `--bypass`는 기본 항목 자체를 대체하며, 일회성 항목을 버리는 펌웨어를 위한 것이다. 환경이 올라오지 못했을 때 장비가 아예 부팅하지 못하는 경로는 이것뿐이다.
-
-첫 화면은 `install now? [yes/no]`를 묻고 시간 제한이 없으며, 답하기 전에는 아무것도 지우지 않는다. `--ram`은 ZFS를 담은 Gentoo CJK ISO를 부팅하며 약 2 GiB의 메모리가 필요하다. `--lowram`은 더 작고 `zfs.ko`가 없는 Alpine netboot 아카이브를 부팅한다. `--ssh-port`는 데몬을 22번에서 옮긴다. 첫 화면은 설치를 나중에 시작하는 명령을 제시하므로, `no`라고 답하거나 답하기 전에 연결이 끊겨도 재부팅만이 돌아가는 길이 되지는 않는다.
-
-`--ram`은 wifi에 도달하고 `--lowram`은 도달하지 못한다. Gentoo CJK ISO는 NetworkManager와 `linux-firmware`를 담고 있어 `nmcli device wifi connect <SSID> password <암호>`로 연결을 세운 뒤 설치를 실행할 수 있으며, 첫 화면이 이를 번체 중국어, 간체 중국어, 영어로 알린다. Alpine netboot 환경에는 무선 드라이버도 서플리컨트도 없고 전체 모듈 집합은 그 자체를 내려받아야 하는 `modloop`에 있으므로, wifi만으로 연결된 기계는 `--lowram`을 쓸 수 없다.
-
-## 실행 중인 시스템 변환
-
-<!-- fact: install-in-place -->
-
-`[disk]` 테이블의 `mode = "in-place"`는 디스크를 분할하는 대신 실행 중인 배포판의 사용자 공간을 교체한다. 레이아웃은 기계에서 읽어 오므로 이 테이블은 장치 목록을 담지 않는다.
-
-```toml
-config_version = 1
-
-[system]
-hostname = "converted"
-timezone = "UTC"
-locales = ["en_US.UTF-8"]
-locale = "en_US.UTF-8"
-init = "systemd"
-root_password_hash = "$6$gentooinst$IR3GrdJ862XljQYDqocr4tKniIRDIT.jQNFzIrHE3U75H6B6YSWZoSYoVd5edSHpqaYBdiNfXHCoIPRVgb9lT/"
-
-[portage]
-profile = "default/linux/amd64/23.0/systemd"
-makeopts = "-j4"
-
-[bootloader]
-kind = "grub"
-firmware = "uefi"
-
-[disk]
-mode = "in-place"
-```
-
-위 해시는 예시이며 실행 전에 교체해야 한다. 대화형 실행은 변환이 교체하는 디렉터리를 출력하고 무언가를 쓰기 전에 `convert` 입력을 요구한다. 터미널이 없는 실행은 묻지 않는다. 설정 파일의 `mode = "in-place"`가 승인이며, 거기서 질문하면 시리얼 콘솔을 영원히 기다리게 하기 때문이다.
-
-**이 실행을 시작한 세션이 생명줄이다.** `/usr`와 `/etc`가 새 시스템의 것이 되면 새 SSH 로그인은 성립하지 않으며, 실행을 시작한 세션만 이미 매핑한 바이너리를 유지한다. 
-
-## 중단된 실행 재개
-
-<!-- fact: resume-behavior -->
-
-`--resume`은 저널의 위치와 식별자가 현재 계획과 일치하고 재부팅 후에도 효과가 유지된다고 표시된 완료 작업만 건너뛴다.
-
-```sh
-./bootstrap.sh --config my-install.toml --resume
-```
-
-<!-- fact: resume-limits -->
-
-재개는 동일한 라이브 세션, 동일한 설치 프로그램, 동일한 설정 파일로 제한되며, 그 밖의 경우는 설치 프로그램이 거부한다.
-
-- 저널의 첫 항목에는 설정의 다이제스트, 기계의 boot id, 설치 프로그램 소스의 다이제스트가 기록된다. `--resume`은 이 세 가지를 모두 비교하고, 하나라도 다르면 이유를 밝히고 중단한다. 커널이 boot id를 제공하지 않는 기계에서는 나머지 두 가지만 비교한다.
-- 기본 저널은 `/run/gentoo-install/install.jsonl`에 있으므로 어느 경우에도 재부팅 후에는 남아 있지 않는다.
-- 각 작업 기록에는 해당 작업 클래스의 소스와 필드 값에서 만든 식별자도 포함된다. 식별자가 바뀐 작업은 건너뛰지 않고 다시 수행된다. 공용 헬퍼나 상수의 변경은 그 식별자의 범위 밖이며, 설치 프로그램 다이제스트가 이를 포괄한다.
-
-## 기능
-
-<!-- fact: capability-scope -->
-
-검증 상태에서 더 좁은 범위를 밝힌 경우를 제외하면 아래 경로는 구현되어 있으며 자동화된 단위 테스트 또는 plan 테스트로 검사된다.
-
-<!-- fact: storage-device-graph -->
-
-**저장 장치**
-- 장치 그래프는 GPT와 MBR 파티션 테이블, ext2, ext3, ext4, xfs, f2fs, vfat, subvolume을 포함하는 btrfs, swap, LUKS2 암호화, LVM, mdraid를 다룬다.
-- ZFS도 같은 그래프에 속한다. 풀은 vdev 위에서 stripe, mirror, raidz1, raidz2, raidz3 중 하나를 취하고, 네이티브 암호화는 풀의 속성이며, 각 dataset은 그 자체로 하나의 노드다.
-- 기존 파티션 테이블을 유지할 수 있으며 각 파티션에 유지, 포맷, 삭제 작업을 각각 지정할 수 있다.
-
-| 모델 노드 | `id` 외 필드 | 결과 |
-| --- | --- | --- |
-| `Existing` | `selector`, `wipe` | 기존 장치를 선택한다. |
-| `PartitionTable` | `disk`, `table`, `create`, `remove` | 파티션 테이블을 만들거나 수정한다. |
-| `Partition` | `table`, `index`, `role`, `size`, `label` | 파티션을 정의한다. 마지막 `size`는 남은 공간을 모두 사용할 수 있다. |
-| `Luks` | `backing`, `name`, `passphrase_file` | LUKS 컨테이너를 정의한다. |
-| `MdRaid` | `members`, `level`, `name`, `metadata` | mdraid 배열을 정의한다. |
-| `VolumeGroup` | `members`, `name` | LVM 볼륨 그룹을 정의한다. |
-| `LogicalVolume` | `group`, `name`, `size` | LVM 논리 볼륨을 정의한다. |
-| `ZfsPool` | `vdevs`, `name`, `topology`, `encrypted`, `passphrase_file` | ZFS 풀을 정의한다. |
-| `ZfsDataset` | `pool`, `name` | ZFS dataset을 정의한다. |
-| `Filesystem` | `device`, `kind`, `label`, `create` | 장치를 포맷하거나 `create = false`이면 확인한다. |
-| `Subvolume` | `filesystem`, `name` | Btrfs subvolume을 정의한다. |
-| `Swap` | `device` | 참조한 장치에 swap을 정의한다. |
-| `Mountpoint` | `source`, `path`, `options` | 파일 시스템, Btrfs subvolume 또는 ZFS dataset을 마운트한다. |
-
-| 선택지 | 값 |
-| --- | --- |
-| 파티션 테이블 | `gpt`, `mbr` |
-| 파티션 역할 | `esp`, `bios-boot`, `swap`, `raid`, `lvm`, `zfs`, `data` |
-| mdraid 수준 | `raid0`, `raid1`, `raid5`, `raid6` |
-| mdraid 메타데이터 | `0.90`, `1.0`, `1.1`, `1.2` |
-| 파일 시스템 | `ext2`, `ext3`, `ext4`, `btrfs`, `xfs`, `f2fs`, `vfat` |
-| ZFS 토폴로지 | `stripe`, `mirror`, `raidz1`, `raidz2`, `raidz3` |
-
-<!-- fact: zram-system -->
-
-시스템 설정은 장치 그래프와 swap 파티션과 별도로 zram을 구성할 수 있다.
-
-<!-- fact: in-place-conversion -->
-
-**인플레이스 변환.**
-- `[disk]` 테이블에 `mode = "in-place"`를 설정하면 설치 도구는 디스크를 분할하는 대신 실행 중인 배포판의 사용자 공간을 Gentoo로 교체한다.
-- 레이아웃은 기계에서 읽어 오므로 이 테이블은 장치 목록을 담지 않는다.
-- `/bin`, `/sbin`, `/etc`, `/lib`, `/lib64`, `/usr`, `/var`가 교체되고 `/home`, `/root`, `/srv`, `/opt`를 비롯한 나머지 모든 경로는 그대로 남으며, `/etc`는 병합이 아니라 교체다.
-
-- 스테이징된 시스템은 실행 중인 시스템을 건드리지 않은 채 `/gentoo-install.new` 아래에 구축되고, 그다음 `rename(2)`으로 디렉터리마다 교환된다. 교환 이후에 실행되는 것은 esp 또는 부트 섹터에 쓰는 작업뿐이다.
-- 루트가 LUKS, LVM, mdraid 아래에 있는 경우, 루트 파일 시스템이 이 설치 도구가 기술할 수 없는 종류인 경우, 루트 파일 시스템의 여유 공간이 10 GiB 미만인 경우, 라이브 미디어에서 실행한 경우는 모두 아무것도 쓰기 전에 이유를 밝히고 거부한다.
-
-<!-- fact: prepared-image -->
-
-**디스크 이미지**
-- `mode = "image"`는 디스크가 아니라 `disk.image`가 지정하고 `disk.size`가 크기를 정하는 희소 파일에 설치한다. 결과물은 다른 곳으로 복사해 두었다가 나중에 쓸 수 있는 파일이다. `mode = "dd"`는 설치를 수행하지 않는다.
-- `disk.source`의 이미지를 `disk.destination` 디스크 전체로 스트리밍해 쓰고, 읽으면서 `raw`, `gz`, `xz`, `zst`, `tar`를 푼다.
-- 그 이미지가 이미 담고 있는 레이아웃과 부트로더는 그대로 둔다. 두 모드는 서로의 키를 받지 않으며 `partition` 모드는 어느 쪽 키도 받지 않는다.
-
-<!-- fact: boot-system -->
-
-**부팅 및 시스템**
-- 설치 도구에서는 GRUB, systemd-boot, ZFSBootMenu 부트로더를 선택할 수 있다. GRUB은 UEFI와 BIOS를 지원하고 systemd-boot는 UEFI를 지원한다.
-- ZFSBootMenu는 UEFI에서 ZFS 루트를 부팅하며 커널은 풀 안 부트 환경 자체의 `/boot`에서 가져온다. 설치 도구는 systemd 또는 OpenRC, dracut, locale, 키보드 배열, 시간대, 호스트 이름, DNS, 고정 주소, 선택한 네트워크 관리자를 설정할 수도 있다.
-
-<!-- fact: remote-unlock -->
-
-**암호화된 루트를 ssh로 여는 경로**
-- `[kernel.remote_unlock]`은 암호 구절 프롬프트 앞에 아무도 없는 기계를 위해 부팅 경로에 ssh 데몬을 놓는다. `enabled`가 이 경로를 켠다.
-- `port`의 기본값은 22가 아니라 222이며, 실행 중인 시스템에 대한 클라이언트의 `known_hosts` 항목이 initramfs의 항목과 충돌하지 않게 한다. `address`, `gateway`, `interface`는 그 데몬에 고정 주소를 주고, 주소가 비어 있으면 DHCP를 쓴다.
-- LUKS 루트는 시스템 initramfs 안의 `sys-kernel/dracut-crypt-ssh`가 열고, ZFS 루트는 ZFSBootMenu가 자기 이미지에 넣는 dropbear가 연다.
-- 인가 키는 `system.authorized_keys`의 것이다. 이 경로를 켜고도 키를 하나도 적지 않은 설정은 이유를 밝히고 거부된다. 아무도 로그인할 수 없는 데몬을 기술하기 때문이다.
-
-<!-- fact: desktop-language -->
-
-**데스크톱 및 언어 지원**
-- 설치 도구에서는 GNOME, KDE Plasma, Xfce를 선택하고 GDM, SDDM, LightDM, 또는 greetd와 그 tuigreet 콘솔 그리터 중 하나와 조합할 수 있다.
-- 그래픽 설정은 AMD, Intel, NVIDIA, 가상 머신을 지원한다.
-- 패키지 카탈로그에는 Fcitx 5, Rime, Anthy, Mozc, Hangul, CJK 글꼴이 포함된다.
-- 커널 선택 항목에는 cjktty 패치가 적용된 `sys-kernel/gentoo-cjk-kernel-bin`과 `sys-kernel/gentoo-cjk-kernel`이 포함된다.
-
-<!-- fact: portage -->
-
-**Portage**
-- 설정 항목에는 profile, `MAKEOPTS`, `USE`, `ACCEPT_KEYWORDS`, `L10N`, 미러, 저장소 동기화 방식이 포함된다.
-- gentoo-zh와 gig overlay는 각각 선택할 수 있다.
-- 인터페이스 언어로 `zh-TW`, `zh-CN`, `ja`, `ko` 중 하나를 선택하면 gentoo-zh의 패치된 바이너리 커널과 해당 overlay도 선택된다.
-- `en`을 선택하면 자동으로 선택되지 않는다. 공식 바이너리 패키지 소스와 gentoo-zh 바이너리 패키지 소스는 각각 독립된 설정과 키를 사용한다.
-
-<!-- fact: proxy -->
-
-**세션 프록시**
-- `[proxy]` 테이블은 `kind`, `host`, `port`, 선택 사항인 `username`과 `password`, `bypass`를 받는다.
-- `kind`는 `http`, `https`, `socks5` 중 하나이며 `host`가 비어 있으면 직접 연결한다.
-- SOCKS5는 `socks5h://`로 파생되므로 내부 호스트 이름을 프록시에서 확인한다.
-- 주 메뉴에는 값마다 필드가 있고 프록시 종류는 메뉴에서 선택한다.
-- `bypass`는 인터페이스에서 쉼표로 구분한 값이고 TOML에서는 목록이다.
-
-- 프록시를 선택한 뒤 설정한 프록시는 stage3와 서명 키, 메인 트리 및 overlay 버전 조회, `gitweb.gentoo.org`의 ZFS ebuild 조회, `make.conf`와 `FETCHCOMMAND`/`RESUMECOMMAND`를 통한 Portage 다운로드, `wget`, `curl`, `git`, GnuPG, binhost, overlay, paste 업로드에 사용된다.
-- 시계, 초기 연결 검사, 메뉴 전에 실행되는 미러 검사는 설정을 읽기 전에 실행되므로 이 설정의 대상이 아니다.
-- 설치 도구는 dry-run 설명과 공개 설정에서 인증 정보를 제외한다. 공개 설정과 설치된 시스템에는 인증 정보가 없는 엔드포인트와 우회 목록만 남는다.
-
-<!-- fact: memory-environment -->
-
-**메모리 환경.**
-- `--ram`과 `--lowram`은 메모리에 상주하는 라이브 환경으로 한 번만 부팅하도록 설정한 뒤 재부팅 여부를 묻는다.
-- 이 경로에는 화면이 없다. 대상이 되는 컴퓨터는 SSH 연결 하나만 있고 콘솔이 없는 경우가 많기 때문이다. `--ram`은 Gentoo CJK ISO를 사용하며 ZFS를 포함하고 약 2 GiB의 메모리를 요구한다.
-- 그 initramfs는 메모리에서 824 MiB의 라이브 이미지를 뺀 값이 1 GiB 아래로 내려가면 긴급 셸에서 멈춘다.
-- `--lowram`은 Alpine netboot 묶음을 사용하며 더 작고 `zfs.ko`가 없다. 둘 다 판을 고정하지 않는다. 배포자가 현재 이미지와 검사합을 공개하므로 설정하기 전에 내려받아 검증한다.
-
-- 기본 부팅 항목은 바꾸지 않으므로 환경이 올라오지 않아도 컴퓨터는 부팅한다. `--bypass`는 그것을 대체하며 한 번짜리 항목을 버리는 펌웨어를 위한 것이다.
-- 환경이 올라오지 않으면 컴퓨터가 전혀 부팅하지 못하는 유일한 경로이므로 무엇도 이를 자동으로 선택하지 않는다.
-
-<!-- fact: memory-environment-access -->
-
-**SSH로 메모리 설치 관찰하기.**
-- `--ssh-key`는 공개 키 본문(`ssh-ed25519`, `ssh-rsa`, `ecdsa-sha2-nistp256`, `-384`, `-521` 및 `sk-` 계열), 경로, `http` 또는 `https` URL, 그리고 `github:user`와 `gitlab:user`를 받는다.
-- `--ssh-port`와 `--root-password`가 나머지를 정한다.
-- 설치기와 선택된 구성과 키는 모두 initramfs 안으로 들어가므로 환경은 그 구성을 작성한 판을 실행하며 첫 로그인 이전에 `authorized_keys`가 놓여 있다.
-- 운영자는 SSH로 다시 접속해 설치 과정을 지켜보면 되고 콘솔을 열어 둘 필요가 없다. 첫 화면에 답하기 전에는 아무것도 지우지 않는다. 그 화면은 `install now? [yes/no]`를 물으며 시간 제한이 없다.
-
-<!-- fact: plan-records -->
-
-**계획 및 기록**
-- dry run은 저장 장치 하드웨어를 조사하지 않고 작업 계획을 표시한다.
-- 실제 설치는 재사용 장치에서 조사한 mdraid 메타데이터를 추가한 뒤 같은 planner를 사용하므로 하드웨어에 의존하는 검증 결과가 달라질 수 있다.
-- `install.log`는 명령 출력을 기록하고, `install.jsonl`은 작업, 패키지 소스, 바이너리 패키지에서 소스 빌드로 전환한 사유를 기록한다.
-- 메뉴는 설정을 `paste.gentoozh.org`에 업로드하기 전에 `password_hash`와 `root_password_hash` 값을 `removed-before-publishing`으로 바꾸고, 프록시의 `username`과 `password`는 키 자체를 출력하지 않는다.
-- 다른 설정값은 업로드에 남는다. 메뉴는 업로드된 페이지의 주소를 텍스트와 QR 코드로 표시한다.
-
-### 호환성 규칙
-
-검증은 다음 조합을 거부한다.
-
-| 거부되는 조합 |
-| --- |
-| 비어 있거나 잠겨 있거나 형식이 잘못된 root hash와 비밀번호 인증 사용자가 없고 사용할 수 있는 SSH 키 로그인도 없는 조합. |
-| ZFS 루트와 GRUB의 조합. |
-| GRUB를 사용하는 `/boot`의 ZFS 배치. |
-| ZFS 루트와 BIOS 부팅의 조합. |
-| ZFS 루트와 LUKS 루트 체인의 조합. |
-| ZFS가 아닌 루트와 ZFSBootMenu의 조합. |
-| 마운트된 ESP가 없는 UEFI 부팅. |
-| 암호화된 ESP가 있는 UEFI 부팅. |
-| BIOS 부팅과 systemd-boot의 조합. |
-| `/boot`이 암호화되었거나 vfat이어서 ESP에서 접근할 수 없는 커널 또는 initramfs와 systemd-boot의 조합. |
-| 메타데이터가 `1.1` 또는 `1.2`인 mdraid 위의 ESP. |
-| `bios-boot` 파티션이 없는 GPT 디스크의 BIOS 부팅. |
-| cjktty가 없는 커널에서 CJK 콘솔 렌더링을 사용하는 경우. |
-| 인증된 SSH 키가 없는 원격 잠금 해제. |
-| 암호화된 루트 컨테이너 또는 풀이 없는 원격 잠금 해제. |
-| initramfs SSH가 시작하기 전에 `/boot` 잠금을 해제해야 하는 GRUB를 사용하는 원격 잠금 해제. |
-| GRUB 또는 systemd-boot 시스템 initramfs가 수행하는 네이티브 ZFS 암호화의 원격 잠금 해제. |
-| `gentoo-zh` overlay가 없는 CJK 커널. |
-| `8x16` 이외의 콘솔 글꼴을 사용하는 CJK 콘솔 렌더링. |
-| `gentoo-zh` overlay가 없는 ZFSBootMenu. |
-| `gentoo-zh` overlay가 없는 gentoo-zh 커뮤니티 binhost. |
-
-## 검증 상태
-
-<!-- fact: verification-scope -->
-
-[`TESTED.md`](TESTED.md)이 검증 기록이다. 실제로 수행한 경로마다 한 행이 있으며, 그것이 동작한 설치기 리비전과 동작한 장소를 적는다. 어떤 실행이 기록으로 인정되려면 기록된 리비전이 설치기와 일치하고, 설치 종료 코드가 `0`이며, 설치된 시스템이 부팅하고, 부팅 후 구성 점검이 모두 통과해야 한다.
-
-| 경로 | 기록 |
-| --- | --- |
-| 디스크에 설치 | ext4, ext2, ext3, xfs, btrfs, f2fs, ZFS, LVM, mdraid, LUKS2를 두 펌웨어와 두 init 시스템에서 |
-| ZFS 풀 | stripe, mirror, raidz, 암호화된 풀, 그리고 ZFSBootMenu가 부팅한 풀 |
-| ssh를 통한 잠금 해제 | 시스템 initramfs가 연 LUKS 루트와 ZFSBootMenu 자체 이미지가 연 ZFS 풀 |
-| 고정 주소와 greetd | 각각 클러스터 기록 |
-| 실행 중인 시스템의 인플레이스 변환 | QEMU 기록 네 건. 두 건은 BIOS, 한 건은 `/home`을 보존한 UEFI, 한 건은 루트가 btrfs이고 `/home`과 `/var`을 subvolume으로 유지한 UEFI |
-| 이 설치기가 만든 기계의 변환 | 재부팅까지 도달한 클러스터 변환 여섯 건 가운데 다섯 건은 부팅했고 한 건은 모듈이 없어 GRUB 구조 셸에서 멈췄으나 변환 자체의 종료 코드는 `0`이어서, 이 경로는 아직 신뢰할 수 없다 |
-| `--ram`과 `--lowram` | Debian 12 기기가 한 번의 부팅을 설정하고 기본 부팅 항목을 바꾸지 않은 채 재부팅하여, 전달받은 설정을 지닌 채 전달된 환경으로 올라왔다. 그 화면에서 `install`을 답하면 Gentoo를 설치하고 기록한 디스크로 부팅했다 |
-| `--bypass` | 기본 부팅 항목을 바꾼 상태가 전원 재투입을 넘겨 유지되었고, 두 번의 부팅 모두 전달된 환경으로 올라왔다 |
-| 설정한 부팅이 올라오지 않는 경우 | 설정된 항목의 initramfs를 지운 기기는 전달된 화면을 보여 주지 않았고, 이어진 두 번의 부팅 모두 원래 클라우드 시스템에 도달했다 |
-| `dd` | 기록 하나. live 매체에서 준비된 이미지를 디스크 전체에 쓰고 raw와 gzip 두 형식 모두 바이트 단위로 읽어 냈다 |
-| 파일에 설치 | 기록 하나. 이미지를 `losetup -Pf`로 붙여 그 레이아웃이 선언한 두 파일 시스템으로 읽어 냈으나, 그 파일로 부팅한 기계는 아직 없다 |
-| 메뉴 | 80x24 직렬 콘솔에서 한 줄씩 열렸고, 영어, 번체 중국어, 간체 중국어, 일본어, 한국어에서 터미널보다 넓은 줄은 없었다 |
-
-소스에서 빌드하는 커널과 바이너리 패키지 폴백에는 runner 수준의 시험만 있으며, runner 수준의 시험은 엔드투엔드 기록이 아니다. `tests/fixtures/` 아래의 파일이 다루는 것은 구성 모델이며, 그 존재는 설치된 기계에 대해 아무것도 입증하지 않는다.
+대화형 실행은 마운트를 해제하기 전에 대상 root 셸을 제시한다. `--no-shell`은 해당 프롬프트를 생략한다.
 
 ## 설정 파일
 
-<!-- fact: config-model -->
+<!-- fact: configuration-reference -->
 
-설정 파일은 TOML 형식이다. 최상위 `config_version` 필드가 스키마 버전을 지정한다. 저장 장치는 장치 그래프로 표현된다. 각 장치에는 `id`가 있으며, 장치는 다른 장치를 `id`로 참조한다. 선택자는 실제 설치 중에만 해석된다.
+설정 파일은 TOML을 사용하며 `config_version`이 스키마 버전을 선택한다.[설정 참조 문서](REFERENCE.md#configuration-files)는 모든 영속 키와 검증된 예시를 나열한다.[`tests/fixtures/vm-binpkg.toml`](tests/fixtures/vm-binpkg.toml)은 스키마 참조다. 이 가상 머신 디스크 선택자와 테스트 자격 증명을 실제 시스템에 그대로 사용해서는 안 된다.
 
-<!-- fact: config-simple -->
+## 중단된 실행 재개
 
-디스크가 하나인 배치는 장치 그래프 대신 `[disk.simple]` 로 작성합니다. 파서는 메뉴가 사용하는 것과 같은 템플릿으로 전개하므로 두 표기는 동일한 그래프를 만듭니다. 그래프 표기는 LUKS, ZFS, RAID, 손으로 만든 파티션 테이블을 위해 남아 있습니다.
+<!-- fact: resume-limits -->
 
-```toml
-config_version = 1
+`--resume`은 동일한 라이브 세션, 동일한 설치 도구 리비전, 동일한 설정 파일에 한정된다. 설치 도구는 일치하지 않는 실행을 거부한다. 기본 저널은 `/run/gentoo-install/install.jsonl`에 있으므로 재부팅 후에는 남지 않는다.
 
-[system]
-hostname = "workstation"
-timezone = "UTC"
-locales = ["en_US.UTF-8"]
-locale = "en_US.UTF-8"
-init = "systemd"
-root_password_hash = "$6$gentooinst$IR3GrdJ862XljQYDqocr4tKniIRDIT.jQNFzIrHE3U75H6B6YSWZoSYoVd5edSHpqaYBdiNfXHCoIPRVgb9lT/"
-
-[portage]
-profile = "default/linux/amd64/23.0/systemd"
-makeopts = "-j4"
-
-[bootloader]
-kind = "grub"
-firmware = "uefi"
-
-[disk.simple]
-disk = "/dev/disk/by-id/virtio-target0"
-filesystem = "ext4"
-swap = "2GiB"
-```
-
-위 해시는 예시이며 실행 전에 교체해야 합니다. 필수 항목은 `disk` 하나입니다. 생략한 키는 설치기 기본값을 따릅니다: `whole-disk`, `uefi`, 펌웨어가 정하는 파티션 테이블, `xfs`, 스왑 없음, 암호화 없음. 한 파일에 `[disk.simple]` 과 `[[disk.devices]]` 를 함께 쓸 수 없습니다.
-
-<!-- fact: config-fixtures -->
-
-[`tests/fixtures/vm-binpkg.toml`](tests/fixtures/vm-binpkg.toml)은 UEFI와 Ext4 구성을 모두 포함한 완전한 스키마 참조 파일이다. [`tests/fixtures/`](tests/fixtures/)의 다른 파일은 BIOS, LUKS2, LVM, mdraid, ZFS, Btrfs subvolume, 데스크톱을 다룬다. 이 설정 파일들에는 가상 머신 디스크 선택자와 테스트용 암호가 포함되어 있으므로, 내용을 수정하지 않은 채 실제 머신 설치에 사용해서는 안 된다.
-
-<!-- fact: config-dry-run -->
-
-구문 분석과 계획 단계에서는 저장 장치 하드웨어를 조사하지 않으므로 대상 디스크가 없는 머신에서도 `--dry-run`으로 설정을 확인할 수 있다.
-
-다음 참조에는 영속되는 모든 키가 있다. 테이블 경로는 TOML 테이블 표기법이며, `[[disk.devices]]`에는 그래프 노드가 들어간다.
-
-| 키 | 의미 및 기본값 또는 선택지 |
-| --- | --- |
-| `config_version` | 영속되는 스키마 버전이며 기본값은 `1`이다. |
-| `proxy.kind` | 프록시 체계이며 `http`, `https`, `socks5` 중 하나이고 기본값은 `http`다. |
-| `proxy.host` | 프록시 호스트이며 `""`이면 프록시를 비활성화한다. |
-| `proxy.port` | 프록시 포트이며 기본값은 `0`이다. |
-| `proxy.username` | 선택적 프록시 사용자 이름이며 기본값은 `""`이다. |
-| `proxy.password` | 선택적 프록시 비밀번호이며 기본값은 `""`이다. |
-| `proxy.bypass` | 프록시를 우회하는 호스트이며 기본값은 `[]`이다. |
-
-| `system` 키 | 의미 및 기본값 또는 선택지 |
-| --- | --- |
-| `hostname` | 대상 hostname이며 기본값은 `gentoo`다. |
-| `timezone` | 대상 timezone이며 기본값은 `Asia/Shanghai`다. |
-| `locales` | 생성되는 locale이며 기본값은 `en_US.UTF-8`, `zh_CN.UTF-8`, `zh_TW.UTF-8`다. |
-| `locale` | 선택한 locale이며 기본값은 `zh_CN.UTF-8`다. |
-| `keymap` | 설치된 시스템의 keymap이며 기본값은 `us`다. |
-| `keymap_initramfs` | initramfs의 keymap이며 `""`이면 `keymap`을 따른다. |
-| `interface` | 네트워크 인터페이스 패턴이며 `""`이면 `en*`과 `eth*`에 일치한다. |
-| `addresses` | 고정 CIDR 주소이며 `[]`이면 DHCP 또는 라우터 광고를 선택한다. |
-| `gateways` | 게이트웨이이며 주소 계열마다 최대 하나이고 기본값은 `[]`이다. |
-| `dns` | 리졸버 주소이며 기본값은 `[]`이다. |
-| `authorized_keys` | root 및 sudo 사용자의 키이며 기본값은 `[]`이다. |
-| `console_cjk` | CJK 콘솔 렌더링을 요청하며 기본값은 `false`이고 cjktty가 필요하다. |
-| `console_font` | 콘솔 셀 크기이며 `8x8`, `8x16`, `16x32` 중 하나이고 기본값은 `8x16`이다. |
-| `init` | init 시스템이며 `openrc` 또는 `systemd`이고 기본값은 `systemd`다. |
-| `zram` | 압축 RAM swap 크기이며 설정하지 않으면 비활성화한다. |
-| `hardware_clock_utc` | RTC가 UTC를 저장하며 기본값은 `true`다. |
-| `users` | 사용자 기록이며 기본값은 `[]`이다. |
-| `root_password_hash` | root `crypt(3)` hash이며 `""`이면 root를 잠근다. |
-| `logger` | 로거이며 `none`, `sysklogd`, `syslog-ng`, `metalog` 중 하나이고 기본값은 `sysklogd`다. |
-| `cron` | `sys-process/cronie`를 설치하며 기본값은 `true`다. |
-| `sshd` | SSH 데몬 지원을 설치하고 구성하며 기본값은 `false`다. |
-| `sshd_password_login` | SSH 데몬이 비밀번호를 허용하며 기본값은 `false`다. |
-| `sshd_root_login` | root가 SSH로 로그인할 수 있으며 기본값은 `false`다. |
-| `networking` | 링크 관리 방식이며 `builtin`, `networkmanager-wpa`, `networkmanager-iwd`, `none` 중 하나이고 기본값은 `builtin`이다. |
-| `firewall` | 패킷 필터 패키지이며 `none`, `nftables`, `iptables` 중 하나이고 기본값은 `none`이다. |
-| `first_boot` | 첫 부팅 기록이며 기본값은 비어 있는 기록이다. |
-
-| `system.users` 항목 | 의미 및 기본값 |
-| --- | --- |
-| `name` | 사용자 이름이며 필수다. |
-| `groups` | 보조 그룹이며 기본값은 `[]`이다. |
-| `shell` | 로그인 셸이며 기본값은 `/bin/bash`다. |
-| `sudo` | 사용자를 sudo 사용자로 만들며 기본값은 `false`다. |
-| `password_hash` | 사용자 `crypt(3)` hash이며 `""`이면 계정을 잠근다. |
-
-| `system.first_boot` 키 | 의미 및 기본값 |
-| --- | --- |
-| `commands` | 가져온 script 뒤에 순서대로 실행할 셸 줄이며 기본값은 `[]`이다. |
-| `url` | script URL이며 `""`이면 가져온 script를 생략한다. |
-
-| `portage` 키 | 의미 및 기본값 또는 선택지 |
-| --- | --- |
-| `profile` | Portage profile이며 기본값은 `default/linux/amd64/23.0/systemd`다. |
-| `keywords` | 전역 keyword 채널이며 `stable` 또는 `testing`이고 기본값은 `stable`이다. |
-| `sync` | 지속 동기화 방식이며 `git`, `webrsync`, `rsync` 중 하나이고 기본값은 `git`다. 최초 동기화에는 webrsync를 사용한다. |
-| `testing_packages` | 시스템이 안정 상태를 유지하는 동안 testing으로 허용할 atom이며 기본값은 `[]`이다. |
-| `makeopts` | `MAKEOPTS`이며 기본값은 `""`이다. |
-| `common_flags` | 공통 컴파일러 플래그이며 기본값은 `-O2 -pipe`다. |
-| `use` | `USE` 플래그이며 기본값은 `[]`이다. |
-| `video_cards` | `VIDEO_CARDS` 값이며 기본값은 `[]`이다. |
-| `l10n` | `L10N`이며 기본값은 `[]`이고 생성되는 locale에서 값을 도출한다. |
-| `input_devices` | `INPUT_DEVICES`이며 기본값은 `["libinput"]`이다. |
-| `accept_license` | 수락하는 라이선스이며 기본값은 `["@FREE"]`다. |
-| `cpu_flags` | CPU 플래그이며 기본값은 `[]`이고 profile 값을 보존한다. |
-| `build_in_ram` | `/var/tmp/portage` tmpfs 크기이며 설정하지 않으면 디스크에서 빌드한다. |
-| `mirrors` | 미러 기록이며 기본값은 아래에 표시한다. |
-| `binhost` | 바이너리 호스트 기록이며 기본값은 아래에 표시한다. |
-| `overlays` | overlay 기록이며 기본값은 `[]`이다. |
-
-| `portage.mirrors` 키 | 의미 및 기본값 또는 선택지 |
-| --- | --- |
-| `region` | Gentoo 미러 지역이며 `cn` 또는 `global`이고 기본값은 `global`이다. |
-| `speed_test` | 제안된 미러의 속도를 시험하며 기본값은 `false`다. |
-| `distfiles` | 사용자 지정 distfile 기반이며 비어 있지 않은 목록은 내장 목록을 교체한다. |
-| `repo_sync_uri` | 명시적 저장소 동기화 URI이며 기본값은 `""`이다. |
-| `site` | `region`의 사이트 키이며 `""`이면 해당 지역의 첫 사이트를 선택한다. |
-| `gentoo_distfiles` | `GENTOO_MIRRORS`를 기록하며 기본값은 `true`다. |
-| `gentoo_zh` | gentoo-zh 미러이며 `upstream`, `cernet`, `nju`, `nyist`, `ha` 중 하나이고 기본값은 `upstream`이다. |
-| `gentoo_zh_distfiles` | gentoo-zh distfile을 `GENTOO_MIRRORS`에 추가하며 기본값은 `true`다. |
-
-| 미러 지역 | 사이트 키 |
-| --- | --- |
-| `cn` | `ustc`, `nju`, `bfsu`, `tuna`, `zju`, `sdu`, `hust`, `sustech`, `hit`, `lzu`, `aliyun`, `netease`, `cernet`, `cicku-hk`, `planetunix-hk`, `xtom-hk`, `rackspace-hk`, `aditsu-hk`, `nchc-tw`, `cicku-tw`, `freedif-sg`, `cicku-sg`, `planetunix-sg` |
-| `global` | `gentoo`, `osuosl` |
-
-| `portage.binhost` 키 | 의미 및 기본값 또는 선택지 |
-| --- | --- |
-| `official` | 공식 바이너리 호스트를 활성화하며 기본값은 `true`다. |
-| `subarch` | 공식 바이너리 호스트의 subarchitecture이며 기본값은 `x86-64`다. |
-| `community` | gentoo-zh 채널이며 `off`, `stable`, `unstable` 중 하나이고 기본값은 `off`다. |
-
-| `portage.overlays` 항목 | 의미 |
-| --- | --- |
-| `name` | overlay 이름이며 필수다. |
-| `sync_uri` | overlay 동기화 URI이며 필수다. |
-
-| `kernel` 키 | 의미 및 기본값 또는 선택지 |
-| --- | --- |
-| `source` | 커널 선택지이며 `dist-bin`, `dist-source`, `cjk-bin`, `cjk` 중 하나이고 기본값은 `dist-bin`이다. |
-| `package` | `source`가 암시하는 패키지를 재정의하며 기본값은 `""`이다. |
-| `version` | 버전 고정값이며 `""`이면 Portage가 keyword 허용 최신 버전을 선택한다. |
-| `dracut_modules` | 디스크 레이아웃에 필요한 dracut 모듈을 추가하며 기본값은 `[]`이다. |
-| `remote_unlock` | initramfs SSH 잠금 해제 기록이며 기본값은 비어 있는 기록이다. |
-
-| `kernel.source` | 패키지 및 CJK 상태 |
-| --- | --- |
-| `dist-bin` | `sys-kernel/gentoo-kernel-bin`이며 CJK 커널이 아니다. |
-| `dist-source` | `sys-kernel/gentoo-kernel`이며 CJK 커널이 아니다. |
-| `cjk-bin` | `sys-kernel/gentoo-cjk-kernel-bin`이며 CJK 커널이다. |
-| `cjk` | `sys-kernel/gentoo-cjk-kernel`이며 CJK 커널이다. |
-
-| `kernel.remote_unlock` 키 | 의미 및 기본값 |
-| --- | --- |
-| `enabled` | initramfs SSH 잠금 해제를 활성화하며 기본값은 `false`다. |
-| `port` | initramfs SSH 포트이며 기본값은 `222`다. |
-| `address` | 고정 CIDR 주소이며 `""`이면 DHCP를 사용한다. |
-| `gateway` | 고정 주소 게이트웨이이며 기본값은 `""`이다. |
-| `interface` | initramfs 네트워크 인터페이스이며 기본값은 `""`이다. |
-
-| `bootloader` 키 | 의미 및 기본값 또는 선택지 |
-| --- | --- |
-| `kind` | 부트로더이며 `grub`, `systemd-boot`, `zfsbootmenu` 중 하나이고 기본값은 `grub`다. |
-| `firmware` | 펌웨어이며 `uefi` 또는 `bios`이고 기본값은 `uefi`다. |
-| `kernel_params` | 추가 커널 명령줄 매개변수이며 기본값은 `[]`이다. |
-
-| `packages` 키 | 의미 및 기본값 |
-| --- | --- |
-| `desktop` | 데스크톱 profile 이름이며 `""`이면 데스크톱을 선택하지 않는다. |
-| `applications` | 패키지 그룹 이름이며 기본값은 `[]`이다. |
-| `graphics` | 그래픽 드라이버 그룹 이름이며 기본값은 `[]`이다. 여러 그룹은 하이브리드 하드웨어에 적합하다. |
-| `display_manager` | 디스플레이 관리자 그룹이며 `""`이면 콘솔 로그인을 선택한다. |
-| `extra` | 다른 선택 뒤에 병합할 패키지 atom이며 기본값은 `[]`이다. |
-
-| `disk` 키 | 의미 및 기본값 또는 선택지 |
-| --- | --- |
-| `graph` | `[[disk.devices]]`로 표현하는 장치 그래프이며 필수다. |
-| `root` | 루트 그래프 노드 식별자이며 변환 밖에서는 필수다. `""`이면 변환에서 실행 중인 레이아웃을 사용한다. |
-| `mode` | `partition`, `in-place`, `image`, `dd` 중 하나이며 기본값은 `partition`이다. |
-| `image` | image 모드의 희소 이미지 경로이며 기본값은 `""`이다. |
-| `size` | image 모드의 희소 이미지 크기이며 설정되지 않음이다. |
-| `wipe` | 디스크 수준 wipe 설정이며 기본값은 `false`다. |
-| `source` | `dd` 모드의 준비된 이미지 소스이며 기본값은 `""`이다. |
-| `source_format` | 소스 인코딩이며 `raw`, `gz`, `xz`, `zst`, `tar` 중 하나이고 기본값은 `raw`다. |
-| `destination` | 디스크 전체 `dd` 대상이며 기본값은 `""`이다. |
-
-| 템플릿 입력 | 의미 및 기본값 또는 선택지 |
-| --- | --- |
-| `disk` | 디스크 전체 선택자이며 필수다. |
-| `layout` | `whole-disk`, `whole-disk-btrfs`, `whole-disk-zfs`, `reuse` 중 하나이며 기본값은 `whole-disk`다. |
-| `firmware` | 템플릿 펌웨어이며 기본값은 `uefi`다. |
-| `table` | 파티션 테이블 재정의이며 설정하지 않으면 UEFI는 GPT, BIOS는 MBR을 도출한다. |
-| `filesystem` | Btrfs 및 ZFS가 아닌 디스크 전체 레이아웃의 루트 파일 시스템이며 기본값은 `xfs`다. |
-| `swap` | swap 파티션 크기이며 설정되지 않음이다. |
-| `passphrase_file` | 설치 시스템의 passphrase 파일 경로이며 `""`이면 레이아웃을 암호화하지 않는다. |
-| `pool` | ZFS 풀 이름이며 기본값은 `rpool`이다. |
-
-다음 완전한 설정은 인증 정보와 우회 호스트 두 개가 있는 프록시를 보여 준다. 인증 정보는 예시이므로 실행하기 전에 바꿔야 한다.
-
-```toml
-config_version = 1
-
-[proxy]
-kind = "socks5"
-host = "proxy.example"
-port = 1080
-username = "operator"
-password = "secret"
-bypass = ["localhost", "intranet.example"]
-
-[system]
-hostname = "proxy-target"
-timezone = "UTC"
-locales = ["en_US.UTF-8"]
-locale = "en_US.UTF-8"
-init = "openrc"
-root_password_hash = "$6$gentooinst$IR3GrdJ862XljQYDqocr4tKniIRDIT.jQNFzIrHE3U75H6B6YSWZoSYoVd5edSHpqaYBdiNfXHCoIPRVgb9lT/"
-
-[portage]
-profile = "default/linux/amd64/23.0"
-makeopts = "-j4"
-
-[portage.binhost]
-official = false
-
-[bootloader]
-firmware = "bios"
-
-[disk]
-root = "mnt-root"
-
-[[disk.devices]]
-kind = "existing"
-id = "disk"
-selector = "/dev/disk/by-id/virtio-target0"
-wipe = true
-
-[[disk.devices]]
-kind = "table"
-id = "table"
-disk = "disk"
-table = "mbr"
-
-[[disk.devices]]
-kind = "partition"
-id = "rootpart"
-table = "table"
-index = 1
-role = "data"
-
-[[disk.devices]]
-kind = "filesystem"
-id = "rootfs"
-device = "rootpart"
-type = "ext4"
-
-[[disk.devices]]
-kind = "mountpoint"
-id = "mnt-root"
-source = "rootfs"
-path = "/"
+```sh
+./bootstrap.sh --config my-install.toml --resume
 ```
 
 ## 바이너리 패키지
 
 <!-- fact: binary-packages -->
 
-바이너리 패키지는 선택 사항이다. 비활성화해도 소스에서 빌드할 수 있다. 공식 binhost와 gentoo-zh binhost는 별도의 선택 사항이며 각각 독립된 신뢰 설정을 사용한다. binhost에 연결할 수 없거나 서명이 없거나 키를 신뢰할 수 없는 경우를 다루는 현재 엔드투엔드 증거는 없으며, 이 전환 경로는 검증되지 않았다.
+바이너리 패키지는 선택 사항이다. 비활성화해도 소스에서 빌드할 수 있다. 공식 binhost와 gentoo-zh binhost에는 별도의 신뢰 구성이 있다. 도달할 수 없는 binhost, 누락된 서명, 신뢰하지 않는 키는 현재 엔드투엔드 증거가 없다. 이 강등 경로는 미검증 상태다.
 
-## 종료 코드
+## 참조 문서
 
-<!-- fact: exit-codes -->
+<!-- fact: reference -->
 
-| 종료 코드 | `gentoo-install` |
-| --- | --- |
-| `0` | 정상 완료 |
-| `1` | 설정 오류 |
-| `2` | `argparse` 사용법 오류 또는 preflight 실패 |
-| `3` | 무결성 검증 실패 |
-| `4` | 다운로드, 외부 명령, OS 또는 분류되지 않은 설치 도구 실패 |
-| `5` | 운영자 중단 |
-
-Python CLI가 시작되기 전에 Python, 필수 명령 또는 root 권한 검사가 실패하면 `bootstrap.sh`도 `1`로 종료될 수 있다.
-
-## 자주 묻는 질문
-
-<!-- fact: faq-customisation -->
-
-**이런 설치 프로그램이 Gentoo의 자유로운 구성을 해치는가?**
-
-해치지 않는다. 기본 설치만 수행하고 끝난다. 파티션, stage3, Portage 설정, 커널, 부트로더, 그리고 선택적인 데스크톱이다. 그 이후의 모든 결정은 운영자의 것이며, 완성된 기계는 이 프로젝트의 구성 요소가 하나도 남지 않은 평범한 Gentoo이다. 없어지는 것은 첫 한 시간의 비용이고, 그것이 Gentoo를 시작하기 어렵게 하고 많은 기계나 VPS에 배포하기 어렵게 만든다.
+[REFERENCE.md](REFERENCE.md)에는 런타임 요구 사항, 명령줄 옵션, 메모리 환경, 인플레이스 변환, 기능과 검증의 세부 사항, 설정 파일, 바이너리 패키지 신뢰, 종료 코드가 있다.
 
 ## 기여
 
 <!-- fact: contributing -->
 
-개발 환경, 아키텍처, 필수 검사는 [CONTRIBUTING.md](CONTRIBUTING.md)에 설명되어 있다.
+[CONTRIBUTING.md](CONTRIBUTING.md)는 개발 환경, 아키텍처, 필요한 검사를 설명한다.
 
 ## 라이선스
 
 <!-- fact: license -->
 
-이 프로젝트는 GNU General Public License 버전 2 또는 수령자가 선택하는 이후 버전에 따라 배포된다. 버전 2 전문은 [LICENSE](LICENSE)에 있으며, 각 소스 파일은 `SPDX-License-Identifier: GPL-2.0-or-later`를 가진다.
+gentoo-install은 GNU General Public License 버전 2 또는 수령자가 선택하는 이후 버전에 따라 배포된다. 버전 2 전문은 [LICENSE](LICENSE)에 있으며, 각 소스 파일은 `SPDX-License-Identifier: GPL-2.0-or-later`를 가진다.

--- a/README.md
+++ b/README.md
@@ -8,7 +8,26 @@ gentoo-install runs in a Linux live environment to install an amd64 Gentoo syste
 
 ![The menu showing the installation decisions](screenshot-en.png)
 
-![The cjktty console rendering Simplified Chinese, Traditional Chinese, Japanese and Korean](cjk-console.png)
+## Capabilities at a glance
+
+<!-- fact: capability-summary -->
+
+The implementation covers normal disk installation, storage and boot configuration, desktop and language profiles, and special modes.
+
+- **Storage.** The device graph covers partition tables, filesystems, LUKS2, LVM, mdraid and ZFS.
+- **Boot and system.** GRUB, systemd-boot and ZFSBootMenu configure UEFI or BIOS as their configurations allow.
+- **Desktop and language.** GNOME, KDE Plasma, Xfce, CJK fonts and input methods are configuration choices.
+- **Special modes.** Memory environments, in-place conversion, sparse images and `dd` have separate constraints.
+
+[The reference](REFERENCE.md#capabilities) defines the models, limits and special-mode procedures.
+
+## Verification status
+
+<!-- fact: verification-scope -->
+
+[`TESTED.md`](TESTED.md) records each exercised path, its installer revision and its environment. A run counts only when the recorded revision matches the installer, its installation exits `0`, the installed system boots, and the post-boot configuration checks pass.
+
+Unit, plan and fixture coverage describes implementation behavior; it does not establish that an installed system booted. [`tests/fixtures/`](tests/fixtures/) exercise the configuration model, not an installed machine. The record names unverified combinations.
 
 ## Requirements
 
@@ -16,23 +35,11 @@ gentoo-install runs in a Linux live environment to install an amd64 Gentoo syste
 
 A real installation requires root privileges, an amd64 target and Python 3.11 or newer. A configuration-file dry run does not require root privileges. The installer has no third-party Python runtime dependency.
 
-<!-- fact: requirements-version-sources -->
-
-The menu reads Gentoo main-tree package versions from `packages.gentoo.org` and gentoo-zh patched-kernel versions from `api.github.com/repos/gentoo-zh/overlay/contents`. It reads the maximum kernel version accepted by `sys-fs/zfs` from `gitweb.gentoo.org`. An installation from a configuration file requires the mirror that configuration names instead; `--missing-commands` and `--config FILE --dry-run` require none of these version endpoints.
-
-<!-- fact: requirements-network-filter -->
-
-The menu disables recorded IPv4-only Gentoo mirrors when the live environment has IPv6 but no IPv4.
-
-<!-- fact: requirements-bootstrap -->
-
-`bootstrap.sh` reads `/etc/os-release`, reports missing commands and prints a candidate package-manager command. It recognizes these distribution families: Debian and Ubuntu; Arch; openSUSE; Fedora, RHEL and CentOS; Gentoo; and Alpine. The printed command must be reviewed before it is run.
-
 ## Safety
 
 <!-- fact: safety-destructive -->
 
-A real run writes to the selected disks. A configuration-file run starts without a second erase confirmation; `wipe = true`, partition deletion and filesystem creation can destroy existing data.
+A real run writes to the selected disks. A configuration-file run has no second erase confirmation; `wipe = true`, partition deletion and filesystem creation can destroy existing data.
 
 <!-- fact: safety-review-backup -->
 
@@ -52,562 +59,37 @@ cd gentoo-install-master
 
 <!-- fact: install-terminal -->
 
-The menu requires an interactive terminal of at least 80x24 cells. It asks for the interface language once; `--lang en` selects English without that question.
+The menu requires an interactive terminal of at least 80x24 cells.
 
 <!-- fact: install-config-workflow -->
 
-The menu can save its answers as `my-install.toml` and exit. The configuration-file workflow below prints the complete plan before the real run:
+The menu saves its answers as `my-install.toml`. The configuration-file workflow is save, dry-run, inspect, then install:
 
 ```sh
 ./bootstrap.sh --config my-install.toml --dry-run
-# Then one of the two below. Each writes the selected disks.
+# Inspect the rendered plan before choosing one real command.
 ./bootstrap.sh --config my-install.toml
 ./bootstrap.sh --config my-install.toml --no-shell   # the same run, without the root-shell prompt
 ```
 
 <!-- fact: install-root-shell -->
 
-Before unmounting, an interactive run offers a root shell in the target after either success or failure. `--no-shell` suppresses that question.
-
-| Option | Argument and default | Effect |
-| --- | --- | --- |
-| `--config` | file or URL; unset | Loads that source instead of opening the menu. |
-| `--dry-run` | none; `false` | Renders the derived operations and summary, then exits without applying operations. |
-| `--mirror` | stage3 mirror string; installer default | Selects the stage3 source for a normal installation. Memory arming derives its region from configuration. |
-| `--lang` | language tag; `""` | Overrides `LC_ALL`, `LC_MESSAGES`, and `LANG` while the menu creates configuration. |
-| `--target` | path; `/mnt/gentoo` | Selects the normal installation mount target. Conversion and memory arming use `/`. |
-| `--work` | path; `/run/gentoo-install` | Holds run state, including the report and journal. |
-| `--missing-commands` | none; `false` | Prints missing host commands, one per line, then exits. |
-| `--resume` | none; `false` | Uses the existing journal to skip compatible completed operations. |
-| `--no-shell` | none; `false` | Suppresses the target root-shell offer. It also makes memory arming unattended. |
-| `--skip-preflight` | none; `false` | Skips normal-installation preflight checks. |
-| `--ram` | none; unset memory mode | Arms one boot into the Gentoo CJK ISO held in memory. It conflicts with `--lowram`. |
-| `--lowram` | none; unset memory mode | Arms one boot into the Alpine netboot environment held in memory. It conflicts with `--ram`. |
-| `--ssh-key` | key, file, HTTP(S) URL, or `github:`/`gitlab:` reference; `""` | Sets a memory-environment authorised public key. It requires a memory mode. |
-| `--ssh-port` | integer; unset | Sets the memory environment's `sshd` port. It requires a memory mode. |
-| `--root-password` | string; `""` | Sets the memory environment root password. It requires a memory mode. |
-| `--bypass` | none; `false` | Replaces the default boot entry instead of arming a one-shot entry. It requires a memory mode. |
-| `--disarm` | none; `false` | Removes a previously armed memory boot and files it placed before configuration loading. |
-
-## Installing from memory
-
-<!-- fact: install-memory -->
-
-`--ram` and `--lowram` arm one boot into a live environment held in memory, which is what a rented machine with no console and no rescue image needs before its own disk can be installed over. The installer, the chosen configuration and the authorised keys travel inside the initramfs, so the environment comes up running the revision that armed it:
-
-```sh
-./bootstrap.sh --ram --ssh-key github:zakkaus --root-password 'replace this'
-reboot
-ssh root@the-machine
-```
-
-The default boot entry is not changed, so a machine that does not come up in the environment boots what it booted before; `--disarm` takes the arming back. `--bypass` replaces the default entry instead, for firmware that drops a one-shot entry, and it is the one path where an environment that fails to come up leaves a machine that does not boot at all.
-
-The first screen asks `install now? [yes/no]` and has no timeout, and nothing is erased until it is answered. `--ram` boots the Gentoo CJK ISO, which carries ZFS and needs about 2 GiB of RAM; `--lowram` boots the Alpine netboot bundle, which is smaller and has no `zfs.ko`. `--ssh-port` moves the daemon off 22. The first page names the command that starts the install later, so answering `no` or losing the connection before answering does not make rebooting the only way back to it.
-
-`--ram` reaches wifi and `--lowram` does not. The Gentoo CJK ISO carries NetworkManager and `linux-firmware`, so `nmcli device wifi connect <SSID> password <PASSWORD>` brings a link up and the install runs after it; the first page says so in Traditional Chinese, Simplified Chinese and English. The Alpine netboot environment has no wireless driver and no supplicant, and its full module set is in a `modloop` that itself has to be fetched, so a machine whose only link is wifi cannot use `--lowram` at all.
-
-## Converting a running system
-
-<!-- fact: install-in-place -->
-
-`mode = "in-place"` in the `[disk]` table replaces the userland of the running distribution instead of partitioning a disk. The table carries no device list, because the layout is read from the machine:
-
-```toml
-config_version = 1
-
-[system]
-hostname = "converted"
-timezone = "UTC"
-locales = ["en_US.UTF-8"]
-locale = "en_US.UTF-8"
-init = "systemd"
-root_password_hash = "$6$gentooinst$IR3GrdJ862XljQYDqocr4tKniIRDIT.jQNFzIrHE3U75H6B6YSWZoSYoVd5edSHpqaYBdiNfXHCoIPRVgb9lT/"
-
-[portage]
-profile = "default/linux/amd64/23.0/systemd"
-makeopts = "-j4"
-
-[bootloader]
-kind = "grub"
-firmware = "uefi"
-
-[disk]
-mode = "in-place"
-```
-
-The hash above is an example and must be replaced before execution. An interactive run prints what the conversion replaces and requires the word `convert` before anything is written; a run with no terminal is not asked, because `mode = "in-place"` in the file is the authorisation and a question there would hold a serial console open for ever.
-
-**The session that started the run is the lifeline.** A new SSH login stops working once `/usr` and `/etc` belong to the new system, while the session that started the run keeps the binaries it already mapped.
-
-## Resuming an interrupted run
-
-<!-- fact: resume-behavior -->
-
-`--resume` skips an operation recorded as complete only when its journal position and identity match the current plan and its effect is marked as surviving a reboot:
-
-```sh
-./bootstrap.sh --config my-install.toml --resume
-```
-
-<!-- fact: resume-limits -->
-
-Resume is limited to the same live session, the same installer and the same configuration file, and the installer refuses the other cases instead of documenting them.
-
-- The journal opens with a digest of the configuration, the machine's boot id and a digest of the installer's own source; `--resume` compares all three and stops with an explanatory message on any mismatch. Where the kernel publishes no boot id, only the other two are compared.
-- The default journal is `/run/gentoo-install/install.jsonl`, so it does not survive a reboot in any case.
-- Each operation record also carries an identity derived from that operation's class source and field values, so an operation whose identity changed is performed again rather than skipped. A change to a shared helper or constant is outside that per-operation identity and is covered by the installer digest instead.
-
-## Capabilities
-
-<!-- fact: capability-scope -->
-
-The paths below are implemented and have automated unit or plan coverage unless the verification status identifies a narrower boundary.
-
-<!-- fact: storage-device-graph -->
-
-**Storage.**
-- The device graph covers GPT and MBR; ext2, ext3, ext4, btrfs subvolumes, xfs, f2fs and vfat; swap; and LUKS2, LVM and mdraid.
-- ZFS belongs to the same graph: a pool is a stripe, a mirror, or raidz1, raidz2 or raidz3 over its vdevs, native encryption is a property of the pool, and each dataset is a node of its own.
-- Existing partition tables can be retained, with a separate keep, format or delete decision for each partition.
-
-| Model node | Fields beyond `id` | Result |
-| --- | --- | --- |
-| `Existing` | `selector`, `wipe` | Selects a pre-existing device. |
-| `PartitionTable` | `disk`, `table`, `create`, `remove` | Creates or edits a partition table. |
-| `Partition` | `table`, `index`, `role`, `size`, `label` | Defines a partition; final `size` may consume remaining space. |
-| `Luks` | `backing`, `name`, `passphrase_file` | Defines a LUKS container. |
-| `MdRaid` | `members`, `level`, `name`, `metadata` | Defines an mdraid array. |
-| `VolumeGroup` | `members`, `name` | Defines an LVM volume group. |
-| `LogicalVolume` | `group`, `name`, `size` | Defines an LVM logical volume. |
-| `ZfsPool` | `vdevs`, `name`, `topology`, `encrypted`, `passphrase_file` | Defines a ZFS pool. |
-| `ZfsDataset` | `pool`, `name` | Defines a ZFS dataset. |
-| `Filesystem` | `device`, `kind`, `label`, `create` | Formats a device, or verifies it when `create = false`. |
-| `Subvolume` | `filesystem`, `name` | Defines a Btrfs subvolume. |
-| `Swap` | `device` | Defines swap on a referenced device. |
-| `Mountpoint` | `source`, `path`, `options` | Mounts a filesystem, Btrfs subvolume, or ZFS dataset. |
-
-| Choice | Values |
-| --- | --- |
-| Partition table | `gpt`, `mbr` |
-| Partition role | `esp`, `bios-boot`, `swap`, `raid`, `lvm`, `zfs`, `data` |
-| mdraid level | `raid0`, `raid1`, `raid5`, `raid6` |
-| mdraid metadata | `0.90`, `1.0`, `1.1`, `1.2` |
-| Filesystem | `ext2`, `ext3`, `ext4`, `btrfs`, `xfs`, `f2fs`, `vfat` |
-| ZFS topology | `stripe`, `mirror`, `raidz1`, `raidz2`, `raidz3` |
-
-<!-- fact: zram-system -->
-
-The system configuration can configure zram independently of the device graph and swap partitions.
-
-<!-- fact: in-place-conversion -->
-
-**In-place conversion.**
-- Setting `mode = "in-place"` in the `[disk]` table replaces the userland of the running distribution with Gentoo instead of partitioning a disk.
-- The layout is read from the machine, so the table carries no device list.
-- `/bin`, `/sbin`, `/etc`, `/lib`, `/lib64`, `/usr` and `/var` are replaced; `/home`, `/root`, `/srv`, `/opt` and every other path are left alone, and `/etc` is replaced rather than merged.
-
-- The staged system is built under `/gentoo-install.new` while the running one is untouched, each directory is then exchanged with `rename(2)`, and only the writes to the esp or the boot sector follow the exchange.
-- A root below LUKS, LVM or mdraid, a root filesystem this installer cannot describe, a machine with less than 10 GiB free on the root filesystem, and a live medium are each refused by name before anything is written.
-
-<!-- fact: prepared-image -->
-
-**Disk images.**
-- `mode = "image"` installs into the sparse file named by `disk.image` and sized by `disk.size` instead of onto a disk, so the product is a file that can be copied elsewhere and written later.
-- `mode = "dd"` installs nothing: it streams the image at `disk.source` onto the whole disk at `disk.destination`, decoding `raw`, `gz`, `xz`, `zst` or `tar` as it reads, and keeps whatever layout and bootloader that image already carries.
-- Neither mode accepts the keys of the other, and `partition` mode accepts neither set.
-
-<!-- fact: boot-system -->
-
-**Boot and system.**
-- GRUB supports UEFI and BIOS, systemd-boot supports UEFI, and ZFSBootMenu boots a ZFS root on UEFI, taking each kernel from the boot environment's own `/boot` inside the pool.
-- The installer configures systemd or OpenRC, dracut, locale, keyboard layout, timezone, hostname, DNS, static addresses and the selected network manager.
-
-<!-- fact: remote-unlock -->
-
-**Unlocking an encrypted root over SSH.**
-- `[kernel.remote_unlock]` puts an SSH daemon in the boot path, for a machine whose passphrase prompt nobody is sitting in front of.
-- `enabled` turns it on, `port` defaults to 222 rather than 22 so a client's `known_hosts` entry for the running system does not collide with the initramfs one, and `address`, `gateway` and `interface` give that daemon a static address; an empty address asks for DHCP.
-- A LUKS root is opened by `sys-kernel/dracut-crypt-ssh` in the system initramfs, and a ZFS root by the dropbear ZFSBootMenu builds into its own image.
-- The authorised keys are the ones in `system.authorized_keys`: a configuration that enables the unlock and lists no key is refused by name, because the daemon it describes is one nobody can log in to.
-
-<!-- fact: desktop-language -->
-
-**Desktop and language support.**
-- GNOME, KDE Plasma and Xfce are available with gdm, sddm, lightdm, or greetd and its tuigreet console greeter.
-- Graphics settings cover AMD, Intel, NVIDIA and virtual machines.
-- The package catalog includes fcitx5, Rime, Anthy, Mozc, Hangul and CJK fonts.
-- The kernel choices include `sys-kernel/gentoo-cjk-kernel-bin` and `sys-kernel/gentoo-cjk-kernel`, both of which carry the cjktty patch.
-
-<!-- fact: portage -->
-
-**Portage.**
-- The configuration covers the profile, `MAKEOPTS`, `USE`, `ACCEPT_KEYWORDS`, `L10N`, mirrors and repository synchronization.
-- The gentoo-zh and gig overlays can be selected independently.
-- Selecting `zh-TW`, `zh-CN`, `ja` or `ko` as the interface language also selects the gentoo-zh patched binary kernel and its overlay; selecting `en` does not.
-- Official and gentoo-zh binary package sources have separate settings and keys.
-
-<!-- fact: proxy -->
-
-**Session proxy.**
-- The `[proxy]` table accepts `kind`, `host`, `port`, optional `username` and `password`, and `bypass`.
-- `kind` is `http`, `https` or `socks5`; an empty host selects direct connection, which is the default.
-- SOCKS5 derives `socks5h://`, so host names resolve at the proxy for intranet access.
-- The interface has one field per value and a menu for the proxy kind.
-- The bypass value is comma-separated in the interface and a list in TOML.
-
-- The configured proxy is used for stage3 and its signing key, main-tree and overlay version lookups, the `gitweb.gentoo.org` ZFS ebuild lookup, Portage downloads through `make.conf` and `FETCHCOMMAND`/`RESUMECOMMAND`, `wget`, `curl`, `git`, GnuPG, the binhost, overlays and paste upload.
-- The clock, the initial connectivity check and the pre-menu mirror check run before the configuration is available and are therefore not covered by this setting.
-- The installer keeps the credential out of dry-run descriptions and publishes a credential-free proxy endpoint with the bypass list; the installed system receives that endpoint and list.
-
-<!-- fact: memory-environment -->
-
-**Memory environment.**
-- `--ram` and `--lowram` arm one boot into a live environment held in memory, then ask whether to reboot; there is no interface on this path, because the machine it addresses usually has one SSH session and no console.
-- `--ram` uses the Gentoo CJK ISO, which carries ZFS and needs about 2 GiB of RAM, because its initramfs stops at an emergency shell when memory less the 824 MiB live image falls under 1 GiB.
-- `--lowram` uses the Alpine netboot bundle, which is smaller and has no `zfs.ko`.
-- Neither pins a version: both publishers list the current image with its checksum, which is fetched and verified before anything is armed.
-
-- The default boot entry is never changed, so an environment that does not come up leaves a machine that still boots.
-- `--bypass` replaces it instead, for firmware that drops a one-shot entry; it is the one path where an environment that does not come up leaves a machine that does not boot at all, and nothing selects it automatically.
-
-<!-- fact: memory-environment-access -->
-
-**Watching a memory install over SSH.**
-- `--ssh-key` accepts a literal public key (`ssh-ed25519`, `ssh-rsa`, `ecdsa-sha2-nistp256`, `-384`, `-521`, and the `sk-` variants), a path, an `http` or `https` URL, or `github:user` and `gitlab:user`; `--ssh-port` and `--root-password` set the rest.
-- The installer, the chosen configuration and the keys travel inside the initramfs, so the environment runs the revision that wrote that configuration and reaches `authorized_keys` before the first login.
-- The operator reconnects over SSH and watches the install rather than holding a console open.
-- Nothing is erased until the first screen is answered: it asks `install now? [yes/no]`, and has no timeout.
-
-<!-- fact: plan-records -->
-
-**Plan and records.**
-- A dry run prints an operation plan without probing storage hardware.
-- A real installation uses the same planner after adding probed mdraid metadata for reused devices, so hardware-dependent validation can change the result.
-- `install.log` records command output, and `install.jsonl` records operations, package sources and binary-package degradation reasons.
-- Before uploading a configuration to `paste.gentoozh.org`, the menu replaces `password_hash` and `root_password_hash` with `removed-before-publishing` and omits the proxy `username` and `password` keys entirely; the other configuration values remain in the upload.
-- The menu displays the resulting page address as text and as a QR code.
-
-### Compatibility rules
-
-Validation rejects these combinations:
-
-| Refused combination |
-| --- |
-| An empty, locked, or malformed root hash with no password-authenticating user and no usable SSH-key login. |
-| A ZFS root with GRUB. |
-| `/boot` on ZFS with GRUB. |
-| A ZFS root with BIOS boot. |
-| A ZFS root with a LUKS root chain. |
-| ZFSBootMenu with a root that is not ZFS. |
-| UEFI boot without a mounted ESP. |
-| UEFI boot with an encrypted ESP. |
-| systemd-boot with BIOS boot. |
-| systemd-boot with a kernel or initramfs inaccessible from the ESP because `/boot` is encrypted or not vfat. |
-| An ESP on mdraid with metadata `1.1` or `1.2`. |
-| BIOS boot on a GPT disk without a `bios-boot` partition. |
-| CJK console rendering with a kernel lacking cjktty. |
-| Remote unlock without an authorised SSH key. |
-| Remote unlock without an encrypted root container or pool. |
-| Remote unlock with GRUB that must unlock `/boot` before initramfs SSH starts. |
-| Remote unlock of native ZFS encryption by a GRUB or systemd-boot system initramfs. |
-| A CJK kernel without the `gentoo-zh` overlay. |
-| CJK console rendering with a console font other than `8x16`. |
-| ZFSBootMenu without the `gentoo-zh` overlay. |
-| A gentoo-zh community binhost without the `gentoo-zh` overlay. |
-
-## Verification status
-
-<!-- fact: verification-scope -->
-
-[`TESTED.md`](TESTED.md) is the verification record: one row for each exercised path, naming the installer revision it ran at and where it ran. A run counts only when its recorded revision matches the installer, its installation exit code is `0`, the installed system boots, and the post-boot configuration checks pass.
-
-| Path | Record |
-| --- | --- |
-| Installing onto a disk | ext4, ext2, ext3, xfs, btrfs, f2fs, ZFS, LVM, mdraid and LUKS2, on both firmwares and both init systems |
-| ZFS pools | a stripe, a mirror, a raidz, an encrypted pool, and a pool booted by ZFSBootMenu |
-| Unlocking over SSH | a LUKS root opened from the system initramfs, and a ZFS pool opened from ZFSBootMenu's own image |
-| Static addressing and greetd | cluster records of their own |
-| Converting a running system | four QEMU records: two on BIOS, one on UEFI that retained `/home`, and one on UEFI whose btrfs root carries `/home` and `/var` as subvolumes |
-| Converting a machine this installer produced | six cluster conversions reached the reboot; five booted and one stopped in GRUB's rescue shell for a missing module while the conversion exited `0`, so this path is not yet reliable |
-| `--ram` and `--lowram` | a Debian 12 machine armed one boot, kept its default entry and came up in the delivered environment, carrying the configuration it was given; answering `install` there installed Gentoo and booted the disk it had written |
-| `--bypass` | replacing the default entry survived a power cycle: both boots came up in the memory environment |
-| An armed boot that does not come up | a machine whose armed initramfs was removed never showed the delivered screen and reached its own cloud system on the two boots that followed |
-| `dd` | one prepared image written onto a whole disk from a live medium and read back byte for byte, raw and gzipped |
-| Installing into a file | one record: the image was attached with `losetup -Pf` and read back as the two filesystems its layout declares, and nothing has booted from that file |
-| The menu | opened row by row on an 80x24 serial console in English, Traditional and Simplified Chinese, Japanese and Korean, with no row wider than the terminal |
-
-A source-built kernel and binary-package degradation have runner-level tests only, and a runner-level test is not an end-to-end record. Files under `tests/fixtures/` exercise the configuration model; their presence establishes nothing about an installed machine.
+An interactive run offers a target root shell before unmounting. `--no-shell` suppresses that prompt.
 
 ## Configuration files
 
-<!-- fact: config-model -->
+<!-- fact: configuration-reference -->
 
-Configuration files use TOML. The top-level `config_version` field selects the schema version. Storage is a device graph: every device has an `id`, devices refer to other devices by `id`, and selectors are resolved only during a real run.
+Configuration files use TOML, and `config_version` selects the schema version. [The configuration reference](REFERENCE.md#configuration-files) lists every persisted key and validated examples. [`tests/fixtures/vm-binpkg.toml`](tests/fixtures/vm-binpkg.toml) is a schema reference; its virtual-machine disk selector and test credentials must not be installed unchanged on a real machine.
 
-<!-- fact: config-simple -->
+## Resuming an interrupted run
 
-A single-disk layout is written as `[disk.simple]` instead of a device graph. The parser expands it with the same template the menu uses, so both forms produce the same graph. The graph form remains for LUKS, ZFS, RAID and hand-made partition tables.
+<!-- fact: resume-limits -->
 
-```toml
-config_version = 1
+`--resume` is limited to the same live session, installer revision and configuration file. The installer rejects mismatches. The default journal is `/run/gentoo-install/install.jsonl`, so it does not survive a reboot.
 
-[system]
-hostname = "workstation"
-timezone = "UTC"
-locales = ["en_US.UTF-8"]
-locale = "en_US.UTF-8"
-init = "systemd"
-root_password_hash = "$6$gentooinst$IR3GrdJ862XljQYDqocr4tKniIRDIT.jQNFzIrHE3U75H6B6YSWZoSYoVd5edSHpqaYBdiNfXHCoIPRVgb9lT/"
-
-[portage]
-profile = "default/linux/amd64/23.0/systemd"
-makeopts = "-j4"
-
-[bootloader]
-kind = "grub"
-firmware = "uefi"
-
-[disk.simple]
-disk = "/dev/disk/by-id/virtio-target0"
-filesystem = "ext4"
-swap = "2GiB"
-```
-
-The hash above is an example and must be replaced before execution. Only `disk` is required. An omitted key takes the installer default: `whole-disk`, `uefi`, a partition table chosen by the firmware, `xfs`, no swap, no encryption. A file must not carry both `[disk.simple]` and `[[disk.devices]]`.
-
-<!-- fact: config-fixtures -->
-
-[`tests/fixtures/vm-binpkg.toml`](tests/fixtures/vm-binpkg.toml) is a complete UEFI and ext4 schema reference. Other files under [`tests/fixtures/`](tests/fixtures/) cover BIOS, LUKS2, LVM, mdraid, ZFS, btrfs subvolumes and desktops. They contain virtual-machine disk selectors and test credentials, so they must not be installed unchanged on a real machine.
-
-<!-- fact: config-dry-run -->
-
-Parsing and planning do not probe storage hardware. A machine without the target disk can therefore check a configuration with `--dry-run`.
-
-The following reference names every persisted key. A table path is TOML table notation, and `[[disk.devices]]` carries the graph nodes.
-
-| Key | Meaning and default or choices |
-| --- | --- |
-| `config_version` | Persisted schema version; `1`. |
-| `proxy.kind` | Proxy scheme: `http`, `https`, or `socks5`; `http`. |
-| `proxy.host` | Proxy host; `""` disables the proxy. |
-| `proxy.port` | Proxy port; `0`. |
-| `proxy.username` | Optional proxy user name; `""`. |
-| `proxy.password` | Optional proxy password; `""`. |
-| `proxy.bypass` | Hosts that bypass the proxy; `[]`. |
-
-| `system` key | Meaning and default or choices |
-| --- | --- |
-| `hostname` | Target hostname; `gentoo`. |
-| `timezone` | Target timezone; `Asia/Shanghai`. |
-| `locales` | Generated locales; `en_US.UTF-8`, `zh_CN.UTF-8`, `zh_TW.UTF-8`. |
-| `locale` | Selected locale; `zh_CN.UTF-8`. |
-| `keymap` | Installed-system keymap; `us`. |
-| `keymap_initramfs` | Initramfs keymap; `""` follows `keymap`. |
-| `interface` | Network-interface pattern; `""` matches `en*` and `eth*`. |
-| `addresses` | Static CIDR addresses; `[]` selects DHCP or router advertisements. |
-| `gateways` | Gateways, at most one per address family; `[]`. |
-| `dns` | Resolver addresses; `[]`. |
-| `authorized_keys` | Keys for root and sudo users; `[]`. |
-| `console_cjk` | Requests CJK console rendering; `false`; it needs cjktty. |
-| `console_font` | Console cell size: `8x8`, `8x16`, or `16x32`; `8x16`. |
-| `init` | Init system: `openrc` or `systemd`; `systemd`. |
-| `zram` | Compressed-RAM swap size; unset disables it. |
-| `hardware_clock_utc` | RTC stores UTC; `true`. |
-| `users` | User records; `[]`. |
-| `root_password_hash` | Root `crypt(3)` hash; `""` locks root. |
-| `logger` | Logger: `none`, `sysklogd`, `syslog-ng`, or `metalog`; `sysklogd`. |
-| `cron` | Installs `sys-process/cronie`; `true`. |
-| `sshd` | Installs and configures SSH daemon support; `false`. |
-| `sshd_password_login` | SSH daemon accepts passwords; `false`. |
-| `sshd_root_login` | Root may log in through SSH; `false`. |
-| `networking` | Link management: `builtin`, `networkmanager-wpa`, `networkmanager-iwd`, or `none`; `builtin`. |
-| `firewall` | Packet-filter package: `none`, `nftables`, or `iptables`; `none`. |
-| `first_boot` | First-boot record; empty record by default. |
-
-| `system.users` item | Meaning and default |
-| --- | --- |
-| `name` | User name; required. |
-| `groups` | Supplementary groups; `[]`. |
-| `shell` | Login shell; `/bin/bash`. |
-| `sudo` | Makes the user a sudo user; `false`. |
-| `password_hash` | User `crypt(3)` hash; `""` locks the account. |
-
-| `system.first_boot` key | Meaning and default |
-| --- | --- |
-| `commands` | Shell lines run in order after the fetched script; `[]`. |
-| `url` | Script URL; `""` omits a fetched script. |
-
-| `portage` key | Meaning and default or choices |
-| --- | --- |
-| `profile` | Portage profile; `default/linux/amd64/23.0/systemd`. |
-| `keywords` | Global keyword channel: `stable` or `testing`; `stable`. |
-| `sync` | Ongoing sync: `git`, `webrsync`, or `rsync`; `git`. First sync uses webrsync. |
-| `testing_packages` | Atoms accepted as testing while the system remains stable; `[]`. |
-| `makeopts` | `MAKEOPTS`; `""`. |
-| `common_flags` | Common compiler flags; `-O2 -pipe`. |
-| `use` | `USE` flags; `[]`. |
-| `video_cards` | `VIDEO_CARDS` values; `[]`. |
-| `l10n` | `L10N`; `[]` derives values from generated locales. |
-| `input_devices` | `INPUT_DEVICES`; `["libinput"]`. |
-| `accept_license` | Accepted licenses; `["@FREE"]`. |
-| `cpu_flags` | CPU flags; `[]` preserves the profile value. |
-| `build_in_ram` | `/var/tmp/portage` tmpfs size; unset builds on disk. |
-| `mirrors` | Mirror record; defaults shown below. |
-| `binhost` | Binary-host record; defaults shown below. |
-| `overlays` | Overlay records; `[]`. |
-
-| `portage.mirrors` key | Meaning and default or choices |
-| --- | --- |
-| `region` | Gentoo mirror region: `cn` or `global`; `global`. |
-| `speed_test` | Speed-tests offered mirrors; `false`. |
-| `distfiles` | Custom distfile bases; a nonempty list replaces the built-in list. |
-| `repo_sync_uri` | Explicit repository sync URI; `""`. |
-| `site` | Site key in `region`; `""` selects the region's first site. |
-| `gentoo_distfiles` | Writes `GENTOO_MIRRORS`; `true`. |
-| `gentoo_zh` | gentoo-zh mirror: `upstream`, `cernet`, `nju`, `nyist`, or `ha`; `upstream`. |
-| `gentoo_zh_distfiles` | Appends gentoo-zh distfiles to `GENTOO_MIRRORS`; `true`. |
-
-| Mirror region | Site keys |
-| --- | --- |
-| `cn` | `ustc`, `nju`, `bfsu`, `tuna`, `zju`, `sdu`, `hust`, `sustech`, `hit`, `lzu`, `aliyun`, `netease`, `cernet`, `cicku-hk`, `planetunix-hk`, `xtom-hk`, `rackspace-hk`, `aditsu-hk`, `nchc-tw`, `cicku-tw`, `freedif-sg`, `cicku-sg`, `planetunix-sg` |
-| `global` | `gentoo`, `osuosl` |
-
-| `portage.binhost` key | Meaning and default or choices |
-| --- | --- |
-| `official` | Enables the official binary host; `true`. |
-| `subarch` | Official binary-host subarchitecture; `x86-64`. |
-| `community` | gentoo-zh channel: `off`, `stable`, or `unstable`; `off`. |
-
-| `portage.overlays` item | Meaning |
-| --- | --- |
-| `name` | Overlay name; required. |
-| `sync_uri` | Overlay synchronization URI; required. |
-
-| `kernel` key | Meaning and default or choices |
-| --- | --- |
-| `source` | Kernel choice: `dist-bin`, `dist-source`, `cjk-bin`, or `cjk`; `dist-bin`. |
-| `package` | Overrides the package implied by `source`; `""`. |
-| `version` | Version pin; `""` lets Portage choose the newest keyword-allowed version. |
-| `dracut_modules` | Adds dracut modules required by the disk layout; `[]`. |
-| `remote_unlock` | Initramfs SSH-unlock record; empty record by default. |
-
-| `kernel.source` | Package and CJK status |
-| --- | --- |
-| `dist-bin` | `sys-kernel/gentoo-kernel-bin`; not a CJK kernel. |
-| `dist-source` | `sys-kernel/gentoo-kernel`; not a CJK kernel. |
-| `cjk-bin` | `sys-kernel/gentoo-cjk-kernel-bin`; CJK kernel. |
-| `cjk` | `sys-kernel/gentoo-cjk-kernel`; CJK kernel. |
-
-| `kernel.remote_unlock` key | Meaning and default |
-| --- | --- |
-| `enabled` | Enables initramfs SSH unlocking; `false`. |
-| `port` | Initramfs SSH port; `222`. |
-| `address` | Static CIDR address; `""` uses DHCP. |
-| `gateway` | Static-address gateway; `""`. |
-| `interface` | Initramfs network interface; `""`. |
-
-| `bootloader` key | Meaning and default or choices |
-| --- | --- |
-| `kind` | Bootloader: `grub`, `systemd-boot`, or `zfsbootmenu`; `grub`. |
-| `firmware` | Firmware: `uefi` or `bios`; `uefi`. |
-| `kernel_params` | Additional kernel command-line parameters; `[]`. |
-
-| `packages` key | Meaning and default |
-| --- | --- |
-| `desktop` | Desktop profile name; `""` selects no desktop. |
-| `applications` | Package-group names; `[]`. |
-| `graphics` | Graphics-driver group names; `[]`; multiple groups fit hybrid hardware. |
-| `display_manager` | Display-manager group; `""` selects console login. |
-| `extra` | Package atoms merged after other selections; `[]`. |
-
-| `disk` key | Meaning and default or choices |
-| --- | --- |
-| `graph` | Device graph represented by `[[disk.devices]]`; required. |
-| `root` | Root graph-node identifier; required outside conversion; `""` uses the running layout in conversion. |
-| `mode` | `partition`, `in-place`, `image`, or `dd`; `partition`. |
-| `image` | Sparse image path in image mode; `""`. |
-| `size` | Sparse image size in image mode; unset. |
-| `wipe` | Disk-level wipe setting; `false`. |
-| `source` | Prepared-image source in `dd` mode; `""`. |
-| `source_format` | Source encoding: `raw`, `gz`, `xz`, `zst`, or `tar`; `raw`. |
-| `destination` | Whole-disk `dd` destination; `""`. |
-
-| Template input | Meaning and default or choices |
-| --- | --- |
-| `disk` | Whole-disk selector; required. |
-| `layout` | `whole-disk`, `whole-disk-btrfs`, `whole-disk-zfs`, or `reuse`; `whole-disk`. |
-| `firmware` | Template firmware; `uefi`. |
-| `table` | Partition-table override; unset derives GPT for UEFI and MBR for BIOS. |
-| `filesystem` | Root filesystem for non-Btrfs and non-ZFS whole-disk layouts; `xfs`. |
-| `swap` | Swap-partition size; unset. |
-| `passphrase_file` | Installing-system passphrase-file path; `""` leaves the layout unencrypted. |
-| `pool` | ZFS pool name; `rpool`. |
-
-The following complete configuration demonstrates a proxy with credentials and two bypass hosts. The credential is an example and must be replaced before execution:
-
-```toml
-config_version = 1
-
-[proxy]
-kind = "socks5"
-host = "proxy.example"
-port = 1080
-username = "operator"
-password = "secret"
-bypass = ["localhost", "intranet.example"]
-
-[system]
-hostname = "proxy-target"
-timezone = "UTC"
-locales = ["en_US.UTF-8"]
-locale = "en_US.UTF-8"
-init = "openrc"
-root_password_hash = "$6$gentooinst$IR3GrdJ862XljQYDqocr4tKniIRDIT.jQNFzIrHE3U75H6B6YSWZoSYoVd5edSHpqaYBdiNfXHCoIPRVgb9lT/"
-
-[portage]
-profile = "default/linux/amd64/23.0"
-makeopts = "-j4"
-
-[portage.binhost]
-official = false
-
-[bootloader]
-firmware = "bios"
-
-[disk]
-root = "mnt-root"
-
-[[disk.devices]]
-kind = "existing"
-id = "disk"
-selector = "/dev/disk/by-id/virtio-target0"
-wipe = true
-
-[[disk.devices]]
-kind = "table"
-id = "table"
-disk = "disk"
-table = "mbr"
-
-[[disk.devices]]
-kind = "partition"
-id = "rootpart"
-table = "table"
-index = 1
-role = "data"
-
-[[disk.devices]]
-kind = "filesystem"
-id = "rootfs"
-device = "rootpart"
-type = "ext4"
-
-[[disk.devices]]
-kind = "mountpoint"
-id = "mnt-root"
-source = "rootfs"
-path = "/"
+```sh
+./bootstrap.sh --config my-install.toml --resume
 ```
 
 ## Binary packages
@@ -616,28 +98,11 @@ path = "/"
 
 Binary packages are optional. Disabling them keeps source builds available. The official binhost and the gentoo-zh binhost are separate options with separate trust configuration. No current end-to-end evidence covers an unreachable binhost, a missing signature or an untrusted key; these degradation paths remain unverified.
 
-## Exit codes
+## Reference
 
-<!-- fact: exit-codes -->
+<!-- fact: reference -->
 
-| Code | `gentoo-install` |
-| --- | --- |
-| `0` | successful completion |
-| `1` | configuration error |
-| `2` | `argparse` usage error or preflight failure |
-| `3` | integrity failure |
-| `4` | download, external-command, OS or uncategorized installer failure |
-| `5` | operator abort |
-
-`bootstrap.sh` can also exit `1` before the Python CLI starts when its Python, required-command or root checks fail.
-
-## Questions
-
-<!-- fact: faq-customisation -->
-
-**Does an installer of this kind take away what makes Gentoo Gentoo?**
-
-No. It performs the base installation and stops there: partitions, a stage3, Portage configuration, a kernel, a bootloader and an optional desktop. Every decision after that remains the operator's, on a system that is an ordinary Gentoo installation with no component of this project left running on it. What it removes is the cost of the first hour, which is what makes Gentoo hard to start with and hard to deploy across many machines or on a VPS.
+[REFERENCE.md](REFERENCE.md) contains runtime requirements, command-line options, memory environments, in-place conversion, capability and validation detail, configuration files, binary-package trust and exit codes.
 
 ## Contributing
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -8,35 +8,42 @@ gentoo-install 在 Linux live 环境中运行，用于安装 amd64 架构的 Gen
 
 ![显示各项安装决定的菜单](screenshot-zh-CN.png)
 
-![cjktty 控制台显示简体中文、繁体中文、日文和韩文](cjk-console.png)
+## 功能概要
+
+<!-- fact: capability-summary -->
+
+实现范围包括常规磁盘安装、存储与引导配置、桌面与语言 profile，以及特殊模式。
+
+- **存储。**设备图涵盖分区表、文件系统、LUKS2、LVM、mdraid 和 ZFS。
+- **引导与系统。**GRUB、systemd-boot 和 ZFSBootMenu 按配置提供 UEFI 或 BIOS 引导。
+- **桌面与语言。**GNOME、KDE Plasma、Xfce、CJK 字体和输入法都是配置选项。
+- **特殊模式。**内存环境、原地转换、稀疏镜像和 `dd` 各有独立限制。
+
+[参考资料](REFERENCE.md#capabilities)说明模型、限制和特殊模式流程。
+
+## 验证状态
+
+<!-- fact: verification-scope -->
+
+[`TESTED.md`](TESTED.md)记录每条已执行路径、安装程序修订版和执行环境。一次运行只有在记录的修订版符合安装程序、安装以 `0` 结束、已安装系统可引导，且引导后配置检查通过时才计入。
+
+单元、计划和 fixture coverage 说明实现行为，不能证明已安装系统已经引导。[`tests/fixtures/`](tests/fixtures/)验证配置模型，不是已安装的机器。记录会列出尚未验证的组合。
 
 ## 要求
 
 <!-- fact: requirements-runtime -->
 
-实际安装需要 root 权限、amd64 架构和 Python 3.11 或更高版本。使用配置文件执行 dry run 不需要 root 权限。安装程序没有第三方 Python 运行时依赖项。
-
-<!-- fact: requirements-version-sources -->
-
-菜单从 `packages.gentoo.org` 读取 Gentoo 主仓库的软件包版本，并从 `api.github.com/repos/gentoo-zh/overlay/contents` 读取 gentoo-zh 补丁内核版本。`sys-fs/zfs` 接受的最高内核版本从 `gitweb.gentoo.org` 读取。使用配置文件安装时需要连接的是该配置指定的镜像；`--missing-commands` 和 `--config FILE --dry-run` 都不需要这些版本端点。
-
-<!-- fact: requirements-network-filter -->
-
-live 环境有 IPv6 但没有 IPv4 时，菜单会停用记录中标为仅可通过 IPv4 访问的 Gentoo 镜像。
-
-<!-- fact: requirements-bootstrap -->
-
-`bootstrap.sh` 会读取 `/etc/os-release`、报告缺少的命令，并显示候选的软件包管理器命令。它可识别以下发行版系列：Debian 和 Ubuntu、Arch、openSUSE、Fedora、RHEL 和 CentOS、Gentoo、Alpine。显示的命令必须在执行前核对。
+实际安装需要 root 权限、amd64 目标和 Python 3.11 或更高版本。使用配置文件执行 dry run 不需要 root 权限。安装程序没有第三方 Python 运行时依赖项。
 
 ## 安全事项
 
 <!-- fact: safety-destructive -->
 
-实际安装会写入所选磁盘。使用配置文件运行时不会再次要求确认擦除磁盘；`wipe = true`、删除分区和创建文件系统都可能破坏现有数据。
+实际运行会写入所选磁盘。配置文件运行没有第二次擦除确认；`wipe = true`、删除分区和创建文件系统都可能破坏现有数据。
 
 <!-- fact: safety-review-backup -->
 
-实际安装前，必须在 dry-run 输出中核对磁盘选择器和每项破坏性操作。稳定的 `/dev/disk/by-id/` 选择器优于 `/dev/sda` 之类的名称；需要保留的数据必须另有一份独立于所选磁盘的备份。
+实际运行前，必须在 dry-run 输出中核对磁盘选择器和每项破坏性操作。稳定的 `/dev/disk/by-id/` 选择器优于 `/dev/sda` 之类的名称；需要保留的数据必须另有一份独立于所选磁盘的备份。
 
 ## 安装
 
@@ -52,601 +59,59 @@ cd gentoo-install-master
 
 <!-- fact: install-terminal -->
 
-菜单需要至少 80 列、24 行的交互式终端。安装程序启动时会询问一次界面语言；`--lang zh-CN` 直接选择简体中文。
+菜单需要至少 80 列、24 行的交互式终端。
 
 <!-- fact: install-config-workflow -->
 
-菜单可将配置保存为 `my-install.toml` 后退出。以下流程会先显示完整的配置计划，再执行实际安装：
+菜单会将配置保存为 `my-install.toml`。配置文件流程依次为保存、dry run、检查、安装：
 
 ```sh
 ./bootstrap.sh --config my-install.toml --dry-run
-# 接着择一执行下列其中一行。两者都会写入所选磁盘。
+# 选择实际命令前检查呈现的计划。
 ./bootstrap.sh --config my-install.toml
-./bootstrap.sh --config my-install.toml --no-shell   # 同一次安装，不询问是否打开 root shell
+./bootstrap.sh --config my-install.toml --no-shell   # 同一次运行，不询问 root shell
 ```
 
 <!-- fact: install-root-shell -->
 
-交互式安装无论成功或失败，都会在卸载前提供在目标系统内打开 root shell 的选项。`--no-shell` 跳过这项确认。
-
-| 选项 | 参数与默认值 | 效果 |
-| --- | --- | --- |
-| `--config` | 文件或 URL；未设置 | 加载该来源，而不是打开菜单。 |
-| `--dry-run` | 无；`false` | 显示推导出的操作和摘要，然后在不应用操作的情况下退出。 |
-| `--mirror` | stage3 镜像字符串；安装程序默认值 | 为普通安装选择 stage3 来源。内存环境的预约从配置推导其区域。 |
-| `--lang` | 语言标签；`""` | 菜单创建配置时覆盖 `LC_ALL`、`LC_MESSAGES` 和 `LANG`。 |
-| `--target` | 路径；`/mnt/gentoo` | 选择普通安装的挂载目标。转换和内存环境的预约使用 `/`。 |
-| `--work` | 路径；`/run/gentoo-install` | 保存运行状态，包括报告和日志。 |
-| `--missing-commands` | 无；`false` | 每行显示一个缺少的主机命令，然后退出。 |
-| `--resume` | 无；`false` | 使用现有日志跳过兼容的已完成操作。 |
-| `--no-shell` | 无；`false` | 不提供目标 root shell。它还会使内存环境的预约无需值守。 |
-| `--skip-preflight` | 无；`false` | 跳过普通安装的预检。 |
-| `--ram` | 无；未设置内存模式 | 预约一次进入保存在内存中的 Gentoo CJK ISO 的启动。它与 `--lowram` 冲突。 |
-| `--lowram` | 无；未设置内存模式 | 预约一次进入保存在内存中的 Alpine netboot 环境的启动。它与 `--ram` 冲突。 |
-| `--ssh-key` | 密钥、文件、HTTP(S) URL 或 `github:`/`gitlab:` 引用；`""` | 设置内存环境的授权公钥。它需要内存模式。 |
-| `--ssh-port` | 整数；未设置 | 设置内存环境的 `sshd` 端口；设置内存模式时可用。 |
-| `--root-password` | 字符串；`""` | 设置内存环境的 root 密码；仅支持内存模式。 |
-| `--bypass` | 无；`false` | 以替换默认引导项的方式预约，而不是建立一次性引导项；只适用于内存模式。 |
-| `--disarm` | 无；`false` | 在加载配置前移除先前预约的内存启动及其放置的文件。 |
-
-## 从内存安装
-
-<!-- fact: install-memory -->
-
-`--ram` 与 `--lowram` 预约一次进入内存中活环境的引导，那是一台没有控制台、也没有救援镜像的租用机器覆盖自己磁盘之前所需要的。安装程序、选定的配置与授权密钥都随 initramfs 送达，因此环境起来时运行的正是完成这次预约的那一版：
-
-```sh
-./bootstrap.sh --ram --ssh-key github:zakkaus --root-password 'replace this'
-reboot
-ssh root@the-machine
-```
-
-默认引导项不会改动，所以没有进入该环境的机器仍引导回原本的系统；`--disarm` 取消这次预约。`--bypass` 改为取代默认项，供会丢弃一次性引导项的固件使用，那也是唯一一条「环境起不来就连机器都引导不了」的路径。
-
-第一个界面问 `install now? [yes/no]`，没有超时，未回答之前不会擦除任何数据。`--ram` 引导的是带 ZFS 的 Gentoo CJK ISO，约需 2 GiB 内存；`--lowram` 引导的是较小、没有 `zfs.ko` 的 Alpine netboot 压缩包。`--ssh-port` 把服务移离 22 端口。第一页写出稍后启动安装的命令，因此回答 `no` 或在回答之前断线，都不必重启才能再次看到该提示。
-
-`--ram` 可使用 Wi-Fi，`--lowram` 不可。Gentoo CJK ISO 带着 NetworkManager 与 `linux-firmware`，以 `nmcli device wifi connect <SSID> password <密码>` 建立连接之后即可执行安装；第一页以正体中文、简体中文与英文写出这件事。Alpine netboot 环境没有无线驱动也没有 supplicant，完整模块在一份本身也要下载的 `modloop` 里，因此只有 Wi-Fi 一条连接的机器完全无法使用 `--lowram`。
-
-## 转换运行中的系统
-
-<!-- fact: install-in-place -->
-
-在 `[disk]` 表设 `mode = "in-place"`，安装程序取代运行中发行版的用户空间，而不是分区磁盘。该表不带设备列表，因为布局由机器读出：
-
-```toml
-config_version = 1
-
-[system]
-hostname = "converted"
-timezone = "UTC"
-locales = ["en_US.UTF-8"]
-locale = "en_US.UTF-8"
-init = "systemd"
-root_password_hash = "$6$gentooinst$IR3GrdJ862XljQYDqocr4tKniIRDIT.jQNFzIrHE3U75H6B6YSWZoSYoVd5edSHpqaYBdiNfXHCoIPRVgb9lT/"
-
-[portage]
-profile = "default/linux/amd64/23.0/systemd"
-makeopts = "-j4"
-
-[bootloader]
-kind = "grub"
-firmware = "uefi"
-
-[disk]
-mode = "in-place"
-```
-
-上面那个哈希是示例，执行前必须替换。交互式执行会打印这次转换取代哪些目录，并要求输入 `convert` 才会写入任何数据；没有终端的执行不会被询问，因为配置文件里的 `mode = "in-place"` 就是授权，而在那里发问会让串口控制台永远等下去。
-
-**发起这次执行的会话必须保持连接。**`/usr` 与 `/etc` 换成新系统之后，新的 SSH 登录不再成立，而发起执行的会话仍持有它已经映射的可执行文件。
-
-## 从中断处继续
-
-<!-- fact: resume-behavior -->
-
-`--resume` 只会跳过位置和标识均与当前计划匹配，且效果标记为重新启动后仍然存在的已完成操作：
-
-```sh
-./bootstrap.sh --config my-install.toml --resume
-```
-
-<!-- fact: resume-limits -->
-
-继续执行仅限同一个 live 会话、同一个安装程序与同一份配置文件，而且安装程序会拒绝其他情况，不再只是写在文档里。
-
-- 日志开头记录配置的摘要、机器的 boot id 与安装程序源代码的摘要；`--resume` 三者都比对，任何一项不同就停下并说明原因。内核不提供 boot id 的机器只比对其余两项。
-- 默认日志位于 `/run/gentoo-install/install.jsonl`，本来就不会在重新启动后保留。
-- 每条操作记录另外包含根据该操作类源代码和字段值生成的标识，标识变化的操作会重新执行而不是跳过。共用辅助函数或常量的更改不在该标识范围内，改由安装程序摘要覆盖。
-
-## 功能
-
-<!-- fact: capability-scope -->
-
-除非验证状态另行说明更窄的范围，以下路径均已实现，并有自动化单元测试或 plan 测试。
-
-<!-- fact: storage-device-graph -->
-
-**存储设备**
-- 设备图涵盖 GPT 和 MBR 分区表、ext2、ext3、ext4、xfs、f2fs、vfat、包含 subvolume 的 btrfs、swap、LUKS2 加密、LVM 和 mdraid。
-- ZFS 属于同一张设备图：pool 在其 vdev 之上采用 stripe、mirror 或 raidz1、raidz2、raidz3，原生加密是 pool 的属性，每个 dataset 各为一个节点。
-- 现有分区表可以保留，每个分区可以分别指定保留、格式化或删除操作。
-
-| 模型节点 | `id` 之外的字段 | 结果 |
-| --- | --- | --- |
-| `Existing` | `selector`, `wipe` | 选择预先存在的设备。 |
-| `PartitionTable` | `disk`, `table`, `create`, `remove` | 创建或编辑分区表。 |
-| `Partition` | `table`, `index`, `role`, `size`, `label` | 定义分区；最后一个 `size` 可占用剩余空间。 |
-| `Luks` | `backing`, `name`, `passphrase_file` | 定义 LUKS 容器。 |
-| `MdRaid` | `members`, `level`, `name`, `metadata` | 定义 mdraid 阵列。 |
-| `VolumeGroup` | `members`, `name` | 定义 LVM 卷组。 |
-| `LogicalVolume` | `group`, `name`, `size` | 定义 LVM 逻辑卷。 |
-| `ZfsPool` | `vdevs`, `name`, `topology`, `encrypted`, `passphrase_file` | 定义 ZFS pool。 |
-| `ZfsDataset` | `pool`, `name` | 定义 ZFS dataset。 |
-| `Filesystem` | `device`, `kind`, `label`, `create` | 格式化设备；`create = false` 时验证设备。 |
-| `Subvolume` | `filesystem`, `name` | 定义 Btrfs subvolume。 |
-| `Swap` | `device` | 在引用的设备上定义 swap。 |
-| `Mountpoint` | `source`, `path`, `options` | 挂载文件系统、Btrfs subvolume 或 ZFS dataset。 |
-
-| 选项 | 值 |
-| --- | --- |
-| 分区表 | `gpt`, `mbr` |
-| 分区角色 | `esp`, `bios-boot`, `swap`, `raid`, `lvm`, `zfs`, `data` |
-| mdraid 级别 | `raid0`, `raid1`, `raid5`, `raid6` |
-| mdraid 元数据 | `0.90`, `1.0`, `1.1`, `1.2` |
-| 文件系统 | `ext2`, `ext3`, `ext4`, `btrfs`, `xfs`, `f2fs`, `vfat` |
-| ZFS 拓扑 | `stripe`, `mirror`, `raidz1`, `raidz2`, `raidz3` |
-
-<!-- fact: zram-system -->
-
-系统配置可以在设备图和 swap 分区之外单独配置 zram。
-
-<!-- fact: in-place-conversion -->
-
-**就地转换。**
-- 在 `[disk]` 表设置 `mode = "in-place"` 时，安装程序替换正在运行的发行版的用户空间，而不是分区磁盘。
-- 布局由机器读出，因此该表不带设备列表。
-- `/bin`、`/sbin`、`/etc`、`/lib`、`/lib64`、`/usr` 和 `/var` 会被替换；`/home`、`/root`、`/srv`、`/opt` 和其余所有路径保持原样，且 `/etc` 是替换而非合并。
-
-- 暂存的系统构建在 `/gentoo-install.new`，正在运行的系统在此期间不受影响；随后以 `rename(2)` 逐个目录交换，只有写入 esp 或引导扇区的操作排在交换之后。
-- 根位于 LUKS、LVM 或 mdraid 之下、根文件系统为安装程序无法描述的类型、根文件系统可用空间低于 10 GiB，以及在 live 介质上执行，这四种情况都会在写入任何数据之前逐项指名并拒绝。
-
-<!-- fact: prepared-image -->
-
-**磁盘镜像**
-- `mode = "image"` 把系统装进 `disk.image` 指定、`disk.size` 决定大小的稀疏文件，而不是装到磁盘上，产物因此是一份可以复制到别处、之后再写入的文件。
-- `mode = "dd"` 不执行安装：它把 `disk.source` 的镜像流式写入 `disk.destination` 这整块磁盘，读取时解开 `raw`、`gz`、`xz`、`zst` 或 `tar`，并保留该镜像原本带的布局与引导程序。
-- 两种模式互不接受对方的键，`partition` 模式两组都不接受。
-
-<!-- fact: boot-system -->
-
-**引导与系统**
-- 引导程序可选择 GRUB、systemd-boot 或 ZFSBootMenu。GRUB 支持 UEFI 和 BIOS，systemd-boot 支持 UEFI。
-- ZFSBootMenu 在 UEFI 上引导 ZFS 根，内核取自 pool 内引导环境自己的 `/boot`。还可配置 systemd 或 OpenRC、dracut、locale、键盘布局、时区、主机名、DNS、静态地址和所选的网络管理程序。
-
-<!-- fact: remote-unlock -->
-
-**以 ssh 解开加密的根**
-- `[kernel.remote_unlock]` 在引导路径放进一个 ssh 服务，供无人在旁边回答密语提示的机器使用。
-- `enabled` 开启这条路径；`port` 默认 222 而不是 22，避免客户端对运行中系统的 `known_hosts` 记录与 initramfs 的那条相撞；`address`、`gateway` 和 `interface` 给该服务一个静态地址，地址留空则改用 DHCP。
-- LUKS 根由系统 initramfs 里的 `sys-kernel/dracut-crypt-ssh` 打开，ZFS 根则由 ZFSBootMenu 构建进自己镜像的 dropbear 打开。
-- 授权密钥取自 `system.authorized_keys`：开了这条路径又没有列出任何密钥的配置会被逐项指名并拒绝，因为那描述的是一个没有人登录得进去的服务。
-
-<!-- fact: desktop-language -->
-
-**桌面与语言支持**
-- 桌面可以选择 GNOME、KDE Plasma 和 Xfce，并搭配 GDM、SDDM、LightDM，或 greetd 和它的 tuigreet 控制台登录界面。
-- 图形设置涵盖 AMD、Intel、NVIDIA 和虚拟机。
-- 软件包目录包含 Fcitx 5、Rime、Anthy、Mozc、Hangul 和 CJK 字体。
-- 内核选项包括 `sys-kernel/gentoo-cjk-kernel-bin` 和 `sys-kernel/gentoo-cjk-kernel`，两者都包含 cjktty 补丁。
-
-<!-- fact: portage -->
-
-**Portage**
-- 配置项包括 profile、`MAKEOPTS`、`USE`、`ACCEPT_KEYWORDS`、`L10N`、镜像和仓库同步方式。
-- gentoo-zh 和 gig overlay 可以分别选择。
-- 界面语言选择 `zh-TW`、`zh-CN`、`ja` 或 `ko` 时，也会选择 gentoo-zh 的补丁二进制内核及其 overlay；选择 `en` 时不会自动选择。
-- 官方与 gentoo-zh 的二进制软件包来源分别使用独立的设置和密钥。
-
-<!-- fact: proxy -->
-
-**会话代理**
-- `[proxy]` 配置表接受 `kind`、`host`、`port`、可选的 `username` 和 `password`，以及 `bypass`。
-- `kind` 可以是 `http`、`https` 或 `socks5`；`host` 留空表示直接连接，这是默认值。
-- SOCKS5 派生为 `socks5h://`，所以由代理解析主机名以访问内网。
-- 界面主菜单为每个值提供字段，并使用菜单选择代理类型。
-- `bypass` 在界面中是逗号分隔的值，在 TOML 中是列表。
-
-- 选择代理后，配置的代理用于 stage3 及其签名密钥、主仓库与 overlay 版本查询，以及 `gitweb.gentoo.org` 的 ZFS ebuild 查询。
-- 它也用于通过 `make.conf` 和 `FETCHCOMMAND`/`RESUMECOMMAND` 的 Portage 下载、`wget`、`curl`、`git`、GnuPG、binhost、overlay 及 paste 上传。
-- 时钟、初始连接检查和菜单前的镜像检查都在获得配置前执行，因此不在此设置覆盖范围内。安装程序会将认证信息排除在 dry-run 描述和发布的配置之外；发布的配置与已安装系统都只保留不含认证信息的端点和绕过列表。
-
-<!-- fact: memory-environment -->
-
-**内存环境。**
-- `--ram` 与 `--lowram` 预约一次开机进入常驻内存的活环境，接着询问是否重新启动；这条路没有界面，因为它针对的机器通常只有一条 SSH 连接而没有控制台。
-- `--ram` 用 Gentoo CJK ISO，带有 ZFS，需要约 2 GiB 内存：它的 initramfs 在内存减去 824 MiB 的活镜像后低于 1 GiB 时停在急救 shell。
-- `--lowram` 用 Alpine netboot 套件，较小且没有 `zfs.ko`。
-- 两者都不写死版本：发布方各自列出当前的镜像与校验和，预约之前先抓取并验证。
-
-- 默认启动项一律不改，所以环境没有起来时机器仍然开得了机。
-- `--bypass` 改为替换它，用于会丢弃一次性启动项的固件；这是唯一一条环境没起来就完全开不了机的路径，没有任何路径会自动选它。
-
-<!-- fact: memory-environment-access -->
-
-**用 SSH 观察内存安装。**
-- `--ssh-key` 接受公钥本文（`ssh-ed25519`、`ssh-rsa`、`ecdsa-sha2-nistp256`、`-384`、`-521` 以及 `sk-` 变体）、路径、`http` 或 `https` 网址，以及 `github:user` 与 `gitlab:user`；`--ssh-port` 与 `--root-password` 设定其余部分。
-- 安装器、选定的配置与密钥都放在 initramfs 内，所以环境运行的是写出该配置的修订，而且在第一次登录之前 `authorized_keys` 已经就位。
-- 操作者以 SSH 重新连接观察安装，不必一直开着控制台。
-- 回答第一个画面之前不会清除任何数据：该画面问 `install now? [yes/no]`，而且没有超时。
-
-<!-- fact: plan-records -->
-
-**计划与记录**
-- dry run 会在不探测存储硬件的情况下显示操作计划。
-- 实际安装使用相同的规划器，但会先加入从复用设备探测到的 mdraid 元数据，因此依赖硬件的验证结果可能不同。
-- `install.log` 记录命令输出，`install.jsonl` 记录操作、软件包来源和二进制软件包降级原因。
-- 菜单将配置上传至 `paste.gentoozh.org` 前，会把 `password_hash` 和 `root_password_hash` 的值替换为 `removed-before-publishing`，并且完全不写出代理的 `username` 和 `password` 这两个键；其他配置值仍会上传。
-- 菜单会以文本和 QR 码显示上传页面的网址。
-
-### 兼容性规则
-
-验证拒绝下列组合：
-
-| 被拒绝的组合 |
-| --- |
-| 没有可使用密码认证的用户或可用 SSH 密钥登录时，空的、锁定的或格式错误的 root hash。 |
-| ZFS 根与 GRUB。 |
-| ZFS 上的 `/boot` 与 GRUB。 |
-| ZFS 根与 BIOS 引导。 |
-| ZFS 根与 LUKS 根链。 |
-| ZFSBootMenu 与非 ZFS 根。 |
-| 未挂载 ESP 的 UEFI 引导。 |
-| 使用加密 ESP 的 UEFI 引导。 |
-| systemd-boot 与 BIOS 引导。 |
-| systemd-boot 与因 `/boot` 已加密或不是 vfat 而无法从 ESP 访问的 kernel 或 initramfs。 |
-| 带有元数据 `1.1` 或 `1.2` 的 mdraid 上的 ESP。 |
-| 没有 `bios-boot` 分区的 GPT 磁盘上的 BIOS 引导。 |
-| 使用缺少 cjktty 的 kernel 进行 CJK 控制台渲染。 |
-| 没有授权 SSH 密钥的远程解锁。 |
-| 没有加密根容器或 pool 的远程解锁。 |
-| 使用必须在 initramfs SSH 启动前解锁 `/boot` 的 GRUB 的远程解锁。 |
-| 由 GRUB 或 systemd-boot 系统 initramfs 解锁的原生 ZFS 加密远程解锁。 |
-| 没有 `gentoo-zh` overlay 的 CJK kernel。 |
-| 使用非 `8x16` 控制台字体的 CJK 控制台渲染。 |
-| 没有 `gentoo-zh` overlay 的 ZFSBootMenu。 |
-| 没有 `gentoo-zh` overlay 的 gentoo-zh 社区 binhost。 |
-
-## 验证状态
-
-<!-- fact: verification-scope -->
-
-[`TESTED.md`](TESTED.md) 是验证记录：每一条走过的路径各一行，写明它运行时的安装器修订版与运行的地点。一次运行要记录的修订版与安装器相符、安装退出码为 `0`、装出的系统能引导、且引导后的配置检查全部通过，才算数。
-
-| 路径 | 记录 |
-| --- | --- |
-| 装到磁盘上 | ext4、ext2、ext3、xfs、btrfs、f2fs、ZFS、LVM、mdraid 与 LUKS2，两种固件与两种 init 系统皆有 |
-| ZFS pool | stripe、mirror、raidz、加密 pool，以及一个由 ZFSBootMenu 引导的 pool |
-| 通过 ssh 解锁 | 由系统 initramfs 打开的 LUKS 根，以及由 ZFSBootMenu 自己镜像打开的 ZFS pool |
-| 静态地址与 greetd | 各自有集群记录 |
-| 就地转换运行中的系统 | 四条 QEMU 记录：两条 BIOS，一条保留 `/home` 的 UEFI，一条根文件系统为 btrfs、`/home` 与 `/var` 是 subvolume 的 UEFI |
-| 转换这个安装程序装出来的机器 | 六次走到重新启动的集群转换里，五次启动成功，一次因为缺少模块停在 GRUB 的救援 shell，而转换本身的退出码是 `0`，所以这条路径还不可靠 |
-| `--ram` 与 `--lowram` | 一台 Debian 12 机器预约一次启动、默认启动项未变，重新启动后带着交付给它的配置进入送达的环境；在那里回答 `install` 会装出 Gentoo 并引导它写出的磁盘 |
-| `--bypass` | 替换默认启动项挺过了一次电源循环：两次启动都进入送达的环境 |
-| 预约的启动没有起来 | 一台被移除预约项 initramfs 的机器，没有出现送达的画面，接下来两次启动都进入原本的云系统 |
-| `dd` | 一条记录：从 live 介质把准备好的镜像写入整块磁盘并逐字节读回，原始和 gzip 两种格式皆是 |
-| 装进文件 | 一条记录：镜像以 `losetup -Pf` 挂上，读回的是它布局声明的那两个文件系统，而没有任何机器从那份文件引导过 |
-| 菜单 | 在 80x24 的串行控制台上逐行打开过，覆盖英文、繁体中文、简体中文、日文与韩文，没有一行宽过终端 |
-
-源代码构建的内核和二进制软件包降级只有 runner 层级的测试，而 runner 层级的测试不是端到端记录。`tests/fixtures/` 下的文件验证的是配置模型，它们存在并不代表任何一台装出来的机器。
+交互式运行会在卸载前提供目标 root shell。`--no-shell` 会跳过该提示。
 
 ## 配置文件
 
-<!-- fact: config-model -->
+<!-- fact: configuration-reference -->
 
-配置文件使用 TOML。顶层 `config_version` 字段指定结构版本。存储设备以设备图表示：每个设备都有 `id`，设备通过其他设备的 `id` 建立引用，选择器仅在实际安装时解析。
+配置文件使用 TOML，`config_version` 选择 schema 版本。[配置参考资料](REFERENCE.md#configuration-files)列出所有持久化键和通过验证的示例。[`tests/fixtures/vm-binpkg.toml`](tests/fixtures/vm-binpkg.toml)是 schema reference；其中的虚拟机磁盘选择器和测试凭证不得原样用于实际机器。
 
-<!-- fact: config-simple -->
+## 从中断处继续
 
-单一磁盘的布局写成 `[disk.simple]`，不必写设备图。解析时以菜单所用的同一份模板展开，因此两种写法产生相同的图。设备图的写法保留给 LUKS、ZFS、RAID 与手动分区表。
+<!-- fact: resume-limits -->
 
-```toml
-config_version = 1
+`--resume` 仅限同一个 live 会话、同一安装程序修订版和同一份配置文件。安装程序会拒绝不匹配的情况。默认日志位于 `/run/gentoo-install/install.jsonl`，因此不会在重新启动后保留。
 
-[system]
-hostname = "workstation"
-timezone = "UTC"
-locales = ["en_US.UTF-8"]
-locale = "en_US.UTF-8"
-init = "systemd"
-root_password_hash = "$6$gentooinst$IR3GrdJ862XljQYDqocr4tKniIRDIT.jQNFzIrHE3U75H6B6YSWZoSYoVd5edSHpqaYBdiNfXHCoIPRVgb9lT/"
-
-[portage]
-profile = "default/linux/amd64/23.0/systemd"
-makeopts = "-j4"
-
-[bootloader]
-kind = "grub"
-firmware = "uefi"
-
-[disk.simple]
-disk = "/dev/disk/by-id/virtio-target0"
-filesystem = "ext4"
-swap = "2GiB"
-```
-
-上面的哈希值是示例，执行前必须替换。只有 `disk` 必填。省略的键取安装器默认值：`whole-disk`、`uefi`、由固件决定的分区表、`xfs`、无交换空间、不加密。同一份文件不得同时写 `[disk.simple]` 与 `[[disk.devices]]`。
-
-<!-- fact: config-fixtures -->
-
-[`tests/fixtures/vm-binpkg.toml`](tests/fixtures/vm-binpkg.toml) 是完整的 UEFI 和 ext4 结构参考。其他 [`tests/fixtures/`](tests/fixtures/) 文件覆盖 BIOS、LUKS2、LVM、mdraid、ZFS、btrfs subvolume 和桌面。这些文件使用虚拟机磁盘选择器和测试密码，不得原样用于实际机器的安装。
-
-<!-- fact: config-dry-run -->
-
-解析与计划阶段不会探测存储硬件，因此没有目标磁盘的机器也能通过 `--dry-run` 检查配置。
-
-以下参考列出每个持久化键。表路径采用 TOML 表记法，`[[disk.devices]]` 包含图节点。
-
-| 键 | 含义和默认值或选项 |
-| --- | --- |
-| `config_version` | 持久化的结构版本；`1`。 |
-| `proxy.kind` | 代理协议：`http`、`https` 或 `socks5`；`http`。 |
-| `proxy.host` | 代理主机；`""` 禁用代理。 |
-| `proxy.port` | 代理端口；`0`。 |
-| `proxy.username` | 可选代理用户名；`""`。 |
-| `proxy.password` | 可选代理密码；`""`。 |
-| `proxy.bypass` | 绕过代理的主机；`[]`。 |
-
-| `system` 键 | 含义和默认值或选项 |
-| --- | --- |
-| `hostname` | 目标主机名；`gentoo`。 |
-| `timezone` | 目标时区；`Asia/Shanghai`。 |
-| `locales` | 生成的 locale；`en_US.UTF-8`、`zh_CN.UTF-8`、`zh_TW.UTF-8`。 |
-| `locale` | 选定的 locale；`zh_CN.UTF-8`。 |
-| `keymap` | 已安装系统的键盘映射；`us`。 |
-| `keymap_initramfs` | initramfs 键盘映射；`""` 表示跟随 `keymap`。 |
-| `interface` | 网络接口模式；`""` 匹配 `en*` 和 `eth*`。 |
-| `addresses` | 静态 CIDR 地址；`[]` 选择 DHCP 或路由器通告。 |
-| `gateways` | 网关，每个地址族最多一个；`[]`。 |
-| `dns` | 解析器地址；`[]`。 |
-| `authorized_keys` | root 和 sudo 用户的密钥；`[]`。 |
-| `console_cjk` | 要求 CJK 控制台渲染；`false`；需要 cjktty。 |
-| `console_font` | 控制台单元格大小：`8x8`、`8x16` 或 `16x32`；`8x16`。 |
-| `init` | init 系统：`openrc` 或 `systemd`；`systemd`。 |
-| `zram` | 压缩 RAM swap 大小；未设置则禁用。 |
-| `hardware_clock_utc` | RTC 存储 UTC；`true`。 |
-| `users` | 用户记录；`[]`。 |
-| `root_password_hash` | root `crypt(3)` 哈希；`""` 锁定 root。 |
-| `logger` | 日志程序：`none`、`sysklogd`、`syslog-ng` 或 `metalog`；`sysklogd`。 |
-| `cron` | 安装 `sys-process/cronie`；`true`。 |
-| `sshd` | 安装并配置 SSH 守护进程支持；`false`。 |
-| `sshd_password_login` | SSH 守护进程接受密码；`false`。 |
-| `sshd_root_login` | root 可通过 SSH 登录；`false`。 |
-| `networking` | 链路管理：`builtin`、`networkmanager-wpa`、`networkmanager-iwd` 或 `none`；`builtin`。 |
-| `firewall` | 数据包过滤软件包：`none`、`nftables` 或 `iptables`；`none`。 |
-| `first_boot` | 首次启动记录；默认为空记录。 |
-
-| `system.users` 项 | 含义和默认值 |
-| --- | --- |
-| `name` | 用户名；必填。 |
-| `groups` | 补充组；`[]`。 |
-| `shell` | 登录 shell；`/bin/bash`。 |
-| `sudo` | 使该用户成为 sudo 用户；`false`。 |
-| `password_hash` | 用户 `crypt(3)` 哈希；`""` 锁定账户。 |
-
-| `system.first_boot` 键 | 含义和默认值 |
-| --- | --- |
-| `commands` | 在获取的脚本之后按顺序执行的 shell 行；`[]`。 |
-| `url` | 脚本 URL；`""` 表示不获取脚本。 |
-
-| `portage` 键 | 含义和默认值或选项 |
-| --- | --- |
-| `profile` | Portage profile；`default/linux/amd64/23.0/systemd`。 |
-| `keywords` | 全局关键词通道：`stable` 或 `testing`；`stable`。 |
-| `sync` | 持续同步：`git`、`webrsync` 或 `rsync`；`git`。首次同步使用 webrsync。 |
-| `testing_packages` | 系统保持稳定时允许使用 testing 的 atom；`[]`。 |
-| `makeopts` | `MAKEOPTS`；`""`。 |
-| `common_flags` | 通用编译器标志；`-O2 -pipe`。 |
-| `use` | `USE` 标志；`[]`。 |
-| `video_cards` | `VIDEO_CARDS` 值；`[]`。 |
-| `l10n` | `L10N`；`[]` 从生成的 locale 推导值。 |
-| `input_devices` | `INPUT_DEVICES`；`["libinput"]`。 |
-| `accept_license` | 接受的许可证；`["@FREE"]`。 |
-| `cpu_flags` | CPU 标志；`[]` 保留 profile 值。 |
-| `build_in_ram` | `/var/tmp/portage` tmpfs 大小；未设置则在磁盘上构建。 |
-| `mirrors` | 镜像记录；默认值见下文。 |
-| `binhost` | 二进制主机记录；默认值见下文。 |
-| `overlays` | Overlay 记录；`[]`。 |
-
-| `portage.mirrors` 键 | 含义和默认值或选项 |
-| --- | --- |
-| `region` | Gentoo 镜像区域：`cn` 或 `global`；`global`。 |
-| `speed_test` | 对提供的镜像执行速度测试；`false`。 |
-| `distfiles` | 自定义 distfile 基地址；非空列表会替换内置列表。 |
-| `repo_sync_uri` | 显式仓库同步 URI；`""`。 |
-| `site` | `region` 中的站点键；`""` 选择该区域的第一个站点。 |
-| `gentoo_distfiles` | 写入 `GENTOO_MIRRORS`；`true`。 |
-| `gentoo_zh` | gentoo-zh 镜像：`upstream`、`cernet`、`nju`、`nyist` 或 `ha`；`upstream`。 |
-| `gentoo_zh_distfiles` | 将 gentoo-zh distfile 追加到 `GENTOO_MIRRORS`；`true`。 |
-
-| 镜像区域 | 站点键 |
-| --- | --- |
-| `cn` | `ustc`, `nju`, `bfsu`, `tuna`, `zju`, `sdu`, `hust`, `sustech`, `hit`, `lzu`, `aliyun`, `netease`, `cernet`, `cicku-hk`, `planetunix-hk`, `xtom-hk`, `rackspace-hk`, `aditsu-hk`, `nchc-tw`, `cicku-tw`, `freedif-sg`, `cicku-sg`, `planetunix-sg` |
-| `global` | `gentoo`, `osuosl` |
-
-| `portage.binhost` 键 | 含义和默认值或选项 |
-| --- | --- |
-| `official` | 启用官方二进制主机；`true`。 |
-| `subarch` | 官方二进制主机子架构；`x86-64`。 |
-| `community` | gentoo-zh 通道：`off`、`stable` 或 `unstable`；`off`。 |
-
-| `portage.overlays` 项 | 含义 |
-| --- | --- |
-| `name` | Overlay 名称；必填。 |
-| `sync_uri` | Overlay 同步 URI；必填。 |
-
-| `kernel` 键 | 含义和默认值或选项 |
-| --- | --- |
-| `source` | kernel 选择：`dist-bin`、`dist-source`、`cjk-bin` 或 `cjk`；`dist-bin`。 |
-| `package` | 覆盖 `source` 隐含的软件包；`""`。 |
-| `version` | 版本固定；`""` 让 Portage 选择允许的最新关键词版本。 |
-| `dracut_modules` | 添加磁盘布局所需的 dracut 模块；`[]`。 |
-| `remote_unlock` | initramfs SSH 解锁记录；默认为空记录。 |
-
-| `kernel.source` | 软件包和 CJK 状态 |
-| --- | --- |
-| `dist-bin` | `sys-kernel/gentoo-kernel-bin`；不是 CJK kernel。 |
-| `dist-source` | `sys-kernel/gentoo-kernel`；不属于 CJK kernel。 |
-| `cjk-bin` | `sys-kernel/gentoo-cjk-kernel-bin`；CJK kernel。 |
-| `cjk` | `sys-kernel/gentoo-cjk-kernel`；CJK kernel。 |
-
-| `kernel.remote_unlock` 键 | 含义和默认值 |
-| --- | --- |
-| `enabled` | 启用 initramfs SSH 解锁；`false`。 |
-| `port` | initramfs SSH 端口；`222`。 |
-| `address` | 静态 CIDR 地址；`""` 使用 DHCP。 |
-| `gateway` | 静态地址网关；`""`。 |
-| `interface` | initramfs 网络接口；`""`。 |
-
-| `bootloader` 键 | 含义和默认值或选项 |
-| --- | --- |
-| `kind` | 引导程序：`grub`、`systemd-boot` 或 `zfsbootmenu`；`grub`。 |
-| `firmware` | 固件：`uefi` 或 `bios`；`uefi`。 |
-| `kernel_params` | 额外 kernel 命令行参数；`[]`。 |
-
-| `packages` 键 | 含义和默认值 |
-| --- | --- |
-| `desktop` | 桌面 profile 名称；`""` 表示不选择桌面。 |
-| `applications` | 软件包组名称；`[]`。 |
-| `graphics` | 图形驱动程序组名称；`[]`；多个组适用于混合硬件。 |
-| `display_manager` | 显示管理器组；`""` 选择控制台登录。 |
-| `extra` | 在其他选择之后合并的软件包 atom；`[]`。 |
-
-| `disk` 键 | 含义和默认值或选项 |
-| --- | --- |
-| `graph` | 由 `[[disk.devices]]` 表示的设备图；必填。 |
-| `root` | 根图节点标识符；转换之外必填；`""` 在转换时使用运行中布局。 |
-| `mode` | `partition`、`in-place`、`image` 或 `dd`；`partition`。 |
-| `image` | image 模式下的稀疏镜像路径；`""`。 |
-| `size` | image 模式下的稀疏镜像大小；未设置。 |
-| `wipe` | 磁盘级擦除设置；`false`。 |
-| `source` | `dd` 模式下的准备镜像来源；`""`。 |
-| `source_format` | 来源编码：`raw`、`gz`、`xz`、`zst` 或 `tar`；`raw`。 |
-| `destination` | 整盘 `dd` 目标；`""`。 |
-
-| 模板输入 | 含义和默认值或选项 |
-| --- | --- |
-| `disk` | 整盘选择器；必填。 |
-| `layout` | `whole-disk`、`whole-disk-btrfs`、`whole-disk-zfs` 或 `reuse`；`whole-disk`。 |
-| `firmware` | 模板固件；`uefi`。 |
-| `table` | 分区表覆盖；未设置时 UEFI 推导为 GPT，BIOS 推导为 MBR。 |
-| `filesystem` | 非 Btrfs、非 ZFS 整盘布局的根文件系统；`xfs`。 |
-| `swap` | swap 分区大小；未设置。 |
-| `passphrase_file` | 安装系统的 passphrase 文件路径；`""` 表示布局不加密。 |
-| `pool` | ZFS pool 名称；`rpool`。 |
-
-以下完整配置演示包含认证信息和两个绕过主机。认证信息只是示例，执行前必须替换：
-
-```toml
-config_version = 1
-
-[proxy]
-kind = "socks5"
-host = "proxy.example"
-port = 1080
-username = "operator"
-password = "secret"
-bypass = ["localhost", "intranet.example"]
-
-[system]
-hostname = "proxy-target"
-timezone = "UTC"
-locales = ["en_US.UTF-8"]
-locale = "en_US.UTF-8"
-init = "openrc"
-root_password_hash = "$6$gentooinst$IR3GrdJ862XljQYDqocr4tKniIRDIT.jQNFzIrHE3U75H6B6YSWZoSYoVd5edSHpqaYBdiNfXHCoIPRVgb9lT/"
-
-[portage]
-profile = "default/linux/amd64/23.0"
-makeopts = "-j4"
-
-[portage.binhost]
-official = false
-
-[bootloader]
-firmware = "bios"
-
-[disk]
-root = "mnt-root"
-
-[[disk.devices]]
-kind = "existing"
-id = "disk"
-selector = "/dev/disk/by-id/virtio-target0"
-wipe = true
-
-[[disk.devices]]
-kind = "table"
-id = "table"
-disk = "disk"
-table = "mbr"
-
-[[disk.devices]]
-kind = "partition"
-id = "rootpart"
-table = "table"
-index = 1
-role = "data"
-
-[[disk.devices]]
-kind = "filesystem"
-id = "rootfs"
-device = "rootpart"
-type = "ext4"
-
-[[disk.devices]]
-kind = "mountpoint"
-id = "mnt-root"
-source = "rootfs"
-path = "/"
+```sh
+./bootstrap.sh --config my-install.toml --resume
 ```
 
 ## 二进制软件包
 
 <!-- fact: binary-packages -->
 
-二进制软件包属于可选功能。关闭后仍可从源代码构建。官方 binhost 和 gentoo-zh binhost 是两个独立选项，并使用不同的信任配置。目前没有端到端证据覆盖 binhost 无法连接、缺少签名或密钥不受信任的情况；这些降级路径仍未验证。
+二进制软件包是可选项。停用后仍可从源代码构建。官方 binhost 和 gentoo-zh binhost 有各自的信任配置。无法连接的 binhost、缺少签名和不受信任的密钥目前都没有端到端证据；这些降级路径仍未验证。
 
-## 退出码
+## 参考资料
 
-<!-- fact: exit-codes -->
+<!-- fact: reference -->
 
-| 退出码 | `gentoo-install` |
-| --- | --- |
-| `0` | 成功完成 |
-| `1` | 配置错误 |
-| `2` | `argparse` 用法错误或 preflight 失败 |
-| `3` | 完整性验证失败 |
-| `4` | 下载、外部命令、操作系统或未分类的安装程序失败 |
-| `5` | 操作者中止 |
-
-Python CLI 启动前，如果 Python、必要命令或 root 权限检查失败，`bootstrap.sh` 也可能以 `1` 退出。
-
-## 常见问题
-
-<!-- fact: faq-customisation -->
-
-**这种安装器会不会让 Gentoo 失去可定制性？**
-
-不会。它只执行基础安装：分区、stage3、Portage 配置、内核、bootloader，以及可选的桌面。之后的每个决定仍然属于操作者，而那台机器是一套普通的 Gentoo，上面不留本项目的任何组件。它省掉的是第一个小时的成本，而那正是 Gentoo 难以入门、也难以在大量机器或 VPS 上部署的原因。
+[REFERENCE.md](REFERENCE.md)收录运行时要求、命令行选项、内存环境、原地转换、功能和验证细节、配置文件、二进制软件包信任和退出码。
 
 ## 参与开发
 
 <!-- fact: contributing -->
 
-[CONTRIBUTING.md](CONTRIBUTING.md) 介绍开发环境、架构和必要检查。
+[CONTRIBUTING.md](CONTRIBUTING.md)说明开发环境、架构和必要检查。
 
 ## 许可
 
 <!-- fact: license -->
 
-本项目以 GNU General Public License 发布，版本为第 2 版，或由接收者选择任何更新的版本。第 2 版全文见 [LICENSE](LICENSE)，每份源代码文件带有 `SPDX-License-Identifier: GPL-2.0-or-later`。
+gentoo-install 以 GNU General Public License 发布，版本为第 2 版，或由接收者选择任何更新的版本。第 2 版全文见 [LICENSE](LICENSE)，每份源代码文件带有 `SPDX-License-Identifier: GPL-2.0-or-later`。

--- a/README.zh-TW.md
+++ b/README.zh-TW.md
@@ -8,7 +8,26 @@ gentoo-install 在 Linux live 環境中執行，用於安裝 amd64 架構的 Gen
 
 ![顯示各項安裝決定的選單](screenshot-zh-TW.png)
 
-![cjktty 主控台顯示簡體中文、正體中文、日文與韓文](cjk-console.png)
+## 功能概要
+
+<!-- fact: capability-summary -->
+
+實作範圍包括一般磁碟安裝、儲存與開機設定、桌面與語言 profile，以及特殊模式。
+
+- **儲存。**裝置圖涵蓋分割區表、檔案系統、LUKS2、LVM、mdraid 與 ZFS。
+- **開機與系統。**GRUB、systemd-boot 與 ZFSBootMenu 依設定提供 UEFI 或 BIOS 開機。
+- **桌面與語言。**GNOME、KDE Plasma、Xfce、CJK 字型與輸入法都是設定選項。
+- **特殊模式。**記憶體環境、原地轉換、sparse image 與 `dd` 各有獨立限制。
+
+[參考資料](REFERENCE.md#capabilities)說明模型、限制與特殊模式程序。
+
+## 驗證狀態
+
+<!-- fact: verification-scope -->
+
+[`TESTED.md`](TESTED.md)記錄每條已執行路徑、安裝器修訂版與執行環境。一次執行只有在記錄的修訂版符合安裝器、安裝以 `0` 結束、已安裝系統可開機，且開機後設定檢查通過時才計入。
+
+單元、計畫與 fixture coverage 說明實作行為，不能證明已安裝系統已開機。[`tests/fixtures/`](tests/fixtures/)驗證設定模型，不是已安裝的機器。紀錄會列出尚未驗證的組合。
 
 ## 需求
 
@@ -16,27 +35,15 @@ gentoo-install 在 Linux live 環境中執行，用於安裝 amd64 架構的 Gen
 
 實際安裝需要 root 權限、amd64 目標與 Python 3.11 以上版本。使用設定檔執行 dry run 不需要 root 權限。安裝器沒有第三方 Python 執行期相依套件。
 
-<!-- fact: requirements-version-sources -->
-
-選單從 `packages.gentoo.org` 讀取 Gentoo 主儲存庫的套件版本，並從 `api.github.com/repos/gentoo-zh/overlay/contents` 讀取 gentoo-zh 修補核心的版本。`sys-fs/zfs` 接受的最高核心版本從 `gitweb.gentoo.org` 讀取。以設定檔安裝時需要連線的是該設定指定的鏡像；`--missing-commands` 與 `--config FILE --dry-run` 都不需要這些版本端點。
-
-<!-- fact: requirements-network-filter -->
-
-live 環境有 IPv6 但沒有 IPv4 時，選單會停用記錄中標為僅能透過 IPv4 存取的 Gentoo 鏡像。
-
-<!-- fact: requirements-bootstrap -->
-
-`bootstrap.sh` 會讀取 `/etc/os-release`、回報缺少的指令，並印出候選的套件管理器指令。它可辨識下列發行版系列：Debian 與 Ubuntu、Arch、openSUSE、Fedora、RHEL 與 CentOS、Gentoo、Alpine。印出的指令必須在執行前核對。
-
 ## 安全事項
 
 <!-- fact: safety-destructive -->
 
-實際安裝會寫入所選磁碟。使用設定檔執行時不會再次要求確認清除磁碟；`wipe = true`、刪除分割區與建立檔案系統都可能毀損既有資料。
+實際執行會寫入所選磁碟。設定檔執行沒有第二次清除確認；`wipe = true`、刪除分割區與建立檔案系統都可能毀損既有資料。
 
 <!-- fact: safety-review-backup -->
 
-實際安裝前，必須在 dry-run 輸出中核對磁碟選擇器與每項破壞性操作。穩定的 `/dev/disk/by-id/` 選擇器優於 `/dev/sda` 之類的名稱；需要保留的資料必須另有備份。
+實際執行前，必須在 dry-run 輸出中核對磁碟選擇器與每項破壞性操作。穩定的 `/dev/disk/by-id/` 選擇器優於 `/dev/sda` 之類的名稱；需要保留的資料必須另有備份。
 
 ## 安裝
 
@@ -52,601 +59,59 @@ cd gentoo-install-master
 
 <!-- fact: install-terminal -->
 
-選單需要至少 80 欄、24 列的互動式終端機。安裝器啟動時會詢問一次介面語言；`--lang zh-TW` 可直接選用正體中文。
+選單需要至少 80 欄、24 列的互動式終端機。
 
 <!-- fact: install-config-workflow -->
 
-選單可將答案儲存為 `my-install.toml` 後離開。下列流程會先印出完整計畫，再執行實際安裝：
+選單會將答案儲存為 `my-install.toml`。設定檔流程依序為儲存、dry run、檢視、安裝：
 
 ```sh
 ./bootstrap.sh --config my-install.toml --dry-run
-# 接著擇一執行下列其中一行。兩者都會寫入所選磁碟。
+# 在選擇實際指令前檢視呈現的計畫。
 ./bootstrap.sh --config my-install.toml
-./bootstrap.sh --config my-install.toml --no-shell   # 同一次安裝，不詢問是否開啟 root shell
+./bootstrap.sh --config my-install.toml --no-shell   # 同一次執行，不詢問 root shell
 ```
 
 <!-- fact: install-root-shell -->
 
-互動式安裝無論成功或失敗，都會在卸載前提供於目標系統內開啟 root shell 的選項。`--no-shell` 可略過這項確認。
-
-| 選項 | 引數與預設值 | 效果 |
-| --- | --- | --- |
-| `--config` | 檔案或 URL；未設定 | 從該來源載入，而不開啟選單。 |
-| `--dry-run` | 無；`false` | 呈現衍生的操作與摘要，然後結束且不套用操作。 |
-| `--mirror` | stage3 鏡像字串；安裝器預設值 | 選取一般安裝的 stage3 來源。記憶體環境的預約從設定衍生其區域。 |
-| `--lang` | 語言標籤；`""` | 選單建立設定時，覆寫 `LC_ALL`、`LC_MESSAGES` 與 `LANG`。 |
-| `--target` | 路徑；`/mnt/gentoo` | 選取一般安裝的掛載目標。轉換與記憶體環境的預約使用 `/`。 |
-| `--work` | 路徑；`/run/gentoo-install` | 保存本次執行狀態，包含報告與日誌。 |
-| `--missing-commands` | 無；`false` | 每行印出一個缺少的主機指令，然後結束。 |
-| `--resume` | 無；`false` | 使用既有日誌略過相容的已完成操作。 |
-| `--no-shell` | 無；`false` | 略過目標 root shell 的提供。它也使記憶體環境的預約成為無人值守。 |
-| `--skip-preflight` | 無；`false` | 略過一般安裝的 preflight 檢查。 |
-| `--ram` | 無；未設定記憶體模式 | 預約一次進入記憶體內 Gentoo CJK ISO 的開機。它與 `--lowram` 衝突。 |
-| `--lowram` | 無；未設定記憶體模式 | 預約一次進入記憶體內 Alpine netboot 環境的開機。它與 `--ram` 衝突。 |
-| `--ssh-key` | 金鑰、檔案、HTTP(S) URL 或 `github:`/`gitlab:` 參照；`""` | 設定記憶體環境的授權公開金鑰。它需要記憶體模式。 |
-| `--ssh-port` | 整數；未設定 | 設定記憶體環境的 `sshd` 連接埠。這個選項只在記憶體模式下有效。 |
-| `--root-password` | 字串；`""` | 設定記憶體環境 root 密碼。這個選項需要啟用記憶體模式。 |
-| `--bypass` | 無；`false` | 以替換預設開機項目的方式預約，而非建立一次性項目。這個選項只可與記憶體模式一同使用。 |
-| `--disarm` | 無；`false` | 在載入設定前移除先前預約的記憶體開機及其放置的檔案。 |
-
-## 從記憶體安裝
-
-<!-- fact: install-memory -->
-
-`--ram` 與 `--lowram` 預約一次進入記憶體中活環境的開機，那是一台沒有主控台、也沒有救援映像的租用機器覆蓋自己磁碟之前所需要的。安裝器、選定的設定與授權金鑰都隨 initramfs 送達，因此環境起來時執行的正是完成這次預約的那一版：
-
-```sh
-./bootstrap.sh --ram --ssh-key github:zakkaus --root-password 'replace this'
-reboot
-ssh root@the-machine
-```
-
-預設開機項目不會更動，所以沒有進入該環境的機器仍開回原本的系統；`--disarm` 取消這次預約。`--bypass` 改為取代預設項目，供會丟棄一次性項目的韌體使用，那也是唯一一條「環境起不來就連機器都開不起來」的路徑。
-
-第一個畫面問 `install now? [yes/no]`，沒有逾時，未回答之前不會抹除任何資料。`--ram` 開的是帶 ZFS 的 Gentoo CJK ISO，約需 2 GiB 記憶體；`--lowram` 開的是較小、沒有 `zfs.ko` 的 Alpine netboot 壓縮檔。`--ssh-port` 把服務移離 22 埠。第一頁寫出稍後啟動安裝的命令，因此回答 `no` 或在回答之前斷線，都不必重新開機才能再次看到該提示。
-
-`--ram` 可使用 Wi-Fi，`--lowram` 不可。Gentoo CJK ISO 帶著 NetworkManager 與 `linux-firmware`，以 `nmcli device wifi connect <SSID> password <密碼>` 建立連線之後即可執行安裝；第一頁以正體中文、简体中文與英文寫出這件事。Alpine netboot 環境沒有無線驅動也沒有 supplicant，完整模組在一份本身也要下載的 `modloop` 裡，因此只有 Wi-Fi 一條連線的機器完全無法使用 `--lowram`。
-
-## 轉換執行中的系統
-
-<!-- fact: install-in-place -->
-
-在 `[disk]` 表設 `mode = "in-place"`，安裝器取代執行中發行版的使用者空間，而不是分割磁碟。該表不帶裝置清單，因為版面由機器讀出：
-
-```toml
-config_version = 1
-
-[system]
-hostname = "converted"
-timezone = "UTC"
-locales = ["en_US.UTF-8"]
-locale = "en_US.UTF-8"
-init = "systemd"
-root_password_hash = "$6$gentooinst$IR3GrdJ862XljQYDqocr4tKniIRDIT.jQNFzIrHE3U75H6B6YSWZoSYoVd5edSHpqaYBdiNfXHCoIPRVgb9lT/"
-
-[portage]
-profile = "default/linux/amd64/23.0/systemd"
-makeopts = "-j4"
-
-[bootloader]
-kind = "grub"
-firmware = "uefi"
-
-[disk]
-mode = "in-place"
-```
-
-上面那個雜湊是範例，執行前必須替換。互動式執行會印出這次轉換取代哪些目錄，並要求輸入 `convert` 才會寫入任何資料；沒有終端機的執行不會被詢問，因為設定檔裡的 `mode = "in-place"` 就是授權，而在那裡發問會讓序列主控台永遠等下去。
-
-**發起這次執行的工作階段必須保持連線。**`/usr` 與 `/etc` 換成新系統之後，新的 SSH 登入不再成立，而發起執行的工作階段仍持有它已經映射的執行檔。
-
-## 從中斷處繼續
-
-<!-- fact: resume-behavior -->
-
-`--resume` 只會略過位置與識別碼均符合現行計畫，且效果標記為重新開機後仍然存在的已完成操作：
-
-```sh
-./bootstrap.sh --config my-install.toml --resume
-```
-
-<!-- fact: resume-limits -->
-
-繼續執行僅限同一個 live 工作階段、同一個安裝器與同一份設定檔，而且安裝器會拒絕其他情況，不再只是寫在文件裡。
-
-- 日誌開頭記錄設定的摘要、機器的 boot id 與安裝器原始碼的摘要；`--resume` 三者都比對，任何一項不同就停下並說明原因。核心不提供 boot id 的機器只比對其餘兩項。
-- 預設日誌位於 `/run/gentoo-install/install.jsonl`，本來就不會在重新開機後保留。
-- 每筆操作記錄另外包含根據該操作類別原始碼與欄位值產生的識別碼，識別碼改變的操作會重新執行而不是略過。共用輔助函式或常數的變更不在該識別碼範圍內，改由安裝器摘要涵蓋。
-
-## 功能
-
-<!-- fact: capability-scope -->
-
-除非驗證狀態另行指出較窄的範圍，以下路徑均已實作，並有自動化單元測試或 plan 測試。
-
-<!-- fact: storage-device-graph -->
-
-**儲存裝置**
-- 裝置圖涵蓋 GPT 與 MBR 分割表、ext2、ext3、ext4、xfs、f2fs、vfat、含 subvolume 的 btrfs、swap、LUKS2 加密、LVM 與 mdraid。
-- ZFS 屬於同一張裝置圖：pool 在其 vdev 之上採 stripe、mirror 或 raidz1、raidz2、raidz3，原生加密是 pool 的屬性，每個 dataset 各為一個節點。
-- 既有分割表可以保留，每個分割區可分別指定保留、格式化或刪除。
-
-| 模型節點 | 除了 `id` 以外的欄位 | 結果 |
-| --- | --- | --- |
-| `Existing` | `selector`, `wipe` | 選取預先存在的裝置。 |
-| `PartitionTable` | `disk`, `table`, `create`, `remove` | 建立或編輯分割表。 |
-| `Partition` | `table`, `index`, `role`, `size`, `label` | 定義分割區；最後一個 `size` 可耗盡剩餘空間。 |
-| `Luks` | `backing`, `name`, `passphrase_file` | 定義 LUKS 容器。 |
-| `MdRaid` | `members`, `level`, `name`, `metadata` | 定義 mdraid 陣列。 |
-| `VolumeGroup` | `members`, `name` | 定義 LVM 磁碟區群組。 |
-| `LogicalVolume` | `group`, `name`, `size` | 定義 LVM 邏輯磁碟區。 |
-| `ZfsPool` | `vdevs`, `name`, `topology`, `encrypted`, `passphrase_file` | 定義 ZFS pool。 |
-| `ZfsDataset` | `pool`, `name` | 定義 ZFS dataset。 |
-| `Filesystem` | `device`, `kind`, `label`, `create` | 格式化裝置；`create = false` 時會驗證裝置。 |
-| `Subvolume` | `filesystem`, `name` | 定義 Btrfs subvolume。 |
-| `Swap` | `device` | 在參照的裝置上定義 swap。 |
-| `Mountpoint` | `source`, `path`, `options` | 掛載檔案系統、Btrfs subvolume 或 ZFS dataset。 |
-
-| 選項 | 值 |
-| --- | --- |
-| 分割表 | `gpt`, `mbr` |
-| 分割區角色 | `esp`, `bios-boot`, `swap`, `raid`, `lvm`, `zfs`, `data` |
-| mdraid 層級 | `raid0`, `raid1`, `raid5`, `raid6` |
-| mdraid 中繼資料 | `0.90`, `1.0`, `1.1`, `1.2` |
-| 檔案系統 | `ext2`, `ext3`, `ext4`, `btrfs`, `xfs`, `f2fs`, `vfat` |
-| ZFS 拓撲 | `stripe`, `mirror`, `raidz1`, `raidz2`, `raidz3` |
-
-<!-- fact: zram-system -->
-
-系統設定可在裝置圖與 swap 分割區之外，獨立設定 zram。
-
-<!-- fact: in-place-conversion -->
-
-**就地轉換。**
-- 在 `[disk]` 表設定 `mode = "in-place"` 時，安裝器取代執行中發行版的使用者空間，而不是分割磁碟。
-- 版面由機器讀出，因此該表不帶裝置清單。
-- `/bin`、`/sbin`、`/etc`、`/lib`、`/lib64`、`/usr` 與 `/var` 會被取代；`/home`、`/root`、`/srv`、`/opt` 與其餘所有路徑維持原狀，且 `/etc` 是取代而非合併。
-
-- 暫存的系統建置在 `/gentoo-install.new`，執行中的系統在此期間不受影響；隨後以 `rename(2)` 逐個目錄交換，只有寫入 esp 或開機磁區的操作排在交換之後。
-- 根位於 LUKS、LVM 或 mdraid 之下、根檔案系統為安裝器無法描述的類型、根檔案系統可用空間低於 10 GiB，以及在 live 媒介上執行，這四種情況都會在寫入任何資料之前逐項指名並拒絕。
-
-<!-- fact: prepared-image -->
-
-**磁碟映像**
-- `mode = "image"` 把系統裝進 `disk.image` 指定、`disk.size` 決定大小的稀疏檔案，而不是裝到磁碟上，產物因此是一份可以複製到別處、之後再寫入的檔案。
-- `mode = "dd"` 不執行安裝：它把 `disk.source` 的映像串流寫到 `disk.destination` 這顆整顆磁碟，讀取時解開 `raw`、`gz`、`xz`、`zst` 或 `tar`，並保留該映像原本帶的版面與開機載入器。
-- 兩種模式互不接受對方的鍵，`partition` 模式兩組都不接受。
-
-<!-- fact: boot-system -->
-
-**開機與系統**
-- 開機載入器可選 GRUB、systemd-boot 或 ZFSBootMenu。GRUB 支援 UEFI 與 BIOS，systemd-boot 支援 UEFI。
-- ZFSBootMenu 在 UEFI 上開機 ZFS 根，核心取自 pool 內開機環境自己的 `/boot`。安裝器另可設定 systemd 或 OpenRC、dracut、locale、鍵盤配置、時區、主機名稱、DNS、靜態位址與所選的網路管理程式。
-
-<!-- fact: remote-unlock -->
-
-**以 ssh 解開加密的根**
-- `[kernel.remote_unlock]` 在開機路徑放進一個 ssh 服務，供無人在旁邊回答密語提示的機器使用。
-- `enabled` 開啟這條路徑；`port` 預設 222 而不是 22，避免用戶端對執行中系統的 `known_hosts` 記錄與 initramfs 的那筆相撞；`address`、`gateway` 與 `interface` 給該服務一個靜態位址，位址留空則改用 DHCP。
-- LUKS 根由系統 initramfs 裡的 `sys-kernel/dracut-crypt-ssh` 開啟，ZFS 根則由 ZFSBootMenu 建進自己映像的 dropbear 開啟。
-- 授權金鑰取自 `system.authorized_keys`：開了這條路徑又沒有列出任何金鑰的設定會被逐項指名並拒絕，因為那描述的是一個沒有人登入得進去的服務。
-
-<!-- fact: desktop-language -->
-
-**桌面與語言支援**
-- 桌面可選 GNOME、KDE Plasma 與 Xfce，並搭配 gdm、sddm、lightdm，或 greetd 與它的 tuigreet 主控台登入畫面。
-- 圖形設定涵蓋 AMD、Intel、NVIDIA 與虛擬機。
-- 套件目錄包含 fcitx5、Rime、Anthy、Mozc、Hangul 與 CJK 字型。
-- 核心選項包括 `sys-kernel/gentoo-cjk-kernel-bin` 與 `sys-kernel/gentoo-cjk-kernel`，兩者都包含 cjktty 修補程式。
-
-<!-- fact: portage -->
-
-**Portage**
-- 設定項目包含 profile、`MAKEOPTS`、`USE`、`ACCEPT_KEYWORDS`、`L10N`、鏡像與儲存庫同步方式。
-- gentoo-zh 與 gig overlay 可分別選取。
-- 介面語言選為 `zh-TW`、`zh-CN`、`ja` 或 `ko` 時，也會選取 gentoo-zh 的修補版二進位核心及其 overlay；選為 `en` 時不會自動選取。
-- 官方與 gentoo-zh 的二進位套件來源各有獨立設定與金鑰。
-
-<!-- fact: proxy -->
-
-**工作階段 Proxy**
-- `[proxy]` 設定表接受 `kind`、`host`、`port`、可選的 `username` 與 `password`，以及 `bypass`。
-- `kind` 可以是 `http`、`https` 或 `socks5`；`host` 留白表示直接連線，這是預設值。
-- SOCKS5 會導出為 `socks5h://`，所以由 Proxy 解析主機名稱以存取內網。
-- 介面主選單為每個值提供欄位，並以選單選擇 Proxy 類型。
-- `bypass` 在介面中是逗號分隔的值，在 TOML 中是清單。
-
-- 選取 Proxy 後，設定的 Proxy 用於 stage3 與其簽署金鑰、主儲存庫與 overlay 版本查詢，以及 `gitweb.gentoo.org` 的 ZFS ebuild 查詢。
-- 它也用於透過 `make.conf` 與 `FETCHCOMMAND`/`RESUMECOMMAND` 的 Portage 下載、`wget`、`curl`、`git`、GnuPG、binhost、overlay 與 paste 上傳。
-- 時鐘、初始連線檢查與選單前的鏡像檢查都在取得設定前執行，因此不在此設定涵蓋範圍內。安裝器會將認證資訊排除在 dry-run 說明與發佈的設定之外；發佈的設定與已安裝系統都只保留不含認證資訊的端點及略過清單。
-
-<!-- fact: memory-environment -->
-
-**記憶體環境。**
-- `--ram` 與 `--lowram` 預約一次開機進入常駐記憶體的活環境，接著詢問是否重新開機；這條路沒有介面，因為它針對的機器通常只有一條 SSH 連線而沒有主控台。
-- `--ram` 用 Gentoo CJK ISO，帶有 ZFS，需要約 2 GiB 記憶體：它的 initramfs 在記憶體扣掉 824 MiB 的活映像後低於 1 GiB 時停在急救殼。
-- `--lowram` 用 Alpine netboot 套組，較小且沒有 `zfs.ko`。
-- 兩者都不寫死版本：發佈方各自列出目前的映像與校驗和，預約之前先抓取並驗證。
-
-- 預設開機項目一律不改，所以環境沒有起來時機器仍然開得了機。
-- `--bypass` 改為替換它，用於會丟棄一次性項目的韌體；這是唯一一條環境沒起來就完全開不了機的路徑，沒有任何路徑會自動選它。
-
-<!-- fact: memory-environment-access -->
-
-**用 SSH 觀察記憶體安裝。**
-- `--ssh-key` 接受公鑰本文（`ssh-ed25519`、`ssh-rsa`、`ecdsa-sha2-nistp256`、`-384`、`-521` 以及 `sk-` 變體）、路徑、`http` 或 `https` 網址，以及 `github:user` 與 `gitlab:user`；`--ssh-port` 與 `--root-password` 設定其餘部分。
-- 安裝器、選定的設定與金鑰都放在 initramfs 內，所以環境執行的是寫出該設定的修訂，而且在第一次登入之前 `authorized_keys` 已經就位。
-- 操作者以 SSH 重新連線觀察安裝，不必一直開著主控台。
-- 回答第一個畫面之前不會清除任何資料：該畫面問 `install now? [yes/no]`，而且沒有逾時。
-
-<!-- fact: plan-records -->
-
-**計畫與記錄**
-- dry run 會在不探測儲存硬體的情況下顯示操作計畫。
-- 實際安裝使用相同的規劃器，但會先加入從重用裝置探測到的 mdraid 中繼資料，因此依賴硬體的驗證結果可能不同。
-- `install.log` 記錄指令輸出，`install.jsonl` 記錄操作、套件來源與二進位套件降級原因。
-- 選單將設定上傳至 `paste.gentoozh.org` 前，會把 `password_hash` 與 `root_password_hash` 的值替換為 `removed-before-publishing`，並且完全不寫出代理的 `username` 與 `password` 這兩個鍵；其他設定值仍會上傳。
-- 選單會以文字與 QR 碼顯示上傳頁面的網址。
-
-### 相容性規則
-
-驗證會拒絕以下組合：
-
-| 拒絕的組合 |
-| --- |
-| root 雜湊為空白、鎖定或格式錯誤，且沒有可透過密碼驗證的使用者與可用的 SSH 金鑰登入方式。 |
-| ZFS 根搭配 GRUB。 |
-| `/boot` 位於 ZFS 且搭配 GRUB。 |
-| ZFS 根搭配 BIOS 開機。 |
-| ZFS 根搭配 LUKS 根鏈。 |
-| ZFSBootMenu 搭配非 ZFS 的根。 |
-| UEFI 開機未掛載 ESP。 |
-| UEFI 開機搭配已加密的 ESP。 |
-| systemd-boot 搭配 BIOS 開機。 |
-| systemd-boot 搭配無法從 ESP 存取的核心或 initramfs，原因是 `/boot` 已加密或不是 vfat。 |
-| ESP 位於中繼資料為 `1.1` 或 `1.2` 的 mdraid。 |
-| GPT 磁碟上的 BIOS 開機未設 `bios-boot` 分割區。 |
-| CJK 主控台呈現搭配缺少 cjktty 的核心。 |
-| 遠端解鎖沒有授權 SSH 金鑰。 |
-| 遠端解鎖沒有加密的根容器或 pool。 |
-| 遠端解鎖搭配必須在 initramfs SSH 啟動前解開 `/boot` 的 GRUB。 |
-| GRUB 或 systemd-boot 的系統 initramfs 遠端解鎖原生 ZFS 加密。 |
-| CJK 核心沒有 `gentoo-zh` overlay。 |
-| CJK 主控台呈現搭配非 `8x16` 的主控台字型。 |
-| ZFSBootMenu 沒有 `gentoo-zh` overlay。 |
-| gentoo-zh 社群 binhost 沒有 `gentoo-zh` overlay。 |
-
-## 驗證狀態
-
-<!-- fact: verification-scope -->
-
-[`TESTED.md`](TESTED.md) 是驗證記錄：每一條走過的路徑各一列，寫明它執行時的安裝器修訂版與執行的地點。一次執行要記錄的修訂版與安裝器相符、安裝退出碼為 `0`、裝出的系統能開機、且開機後的設定檢查全部通過，才算數。
-
-| 路徑 | 記錄 |
-| --- | --- |
-| 裝到磁碟上 | ext4、ext2、ext3、xfs、btrfs、f2fs、ZFS、LVM、mdraid 與 LUKS2，兩種韌體與兩種 init 系統皆有 |
-| ZFS pool | stripe、mirror、raidz、加密 pool，以及一個由 ZFSBootMenu 開機的 pool |
-| 以 ssh 解鎖 | 由系統 initramfs 開啟的 LUKS 根，以及由 ZFSBootMenu 自己映像開啟的 ZFS pool |
-| 靜態位址與 greetd | 各自有叢集記錄 |
-| 就地轉換執行中的系統 | 四筆 QEMU 記錄：兩筆 BIOS，一筆保留 `/home` 的 UEFI，一筆根檔案系統是 btrfs、`/home` 與 `/var` 為 subvolume 的 UEFI |
-| 轉換這個安裝器裝出來的機器 | 六次走到重新開機的叢集轉換裡，五次開得起來，一次因為缺少模組停在 GRUB 的救援殼層，而轉換本身的退出碼是 `0`，所以這條路徑還不可靠 |
-| `--ram` 與 `--lowram` | 一台 Debian 12 機器預約一次開機、預設開機項目未變，重新開機後帶著交付給它的設定進入送達的環境；在那裡回答 `install` 會裝出 Gentoo 並開起它寫出的磁碟 |
-| `--bypass` | 取代預設開機項目撐過了一次電源循環：兩次開機都進入送達的環境 |
-| 預約的開機沒有起來 | 一台被移除預約項目 initramfs 的機器，沒有出現送達的畫面，接續的兩次開機都進入原本的雲系統 |
-| `dd` | 一筆記錄：從 live 媒介把準備好的映像寫入整顆磁碟並逐位元組讀回，原始與 gzip 兩種格式皆是 |
-| 裝進檔案 | 一筆記錄：映像以 `losetup -Pf` 掛上，讀回的是它版面宣告的那兩個檔案系統，而沒有任何機器從那份檔案開機過 |
-| 選單 | 在 80x24 的序列主控台上逐列開過，涵蓋英文、正體中文、簡體中文、日文與韓文，沒有一列寬過終端機 |
-
-原始碼建置的核心與二進位套件降級只有 runner 層級的測試，而 runner 層級的測試不是端到端記錄。`tests/fixtures/` 底下的檔案驗證的是設定模型，它們存在並不代表任何一台裝出來的機器。
+互動式執行會在卸載前提供目標 root shell。`--no-shell` 會略過該提示。
 
 ## 設定檔
 
-<!-- fact: config-model -->
+<!-- fact: configuration-reference -->
 
-設定檔使用 TOML。頂層的 `config_version` 欄位指定結構版本。儲存裝置以裝置圖表示：每個裝置都有 `id`，裝置以其他裝置的 `id` 建立引用，選擇器只在實際安裝時解析。
+設定檔使用 TOML，`config_version` 選擇 schema 版本。[設定參考資料](REFERENCE.md#configuration-files)列出所有持久化鍵與通過驗證的範例。[`tests/fixtures/vm-binpkg.toml`](tests/fixtures/vm-binpkg.toml)是 schema reference；其中的虛擬機磁碟選擇器與測試憑證不得原樣用於實機。
 
-<!-- fact: config-simple -->
+## 從中斷處繼續
 
-單一磁碟的版面寫成 `[disk.simple]`，不必寫裝置圖。解析時以選單所用的同一份樣板展開，因此兩種寫法產生相同的圖。裝置圖的寫法保留給 LUKS、ZFS、RAID 與手動分割表。
+<!-- fact: resume-limits -->
 
-```toml
-config_version = 1
+`--resume` 僅限同一個 live 工作階段、同一安裝器修訂版與同一份設定檔。安裝器會拒絕不相符的情況。預設日誌位於 `/run/gentoo-install/install.jsonl`，所以不會在重新開機後保留。
 
-[system]
-hostname = "workstation"
-timezone = "UTC"
-locales = ["en_US.UTF-8"]
-locale = "en_US.UTF-8"
-init = "systemd"
-root_password_hash = "$6$gentooinst$IR3GrdJ862XljQYDqocr4tKniIRDIT.jQNFzIrHE3U75H6B6YSWZoSYoVd5edSHpqaYBdiNfXHCoIPRVgb9lT/"
-
-[portage]
-profile = "default/linux/amd64/23.0/systemd"
-makeopts = "-j4"
-
-[bootloader]
-kind = "grub"
-firmware = "uefi"
-
-[disk.simple]
-disk = "/dev/disk/by-id/virtio-target0"
-filesystem = "ext4"
-swap = "2GiB"
-```
-
-上面的雜湊值是範例，執行前必須替換。只有 `disk` 必填。省略的鍵取安裝器預設值：`whole-disk`、`uefi`、由韌體決定的分割表、`xfs`、無交換空間、不加密。同一份檔案不得同時寫 `[disk.simple]` 與 `[[disk.devices]]`。
-
-<!-- fact: config-fixtures -->
-
-[`tests/fixtures/vm-binpkg.toml`](tests/fixtures/vm-binpkg.toml) 是完整的 UEFI 與 ext4 結構參考。其他 [`tests/fixtures/`](tests/fixtures/) 檔案涵蓋 BIOS、LUKS2、LVM、mdraid、ZFS、btrfs subvolume 與桌面。這些檔案使用虛擬機磁碟選擇器與測試密碼，不得原樣用於實機安裝。
-
-<!-- fact: config-dry-run -->
-
-解析與計畫階段不會探測儲存硬體，因此沒有目標磁碟的機器也能以 `--dry-run` 檢查設定。
-
-以下參考列出每個保存的鍵。表格路徑使用 TOML 表格表示法，且 `[[disk.devices]]` 載有圖節點。
-
-| 鍵 | 說明與預設值或選項 |
-| --- | --- |
-| `config_version` | 保存的結構版本；`1`。 |
-| `proxy.kind` | 代理協定：`http`、`https` 或 `socks5`；`http`。 |
-| `proxy.host` | 代理主機；`""` 會停用代理。 |
-| `proxy.port` | 代理連接埠；`0`。 |
-| `proxy.username` | 可選的代理使用者名稱；`""`。 |
-| `proxy.password` | 可選的代理密碼；`""`。 |
-| `proxy.bypass` | 略過代理的主機；`[]`。 |
-
-| `system` 鍵 | 說明與預設值或選項 |
-| --- | --- |
-| `hostname` | 目標主機名稱；`gentoo`。 |
-| `timezone` | 目標時區；`Asia/Shanghai`。 |
-| `locales` | 產生的 locale；`en_US.UTF-8`、`zh_CN.UTF-8`、`zh_TW.UTF-8`。 |
-| `locale` | 選定的 locale；`zh_CN.UTF-8`。 |
-| `keymap` | 已安裝系統的鍵盤對應；`us`。 |
-| `keymap_initramfs` | initramfs 的鍵盤對應；`""` 會沿用 `keymap`。 |
-| `interface` | 網路介面模式；`""` 會比對 `en*` 與 `eth*`。 |
-| `addresses` | 靜態 CIDR 位址；`[]` 會選取 DHCP 或路由器宣告。 |
-| `gateways` | 閘道；每個位址系列至多一個；`[]`。 |
-| `dns` | 解析器位址；`[]`。 |
-| `authorized_keys` | root 與 sudo 使用者的金鑰；`[]`。 |
-| `console_cjk` | 要求 CJK 主控台呈現；`false`；它需要 cjktty。 |
-| `console_font` | 主控台字元格大小：`8x8`、`8x16` 或 `16x32`；`8x16`。 |
-| `init` | Init 系統：`openrc` 或 `systemd`；`systemd`。 |
-| `zram` | 壓縮 RAM 的 swap 大小；未設定會停用。 |
-| `hardware_clock_utc` | RTC 保存 UTC；`true`。 |
-| `users` | 使用者記錄；`[]`。 |
-| `root_password_hash` | root 的 `crypt(3)` 雜湊；`""` 會鎖定 root。 |
-| `logger` | 日誌程式：`none`、`sysklogd`、`syslog-ng` 或 `metalog`；`sysklogd`。 |
-| `cron` | 安裝 `sys-process/cronie`；`true`。 |
-| `sshd` | 安裝並設定 SSH daemon 支援；`false`。 |
-| `sshd_password_login` | SSH daemon 接受密碼；`false`。 |
-| `sshd_root_login` | root 可透過 SSH 登入；`false`。 |
-| `networking` | 連線管理：`builtin`、`networkmanager-wpa`、`networkmanager-iwd` 或 `none`；`builtin`。 |
-| `firewall` | 封包過濾套件：`none`、`nftables` 或 `iptables`；`none`。 |
-| `first_boot` | 首次開機記錄；預設為空白記錄。 |
-
-| `system.users` 項目 | 說明與預設值 |
-| --- | --- |
-| `name` | 使用者名稱；必填。 |
-| `groups` | 補充群組；`[]`。 |
-| `shell` | 登入 shell；`/bin/bash`。 |
-| `sudo` | 將使用者設為 sudo 使用者；`false`。 |
-| `password_hash` | 使用者的 `crypt(3)` 雜湊；`""` 會鎖定帳號。 |
-
-| `system.first_boot` 鍵 | 說明與預設值 |
-| --- | --- |
-| `commands` | 擷取的指令碼後依序執行的 shell 行；`[]`。 |
-| `url` | 指令碼 URL；`""` 不會擷取指令碼。 |
-
-| `portage` 鍵 | 說明與預設值或選項 |
-| --- | --- |
-| `profile` | Portage profile；`default/linux/amd64/23.0/systemd`。 |
-| `keywords` | 全域關鍵字通道：`stable` 或 `testing`；`stable`。 |
-| `sync` | 持續同步：`git`、`webrsync` 或 `rsync`；`git`。首次同步使用 webrsync。 |
-| `testing_packages` | 系統維持 stable 時接受為 testing 的 atom；`[]`。 |
-| `makeopts` | `MAKEOPTS`；`""`。 |
-| `common_flags` | 通用編譯器旗標；`-O2 -pipe`。 |
-| `use` | `USE` 旗標；`[]`。 |
-| `video_cards` | `VIDEO_CARDS` 值；`[]`。 |
-| `l10n` | `L10N`；`[]` 會從產生的 locale 衍生值。 |
-| `input_devices` | `INPUT_DEVICES`；`["libinput"]`。 |
-| `accept_license` | 接受的授權；`["@FREE"]`。 |
-| `cpu_flags` | CPU 旗標；`[]` 會保留 profile 值。 |
-| `build_in_ram` | `/var/tmp/portage` 的 tmpfs 大小；未設定時在磁碟上建置。 |
-| `mirrors` | 鏡像記錄；下方列出預設值。 |
-| `binhost` | binhost 記錄；下方列出預設值。 |
-| `overlays` | overlay 記錄；`[]`。 |
-
-| `portage.mirrors` 鍵 | 說明與預設值或選項 |
-| --- | --- |
-| `region` | Gentoo 鏡像區域：`cn` 或 `global`；`global`。 |
-| `speed_test` | 測試提供的鏡像速度；`false`。 |
-| `distfiles` | 自訂 distfile 基底；非空清單會取代內建清單。 |
-| `repo_sync_uri` | 明確指定的儲存庫同步 URI；`""`。 |
-| `site` | `region` 中的站台鍵；`""` 會選取該區域的第一個站台。 |
-| `gentoo_distfiles` | 寫入 `GENTOO_MIRRORS`；`true`。 |
-| `gentoo_zh` | gentoo-zh 鏡像：`upstream`、`cernet`、`nju`、`nyist` 或 `ha`；`upstream`。 |
-| `gentoo_zh_distfiles` | 將 gentoo-zh distfile 附加至 `GENTOO_MIRRORS`；`true`。 |
-
-| 鏡像區域 | 站台鍵 |
-| --- | --- |
-| `cn` | `ustc`, `nju`, `bfsu`, `tuna`, `zju`, `sdu`, `hust`, `sustech`, `hit`, `lzu`, `aliyun`, `netease`, `cernet`, `cicku-hk`, `planetunix-hk`, `xtom-hk`, `rackspace-hk`, `aditsu-hk`, `nchc-tw`, `cicku-tw`, `freedif-sg`, `cicku-sg`, `planetunix-sg` |
-| `global` | `gentoo`, `osuosl` |
-
-| `portage.binhost` 鍵 | 說明與預設值或選項 |
-| --- | --- |
-| `official` | 啟用官方二進位主機；`true`。 |
-| `subarch` | 官方 binhost 子架構；`x86-64`。 |
-| `community` | gentoo-zh 通道：`off`、`stable` 或 `unstable`；`off`。 |
-
-| `portage.overlays` 項目 | 說明 |
-| --- | --- |
-| `name` | overlay 名稱；必填。 |
-| `sync_uri` | overlay 同步 URI；必填。 |
-
-| `kernel` 鍵 | 說明與預設值或選項 |
-| --- | --- |
-| `source` | 核心選擇：`dist-bin`、`dist-source`、`cjk-bin` 或 `cjk`；`dist-bin`。 |
-| `package` | 覆寫 `source` 所隱含的套件；`""`。 |
-| `version` | 版本固定；`""` 會讓 Portage 選取最新且關鍵字允許的版本。 |
-| `dracut_modules` | 新增磁碟版面所需的 dracut 模組；`[]`。 |
-| `remote_unlock` | initramfs SSH 解鎖記錄；預設為空白記錄。 |
-
-| `kernel.source` | 套件與 CJK 狀態 |
-| --- | --- |
-| `dist-bin` | `sys-kernel/gentoo-kernel-bin`；不是 CJK 核心。 |
-| `dist-source` | `sys-kernel/gentoo-kernel`；屬於非 CJK 核心。 |
-| `cjk-bin` | `sys-kernel/gentoo-cjk-kernel-bin`；是 CJK 核心。 |
-| `cjk` | `sys-kernel/gentoo-cjk-kernel`；屬於 CJK 核心。 |
-
-| `kernel.remote_unlock` 鍵 | 說明與預設值 |
-| --- | --- |
-| `enabled` | 啟用 initramfs SSH 解鎖；`false`。 |
-| `port` | initramfs SSH 連接埠；`222`。 |
-| `address` | 靜態 CIDR 位址；`""` 會使用 DHCP。 |
-| `gateway` | 靜態位址閘道；`""`。 |
-| `interface` | initramfs 網路介面；`""`。 |
-
-| `bootloader` 鍵 | 說明與預設值或選項 |
-| --- | --- |
-| `kind` | 開機載入器：`grub`、`systemd-boot` 或 `zfsbootmenu`；`grub`。 |
-| `firmware` | 韌體：`uefi` 或 `bios`；`uefi`。 |
-| `kernel_params` | 額外核心命令列參數；`[]`。 |
-
-| `packages` 鍵 | 說明與預設值 |
-| --- | --- |
-| `desktop` | 桌面 profile 名稱；`""` 不選取桌面。 |
-| `applications` | 套件群組名稱；`[]`。 |
-| `graphics` | 圖形驅動程式群組名稱；`[]`；多個群組可配合混合硬體。 |
-| `display_manager` | 顯示管理程式群組；`""` 會選取主控台登入。 |
-| `extra` | 在其他選項後合併的套件 atom；`[]`。 |
-
-| `disk` 鍵 | 說明與預設值或選項 |
-| --- | --- |
-| `graph` | 由 `[[disk.devices]]` 表示的裝置圖；必填。 |
-| `root` | root 圖節點識別碼；轉換外為必填；`""` 在轉換中使用執行中版面。 |
-| `mode` | `partition`、`in-place`、`image` 或 `dd`；`partition`。 |
-| `image` | image 模式的稀疏映像路徑；`""`。 |
-| `size` | image 模式的稀疏映像大小；未設定。 |
-| `wipe` | 磁碟層級的清除設定；`false`。 |
-| `source` | `dd` 模式的準備映像來源；`""`。 |
-| `source_format` | 來源編碼：`raw`、`gz`、`xz`、`zst` 或 `tar`；`raw`。 |
-| `destination` | 整顆磁碟的 `dd` 目的地；`""`。 |
-
-| 範本輸入 | 說明與預設值或選項 |
-| --- | --- |
-| `disk` | 整顆磁碟選擇器；必填。 |
-| `layout` | `whole-disk`、`whole-disk-btrfs`、`whole-disk-zfs` 或 `reuse`；`whole-disk`。 |
-| `firmware` | 範本韌體；`uefi`。 |
-| `table` | 分割表覆寫；未設定時為 UEFI 衍生 GPT，為 BIOS 衍生 MBR。 |
-| `filesystem` | 非 Btrfs 與非 ZFS 整顆磁碟版面的根檔案系統；`xfs`。 |
-| `swap` | swap 分割區大小；未設定。 |
-| `passphrase_file` | 安裝系統的密語檔路徑；`""` 會讓版面保持未加密。 |
-| `pool` | ZFS pool 名稱；`rpool`。 |
-
-以下完整設定示範包含認證資訊與兩個略過主機的 Proxy。認證資訊只是範例，執行前必須替換：
-
-```toml
-config_version = 1
-
-[proxy]
-kind = "socks5"
-host = "proxy.example"
-port = 1080
-username = "operator"
-password = "secret"
-bypass = ["localhost", "intranet.example"]
-
-[system]
-hostname = "proxy-target"
-timezone = "UTC"
-locales = ["en_US.UTF-8"]
-locale = "en_US.UTF-8"
-init = "openrc"
-root_password_hash = "$6$gentooinst$IR3GrdJ862XljQYDqocr4tKniIRDIT.jQNFzIrHE3U75H6B6YSWZoSYoVd5edSHpqaYBdiNfXHCoIPRVgb9lT/"
-
-[portage]
-profile = "default/linux/amd64/23.0"
-makeopts = "-j4"
-
-[portage.binhost]
-official = false
-
-[bootloader]
-firmware = "bios"
-
-[disk]
-root = "mnt-root"
-
-[[disk.devices]]
-kind = "existing"
-id = "disk"
-selector = "/dev/disk/by-id/virtio-target0"
-wipe = true
-
-[[disk.devices]]
-kind = "table"
-id = "table"
-disk = "disk"
-table = "mbr"
-
-[[disk.devices]]
-kind = "partition"
-id = "rootpart"
-table = "table"
-index = 1
-role = "data"
-
-[[disk.devices]]
-kind = "filesystem"
-id = "rootfs"
-device = "rootpart"
-type = "ext4"
-
-[[disk.devices]]
-kind = "mountpoint"
-id = "mnt-root"
-source = "rootfs"
-path = "/"
+```sh
+./bootstrap.sh --config my-install.toml --resume
 ```
 
 ## 二進位套件
 
 <!-- fact: binary-packages -->
 
-二進位套件為選用功能。關閉後仍可從原始碼建置。官方 binhost 與 gentoo-zh binhost 是兩個獨立選項，並使用不同的信任設定。目前沒有端到端實據涵蓋 binhost 無法連線、缺少簽章或金鑰不受信任的情況；這些降級路徑仍未驗證。
+二進位套件是可選項。停用後仍可從原始碼建置。官方 binhost 與 gentoo-zh binhost 有各自的信任設定。無法連線的 binhost、缺少簽章與不受信任的金鑰目前都沒有端對端證據；這些降級路徑仍未驗證。
 
-## 退出碼
+## 參考資料
 
-<!-- fact: exit-codes -->
+<!-- fact: reference -->
 
-| 退出碼 | `gentoo-install` |
-| --- | --- |
-| `0` | 成功完成 |
-| `1` | 設定錯誤 |
-| `2` | `argparse` 用法錯誤或 preflight 失敗 |
-| `3` | 完整性驗證失敗 |
-| `4` | 下載、外部指令、作業系統或未分類的安裝器失敗 |
-| `5` | 操作者中止 |
-
-Python CLI 啟動前，如果 Python、必要指令或 root 權限檢查失敗，`bootstrap.sh` 也可能以 `1` 退出。
-
-## 常見問題
-
-<!-- fact: faq-customisation -->
-
-**這種安裝器會不會讓 Gentoo 失去可自訂性？**
-
-不會。它只執行基礎安裝：分割區、stage3、Portage 設定、核心、bootloader，以及選用的桌面。之後的每個決定仍然屬於操作者，而那台機器是一套普通的 Gentoo，上面不留本專案的任何元件。它省掉的是第一個小時的成本，而那正是 Gentoo 難以入門、也難以在大量機器或 VPS 上部署的原因。
+[REFERENCE.md](REFERENCE.md)收錄執行期需求、命令列選項、記憶體環境、原地轉換、功能與驗證細節、設定檔、二進位套件信任與退出碼。
 
 ## 參與開發
 
 <!-- fact: contributing -->
 
-[CONTRIBUTING.md](CONTRIBUTING.md) 說明開發環境、架構與必要檢查。
+[CONTRIBUTING.md](CONTRIBUTING.md)說明開發環境、架構與必要檢查。
 
 ## 授權
 
 <!-- fact: license -->
 
-本專案以 GNU General Public License 散布，版本為第 2 版，或由接收者選擇任何較新的版本。第 2 版全文見 [LICENSE](LICENSE)，每份原始碼檔案帶有 `SPDX-License-Identifier: GPL-2.0-or-later`。
+gentoo-install 以 GNU General Public License 散布，版本為第 2 版，或由接收者選擇任何較新的版本。第 2 版全文見 [LICENSE](LICENSE)，每份原始碼檔案帶有 `SPDX-License-Identifier: GPL-2.0-or-later`。

--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -1,0 +1,496 @@
+# gentoo-install reference
+
+This English lookup reference holds command, configuration and special-mode detail that does not belong in the normal installation flow.
+
+## Runtime requirements
+
+The menu reads Gentoo main-tree package versions from `packages.gentoo.org` and gentoo-zh patched-kernel versions from `api.github.com/repos/gentoo-zh/overlay/contents`. It reads the maximum kernel version accepted by `sys-fs/zfs` from `gitweb.gentoo.org`. An installation from a configuration file requires the mirror that configuration names instead; `--missing-commands` and `--config FILE --dry-run` require none of these version endpoints.
+
+The menu disables recorded IPv4-only Gentoo mirrors when the live environment has IPv6 but no IPv4.
+
+`bootstrap.sh` reads `/etc/os-release`, reports missing commands and prints a candidate package-manager command. It recognizes these distribution families: Debian and Ubuntu; Arch; openSUSE; Fedora, RHEL and CentOS; Gentoo; and Alpine. The printed command must be reviewed before it is run.
+
+## Command line
+
+| Option | Argument and default | Effect |
+| --- | --- | --- |
+| `--config` | file or URL; unset | Loads that source instead of opening the menu. |
+| `--dry-run` | none; `false` | Renders the derived operations and summary, then exits without applying operations. |
+| `--mirror` | stage3 mirror string; installer default | Selects the stage3 source for a normal installation. Memory arming derives its region from configuration. |
+| `--lang` | language tag; `""` | Overrides `LC_ALL`, `LC_MESSAGES`, and `LANG` while the menu creates configuration. |
+| `--target` | path; `/mnt/gentoo` | Selects the normal installation mount target. Conversion and memory arming use `/`. |
+| `--work` | path; `/run/gentoo-install` | Holds run state, including the report and journal. |
+| `--missing-commands` | none; `false` | Prints missing host commands, one per line, then exits. |
+| `--resume` | none; `false` | Uses the existing journal to skip compatible completed operations. |
+| `--no-shell` | none; `false` | Suppresses the target root-shell offer. It also makes memory arming unattended. |
+| `--skip-preflight` | none; `false` | Skips normal-installation preflight checks. |
+| `--ram` | none; unset memory mode | Arms one boot into the Gentoo CJK ISO held in memory. It conflicts with `--lowram`. |
+| `--lowram` | none; unset memory mode | Arms one boot into the Alpine netboot environment held in memory. It conflicts with `--ram`. |
+| `--ssh-key` | key, file, HTTP(S) URL, or `github:`/`gitlab:` reference; `""` | Sets a memory-environment authorised public key. It requires a memory mode. |
+| `--ssh-port` | integer; unset | Sets the memory environment's `sshd` port. It requires a memory mode. |
+| `--root-password` | string; `""` | Sets the memory environment root password. It requires a memory mode. |
+| `--bypass` | none; `false` | Replaces the default boot entry instead of arming a one-shot entry. It requires a memory mode. |
+| `--disarm` | none; `false` | Removes a previously armed memory boot and files it placed before configuration loading. |
+
+## Memory environment
+
+`--ram` and `--lowram` arm one boot into a live environment held in memory, which is what a rented machine with no console and no rescue image needs before its own disk can be installed over. The installer, the chosen configuration and the authorised keys travel inside the initramfs, so the environment comes up running the revision that armed it:
+
+```sh
+./bootstrap.sh --ram --ssh-key github:zakkaus --root-password 'replace this'
+reboot
+ssh root@the-machine
+```
+
+The default boot entry is not changed, so a machine that does not come up in the environment boots what it booted before; `--disarm` takes the arming back. `--bypass` replaces the default entry instead, for firmware that drops a one-shot entry, and it is the one path where an environment that fails to come up leaves a machine that does not boot at all.
+
+The first screen asks `install now? [yes/no]` and has no timeout, and nothing is erased until it is answered. `--ram` boots the Gentoo CJK ISO, which carries ZFS and needs about 2 GiB of RAM; `--lowram` boots the Alpine netboot bundle, which is smaller and has no `zfs.ko`. `--ssh-port` moves the daemon off 22. The first page names the command that starts the install later, so answering `no` or losing the connection before answering does not make rebooting the only way back to it.
+
+`--ram` reaches wifi and `--lowram` does not. The Gentoo CJK ISO carries NetworkManager and `linux-firmware`, so `nmcli device wifi connect <SSID> password <PASSWORD>` brings a link up and the install runs after it; the first page says so in Traditional Chinese, Simplified Chinese and English. The Alpine netboot environment has no wireless driver and no supplicant, and its full module set is in a `modloop` that itself has to be fetched, so a machine whose only link is wifi cannot use `--lowram` at all.
+
+**Memory environment.**
+- `--ram` and `--lowram` arm one boot into a live environment held in memory, then ask whether to reboot; there is no interface on this path, because the machine it addresses usually has one SSH session and no console.
+- `--ram` uses the Gentoo CJK ISO, which carries ZFS and needs about 2 GiB of RAM, because its initramfs stops at an emergency shell when memory less the 824 MiB live image falls under 1 GiB.
+- `--lowram` uses the Alpine netboot bundle, which is smaller and has no `zfs.ko`.
+- Neither pins a version: both publishers list the current image with its checksum, which is fetched and verified before anything is armed.
+
+- The default boot entry is never changed, so an environment that does not come up leaves a machine that still boots.
+- `--bypass` replaces it instead, for firmware that drops a one-shot entry; it is the one path where an environment that does not come up leaves a machine that does not boot at all, and nothing selects it automatically.
+
+**Watching a memory install over SSH.**
+- `--ssh-key` accepts a literal public key (`ssh-ed25519`, `ssh-rsa`, `ecdsa-sha2-nistp256`, `-384`, `-521`, and the `sk-` variants), a path, an `http` or `https` URL, or `github:user` and `gitlab:user`; `--ssh-port` and `--root-password` set the rest.
+- The installer, the chosen configuration and the keys travel inside the initramfs, so the environment runs the revision that wrote that configuration and reaches `authorized_keys` before the first login.
+- The operator reconnects over SSH and watches the install rather than holding a console open.
+- Nothing is erased until the first screen is answered: it asks `install now? [yes/no]`, and has no timeout.
+
+## In-place conversion
+
+`mode = "in-place"` in the `[disk]` table replaces the userland of the running distribution instead of partitioning a disk. The table carries no device list, because the layout is read from the machine:
+
+```toml
+config_version = 1
+
+[system]
+hostname = "converted"
+timezone = "UTC"
+locales = ["en_US.UTF-8"]
+locale = "en_US.UTF-8"
+init = "systemd"
+root_password_hash = "$6$gentooinst$IR3GrdJ862XljQYDqocr4tKniIRDIT.jQNFzIrHE3U75H6B6YSWZoSYoVd5edSHpqaYBdiNfXHCoIPRVgb9lT/"
+
+[portage]
+profile = "default/linux/amd64/23.0/systemd"
+makeopts = "-j4"
+
+[bootloader]
+kind = "grub"
+firmware = "uefi"
+
+[disk]
+mode = "in-place"
+```
+
+The hash above is an example and must be replaced before execution. An interactive run prints what the conversion replaces and requires the word `convert` before anything is written; a run with no terminal is not asked, because `mode = "in-place"` in the file is the authorisation and a question there would hold a serial console open for ever.
+
+**The session that started the run is the lifeline.** A new SSH login stops working once `/usr` and `/etc` belong to the new system, while the session that started the run keeps the binaries it already mapped.
+
+**In-place conversion.**
+- Setting `mode = "in-place"` in the `[disk]` table replaces the userland of the running distribution with Gentoo instead of partitioning a disk.
+- The layout is read from the machine, so the table carries no device list.
+- `/bin`, `/sbin`, `/etc`, `/lib`, `/lib64`, `/usr` and `/var` are replaced; `/home`, `/root`, `/srv`, `/opt` and every other path are left alone, and `/etc` is replaced rather than merged.
+
+- The staged system is built under `/gentoo-install.new` while the running one is untouched, each directory is then exchanged with `rename(2)`, and only the writes to the esp or the boot sector follow the exchange.
+- A root below LUKS, LVM or mdraid, a root filesystem this installer cannot describe, a machine with less than 10 GiB free on the root filesystem, and a live medium are each refused by name before anything is written.
+
+## Capabilities
+
+The paths below are implemented and have automated unit or plan coverage unless the verification status identifies a narrower boundary.
+
+**Storage.**
+- The device graph covers GPT and MBR; ext2, ext3, ext4, btrfs subvolumes, xfs, f2fs and vfat; swap; and LUKS2, LVM and mdraid.
+- ZFS belongs to the same graph: a pool is a stripe, a mirror, or raidz1, raidz2 or raidz3 over its vdevs, native encryption is a property of the pool, and each dataset is a node of its own.
+- Existing partition tables can be retained, with a separate keep, format or delete decision for each partition.
+
+| Model node | Fields beyond `id` | Result |
+| --- | --- | --- |
+| `Existing` | `selector`, `wipe` | Selects a pre-existing device. |
+| `PartitionTable` | `disk`, `table`, `create`, `remove` | Creates or edits a partition table. |
+| `Partition` | `table`, `index`, `role`, `size`, `label` | Defines a partition; final `size` may consume remaining space. |
+| `Luks` | `backing`, `name`, `passphrase_file` | Defines a LUKS container. |
+| `MdRaid` | `members`, `level`, `name`, `metadata` | Defines an mdraid array. |
+| `VolumeGroup` | `members`, `name` | Defines an LVM volume group. |
+| `LogicalVolume` | `group`, `name`, `size` | Defines an LVM logical volume. |
+| `ZfsPool` | `vdevs`, `name`, `topology`, `encrypted`, `passphrase_file` | Defines a ZFS pool. |
+| `ZfsDataset` | `pool`, `name` | Defines a ZFS dataset. |
+| `Filesystem` | `device`, `kind`, `label`, `create` | Formats a device, or verifies it when `create = false`. |
+| `Subvolume` | `filesystem`, `name` | Defines a Btrfs subvolume. |
+| `Swap` | `device` | Defines swap on a referenced device. |
+| `Mountpoint` | `source`, `path`, `options` | Mounts a filesystem, Btrfs subvolume, or ZFS dataset. |
+
+| Choice | Values |
+| --- | --- |
+| Partition table | `gpt`, `mbr` |
+| Partition role | `esp`, `bios-boot`, `swap`, `raid`, `lvm`, `zfs`, `data` |
+| mdraid level | `raid0`, `raid1`, `raid5`, `raid6` |
+| mdraid metadata | `0.90`, `1.0`, `1.1`, `1.2` |
+| Filesystem | `ext2`, `ext3`, `ext4`, `btrfs`, `xfs`, `f2fs`, `vfat` |
+| ZFS topology | `stripe`, `mirror`, `raidz1`, `raidz2`, `raidz3` |
+
+The system configuration can configure zram independently of the device graph and swap partitions.
+
+**Disk images.**
+- `mode = "image"` installs into the sparse file named by `disk.image` and sized by `disk.size` instead of onto a disk, so the product is a file that can be copied elsewhere and written later.
+- `mode = "dd"` installs nothing: it streams the image at `disk.source` onto the whole disk at `disk.destination`, decoding `raw`, `gz`, `xz`, `zst` or `tar` as it reads, and keeps whatever layout and bootloader that image already carries.
+- Neither mode accepts the keys of the other, and `partition` mode accepts neither set.
+
+**Boot and system.**
+- GRUB supports UEFI and BIOS, systemd-boot supports UEFI, and ZFSBootMenu boots a ZFS root on UEFI, taking each kernel from the boot environment's own `/boot` inside the pool.
+- The installer configures systemd or OpenRC, dracut, locale, keyboard layout, timezone, hostname, DNS, static addresses and the selected network manager.
+
+**Unlocking an encrypted root over SSH.**
+- `[kernel.remote_unlock]` puts an SSH daemon in the boot path, for a machine whose passphrase prompt nobody is sitting in front of.
+- `enabled` turns it on, `port` defaults to 222 rather than 22 so a client's `known_hosts` entry for the running system does not collide with the initramfs one, and `address`, `gateway` and `interface` give that daemon a static address; an empty address asks for DHCP.
+- A LUKS root is opened by `sys-kernel/dracut-crypt-ssh` in the system initramfs, and a ZFS root by the dropbear ZFSBootMenu builds into its own image.
+- The authorised keys are the ones in `system.authorized_keys`: a configuration that enables the unlock and lists no key is refused by name, because the daemon it describes is one nobody can log in to.
+
+**Desktop and language support.**
+- GNOME, KDE Plasma and Xfce are available with gdm, sddm, lightdm, or greetd and its tuigreet console greeter.
+- Graphics settings cover AMD, Intel, NVIDIA and virtual machines.
+- The package catalog includes fcitx5, Rime, Anthy, Mozc, Hangul and CJK fonts.
+- The kernel choices include `sys-kernel/gentoo-cjk-kernel-bin` and `sys-kernel/gentoo-cjk-kernel`, both of which carry the cjktty patch.
+
+**Portage.**
+- The configuration covers the profile, `MAKEOPTS`, `USE`, `ACCEPT_KEYWORDS`, `L10N`, mirrors and repository synchronization.
+- The gentoo-zh and gig overlays can be selected independently.
+- Selecting `zh-TW`, `zh-CN`, `ja` or `ko` as the interface language also selects the gentoo-zh patched binary kernel and its overlay; selecting `en` does not.
+- Official and gentoo-zh binary package sources have separate settings and keys.
+
+**Session proxy.**
+- The `[proxy]` table accepts `kind`, `host`, `port`, optional `username` and `password`, and `bypass`.
+- `kind` is `http`, `https` or `socks5`; an empty host selects direct connection, which is the default.
+- SOCKS5 derives `socks5h://`, so host names resolve at the proxy for intranet access.
+- The interface has one field per value and a menu for the proxy kind.
+- The bypass value is comma-separated in the interface and a list in TOML.
+
+- The configured proxy is used for stage3 and its signing key, main-tree and overlay version lookups, the `gitweb.gentoo.org` ZFS ebuild lookup, Portage downloads through `make.conf` and `FETCHCOMMAND`/`RESUMECOMMAND`, `wget`, `curl`, `git`, GnuPG, the binhost, overlays and paste upload.
+- The clock, the initial connectivity check and the pre-menu mirror check run before the configuration is available and are therefore not covered by this setting.
+- The installer keeps the credential out of dry-run descriptions and publishes a credential-free proxy endpoint with the bypass list; the installed system receives that endpoint and list.
+
+**Plan and records.**
+- A dry run prints an operation plan without probing storage hardware.
+- A real installation uses the same planner after adding probed mdraid metadata for reused devices, so hardware-dependent validation can change the result.
+- `install.log` records command output, and `install.jsonl` records operations, package sources and binary-package degradation reasons.
+- Before uploading a configuration to `paste.gentoozh.org`, the menu replaces `password_hash` and `root_password_hash` with `removed-before-publishing` and omits the proxy `username` and `password` keys entirely; the other configuration values remain in the upload.
+- The menu displays the resulting page address as text and as a QR code.
+
+## Validation
+
+Validation rejects these combinations:
+
+| Refused combination |
+| --- |
+| An empty, locked, or malformed root hash with no password-authenticating user and no usable SSH-key login. |
+| A ZFS root with GRUB. |
+| `/boot` on ZFS with GRUB. |
+| A ZFS root with BIOS boot. |
+| A ZFS root with a LUKS root chain. |
+| ZFSBootMenu with a root that is not ZFS. |
+| UEFI boot without a mounted ESP. |
+| UEFI boot with an encrypted ESP. |
+| systemd-boot with BIOS boot. |
+| systemd-boot with a kernel or initramfs inaccessible from the ESP because `/boot` is encrypted or not vfat. |
+| An ESP on mdraid with metadata `1.1` or `1.2`. |
+| BIOS boot on a GPT disk without a `bios-boot` partition. |
+| CJK console rendering with a kernel lacking cjktty. |
+| Remote unlock without an authorised SSH key. |
+| Remote unlock without an encrypted root container or pool. |
+| Remote unlock with GRUB that must unlock `/boot` before initramfs SSH starts. |
+| Remote unlock of native ZFS encryption by a GRUB or systemd-boot system initramfs. |
+| A CJK kernel without the `gentoo-zh` overlay. |
+| CJK console rendering with a console font other than `8x16`. |
+| ZFSBootMenu without the `gentoo-zh` overlay. |
+| A gentoo-zh community binhost without the `gentoo-zh` overlay. |
+
+The rules are implemented by [the compatibility model](gentoo_install/model/compat.py) and covered by [its unit tests](tests/unit/test_compat.py). They define accepted configuration, not an end-to-end boot record.
+
+## Configuration files
+
+Configuration files use TOML. The top-level `config_version` field selects the schema version. Storage is a device graph: every device has an `id`, devices refer to other devices by `id`, and selectors are resolved only during a real run.
+
+A single-disk layout is written as `[disk.simple]` instead of a device graph. The parser expands it with the same template the menu uses, so both forms produce the same graph. The graph form remains for LUKS, ZFS, RAID and hand-made partition tables.
+
+```toml
+config_version = 1
+
+[system]
+hostname = "workstation"
+timezone = "UTC"
+locales = ["en_US.UTF-8"]
+locale = "en_US.UTF-8"
+init = "systemd"
+root_password_hash = "$6$gentooinst$IR3GrdJ862XljQYDqocr4tKniIRDIT.jQNFzIrHE3U75H6B6YSWZoSYoVd5edSHpqaYBdiNfXHCoIPRVgb9lT/"
+
+[portage]
+profile = "default/linux/amd64/23.0/systemd"
+makeopts = "-j4"
+
+[bootloader]
+kind = "grub"
+firmware = "uefi"
+
+[disk.simple]
+disk = "/dev/disk/by-id/virtio-target0"
+filesystem = "ext4"
+swap = "2GiB"
+```
+
+The hash above is an example and must be replaced before execution. Only `disk` is required. An omitted key takes the installer default: `whole-disk`, `uefi`, a partition table chosen by the firmware, `xfs`, no swap, no encryption. A file must not carry both `[disk.simple]` and `[[disk.devices]]`.
+
+[`tests/fixtures/vm-binpkg.toml`](tests/fixtures/vm-binpkg.toml) is a complete UEFI and ext4 schema reference. Other files under [`tests/fixtures/`](tests/fixtures/) cover BIOS, LUKS2, LVM, mdraid, ZFS, btrfs subvolumes and desktops. They contain virtual-machine disk selectors and test credentials, so they must not be installed unchanged on a real machine.
+
+Parsing and planning do not probe storage hardware. A machine without the target disk can therefore check a configuration with `--dry-run`.
+
+The following reference names every persisted key. A table path is TOML table notation, and `[[disk.devices]]` carries the graph nodes.
+
+| Key | Meaning and default or choices |
+| --- | --- |
+| `config_version` | Persisted schema version; `1`. |
+| `proxy.kind` | Proxy scheme: `http`, `https`, or `socks5`; `http`. |
+| `proxy.host` | Proxy host; `""` disables the proxy. |
+| `proxy.port` | Proxy port; `0`. |
+| `proxy.username` | Optional proxy user name; `""`. |
+| `proxy.password` | Optional proxy password; `""`. |
+| `proxy.bypass` | Hosts that bypass the proxy; `[]`. |
+
+| `system` key | Meaning and default or choices |
+| --- | --- |
+| `hostname` | Target hostname; `gentoo`. |
+| `timezone` | Target timezone; `Asia/Shanghai`. |
+| `locales` | Generated locales; `en_US.UTF-8`, `zh_CN.UTF-8`, `zh_TW.UTF-8`. |
+| `locale` | Selected locale; `zh_CN.UTF-8`. |
+| `keymap` | Installed-system keymap; `us`. |
+| `keymap_initramfs` | Initramfs keymap; `""` follows `keymap`. |
+| `interface` | Network-interface pattern; `""` matches `en*` and `eth*`. |
+| `addresses` | Static CIDR addresses; `[]` selects DHCP or router advertisements. |
+| `gateways` | Gateways, at most one per address family; `[]`. |
+| `dns` | Resolver addresses; `[]`. |
+| `authorized_keys` | Keys for root and sudo users; `[]`. |
+| `console_cjk` | Requests CJK console rendering; `false`; it needs cjktty. |
+| `console_font` | Console cell size: `8x8`, `8x16`, or `16x32`; `8x16`. |
+| `init` | Init system: `openrc` or `systemd`; `systemd`. |
+| `zram` | Compressed-RAM swap size; unset disables it. |
+| `hardware_clock_utc` | RTC stores UTC; `true`. |
+| `users` | User records; `[]`. |
+| `root_password_hash` | Root `crypt(3)` hash; `""` locks root. |
+| `logger` | Logger: `none`, `sysklogd`, `syslog-ng`, or `metalog`; `sysklogd`. |
+| `cron` | Installs `sys-process/cronie`; `true`. |
+| `sshd` | Installs and configures SSH daemon support; `false`. |
+| `sshd_password_login` | SSH daemon accepts passwords; `false`. |
+| `sshd_root_login` | Root may log in through SSH; `false`. |
+| `networking` | Link management: `builtin`, `networkmanager-wpa`, `networkmanager-iwd`, or `none`; `builtin`. |
+| `firewall` | Packet-filter package: `none`, `nftables`, or `iptables`; `none`. |
+| `first_boot` | First-boot record; empty record by default. |
+
+| `system.users` item | Meaning and default |
+| --- | --- |
+| `name` | User name; required. |
+| `groups` | Supplementary groups; `[]`. |
+| `shell` | Login shell; `/bin/bash`. |
+| `sudo` | Makes the user a sudo user; `false`. |
+| `password_hash` | User `crypt(3)` hash; `""` locks the account. |
+
+| `system.first_boot` key | Meaning and default |
+| --- | --- |
+| `commands` | Shell lines run in order after the fetched script; `[]`. |
+| `url` | Script URL; `""` omits a fetched script. |
+
+| `portage` key | Meaning and default or choices |
+| --- | --- |
+| `profile` | Portage profile; `default/linux/amd64/23.0/systemd`. |
+| `keywords` | Global keyword channel: `stable` or `testing`; `stable`. |
+| `sync` | Ongoing sync: `git`, `webrsync`, or `rsync`; `git`. First sync uses webrsync. |
+| `testing_packages` | Atoms accepted as testing while the system remains stable; `[]`. |
+| `makeopts` | `MAKEOPTS`; `""`. |
+| `common_flags` | Common compiler flags; `-O2 -pipe`. |
+| `use` | `USE` flags; `[]`. |
+| `video_cards` | `VIDEO_CARDS` values; `[]`. |
+| `l10n` | `L10N`; `[]` derives values from generated locales. |
+| `input_devices` | `INPUT_DEVICES`; `["libinput"]`. |
+| `accept_license` | Accepted licenses; `["@FREE"]`. |
+| `cpu_flags` | CPU flags; `[]` preserves the profile value. |
+| `build_in_ram` | `/var/tmp/portage` tmpfs size; unset builds on disk. |
+| `mirrors` | Mirror record; defaults shown below. |
+| `binhost` | Binary-host record; defaults shown below. |
+| `overlays` | Overlay records; `[]`. |
+
+| `portage.mirrors` key | Meaning and default or choices |
+| --- | --- |
+| `region` | Gentoo mirror region: `cn` or `global`; `global`. |
+| `speed_test` | Speed-tests offered mirrors; `false`. |
+| `distfiles` | Custom distfile bases; a nonempty list replaces the built-in list. |
+| `repo_sync_uri` | Explicit repository sync URI; `""`. |
+| `site` | Site key in `region`; `""` selects the region's first site. |
+| `gentoo_distfiles` | Writes `GENTOO_MIRRORS`; `true`. |
+| `gentoo_zh` | gentoo-zh mirror: `upstream`, `cernet`, `nju`, `nyist`, or `ha`; `upstream`. |
+| `gentoo_zh_distfiles` | Appends gentoo-zh distfiles to `GENTOO_MIRRORS`; `true`. |
+
+| Mirror region | Site keys |
+| --- | --- |
+| `cn` | `ustc`, `nju`, `bfsu`, `tuna`, `zju`, `sdu`, `hust`, `sustech`, `hit`, `lzu`, `aliyun`, `netease`, `cernet`, `cicku-hk`, `planetunix-hk`, `xtom-hk`, `rackspace-hk`, `aditsu-hk`, `nchc-tw`, `cicku-tw`, `freedif-sg`, `cicku-sg`, `planetunix-sg` |
+| `global` | `gentoo`, `osuosl` |
+
+| `portage.binhost` key | Meaning and default or choices |
+| --- | --- |
+| `official` | Enables the official binary host; `true`. |
+| `subarch` | Official binary-host subarchitecture; `x86-64`. |
+| `community` | gentoo-zh channel: `off`, `stable`, or `unstable`; `off`. |
+
+| `portage.overlays` item | Meaning |
+| --- | --- |
+| `name` | Overlay name; required. |
+| `sync_uri` | Overlay synchronization URI; required. |
+
+| `kernel` key | Meaning and default or choices |
+| --- | --- |
+| `source` | Kernel choice: `dist-bin`, `dist-source`, `cjk-bin`, or `cjk`; `dist-bin`. |
+| `package` | Overrides the package implied by `source`; `""`. |
+| `version` | Version pin; `""` lets Portage choose the newest keyword-allowed version. |
+| `dracut_modules` | Adds dracut modules required by the disk layout; `[]`. |
+| `remote_unlock` | Initramfs SSH-unlock record; empty record by default. |
+
+| `kernel.source` | Package and CJK status |
+| --- | --- |
+| `dist-bin` | `sys-kernel/gentoo-kernel-bin`; not a CJK kernel. |
+| `dist-source` | `sys-kernel/gentoo-kernel`; not a CJK kernel. |
+| `cjk-bin` | `sys-kernel/gentoo-cjk-kernel-bin`; CJK kernel. |
+| `cjk` | `sys-kernel/gentoo-cjk-kernel`; CJK kernel. |
+
+| `kernel.remote_unlock` key | Meaning and default |
+| --- | --- |
+| `enabled` | Enables initramfs SSH unlocking; `false`. |
+| `port` | Initramfs SSH port; `222`. |
+| `address` | Static CIDR address; `""` uses DHCP. |
+| `gateway` | Static-address gateway; `""`. |
+| `interface` | Initramfs network interface; `""`. |
+
+| `bootloader` key | Meaning and default or choices |
+| --- | --- |
+| `kind` | Bootloader: `grub`, `systemd-boot`, or `zfsbootmenu`; `grub`. |
+| `firmware` | Firmware: `uefi` or `bios`; `uefi`. |
+| `kernel_params` | Additional kernel command-line parameters; `[]`. |
+
+| `packages` key | Meaning and default |
+| --- | --- |
+| `desktop` | Desktop profile name; `""` selects no desktop. |
+| `applications` | Package-group names; `[]`. |
+| `graphics` | Graphics-driver group names; `[]`; multiple groups fit hybrid hardware. |
+| `display_manager` | Display-manager group; `""` selects console login. |
+| `extra` | Package atoms merged after other selections; `[]`. |
+
+| `disk` key | Meaning and default or choices |
+| --- | --- |
+| `graph` | Device graph represented by `[[disk.devices]]`; required. |
+| `root` | Root graph-node identifier; required outside conversion; `""` uses the running layout in conversion. |
+| `mode` | `partition`, `in-place`, `image`, or `dd`; `partition`. |
+| `image` | Sparse image path in image mode; `""`. |
+| `size` | Sparse image size in image mode; unset. |
+| `wipe` | Disk-level wipe setting; `false`. |
+| `source` | Prepared-image source in `dd` mode; `""`. |
+| `source_format` | Source encoding: `raw`, `gz`, `xz`, `zst`, or `tar`; `raw`. |
+| `destination` | Whole-disk `dd` destination; `""`. |
+
+| Template input | Meaning and default or choices |
+| --- | --- |
+| `disk` | Whole-disk selector; required. |
+| `layout` | `whole-disk`, `whole-disk-btrfs`, `whole-disk-zfs`, or `reuse`; `whole-disk`. |
+| `firmware` | Template firmware; `uefi`. |
+| `table` | Partition-table override; unset derives GPT for UEFI and MBR for BIOS. |
+| `filesystem` | Root filesystem for non-Btrfs and non-ZFS whole-disk layouts; `xfs`. |
+| `swap` | Swap-partition size; unset. |
+| `passphrase_file` | Installing-system passphrase-file path; `""` leaves the layout unencrypted. |
+| `pool` | ZFS pool name; `rpool`. |
+
+The following complete configuration demonstrates a proxy with credentials and two bypass hosts. The credential is an example and must be replaced before execution:
+
+```toml
+config_version = 1
+
+[proxy]
+kind = "socks5"
+host = "proxy.example"
+port = 1080
+username = "operator"
+password = "secret"
+bypass = ["localhost", "intranet.example"]
+
+[system]
+hostname = "proxy-target"
+timezone = "UTC"
+locales = ["en_US.UTF-8"]
+locale = "en_US.UTF-8"
+init = "openrc"
+root_password_hash = "$6$gentooinst$IR3GrdJ862XljQYDqocr4tKniIRDIT.jQNFzIrHE3U75H6B6YSWZoSYoVd5edSHpqaYBdiNfXHCoIPRVgb9lT/"
+
+[portage]
+profile = "default/linux/amd64/23.0"
+makeopts = "-j4"
+
+[portage.binhost]
+official = false
+
+[bootloader]
+firmware = "bios"
+
+[disk]
+root = "mnt-root"
+
+[[disk.devices]]
+kind = "existing"
+id = "disk"
+selector = "/dev/disk/by-id/virtio-target0"
+wipe = true
+
+[[disk.devices]]
+kind = "table"
+id = "table"
+disk = "disk"
+table = "mbr"
+
+[[disk.devices]]
+kind = "partition"
+id = "rootpart"
+table = "table"
+index = 1
+role = "data"
+
+[[disk.devices]]
+kind = "filesystem"
+id = "rootfs"
+device = "rootpart"
+type = "ext4"
+
+[[disk.devices]]
+kind = "mountpoint"
+id = "mnt-root"
+source = "rootfs"
+path = "/"
+```
+
+## Binary packages
+
+Binary packages are optional. Disabling them keeps source builds available. The official binhost and the gentoo-zh binhost are separate options with separate trust configuration. No current end-to-end evidence covers an unreachable binhost, a missing signature or an untrusted key; these degradation paths remain unverified.
+
+A verified binhost runs `getuto`, imports its signing key, locally signs that key with `lsign`, and enables signature verification. A failed host, missing signature, or untrusted key degrades that binhost to source compilation and records the reason.
+
+## Exit codes
+
+| Code | `gentoo-install` |
+| --- | --- |
+| `0` | successful completion |
+| `1` | configuration error |
+| `2` | `argparse` usage error or preflight failure |
+| `3` | integrity failure |
+| `4` | download, external-command, OS or uncategorized installer failure |
+| `5` | operator abort |
+
+`bootstrap.sh` can also exit `1` before the Python CLI starts when its Python, required-command or root checks fail.

--- a/tests/unit/test_readme.py
+++ b/tests/unit/test_readme.py
@@ -1,18 +1,14 @@
 # SPDX-License-Identifier: GPL-2.0-or-later
-"""The README set is five files that have to move together.
-
-Five translations drift the moment one of them is edited alone, and the drift
-is invisible to a reader who reads only one of them.
-"""
+"""Keep the five concise READMEs and English reference aligned."""
 
 from __future__ import annotations
 
 import re
+import tomllib
 from pathlib import Path
 
 ROOT = Path(__file__).resolve().parents[2]
 
-#: Every translation, and the language each one is written in.
 READMES = {
     "README.md": "en",
     "README.zh-TW.md": "zh-TW",
@@ -20,26 +16,8 @@ READMES = {
     "README.ja.md": "ja",
     "README.ko.md": "ko",
 }
-
-#: What the top of each file has to offer, so a reader who lands on any one of
-#: them can reach the other four.
+REFERENCE = "REFERENCE.md"
 SWITCHER = tuple(READMES)
-
-#: Both pictures, in both files, at the top. A README that lost one of them
-#: still reads as complete.
-#: One menu capture per locale, so a reader sees the interface in the
-#: language the file they opened is written in.
-PICTURES = (
-    "screenshot-en.png",
-    "screenshot-zh-TW.png",
-    "screenshot-zh-CN.png",
-    "screenshot-ja.png",
-    "screenshot-ko.png",
-    "cjk-console.png",
-)
-
-#: Which capture each file shows, so the interface is in the language the
-#: reader chose by opening that file.
 MENU_PICTURES = {
     "README.md": "screenshot-en.png",
     "README.zh-TW.md": "screenshot-zh-TW.png",
@@ -47,70 +25,102 @@ MENU_PICTURES = {
     "README.ja.md": "screenshot-ja.png",
     "README.ko.md": "screenshot-ko.png",
 }
-
 SECTIONS = {
     "README.md": (
-        "Requirements", "Safety", "Installation", "Installing from memory",
-        "Converting a running system", "Resuming an interrupted run", "Capabilities",
-        "Verification status", "Configuration files", "Binary packages", "Exit codes",
-        "Questions", "Contributing", "License"
+        "Capabilities at a glance",
+        "Verification status",
+        "Requirements",
+        "Safety",
+        "Installation",
+        "Configuration files",
+        "Resuming an interrupted run",
+        "Binary packages",
+        "Reference",
+        "Contributing",
+        "License",
     ),
     "README.zh-TW.md": (
-        "\u9700\u6c42", "\u5b89\u5168\u4e8b\u9805", "\u5b89\u88dd",
-        "\u5f9e\u8a18\u61b6\u9ad4\u5b89\u88dd",
-        "\u8f49\u63db\u57f7\u884c\u4e2d\u7684\u7cfb\u7d71",
-        "\u5f9e\u4e2d\u65b7\u8655\u7e7c\u7e8c", "\u529f\u80fd", "\u9a57\u8b49\u72c0\u614b",
-        "\u8a2d\u5b9a\u6a94", "\u4e8c\u9032\u4f4d\u5957\u4ef6", "\u9000\u51fa\u78bc",
-        "\u5e38\u898b\u554f\u984c", "\u53c3\u8207\u958b\u767c", "\u6388\u6b0a"
+        "\u529f\u80fd\u6982\u8981",
+        "\u9a57\u8b49\u72c0\u614b",
+        "\u9700\u6c42",
+        "\u5b89\u5168\u4e8b\u9805",
+        "\u5b89\u88dd",
+        "\u8a2d\u5b9a\u6a94",
+        "\u5f9e\u4e2d\u65b7\u8655\u7e7c\u7e8c",
+        "\u4e8c\u9032\u4f4d\u5957\u4ef6",
+        "\u53c3\u8003\u8cc7\u6599",
+        "\u53c3\u8207\u958b\u767c",
+        "\u6388\u6b0a",
     ),
     "README.zh-CN.md": (
-        "\u8981\u6c42", "\u5b89\u5168\u4e8b\u9879", "\u5b89\u88c5",
-        "\u4ece\u5185\u5b58\u5b89\u88c5", "\u8f6c\u6362\u8fd0\u884c\u4e2d\u7684\u7cfb\u7edf",
-        "\u4ece\u4e2d\u65ad\u5904\u7ee7\u7eed", "\u529f\u80fd", "\u9a8c\u8bc1\u72b6\u6001",
-        "\u914d\u7f6e\u6587\u4ef6", "\u4e8c\u8fdb\u5236\u8f6f\u4ef6\u5305",
-        "\u9000\u51fa\u7801", "\u5e38\u89c1\u95ee\u9898", "\u53c2\u4e0e\u5f00\u53d1",
-        "\u8bb8\u53ef"
+        "\u529f\u80fd\u6982\u8981",
+        "\u9a8c\u8bc1\u72b6\u6001",
+        "\u8981\u6c42",
+        "\u5b89\u5168\u4e8b\u9879",
+        "\u5b89\u88c5",
+        "\u914d\u7f6e\u6587\u4ef6",
+        "\u4ece\u4e2d\u65ad\u5904\u7ee7\u7eed",
+        "\u4e8c\u8fdb\u5236\u8f6f\u4ef6\u5305",
+        "\u53c2\u8003\u8d44\u6599",
+        "\u53c2\u4e0e\u5f00\u53d1",
+        "\u8bb8\u53ef",
     ),
     "README.ja.md": (
-        "\u8981\u4ef6", "\u5b89\u5168\u4e0a\u306e\u6ce8\u610f",
+        "\u6a5f\u80fd\u306e\u6982\u8981",
+        "\u691c\u8a3c\u72b6\u6cc1",
+        "\u8981\u4ef6",
+        "\u5b89\u5168\u4e0a\u306e\u6ce8\u610f",
         "\u30a4\u30f3\u30b9\u30c8\u30fc\u30eb",
-        "\u30e1\u30e2\u30ea\u304b\u3089\u306e\u30a4\u30f3\u30b9\u30c8\u30fc\u30eb",
-        "\u7a3c\u50cd\u4e2d\u306e\u30b7\u30b9\u30c6\u30e0\u306e\u5909\u63db",
-        "\u4e2d\u65ad\u3057\u305f\u5b9f\u884c\u306e\u518d\u958b", "\u6a5f\u80fd",
-        "\u691c\u8a3c\u72b6\u6cc1", "\u8a2d\u5b9a\u30d5\u30a1\u30a4\u30eb",
+        "\u8a2d\u5b9a\u30d5\u30a1\u30a4\u30eb",
+        "\u4e2d\u65ad\u3057\u305f\u5b9f\u884c\u306e\u518d\u958b",
         "\u30d0\u30a4\u30ca\u30ea\u30d1\u30c3\u30b1\u30fc\u30b8",
-        "\u7d42\u4e86\u30b3\u30fc\u30c9", "\u3088\u304f\u3042\u308b\u8cea\u554f",
-        "\u958b\u767a\u3078\u306e\u53c2\u52a0", "\u30e9\u30a4\u30bb\u30f3\u30b9"
+        "\u30ea\u30d5\u30a1\u30ec\u30f3\u30b9",
+        "\u958b\u767a\u3078\u306e\u53c2\u52a0",
+        "\u30e9\u30a4\u30bb\u30f3\u30b9",
     ),
     "README.ko.md": (
-        "\uc694\uad6c \uc0ac\ud56d", "\uc548\uc804", "\uc124\uce58",
-        "\uba54\ubaa8\ub9ac\uc5d0\uc11c \uc124\uce58",
-        "\uc2e4\ud589 \uc911\uc778 \uc2dc\uc2a4\ud15c \ubcc0\ud658",
-        "\uc911\ub2e8\ub41c \uc2e4\ud589 \uc7ac\uac1c", "\uae30\ub2a5",
-        "\uac80\uc99d \uc0c1\ud0dc", "\uc124\uc815 \ud30c\uc77c",
-        "\ubc14\uc774\ub108\ub9ac \ud328\ud0a4\uc9c0", "\uc885\ub8cc \ucf54\ub4dc",
-        "\uc790\uc8fc \ubb3b\ub294 \uc9c8\ubb38", "\uae30\uc5ec", "\ub77c\uc774\uc120\uc2a4"
+        "\uae30\ub2a5 \uac1c\uc694",
+        "\uac80\uc99d \uc0c1\ud0dc",
+        "\uc694\uad6c \uc0ac\ud56d",
+        "\uc548\uc804",
+        "\uc124\uce58",
+        "\uc124\uc815 \ud30c\uc77c",
+        "\uc911\ub2e8\ub41c \uc2e4\ud589 \uc7ac\uac1c",
+        "\ubc14\uc774\ub108\ub9ac \ud328\ud0a4\uc9c0",
+        "\ucc38\uc870 \ubb38\uc11c",
+        "\uae30\uc5ec",
+        "\ub77c\uc774\uc120\uc2a4",
     ),
 }
-
 FACT_UNITS = (
     "identity",
+    "capability-summary",
+    "verification-scope",
     "requirements-runtime",
-    "requirements-version-sources", "requirements-network-filter", "requirements-bootstrap",
-    "safety-destructive", "safety-review-backup", "install-download", "install-terminal",
-    "install-config-workflow", "install-root-shell",
-    "install-memory", "install-in-place",
-    "resume-behavior", "resume-limits",
-    "capability-scope", "storage-device-graph", "zram-system",
-    "in-place-conversion", "prepared-image", "boot-system", "remote-unlock",
-    "desktop-language", "portage", "proxy",
-    "memory-environment", "memory-environment-access",
-    "plan-records", "verification-scope",
-    "config-model", "config-simple", "config-fixtures", "config-dry-run",
-    "binary-packages", "exit-codes",
-    "faq-customisation", "contributing", "license",
+    "safety-destructive",
+    "safety-review-backup",
+    "install-download",
+    "install-terminal",
+    "install-config-workflow",
+    "install-root-shell",
+    "configuration-reference",
+    "resume-limits",
+    "binary-packages",
+    "reference",
+    "contributing",
+    "license",
 )
-
+REFERENCE_SECTIONS = (
+    "Runtime requirements",
+    "Command line",
+    "Memory environment",
+    "In-place conversion",
+    "Capabilities",
+    "Validation",
+    "Configuration files",
+    "Binary packages",
+    "Exit codes",
+)
 SECOND_PERSON = {
     "en": re.compile(r"\b(?:you|your|yours)\b", re.IGNORECASE),
     "zh-TW": re.compile(r"[\u4f60\u59b3\u60a8]|\u8acb"),
@@ -120,407 +130,183 @@ SECOND_PERSON = {
 }
 
 
-def readme(name: str) -> str:
-    return (ROOT / name).read_text()
+def document(name: str) -> str:
+    return (ROOT / name).read_text(encoding="utf-8")
 
 
 def fact_bodies(name: str) -> dict[str, str]:
     found: dict[str, str] = {}
     for match in re.finditer(
         r"<!-- fact: ([a-z0-9-]+) -->\n\n(.*?)(?=\n\n<!-- fact:|\n\n## |\Z)",
-        readme(name),
+        document(name),
         re.S,
     ):
         found[match.group(1)] = match.group(2).strip()
     return found
 
 
-def test_every_readme_exists_and_links_to_all_the_others() -> None:
+def shell_commands(name: str) -> list[str]:
+    commands: list[str] = []
+    for block in re.findall(r"```sh\n(.*?)```", document(name), re.S):
+        for line in block.splitlines():
+            command = line.split("#", 1)[0].strip()
+            if command:
+                commands.append(command)
+    return commands
+
+
+def links(name: str) -> set[str]:
+    return set(re.findall(r"\]\(([^)#]+)", document(name)))
+
+
+def test_every_readme_exists_links_to_all_translations_and_shows_its_menu() -> None:
     for name in READMES:
-        first = (ROOT / name).read_text().splitlines()[0]
+        first = document(name).splitlines()[0]
         for other in SWITCHER:
             if other == name:
-                continue
-            assert f"({other})" in first, f"{name} does not link to {other}"
+                assert f"({other})" not in first, name
+            else:
+                assert f"({other})" in first, f"{name} does not link to {other}"
 
-
-def test_no_readme_links_to_itself() -> None:
-    """A self-link reads as another translation and goes nowhere."""
-    for name in READMES:
-        first = (ROOT / name).read_text().splitlines()[0]
-        assert f"({name})" not in first, name
-
-
-def test_both_pictures_are_in_every_readme_and_on_disk() -> None:
-    for picture in PICTURES:
+        picture = MENU_PICTURES[name]
         assert (ROOT / picture).is_file(), picture
-    for name in READMES:
-        said = (ROOT / name).read_text()
-        # The menu capture is the one in this file's own language: a reader
-        # who opened the Korean file is shown the Korean interface.
-        assert f"({MENU_PICTURES[name]})" in said, f"{name} is missing its own menu capture"
-        assert "(cjk-console.png)" in said, f"{name} is missing cjk-console.png"
+        assert f"({picture})" in document(name), name
+        assert "(cjk-console.png)" not in document(name), name
 
 
-def test_every_readme_carries_the_complete_ordered_sections() -> None:
+def test_every_readme_has_the_same_concise_factual_shape() -> None:
     for name, expected in SECTIONS.items():
-        assert tuple(re.findall(r"^## (.+)$", readme(name), re.M)) == expected, name
-
-
-def test_every_readme_carries_the_same_nonempty_factual_units() -> None:
-    for name in READMES:
+        assert tuple(re.findall(r"^## (.+)$", document(name), re.M)) == expected, name
         bodies = fact_bodies(name)
         assert tuple(bodies) == FACT_UNITS, name
         assert all(bodies.values()), name
 
 
-def test_reviewed_cross_locale_claims_stay_attached_to_their_factual_units() -> None:
-    common = {
-        # The records themselves live in `TESTED.md`, which is one file rather
-        # than five: what every README has to carry is the boundary and the
-        # pointer, or a reader takes an implemented path for a tested one.
-        "verification-scope": ("TESTED.md", "tests/fixtures/", "ext4", "LUKS2"),
-        "requirements-version-sources": (
-            "packages.gentoo.org", "api.github.com/repos/gentoo-zh/overlay/contents",
-            "gitweb.gentoo.org",
-        ),
-        "portage": ("zh-TW", "zh-CN", "ja", "ko", "en", "gentoo-zh"),
-        # Each of these is a name or a number a reader acts on, so a
-        # translation that drops one leaves that locale unable to use the
-        # path the other four document.
-        "storage-device-graph": ("ZFS", "stripe", "mirror", "raidz1", "raidz2", "raidz3"),
-        "prepared-image": (
-            "disk.image", "disk.size", "disk.source", "disk.destination",
-            "`raw`", "`gz`", "`xz`", "`zst`", "`tar`",
-        ),
-        "boot-system": ("GRUB", "systemd-boot", "ZFSBootMenu"),
-        "remote-unlock": (
-            "[kernel.remote_unlock]", "222", "dracut-crypt-ssh",
-            "system.authorized_keys", "ZFSBootMenu",
-        ),
-        "desktop-language": ("greetd", "tuigreet"),
-        "exit-codes": ("argparse", "bootstrap.sh", "`1`", "`2`"),
-    }
-    backups = {
-        "README.md": "separate backup",
-        "README.zh-TW.md": "\u53e6\u6709\u5099\u4efd",
-        "README.zh-CN.md": "\u72ec\u7acb\u4e8e\u6240\u9009\u78c1\u76d8\u7684\u5907\u4efd",
-        "README.ja.md": "\u9078\u629e\u3057\u305f\u30c7\u30a3\u30b9\u30af\u3068\u306f\u5225\u306e\u30d0\u30c3\u30af\u30a2\u30c3\u30d7",
-        "README.ko.md": "\uc120\ud0dd\ud55c \ub514\uc2a4\ud06c\uc640 \ubd84\ub9ac\ub41c \uc704\uce58\uc5d0 \ubcc4\ub3c4 \ubc31\uc5c5",
-    }
-    install_alternatives = {
-        "README.md": "one of the two",
-        "README.zh-TW.md": "\u64c7\u4e00",
-        "README.zh-CN.md": "\u62e9\u4e00",
-        "README.ja.md": "\u3044\u305a\u308c\u304b\u4e00\u65b9",
-        "README.ko.md": "\ud558\ub098\ub9cc",
-    }
-    # The three the installer now compares, in each locale's own words. The
-    # sentence used to name what was *not* checked; it names what is.
-    resume_identity = {
-        "README.md": "same installer and the same configuration file",
-        "README.zh-TW.md": "\u540c\u4e00\u500b\u5b89\u88dd\u5668\u8207\u540c\u4e00\u4efd\u8a2d\u5b9a\u6a94",
-        "README.zh-CN.md": "\u540c\u4e00\u4e2a\u5b89\u88c5\u7a0b\u5e8f\u4e0e\u540c\u4e00\u4efd\u914d\u7f6e\u6587\u4ef6",
-        "README.ja.md": "\u540c\u3058\u30a4\u30f3\u30b9\u30c8\u30fc\u30e9\u30fc\u3001\u540c\u3058\u8a2d\u5b9a\u30d5\u30a1\u30a4\u30eb",
-        "README.ko.md": "\ub3d9\uc77c\ud55c \uc124\uce58 \ud504\ub85c\uadf8\ub7a8, \ub3d9\uc77c\ud55c \uc124\uc815 \ud30c\uc77c",
-    }
-    #: Every locale says the installer stops rather than only documenting it.
-    resume_boot_id = dict.fromkeys(resume_identity, "boot id")
-    resume_digest_limit = {
-        "README.md": "shared helper or constant",
-        "README.zh-TW.md": "\u5171\u7528\u8f14\u52a9\u51fd\u5f0f\u6216\u5e38\u6578",
-        "README.zh-CN.md": "\u5171\u7528\u8f85\u52a9\u51fd\u6570\u6216\u5e38\u91cf",
-        "README.ja.md": "\u5171\u6709\u306e\u30d8\u30eb\u30d1\u30fc\u3084\u5b9a\u6570",
-        "README.ko.md": "\uacf5\uc6a9 \ud5ec\ud37c\ub098 \uc0c1\uc218",
-    }
+def test_readme_facts_preserve_safety_configuration_and_verification_boundaries() -> None:
     for name in READMES:
         bodies = fact_bodies(name)
-        for unit, tokens in common.items():
-            assert all(token in bodies[unit] for token in tokens), (name, unit)
-        assert backups[name] in bodies["safety-review-backup"], name
-        assert install_alternatives[name] in bodies["install-config-workflow"], name
-        assert resume_identity[name] in bodies["resume-limits"], name
-        assert resume_boot_id[name] in bodies["resume-limits"], name
-        assert resume_digest_limit[name] in bodies["resume-limits"], name
-        assert "zram" not in bodies["storage-device-graph"], name
-        assert "zram" in bodies["zram-system"], name
+        assert "TESTED.md" in bodies["verification-scope"], name
+        assert "tests/fixtures/" in bodies["verification-scope"], name
+        assert "`0`" in bodies["verification-scope"], name
+        assert "wipe = true" in bodies["safety-destructive"], name
+        assert "dry-run" in bodies["safety-review-backup"], name
+        assert "/dev/disk/by-id/" in bodies["safety-review-backup"], name
+        assert "my-install.toml" in bodies["install-config-workflow"], name
+        assert "--no-shell" in bodies["install-root-shell"], name
+        assert "REFERENCE.md#configuration-files" in bodies["configuration-reference"], name
+        assert "tests/fixtures/vm-binpkg.toml" in bodies["configuration-reference"], name
+        assert "--resume" in bodies["resume-limits"], name
+        assert "/run/gentoo-install/install.jsonl" in bodies["resume-limits"], name
+        assert "binhost" in bodies["binary-packages"], name
+        assert "gentoo-zh" in bodies["binary-packages"], name
+        assert "REFERENCE.md" in bodies["reference"], name
 
 
-def test_the_record_file_holds_what_the_readmes_stopped_carrying() -> None:
-    """Five copies of a record set drift; one does not. What the READMEs keep
-    is the boundary and the pointer, and `TESTED.md` keeps the rows."""
-    from pathlib import Path
+def test_configuration_workflow_remains_safe_and_identical_across_locales() -> None:
+    english = shell_commands("README.md")
+    assert english == [
+        "curl -fsSL https://github.com/Zakkaus/gentoo-install/archive/refs/heads/master.tar.gz | tar xz",
+        "cd gentoo-install-master",
+        "./bootstrap.sh",
+        "./bootstrap.sh --config my-install.toml --dry-run",
+        "./bootstrap.sh --config my-install.toml",
+        "./bootstrap.sh --config my-install.toml --no-shell",
+        "./bootstrap.sh --config my-install.toml --resume",
+    ]
+    for name in READMES:
+        assert shell_commands(name) == english, name
+        workflow = fact_bodies(name)["install-config-workflow"]
+        assert workflow.index("--dry-run") < workflow.index("./bootstrap.sh --config my-install.toml\n")
 
-    record = Path("TESTED.md").read_text(encoding="utf-8")
-    for revision in (
-        "b931ef46fc15ed50385f70467f2bfb0a8d1fd154",
-        "7cf09c2f9d9c",
-        "bcc090fab621",
-        "71e751cf14a1",
-        "0827931289d0",
+
+def test_reference_holds_the_moved_lookup_material() -> None:
+    text = document(REFERENCE)
+    assert not re.search(r"[\u4e00-\u9fff]", text)
+    assert tuple(re.findall(r"^## (.+)$", text, re.M)) == REFERENCE_SECTIONS
+    for required in (
+        "packages.gentoo.org",
+        "--disarm",
+        'mode = "in-place"',
+        "gentoo_install/model/compat.py",
+        "config_version",
+        "getuto",
+        "`5`",
     ):
-        assert revision in record, revision
-    # A section for each mode, including the one with nothing in it yet: an
-    # absent section reads as an oversight, an empty one as a fact.
-    for heading in ("## Mode 1", "## Mode 2", "## Mode 3"):
-        assert heading in record, heading
-    # Every path in mode 3 has a record, and what is still missing is named
-    # where the rows are: a section carrying only records reads as a finished
-    # mode, and one carrying only gaps reads as a plan.
-    assert "install or shell>" in record, "the record says what came up"
-    assert "read it back byte-for-byte" in record, "and what was written"
-    assert (
-        "a machine that goes on to install Gentoo from inside the environment"
-        in " ".join(record.split())
-    ), "the boundary of mode 3 is stated where its rows are"
-
-    # And every README points at it rather than repeating it.
-    for name in READMES:
-        body = fact_bodies(name)["verification-scope"]
-        assert "TESTED.md" in body, name
-        assert "b931ef46" not in body, f"{name} still carries a record"
+        assert required in text, required
 
 
-def test_proxy_is_documented_in_every_readme_and_the_example_parses() -> None:
-    from dataclasses import fields
-    import tomllib
-
-    from gentoo_install.model.config import InstallConfig
+def test_all_embedded_toml_examples_parse_and_validate() -> None:
     from gentoo_install.model.parse import parse
     from gentoo_install.model.validate import validate
 
-    proxy_implemented = any(field.name == "proxy" for field in fields(InstallConfig))
-    for name in READMES:
-        body = fact_bodies(name)["proxy"]
-        assert "socks5h" in body and "bypass" in body and "dry-run" in body, name
-        examples = re.findall(r"```toml\n(.*?)```", readme(name), re.S)
-        example = next(example for example in examples if "[proxy]" in example)
-        raw = tomllib.loads(example)
-        assert raw["proxy"]["kind"] == "socks5"
-        assert raw["proxy"]["host"] == "proxy.example"
-        if proxy_implemented:
-            validate(parse(raw))
-
-
-def test_translated_closed_lists_have_no_open_ended_marker() -> None:
-    banned = {
-        "README.zh-CN.md": ("\u7b49", "\u5305\u62ec"),
-        "README.ja.md": ("\u306a\u3069",),
-        "README.ko.md": ("\ub4f1\uc758", "\ube44\ub86f\ud55c"),
-    }
-    for name, markers in banned.items():
-        bodies = fact_bodies(name)
-        scope = bodies["storage-device-graph"] + bodies["requirements-bootstrap"]
-        assert all(marker not in scope for marker in markers), name
-
-
-def test_simplified_chinese_keeps_required_inline_spacing() -> None:
-    banned = (
-        "\u5305\u542b \u5b50\u5377 \u7684",
-        "Xfce \uff0c",
-        "\u65e5\u5fd7`install.log`",
-        "\u4f7f\u7528`--lang",
-        "\u4f7f\u7528`--no-shell`",
-    )
-    said = readme("README.zh-CN.md")
-    assert all(fragment not in said for fragment in banned)
-
-
-def test_every_configuration_a_readme_prints_can_produce_a_plan() -> None:
-    """The published example described a disk with no table, no esp and no
-    root mountpoint: it parsed and then failed validation with two errors, so
-    a reader who copied it got no plan at all."""
-    import re
-    import tomllib
-
-    from gentoo_install.model.parse import parse
-    from gentoo_install.model.validate import validate
-
-    from dataclasses import fields
-    from gentoo_install.model.config import InstallConfig
-
-    proxy_implemented = any(field.name == "proxy" for field in fields(InstallConfig))
-    for name in READMES:
-        for block in re.findall(r"```toml\n(.*?)```", (ROOT / name).read_text(), re.S):
-            if not proxy_implemented and "[proxy]" in block:
-                continue
+    for name in (*READMES, REFERENCE):
+        blocks = re.findall(r"```toml\n(.*?)```", document(name), re.S)
+        if name == REFERENCE:
+            assert blocks, "REFERENCE.md carries the published TOML examples"
+        for block in blocks:
             validate(parse(tomllib.loads(block)))
-
-
-def test_every_path_a_readme_links_to_exists() -> None:
-    """A schema reference nobody can open is worse than none."""
-    import re
-
-    for name in READMES:
-        said = (ROOT / name).read_text()
-        for target in re.findall(r"\]\(([^)#]+)\)", said):
-            if target.startswith(("http://", "https://", "mailto:")):
-                continue
-            assert (ROOT / target).exists(), f"{name} links to {target}"
-
-
-def test_the_shell_commands_are_the_same_in_every_translation() -> None:
-    """A translated comment is fine; a translated command is a different
-    instruction, and one locale losing `--dry-run` is a destructive run."""
-    import re
-
-    def commands(name: str) -> list[str]:
-        found: list[str] = []
-        for block in re.findall(r"```sh\n(.*?)```", (ROOT / name).read_text(), re.S):
-            for line in block.splitlines():
-                bare = line.split("#", 1)[0].strip()
-                if bare:
-                    found.append(bare)
-        return found
-
-    English = commands("README.md")
-    assert English, "the English README prints no commands"
-    for name in READMES:
-        assert commands(name) == English, name
-
-
-def test_no_readme_addresses_the_reader_in_the_second_person() -> None:
-    """The whole set is written about the installer and the operator, and one
-    locale slipping into instructions to `you` reads as a different document."""
-    for name, locale in READMES.items():
-        for number, line in enumerate(readme(name).splitlines(), 1):
-            assert not SECOND_PERSON[locale].search(line), f"{name}:{number}"
 
 
 def test_every_documented_long_option_exists_in_cli_help() -> None:
     from gentoo_install.cli import parser
 
-    documented = set(re.findall(r"--[a-z][a-z-]*", readme("README.md")))
+    documented = set(re.findall(r"--[a-z][a-z-]*", document(REFERENCE)))
+    documented.update(re.findall(r"--[a-z][a-z-]*", document("README.md")))
     cli_help = parser().format_help()
     assert documented
     assert all(option in cli_help for option in documented), documented
 
 
-def test_the_readme_set_holds_no_contributor_instructions() -> None:
-    """`CONTRIBUTING.md` holds those, and a second copy goes stale."""
-    assert (ROOT / "CONTRIBUTING.md").is_file()
-    for name in READMES:
-        said = (ROOT / name).read_text()
-        assert "mypy" not in said, name
-        assert "pytest" not in said, name
-
-
-def test_the_readme_names_everything_publishing_removes() -> None:
-    """The README said the menu replaces `only` those two values and that the
-    other values remain. `to_toml(publishing=True)` also drops the proxy
-    username and password, and drops them rather than replacing them — so the
-    sentence understated the protection and mis-stated its mechanism, on the
-    one paragraph a reader consults before putting a configuration on a public
-    address."""
-    from dataclasses import fields
-
-    from gentoo_install.model.config import ProxyConfig
-    from gentoo_install.model.serialise import REDACTED, SECRET
-
-    english = (ROOT / "README.md").read_text(encoding="utf-8")
-    said = next(line for line in english.splitlines() if REDACTED in line)
-
-    for name in SECRET:
-        assert f"`{name}`" in said, name
-    # And the keys that are omitted rather than replaced, by their real names.
-    dropped = {"username", "password"}
-    assert dropped <= {field.name for field in fields(ProxyConfig)}, "the model moved"
-    for name in dropped:
-        assert f"`{name}`" in said, name
-
-    # `only` was the word that made it wrong; it must not come back beside the
-    # two hashes it used to qualify.
-    assert "replaces only" not in said, said
-
-
-def test_every_fixture_a_record_used_is_named_in_it() -> None:
-    """A row that says `dd`, raw and gz` does not say which configuration ran,
-    and a reader cannot check the claim against the tree. Six of the forty
-    fixtures were used by a record that never named them.
-
-    Only the fixtures a record exists for: one that has never run is absent
-    from `TESTED.md` on purpose, and this must not turn into a rule that every
-    fixture has a record.
-    """
-    import re
-
-    recorded = set(re.findall(r"`([a-z0-9][a-z0-9-]+)`", (ROOT / "TESTED.md").read_text()))
-    fixtures = {one.stem for one in (ROOT / "tests" / "fixtures").glob("*.toml")}
-
-    # Named anywhere in the file, which includes a row that records why a
-    # fixture failed: this rule is about a record a reader can trace back to a
-    # configuration, not about a fixture having passed. The set is empty since
-    # `vm-source-kernel` finished at `43b5737b04478` on its fourth attempt,
-    # and it stays a set rather than an assertion of emptiness because a new
-    # fixture arrives before its first run.
-    without_a_record: set[str] = set()
-    assert without_a_record <= fixtures, without_a_record
-    assert fixtures - recorded == without_a_record, sorted(fixtures - recorded)
-
-
-def test_the_readme_gives_each_memory_option_the_outcome_its_record_holds() -> None:
-    """`--bypass` was given the result of a `--lowram` row: the README said a
-    machine reached its own cloud system, and every `--bypass` record in
-    `TESTED.md` says the memory environment came up. Attributing one option's
-    record to another is the failure this holds shut."""
-    import re
-
-    record = (ROOT / "TESTED.md").read_text()
-    rows = [line for line in record.splitlines() if line.startswith("| `") and "|" in line[3:]]
-    for option, outcome, forbidden in (
-        ("`--bypass`", "came up in the memory environment", "cloud system"),
-    ):
-        mine = [row for row in rows if option in row]
-        assert mine, f"{option} has no row in TESTED.md"
-        assert all(outcome in row for row in mine), mine
-        assert not any(forbidden in row for row in mine), mine
-
-        # The verification table only: the option table in `Installation`
-        # carries a row for the same option, and that one describes the flag.
-        table = [
-            line
-            for line in fact_bodies("README.md")["verification-scope"].splitlines()
-            if line.startswith("| ") and line.split("|")[1].strip() == option
-        ]
-        assert len(table) == 1, table
-        assert forbidden not in table[0], table[0]
-
-
-def test_every_table_row_carries_the_same_identifiers_in_every_readme() -> None:
-    """A reference table is names and values, and a translation that renders
-    one of them into its own language documents a key nobody can type. Four
-    cells lost `dd` this way while every structural check stayed green."""
-    import re
-
-    single = re.compile(r"^`[^`]+`$")
-
-    def rows(name: str) -> dict[str, list[frozenset[str]]]:
-        found: dict[str, list[frozenset[str]]] = {}
-        for line in readme(name).splitlines():
-            if not line.startswith("| "):
+def test_every_relative_link_resolves() -> None:
+    for name in (*READMES, REFERENCE):
+        for target in links(name):
+            if target.startswith(("http://", "https://", "mailto:")):
                 continue
-            cells = line.split("|")
-            key = cells[1].strip()
-            if single.match(key):
-                found.setdefault(key, []).append(
-                    frozenset(re.findall(r"`([^`]+)`", "|".join(cells[2:])))
-                )
-        return found
+            assert (ROOT / target).exists(), f"{name} links to {target}"
 
-    english = rows("README.md")
-    assert len(english) >= 100, len(english)
+
+def test_readmes_do_not_address_the_reader_or_repeat_contributor_guidance() -> None:
+    assert (ROOT / "CONTRIBUTING.md").is_file()
+    for name, locale in READMES.items():
+        text = document(name)
+        for number, line in enumerate(text.splitlines(), 1):
+            assert not SECOND_PERSON[locale].search(line), f"{name}:{number}"
+        assert "mypy" not in text, name
+        assert "pytest" not in text, name
+
+
+def test_tested_record_holds_the_detail_the_readmes_do_not_repeat() -> None:
+    record = document("TESTED.md")
+    for heading in ("## Mode 1", "## Mode 2", "## Mode 3"):
+        assert heading in record, heading
+    assert "post-boot" in record
     for name in READMES:
-        if name != "README.md":
-            assert rows(name) == english, name
+        body = fact_bodies(name)["verification-scope"]
+        assert "b931ef46" not in body, name
+        assert "\n|" not in body, name
+
+
+def test_the_chinese_readmes_space_code_spans_away_from_han_text() -> None:
+    """A code span written flush against a Han character reads as one word.
+
+    `chinese_lint.py` does not see this, so the rule lives here. The check it
+    replaces named five literal fragments, four of which described prose the
+    compact README no longer carries.
+    """
+    han = "[\u3400-\u4dbf\u4e00-\u9fff]"
+    before = re.compile(han + r"`")
+    after = re.compile(r"`" + han)
+    for name in ("README.zh-TW.md", "README.zh-CN.md"):
+        said = document(name)
+        assert not before.search(said), (name, before.search(said))
+        assert not after.search(said), (name, after.search(said))
 
 
 def test_no_chinese_readme_calls_arming_a_boot_by_the_weapon_word() -> None:
-    """The word for arming a weapon reads as slang for what `bootctl
-    set-oneshot` does, so both Chinese files use the word for a reservation:
-    the boot is booked for the next start and happens once."""
-    weapon = ("\u6b66\u88dd", "\u6b66\u88c5")
-    reservation = {"README.zh-TW.md": "\u9810\u7d04", "README.zh-CN.md": "\u9884\u7ea6"}
-    for name, wanted in reservation.items():
-        text = readme(name)
-        assert not any(one in text for one in weapon), name
-        assert text.count(wanted) >= 10, (name, text.count(wanted))
+    """The Chinese word for arming a weapon is not the word for a one-shot
+    boot entry. The prose that used it moved to the English `REFERENCE.md`,
+    and this keeps it from coming back."""
+    for name in ("README.zh-TW.md", "README.zh-CN.md"):
+        said = document(name)
+        assert "\u6b66\u88dd" not in said, name
+        assert "\u6b66\u88c5" not in said, name


### PR DESCRIPTION
Each of the five READMEs was 652 lines, of which `Capabilities` and `Configuration files` were two thirds. They are now 117 lines each: identity, a capability summary, the verification boundary, requirements, safety, the shortest interactive and configuration paths, and links.

The look-up material moves to a new English `REFERENCE.md` — the option table, the memory environment, in-place conversion, the device model, the compatibility refusals, the TOML schema and the exit codes — linked from all five and translated in none, since everything committed here is English except the README set.

The per-path verification table is deleted rather than moved: `TESTED.md` already holds it with more detail. Safety still precedes the first executable path, `--dry-run` still precedes the real command, and the test keeps validating every embedded TOML through `parse` and `validate`.