### PR TITLE
portage: draw the binhost a merge may not use

### DIFF
--- a/gentoo_install/data/locale/ja.toml
+++ b/gentoo_install/data/locale/ja.toml
@@ -652,6 +652,8 @@
 "accept ~amd64 for packages from {} only" = "{} のパッケージだけに ~amd64 を許可"
 "{}: emerge {}, from source" = "{}：{} をソースから emerge"
 "{}: emerge {}, building {} here" = "{}：{} を emerge し、{} をここでビルド"
+"{}: emerge {}, with no binhost" = "{}：binhost を使わずに {} を emerge"
+"{}: emerge {}, building {} here, with no binhost" = "{}：binhost を使わずに {} を emerge し、{} をここでビルド"
 "{}: emerge {}" = "{}：{} を emerge"
 "run getuto so Portage has a keyring to verify binary packages against, and write dirmngr.conf" = "Portage がバイナリーパッケージを検証する鍵束を持つよう getuto を実行し、dirmngr.conf を書き込む"
 "import {} from {} and locally sign it for {}" = "{} を {} からインポートし、{} 用にローカル署名"

--- a/gentoo_install/data/locale/ko.toml
+++ b/gentoo_install/data/locale/ko.toml
@@ -652,6 +652,8 @@
 "accept ~amd64 for packages from {} only" = "{}의 패키지에만 ~amd64 허용"
 "{}: emerge {}, from source" = "{}: {}를 소스에서 emerge"
 "{}: emerge {}, building {} here" = "{}: {}를 emerge하고 {}를 여기서 빌드"
+"{}: emerge {}, with no binhost" = "{}: binhost 없이 {}를 emerge"
+"{}: emerge {}, building {} here, with no binhost" = "{}: binhost 없이 {}를 emerge하고 {}를 여기서 빌드"
 "{}: emerge {}" = "{}: {}를 emerge"
 "run getuto so Portage has a keyring to verify binary packages against, and write dirmngr.conf" = "Portage가 바이너리 패키지를 검증할 키링을 갖도록 getuto 실행 및 dirmngr.conf 작성"
 "import {} from {} and locally sign it for {}" = "{}를 {}에서 가져와 {}용으로 로컬 서명"

--- a/gentoo_install/data/locale/zh-CN.toml
+++ b/gentoo_install/data/locale/zh-CN.toml
@@ -653,6 +653,8 @@
 "accept ~amd64 for packages from {} only" = "仅接受仓库 {} 中软件包的 ~amd64"
 "{}: emerge {}, from source" = "{}：从源代码 emerge {}"
 "{}: emerge {}, building {} here" = "{}：emerge {}，在本机构建 {}"
+"{}: emerge {}, with no binhost" = "{}：emerge {}，不使用 binhost"
+"{}: emerge {}, building {} here, with no binhost" = "{}：emerge {}，在本机构建 {}，不使用 binhost"
 "{}: emerge {}" = "{}：emerge {}"
 "run getuto so Portage has a keyring to verify binary packages against, and write dirmngr.conf" = "运行 getuto，让 Portage 拥有验证二进制软件包的密钥环，并写入 dirmngr.conf"
 "import {} from {} and locally sign it for {}" = "导入 {}，来源 {}，并为 {} 本地签名"

--- a/gentoo_install/data/locale/zh-TW.toml
+++ b/gentoo_install/data/locale/zh-TW.toml
@@ -653,6 +653,8 @@
 "accept ~amd64 for packages from {} only" = "只接受套件庫 {} 中套件的 ~amd64"
 "{}: emerge {}, from source" = "{}：從原始碼 emerge {}"
 "{}: emerge {}, building {} here" = "{}：emerge {}，在本機建置 {}"
+"{}: emerge {}, with no binhost" = "{}：emerge {}，不使用 binhost"
+"{}: emerge {}, building {} here, with no binhost" = "{}：emerge {}，在本機建置 {}，不使用 binhost"
 "{}: emerge {}" = "{}：emerge {}"
 "run getuto so Portage has a keyring to verify binary packages against, and write dirmngr.conf" = "執行 getuto，讓 Portage 擁有驗證二進位套件的金鑰圈，並寫入 dirmngr.conf"
 "import {} from {} and locally sign it for {}" = "匯入 {}，來源 {}，並為 {} 本地簽署"

--- a/gentoo_install/plan/portage.py
+++ b/gentoo_install/plan/portage.py
@@ -905,12 +905,23 @@ class Emerge(Operation):
         built = self._built_here()
         if built == self.packages:
             return "{}: emerge {}, from source", (self.summary, packages)
+        # `binary_host` as well as `built`: they are different facts, and only
+        # the second one was drawn, so a plan that stopped carrying a disabled
+        # binhost read exactly like one that still had it.
         if built:
