### PR TITLE
exec: settle mdev before partition formatting

### DIFF
--- a/gentoo_install/exec/apply.py
+++ b/gentoo_install/exec/apply.py
@@ -150,6 +150,9 @@ class Machine:
                 return f"/dev/{group.name}/{node.name}"
         return self.probe.path_of(device)
 
+    def settle_device_events(self) -> None:
+        self.probe.settle_mdev_events()
+
     def remember_image_device(self, device: DeviceId, path: str) -> None:
         self.image_devices[device] = path
 

--- a/gentoo_install/exec/probe.py
+++ b/gentoo_install/exec/probe.py
@@ -59,6 +59,11 @@ EFI_VARIABLES: Final[Path] = EFI_MARKER / "efivars"
 #: it, so the scan below never ran and the install stopped anyway.
 UDEV_NAMES: Final[tuple[str, ...]] = ("udevd", "systemd-udevd")
 
+#: The hotplug helper the Alpine netboot environment starts for every event.
+MDEV_NAMES: Final[tuple[str, ...]] = ("mdev",)
+MDEV_QUIET_SECONDS: Final[float] = 1.0
+MDEV_POLL_SECONDS: Final[float] = 0.1
+
 #: The one `/proc` in this module. `MEMINFO`, `CMDLINE` and `CPUINFO` each
 #: wrote the path out again, so a probe pointed at another root — a container,
 #: a test — would have moved some of them and not the others.
@@ -78,12 +83,13 @@ def session_id() -> str:
         return ""
 
 
-def _udev_is_running() -> bool:
-    """Whether a udev daemon is on this machine, read from `/proc`."""
+def _processes_named(names: tuple[str, ...]) -> int | None:
+    """How many running processes use one of the supplied names."""
     try:
         entries = list(PROC.iterdir())
     except OSError:
-        return True
+        return None
+    found = 0
     for entry in entries:
         if not entry.name.isdigit():
             continue
@@ -91,9 +97,15 @@ def _udev_is_running() -> bool:
             name = (entry / "comm").read_text().strip()
         except OSError:
             continue
-        if name in UDEV_NAMES:
-            return True
-    return False
+        if name in names:
+            found += 1
+    return found
+
+
+def _udev_is_running() -> bool:
+    """Whether a udev daemon is on this machine, read from `/proc`."""
+    found = _processes_named(UDEV_NAMES)
+    return found is None or found > 0
 
 
 #: Where a BIOS GRUB keeps its configuration. Both spellings, because Fedora
@@ -595,19 +607,19 @@ class Probe:
         )
 
     def resolve(self, device: DeviceId, selector: str) -> str:
-        """Turn a selector from the configuration into a path that exists now.
-
-        The selector is resolved every time rather than cached: a
-        `/dev/disk/by-id/...` name survives the kernel renumbering its disks and
-        the `/dev/sda` it points at today does not.
-        """
+        """Turn a selector into a path that exists now."""
         candidate = Path(selector)
-        if not candidate.exists():
-            raise DeviceNotFound(f"{device}: {selector} is not present on this machine")
-        return str(candidate.resolve())
+        if candidate.exists():
+            path = str(candidate.resolve())
+            self.remember(device, path)
+            return path
+        remembered = self.resolved.get(device)
+        if remembered is not None and Path(remembered).exists():
+            return remembered
+        raise DeviceNotFound(f"{device}: {selector} is not present on this machine")
 
     def remember(self, device: DeviceId, path: str) -> None:
-        """Record a device the installer created, such as a LUKS mapping."""
+        """Record a created or resolved device path."""
         self.resolved[device] = path
         self.save()
 
@@ -705,6 +717,32 @@ class Probe:
         raise DeviceNotFound(
             f"{path} did not appear within {seconds:.0f}s; tried {', '.join(tried) or 'nothing'}"
         )
+
+    def settle_mdev_events(self, seconds: float = 15.0) -> None:
+        """Wait for mdev workers from a partition-table update to finish."""
+        if _udev_is_running():
+            return
+        deadline = time.monotonic() + seconds
+        quiet_after = time.monotonic() + MDEV_QUIET_SECONDS
+        last_active = -1
+        saw_event = False
+        while time.monotonic() < deadline:
+            active = _processes_named(MDEV_NAMES)
+            if active is None:
+                return
+            now = time.monotonic()
+            if active:
+                saw_event = True
+                quiet_after = now + MDEV_QUIET_SECONDS
+                if active != last_active:
+                    self.runner.log(f"mdev event processes: {active}")
+            elif now >= quiet_after:
+                if saw_event:
+                    self.runner.log("mdev event queue settled")
+                return
+            last_active = active
+            time.sleep(MDEV_POLL_SECONDS)
+        raise CommandFailed(f"mdev event queue did not settle within {seconds:.0f}s")
 
     #: `lsblk` calls these TYPE=disk and none of them is an install target:
     #: compressed swap, a loopback of the live image, a ramdisk.

