### PR TITLE
exec: checkpoint storage operations before dispatch

### DIFF
--- a/gentoo_install/exec/apply.py
+++ b/gentoo_install/exec/apply.py
@@ -16,7 +16,7 @@ from functools import lru_cache
 from pathlib import Path, PurePosixPath
 from typing import Callable, Sequence
 
-from ..errors import CommandFailed, GentooInstallError, InvalidLayout, TargetEscape
+from ..errors import CommandFailed, GentooInstallError, InvalidLayout, ResumeRefused, TargetEscape
 from ..model.config import InstallConfig
 from ..model.validate import KernelCeiling
 from ..model.device import (
@@ -379,20 +379,39 @@ def completed(journal: Journal | None) -> frozenset[tuple[int, str]]:
     appends to the same file, so after one resume every position was wrong and
     the next resume re-ran operations that had already partitioned the disk.
     Position as well as text, because a plan can hold two operations whose
-    descriptions match.
+    descriptions match. A `started` record without a result is an operation
+    that may have changed a disk before the process disappeared, so resume
+    refuses rather than dispatching it again.
     """
     if journal is None:
         return frozenset()
-    done: set[tuple[int, str]] = set()
-    for entry in journal.resume_entries():
-        if entry.get("event") != "operation" or entry.get("status") != "done":
+    entries = tuple(journal.resume_entries())
+    latest: dict[tuple[int, str], dict[str, object]] = {}
+    for entry in entries:
+        if entry.get("event") != "operation":
             continue
         position = entry.get("position")
-        # An entry from before positions were recorded says nothing reliable
-        # about where it sat, and redoing work is safer than skipping it.
-        if isinstance(position, int):
-            done.add((position, str(entry.get("identity", ""))))
-    return frozenset(done)
+        identified = entry.get("identity")
+        status = entry.get("status")
+        if isinstance(position, int) and isinstance(identified, str) and status in {
+            "started",
+            "failed",
+            "done",
+        }:
+            latest[(position, identified)] = entry
+    for (position, _), entry in latest.items():
+        if entry["status"] != "started":
+            continue
+        stage = str(entry.get("stage", "unknown"))
+        described = str(entry.get("describe", "unknown operation"))
+        raise ResumeRefused(
+            f"cannot resume: {stage} operation {position + 1} was interrupted: {described}"
+        )
+    return frozenset(
+        (position, identified)
+        for (position, identified), entry in latest.items()
+        if entry["status"] == "done"
+    )
 
 
 def apply(
@@ -423,6 +442,8 @@ def apply(
                 on_start(operation)
             machine.runner.log(f"{counted} [{operation.stage.value}] {operation.describe()}")
             started = time.monotonic()
+            if operation.needs_pre_dispatch_checkpoint:
+                _record(machine, operation, started, "started", position)
             try:
                 operation.apply(machine)
             except GentooInstallError:

--- a/gentoo_install/plan/operations.py
+++ b/gentoo_install/plan/operations.py
@@ -50,6 +50,13 @@ class Stage(Enum):
         return list(Stage).index(self)
 
 
+#: A process loss while these stages run cannot show whether a device changed,
+#: so resume records their intent and refuses a second dispatch without a result.
+CHECKPOINT_BEFORE_APPLY_STAGES: Final[frozenset[Stage]] = frozenset(
+    (Stage.PARTITION, Stage.ARRAY, Stage.FORMAT, Stage.ZFS)
+)
+
+
 def ending(returncode: int) -> str:
     """How a command ended, in words a reader can act on.
 
@@ -307,3 +314,8 @@ class Operation(ABC):
         mounted.
         """
         return True
+
+    @property
+    def needs_pre_dispatch_checkpoint(self) -> bool:
+        """Whether a missing result makes this operation unsafe to dispatch again."""
+        return self.stage in CHECKPOINT_BEFORE_APPLY_STAGES

--- a/tests/unit/test_resume.py
+++ b/tests/unit/test_resume.py
@@ -16,7 +16,7 @@ from pathlib import Path, PurePosixPath
 from gentoo_install.exec.apply import completed
 from gentoo_install.log import Journal
 from gentoo_install.model.device import DeviceId
-from gentoo_install.plan.operations import Operation, Stage
+from gentoo_install.plan.operations import CHECKPOINT_BEFORE_APPLY_STAGES, Operation, Stage
 
 from .recorder import Recorder
 
@@ -31,6 +31,42 @@ class Noted(Operation):
 
     def apply(self, context: object) -> None:  # pragma: no cover - never run here
         raise AssertionError("this test never applies an operation")
+
+
+@dataclass(frozen=True, kw_only=True)
+class InterruptedStorageOperation(Operation):
+    """A storage operation whose process disappears before it returns."""
+
+    stage: Stage
+
+    def describe(self) -> str:
+        return "change storage"
+
+    def apply(self, context: object) -> None:
+        raise KeyboardInterrupt
+
+
+@dataclass(frozen=True, kw_only=True)
+class FailedStorageOperation(Operation):
+    """A storage operation whose command returns a named failure."""
+
+    stage: Stage
+
+    def describe(self) -> str:
+        return "change storage"
+
+    def apply(self, context: object) -> None:
+        from gentoo_install.errors import CommandFailed
+
+        raise CommandFailed("storage command failed")
+
+
+#: One configured storage path for every stage in the production checkpoint table.
+CHECKPOINT_CASES: tuple[tuple[str, frozenset[Stage]], ...] = (
+    ("ext4-bios", frozenset((Stage.PARTITION, Stage.FORMAT))),
+    ("vm-luks", frozenset((Stage.ARRAY,))),
+    ("vm-zfs", frozenset((Stage.ZFS,))),
+)
 
 
 def journal_with(tmp_path: Path, entries: list[tuple[int, str, str]]) -> Journal:
@@ -57,6 +93,82 @@ def test_only_the_operations_that_finished_are_skipped(tmp_path: Path) -> None:
         [(0, "partition", "done"), (1, "mkfs", "done"), (2, "emerge plasma", "failed")],
     )
     assert completed(journal) == {(0, "partition"), (1, "mkfs")}
+
+
+@pytest.mark.parametrize(("fixture", "stages"), CHECKPOINT_CASES)
+def test_every_storage_stage_records_an_intent_before_dispatch(
+    fixture: str,
+    stages: frozenset[Stage],
+) -> None:
+    from gentoo_install.data import load_catalog
+    from gentoo_install.exec.config import load
+    from gentoo_install.plan.build import build
+
+    operations = build(load(Path("tests/fixtures") / f"{fixture}.toml"), load_catalog())
+    checkpointed = {
+        operation.stage for operation in operations if operation.needs_pre_dispatch_checkpoint
+    }
+    assert stages <= checkpointed
+
+
+def test_checkpoint_cases_cover_the_storage_stage_table() -> None:
+    covered = frozenset(stage for _, stages in CHECKPOINT_CASES for stage in stages)
+    assert covered == CHECKPOINT_BEFORE_APPLY_STAGES
+
+
+def test_a_resume_refuses_a_storage_operation_interrupted_after_its_intent(
+    tmp_path: Path,
+) -> None:
+    """A process loss between dispatch and `done` leaves no safe replay answer."""
+    from gentoo_install.errors import ResumeRefused
+    from gentoo_install.exec.apply import Machine, apply as apply_operations
+    from gentoo_install.exec.probe import Probe
+    from gentoo_install.exec.runner import Runner
+
+    from .layouts import config
+
+    journal = Journal(tmp_path / "install.jsonl")
+    runner = Runner(log=lambda line: None, journal=journal)
+    machine = Machine(
+        config=config(),
+        runner=runner,
+        probe=Probe(runner=runner, work=tmp_path),
+        work=tmp_path,
+    )
+    operation = InterruptedStorageOperation(stage=Stage.ARRAY)
+
+    with pytest.raises(KeyboardInterrupt):
+        apply_operations((operation,), machine)
+
+    records = [entry for entry in journal.replay() if entry["event"] == "operation"]
+    assert [entry["status"] for entry in records] == ["started"]
+    with pytest.raises(ResumeRefused, match=r"array operation 1 was interrupted: change storage"):
+        completed(Journal(tmp_path / "install.jsonl"))
+
+
+def test_a_storage_failure_is_not_mistaken_for_an_interruption(tmp_path: Path) -> None:
+    from gentoo_install.errors import CommandFailed
+    from gentoo_install.exec.apply import Machine, apply as apply_operations
+    from gentoo_install.exec.probe import Probe
+    from gentoo_install.exec.runner import Runner
+
+    from .layouts import config
+
+    journal = Journal(tmp_path / "install.jsonl")
+    runner = Runner(log=lambda line: None, journal=journal)
+    machine = Machine(
+        config=config(),
+        runner=runner,
+        probe=Probe(runner=runner, work=tmp_path),
+        work=tmp_path,
+    )
+
+    with pytest.raises(CommandFailed, match="storage command failed"):
+        apply_operations((FailedStorageOperation(stage=Stage.FORMAT),), machine)
+
+    records = [entry for entry in journal.replay() if entry["event"] == "operation"]
+    assert [entry["status"] for entry in records] == ["started", "failed"]
+    assert completed(Journal(tmp_path / "install.jsonl")) == frozenset()
 
 
 def test_position_counts_as_well_as_the_text(tmp_path: Path) -> None:


### PR DESCRIPTION
A missing `done` record meant "it did not run". It also means "it ran and the process disappeared before the record", and for `CreateLuks` — `cryptsetup luksFormat --batch-mode` — guessing wrong destroys the container the first attempt created and every keyslot in it.

One table names the stages whose result cannot be read back from the machine: `PARTITION`, `ARRAY`, `FORMAT`, `ZFS`. Those record an intent before dispatch, and a resume that finds an intent with no result stops with `ResumeRefused` naming the stage, position and description rather than dispatching again.