### PR TITLE
vm: bound the installed-state check patterns

### DIFF
--- a/tests/unit/test_cluster.py
+++ b/tests/unit/test_cluster.py
@@ -342,6 +342,7 @@ def test_the_init_check_asks_the_running_init_not_a_file_listing() -> None:
     answered `-rwxr-xr-x 1 root root 49064 Nov 22 2025 /sbin/init` and the
     check looked for `openrc` in it. Two fixtures failed every round on that.
     """
+    import re
     from pathlib import Path
 
     from gentoo_install.exec.config import load
@@ -354,9 +355,10 @@ def test_the_init_check_asks_the_running_init_not_a_file_listing() -> None:
         assert "ls -l /sbin/init" not in init[1], init
         assert "/run/openrc" in init[1], init
         expected = "systemd" if installation.system.init is InitSystem.SYSTEMD else "openrc"
-        assert init[2] == expected, init
+        assert re.search(init[2], f"{expected}\n"), init
+        assert not re.search(init[2], f"{expected}-runtime\n"), init
         if wanted:
-            assert init[2] == wanted, init
+            assert expected == wanted, init
 
 
 def test_a_pinned_site_moves_every_address_that_follows_a_mirror(tmp_path: Path) -> None:

--- a/tests/unit/test_harness.py
+++ b/tests/unit/test_harness.py
@@ -535,6 +535,118 @@ def test_an_installed_check_matches_the_value_and_not_the_text_around_it() -> No
     assert not re.search(systemd, "vmtestlonger\n")
 
 
+def test_every_installed_check_is_line_bounded_or_names_why_it_is_not() -> None:
+    """A bare pattern accepts its token from any longer line, so each check
+    either matches one complete line or records the multi-line relation it needs.
+    """
+    from dataclasses import replace
+
+    from gentoo_install.exec.config import load
+    from gentoo_install.model.config import DiskMode, InitSystem
+    from tests.vm.installed import checks
+
+    configurations = [
+        load(path)
+        for path in sorted(Path("tests/fixtures").glob("*.toml"))
+        if load(path).disk.mode is not DiskMode.DD
+    ]
+    greetd = load(Path("tests/fixtures/vm-greetd.toml"))
+    configurations.append(replace(greetd, system=replace(greetd.system, init=InitSystem.OPENRC)))
+    exceptions = {
+        (check.name, check.line_boundary_exception)
+        for installation in configurations
+        for check in checks(installation)
+        if check.line_boundary_exception is not None
+    }
+    assert exceptions == {
+        ("mounts", "requires every configured mount line"),
+        ("kernel", "joins a running release to a boot path"),
+        ("greetd service", "requires enabled and active state lines"),
+        ("greetd service", "requires default service and process lines"),
+        ("greetd config", "requires constraints across greetd config lines"),
+        ("inputmethod", "requires the binary and every environment line"),
+    }
+    for installation in configurations:
+        for check in checks(installation):
+            if check.line_boundary_exception is not None:
+                continue
+            assert check.pattern.startswith("(?m)^"), check
+            assert check.pattern.endswith("$"), check
+
+
+def test_installed_checks_reject_embedded_or_stale_values() -> None:
+    """Each control matches its former pattern, rejects the wrong machine now,
+    and preserves a complete matching output.
+    """
+    from dataclasses import replace
+
+    from gentoo_install.exec.config import load
+    from tests.vm.installed import checks
+
+    def pattern(installation: InstallConfig, name: str) -> str:
+        return next(check.pattern for check in checks(installation) if check.name == name)
+
+    systemd = load(Path("tests/fixtures/vm-binpkg.toml"))
+    chinese_locale = replace(systemd, system=replace(systemd.system, locale="zh_CN.UTF-8"))
+    static_ip = load(Path("tests/fixtures/static-ip.toml"))
+    configured_ip = replace(
+        static_ip,
+        system=replace(
+            static_ip.system,
+            addresses=("192.0.2.1",),
+            gateways=("192.0.2.1",),
+        ),
+    )
+    cases = (
+        (
+            "resolver",
+            r"RESOLVCONF-OK",
+            pattern(systemd, "resolver"),
+            "/run/RESOLVCONF-OK-missing\nRESOLVCONF-EMPTY\n",
+            "/run/systemd/resolve/stub-resolv.conf\nRESOLVCONF-OK\n",
+        ),
+        (
+            "locale",
+            r"LANG=zh_CN.UTF-8",
+            pattern(chinese_locale, "locale"),
+            "LANG=zh_CN.UTF-8-broken\n",
+            "LANG=zh_CN.UTF-8\nLANGUAGE=zh_CN\n",
+        ),
+        (
+            "timezone",
+            r"(?m)^(?:/usr/share/zoneinfo/)?UTC$",
+            pattern(systemd, "timezone"),
+            "/usr/share/zoneinfo/Asia/Tokyo\nUTC\n",
+            "/usr/share/zoneinfo/UTC\nUTC\n",
+        ),
+        (
+            "address",
+            r"192\.0\.2\.1",
+            pattern(configured_ip, "address 192.0.2.1"),
+            "2: ens18    inet 192.0.2.10/24 brd 192.0.2.255 scope global ens18\n",
+            "2: ens18    inet 192.0.2.1/24 brd 192.0.2.255 scope global ens18\n",
+        ),
+        (
+            "default route",
+            r"default via 192\.0\.2\.1",
+            pattern(configured_ip, "default route 192.0.2.1"),
+            "default via 192.0.2.10 dev ens18 proto static\n",
+            "default via 192.0.2.1 dev ens18 proto static\n",
+        ),
+        (
+            "sshd",
+            r"(?m)^enabled\b",
+            pattern(systemd, "sshd"),
+            "enabled-runtime\n",
+            "enabled\n",
+        ),
+    )
+    for name, legacy, current, wrong, correct in cases:
+        assert re.search(legacy, wrong), f"{name}: legacy pattern missed its control"
+        assert not re.search(current, wrong), f"{name}: accepted the wrong machine"
+        assert re.search(current, correct), f"{name}: rejected complete output"
+
+
 def test_an_image_install_is_judged_by_the_image_it_wrote() -> None:
     """The product is a file on the scratch filesystem this runner mounts, and
     nothing here can boot a file on the guest's own disk. `--and-boot` booted
