### PR TITLE
harness: the usage example names a path the runner can load

### DIFF
--- a/tests/unit/test_harness.py
+++ b/tests/unit/test_harness.py
@@ -5294,3 +5294,18 @@ def test_one_module_announces_the_revision_and_the_runners_do_not() -> None:
     assert announcing == {"driver.py", "cluster.py"}, sorted(announcing)
     runners = {"run.py", "ram.py", "dd.py", "convert.py"}
     assert not announcing & runners, sorted(announcing & runners)
+
+
+def test_the_usage_examples_name_a_path_the_runner_can_load() -> None:
+    """`--install` is resolved under `tests/`, and the module's own example
+    said `tests/fixtures/...`, which resolves to `tests/tests/fixtures/...`."""
+    import re
+
+    from tests.vm import run as runner
+
+    room = Path(__file__).resolve().parents[2] / "tests"
+    said = runner.__doc__ or ""
+    examples = re.findall(r"--install (\S+)", said)
+    assert examples, said
+    for one in examples:
+        assert (room / one).is_file(), (one, str(room / one))

--- a/tests/vm/run.py
+++ b/tests/vm/run.py
@@ -3,7 +3,7 @@
 to a human.
 
     python3 -m tests.vm.run --medium official-minimal
-    python3 -m tests.vm.run --medium official-minimal --install tests/fixtures/ext4-bios.toml
+    python3 -m tests.vm.run --medium official-minimal --install fixtures/ext4-bios.toml
     python3 -m tests.vm.run --medium gigos --interactive
 """
 


### PR DESCRIPTION
`--install` is resolved as `REPOSITORY / "tests" / args.install`, and the module docstring's example passed `tests/fixtures/ext4-bios.toml`, which resolves to `tests/tests/fixtures/...`. The option's own help text already said `fixtures/ext4-bios.toml`; one fact in two places and the example was the stale one. Following it ends the run before a guest boots, which is how it was found tonight.

The test loads every `--install` path the docstring names.