### PR TITLE
exec: hold the work directory against a second install

### DIFF
--- a/gentoo_install/cli.py
+++ b/gentoo_install/cli.py
@@ -529,6 +529,11 @@ def _once(arguments: argparse.Namespace, state: RunState, refused: str) -> int |
         _print_machine_state(state)
         print(f"device: {error}", file=sys.stderr)
         return EXIT_PREFLIGHT
+    except errors.WorkDirectoryBusy as error:
+        # Preflight, not a command failure: nothing has run, and the operator
+        # can act on it by waiting or choosing another `--work`.
+        print(f"work directory: {error}", file=sys.stderr)
+        return EXIT_PREFLIGHT
     except errors.ResumeRefused as error:
         # Before the machine state is printed: nothing of this run has touched
         # the disks, and the state to report is the earlier run's.

--- a/gentoo_install/errors.py
+++ b/gentoo_install/errors.py
@@ -105,6 +105,10 @@ class ResumeRefused(GentooInstallError):
     """A `--resume` whose journal was written by a different run."""
 
 
+class WorkDirectoryBusy(GentooInstallError):
+    """Another invocation holds this work directory."""
+
+
 class ConversionUnsupported(GentooInstallError):
     """The running layout is one the conversion cannot rebuild.
 

--- a/gentoo_install/exec/report.py
+++ b/gentoo_install/exec/report.py
@@ -4,6 +4,7 @@
 from __future__ import annotations
 
 import os
+import fcntl
 import shutil
 import sys
 import stat
@@ -16,7 +17,7 @@ from typing import Final
 from pathlib import Path, PurePosixPath
 
 from .. import errors
-from ..errors import GentooInstallError, TargetEscape
+from ..errors import GentooInstallError, TargetEscape, WorkDirectoryBusy
 from ..log import Journal
 from ..model import config as model_config
 from ..model import paste
@@ -52,10 +53,25 @@ class ActiveReport:
     journal: Journal
 
 
+#: Held for the whole of a run. Two invocations sharing a `--work` both pass
+#: preflight, then partition the same disks and append to one journal, and a
+#: later `--resume` reads only the attempt whose `started` it happened to see
+#: last.
+LOCK_FILE: Final[str] = "install.lock"
+
+
 @contextmanager
 def recording(work: Path, target: Path) -> Iterator[ActiveReport]:
     """Open the files that record a run and close them when it finishes."""
     work.mkdir(parents=True, exist_ok=True)
+    lock = (work / LOCK_FILE).open("a")
+    try:
+        fcntl.flock(lock.fileno(), fcntl.LOCK_EX | fcntl.LOCK_NB)
+    except OSError as error:
+        lock.close()
+        raise WorkDirectoryBusy(
+            f"another install is using {work}; wait for it or pass a different --work"
+        ) from error
     log = (work / RunFile.LOG.value).open("a")
 
     def record(line: str) -> None:
@@ -78,6 +94,9 @@ def recording(work: Path, target: Path) -> Iterator[ActiveReport]:
             log.close()
         except OSError as error:
             print(f"WARNING: the run log could not be closed: {error}", file=sys.stderr)
+        # Closing the descriptor releases the lock; the file stays so a reader
+        # of the work directory can see what it is for.
+        lock.close()
 
 
 #: Target-absolute, so `open_in_target` refuses a symlink on the way. A

--- a/tests/unit/test_resume.py
+++ b/tests/unit/test_resume.py
@@ -523,3 +523,21 @@ def test_every_kind_of_storage_that_needs_activation_has_a_fixture_here() -> Non
         and isinstance(getattr(plan_disk, name), type)
     }
     assert defined - named == set(), defined - named
+
+
+def test_a_second_install_cannot_open_a_work_directory_that_is_in_use(
+    tmp_path: Path,
+) -> None:
+    """Two invocations sharing a `--work` both passed preflight, then wrote
+    independent attempts into one journal and partitioned the same disks."""
+    from gentoo_install.errors import WorkDirectoryBusy
+    from gentoo_install.exec.report import recording
+
+    with recording(tmp_path / "work", tmp_path / "target") as first:
+        assert first.work.is_dir()
+        with pytest.raises(WorkDirectoryBusy, match="another install is using"):
+            with recording(tmp_path / "work", tmp_path / "target"):
+                pass
+    # Released when the first run finishes, so a later run is not locked out.
+    with recording(tmp_path / "work", tmp_path / "target") as second:
+        assert second.work.is_dir()


### PR DESCRIPTION
Two invocations sharing a `--work` both pass preflight, then write independent attempts into one `install.jsonl` and partition the same disks. A later `--resume` selects the last `started` it reads and filters to that attempt, so the other live run's checkpoints are ignored even though it changed the same target. There was no `flock`, `lockf` or lock file anywhere in the tree.

`recording()` now takes an exclusive `flock` for the length of the run and stops with `WorkDirectoryBusy` and exit code 2 when it cannot: nothing has run, and the operator can wait or choose another `--work`. `fcntl` is standard library, so no runtime dependency is added.