@@ -672,6 +784,7 @@ def test_greetd_service_check_reads_systemd_state() -> None:
             "greetd service",
             "systemctl is-enabled greetd.service; systemctl is-active greetd.service",
             r"(?m)^enabled$\n^active$",
+            "requires enabled and active state lines",
         )
     ]
     assert re.search(actual[0].pattern, "enabled\nactive\n")
@@ -691,6 +804,7 @@ def test_greetd_config_check_requires_tuigreet_session_directories() -> None:
             r"(?ms)\A(?!.*^\s*command\s*=\s*\"agreety)"
             r"(?=.*^command = \"tuigreet .*--sessions /usr/share/wayland-sessions"
             r" --xsessions /usr/share/xsessions\"$)",
+            "requires constraints across greetd config lines",
         )
     ]
     configured = (
@@ -718,6 +832,7 @@ def test_ibus_check_reads_its_binary_and_session_environment() -> None:
             "command -v ibus-daemon; cat /etc/environment",
             r"(?ms)(?=.*^/usr/bin/ibus\-daemon$)(?=.*^XMODIFIERS=@im=ibus$)"
             r"(?=.*^GTK_IM_MODULE=ibus$)(?=.*^QT_IM_MODULE=ibus$)",
+            "requires the binary and every environment line",
         )
     ]
     configured = (
@@ -2536,31 +2651,37 @@ def test_a_healthy_init_is_judged_by_the_marker_it_prints() -> None:
 
     fixture = Path(__file__).resolve().parents[1] / "fixtures" / "vm-btrfs.toml"
     installation = load(fixture)
-    # The pattern as its own output holds only while every pattern is a
-    # literal. Four of them relate one part of the machine's answer to
-    # another, so those four carry a line copied from a guest instead.
+    # These output forms are copied from the command contracts. Regex syntax is
+    # not output, so every bounded check gets an explicit line.
     written = {
         "os-release": b"NAME=Gentoo\nID='gentoo'\n",
-        "hostname": installation.system.hostname.encode() + b"\n",
-        "kernel": b"6.18.43-gentoo-dist-bin\n/boot/kernel-6.18.43-gentoo-dist-bin\n",
-        "fstab": b"UUID=ab2e555d\t/\tbtrfs\tdefaults,subvol=@\t0\t1\n",
-        "esp": b"/efi /dev/vda1 vfat\n",
         "mounts": (
             b"/       /dev/vda2[/@]      btrfs\n"
             b"/efi    /dev/vda1          vfat\n"
             b"/home   /dev/vda2[/@home]  btrfs\n"
         ),
+        "locale": b"LANG=zh_TW.UTF-8\n",
         "timezone": (
             f"/usr/share/zoneinfo/{installation.system.timezone}\n"
             f"{installation.system.timezone}\n"
         ).encode(),
+        "hostname": installation.system.hostname.encode() + b"\n",
+        "kernel": b"6.18.43-gentoo-dist-bin\n/boot/kernel-6.18.43-gentoo-dist-bin\n",
+        "resolver": b"/run/systemd/resolve/stub-resolv.conf\nRESOLVCONF-OK\n",
+        "portage": b"EMERGE-OK\n",
+        "cpu-flags": b"CPUFLAGS-ALL-KNOWN\n",
+        "init": b"systemd\n",
+        "units": b"systemd-networkd.service enabled enabled\n",
+        "failed": b"NO-FAILED-UNITS\n",
+        "network": b"systemd-networkd.service enabled enabled\n",
+        "esp": b"/efi /dev/vda1 vfat\n",
+        "root filesystem": b"btrfs\n",
+        "fstab": b"UUID=ab2e555d\t/\tbtrfs\tdefaults,subvol=@\t0\t1\n",
     }
-    healthy = {
-        f"{one.name}.txt": written.get(
-            one.name, one.pattern.replace("\\", "").encode() + b"\n"
-        )
-        for one in checks(installation)
-    }
+    checks_for_fixture = checks(installation)
+    missing = {one.name for one in checks_for_fixture} - written.keys()
+    assert not missing, missing
+    healthy = {f"{one.name}.txt": written[one.name] for one in checks_for_fixture}
     assert check_expected(healthy, fixture) == 0
     broken = dict(healthy)
     broken["failed.txt"] = b"cronie.service loaded failed failed\n"
@@ -3770,7 +3891,7 @@ def test_the_check_cannot_pass_by_the_tool_being_absent(tmp_path: Path) -> None:
     assert "CPUFLAGS-ALL-KNOWN" not in said, said
 
     wanted = next(one for one in checks(config()) if one.name == "cpu-flags")
-    assert wanted.pattern == "CPUFLAGS-ALL-KNOWN", wanted
+    assert wanted.pattern == r"(?m)^CPUFLAGS-ALL-KNOWN$", wanted
     assert "cpuid2cpuflags" in CPU_FLAGS_COMMAND
 
 
@@ -4515,26 +4636,21 @@ def test_a_conversion_reads_its_exit_code_and_not_the_echo() -> None:
 
 
 def test_no_installed_check_is_ever_read_with_its_own_echo() -> None:
-    """Twelve of the sixty-nine checks are satisfied by the text of the
-    command that asks them — `echo NO-FAILED-UNITS`, `findmnt … /efi` against
-    `/efi`, `rc-update show default` against `default`. That is harmless only
-    while every reader takes what lies between the two markers: one call site
-    moved to `expect_command` would pass all twelve on any machine, and the
-    conversion's exit code was read that way until today."""
+    """Console transports read only framed output, and a bounded pattern must
+    not match the shell line that framed it.
+    """
     import ast
     import re
 
     from gentoo_install.exec.config import load
     from tests.vm.installed import checks
 
-    # First the premise, measured rather than assumed: at least one check does
-    # match its own question, so the rule below is guarding something.
     echoed = [
         check.name
         for check in checks(load(Path("tests/fixtures/zfs-zbm.toml")))
         if re.search(check.pattern, f"root@livecd ~ # {check.command}\r\n")
     ]
-    assert echoed, "no check names its own answer, so this rule is dead"
+    assert not echoed, f"an installed check matched its shell echo: {echoed}"
 
     # `cluster.py` and `convert.py` ask over a console; `run.py` redirects each
     # answer into a file, where no echo reaches.
@@ -5171,23 +5287,23 @@ def test_the_pool_scan_is_bounded_and_outlives_its_own_window() -> None:
 
 
 def test_an_installed_check_is_read_between_the_markers() -> None:
-    """`installed.py` writes checks whose expected value is spelled out in the
-    command that produces it — `NO-FAILED-UNITS`, `EMERGE-OK`, `RESOLVCONF-OK`.
-    A shell echoes the line it was given, so a reader that keeps the echo finds
-    every one of those in the question and the check passes on any machine.
-    `expect_output` keeps only what arrived between its markers; the readers
-    use it today, and this is what stops the next one from not."""
+    """Commands that emit success markers keep their readers on framed output."""
     import ast
+    import re
     from pathlib import Path as _Path
 
     from tests.vm import installed
 
+    markers = ("RESOLVCONF-OK", "EMERGE-OK", "NO-FAILED-UNITS", "CPUFLAGS-ALL-KNOWN")
     spelled = [
-        one.pattern
+        one.name
         for one in installed.checks(_a_conversion())
-        if one.pattern in one.command
+        if any(
+            marker in one.command and re.search(one.pattern, f"{marker}\n")
+            for marker in markers
+        )
     ]
-    assert spelled, "no check spells its own answer, so this rule guards nothing"
+    assert {"resolver", "portage", "failed", "cpu-flags"} <= set(spelled), spelled
 
     root = _Path(__file__).resolve().parents[1] / "vm"
     echoed = []

--- a/tests/unit/test_plan_system.py
+++ b/tests/unit/test_plan_system.py
@@ -1,6 +1,7 @@
 # SPDX-License-Identifier: GPL-2.0-or-later
 from __future__ import annotations
 
+import re
 from dataclasses import replace
 from pathlib import Path, PurePosixPath
 from typing import Any
@@ -630,18 +631,31 @@ def test_static_ip_fixture_validates_and_writes_the_configured_network_for_both_
     assert installation.system.gateways == ("10.31.0.254",)
     assert installation.system.dns == ("10.31.0.199", "10.31.0.254")
 
-    expected_checks = {
-        ("address 10.31.0.150/24", "ip -o address show", r"10\.31\.0\.150/24"),
-        (
-            "default route 10.31.0.254",
-            "ip -4 route show default; ip -6 route show default",
-            r"default via 10\.31\.0\.254",
-        ),
-        ("resolver 10.31.0.199", "resolvectl dns", r"10\.31\.0\.199"),
-        ("resolver 10.31.0.254", "resolvectl dns", r"10\.31\.0\.254"),
+    expected_commands = {
+        "address 10.31.0.150/24": "ip -o address show",
+        "default route 10.31.0.254": "ip -4 route show default; ip -6 route show default",
+        "resolver 10.31.0.199": "resolvectl dns",
+        "resolver 10.31.0.254": "resolvectl dns",
     }
-    actual_checks = {(check.name, check.command, check.pattern) for check in checks(installation)}
-    assert expected_checks <= actual_checks
+    actual_checks = {check.name: check for check in checks(installation)}
+    assert {
+        (name, command) for name, command in expected_commands.items()
+    } <= {
+        (name, check.command) for name, check in actual_checks.items()
+    }
+    assert re.search(
+        actual_checks["address 10.31.0.150/24"].pattern,
+        "2: ens18    inet 10.31.0.150/24 brd 10.31.0.255 scope global ens18\n",
+    )
+    assert re.search(
+        actual_checks["default route 10.31.0.254"].pattern,
+        "default via 10.31.0.254 dev ens18 proto static\n",
+    )
+    for resolver in installation.system.dns:
+        assert re.search(
+            actual_checks[f"resolver {resolver}"].pattern,
+            "Global: 10.31.0.199 10.31.0.254\n",
+        )
 
     networkd = networked(installation).files[NETWORKD]
     assert "Address=10.31.0.150/24" in networkd

--- a/tests/vm/installed.py
+++ b/tests/vm/installed.py
@@ -41,7 +41,8 @@ class InstalledCheck:
     name: str
     command: str
     pattern: str
-
+    # Compound checks must name the relation that prevents a single-line match.
+    line_boundary_exception: str | None = None
 
 #: Read on the installed machine, against the tree that machine has: every
 #: `CPU_FLAGS_X86` value portage accepts is one line of
@@ -75,49 +76,111 @@ INPUT_METHOD_BINARIES: Final[dict[str, str]] = {
 #: The root entry, not any `UUID=` in the file. Every layout writes an esp
 #: line by UUID as well, so `UUID=` alone was satisfied by a machine whose
 #: root was still named by device. The separator is a tab on every guest read.
-ROOT_BY_UUID: Final[str] = r"(?m)^UUID=\S+\s+/\s"
+ROOT_BY_UUID: Final[str] = r"(?m)^UUID=\S+[ \t]+/[ \t]+\S+[ \t]+[^\n]*$"
 
 
 def checks(installation: InstallConfig) -> tuple[InstalledCheck, ...]:
     """Derive every installed-state check from the configuration."""
     result = [
         InstalledCheck("os-release", "cat /etc/os-release", r"(?m)^ID=['\"]?gentoo['\"]?$"),
+        # A layout is a set of mount lines; one matching line cannot prove all
+        # configured targets are present.
         InstalledCheck(
             "mounts",
             "findmnt --noheadings --list --output TARGET,SOURCE,FSTYPE",
             _mount_pattern(installation),
+            "requires every configured mount line",
         ),
-        InstalledCheck("locale", "locale", f"LANG={installation.system.locale}"),
-        # Nothing asked for the timezone at all, and the installer writes two
-        # files for it: a machine installed in the wrong zone passed every
-        # check. Either line answers, so the resolution of `UTC` — a file on
-        # Gentoo, a symlink elsewhere — does not decide the verdict.
+        InstalledCheck(
+            "locale",
+            "locale",
+            rf"(?m)^LANG={re.escape(installation.system.locale)}$",
+        ),
+        # Nothing checked timezone until wrong-zone machines passed. libc reads
+        # `localtime`, so it and `/etc/timezone` must agree.
         InstalledCheck(
             "timezone",
             "readlink -f /etc/localtime; cat /etc/timezone 2>/dev/null",
-            rf"(?m)^(?:/usr/share/zoneinfo/)?{re.escape(installation.system.timezone)}$",
+            rf"(?m)^(?:/usr/share/zoneinfo/)?{re.escape(installation.system.timezone)}$"
+            rf"\n^{re.escape(installation.system.timezone)}$",
         ),
         InstalledCheck("hostname", _hostname_command(installation), _hostname_pattern(installation)),
-        InstalledCheck("kernel", "uname -r; find /boot -maxdepth 4 -type f "
-                       r"\( -name 'vmlinuz*' -o -name 'kernel-*' -o -name linux -o -name '*.conf' \) | sort",
-                       _kernel_pattern(installation)),
-        InstalledCheck("resolver", "readlink -f /etc/resolv.conf; test -s /etc/resolv.conf && echo RESOLVCONF-OK || echo RESOLVCONF-EMPTY", "RESOLVCONF-OK"),
-        InstalledCheck("portage", "emerge --info >/dev/null 2>&1 && echo EMERGE-OK || echo EMERGE-FAIL", "EMERGE-OK"),
-        InstalledCheck("cpu-flags", CPU_FLAGS_COMMAND, "CPUFLAGS-ALL-KNOWN"),
-        InstalledCheck("init", "test -d /run/openrc && echo openrc || { test -d /run/systemd/system && echo systemd || echo unknown; }", "systemd" if installation.system.init is InitSystem.SYSTEMD else "openrc"),
+        # The release has to equal a boot filename, so this relation spans two lines.
+        InstalledCheck(
+            "kernel",
+            "uname -r; find /boot -maxdepth 4 -type f "
+            r"\( -name 'vmlinuz*' -o -name 'kernel-*' -o -name linux -o -name '*.conf' \) | sort",
+            _kernel_pattern(installation),
+            "joins a running release to a boot path",
+        ),
+        InstalledCheck(
+            "resolver",
+            "readlink -f /etc/resolv.conf; test -s /etc/resolv.conf "
+            "&& echo RESOLVCONF-OK || echo RESOLVCONF-EMPTY",
+            r"(?m)^RESOLVCONF-OK$",
+        ),
+        InstalledCheck(
+            "portage",
+            "emerge --info >/dev/null 2>&1 && echo EMERGE-OK || echo EMERGE-FAIL",
+            r"(?m)^EMERGE-OK$",
+        ),
+        InstalledCheck("cpu-flags", CPU_FLAGS_COMMAND, r"(?m)^CPUFLAGS-ALL-KNOWN$"),
+        InstalledCheck(
+            "init",
+            "test -d /run/openrc && echo openrc || { test -d /run/systemd/system "
+            "&& echo systemd || echo unknown; }",
+            rf"(?m)^{'systemd' if installation.system.init is InitSystem.SYSTEMD else 'openrc'}$",
+        ),
     ]
     if installation.system.init is InitSystem.SYSTEMD:
-        result.extend([InstalledCheck("units", "systemctl list-unit-files --state=enabled --no-legend --no-pager", "enabled"), InstalledCheck("failed", "test -z \"$(systemctl --failed --no-legend --no-pager)\" && echo NO-FAILED-UNITS", "NO-FAILED-UNITS")])
+        result.extend(
+            [
+                InstalledCheck(
+                    "units",
+                    "systemctl list-unit-files --state=enabled --no-legend --no-pager",
+                    r"(?m)^\S+[ \t]+enabled(?:[ \t]+\S+)?$",
+                ),
+                InstalledCheck(
+                    "failed",
+                    "test -z \"$(systemctl --failed --no-legend --no-pager)\" "
+                    "&& echo NO-FAILED-UNITS",
+                    r"(?m)^NO-FAILED-UNITS$",
+                ),
+            ]
+        )
     else:
-        result.extend([InstalledCheck("units", "rc-update show default", "default"), InstalledCheck("failed", "test -z \"$(rc-status --crashed)\" && echo NO-FAILED-UNITS", "NO-FAILED-UNITS")])
+        result.extend(
+            [
+                InstalledCheck(
+                    "units",
+                    "rc-update show default",
+                    r"(?m)^[ \t]*\S+[ \t]*\|[ \t]*default$",
+                ),
+                InstalledCheck(
+                    "failed",
+                    "test -z \"$(rc-status --crashed)\" && echo NO-FAILED-UNITS",
+                    r"(?m)^NO-FAILED-UNITS$",
+                ),
+            ]
+        )
     if installation.system.networking is not Networking.NONE:
-        result.append(InstalledCheck("network", "systemctl list-unit-files --state=enabled --no-legend --no-pager; rc-update show default", re.escape(network_service(installation.system))))
+        service = re.escape(network_service(installation.system))
+        result.append(
+            InstalledCheck(
+                "network",
+                "systemctl list-unit-files --state=enabled --no-legend --no-pager; "
+                "rc-update show default",
+                rf"(?m)^(?:{service}\.service[ \t]+enabled(?:[ \t]+\S+)?|"
+                rf"[ \t]*{service}[ \t]*\|[ \t]*default)$",
+            )
+        )
     if installation.system.addresses:
         result.extend(
             InstalledCheck(
                 f"address {address}",
                 "ip -o address show",
-                re.escape(address),
+                rf"(?m)^\d+:[ \t]+\S+[ \t]+inet6?[ \t]+{re.escape(address)}"
+                rf"(?=[ \t/])[^\n]*$",
             )
             for address in installation.system.addresses
         )
@@ -125,7 +188,7 @@ def checks(installation: InstallConfig) -> tuple[InstalledCheck, ...]:
             InstalledCheck(
                 f"default route {gateway}",
                 "ip -4 route show default; ip -6 route show default",
-                rf"default via {re.escape(gateway)}",
+                rf"(?m)^default[ \t]+via[ \t]+{re.escape(gateway)}[ \t]+[^\n]*$",
             )
             for gateway in installation.system.gateways
         )
@@ -134,7 +197,7 @@ def checks(installation: InstallConfig) -> tuple[InstalledCheck, ...]:
                 InstalledCheck(
                     f"resolver {resolver}",
                     "resolvectl dns",
-                    re.escape(resolver),
+                    rf"(?m)^(?=[^\n]*(?<!\S){re.escape(resolver)}(?!\S))[^\n]+$",
                 )
                 for resolver in installation.system.dns
             )
@@ -151,11 +214,16 @@ def checks(installation: InstallConfig) -> tuple[InstalledCheck, ...]:
             )
         )
         if user.groups:
