### PR TITLE
tui: carry the Chinese defaults to the switches that were left out

### DIFF
--- a/gentoo_install/data/locale/ja.toml
+++ b/gentoo_install/data/locale/ja.toml
@@ -76,6 +76,7 @@
 "Layout" = "ディスク構成"
 "Keyboard layout" = "キーボード配列"
 "Console font" = "コンソールフォント"
+"Console CJK" = "コンソール CJK"
 "Partition table" = "パーティションテーブル"
 "Firmware" = "ファームウェア"
 "Network configuration" = "ネットワーク設定"

--- a/gentoo_install/data/locale/ko.toml
+++ b/gentoo_install/data/locale/ko.toml
@@ -76,6 +76,7 @@
 "Layout" = "디스크 구성"
 "Keyboard layout" = "키보드 배열"
 "Console font" = "콘솔 글꼴"
+"Console CJK" = "콘솔 CJK"
 "Partition table" = "파티션 테이블"
 "Firmware" = "펌웨어"
 "Network configuration" = "네트워크 설정"

--- a/gentoo_install/data/locale/zh-CN.toml
+++ b/gentoo_install/data/locale/zh-CN.toml
@@ -76,6 +76,7 @@
 "Layout" = "磁盘布局"
 "Keyboard layout" = "键盘布局"
 "Console font" = "控制台字体"
+"Console CJK" = "控制台 CJK"
 "Partition table" = "分区表"
 "Firmware" = "固件"
 "Network configuration" = "网络配置"

--- a/gentoo_install/data/locale/zh-TW.toml
+++ b/gentoo_install/data/locale/zh-TW.toml
@@ -76,6 +76,7 @@
 "Layout" = "磁碟配置"
 "Keyboard layout" = "鍵盤配置"
 "Console font" = "主控台字型"
+"Console CJK" = "主控台 CJK"
 "Partition table" = "分割表"
 "Firmware" = "韌體"
 "Network configuration" = "網路設定"