+            if not self.binary_host:
+                return "{}: emerge {}, building {} here, with no binhost", (
+                    self.summary,
+                    packages,
+                    " ".join(built),
+                )
             return "{}: emerge {}, building {} here", (
                 self.summary,
                 packages,
                 " ".join(built),
             )
+        if not self.binary_host:
+            return "{}: emerge {}, with no binhost", (self.summary, packages)
         return "{}: emerge {}", (self.summary, packages)
 
     def _built_here(self) -> tuple[str, ...]:

--- a/tests/golden/ext2.txt
+++ b/tests/golden/ext2.txt
@@ -26,7 +26,7 @@
   create the three autounmask files emerge writes its decisions into
   fetch the first ebuild repository snapshot with emerge-webrsync
   select profile default/linux/amd64/23.0
-  install git, which every later repository sync needs: emerge dev-vcs/git
+  install git, which every later repository sync needs: emerge dev-vcs/git, with no binhost
   point repository gentoo at https://github.com/gentoo-mirror/gentoo.git, commit signatures verified
   sync repository gentoo
   set sys-kernel/installkernel to dracut
@@ -44,24 +44,24 @@
   treat the hardware clock as UTC
   start a login on ttyS0 at 115200 baud
   set the root password
-  install the network tools: emerge net-misc/netifrc net-misc/dhcpcd
+  install the network tools: emerge net-misc/netifrc net-misc/dhcpcd, with no binhost
   configure the wired interface for DHCP
   enable dhcpcd in the default runlevel
-  install the system logger: emerge app-admin/sysklogd
+  install the system logger: emerge app-admin/sysklogd, with no binhost
   enable sysklogd in the default runlevel
-  install cron: emerge sys-process/cronie
+  install cron: emerge sys-process/cronie, with no binhost
   enable cronie in the default runlevel
 
 [kernel]
-  install the hook that puts a kernel in /boot: emerge sys-kernel/installkernel
-  install the initramfs builder and firmware: emerge sys-kernel/dracut sys-kernel/linux-firmware
-  install the storage tools: emerge sys-fs/e2fsprogs
-  install the kernel: emerge sys-kernel/gentoo-kernel-bin
+  install the hook that puts a kernel in /boot: emerge sys-kernel/installkernel, with no binhost
+  install the initramfs builder and firmware: emerge sys-kernel/dracut sys-kernel/linux-firmware, with no binhost
+  install the storage tools: emerge sys-fs/e2fsprogs, with no binhost
+  install the kernel: emerge sys-kernel/gentoo-kernel-bin, with no binhost
   rebuild the initramfs from sys-kernel/gentoo-kernel-bin with the modules written above
   check the installkernel payload names existing kernel files
 
 [bootloader]
-  install the bootloader: emerge sys-boot/grub
+  install the bootloader: emerge sys-boot/grub, with no binhost
   write /etc/default/grub with cmdline console=ttyS0,115200, its menu on ttyS0
   install GRUB for bios on the disk under disk
 

--- a/tests/golden/ext3.txt
+++ b/tests/golden/ext3.txt
@@ -26,7 +26,7 @@
   create the three autounmask files emerge writes its decisions into
   fetch the first ebuild repository snapshot with emerge-webrsync
   select profile default/linux/amd64/23.0
-  install git, which every later repository sync needs: emerge dev-vcs/git
+  install git, which every later repository sync needs: emerge dev-vcs/git, with no binhost
   point repository gentoo at https://github.com/gentoo-mirror/gentoo.git, commit signatures verified
   sync repository gentoo
   set sys-kernel/installkernel to dracut
@@ -44,24 +44,24 @@
   treat the hardware clock as UTC
   start a login on ttyS0 at 115200 baud
   set the root password
-  install the network tools: emerge net-misc/netifrc net-misc/dhcpcd
+  install the network tools: emerge net-misc/netifrc net-misc/dhcpcd, with no binhost
   configure the wired interface for DHCP
   enable dhcpcd in the default runlevel
-  install the system logger: emerge app-admin/sysklogd
+  install the system logger: emerge app-admin/sysklogd, with no binhost
   enable sysklogd in the default runlevel
-  install cron: emerge sys-process/cronie
+  install cron: emerge sys-process/cronie, with no binhost
   enable cronie in the default runlevel
 
 [kernel]
-  install the hook that puts a kernel in /boot: emerge sys-kernel/installkernel
-  install the initramfs builder and firmware: emerge sys-kernel/dracut sys-kernel/linux-firmware
-  install the storage tools: emerge sys-fs/e2fsprogs
-  install the kernel: emerge sys-kernel/gentoo-kernel-bin
+  install the hook that puts a kernel in /boot: emerge sys-kernel/installkernel, with no binhost
+  install the initramfs builder and firmware: emerge sys-kernel/dracut sys-kernel/linux-firmware, with no binhost
+  install the storage tools: emerge sys-fs/e2fsprogs, with no binhost
+  install the kernel: emerge sys-kernel/gentoo-kernel-bin, with no binhost
   rebuild the initramfs from sys-kernel/gentoo-kernel-bin with the modules written above
   check the installkernel payload names existing kernel files
 
 [bootloader]