+            # `id -nG` returns one space-delimited line, so every configured
+            # group must be a complete token on that same line.
+            group_patterns = "".join(
+                rf"(?=[^\n]*(?<!\S){re.escape(one)}(?!\S))" for one in user.groups
+            )
             result.append(
                 InstalledCheck(
                     f"user {user.name} groups",
                     f"id -nG {user.name}",
-                    "".join(rf"(?=.*\b{re.escape(one)}\b)" for one in user.groups),
+                    rf"(?m)^{group_patterns}[^\n]+$",
                 )
             )
     if installation.system.sshd:
@@ -168,7 +236,7 @@ def checks(installation: InstallConfig) -> tuple[InstalledCheck, ...]:
                 InstalledCheck(
                     "sshd",
                     f"systemctl show --property=UnitFileState --value {sshd_service()}.service",
-                    r"(?m)^enabled\b",
+                    r"(?m)^enabled$",
                 )
             )
         else:
@@ -176,7 +244,7 @@ def checks(installation: InstallConfig) -> tuple[InstalledCheck, ...]:
                 InstalledCheck(
                     "sshd",
                     "rc-update show default",
-                    rf"(?m)^\s*{sshd_service()}\s*\|",
+                    rf"(?m)^[ \t]*{sshd_service()}[ \t]*\|[ \t]*default$",
                 )
             )
     if installation.system.zram is not None:
@@ -187,7 +255,7 @@ def checks(installation: InstallConfig) -> tuple[InstalledCheck, ...]:
             InstalledCheck(
                 "zram",
                 "swapon --show=NAME --noheadings; zramctl --noheadings --output NAME",
-                r"(?m)^/dev/zram0\b",
+                r"(?m)^/dev/zram0$",
             )
         )
     if installation.packages.display_manager == "greetd":
@@ -197,6 +265,7 @@ def checks(installation: InstallConfig) -> tuple[InstalledCheck, ...]:
                     "greetd service",
                     "systemctl is-enabled greetd.service; systemctl is-active greetd.service",
                     r"(?m)^enabled$\n^active$",
+                    "requires enabled and active state lines",
                 )
             )
         else:
@@ -205,6 +274,7 @@ def checks(installation: InstallConfig) -> tuple[InstalledCheck, ...]:
                     "greetd service",
                     "rc-update show default; pgrep -x greetd",
                     r"(?ms)(?=.*^display-manager\s+\|\s+default$)(?=.*^[1-9][0-9]*$)",
+                    "requires default service and process lines",
                 )
             )
         result.append(
@@ -219,6 +289,7 @@ def checks(installation: InstallConfig) -> tuple[InstalledCheck, ...]:
                 r"(?ms)\A(?!.*^\s*command\s*=\s*\"agreety)"
                 r"(?=.*^command = \"tuigreet .*--sessions /usr/share/wayland-sessions"
                 r" --xsessions /usr/share/xsessions\"$)",
+                "requires constraints across greetd config lines",
             )
         )
     groups = load_catalog()
