### PR TITLE
vm: require the configured mount targets

### DIFF
--- a/tests/unit/test_harness.py
+++ b/tests/unit/test_harness.py
@@ -2545,6 +2545,11 @@ def test_a_healthy_init_is_judged_by_the_marker_it_prints() -> None:
         "kernel": b"6.18.43-gentoo-dist-bin\n/boot/kernel-6.18.43-gentoo-dist-bin\n",
         "fstab": b"UUID=ab2e555d\t/\tbtrfs\tdefaults,subvol=@\t0\t1\n",
         "esp": b"/efi /dev/vda1 vfat\n",
+        "mounts": (
+            b"/       /dev/vda2[/@]      btrfs\n"
+            b"/efi    /dev/vda1          vfat\n"
+            b"/home   /dev/vda2[/@home]  btrfs\n"
+        ),
         "timezone": (
             f"/usr/share/zoneinfo/{installation.system.timezone}\n"
             f"{installation.system.timezone}\n"
@@ -2560,6 +2565,46 @@ def test_a_healthy_init_is_judged_by_the_marker_it_prints() -> None:
     broken = dict(healthy)
     broken["failed.txt"] = b"cronie.service loaded failed failed\n"
     assert check_expected(broken, fixture) != 0
+
+
+def test_installed_mount_check_requires_every_configured_target() -> None:
+    """A partial btrfs layout must not pass as fully mounted."""
+    from gentoo_install.exec.config import load
+    from tests.vm.installed import checks
+
+    fixture = Path("tests/fixtures/vm-btrfs.toml")
+    mount_check = next(
+        check for check in checks(load(fixture)) if check.name == "mounts"
+    )
+    missing_home = (
+        "/       /dev/vda2[/@]      btrfs\n"
+        "/efi    /dev/vda1          vfat\n"
+    )
+    complete = missing_home + "/home   /dev/vda2[/@home]  btrfs\n"
+
+    assert re.search(mount_check.pattern, missing_home) is None
+    assert re.search(mount_check.pattern.encode(), missing_home.encode()) is None
+    assert re.search(mount_check.pattern, complete) is not None
+    assert re.search(mount_check.pattern.encode(), complete.encode()) is not None
+
+
+def test_installed_mount_check_handles_swap_and_unprobed_conversion() -> None:
+    """Swap has no target; an unprobed conversion still requires its root."""
+    from gentoo_install.exec.config import load
+    from tests.vm.installed import checks
+
+    bios_installation = load(Path("tests/fixtures/vm-bios.toml"))
+    bios_check = next(
+        check for check in checks(bios_installation) if check.name == "mounts"
+    )
+    conversion_check = next(
+        check for check in checks(load(Path("tests/fixtures/vm-convert.toml")))
+        if check.name == "mounts"
+    )
+
+    assert re.search(bios_check.pattern, "/ /dev/vda2 ext4\n") is not None
+    assert re.search(conversion_check.pattern, "/ /dev/vda1 xfs\n") is not None
+    assert re.search(conversion_check.pattern, "/proc proc proc\n") is None
 
 
 def test_a_proxy_on_the_workstation_must_be_listening_before_the_run() -> None:

--- a/tests/vm/installed.py
+++ b/tests/vm/installed.py
@@ -26,9 +26,10 @@ from gentoo_install.model.device import (
     ZfsPool,
     ZfsTopology,
 )
+from gentoo_install.plan.mounts import ResolvedMount, resolve_mounts
+from gentoo_install.plan.packages import ENVIRONMENT_FILE, input_environment
 from gentoo_install.plan.system import _network_service as network_service
 from gentoo_install.plan.system import _sshd_service as sshd_service
-from gentoo_install.plan.packages import ENVIRONMENT_FILE, input_environment
 
 from .console import DISK_PASSPHRASE
 
@@ -81,7 +82,11 @@ def checks(installation: InstallConfig) -> tuple[InstalledCheck, ...]:
     """Derive every installed-state check from the configuration."""
     result = [
         InstalledCheck("os-release", "cat /etc/os-release", r"(?m)^ID=['\"]?gentoo['\"]?$"),
-        InstalledCheck("mounts", "findmnt --noheadings --list --output TARGET,SOURCE,FSTYPE", "/"),
+        InstalledCheck(
+            "mounts",
+            "findmnt --noheadings --list --output TARGET,SOURCE,FSTYPE",
+            _mount_pattern(installation),
+        ),
         InstalledCheck("locale", "locale", f"LANG={installation.system.locale}"),
         # Nothing asked for the timezone at all, and the installer writes two
         # files for it: a machine installed in the wrong zone passed every
@@ -300,6 +305,36 @@ def checks(installation: InstallConfig) -> tuple[InstalledCheck, ...]:
     if not isinstance(source, ZfsDataset):
         result.append(InstalledCheck("fstab", "cat /etc/fstab", ROOT_BY_UUID))
     return tuple(result)
+
+
+def _mount_pattern(installation: InstallConfig) -> str:
+    """Require every configured mount, or the root of an unprobed conversion."""
+    if installation.disk.layout_is_read_from_the_machine:
+        # The initial in-place configuration has no graph, but conversion still needs
+        # its root mounted.
+        return r"(?m)^/\s+\S+\s+\S+$"
+    mounts = resolve_mounts(installation.disk.graph)
+    if not mounts:
+        # Only unprobed in-place configurations lack mountpoints; no planned mount
+        # must pass.
+        return r"(?!)"
+    return "(?ms)" + "".join(_mount_line_pattern(mount) for mount in mounts)
+
+
+def _mount_line_pattern(mount: ResolvedMount) -> str:
+    """Require one `findmnt` line with the mount's configured filesystem type."""
+    if mount.dataset is not None:
+        filesystem_type = "zfs"
+    elif mount.filesystem_kind is not None:
+        filesystem_type = mount.filesystem_kind.value
+    else:
+        raise ValueError(
+            f"resolved mount {mount.path} has neither a filesystem type nor a ZFS dataset"
+        )
+    return (
+        rf"(?=.*^{re.escape(str(mount.path))}\s+\S+\s+"
+        rf"{re.escape(filesystem_type)}$)"
+    )
 
 
 def _hostname_command(installation: InstallConfig) -> str:


### PR DESCRIPTION
The `mounts` check expected the pattern `/` matched with `re.search`, so any `findmnt` output containing a slash satisfied it. Every verdict saying `mounted its layout` rested on that.

It now derives the requirement from the configuration through `plan.mounts.resolve_mounts()` — one lookahead per configured mountpoint, anchored to a whole line, carrying the filesystem type the configuration asked for. An in-place layout that has not been probed requires its root and says why; a configuration with no planned mounts gets a pattern that cannot match rather than passing silently.

Measured against tonight's real `ext4-bios` guest output, which is space-aligned: complete passes, a `btrfs-luks` output missing `/home` fails where the old check passed, and a root mounted `ext4` instead of `btrfs` fails where the old check passed.