-  install the bootloader: emerge sys-boot/grub
+  install the bootloader: emerge sys-boot/grub, with no binhost
   write /etc/default/grub with cmdline console=ttyS0,115200, its menu on ttyS0
   install GRUB for bios on the disk under disk
 

--- a/tests/golden/ext4-bios.txt
+++ b/tests/golden/ext4-bios.txt
@@ -26,7 +26,7 @@
   create the three autounmask files emerge writes its decisions into
   fetch the first ebuild repository snapshot with emerge-webrsync
   select profile default/linux/amd64/23.0
-  install git, which every later repository sync needs: emerge dev-vcs/git
+  install git, which every later repository sync needs: emerge dev-vcs/git, with no binhost
   point repository gentoo at https://github.com/gentoo-mirror/gentoo.git, commit signatures verified
   sync repository gentoo
   set sys-kernel/installkernel to dracut
@@ -44,24 +44,24 @@
   treat the hardware clock as UTC
   start a login on ttyS0 at 115200 baud
   set the root password
-  install the network tools: emerge net-misc/netifrc net-misc/dhcpcd
+  install the network tools: emerge net-misc/netifrc net-misc/dhcpcd, with no binhost
   configure the wired interface for DHCP
   enable dhcpcd in the default runlevel
-  install the system logger: emerge app-admin/sysklogd
+  install the system logger: emerge app-admin/sysklogd, with no binhost
   enable sysklogd in the default runlevel
-  install cron: emerge sys-process/cronie
+  install cron: emerge sys-process/cronie, with no binhost
   enable cronie in the default runlevel
 
 [kernel]
-  install the hook that puts a kernel in /boot: emerge sys-kernel/installkernel
-  install the initramfs builder and firmware: emerge sys-kernel/dracut sys-kernel/linux-firmware
-  install the storage tools: emerge sys-fs/e2fsprogs
-  install the kernel: emerge sys-kernel/gentoo-kernel-bin
+  install the hook that puts a kernel in /boot: emerge sys-kernel/installkernel, with no binhost
+  install the initramfs builder and firmware: emerge sys-kernel/dracut sys-kernel/linux-firmware, with no binhost
+  install the storage tools: emerge sys-fs/e2fsprogs, with no binhost
+  install the kernel: emerge sys-kernel/gentoo-kernel-bin, with no binhost
   rebuild the initramfs from sys-kernel/gentoo-kernel-bin with the modules written above
   check the installkernel payload names existing kernel files
 
 [bootloader]
-  install the bootloader: emerge sys-boot/grub
+  install the bootloader: emerge sys-boot/grub, with no binhost
   write /etc/default/grub with cmdline console=ttyS0,115200, its menu on ttyS0
   install GRUB for bios on the disk under disk
 

--- a/tests/unit/test_i18n.py
+++ b/tests/unit/test_i18n.py
@@ -529,7 +529,9 @@ REVIEWED_TEMPLATES: frozenset[str] = frozenset(
         "write {} for {}",
         "{}: emerge {}",
         "{}: emerge {}, building {} here",
+        "{}: emerge {}, building {} here, with no binhost",
         "{}: emerge {}, from source",
+        "{}: emerge {}, with no binhost",
     }
 )
 

--- a/tests/unit/test_plan_portage.py
+++ b/tests/unit/test_plan_portage.py
@@ -2761,3 +2761,15 @@ def test_the_gentoo_tree_is_offered_the_rest_of_its_region() -> None:
         if isinstance(one, portage.SyncRepository) and one.name == "gentoo"
     ]
     assert alone[0].alternates == ()
+
+
+def test_a_merge_that_may_not_use_a_binhost_says_so() -> None:
+    """`apply` passes `--getbinpkg=n` when `binary_host` is false, and nothing
+    drew it: a plan that stopped carrying a disabled binhost rendered exactly
+    like one that still had it, so no golden file could catch that."""
+    from gentoo_install.plan.portage import Emerge
+
+    merge = Emerge(summary="install git", packages=("dev-vcs/git",))
+    assert "binhost" not in merge.describe(), merge.describe()
+    without = replace(merge, binary_host=False)
+    assert "with no binhost" in without.describe(), without.describe()


### PR DESCRIPTION
`Emerge.apply` passes `--usepkg=n --getbinpkg=n` when `binary_host` is false, and `describe_parts` never read that field. A source-only configuration therefore rendered exactly like one with a binhost, and the regression that matters — `build.py` no longer replacing each `Emerge` with `binary_host=False` — changed no golden file.

Measured both ways with that exact mutation: before this change the golden suite exits 0, after it three fixtures fail. `built_from` is a different fact and keeps its own wording, since it is the operator's source preference rather than whether a binhost exists.