### PR TITLE
exec: keep PYTHONPATH out of the commands the installer runs

### DIFF
--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -19,6 +19,11 @@ esac
 say() { printf '%s\n' "$*" >&2; }
 die() { say "error: $*"; exit 1; }
 
+# Absolute, because `PYTHONPATH` is exported and Portage's `python-single-r1`
+# refuses a relative one: an install died at `dev-util/pahole` on
+# `Relative paths in PYTHONPATH are forbidden`.
+HERE=$(CDPATH= cd -- "$HERE" && pwd) || die "could not resolve the installer directory"
+
 distribution() {
 	# ID_LIKE first: derivatives name their parent there, so Mint reports
 	# ubuntu, Manjaro reports arch, and the package manager below matches.

--- a/gentoo_install/exec/runner.py
+++ b/gentoo_install/exec/runner.py
@@ -307,9 +307,15 @@ class Runner:
                     "NO_PROXY": ",".join(self.proxy.bypass),
                 }
             )
-        if not values:
-            return None
-        return {**os.environ, **values}
+        # `PYTHONPATH` never reaches a command this installer runs. `bootstrap.sh`
+        # sets it so `-m gentoo_install` resolves, and Portage's
+        # `python-single-r1` sanity check dies on a relative one: an install
+        # stopped at `dev-util/pahole` with `Relative paths in PYTHONPATH are
+        # forbidden: '.'`. Nothing the installer runs imports the installer.
+        inherited = {
+            name: value for name, value in os.environ.items() if name != "PYTHONPATH"
+        }
+        return {**inherited, **values}
 
 
 def _pretending(argv: Sequence[str]) -> bool:

--- a/tests/unit/test_bootstrap.py
+++ b/tests/unit/test_bootstrap.py
@@ -539,3 +539,44 @@ def test_a_failed_package_command_can_leave_partial_installation(tmp_path: Path)
     assert installed.exists()
     assert "that command failed; some packages may have been installed" in said
     assert "nothing was installed" not in said
+
+
+def test_the_exported_pythonpath_is_absolute(tmp_path: Path) -> None:
+    """Portage's `python-single-r1` refuses a relative one: an install died at
+    `dev-util/pahole` on `Relative paths in PYTHONPATH are forbidden: '.'`, and
+    `bootstrap.sh` reached it as `.` whenever it was run as `./bootstrap.sh`."""
+    helpers = tmp_path / "helpers"
+    helpers.mkdir()
+    # Every name `python_binary()` searches, so the real interpreter earlier on
+    # PATH cannot answer first. It must satisfy the version probe as well.
+    body = (
+        "#!/bin/sh\n"
+        "case \"$*\" in\n"
+        "*version_info\\[1\\]*) echo 14; exit 0 ;;\n"
+        "*version_info\\[0\\]*) echo 3; exit 0 ;;\n"
+        "esac\n"
+        "printf 'PYTHONPATH=[%s]\\n' \"$PYTHONPATH\"\n"
+        "exit 0\n"
+    )
+    for name in ("python3.14", "python3.13", "python3.12", "python3.11", "python3"):
+        fake = helpers / name
+        fake.write_text(body)
+        fake.chmod(0o755)
+    where = tmp_path / "os-release"
+    where.write_text('ID=gentoo\nNAME="Gentoo"\n')
+    # `./bootstrap.sh`, not the absolute path: `${0%/*}` of an absolute
+    # argument is already absolute, so an absolute invocation cannot show this.
+    # The driver CD runs `cd /mnt/driver && sh ./bootstrap.sh`.
+    finished = subprocess.run(
+        [SHELL, "./bootstrap.sh", "--help"],
+        cwd=REPOSITORY,
+        env={"OS_RELEASE": str(where), "PATH": f"{helpers}:/usr/bin:/bin"},
+        capture_output=True,
+        text=True,
+    )
+    said = output(finished)
+    shown = [one for one in said.splitlines() if one.startswith("PYTHONPATH=[")]
+    assert shown, said
+    for one in shown:
+        value = one[len("PYTHONPATH=["):-1]
+        assert value.startswith("/"), one

--- a/tests/unit/test_proxy.py
+++ b/tests/unit/test_proxy.py
@@ -200,3 +200,20 @@ def test_the_threaded_mirror_probe_does_not_force_an_address_family() -> None:
         if isinstance(node, ast.Call) and isinstance(node.func, ast.Name)
     }
     assert not called & reached, sorted(called & reached)
+
+
+def test_no_command_the_installer_runs_inherits_pythonpath(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """`bootstrap.sh` exports `PYTHONPATH` so `-m gentoo_install` resolves, and
+    every command inherited it. Portage's `python-single-r1` sanity check dies
+    on a relative one: an install stopped at `dev-util/pahole` with
+    `Relative paths in PYTHONPATH are forbidden: '.'`."""
+    monkeypatch.setenv("PYTHONPATH", ".")
+    monkeypatch.setenv("GENTOO_INSTALL_MARKER", "kept")
+    passed = Runner(
+        log=lambda line: None, environment={"PORTAGE_NICENESS": "0"}
+    )._environment()
+    assert passed is not None
+    assert "PYTHONPATH" not in passed, sorted(passed)
+    assert passed["GENTOO_INSTALL_MARKER"] == "kept", "the rest of the environment stays"


### PR DESCRIPTION
A cluster run stopped at `sys-apps/systemd-260.1-r2` with `Relative paths in PYTHONPATH are forbidden: $'.'`, from Portage's `python-single-r1` sanity check. A source-built systemd therefore never configures, on any machine.

The value is ours. `bootstrap.sh` computes `HERE` as `${0%/*}`, which is `.` for the `cd /mnt/driver && sh ./bootstrap.sh` the driver CD runs, and every invocation exports `PYTHONPATH=$HERE`. `Runner._environment()` returned `None` when it had nothing of its own to add, so `subprocess` inherited `os.environ` whole and every `emerge` in the chroot saw it. Portage's own message calls a relative entry "guaranteed to cause random breakage".

Both ends: `HERE` is resolved to an absolute path, and the runner drops `PYTHONPATH` from what it hands any command — nothing the installer runs is meant to import the installer.

The first negative control passed: the test invoked the script by absolute path, where `${0%/*}` is already absolute, so the failing case was never exercised. It goes red once the test runs `sh ./bootstrap.sh` the way the CD does.