@@ -239,6 +310,7 @@ def checks(installation: InstallConfig) -> tuple[InstalledCheck, ...]:
                 "inputmethod",
                 f"command -v {binary}; cat {environment}",
                 pattern,
+                "requires the binary and every environment line",
             )
         )
     if (
@@ -285,7 +357,13 @@ def checks(installation: InstallConfig) -> tuple[InstalledCheck, ...]:
     root = graph[installation.disk.root]
     source = graph[root.source] if isinstance(root, Mountpoint) else root
     if isinstance(source, ZfsDataset):
-        result.append(InstalledCheck("root filesystem", "findmnt --noheadings --output FSTYPE /", "zfs"))
+        result.append(
+            InstalledCheck(
+                "root filesystem",
+                "findmnt --noheadings --output FSTYPE /",
+                r"(?m)^zfs$",
+            )
+        )
         pool = graph[source.pool]
         if isinstance(pool, ZfsPool) and pool.topology is not ZfsTopology.STRIPE:
             # The vdev line `zpool status` draws, which is the pool's own
@@ -295,13 +373,13 @@ def checks(installation: InstallConfig) -> tuple[InstalledCheck, ...]:
                 InstalledCheck(
                     "pool topology",
                     f"zpool status {pool.name}",
-                    rf"(?m)^\s+{pool.topology.value}-\d+\s",
+                    rf"(?m)^[ \t]+{pool.topology.value}-\d+[ \t]+[^\n]*$",
                 )
             )
     else:
         filesystem = graph[source.filesystem] if isinstance(source, Subvolume) else source
         kind = filesystem.kind.value if isinstance(filesystem, Filesystem) else ""
