### PR TITLE
golden: cover the memory boot plans

### DIFF
--- a/tests/golden/memory-bypass.txt
+++ b/tests/golden/memory-bypass.txt
@@ -1,0 +1,12 @@
+[preflight]
+  check that this machine can be told to boot once, systemd-boot
+  check this machine has the 1900 MiB --ram needs
+  take back anything an earlier run armed
+
+[stage3]
+  fetch the ram image and verify its checksum
+
+[bootloader]
+  unpack the ram kernel and initramfs into /boot/efi/gentoo-install-ram
+  write a systemd-boot entry for the ram environment
+  replace the default boot entry with the memory environment (systemd-boot)

--- a/tests/golden/memory-disarm.txt
+++ b/tests/golden/memory-disarm.txt
@@ -1,0 +1,2 @@
+[finish]
+  take back the armed boot and delete what it placed

--- a/tests/golden/memory-lowram.txt
+++ b/tests/golden/memory-lowram.txt
@@ -1,0 +1,13 @@
+[preflight]
+  check that this machine can be told to boot once, systemd-boot
+  check this machine has the 512 MiB --lowram needs
+  take back anything an earlier run armed
+
+[stage3]
+  fetch the lowram image and verify its checksum
+
+[bootloader]
+  unpack the lowram kernel and initramfs into /boot/efi/gentoo-install-ram
+  write a systemd-boot entry for the lowram environment
+  delete the downloaded archive, now that its two files are out
+  arm one boot into the memory environment with systemd-boot

--- a/tests/golden/memory-ram.txt
+++ b/tests/golden/memory-ram.txt
@@ -1,0 +1,12 @@
+[preflight]
+  check that this machine can be told to boot once, systemd-boot
+  check this machine has the 1900 MiB --ram needs
+  take back anything an earlier run armed
+
+[stage3]
+  fetch the ram image and verify its checksum
+
+[bootloader]
+  unpack the ram kernel and initramfs into /boot/efi/gentoo-install-ram
+  write a systemd-boot entry for the ram environment
+  arm one boot into the memory environment with systemd-boot

--- a/tests/golden/regenerate.py
+++ b/tests/golden/regenerate.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 
 from gentoo_install.errors import GentooInstallError
 
-from .test_golden import HERE, fixtures, plan_text
+from .test_golden import HERE, golden_names, golden_text
 
 
 def main() -> None:
@@ -16,9 +16,9 @@ def main() -> None:
     and the suite stayed red on files this command claimed to have written.
     """
     refused: list[str] = []
-    for name in fixtures():
+    for name in golden_names():
         try:
-            text = plan_text(name)
+            text = golden_text(name)
         except GentooInstallError as error:
             refused.append(f"{name}: {error}")
             continue

--- a/tests/golden/test_golden.py
+++ b/tests/golden/test_golden.py
@@ -9,13 +9,23 @@ Regenerate with `python3 -m tests.golden.regenerate` after reading the diff.
 
 from __future__ import annotations
 
+from dataclasses import dataclass
 from pathlib import Path
+from typing import Final
 
 import pytest
 
 from gentoo_install.data import load_catalog
 from gentoo_install.exec.config import load
-from gentoo_install.model.config import DiskMode, InstallConfig
+from gentoo_install.model.config import (
+    BootMethod,
+    DiskMode,
+    InstallConfig,
+    MemoryLaunch,
+    MemoryMode,
+    MirrorRegion,
+)
+from gentoo_install.plan import netboot
 from gentoo_install.plan.build import build
 from gentoo_install.plan.render import render
 
@@ -23,6 +33,74 @@ from ..unit.layouts import running_layout
 
 HERE = Path(__file__).resolve().parent
 FIXTURES = HERE.parent / "fixtures"
+
+
+@dataclass(frozen=True)
+class MemoryBuildFixture:
+    """Named arguments for one memory boot arming plan."""
+
+    name: str
+    launch: MemoryLaunch
+    target: netboot.BootTarget
+    bypass: bool
+    configuration: str
+    source: str
+    keys: tuple[str, ...]
+    region: MirrorRegion
+
+
+@dataclass(frozen=True)
+class MemoryDisarmFixture:
+    """Named arguments for one memory boot disarming plan."""
+
+    name: str
+    target: netboot.BootTarget
+
+
+MemoryFixture = MemoryBuildFixture | MemoryDisarmFixture
+
+SYSTEMD_BOOT_TARGET: Final = netboot.BootTarget(
+    method=BootMethod.SYSTEMD_BOOT,
+    architecture="x86_64",
+    esp_mountpoint="/boot/efi",
+)
+
+MEMORY_FIXTURES: Final[tuple[MemoryFixture, ...]] = (
+    MemoryBuildFixture(
+        name="memory-ram",
+        launch=MemoryLaunch(mode=MemoryMode.RAM),
+        target=SYSTEMD_BOOT_TARGET,
+        bypass=False,
+        configuration="",
+        source="",
+        keys=(),
+        region=MirrorRegion.GLOBAL,
+    ),
+    MemoryBuildFixture(
+        name="memory-lowram",
+        launch=MemoryLaunch(mode=MemoryMode.LOWRAM),
+        target=SYSTEMD_BOOT_TARGET,
+        bypass=False,
+        configuration="",
+        source="",
+        keys=(),
+        region=MirrorRegion.GLOBAL,
+    ),
+    MemoryBuildFixture(
+        name="memory-bypass",
+        launch=MemoryLaunch(mode=MemoryMode.RAM),
+        target=SYSTEMD_BOOT_TARGET,
+        bypass=True,
+        configuration="",
+        source="",
+        keys=(),
+        region=MirrorRegion.GLOBAL,
+    ),
+    MemoryDisarmFixture(
+        name="memory-disarm",
+        target=SYSTEMD_BOOT_TARGET,
+    ),
+)
 
 
 def plan_of(installation: InstallConfig) -> str:
@@ -42,15 +120,57 @@ def fixtures() -> list[str]:
     return sorted(path.stem for path in FIXTURES.glob("*.toml"))
 
 
-@pytest.mark.parametrize("name", fixtures())
+def memory_fixture(name: str) -> MemoryFixture | None:
+    """The explicitly named memory-plan fixture, if one has that name."""
+    return next((fixture for fixture in MEMORY_FIXTURES if fixture.name == name), None)
+
+
+def memory_plan_text(fixture: MemoryFixture) -> str:
+    """Render one memory plan from the exact arguments its CLI path receives."""
+    if isinstance(fixture, MemoryDisarmFixture):
+        return render(netboot.disarm(target=fixture.target))
+    return render(
+        netboot.build(
+            launch=fixture.launch,
+            target=fixture.target,
+            bypass=fixture.bypass,
+            configuration=fixture.configuration,
+            source=fixture.source,
+            keys=fixture.keys,
+            region=fixture.region,
+        )
+    )
+
+
+def golden_names() -> list[str]:
+    """Every ordinary-install and memory-plan golden fixture name."""
+    return sorted([*fixtures(), *(fixture.name for fixture in MEMORY_FIXTURES)])
+
+
+def golden_text(name: str) -> str:
+    """Render either the TOML-backed plan or an explicitly named memory plan."""
+    fixture = memory_fixture(name)
+    return memory_plan_text(fixture) if fixture is not None else plan_text(name)
+
+
+@pytest.mark.parametrize("name", golden_names())
 def test_the_plan_matches_its_golden_file(name: str) -> None:
     expected = HERE / f"{name}.txt"
     assert expected.exists(), f"no golden file for {name}; run tests.golden.regenerate"
-    assert plan_text(name) == expected.read_text()
+    assert golden_text(name) == expected.read_text()
 
 
 def test_every_fixture_has_a_golden_file() -> None:
-    assert {path.stem for path in HERE.glob("*.txt")} == set(fixtures())
+    assert {path.stem for path in HERE.glob("*.txt")} == set(golden_names())
+
+
+def test_memory_golden_fixtures_cover_each_mode() -> None:
+    assert {fixture.name for fixture in MEMORY_FIXTURES} == {
+        "memory-ram",
+        "memory-lowram",
+        "memory-bypass",
+        "memory-disarm",
+    }
 
 
 @pytest.mark.parametrize("name", fixtures())


### PR DESCRIPTION
Every golden came from the ordinary install builder. The memory path calls `netboot.build()` instead, and its only description test asserted `describe()` was non-empty, so a wording change, an ordering change, or an operation silently dropped from `--ram`, `--lowram`, `--bypass` or `--disarm` failed nothing.

Four named fixtures, one golden each. Measured both ways: renaming `fetch the {} image` to `download` fails three of them, and restoring passes 86.

The fixtures carry no ssh key and no root password, so no golden holds a credential; that also means the plan branches those inputs select are not yet covered.