--- a/gentoo_install/tui/screens.py
+++ b/gentoo_install/tui/screens.py
@@ -2154,8 +2154,8 @@ INTERFACE_LANGUAGES: tuple[tuple[str, str, bool], ...] = (
 class LanguageDefaults:
     """What picking an interface language pre-fills.
 
-    Locale, timezone, and mirror region follow the language. Every one of
-    these stays a row the operator can change.
+    Locale, timezone, mirror region, fonts, and input methods follow the
+    language. Every one of these stays a row the operator can change.
     """
 
     locale: str
@@ -2165,13 +2165,29 @@ class LanguageDefaults:
     #: gentoo-zh, so it is not a default for a language that would not use the
     #: rest of that overlay.
     cjk_console: bool = False
+    font_groups: tuple[str, ...] = ()
+    input_method_groups: tuple[str, ...] = ()
 
 
 #: One row per interface language. Keyed by the same tags as the catalogs.
 LANGUAGE_DEFAULTS: Final[dict[str, LanguageDefaults]] = {
     "en": LanguageDefaults("en_US.UTF-8", "UTC", MirrorRegion.GLOBAL),
-    "zh-CN": LanguageDefaults("zh_CN.UTF-8", "Asia/Shanghai", MirrorRegion.CN, True),
-    "zh-TW": LanguageDefaults("zh_TW.UTF-8", "Asia/Taipei", MirrorRegion.GLOBAL, True),
+    "zh-CN": LanguageDefaults(
+        "zh_CN.UTF-8",
+        "Asia/Shanghai",
+        MirrorRegion.CN,
+        cjk_console=True,
+        font_groups=("noto-cjk",),
+        input_method_groups=("fcitx5", "rime"),
+    ),
+    "zh-TW": LanguageDefaults(
+        "zh_TW.UTF-8",
+        "Asia/Taipei",
+        MirrorRegion.GLOBAL,
+        cjk_console=True,
+        font_groups=("noto-cjk",),
+        input_method_groups=("fcitx5", "rime"),
+    ),
     # cjktty is what puts Chinese, Japanese and Korean on the console, so all
     # four of those catalogs take the patched kernel and not only the two
     # Chinese ones.
@@ -2188,6 +2204,11 @@ def with_language(config: InstallConfig, tag: str) -> InstallConfig:
     locales = config.system.locales
     if chosen.locale not in locales:
         locales = (*locales, chosen.locale)
+    language_groups = (*chosen.font_groups, *chosen.input_method_groups)
+    applications = (
+        *config.packages.applications,
+        *(group for group in language_groups if group not in config.packages.applications),
+    )
     seeded = replace(
         config,
         system=replace(
@@ -2197,6 +2218,7 @@ def with_language(config: InstallConfig, tag: str) -> InstallConfig:
             locales=locales,
             console_cjk=chosen.cjk_console,
         ),
+        packages=replace(config.packages, applications=applications),
         portage=replace(
             config.portage,
             mirrors=replace(config.portage.mirrors, region=chosen.mirror_region),

--- a/gentoo_install/tui/screens.py
+++ b/gentoo_install/tui/screens.py
@@ -1842,6 +1842,16 @@ def _pick_keymap(
     )
 
 
+def console_cjk_screen(
+    screen: Screen, config: InstallConfig, context: Context
+) -> Answer[InstallConfig]:
+    """Flipped where it stands: the row reads `in use` or `not used` already."""
+    return Answer(
+        Outcome.CHOSE,
+        replace(config, system=replace(config.system, console_cjk=not config.system.console_cjk)),
+    )
+
+
 def console_font_screen(
     screen: Screen, config: InstallConfig, context: Context
 ) -> Answer[InstallConfig]:

--- a/gentoo_install/tui/screens.py
+++ b/gentoo_install/tui/screens.py
@@ -30,6 +30,7 @@ from ..model.config import (
     ImageFormat,
     Firewall,
     InitSystem,
+    MirrorRegion,
     InstallConfig,
     KernelConfig,
     KernelSource,
@@ -2143,13 +2144,13 @@ INTERFACE_LANGUAGES: tuple[tuple[str, str, bool], ...] = (
 class LanguageDefaults:
     """What picking an interface language pre-fills.
 
-    Locale and timezone follow the language; the mirror region does not, and is
-    read from where the machine reaches the internet. Every one of these stays
-    a row the operator can change.
+    Locale, timezone, and mirror region follow the language. Every one of
+    these stays a row the operator can change.
     """
 
     locale: str
     timezone: str
+    mirror_region: MirrorRegion
     #: True for the languages the cjktty patch is the point of. It pulls in
     #: gentoo-zh, so it is not a default for a language that would not use the
     #: rest of that overlay.
@@ -2158,14 +2159,14 @@ class LanguageDefaults:
 
 #: One row per interface language. Keyed by the same tags as the catalogs.
 LANGUAGE_DEFAULTS: Final[dict[str, LanguageDefaults]] = {
-    "en": LanguageDefaults("en_US.UTF-8", "UTC"),
-    "zh-CN": LanguageDefaults("zh_CN.UTF-8", "Asia/Shanghai", True),
-    "zh-TW": LanguageDefaults("zh_TW.UTF-8", "Asia/Taipei", True),
+    "en": LanguageDefaults("en_US.UTF-8", "UTC", MirrorRegion.GLOBAL),
+    "zh-CN": LanguageDefaults("zh_CN.UTF-8", "Asia/Shanghai", MirrorRegion.CN, True),
+    "zh-TW": LanguageDefaults("zh_TW.UTF-8", "Asia/Taipei", MirrorRegion.GLOBAL, True),
     # cjktty is what puts Chinese, Japanese and Korean on the console, so all
     # four of those catalogs take the patched kernel and not only the two
     # Chinese ones.
-    "ja": LanguageDefaults("ja_JP.UTF-8", "Asia/Tokyo", True),
-    "ko": LanguageDefaults("ko_KR.UTF-8", "Asia/Seoul", True),
+    "ja": LanguageDefaults("ja_JP.UTF-8", "Asia/Tokyo", MirrorRegion.GLOBAL, True),
+    "ko": LanguageDefaults("ko_KR.UTF-8", "Asia/Seoul", MirrorRegion.GLOBAL, True),
 }
 
 
@@ -2185,6 +2186,10 @@ def with_language(config: InstallConfig, tag: str) -> InstallConfig:
             timezone=chosen.timezone,
             locales=locales,
             console_cjk=chosen.cjk_console,
+        ),
+        portage=replace(
+            config.portage,
+            mirrors=replace(config.portage.mirrors, region=chosen.mirror_region),
         ),
     )
     if not chosen.cjk_console:

--- a/gentoo_install/tui/settings.py
+++ b/gentoo_install/tui/settings.py
@@ -718,6 +718,14 @@ def _erase(config: InstallConfig, context: Context) -> str:
     return context.translate("confirmed") if targets <= context.confirmed else UNSET
 
 
+
+def _console_cjk_kernel_only(config: InstallConfig, context: Context) -> str:
+    """The cjktty switch cannot turn on without a kernel carrying the patch."""
+    if config.kernel.source not in CJK_KERNELS:
+        return context.translate("only the cjk kernel draws CJK on the console")
+    return ""
+
+
 def _cjk_kernel_only(config: InstallConfig, context: Context) -> str:
     """A font with CJK glyphs draws nothing without the patch that lets the
     console show them, so the size is a choice only under that kernel."""
@@ -811,6 +819,13 @@ BOOT: Final[tuple[Setting, ...]] = (
 #: than held in a table: the list moves every week.
 KERNEL: Final[tuple[Setting, ...]] = (
     Setting("source", "Package", _kernel, screens.kernel_screen),
+    Setting(
+        "console_cjk",
+        "Console CJK",
+        lambda c, x: x.translate("in use" if c.system.console_cjk else "not used"),
+        screens.console_cjk_screen,
+        unavailable=_console_cjk_kernel_only,
+    ),
     Setting(
         "console_font",
         "Console font",

--- a/tests/unit/test_every_row.py
+++ b/tests/unit/test_every_row.py
@@ -275,7 +275,7 @@ def test_reopening_encryption_keeps_the_container_and_its_passphrase() -> None:
 
 #: Rows that answer by flipping rather than by offering a list. Reopening one
 #: and pressing enter flips it again, which is what it is for.
-FLIPPED: frozenset[str] = frozenset({"cron"})
+FLIPPED: frozenset[str] = frozenset({"console_cjk", "cron"})
 
 
 def test_no_row_loses_its_value_when_it_is_opened_again() -> None:

--- a/tests/unit/test_tui_app.py
+++ b/tests/unit/test_tui_app.py
@@ -1121,6 +1121,19 @@ def test_a_chinese_system_locale_selects_no_input_method_or_font_group() -> None
     }
     assert not language_packages.intersection(chosen.packages.applications)
 
+def test_a_chinese_interface_selects_removable_font_and_input_groups() -> None:
+    at = context()
+    chinese = screens.with_language(config(), "zh-CN")
+    assert chinese.packages.desktop == ""
+    assert chinese.packages.applications == ("noto-cjk", "fcitx5", "rime")
+
+    without_fonts = tui_packages.select_cjk_fonts(chinese, at.groups, (), ())
+    assert "noto-cjk" not in without_fonts.packages.applications
+    without_input = tui_packages.select_input_framework(without_fonts, at.groups, "")
+    assert not set(tui_packages.input_method_groups(at.groups)).intersection(
+        without_input.packages.applications
+    )
+
 
 def test_an_input_engine_cannot_be_selected_without_its_framework() -> None:
     with pytest.raises(ConfigError, match="framework"):

--- a/tests/unit/test_tui_app.py
+++ b/tests/unit/test_tui_app.py
@@ -826,16 +826,17 @@ def test_a_paste_needs_only_its_identifier() -> None:
 
 
 def test_choosing_the_traditional_catalog_moves_the_defaults_with_it() -> None:
-    """Locale and timezone follow the language. The mirror region does not: a
-    Taiwanese machine reading Chinese is not behind the Great Firewall and one
-    in China reading English is, so that answer comes from the egress."""
+    """The selected language supplies its locale, timezone, and mirror region."""
+    from gentoo_install.model.config import MirrorRegion
+
     taiwan = screens.with_language(config(), "zh-TW")
     assert taiwan.system.timezone == "Asia/Taipei"
     assert taiwan.system.locale == "zh_TW.UTF-8"
+    assert taiwan.portage.mirrors.region is MirrorRegion.GLOBAL
     china = screens.with_language(config(), "zh-CN")
     assert china.system.timezone == "Asia/Shanghai"
     assert china.system.locale == "zh_CN.UTF-8"
-    assert china.portage.mirrors.region is taiwan.portage.mirrors.region
+    assert china.portage.mirrors.region is MirrorRegion.CN
 
 
 def test_language_selector_translates_its_footer() -> None:

--- a/tests/unit/test_tui_app.py
+++ b/tests/unit/test_tui_app.py
@@ -1088,6 +1088,18 @@ def test_language_section_reaches_every_language_setting_from_the_menu() -> None
     for label in ("System language", "Other locales", "Fonts"):
         assert label in drawn, label
 
+def test_console_cjk_has_an_independent_switch_beside_its_font() -> None:
+    cjk, font = settings.KERNEL[1:3]
+    assert (cjk.key, font.key) == ("console_cjk", "console_font")
+
+    at = context()
+    assert cjk.unavailable(config(), at)
+    chinese = screens.with_language(config(), "zh-TW")
+    assert cjk.unavailable(chinese, at) == ""
+
+    disabled = screens.console_cjk_screen(FakeScreen(keys=[]), chinese, at).unwrap()
+    assert not disabled.system.console_cjk
+
 
 def test_a_chinese_system_locale_selects_no_input_method_or_font_group() -> None:
     start = replace(
@@ -2635,10 +2647,10 @@ def test_reopening_a_setting_and_accepting_keeps_what_it_held() -> None:
             base.portage, keywords=Keywords.TESTING, profile="default/linux/amd64/23.0"
         ),
     )
-    # Three rows answer a different question and are not selectors:
-    # `Cron` flips where it stands, `Drive` reads `context.choice` rather than
-    # the configuration, and `Bootloader` cannot keep a kind the layout forbids.
-    flipped = {"Cron", "Drive", "Bootloader"}
+    # Four rows answer a different question and are not selectors:
+    # `Console CJK` and `Cron` flip where they stand, `Drive` reads
+    # `context.choice`, and `Bootloader` cannot keep a kind the layout forbids.
+    flipped = {"Console CJK", "Cron", "Drive", "Bootloader"}
     # Four screens enter is not an answer to, named rather than caught: an
     # `except Exception: continue` around the call meant every screen could
     # raise on enter and this test still passed with an empty list.


### PR DESCRIPTION
`docs/design.md:597` settles that the opening language answer sets the mirror region, with its reason: a Traditional Chinese reader is in Taipei rather than Shanghai, and a CN mirror is on the other side of a border from them. The code set locale, timezone, console CJK, kernel and overlay, and left `MirrorRegion.GLOBAL`. `zh-CN` now takes the CN mirrors and `zh-TW` keeps the global set.

`system.console_cjk` had no row at all, so an operator who chose Chinese was held on a gentoo-zh cjk kernel by `compat.RULES` with no way back. It has one now, beside `Console font`, and a kernel without cjktty cannot turn it on.

The CJK font and input-method groups are written into `PackagesConfig.applications` rather than implied, so `Fonts` and `Input method` show as chosen and can each be cleared — a default that is still a switch. No desktop is selected.