-        result.append(InstalledCheck("root filesystem", "findmnt --noheadings --output FSTYPE /", kind))
+        result.append(InstalledCheck("root filesystem", "findmnt --noheadings --output FSTYPE /", rf"(?m)^{kind}$"))
     if not isinstance(source, ZfsDataset):
         result.append(InstalledCheck("fstab", "cat /etc/fstab", ROOT_BY_UUID))
     return tuple(result)


### PR DESCRIPTION
`cluster.py` compares every check with an unanchored `re.search`, so six patterns were satisfied by output from a machine that was configured differently. A configured `192.0.2.1` was satisfied by `192.0.2.10/24` and by `default via 192.0.2.10`, neither of which exists; `systemctl`'s `enabled-runtime` matched `^enabled\b` at the hyphen and is lost on the next boot; `LANG=zh_CN.UTF-8-broken` matched a configuration asking for `zh_CN.UTF-8`; a dangling `/etc/resolv.conf` symlink to `/run/RESOLVCONF-OK-missing` was matched by the token in the path the command itself printed; and a machine whose `/etc/localtime` and `/etc/timezone` disagree passed on the one libc does not read.

The rule is over the table rather than the six: every `InstalledCheck` is bounded to a whole line or names a `line_boundary_exception`, so a seventh written the old way fails. Each of the six is reported three ways — the old pattern accepting the wrong output, the new one rejecting it, and a correct machine's output still passing.