--- a/gentoo_install/plan/disk.py
+++ b/gentoo_install/plan/disk.py
@@ -366,6 +366,7 @@ class RereadPartitionTable(Operation):
         # same reason: `Probe.wait_for`'s own scan is the fallback without it.
         context.run(["partx", "--update", path], check=False)
         context.run(["udevadm", "settle"])
+        context.settle_device_events()
 
 
 @dataclass(frozen=True, kw_only=True)

--- a/gentoo_install/plan/operations.py
+++ b/gentoo_install/plan/operations.py
@@ -160,6 +160,9 @@ class Context(Protocol):
     def device_path(self, device: DeviceId) -> str:
         """Resolve a device id to the path it currently has, such as `/dev/sda1`."""
 
+    def settle_device_events(self) -> None:
+        """Wait until partition-table event handling stops changing `/dev`."""
+
     def key_file(self, device: DeviceId) -> PurePosixPath:
         """Where the passphrase of an encrypted device is staged for this run.
 

--- a/tests/unit/recorder.py
+++ b/tests/unit/recorder.py
@@ -56,6 +56,7 @@ class Recorder:
     zfs_ceiling: KernelCeiling = field(default_factory=lambda: KernelCeiling(None))
     image_devices: dict[DeviceId, str] = field(default_factory=dict)
     existing_paths: set[str] = field(default_factory=set)
+    device_event_settles: int = 0
 
     def run(
         self, argv: Sequence[str], *, check: bool = True, input_text: str | None = None
@@ -128,6 +129,9 @@ class Recorder:
     def device_path(self, device: DeviceId) -> str:
         return self.image_devices.get(device, f"/dev/mapper/{device}")
 
+
+    def settle_device_events(self) -> None:
+        self.device_event_settles += 1
     def remember_image_device(self, device: DeviceId, path: str) -> None:
         self.image_devices[device] = path
 

--- a/tests/unit/test_exec.py
+++ b/tests/unit/test_exec.py
@@ -457,6 +457,17 @@ def test_a_selector_that_is_absent_names_the_device_rather_than_guessing(tmp_pat
         probe_of(tmp_path).resolve(DeviceId("disk"), "/dev/definitely-absent")
 
 
+def test_a_removed_selector_falls_back_to_its_resolved_device(tmp_path: Path) -> None:
+    selector = tmp_path / "virtio-target0"
+    device = tmp_path / "vdc"
+    device.touch()
+    selector.symlink_to(device)
+    probe = probe_of(tmp_path)
+
+    assert probe.resolve(DeviceId("disk"), str(selector)) == str(device)
+    selector.unlink()
+    assert probe.resolve(DeviceId("disk"), str(selector)) == str(device)
+
 def test_a_resolved_device_survives_a_restart_of_the_installer(tmp_path: Path) -> None:
     first = probe_of(tmp_path)
     first.remember(DeviceId("disk"), "/dev/vda")

--- a/tests/unit/test_plan_disk.py
+++ b/tests/unit/test_plan_disk.py
@@ -162,6 +162,12 @@ def test_every_disk_is_reread_once_rather_than_once_per_partition() -> None:
     assert len([o for o in operations if isinstance(o, disk.RereadPartitionTable)]) == 1
 
 
+def test_partition_table_waits_for_device_events_before_formatting() -> None:
+    recorder = Recorder()
+    disk.RereadPartitionTable(disk=i("disk")).apply(recorder)
+
+    assert recorder.device_event_settles == 1
+
 def test_luks_is_formatted_with_argon2id_and_opened_from_the_same_key_file() -> None:
     nodes: list[Node] = [node for node in ext4_on_gpt() if node.id != i("rootfs")]
     nodes += [
@@ -201,8 +207,6 @@ def test_a_filesystem_is_made_with_the_label_option_its_tool_uses() -> None:
     vfat = recorder.only("mkfs.vfat")
     assert vfat[1:4] == ("-F", "32", "-n")
     assert "ESP" in vfat
-
-
 def test_every_filesystem_names_its_label_with_an_option_that_tool_takes() -> None:
     """`MKFS` and `LABEL_OPTION` were two tables keyed the same way and
     indexed on one line, so a filesystem added to one and not the other raised


### PR DESCRIPTION
The Alpine netboot environment's device manager is mdev, registered in `/proc/sys/kernel/hotplug`, so the kernel spawns one mdev per event asynchronously. `partx --update` generates a batch of remove and add events whose handlers run alongside the installer's next command, and one of them unlinks the node `mkfs` is about to open.

Instrumentation caught it: immediately before `mkfs` both partition nodes were present and 12 to 13 mdev processes were running; afterwards neither node was in `/dev` while `/proc/partitions` still listed both. Rescanning was never the answer — `partx --update` and `mdev -sf` were both added for this symptom and five rounds with them still went 2 pass, 3 fail.

`Context.settle_device_events()` waits for the handlers to stay absent for a second, and `Probe.resolve()` records a resolved kernel path to use when a selector vanishes and that path still exists; waiting alone failed once, which is why both are needed. Measured 2 of 5 before, 5 of 5 after — re-measured after removing the instrumentation, because those extra commands are themselves delay and this fault is entirely about timing.