### PR TITLE
bootstrap: match flags as arguments, not as one joined string

### DIFF
--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -190,8 +190,7 @@ say "python: $python ($version)"
 for argument in "$@"; do
 	case "$argument" in
 	-h | --help)
-		cd "$HERE"
-		exec "$python" -m gentoo_install "$@"
+		PYTHONPATH=$HERE exec "$python" -m gentoo_install "$@"
 		;;
 	esac
 done
@@ -263,5 +262,4 @@ yes) ;;
 *) [ "$(id -u)" = 0 ] || die "run as root: sudo $0 $*" ;;
 esac
 
-cd "$HERE"
-exec "$python" -m gentoo_install "$@"
+PYTHONPATH=$HERE exec "$python" -m gentoo_install "$@"

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -148,8 +148,9 @@ python_binary() {
 }
 
 install_missing=no
-# Consumed here rather than passed on: the installer's own parser rejects it,
-# and the memory environment's first screen is where the operator consented.
+dry_run=no
+# Consume launcher-only arguments while recording flags by exact value. A
+# config pathname can contain option-shaped text without becoming an option.
 count=$#
 while [ "$count" -gt 0 ]; do
 	argument=$1
@@ -157,6 +158,10 @@ while [ "$count" -gt 0 ]; do
 	count=$((count - 1))
 	case "$argument" in
 	--install-missing) install_missing=yes ;;
+	--dry-run)
+		dry_run=yes
+		set -- "$@" "$argument"
+		;;
 	*) set -- "$@" "$argument" ;;
 	esac
 done
@@ -192,8 +197,8 @@ done
 # every missing command at once, so the operator fixes them in one pass. Not
 # for a dry run: it performs nothing, and refusing it on a machine without the
 # tools takes away the one way to check a file before reaching the target.
-case " $* " in
-*" --dry-run "*) missing="" ;;
+case "$dry_run" in
+yes) missing="" ;;
 *)
 	# PYTHONPATH rather than a cd: `--config` names a path the operator typed,
 	# which has to resolve against their directory and not against this script's.
@@ -250,8 +255,8 @@ fi
 
 # Last, so the diagnostics above still run for an ordinary user: what needs
 # root is the install itself, which stages keys under /run and writes disks.
-case " $* " in
-*" --dry-run "*) ;;
+case "$dry_run" in
+yes) ;;
 *) [ "$(id -u)" = 0 ] || die "run as root: sudo $0 $*" ;;
 esac
 

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -243,7 +243,7 @@ if [ -n "$missing" ]; then
 	fi
 	# shellcheck disable=SC2086
 	if ! $manager$packages; then
-		say "that command failed, so nothing was installed"
+		say "that command failed; some packages may have been installed"
 		exit 1
 	fi
 	if ! missing=$(PYTHONPATH=$HERE "$python" -m gentoo_install --missing-commands "$@" 2>&1); then

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -182,7 +182,10 @@ if ! python=$(python_binary); then
 	fi
 	exit 1
 fi
-say "python: $python ($("$python" --version 2>&1))"
+if ! version=$("$python" --version 2>&1); then
+	die "could not read Python version: $version"
+fi
+say "python: $python ($version)"
 
 for argument in "$@"; do
 	case "$argument" in

