### PR TITLE
disk: make a second run see what the first one left

### DIFF
--- a/gentoo_install/exec/preflight.py
+++ b/gentoo_install/exec/preflight.py
@@ -86,7 +86,7 @@ BY_FEATURE: Final[dict[str, tuple[str, ...]]] = {
     # The binaries the operations invoke, not the multicall name: a medium
     # carrying lvm without its symlinks passes on `lvm` and dies at `pvcreate`
     # with the disks already partitioned.
-    "lvm": ("pvcreate", "vgcreate", "lvcreate", "vgchange"),
+    "lvm": ("pvcreate", "vgcreate", "lvcreate", "vgchange", "dmsetup"),
     "swap": ("mkswap", "swapoff"),
     # `hostid`, not `zgenhostid`: the host reads its own id and the target
     # writes it, so the tool that writes runs inside the chroot.

--- a/gentoo_install/plan/disk.py
+++ b/gentoo_install/plan/disk.py
@@ -850,7 +850,7 @@ class ImportZpool(Operation):
     name: str
 
     def describe(self) -> str:
-        return f"import zpool {self.name} under {self.pool}"
+        return f"import zpool {self.name} with the installation target as its alternate root"
 
     @property
     def survives_a_reboot(self) -> bool:

--- a/gentoo_install/plan/disk.py
+++ b/gentoo_install/plan/disk.py
@@ -13,7 +13,7 @@ from dataclasses import dataclass
 from pathlib import PurePosixPath
 from typing import Callable, Final, Protocol, cast
 
-from ..errors import CommandFailed, ConfigError, InvalidLayout
+from ..errors import CommandFailed, ConfigError, GentooInstallError, InvalidLayout
 from ..model.config import DiskMode, InstallConfig
 from ..model.device import (
     DeviceGraph,
@@ -669,6 +669,22 @@ class VerifyFilesystem(Operation):
 #: the target rather than under it: the layout is mounted on the target itself.
 SCRATCH_MOUNT: Final[str] = "btrfs-top"
 
+def _unmount_scratch(
+    context: Context, scratch: PurePosixPath, failure: GentooInstallError | None
+) -> None:
+    # A stale top-level mount makes the next run fail at `wipefs` with a busy
+    # device rather than naming the holder that needs cleanup.
+    result: str | None = None
+    try:
+        result = context.run(["umount", str(scratch)], check=False)
+    except CommandFailed:
+        if failure is None:
+            raise
+    if failure is None and isinstance(result, CommandOutput) and result.returncode != 0:
+        raise CommandFailed(
+            f"umount {scratch} exited {result.returncode}: {result.strip() or 'no output'}"
+        )
+
 
 @dataclass(frozen=True, kw_only=True)
 class VerifySubvolume(Operation):
@@ -693,21 +709,26 @@ class VerifySubvolume(Operation):
         scratch = context.target.parent / SCRATCH_MOUNT
         path = context.device_path(self.device)
         context.run(["mkdir", "--parents", str(scratch)])
-        context.run(["mount", "--types", "btrfs", path, str(scratch)])
-        # `btrfs subvolume list`, not a directory test: a plain directory of
-        # the same name is not a subvolume and mounting `subvol=` on it fails
-        # at the mount rather than here.
-        listed = context.run(["btrfs", "subvolume", "list", str(scratch)], check=False)
-        wanted = self.name.lstrip("/")
-        missing = not any(
-            line.rsplit(" path ", 1)[-1].strip() == wanted for line in listed.splitlines()
-        )
-        context.run(["umount", str(scratch)])
-        if missing:
-            raise InvalidLayout(
-                f"{self.device} has no btrfs subvolume {self.name}, and the "
-                "configuration reuses it"
-            )
+        failure: GentooInstallError | None = None
+        try:
+            context.run(["mount", "--types", "btrfs", path, str(scratch)])
+            # `btrfs subvolume list`, not a directory test: a plain directory of
+            # the same name is not a subvolume and mounting `subvol=` on it fails
+            # at the mount rather than here.
+            listed = context.run(["btrfs", "subvolume", "list", str(scratch)], check=False)
+            wanted = self.name.lstrip("/")
+            if not any(
+                line.rsplit(" path ", 1)[-1].strip() == wanted for line in listed.splitlines()
+            ):
+                raise InvalidLayout(
+                    f"{self.device} has no btrfs subvolume {self.name}, and the "
+                    "configuration reuses it"
+                )
+        except GentooInstallError as error:
+            failure = error
+            raise
+        finally:
+            _unmount_scratch(context, scratch, failure)
 
 
 @dataclass(frozen=True, kw_only=True)
@@ -728,27 +749,15 @@ class CreateSubvolume(Operation):
         scratch = context.target.parent / SCRATCH_MOUNT
         path = context.device_path(self.device)
         context.run(["mkdir", "--parents", str(scratch)])
-        context.run(["mount", "--types", "btrfs", path, str(scratch)])
-        failed: CommandFailed | None = None
+        failure: GentooInstallError | None = None
         try:
+            context.run(["mount", "--types", "btrfs", path, str(scratch)])
             context.run(["btrfs", "subvolume", "create", str(scratch / self.name)])
-        except CommandFailed as error:
-            failed = error
+        except GentooInstallError as error:
+            failure = error
             raise
         finally:
-            # In `finally`: a name left by an earlier attempt fails here, and
-            # leaving the device mounted makes the next run die at `wipefs`
-            # with `Device or resource busy` and nothing naming the holder.
-            result: str | None = None
-            try:
-                result = context.run(["umount", str(scratch)], check=False)
-            except CommandFailed:
-                if failed is None:
-                    raise
-            if failed is None and isinstance(result, CommandOutput) and result.returncode != 0:
-                raise CommandFailed(
-                    f"umount {scratch} exited {result.returncode}: {result.strip() or 'no output'}"
-                )
+            _unmount_scratch(context, scratch, failure)
 
 
 @dataclass(frozen=True, kw_only=True)

--- a/gentoo_install/plan/disk.py
+++ b/gentoo_install/plan/disk.py
@@ -118,8 +118,8 @@ class ReleaseTarget(Operation):
 
     An install that stopped halfway leaves the target mounted, containers open
     and arrays assembled, and every one of those makes the disk busy so the
-    rerun fails at `wipefs`. Each step is `check=False`: none of them existing
-    is the normal case on a first run.
+    rerun fails at `wipefs`. A missing container is expected on a first run;
+    an open one after its close command fails is not.
     """
 
     stage: Stage = Stage.PARTITION
@@ -130,22 +130,78 @@ class ReleaseTarget(Operation):
     steps: tuple[tuple[str, ...], ...]
 
     def required_host_commands(self) -> frozenset[str]:
-        return frozenset(("umount", *(step[0] for step in self.steps)))
+        commands = {"umount", "findmnt", "sleep", *(step[0] for step in self.steps)}
+        for argv in self.steps:
+            if argv[:2] in {("vgchange", "--activate"), ("cryptsetup", "close")}:
+                commands.add("dmsetup")
+        return frozenset(commands)
 
     def describe(self) -> str:
         return "release anything a previous run of this configuration left mounted or open"
 
     def apply(self, context: Context) -> None:
-        context.run(["umount", "--recursive", "--lazy", str(context.target)], check=False)
-        # The btrfs top level is mounted beside the target, not under it, so a
-        # recursive unmount of the target never reaches it.
-        context.run(
-            ["umount", "--lazy", str(context.target.parent / SCRATCH_MOUNT)], check=False
-        )
+        self._unmount(context, context.target)
+        self._unmount(context, context.target.parent / SCRATCH_MOUNT)
         for argv in self.steps:
-            # check=False throughout: none of these existing is the normal case
-            # on a first run.
-            context.run(list(argv), check=False)
+            self._close(context, argv)
+
+    def _unmount(self, context: Context, path: PurePosixPath) -> None:
+        context.run(["umount", "--recursive", str(path)], check=False)
+        if not self._still_mounted(context, path):
+            return
+        context.run(["umount", "--recursive", "--lazy", str(path)])
+        if self._still_mounted(context, path):
+            raise CommandFailed(f"{path} remains mounted after lazy unmount")
+
+    def _still_mounted(self, context: Context, path: PurePosixPath) -> bool:
+        found = context.run(["findmnt", "--mountpoint", str(path)], check=False)
+        if not isinstance(found, CommandOutput):
+            raise CommandFailed(f"cannot determine whether {path} is mounted")
+        return found.returncode == 0
+
+    def _close(self, context: Context, argv: tuple[str, ...]) -> None:
+        last: CommandOutput | None = None
+        for attempt in range(RELEASE_TRIES):
+            result = context.run(list(argv), check=False)
+            if not isinstance(result, CommandOutput):
+                raise CommandFailed(f"cannot determine whether {' '.join(argv)} completed")
+            if result.returncode == 0 or self._is_released(context, argv):
+                return
+            last = result
+            if attempt + 1 < RELEASE_TRIES:
+                context.run(["sleep", f"{RELEASE_PAUSE:g}"])
+        assert last is not None
+        raise CommandFailed(
+            f"{' '.join(argv)} left its device open after {RELEASE_TRIES} attempts: "
+            f"{last.strip() or 'no output'}"
+        )
+
+    def _is_released(self, context: Context, argv: tuple[str, ...]) -> bool:
+        if argv[:2] == ("zpool", "export"):
+            listed = self._state(context, ["zpool", "list", "-H", "-o", "name"])
+            return argv[2] not in listed.split()
+        if argv[:2] == ("vgchange", "--activate"):
+            listed = self._state(context, ["dmsetup", "ls"])
+            # device-mapper doubles hyphens, so the final hyphen keeps group
+            # names that share a prefix distinct.
+            prefix = f"{argv[3].replace('-', '--')}-"
+            return not any(
+                line.split() and line.split()[0].startswith(prefix)
+                for line in listed.splitlines()
+            )
+        if argv[:2] == ("cryptsetup", "close"):
+            listed = self._state(context, ["dmsetup", "ls", "--target", "crypt"])
+            return not any(line.split() and line.split()[0] == argv[2] for line in listed.splitlines())
+        if argv[:2] == ("mdadm", "--stop"):
+            listed = self._state(context, ["mdadm", "--detail", "--scan"])
+            return argv[2] not in listed
+        raise ConfigError(f"no release state check for {' '.join(argv)}")
+
+    def _state(self, context: Context, argv: list[str]) -> CommandOutput:
+        result = context.run(argv, check=False)
+        if not isinstance(result, CommandOutput) or result.returncode != 0:
+            raise CommandFailed(f"cannot determine release state with {' '.join(argv)}")
+        return result
 
 
 class _ImageContext(Protocol):
@@ -920,8 +976,8 @@ class DiscardStage3(Operation):
         context.run_in_target(["rm", "--recursive", "--force", f"/{STAGE3_CACHE}"])
 
 
-EXPORT_TRIES: Final[int] = 6
-EXPORT_PAUSE: Final[float] = 5.0
+RELEASE_TRIES: Final[int] = 6
+RELEASE_PAUSE: Final[float] = 5.0
 
 
 @dataclass(frozen=True, kw_only=True)
@@ -1012,14 +1068,14 @@ class UnmountTarget(Operation):
         next boot, so the failure has to say which case it is.
         """
         last: CommandFailed | None = None
-        for attempt in range(EXPORT_TRIES):
+        for attempt in range(RELEASE_TRIES):
             try:
                 context.run(["zpool", "export", pool])
                 return
             except CommandFailed as failed:
                 last = failed
-                if attempt + 1 < EXPORT_TRIES:
-                    context.run(["sleep", f"{EXPORT_PAUSE:g}"])
+                if attempt + 1 < RELEASE_TRIES:
+                    context.run(["sleep", f"{RELEASE_PAUSE:g}"])
         assert last is not None
         if self._mounted_datasets(context, pool):
             context.run(["zpool", "export", "-f", pool])

--- a/gentoo_install/plan/disk.py
+++ b/gentoo_install/plan/disk.py
@@ -231,6 +231,20 @@ class CreateImage(Operation):
         return f"create a {self.size} sparse image at {self.image} and attach it as a loop device"
 
     def apply(self, context: Context) -> None:
+        attached = context.run(
+            ["losetup", "--associated", "--noheadings", "--output", "NAME", self.image],
+            check=False,
+        )
+        if not isinstance(attached, CommandOutput) or attached.returncode != 0:
+            raise CommandFailed(f"cannot determine whether {self.image} is already attached")
+        loops = tuple(line.strip() for line in attached.splitlines() if line.strip())
+        if len(loops) == 1:
+            cast(_ImageContext, context).remember_image_device(self.device, loops[0])
+            return
+        if len(loops) > 1:
+            raise ConfigError(
+                f"{self.image} is attached to multiple loop devices: {', '.join(loops)}"
+            )
         if not self.wipe:
             exists = context.run(["test", "-e", self.image], check=False)
             if not isinstance(exists, CommandOutput):

--- a/tests/golden/vm-raidz.txt
+++ b/tests/golden/vm-raidz.txt
@@ -19,7 +19,7 @@
 
 [zfs]
   create zpool rpool as pool from poolpart, poolpart2, poolpart3 as a raidz1
-  import zpool rpool under pool
+  import zpool rpool with the installation target as its alternate root
   create dataset rpool/ROOT/gentoo as ds-root, mountpoint /
 
 [mount]

--- a/tests/golden/vm-zfs-encrypted.txt
+++ b/tests/golden/vm-zfs-encrypted.txt
@@ -11,7 +11,7 @@
 
 [zfs]
   create zpool rpool as pool from poolpart as a stripe with native encryption
-  import zpool rpool under pool
+  import zpool rpool with the installation target as its alternate root
   create dataset rpool/ROOT/gentoo as ds-root, mountpoint /
 
 [mount]

--- a/tests/golden/vm-zfs-mirror.txt
+++ b/tests/golden/vm-zfs-mirror.txt
@@ -15,7 +15,7 @@
 
 [zfs]
   create zpool rpool as pool from poolpart, poolpart2 as a mirror
-  import zpool rpool under pool
+  import zpool rpool with the installation target as its alternate root
   create dataset rpool/ROOT/gentoo as ds-root, mountpoint /
 
 [mount]

--- a/tests/golden/vm-zfs.txt
+++ b/tests/golden/vm-zfs.txt
@@ -11,7 +11,7 @@
 
 [zfs]
   create zpool rpool as pool from poolpart as a stripe
-  import zpool rpool under pool
+  import zpool rpool with the installation target as its alternate root
   create dataset rpool/ROOT/gentoo as ds-root, mountpoint /
 
 [mount]

--- a/tests/golden/zbm-unlock.txt
+++ b/tests/golden/zbm-unlock.txt
@@ -11,7 +11,7 @@
 
 [zfs]
   create zpool zpcala as pool from poolpart as a stripe with native encryption
-  import zpool zpcala under pool
+  import zpool zpcala with the installation target as its alternate root
   create dataset zpcala/ROOT/gentoo/home as ds-home, mountpoint /home
   create dataset zpcala/ROOT/gentoo/root as ds-root, mountpoint /
 

--- a/tests/golden/zfs-zbm.txt
+++ b/tests/golden/zfs-zbm.txt
@@ -11,7 +11,7 @@
 
 [zfs]
   create zpool zpcala as pool from poolpart as a stripe with native encryption
-  import zpool zpcala under pool
+  import zpool zpcala with the installation target as its alternate root
   create dataset zpcala/ROOT/gentoo/home as ds-home, mountpoint /home
   create dataset zpcala/ROOT/gentoo/root as ds-root, mountpoint /
 

--- a/tests/unit/recorder.py
+++ b/tests/unit/recorder.py
@@ -68,6 +68,9 @@ class Recorder:
             raise CommandFailed(f"{argv[0]} exited 1")
         if argv[:2] == ["test", "-e"]:
             return CommandOutput("", 0 if argv[2] in self.existing_paths else 1)
+        if argv[:2] == ["findmnt", "--mountpoint"]:
+            mounted = argv[2] in self.mounts
+            return CommandOutput(f"{argv[2]}\n" if mounted else "", 0 if mounted else 1)
         if self.answering is not None:
             # Both methods, or a hook covering one of them leaves the other
             # answering an empty string that every caller reads as success.

--- a/tests/unit/test_plan_disk.py
+++ b/tests/unit/test_plan_disk.py
@@ -93,14 +93,28 @@ def test_an_image_refuses_an_existing_file_unless_wipe_is_enabled() -> None:
     create = disk.CreateImage(
         device=i("disk"), image=image, size=Size.parse("20GiB"), wipe=False
     )
-    recorder = Recorder(existing_paths={image}, replies={"losetup": "/dev/loop7\n"})
+
+    def no_existing_loop(argv: Sequence[str]) -> str | None:
+        if argv[:2] == ["losetup", "--associated"]:
+            return CommandOutput("", 0)
+        return None
+
+    recorder = Recorder(
+        existing_paths={image},
+        replies={"losetup": "/dev/loop7\n"},
+        answering=no_existing_loop,
+    )
     with pytest.raises(ConfigError, match="disk.wipe"):
         create.apply(recorder)
-    assert recorder.commands == [("test", "-e", image)]
+    assert recorder.commands == [
+        ("losetup", "--associated", "--noheadings", "--output", "NAME", image),
+        ("test", "-e", image),
+    ]
 
     wiping = replace(create, wipe=True)
     wiping.apply(recorder)
-    assert recorder.commands[-2:] == [
+    assert recorder.commands[-3:] == [
+        ("losetup", "--associated", "--noheadings", "--output", "NAME", image),
         ("truncate", "--size", str(Size.parse("20GiB").bytes), image),
         ("losetup", "--find", "--show", "--partscan", image),
     ]
@@ -112,6 +126,38 @@ def test_an_image_refuses_an_existing_file_unless_wipe_is_enabled() -> None:
     detach.apply(recorder)
     assert recorder.commands[-1] == ("losetup", "--detach", "/dev/loop7")
     assert recorder.image_device_path(i("disk")) is None
+
+
+def test_an_image_resume_reuses_its_existing_loop_device() -> None:
+    image = "/var/tmp/target.raw"
+    create = disk.CreateImage(
+        device=i("disk"), image=image, size=Size.parse("20GiB"), wipe=True
+    )
+    recorder = Recorder(replies={"losetup": "/dev/loop7\n"})
+
+    create.apply(recorder)
+
+    assert recorder.commands == [
+        ("losetup", "--associated", "--noheadings", "--output", "NAME", image)
+    ]
+    assert recorder.device_path(i("disk")) == "/dev/loop7"
+
+    disk.DetachImage(device=i("disk"), image=image).apply(recorder)
+    assert recorder.commands[-1] == ("losetup", "--detach", "/dev/loop7")
+
+
+def test_an_image_resume_refuses_multiple_existing_loop_devices() -> None:
+    image = "/var/tmp/target.raw"
+    create = disk.CreateImage(
+        device=i("disk"), image=image, size=Size.parse("20GiB"), wipe=True
+    )
+    recorder = Recorder(replies={"losetup": "/dev/loop7\n/dev/loop8\n"})
+
+    with pytest.raises(ConfigError, match="multiple loop devices: /dev/loop7, /dev/loop8"):
+        create.apply(recorder)
+    assert recorder.commands == [
+        ("losetup", "--associated", "--noheadings", "--output", "NAME", image)
+    ]
 
 
 def test_a_gpt_partition_is_created_with_its_index_type_and_size() -> None:

--- a/tests/unit/test_plan_disk.py
+++ b/tests/unit/test_plan_disk.py
@@ -438,12 +438,106 @@ def test_a_failed_run_can_be_started_again() -> None:
         if isinstance(operation, disk.ReleaseTarget)
     ]
     assert len(released) == 1
-    recorder = Recorder()
+    recorder = Recorder(
+        answering=lambda argv: CommandOutput("", 1) if argv[0] == "findmnt" else None
+    )
     released[0].apply(recorder)
     ran = [argv[0] for argv in recorder.commands]
     assert ran[0] == "umount"
     assert ("cryptsetup", "close", "root") in recorder.commands
 
+
+def test_release_retries_a_busy_container_until_it_closes() -> None:
+    class BusyOnce(Recorder):
+        closes: int = 0
+
+        def run(
+            self, argv: Sequence[str], *, check: bool = True, input_text: str | None = None
+        ) -> CommandOutput:
+            if argv[0] == "findmnt":
+                self.commands.append(tuple(argv))
+                return CommandOutput("", 1)
+            if argv[:2] == ["cryptsetup", "close"]:
+                self.commands.append(tuple(argv))
+                self.closes += 1
+                return CommandOutput("Device is busy", 1 if self.closes == 1 else 0)
+            if argv[:2] == ["dmsetup", "ls"]:
+                self.commands.append(tuple(argv))
+                return CommandOutput("root\t(253:0)", 0)
+            return super().run(argv, check=check, input_text=input_text)
+
+    recorder = BusyOnce()
+    disk.ReleaseTarget(steps=(("cryptsetup", "close", "root"),)).apply(recorder)
+
+    assert recorder.closes == 2
+    assert ("sleep", "5") in recorder.commands
+
+
+def test_release_accepts_a_missing_container_after_close_fails() -> None:
+    class MissingLuks(Recorder):
+        def run(
+            self, argv: Sequence[str], *, check: bool = True, input_text: str | None = None
+        ) -> CommandOutput:
+            if argv[0] == "findmnt":
+                self.commands.append(tuple(argv))
+                return CommandOutput("", 1)
+            if argv[:2] == ["cryptsetup", "close"]:
+                self.commands.append(tuple(argv))
+                return CommandOutput("Device root is not active", 1)
+            if argv[:2] == ["dmsetup", "ls"]:
+                self.commands.append(tuple(argv))
+                return CommandOutput("No devices found", 0)
+            return super().run(argv, check=check, input_text=input_text)
+
+    recorder = MissingLuks()
+    disk.ReleaseTarget(steps=(("cryptsetup", "close", "root"),)).apply(recorder)
+
+    assert recorder.only("dmsetup", "ls") == ("dmsetup", "ls", "--target", "crypt")
+
+def test_release_accepts_a_volume_group_without_active_mappings() -> None:
+    class MissingVolumeGroup(Recorder):
+        def run(
+            self, argv: Sequence[str], *, check: bool = True, input_text: str | None = None
+        ) -> CommandOutput:
+            if argv[0] == "findmnt":
+                self.commands.append(tuple(argv))
+                return CommandOutput("", 1)
+            if argv[:2] == ["vgchange", "--activate"]:
+                self.commands.append(tuple(argv))
+                return CommandOutput("Volume group data-vg not found", 1)
+            if argv[:2] == ["dmsetup", "ls"]:
+                self.commands.append(tuple(argv))
+                return CommandOutput("No devices found", 0)
+            return super().run(argv, check=check, input_text=input_text)
+
+    recorder = MissingVolumeGroup()
+    disk.ReleaseTarget(steps=(("vgchange", "--activate", "n", "data-vg"),)).apply(recorder)
+
+    assert recorder.only("dmsetup", "ls") == ("dmsetup", "ls")
+
+
+def test_release_refuses_a_container_that_remains_open() -> None:
+    class StillOpen(Recorder):
+        def run(
+            self, argv: Sequence[str], *, check: bool = True, input_text: str | None = None
+        ) -> CommandOutput:
+            if argv[0] == "findmnt":
+                self.commands.append(tuple(argv))
+                return CommandOutput("", 1)
+            if argv[:2] == ["cryptsetup", "close"]:
+                self.commands.append(tuple(argv))
+                return CommandOutput("Device is busy", 1)
+            if argv[:2] == ["dmsetup", "ls"]:
+                self.commands.append(tuple(argv))
+                return CommandOutput("root\t(253:0)", 0)
+            return super().run(argv, check=check, input_text=input_text)
+
+    recorder = StillOpen()
+    operation = disk.ReleaseTarget(steps=(("cryptsetup", "close", "root"),))
+
+    with pytest.raises(CommandFailed, match="cryptsetup close root left its device open"):
+        operation.apply(recorder)
+    assert len(recorder.argv_starting("cryptsetup", "close")) == disk.RELEASE_TRIES
 
 def test_the_teardown_closes_each_device_before_the_one_it_sits_on() -> None:
     """A fixed sequence of kinds gets one nesting wrong, and both occur: a
@@ -855,7 +949,7 @@ def test_a_pool_still_busy_after_the_lazy_unmount_is_exported_on_a_later_try(
                     raise CommandFailed("zpool export rpool exited 1: pool is busy")
             return super().run(argv, check=check, input_text=input_text)
 
-    monkeypatch.setattr(disk, "EXPORT_PAUSE", 0.0)
+    monkeypatch.setattr(disk, "RELEASE_PAUSE", 0.0)
     operation = disk.UnmountTarget(pools=("rpool",))
 
     # Plain before lazy: a lazy unmount leaves the datasets mounted as far as
@@ -909,7 +1003,7 @@ def test_a_pool_still_busy_after_the_lazy_unmount_is_exported_on_a_later_try(
 
     # A non-dataset holder is not released by the installer, so export stops.
     zed = Clean()
-    zed.refusals = disk.EXPORT_TRIES
+    zed.refusals = disk.RELEASE_TRIES
     with pytest.raises(CommandFailed, match="holder is unknown"):
         operation.apply(zed)
 
@@ -922,13 +1016,13 @@ def test_a_pool_still_busy_after_the_lazy_unmount_is_exported_on_a_later_try(
             return super().run(argv, check=check, input_text=input_text)
 
     mounted = MountedDataset()
-    mounted.refusals = disk.EXPORT_TRIES
+    mounted.refusals = disk.RELEASE_TRIES
     operation.apply(mounted)
     assert mounted.commands[-1] == ("zpool", "export", "-f", "rpool")
 
     # A pool that refuses every plain attempt stops the install.
     stubborn = Clean()
-    stubborn.refusals = disk.EXPORT_TRIES
+    stubborn.refusals = disk.RELEASE_TRIES
     with pytest.raises(CommandFailed):
         operation.apply(stubborn)
 
@@ -955,7 +1049,7 @@ def test_a_pool_busy_with_nothing_mounted_is_named_rather_than_forced(
                 return CommandOutput(f"rpool\t{self.mounted_state}\n", 0)
             return super().run(argv, check=check, input_text=input_text)
 
-    monkeypatch.setattr(disk, "EXPORT_PAUSE", 0.0)
+    monkeypatch.setattr(disk, "RELEASE_PAUSE", 0.0)
     operation = disk.UnmountTarget(pools=("rpool",))
 
     held = Stuck()

--- a/tests/unit/test_plan_disk.py
+++ b/tests/unit/test_plan_disk.py
@@ -305,6 +305,49 @@ def test_a_btrfs_scratch_unmount_does_not_replace_creation_failure() -> None:
     with pytest.raises(CommandFailed, match="already exists"):
         operation.apply(BothFail())
 
+@pytest.mark.parametrize(
+    "operation",
+    (
+        disk.VerifySubvolume(subvolume=i("sub-root"), device=i("rootfs"), name="@"),
+        disk.CreateSubvolume(subvolume=i("sub-root"), device=i("rootfs"), name="@"),
+    ),
+)
+def test_a_btrfs_scratch_mount_failure_is_cleaned_for_a_rerun(
+    operation: disk.VerifySubvolume | disk.CreateSubvolume,
+) -> None:
+    class MountFails(Recorder):
+        def run(
+            self, argv: Sequence[str], *, check: bool = True, input_text: str | None = None
+        ) -> CommandOutput:
+            self.commands.append(tuple(argv))
+            if argv[0] == "mount":
+                raise CommandFailed("mount exited 1: btrfs-top is already mounted")
+            return CommandOutput("", 0)
+
+    recorder = MountFails()
+    with pytest.raises(CommandFailed, match="btrfs-top is already mounted"):
+        operation.apply(recorder)
+    assert recorder.commands[-1] == ("umount", "/mnt/btrfs-top")
+
+
+def test_a_btrfs_scratch_unmount_does_not_replace_verification_failure() -> None:
+    class BothFail(Recorder):
+        def run(
+            self, argv: Sequence[str], *, check: bool = True, input_text: str | None = None
+        ) -> CommandOutput:
+            if argv[0] == "umount":
+                self.commands.append(tuple(argv))
+                if check:
+                    raise CommandFailed("umount exited 1: target is busy")
+                return CommandOutput("target is busy", 1)
+            return super().run(argv, check=check, input_text=input_text)
+
+    operation = disk.VerifySubvolume(
+        subvolume=i("sub-root"), device=i("rootfs"), name="@"
+    )
+    with pytest.raises(InvalidLayout, match="has no btrfs subvolume"):
+        operation.apply(BothFail())
+
 
 def test_a_subvolume_mount_carries_both_its_options_and_its_subvolume() -> None:
     nodes: list[Node] = [node for node in ext4_on_gpt() if node.id not in {i("rootfs"), i("mnt-root")}]

--- a/tests/unit/test_plan_disk.py
+++ b/tests/unit/test_plan_disk.py
@@ -420,6 +420,13 @@ def test_a_pool_is_created_under_the_target_with_encryption_only_when_asked() ->
     ]
     assert "encryption=on" not in apply_all(plain).only("zpool", "create")
 
+def test_a_zpool_import_description_names_its_alternate_root() -> None:
+    operation = disk.ImportZpool(pool=i("graph-node"), name="rpool")
+
+    assert operation.describe() == (
+        "import zpool rpool with the installation target as its alternate root"
+    )
+
 
 def test_an_encrypted_pool_gets_its_passphrase_on_stdin() -> None:
     """`keylocation=prompt` reads it here and asks again at boot, which is what


### PR DESCRIPTION
`ReleaseTarget` ran `umount --recursive --lazy` and then every close command with `check=False`, so a container still held open after `cryptsetup close`, `vgchange`, `mdadm --stop` or `zpool export` failed was recorded `done`. `wipefs` then reached a busy device, and a later `--resume` skipped the journaled release and retried against the same holder. It now confirms the unmount and retries the containers, the way `UnmountTarget._export()` already did for pools.

A btrfs scratch mount is a sibling of the target, so failure cleanup — which runs only `Stage.FINISH` — never released it, and a resumed `CreateSubvolume` mounted onto the still-mounted path. Image mode attached a second loop device and leaked the first.

`ImportZpool.describe()` said `under {self.pool}`, a graph identifier `apply()` never reads, while the import happens under the execution target — renaming that identifier moved the golden without moving the command.

Cluster verification is queued. The earlier run failed on the `PYTHONPATH` defect in master rather than on this branch, and that verdict is not being counted.