### PR TITLE
validate: reject configuration values the installer ships the set for

### DIFF
--- a/gentoo_install/cli.py
+++ b/gentoo_install/cli.py
@@ -23,7 +23,7 @@ from typing import Callable, Final, Mapping, Sequence
 
 from . import errors
 from .errors import GentooInstallError, ResumeRefused
-from .data import load_catalog
+from .data import load_catalog, load_timezones
 from .exec import fetch, preflight, report
 from .exec.apply import Machine, already_degraded, apply, completed
 from .exec import probe as probe_module
@@ -61,7 +61,7 @@ from .model.config import (
 from .exec.config import load_source
 from .model import authorized
 from .model.serialise import to_toml
-from .model.validate import validate_memory_launch
+from .model.validate import validate, validate_memory_launch
 from .plan import convert, netboot
 from .plan.convert import SWAP_CONFIRMATION
 from .plan.build import (
@@ -464,6 +464,13 @@ def _once(arguments: argparse.Namespace, state: RunState, refused: str) -> int |
             config = chosen
         else:
             config = load_source(arguments.config)
+        if not arguments.missing_commands:
+            catalog = load_catalog()
+            validate(
+                config,
+                available_timezones=load_timezones(),
+                available_package_groups=catalog,
+            )
         if launch is not None:
             if arguments.config is not None and _needs_network(arguments):
                 _check_the_clock()
@@ -509,7 +516,7 @@ def _once(arguments: argparse.Namespace, state: RunState, refused: str) -> int |
             loader_v3 = reading.supports_v3()
         operations = build(
             config,
-            load_catalog(),
+            catalog,
             mirror=arguments.mirror,
             storage_facts=storage_facts,
             layout=layout,

--- a/gentoo_install/data.py
+++ b/gentoo_install/data.py
@@ -44,6 +44,17 @@ def load_catalog(root: Path | None = None) -> Catalog:
     return catalog
 
 
+def load_timezones(root: Path | None = None) -> frozenset[str]:
+    """Read the zone names the installed system is expected to recognise."""
+    base = root if root is not None else DATA
+    path = base / "timezones.txt"
+    try:
+        listed = path.read_text(encoding="utf-8")
+    except OSError as error:
+        raise ConfigError(f"{path}: {error}") from error
+    return frozenset(("UTC", *(line for line in listed.split() if "/" in line)))
+
+
 def _load(path: Path) -> Group:
     raw = _compose(path)
     return Group(

--- a/gentoo_install/model/validate.py
+++ b/gentoo_install/model/validate.py
@@ -12,6 +12,7 @@ from collections import Counter
 from dataclasses import dataclass, fields
 from pathlib import PurePosixPath
 from typing import Collection, Final, Mapping
+from urllib.parse import urlparse
 
 from ..errors import CommandFailed, ValidationFailed
 from . import compat
@@ -66,6 +67,31 @@ _L10N_TAG: Final[re.Pattern[str]] = re.compile(
     r"^[a-z]{2,3}(?:-[A-Z][a-z]{3})?(?:-(?:[A-Z]{2}|[0-9]{3}))?"
     r"(?:-(?:[0-9][a-z0-9]{3}|[a-z][a-z0-9]{4,7}))*$"
 )
+
+#: The target's locale is not checked here. `docs/plan.md` settles that the
+#: installed system's language is a separate choice from the interface's, and
+#: the set `locale-gen` can produce belongs to the target rather than to this
+#: installer; `plan/system.GenerateLocales` reads `locale --all-locales` after
+#: generating and raises `LocaleMissing` for anything absent, which is the
+#: check that can actually see the answer.
+
+#: Closed system values checked by this module. Keymaps are not here: the
+#: target's kbd version owns that namespace, not the installer.
+CLOSED_SYSTEM_FIELDS: Final[frozenset[str]] = frozenset(
+    {"timezone", "hostname", "first_boot.url"}
+)
+
+#: `extra` is intentionally absent: it is a sequence of Portage atoms, not
+#: package-group names from this installer's catalog.
+PACKAGE_GROUP_FIELDS: Final[tuple[str, ...]] = (
+    "desktop", "applications", "graphics", "display_manager"
+)
+
+HTTP_SCHEMES: Final[frozenset[str]] = frozenset({"http", "https"})
+_HOSTNAME_LABEL: Final[re.Pattern[str]] = re.compile(
+    r"[A-Za-z0-9](?:[A-Za-z0-9-]{0,61}[A-Za-z0-9])?"
+)
+_HOSTNAME_MAXIMUM: Final[int] = 253
 
 #: `[disk]` keys valid after `mode` selects the operation. `mode` itself
 #: selects this table, so it is deliberately not a member of any row.
@@ -133,6 +159,13 @@ class _ProfilesNotRead:
 _PROFILES_NOT_READ: Final[_ProfilesNotRead] = _ProfilesNotRead()
 
 
+class _ShippedValuesNotRead:
+    pass
+
+
+_SHIPPED_VALUES_NOT_READ: Final[_ShippedValuesNotRead] = _ShippedValuesNotRead()
+
+
 class KernelCeiling(str):
     """A read kernel ceiling, with unknown kept distinct from no ceiling."""
 
@@ -189,6 +222,9 @@ def validate(
     *,
     storage_facts: StorageFacts | None = None,
     available_profiles: Collection[str] | None | _ProfilesNotRead = _PROFILES_NOT_READ,
+    available_timezones: Collection[str] | _ShippedValuesNotRead = _SHIPPED_VALUES_NOT_READ,
+    available_package_groups: Collection[str]
+    | _ShippedValuesNotRead = _SHIPPED_VALUES_NOT_READ,
     zfs_kernel_max: str | None | _ZfsKernelCeilingNotChecked = (
         _ZFS_KERNEL_CEILING_NOT_CHECKED
     ),
@@ -247,6 +283,8 @@ def validate(
             )
         ),
         *_locale_problems(config),
+        *_system_value_problems(config, available_timezones),
+        *_package_group_problems(config, available_package_groups),
         *_l10n_problems(config),
         *_repository_name_problems(config),
         *compat.binhost_subarch_problems(config, supports_v3),
@@ -424,10 +462,70 @@ def _l10n_problems(config: InstallConfig) -> list[str]:
 
 
 def _locale_problems(config: InstallConfig) -> list[str]:
-    selected = config.system.locale
-    if selected and selected not in config.system.locales:
-        return [f"system.locale is {selected!r}, which system.locales must include"]
-    return []
+    system = config.system
+    problems: list[str] = []
+    if system.locale not in system.locales:
+        problems.append(f"system.locale is {system.locale!r}, which system.locales must include")
+    return problems
+
+
+def _system_value_problems(
+    config: InstallConfig,
+    available_timezones: Collection[str] | _ShippedValuesNotRead,
+) -> list[str]:
+    system = config.system
+    problems: list[str] = []
+    hostname = system.hostname
+    if len(hostname) > _HOSTNAME_MAXIMUM or any(
+        _HOSTNAME_LABEL.fullmatch(label) is None for label in hostname.split(".")
+    ):
+        problems.append(
+            f"system.hostname is {hostname!r}, which is not an RFC 1123 hostname"
+        )
+    url = system.first_boot.url
+    if url:
+        try:
+            parsed = urlparse(url)
+        except ValueError:
+            parsed = None
+        if (
+            parsed is None
+            or parsed.scheme not in HTTP_SCHEMES
+            or not parsed.netloc
+            or any(character.isspace() for character in url)
+        ):
+            problems.append(
+                f"system.first_boot.url is {url!r}; expected an HTTP(S) URL with a host"
+            )
+    if isinstance(available_timezones, _ShippedValuesNotRead):
+        return problems
+    if system.timezone not in available_timezones:
+        problems.append(
+            f"system.timezone is {system.timezone!r}, which is not in data/timezones.txt"
+        )
+    return problems
+
+
+def _package_group_problems(
+    config: InstallConfig,
+    available_package_groups: Collection[str] | _ShippedValuesNotRead,
+) -> list[str]:
+    if isinstance(available_package_groups, _ShippedValuesNotRead):
+        return []
+    packages = config.packages
+    selections = (
+        (packages.desktop,),
+        packages.applications,
+        packages.graphics,
+        (packages.display_manager,),
+    )
+    return [
+        f"packages.{field} is {name!r}, which is not a group in data/profiles or "
+        "data/packages"
+        for field, names in zip(PACKAGE_GROUP_FIELDS, selections)
+        for name in names
+        if name and name not in available_package_groups
+    ]
 
 
 def _pool_problems(config: InstallConfig) -> list[str]:

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -38,6 +38,29 @@ def test_a_dry_run_prints_every_stage_and_exits_clean(capsys: pytest.CaptureFixt
     assert "operations:" in printed.splitlines()[-1]
 
 
+def test_a_dry_run_refuses_an_unknown_shipped_value_before_network_access(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    configuration = tmp_path / "invalid-locale.toml"
+    configuration.write_text(
+        (FIXTURES / "btrfs-luks.toml")
+        .read_text(encoding="utf-8")
+        .replace('locale = "zh_TW.UTF-8"', 'locale = "zh_CH.UTF-8"'),
+        encoding="utf-8",
+    )
+    monkeypatch.setattr(cli, "_require_root", lambda arguments: None)
+    monkeypatch.setattr(
+        cli,
+        "_check_the_clock",
+        lambda: pytest.fail("an invalid configuration checked the network clock"),
+    )
+
+    assert main(["--config", str(configuration), "--dry-run"]) == EXIT_CONFIG
+    assert "system.locale is 'zh_CH.UTF-8'" in capsys.readouterr().err
+
+
 def test_dd_dry_run_renders_its_only_operation_without_a_network(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
 ) -> None:

--- a/tests/unit/test_validate.py
+++ b/tests/unit/test_validate.py
@@ -9,12 +9,14 @@ from pathlib import Path, PurePosixPath
 import pytest
 
 from gentoo_install.errors import ConfigError, ValidationFailed
+from gentoo_install.data import load_catalog, load_timezones
 from gentoo_install.model import compat
 from gentoo_install.model.config import (
     Bootloader,
     BootloaderConfig,
     DiskConfig,
     DiskMode,
+    FirstBoot,
     ImageFormat,
     InitSystem,
     InstallConfig,
@@ -41,7 +43,14 @@ from gentoo_install.model.size import Size
 from gentoo_install.exec.config import load
 from gentoo_install.exec.probe import amd64_profiles, profiles_from_eselect
 from gentoo_install.model.templates import Choice
-from gentoo_install.model.validate import validate, validate_memory_launch, zfs_kernel_ceiling
+from gentoo_install.model.validate import (
+    CLOSED_SYSTEM_FIELDS,
+    HTTP_SCHEMES,
+    PACKAGE_GROUP_FIELDS,
+    validate,
+    validate_memory_launch,
+    zfs_kernel_ceiling,
+)
 from gentoo_install.model.parse import parse
 
 from .layouts import encrypted_root, config, ext4_on_gpt, i, unlockable_root, zfs_root
@@ -115,6 +124,17 @@ def _with_disk_field(disk: DiskConfig, field: str) -> DiskConfig:
     raise AssertionError(f"no value for disk.{field}")
 
 FIXTURES = Path(__file__).resolve().parents[1] / "fixtures"
+
+_SHIPPED_CATALOG = load_catalog()
+_SHIPPED_TIMEZONES = load_timezones()
+
+
+def _validate_with_shipped_values(installation: InstallConfig) -> None:
+    validate(
+        installation,
+        available_timezones=_SHIPPED_TIMEZONES,
+        available_package_groups=_SHIPPED_CATALOG,
+    )
 
 
 def image_config() -> InstallConfig:
@@ -418,8 +438,139 @@ def test_a_payload_password_rejects_record_separators(password: str) -> None:
         validate_memory_launch(config(), MemoryLaunch(MemoryMode.RAM, root_password=password))
 
 
-def test_the_shipped_fixture_validates() -> None:
-    validate(load(FIXTURES / "btrfs-luks.toml"))
+@pytest.mark.parametrize(
+    "path",
+    sorted(FIXTURES.rglob("*.toml")),
+    ids=lambda path: str(path.relative_to(FIXTURES)),
+)
+def test_every_shipped_fixture_validates_closed_values(path: Path) -> None:
+    _validate_with_shipped_values(load(path))
+
+
+_CLOSED_SYSTEM_FIELD_CASES: tuple[str, ...] = (
+    "timezone",
+    "hostname",
+    "first_boot.url",
+)
+
+
+def test_closed_system_value_cases_cover_the_rule_table() -> None:
+    assert set(_CLOSED_SYSTEM_FIELD_CASES) == CLOSED_SYSTEM_FIELDS
+
+
+@pytest.mark.parametrize("field", _CLOSED_SYSTEM_FIELD_CASES)
+def test_a_closed_system_value_outside_its_namespace_is_refused(field: str) -> None:
+    installation = config()
+    system = installation.system
+    if field == "timezone":
+        system = replace(system, timezone="Mars/Olympus")
+    elif field == "hostname":
+        system = replace(system, hostname="bad_host")
+    elif field == "first_boot.url":
+        system = replace(system, first_boot=FirstBoot(url="file:///run/once.sh"))
+    else:
+        raise AssertionError(f"no invalid value for system.{field}")
+    with pytest.raises(ValidationFailed, match=rf"system\.{field}"):
+        _validate_with_shipped_values(replace(installation, system=system))
+
+
+@pytest.mark.parametrize(
+    "locale", ("en_US.UTF-8", "zh_TW.UTF-8", "de_DE.UTF-8", "fr_FR.UTF-8", "pt_BR.UTF-8")
+)
+def test_a_system_locale_outside_the_interface_languages_validates(locale: str) -> None:
+    """The installed system's language is a separate choice from the
+    interface's, and the set `locale-gen` can produce belongs to the target:
+    `GenerateLocales` reads `locale --all-locales` and raises there."""
+    installation = config()
+    _validate_with_shipped_values(
+        replace(
+            installation,
+            system=replace(installation.system, locale=locale, locales=(locale,)),
+        )
+    )
+
+
+@pytest.mark.parametrize("scheme", sorted(HTTP_SCHEMES))
+def test_each_supported_first_boot_url_scheme_validates(scheme: str) -> None:
+    installation = config()
+    _validate_with_shipped_values(
+        replace(
+            installation,
+            system=replace(
+                installation.system,
+                first_boot=FirstBoot(url=f"{scheme}://example.test/once.sh"),
+            ),
+        )
+    )
+
+
+def test_hostname_uses_rfc_1123_label_and_length_boundaries() -> None:
+    hostname = ".".join(("a" * 63, "b" * 63, "c" * 63, "d" * 61))
+    assert len(hostname) == 253
+    installation = config()
+    _validate_with_shipped_values(
+        replace(
+            installation,
+            system=replace(installation.system, hostname=hostname),
+        )
+    )
+    with pytest.raises(ValidationFailed, match="system.hostname"):
+        _validate_with_shipped_values(
+            replace(
+                installation,
+                system=replace(installation.system, hostname=f"{hostname}a"),
+            )
+        )
+
+
+_PACKAGE_GROUP_CASES: tuple[str, ...] = (
+    "desktop",
+    "applications",
+    "graphics",
+    "display_manager",
+)
+
+
+def test_package_group_cases_cover_the_rule_table() -> None:
+    assert _PACKAGE_GROUP_CASES == PACKAGE_GROUP_FIELDS
+
+
+@pytest.mark.parametrize("field", _PACKAGE_GROUP_CASES)
+def test_an_unknown_package_group_is_refused_and_named(field: str) -> None:
+    unknown = "not-a-shipped-group"
+    packages = PackagesConfig()
+    if field == "desktop":
+        packages = replace(packages, desktop=unknown)
+    elif field == "applications":
+        packages = replace(packages, applications=(unknown,))
+    elif field == "graphics":
+        packages = replace(packages, graphics=(unknown,))
+    elif field == "display_manager":
+        packages = replace(packages, display_manager=unknown)
+    else:
+        raise AssertionError(f"no package selector for {field}")
+    with pytest.raises(ValidationFailed, match=rf"packages\.{field} is '{unknown}'"):
+        _validate_with_shipped_values(replace(config(), packages=packages))
+
+
+def test_extra_package_atoms_remain_open() -> None:
+    _validate_with_shipped_values(
+        replace(config(), packages=PackagesConfig(extra=("app-editors/neovim",)))
+    )
+
+
+def test_keymap_names_remain_open() -> None:
+    installation = config()
+    _validate_with_shipped_values(
+        replace(
+            installation,
+            system=replace(
+                installation.system,
+                keymap="target-console-keymap",
+                keymap_initramfs="target-unlock-keymap",
+            ),
+        )
+    )
 
 
 def test_a_selected_locale_absent_from_system_locales_is_refused_and_named() -> None:


### PR DESCRIPTION
A configuration naming a timezone, a hostname, a first-boot URL scheme or a package group that does not exist was accepted and failed in the target an hour later. Those four sets are shipped by the installer — `data/timezones.txt`, the package catalog, RFC 1123, and HTTP(S) — so they can be checked before anything reaches storage. `cli.py` loads the shipped names and injects them, so `model/` still reads no files.

Deliberately unconstrained: keymaps (the target's `kbd` owns that namespace), Portage atoms, USE flags, `accept_license`, custom overlays and sync URIs, custom kernel packages, `kernel_params` and first-boot commands — an allow-list would refuse legitimate input.

The system locale is also unconstrained, and one earlier revision of this branch got that wrong: it restricted it to the five interface languages, which would have stopped anyone installing a German system. `docs/plan.md` settles that the installed system's language is a separate choice from the interface's, and `GenerateLocales` already reads `locale --all-locales` on the target and raises `LocaleMissing` — the check that can see the answer is there.