--- a/packaging/gig/app-admin/gentoo-install/gentoo-install-9999.ebuild
+++ b/packaging/gig/app-admin/gentoo-install/gentoo-install-9999.ebuild
@@ -23,6 +23,9 @@ src_install() {
 	python_moduleinto gentoo_install
 	python_domodule gentoo_install/.
 
+	exeinto /usr/local/libexec/gentoo-install
+	doexe bootstrap.sh
+
 	# The one path `plan/netboot.py` names in its banner, so the command an
 	# operator is told about is the command the medium has.
 	exeinto /usr/local/sbin

--- a/packaging/launcher/gentoo-install
+++ b/packaging/launcher/gentoo-install
@@ -1,6 +1,14 @@
 #!/bin/sh
 # SPDX-License-Identifier: GPL-2.0-or-later
-# The installer as a command on the Live ISO. No `--config`: the operator on a
-# live desktop wants the menu, and the memory environment's own launcher is the
-# one that carries a prepared file.
-exec python3 -m gentoo_install "$@"
+# The installed command reaches bootstrap, which owns the environment checks.
+case "$0" in
+*/*) here=${0%/*} ;;
+*)
+	here=$(command -v "$0") || exit 127
+	case "$here" in
+	*/*) here=${here%/*} ;;
+	*) here=. ;;
+	esac
+	;;
+esac
+exec "$here/../libexec/gentoo-install/bootstrap.sh" "$@"

--- a/tests/unit/test_bootstrap.py
+++ b/tests/unit/test_bootstrap.py
@@ -501,3 +501,41 @@ def test_install_missing_runs_the_command_it_prints_and_checks_again(
     assert installed.exists()
     # The flag is consumed here: the installer's own parser has no such option.
     assert "--install-missing" not in said.replace("run: ", ""), said
+
+
+def test_a_failed_package_command_can_leave_partial_installation(tmp_path: Path) -> None:
+    """A package manager can install one package before a later one fails."""
+    helpers = tmp_path / "helpers"
+    helpers.mkdir()
+    (helpers / "python3").symlink_to(PYTHON)
+    installed = tmp_path / "installed"
+    (helpers / "apk").write_text(
+        f"#!/bin/sh\n: > {installed}\nexit 23\n", encoding="utf-8"
+    )
+    (helpers / "apk").chmod(0o755)
+    module = tmp_path / "fake"
+    (module / "gentoo_install").mkdir(parents=True)
+    (module / "gentoo_install" / "__init__.py").write_text("", encoding="utf-8")
+    (module / "gentoo_install" / "__main__.py").write_text(
+        "print('sgdisk blkid')\n", encoding="utf-8"
+    )
+    where = tmp_path / "os-release"
+    where.write_text("ID=alpine\n")
+
+    failed = subprocess.run(
+        [SHELL, str(LAUNCHER), "--install-missing", "--config", "x.toml"],
+        cwd=str(module),
+        env={
+            "OS_RELEASE": str(where),
+            "PATH": str(helpers),
+            "PYTHONPATH": str(module),
+        },
+        capture_output=True,
+        text=True,
+    )
+
+    said = output(failed)
+    assert failed.returncode == 1
+    assert installed.exists()
+    assert "that command failed; some packages may have been installed" in said
+    assert "nothing was installed" not in said

--- a/tests/unit/test_bootstrap.py
+++ b/tests/unit/test_bootstrap.py
@@ -171,6 +171,58 @@ def test_a_package_is_never_named_twice(tmp_path: Path) -> None:
     assert len(packages) == len(set(packages))
 
 
+def test_an_argument_value_cannot_enable_dry_run(tmp_path: Path) -> None:
+    """Arguments are separate values, so a config pathname cannot impersonate
+    `--dry-run` and skip the preflight or root diagnostics."""
+    helpers = tmp_path / "helpers"
+    helpers.mkdir()
+    trace = tmp_path / "trace"
+    (helpers / "python3").write_text(
+        """#!/bin/sh
+printf 'python %s\n' "$*" >> "$TRACE"
+case "$1" in
+-c)
+    case "$2" in
+    *version_info\\[1\\]*) printf '11\n' ;;
+    *version_info\\[0\\]*) printf '3\n' ;;
+    esac
+    ;;
+--version) printf 'Python 3.11.0\n' ;;
+esac
+""",
+        encoding="utf-8",
+    )
+    (helpers / "python3").chmod(0o755)
+    (helpers / "id").write_text(
+        """#!/bin/sh
+printf 'id %s\n' "$*" >> "$TRACE"
+printf '1000\n'
+""",
+        encoding="utf-8",
+    )
+    (helpers / "id").chmod(0o755)
+    release = tmp_path / "os-release"
+    release.write_text("ID=gentoo\n")
+
+    finished = subprocess.run(
+        [
+            SHELL,
+            str(LAUNCHER),
+            "--config",
+            "/definitely/missing --dry-run",
+            "--no-shell",
+        ],
+        cwd=REPOSITORY,
+        env={"OS_RELEASE": str(release), "PATH": str(helpers), "TRACE": str(trace)},
+        capture_output=True,
+        text=True,
+    )
+
+    calls = trace.read_text().splitlines()
+    assert finished.returncode == 1
+    assert any("--missing-commands" in call for call in calls)
+    assert "id -u" in calls
+
 def test_a_dry_run_needs_none_of_the_tools(tmp_path: Path) -> None:
     """It performs nothing, and refusing it on a machine without them takes
     away the one way to check a file before reaching the target. Found by

--- a/tests/unit/test_bootstrap.py
+++ b/tests/unit/test_bootstrap.py
@@ -223,6 +223,45 @@ printf '1000\n'
     assert any("--missing-commands" in call for call in calls)
     assert "id -u" in calls
 
+def test_an_unusable_python_version_stops_before_preflight(tmp_path: Path) -> None:
+    """A selected interpreter can become unusable before its version is read."""
+    helpers = tmp_path / "helpers"
+    helpers.mkdir()
+    trace = tmp_path / "trace"
+    (helpers / "python3").write_text(
+        """#!/bin/sh
+printf 'python %s\n' "$*" >> "$TRACE"
+case "$1" in
+-c)
+    case "$2" in
+    *version_info\\[1\\]*) printf '11\n' ;;
+    *version_info\\[0\\]*) printf '3\n' ;;
+    esac
+    ;;
+--version)
+    printf 'unusable interpreter\n' >&2
+    exit 71
+    ;;
+esac
+""",
+        encoding="utf-8",
+    )
+    (helpers / "python3").chmod(0o755)
+    release = tmp_path / "os-release"
+    release.write_text("ID=gentoo\n")
+
+    finished = subprocess.run(
+        [SHELL, str(LAUNCHER)],
+        cwd=REPOSITORY,
+        env={"OS_RELEASE": str(release), "PATH": str(helpers), "TRACE": str(trace)},
+        capture_output=True,
+        text=True,
+    )
+
+    assert finished.returncode == 1
+    assert "could not read Python version: unusable interpreter" in output(finished)
+    assert not any("--missing-commands" in call for call in trace.read_text().splitlines())
+
 def test_a_dry_run_needs_none_of_the_tools(tmp_path: Path) -> None:
     """It performs nothing, and refusing it on a machine without them takes
     away the one way to check a file before reaching the target. Found by

--- a/tests/unit/test_packaging.py
+++ b/tests/unit/test_packaging.py
@@ -4,7 +4,9 @@
 from __future__ import annotations
 
 import configparser
+import shutil
 import stat
+import subprocess
 from pathlib import Path
 
 ROOT = Path(__file__).resolve().parents[2]
@@ -39,7 +41,7 @@ def test_the_live_launcher_opens_the_menu() -> None:
     running = [
         line for line in LAUNCHER.read_text().splitlines() if line.startswith("exec ")
     ]
-    assert running == ['exec python3 -m gentoo_install "$@"'], running
+    assert running == ['exec "$here/../libexec/gentoo-install/bootstrap.sh" "$@"'], running
     assert LAUNCHER.stat().st_mode & stat.S_IXUSR
 
     # Negative control: the memory launcher does carry one, so the rule above
@@ -47,6 +49,55 @@ def test_the_live_launcher_opens_the_menu() -> None:
     from gentoo_install.plan.netboot import _command
 
     assert "--config" in _command()
+
+
+def test_installed_launcher_stays_on_bootstrap_path(tmp_path: Path) -> None:
+    """The installed launcher must keep both bootstrap checks and the caller's
+    working directory."""
+    prefix = tmp_path / "prefix"
+    sbin = prefix / "sbin"
+    libexec = prefix / "libexec" / "gentoo-install"
+    sbin.mkdir(parents=True)
+    libexec.mkdir(parents=True)
+    installed_launcher = sbin / "gentoo-install"
+    installed_bootstrap = libexec / "bootstrap.sh"
+    shutil.copy2(LAUNCHER, installed_launcher)
+    shutil.copy2(ROOT / "bootstrap.sh", installed_bootstrap)
+    helpers = tmp_path / "helpers"
+    helpers.mkdir()
+    python = shutil.which("python3") or "/usr/bin/python3"
+    (helpers / "python3").symlink_to(python)
+    release = tmp_path / "os-release"
+    release.write_text("ID=alpine\n")
+    operator = tmp_path / "operator"
+    module = operator / "gentoo_install"
+    module.mkdir(parents=True)
+    (module / "__init__.py").write_text("", encoding="utf-8")
+    (module / "__main__.py").write_text(
+        "from pathlib import Path\nprint(Path.cwd())\n", encoding="utf-8"
+    )
+
+    def launch(command: str | Path) -> subprocess.CompletedProcess[str]:
+        return subprocess.run(
+            [str(command), "--dry-run"],
+            cwd=operator,
+            env={"OS_RELEASE": str(release), "PATH": f"{sbin}:{helpers}"},
+            capture_output=True,
+            text=True,
+        )
+
+    direct = launch(installed_bootstrap)
+    assert direct.returncode == 0, direct.stderr
+    assert direct.stdout == f"{operator}\n"
+
+    launched = launch("gentoo-install")
+    assert launched.returncode == 0, launched.stderr
+    assert launched.stdout == f"{operator}\n"
+    assert "live system: alpine" in launched.stderr
+
+    recipe = EBUILD.read_text()
+    assert "exeinto /usr/local/libexec/gentoo-install" in recipe
+    assert "doexe bootstrap.sh" in recipe
 
 
 def test_the_desktop_entry_says_it_is_the_text_installer() -> None:


### PR DESCRIPTION
`case " $* " in` searched a joined rendering of every argument, so `--config '/definitely/missing --dry-run'` made `bootstrap.sh` skip its missing-command report and its root check. Measured before and after: the same command now names the whole string as a pathname and bootstrap's own checks run.

A failing `"$python" --version` was inside a command substitution in an argument to `say`, which succeeds, so `set -e` never saw it. A package manager that installs one package and fails on the next was reported as having installed nothing.

The installed launcher ran `python3 -m gentoo_install` directly, so the command an operator runs on the Live ISO got none of bootstrap's checks. `docs/design.md` already calls `bootstrap.sh` the sole entry point, so the launcher goes through it rather than the document being changed to match the code.