### PR TITLE
portage: honour a deselected official binhost, and verify its key

### DIFF
--- a/gentoo_install/data/locale/ja.toml
+++ b/gentoo_install/data/locale/ja.toml
@@ -670,7 +670,7 @@
 "{}: emerge {}" = "{}：{} を emerge"
 "run getuto so Portage has a keyring to verify binary packages against, and write dirmngr.conf" = "Portage がバイナリーパッケージを検証する鍵束を持つよう getuto を実行し、dirmngr.conf を書き込む"
 "disable inherited binary package host {}" = "stage3 から継承したバイナリーパッケージホスト {} を無効化"
-"import {} from {} and locally sign it for {}" = "{} を {} からインポートし、{} 用にローカル署名"
+"import {} from {}, locally sign it for {}, and verify the local signature" = "{} を {} からインポートし、{} 用にローカル署名し、ローカル署名を確認"
 "add verified binary package host {} at {}" = "検証済みバイナリーパッケージホスト {} を {} に追加"
 "add unverified binary package host {} at {}" = "未検証バイナリーパッケージホスト {} を {} に追加"
 "resolve {} together before installing the requested packages" = "要求したパッケージをインストールする前に {} をまとめて解決"

--- a/gentoo_install/data/locale/ja.toml
+++ b/gentoo_install/data/locale/ja.toml
@@ -669,6 +669,7 @@
 "{}: emerge {}, building {} here, with no binhost" = "{}：binhost を使わずに {} を emerge し、{} をここでビルド"
 "{}: emerge {}" = "{}：{} を emerge"
 "run getuto so Portage has a keyring to verify binary packages against, and write dirmngr.conf" = "Portage がバイナリーパッケージを検証する鍵束を持つよう getuto を実行し、dirmngr.conf を書き込む"
+"disable inherited binary package host {}" = "stage3 から継承したバイナリーパッケージホスト {} を無効化"
 "import {} from {} and locally sign it for {}" = "{} を {} からインポートし、{} 用にローカル署名"
 "add verified binary package host {} at {}" = "検証済みバイナリーパッケージホスト {} を {} に追加"
 "add unverified binary package host {} at {}" = "未検証バイナリーパッケージホスト {} を {} に追加"

--- a/gentoo_install/data/locale/ko.toml
+++ b/gentoo_install/data/locale/ko.toml
@@ -670,7 +670,7 @@
 "{}: emerge {}" = "{}: {}를 emerge"
 "run getuto so Portage has a keyring to verify binary packages against, and write dirmngr.conf" = "Portage가 바이너리 패키지를 검증할 키링을 갖도록 getuto 실행 및 dirmngr.conf 작성"
 "disable inherited binary package host {}" = "stage3에서 상속한 바이너리 패키지 호스트 {} 비활성화"
-"import {} from {} and locally sign it for {}" = "{}를 {}에서 가져와 {}용으로 로컬 서명"
+"import {} from {}, locally sign it for {}, and verify the local signature" = "{}를 {}에서 가져와 {}용으로 로컬 서명하고 로컬 서명을 확인"
 "add verified binary package host {} at {}" = "검증된 바이너리 패키지 호스트 {}를 {}에 추가"
 "add unverified binary package host {} at {}" = "검증되지 않은 바이너리 패키지 호스트 {}를 {}에 추가"
 "resolve {} together before installing the requested packages" = "요청한 패키지를 설치하기 전에 {}를 함께 해결"

--- a/gentoo_install/data/locale/ko.toml
+++ b/gentoo_install/data/locale/ko.toml
@@ -669,6 +669,7 @@
 "{}: emerge {}, building {} here, with no binhost" = "{}: binhost 없이 {}를 emerge하고 {}를 여기서 빌드"
 "{}: emerge {}" = "{}: {}를 emerge"
 "run getuto so Portage has a keyring to verify binary packages against, and write dirmngr.conf" = "Portage가 바이너리 패키지를 검증할 키링을 갖도록 getuto 실행 및 dirmngr.conf 작성"
+"disable inherited binary package host {}" = "stage3에서 상속한 바이너리 패키지 호스트 {} 비활성화"
 "import {} from {} and locally sign it for {}" = "{}를 {}에서 가져와 {}용으로 로컬 서명"
 "add verified binary package host {} at {}" = "검증된 바이너리 패키지 호스트 {}를 {}에 추가"
 "add unverified binary package host {} at {}" = "검증되지 않은 바이너리 패키지 호스트 {}를 {}에 추가"

--- a/gentoo_install/data/locale/zh-CN.toml
+++ b/gentoo_install/data/locale/zh-CN.toml
@@ -671,7 +671,7 @@
 "{}: emerge {}" = "{}：emerge {}"
 "run getuto so Portage has a keyring to verify binary packages against, and write dirmngr.conf" = "运行 getuto，让 Portage 拥有验证二进制软件包的密钥环，并写入 dirmngr.conf"
 "disable inherited binary package host {}" = "禁用从 stage3 继承的二进制软件包主机 {}"
-"import {} from {} and locally sign it for {}" = "导入 {}，来源 {}，并为 {} 本地签名"
+"import {} from {}, locally sign it for {}, and verify the local signature" = "导入 {}，来源 {}，为 {} 本地签名，并验证本地签名"
 "add verified binary package host {} at {}" = "添加已验证的二进制软件包主机 {}，地址为 {}"
 "add unverified binary package host {} at {}" = "添加未验证的二进制软件包主机 {}，地址为 {}"
 "resolve {} together before installing the requested packages" = "安装请求的软件包前一并解析 {}"

--- a/gentoo_install/data/locale/zh-CN.toml
+++ b/gentoo_install/data/locale/zh-CN.toml
@@ -670,6 +670,7 @@
 "{}: emerge {}, building {} here, with no binhost" = "{}：emerge {}，在本机构建 {}，不使用 binhost"
 "{}: emerge {}" = "{}：emerge {}"
 "run getuto so Portage has a keyring to verify binary packages against, and write dirmngr.conf" = "运行 getuto，让 Portage 拥有验证二进制软件包的密钥环，并写入 dirmngr.conf"
+"disable inherited binary package host {}" = "禁用从 stage3 继承的二进制软件包主机 {}"
 "import {} from {} and locally sign it for {}" = "导入 {}，来源 {}，并为 {} 本地签名"
 "add verified binary package host {} at {}" = "添加已验证的二进制软件包主机 {}，地址为 {}"
 "add unverified binary package host {} at {}" = "添加未验证的二进制软件包主机 {}，地址为 {}"

--- a/gentoo_install/data/locale/zh-TW.toml
+++ b/gentoo_install/data/locale/zh-TW.toml
@@ -670,6 +670,7 @@
 "{}: emerge {}, building {} here, with no binhost" = "{}：emerge {}，在本機建置 {}，不使用 binhost"
 "{}: emerge {}" = "{}：emerge {}"
 "run getuto so Portage has a keyring to verify binary packages against, and write dirmngr.conf" = "執行 getuto，讓 Portage 擁有驗證二進位套件的金鑰圈，並寫入 dirmngr.conf"
+"disable inherited binary package host {}" = "停用從 stage3 繼承的二進位套件主機 {}"
 "import {} from {} and locally sign it for {}" = "匯入 {}，來源 {}，並為 {} 本地簽署"
 "add verified binary package host {} at {}" = "新增已驗證的二進位套件主機 {}，位址為 {}"
 "add unverified binary package host {} at {}" = "新增未驗證的二進位套件主機 {}，位址為 {}"

--- a/gentoo_install/data/locale/zh-TW.toml
+++ b/gentoo_install/data/locale/zh-TW.toml
@@ -671,7 +671,7 @@
 "{}: emerge {}" = "{}：emerge {}"
 "run getuto so Portage has a keyring to verify binary packages against, and write dirmngr.conf" = "執行 getuto，讓 Portage 擁有驗證二進位套件的金鑰圈，並寫入 dirmngr.conf"
 "disable inherited binary package host {}" = "停用從 stage3 繼承的二進位套件主機 {}"
-"import {} from {} and locally sign it for {}" = "匯入 {}，來源 {}，並為 {} 本地簽署"
+"import {} from {}, locally sign it for {}, and verify the local signature" = "匯入 {}，來源 {}，為 {} 本地簽署，並驗證本機簽章"
 "add verified binary package host {} at {}" = "新增已驗證的二進位套件主機 {}，位址為 {}"
 "add unverified binary package host {} at {}" = "新增未驗證的二進位套件主機 {}，位址為 {}"
 "resolve {} together before installing the requested packages" = "安裝要求的套件前一併解析 {}"

--- a/gentoo_install/plan/portage.py
+++ b/gentoo_install/plan/portage.py
@@ -29,7 +29,7 @@ from ..model.config import (
     Sync,
 )
 from ..model.validate import parse_profile_list, validate_profile
-from .operations import CommandOutput, Context, Operation, Stage, worth_reading
+from .operations import CommandOutput, Context, Operation, Stage, answered, worth_reading
 
 #: The release engineering key, pinned. A fingerprint that does not match this
 #: is a failed install, not a prompt to trust something new.
@@ -43,6 +43,9 @@ GENTOOZH_KEY: Final[PurePosixPath] = PurePosixPath("/usr/share/openpgp-keys/gent
 
 #: A stage3 ships the release engineering key at this path.
 RELEASE_KEY: Final[PurePosixPath] = PurePosixPath("/usr/share/openpgp-keys/gentoo-release.asc")
+
+#: `getuto` records its local signing key here after creating the keyring.
+PORTAGE_TRUST_KEY_ID: Final[PurePosixPath] = PurePosixPath("/etc/portage/gnupg/mykeyid")
 
 
 def _binrepos_path(name: str) -> PurePosixPath:
@@ -129,6 +132,19 @@ EMERGE_OPTIONS: Final[tuple[str, ...]] = (
 #: be verified without one.
 BINARY_PACKAGES: Final[str] = "binary packages"
 
+
+
+def _has_local_signature(signatures: str, signers: frozenset[str]) -> bool:
+    """Whether `gpg --with-colons --list-sigs` names a local signing key."""
+    for line in signatures.splitlines():
+        fields = line.split(":")
+        if len(fields) <= 12 or fields[0] != "sig":
+            continue
+        # The signature class ends in `l` for a local signature; field 13 is
+        # the signing primary key's fingerprint.
+        if fields[10].endswith("l") and fields[12].upper() in signers:
+            return True
+    return False
 
 def binhost_trust(name: str) -> str:
     """What one host's own key degrades. The official host's key comes from
@@ -1168,8 +1184,8 @@ class PrepareBinhostTrust(Operation):
 
 @dataclass(frozen=True, kw_only=True)
 class TrustBinhostKey(Operation):
-    """A key imported into Portage's keyring stays untrusted until `lsign`, and
-    verification then fails the same way it fails with no key at all."""
+    """An imported key stays untrusted until `lsign`, and its local signature
+    is the postcondition that permits the host to serve binary packages."""
 
     stage: Stage = Stage.PORTAGE
     binhost: str
@@ -1177,7 +1193,7 @@ class TrustBinhostKey(Operation):
     key_path: PurePosixPath
 
     def describe_parts(self) -> tuple[str, tuple[str, ...]]:
-        return "import {} from {} and locally sign it for {}", (
+        return "import {} from {}, locally sign it for {}, and verify the local signature", (
             self.fingerprint[-16:],
             str(self.key_path),
             self.binhost,
@@ -1201,15 +1217,45 @@ class TrustBinhostKey(Operation):
         )
         context.run_in_target(
             [
-                "gpg", "--homedir", "/etc/portage/gnupg",
-                "--batch", "--yes",
-                "--pinentry-mode", "loopback",
-                "--passphrase-file", "/etc/portage/gnupg/pass",
-                "--lsign-key", self.fingerprint,
+                "gpg",
+                "--homedir",
+                "/etc/portage/gnupg",
+                "--batch",
+                "--yes",
+                "--pinentry-mode",
+                "loopback",
+                "--passphrase-file",
+                "/etc/portage/gnupg/pass",
+                "--lsign-key",
+                self.fingerprint,
             ]
         )
         context.run_in_target(["gpg", "--homedir", "/etc/portage/gnupg", "--check-trustdb"])
-
+        signers = frozenset(
+            fingerprint.strip().upper()
+            for fingerprint in context.read(PORTAGE_TRUST_KEY_ID).splitlines()
+            if fingerprint.strip()
+        )
+        if not signers:
+            raise CommandFailed("Portage's local signing key is absent")
+        signatures = answered(
+            context.run_in_target(
+                [
+                    "gpg",
+                    "--homedir",
+                    "/etc/portage/gnupg",
+                    "--with-colons",
+                    "--list-sigs",
+                    self.fingerprint,
+                ],
+                check=False,
+            ),
+            f"could not read the local signature for {self.fingerprint[-16:]}",
+        )
+        if not _has_local_signature(signatures, signers):
+            raise CommandFailed(
+                f"{self.fingerprint[-16:]} has no local signature from Portage's trust key"
+            )
 
 
 @dataclass(frozen=True, kw_only=True)
@@ -1471,15 +1517,20 @@ def build(
     if portage.binhost.official:
         # Written rather than left to the stage3's default: entry removal keeps
         # untrusted hosts source-only; profile baseline and subarch are choices here.
-        operations.append(
+        operations += [
+            TrustBinhostKey(
+                binhost="gentoo",
+                fingerprint=RELENG_FINGERPRINT,
+                key_path=RELEASE_KEY,
+            ),
             ConfigureBinhost(
                 name="gentoo",
                 sync_uri=mirrors.gentoo_binhost(
                     portage.mirrors.region, portage.mirrors.site, portage.binhost.subarch
                 ),
                 verify=True,
-            )
-        )
+            ),
+        ]
     operations += [
         WebrsyncRepository(),
         SelectProfile(profile=portage.profile),

--- a/gentoo_install/plan/portage.py
+++ b/gentoo_install/plan/portage.py
@@ -44,6 +44,20 @@ GENTOOZH_KEY: Final[PurePosixPath] = PurePosixPath("/usr/share/openpgp-keys/gent
 #: A stage3 ships the release engineering key at this path.
 RELEASE_KEY: Final[PurePosixPath] = PurePosixPath("/usr/share/openpgp-keys/gentoo-release.asc")
 
+
+def _binrepos_path(name: str) -> PurePosixPath:
+    filename = "gentoo.conf" if name == "gentoo" else f"{name}.conf"
+    return PurePosixPath("/etc/portage/binrepos.conf") / filename
+
+
+def _inherited_binrepos_paths(name: str) -> tuple[PurePosixPath, ...]:
+    if name != "gentoo":
+        return (_binrepos_path(name),)
+    return (
+        _binrepos_path(name),
+        PurePosixPath("/etc/portage/binrepos.conf/gentoobinhost.conf"),
+    )
+
 #: Portage writes automatic keyword, USE and licence decisions into these. They
 #: have to exist before the first emerge, or the writes land outside Portage.
 AUTOUNMASK_FILES: Final[tuple[str, ...]] = (
@@ -1197,6 +1211,22 @@ class TrustBinhostKey(Operation):
         context.run_in_target(["gpg", "--homedir", "/etc/portage/gnupg", "--check-trustdb"])
 
 
+
+@dataclass(frozen=True, kw_only=True)
+class DisableBinhost(Operation):
+    """Remove a binhost inherited from the stage3."""
+
+    stage: Stage = Stage.PORTAGE
+    name: str
+
+    def describe_parts(self) -> tuple[str, tuple[str, ...]]:
+        return "disable inherited binary package host {}", (self.name,)
+
+    def apply(self, context: Context) -> None:
+        for path in _inherited_binrepos_paths(self.name):
+            context.run_in_target(["rm", "--force", "--", str(path)])
+
+
 @dataclass(frozen=True, kw_only=True)
 class ConfigureBinhost(Operation):
     stage: Stage = Stage.PORTAGE
@@ -1221,8 +1251,7 @@ class ConfigureBinhost(Operation):
             f"verify-signature = {'true' if self.verify else 'false'}\n"
             f"location = /var/cache/binhost/{self.name}\n"
         )
-        filename = "gentoobinhost.conf" if self.name == "gentoo" else f"{self.name}.conf"
-        context.write(PurePosixPath(f"/etc/portage/binrepos.conf/{filename}"), stanza)
+        context.write(_binrepos_path(self.name), stanza)
 
 
 @dataclass(frozen=True, kw_only=True)
@@ -1430,6 +1459,7 @@ def build(
         WriteProxyClients(proxy=config.proxy),
         CreateAutounmaskFiles(),
     ]
+    operations.append(DisableBinhost(name="gentoo"))
     if uses_binhost(portage):
         # Before the first emerge, not after it. `make.conf` above already
         # carries `FEATURES=getbinpkg`, so `emerge dev-vcs/git` fetches binary
@@ -1439,8 +1469,8 @@ def build(
         # setup that exists to prevent exactly that.
         operations.append(PrepareBinhostTrust(proxy=config.proxy))
     if portage.binhost.official:
-        # Written rather than left to the stage3's default, because that names
-        # the profile's baseline and the subarchitecture is a choice here.
+        # Written rather than left to the stage3's default: entry removal keeps
+        # untrusted hosts source-only; profile baseline and subarch are choices here.
         operations.append(
             ConfigureBinhost(
                 name="gentoo",

--- a/tests/golden/btrfs-luks.txt
+++ b/tests/golden/btrfs-luks.txt
@@ -34,6 +34,7 @@
   create the three autounmask files emerge writes its decisions into
   disable inherited binary package host gentoo
   run getuto so Portage has a keyring to verify binary packages against, and write dirmngr.conf
+  import BB572E0E2D182910 from /usr/share/openpgp-keys/gentoo-release.asc, locally sign it for gentoo, and verify the local signature
   add verified binary package host gentoo at https://mirrors.ustc.edu.cn/gentoo/releases/amd64/binpackages/23.0/x86-64
   fetch the first ebuild repository snapshot with emerge-webrsync
   select profile default/linux/amd64/23.0/desktop/systemd
@@ -44,7 +45,7 @@
   sync repository gentoo-zh, 4 other sites to fall back on
   accept ~amd64 for packages from gentoo-zh only
   install the key the community binary packages are signed with: emerge sec-keys/openpgp-keys-gentoozh, from source
-  import 38A0234EC16AD42E from /usr/share/openpgp-keys/gentoozh.asc and locally sign it for gentoo-zh
+  import 38A0234EC16AD42E from /usr/share/openpgp-keys/gentoozh.asc, locally sign it for gentoo-zh, and verify the local signature
   add verified binary package host gentoo-zh at https://distfiles.gentoozh.org/binpkgs/x86-64
   set sys-kernel/installkernel to dracut
   ask for sys-apps/systemd[cryptsetup], which provides the unlock generator

--- a/tests/golden/btrfs-luks.txt
+++ b/tests/golden/btrfs-luks.txt
@@ -32,6 +32,7 @@
   write /etc/portage/make.conf with COMMON_FLAGS, CFLAGS, CXXFLAGS, FCFLAGS, FFLAGS, MAKEOPTS, USE, VIDEO_CARDS, INPUT_DEVICES, ACCEPT_LICENSE, L10N, FEATURES; 23 mirrors fastest first, measured, 5 appended
   configure Portage, wget, curl, git and gpg for direct connection
   create the three autounmask files emerge writes its decisions into
+  disable inherited binary package host gentoo
   run getuto so Portage has a keyring to verify binary packages against, and write dirmngr.conf
   add verified binary package host gentoo at https://mirrors.ustc.edu.cn/gentoo/releases/amd64/binpackages/23.0/x86-64
   fetch the first ebuild repository snapshot with emerge-webrsync

--- a/tests/golden/ext2.txt
+++ b/tests/golden/ext2.txt
@@ -24,6 +24,7 @@
   write /etc/portage/make.conf with MAKEOPTS, INPUT_DEVICES, ACCEPT_LICENSE, L10N; 2 mirrors in the configured order, 5 appended
   configure Portage, wget, curl, git and gpg for direct connection
   create the three autounmask files emerge writes its decisions into
+  disable inherited binary package host gentoo
   fetch the first ebuild repository snapshot with emerge-webrsync
   select profile default/linux/amd64/23.0
   install git, which every later repository sync needs: emerge dev-vcs/git, with no binhost

--- a/tests/golden/ext3.txt
+++ b/tests/golden/ext3.txt
@@ -24,6 +24,7 @@
   write /etc/portage/make.conf with MAKEOPTS, INPUT_DEVICES, ACCEPT_LICENSE, L10N; 2 mirrors in the configured order, 5 appended
   configure Portage, wget, curl, git and gpg for direct connection
   create the three autounmask files emerge writes its decisions into
+  disable inherited binary package host gentoo
   fetch the first ebuild repository snapshot with emerge-webrsync
   select profile default/linux/amd64/23.0
   install git, which every later repository sync needs: emerge dev-vcs/git, with no binhost

--- a/tests/golden/ext4-bios.txt
+++ b/tests/golden/ext4-bios.txt
@@ -24,6 +24,7 @@
   write /etc/portage/make.conf with MAKEOPTS, INPUT_DEVICES, ACCEPT_LICENSE, L10N; 2 mirrors in the configured order, 5 appended
   configure Portage, wget, curl, git and gpg for direct connection
   create the three autounmask files emerge writes its decisions into
+  disable inherited binary package host gentoo
   fetch the first ebuild repository snapshot with emerge-webrsync
   select profile default/linux/amd64/23.0
   install git, which every later repository sync needs: emerge dev-vcs/git, with no binhost

--- a/tests/golden/mbr-edit.txt
+++ b/tests/golden/mbr-edit.txt
@@ -21,6 +21,7 @@
   write /etc/portage/make.conf with MAKEOPTS, INPUT_DEVICES, ACCEPT_LICENSE, L10N, FEATURES; 2 mirrors in the configured order, 5 appended
   configure Portage, wget, curl, git and gpg for direct connection
   create the three autounmask files emerge writes its decisions into
+  disable inherited binary package host gentoo
   run getuto so Portage has a keyring to verify binary packages against, and write dirmngr.conf
   add verified binary package host gentoo at https://distfiles.gentoo.org/releases/amd64/binpackages/23.0/x86-64
   fetch the first ebuild repository snapshot with emerge-webrsync

--- a/tests/golden/mbr-edit.txt
+++ b/tests/golden/mbr-edit.txt
@@ -23,6 +23,7 @@
   create the three autounmask files emerge writes its decisions into
   disable inherited binary package host gentoo
   run getuto so Portage has a keyring to verify binary packages against, and write dirmngr.conf
+  import BB572E0E2D182910 from /usr/share/openpgp-keys/gentoo-release.asc, locally sign it for gentoo, and verify the local signature
   add verified binary package host gentoo at https://distfiles.gentoo.org/releases/amd64/binpackages/23.0/x86-64
   fetch the first ebuild repository snapshot with emerge-webrsync
   select profile default/linux/amd64/23.0

--- a/tests/golden/openrc-sdboot.txt
+++ b/tests/golden/openrc-sdboot.txt
@@ -25,6 +25,7 @@
   write /etc/portage/make.conf with MAKEOPTS, INPUT_DEVICES, ACCEPT_LICENSE, L10N, FEATURES; 2 mirrors in the configured order, 5 appended
   configure Portage, wget, curl, git and gpg for direct connection
   create the three autounmask files emerge writes its decisions into
+  disable inherited binary package host gentoo
   run getuto so Portage has a keyring to verify binary packages against, and write dirmngr.conf
   add verified binary package host gentoo at https://distfiles.gentoo.org/releases/amd64/binpackages/23.0/x86-64
   fetch the first ebuild repository snapshot with emerge-webrsync

--- a/tests/golden/openrc-sdboot.txt
+++ b/tests/golden/openrc-sdboot.txt
@@ -27,6 +27,7 @@
   create the three autounmask files emerge writes its decisions into
   disable inherited binary package host gentoo
   run getuto so Portage has a keyring to verify binary packages against, and write dirmngr.conf
+  import BB572E0E2D182910 from /usr/share/openpgp-keys/gentoo-release.asc, locally sign it for gentoo, and verify the local signature
   add verified binary package host gentoo at https://distfiles.gentoo.org/releases/amd64/binpackages/23.0/x86-64
   fetch the first ebuild repository snapshot with emerge-webrsync
   select profile default/linux/amd64/23.0

--- a/tests/golden/static-ip.txt
+++ b/tests/golden/static-ip.txt
@@ -25,6 +25,7 @@
   write /etc/portage/make.conf with MAKEOPTS, INPUT_DEVICES, ACCEPT_LICENSE, L10N, FEATURES; 2 mirrors in the configured order, 5 appended
   configure Portage, wget, curl, git and gpg for direct connection
   create the three autounmask files emerge writes its decisions into
+  disable inherited binary package host gentoo
   run getuto so Portage has a keyring to verify binary packages against, and write dirmngr.conf
   add verified binary package host gentoo at https://distfiles.gentoo.org/releases/amd64/binpackages/23.0/x86-64
   fetch the first ebuild repository snapshot with emerge-webrsync

--- a/tests/golden/static-ip.txt
+++ b/tests/golden/static-ip.txt
@@ -27,6 +27,7 @@
   create the three autounmask files emerge writes its decisions into
   disable inherited binary package host gentoo
   run getuto so Portage has a keyring to verify binary packages against, and write dirmngr.conf
+  import BB572E0E2D182910 from /usr/share/openpgp-keys/gentoo-release.asc, locally sign it for gentoo, and verify the local signature
   add verified binary package host gentoo at https://distfiles.gentoo.org/releases/amd64/binpackages/23.0/x86-64
   fetch the first ebuild repository snapshot with emerge-webrsync
   select profile default/linux/amd64/23.0/systemd

--- a/tests/golden/vm-binhost-fallback.txt
+++ b/tests/golden/vm-binhost-fallback.txt
@@ -25,6 +25,7 @@
   write /etc/portage/make.conf with MAKEOPTS, INPUT_DEVICES, ACCEPT_LICENSE, L10N, FEATURES; 23 mirrors in the configured order, 5 appended
   configure Portage, wget, curl, git and gpg for direct connection
   create the three autounmask files emerge writes its decisions into
+  disable inherited binary package host gentoo
   run getuto so Portage has a keyring to verify binary packages against, and write dirmngr.conf
   add verified binary package host gentoo at https://mirror.xtom.com.hk/gentoo/releases/amd64/binpackages/23.0/x86-64
   fetch the first ebuild repository snapshot with emerge-webrsync

--- a/tests/golden/vm-binhost-fallback.txt
+++ b/tests/golden/vm-binhost-fallback.txt
@@ -27,6 +27,7 @@
   create the three autounmask files emerge writes its decisions into
   disable inherited binary package host gentoo
   run getuto so Portage has a keyring to verify binary packages against, and write dirmngr.conf
+  import BB572E0E2D182910 from /usr/share/openpgp-keys/gentoo-release.asc, locally sign it for gentoo, and verify the local signature
   add verified binary package host gentoo at https://mirror.xtom.com.hk/gentoo/releases/amd64/binpackages/23.0/x86-64
   fetch the first ebuild repository snapshot with emerge-webrsync
   select profile default/linux/amd64/23.0/systemd

--- a/tests/golden/vm-binpkg.txt
+++ b/tests/golden/vm-binpkg.txt
@@ -25,6 +25,7 @@
   write /etc/portage/make.conf with MAKEOPTS, INPUT_DEVICES, ACCEPT_LICENSE, L10N, FEATURES; 2 mirrors in the configured order, 5 appended
   configure Portage, wget, curl, git and gpg for direct connection
   create the three autounmask files emerge writes its decisions into
+  disable inherited binary package host gentoo
   run getuto so Portage has a keyring to verify binary packages against, and write dirmngr.conf
   add verified binary package host gentoo at https://distfiles.gentoo.org/releases/amd64/binpackages/23.0/x86-64
   fetch the first ebuild repository snapshot with emerge-webrsync

--- a/tests/golden/vm-binpkg.txt
+++ b/tests/golden/vm-binpkg.txt
@@ -27,6 +27,7 @@
   create the three autounmask files emerge writes its decisions into
   disable inherited binary package host gentoo
   run getuto so Portage has a keyring to verify binary packages against, and write dirmngr.conf
+  import BB572E0E2D182910 from /usr/share/openpgp-keys/gentoo-release.asc, locally sign it for gentoo, and verify the local signature
   add verified binary package host gentoo at https://distfiles.gentoo.org/releases/amd64/binpackages/23.0/x86-64
   fetch the first ebuild repository snapshot with emerge-webrsync
   select profile default/linux/amd64/23.0/systemd

--- a/tests/golden/vm-bios-luks.txt
+++ b/tests/golden/vm-bios-luks.txt
@@ -30,6 +30,7 @@
   create the three autounmask files emerge writes its decisions into
   disable inherited binary package host gentoo
   run getuto so Portage has a keyring to verify binary packages against, and write dirmngr.conf
+  import BB572E0E2D182910 from /usr/share/openpgp-keys/gentoo-release.asc, locally sign it for gentoo, and verify the local signature
   add verified binary package host gentoo at https://distfiles.gentoo.org/releases/amd64/binpackages/23.0/x86-64
   fetch the first ebuild repository snapshot with emerge-webrsync
   select profile default/linux/amd64/23.0

--- a/tests/golden/vm-bios-luks.txt
+++ b/tests/golden/vm-bios-luks.txt
@@ -28,6 +28,7 @@
   write /etc/portage/make.conf with MAKEOPTS, INPUT_DEVICES, ACCEPT_LICENSE, L10N, FEATURES; 2 mirrors in the configured order, 5 appended
   configure Portage, wget, curl, git and gpg for direct connection
   create the three autounmask files emerge writes its decisions into
+  disable inherited binary package host gentoo
   run getuto so Portage has a keyring to verify binary packages against, and write dirmngr.conf
   add verified binary package host gentoo at https://distfiles.gentoo.org/releases/amd64/binpackages/23.0/x86-64
   fetch the first ebuild repository snapshot with emerge-webrsync

--- a/tests/golden/vm-bios.txt
+++ b/tests/golden/vm-bios.txt
@@ -24,6 +24,7 @@
   write /etc/portage/make.conf with MAKEOPTS, INPUT_DEVICES, ACCEPT_LICENSE, L10N, FEATURES; 2 mirrors in the configured order, 5 appended
   configure Portage, wget, curl, git and gpg for direct connection
   create the three autounmask files emerge writes its decisions into
+  disable inherited binary package host gentoo
   run getuto so Portage has a keyring to verify binary packages against, and write dirmngr.conf
   add verified binary package host gentoo at https://distfiles.gentoo.org/releases/amd64/binpackages/23.0/x86-64
   fetch the first ebuild repository snapshot with emerge-webrsync

--- a/tests/golden/vm-bios.txt
+++ b/tests/golden/vm-bios.txt
@@ -26,6 +26,7 @@
   create the three autounmask files emerge writes its decisions into
   disable inherited binary package host gentoo
   run getuto so Portage has a keyring to verify binary packages against, and write dirmngr.conf
+  import BB572E0E2D182910 from /usr/share/openpgp-keys/gentoo-release.asc, locally sign it for gentoo, and verify the local signature
   add verified binary package host gentoo at https://distfiles.gentoo.org/releases/amd64/binpackages/23.0/x86-64
   fetch the first ebuild repository snapshot with emerge-webrsync
   select profile default/linux/amd64/23.0

--- a/tests/golden/vm-btrfs.txt
+++ b/tests/golden/vm-btrfs.txt
@@ -30,6 +30,7 @@
   create the three autounmask files emerge writes its decisions into
   disable inherited binary package host gentoo
   run getuto so Portage has a keyring to verify binary packages against, and write dirmngr.conf
+  import BB572E0E2D182910 from /usr/share/openpgp-keys/gentoo-release.asc, locally sign it for gentoo, and verify the local signature
   add verified binary package host gentoo at https://distfiles.gentoo.org/releases/amd64/binpackages/23.0/x86-64
   fetch the first ebuild repository snapshot with emerge-webrsync
   select profile default/linux/amd64/23.0/systemd

--- a/tests/golden/vm-btrfs.txt
+++ b/tests/golden/vm-btrfs.txt
@@ -28,6 +28,7 @@
   write /etc/portage/make.conf with MAKEOPTS, INPUT_DEVICES, ACCEPT_LICENSE, L10N, FEATURES; 2 mirrors in the configured order, 5 appended
   configure Portage, wget, curl, git and gpg for direct connection
   create the three autounmask files emerge writes its decisions into
+  disable inherited binary package host gentoo
   run getuto so Portage has a keyring to verify binary packages against, and write dirmngr.conf
   add verified binary package host gentoo at https://distfiles.gentoo.org/releases/amd64/binpackages/23.0/x86-64
   fetch the first ebuild repository snapshot with emerge-webrsync

--- a/tests/golden/vm-cjk-kernel.txt
+++ b/tests/golden/vm-cjk-kernel.txt
@@ -25,6 +25,7 @@
   write /etc/portage/make.conf with MAKEOPTS, INPUT_DEVICES, ACCEPT_LICENSE, L10N, FEATURES; 2 mirrors in the configured order, 5 appended
   configure Portage, wget, curl, git and gpg for direct connection
   create the three autounmask files emerge writes its decisions into
+  disable inherited binary package host gentoo
   run getuto so Portage has a keyring to verify binary packages against, and write dirmngr.conf
   add verified binary package host gentoo at https://distfiles.gentoo.org/releases/amd64/binpackages/23.0/x86-64
   fetch the first ebuild repository snapshot with emerge-webrsync

--- a/tests/golden/vm-cjk-kernel.txt
+++ b/tests/golden/vm-cjk-kernel.txt
@@ -27,6 +27,7 @@
   create the three autounmask files emerge writes its decisions into
   disable inherited binary package host gentoo
   run getuto so Portage has a keyring to verify binary packages against, and write dirmngr.conf
+  import BB572E0E2D182910 from /usr/share/openpgp-keys/gentoo-release.asc, locally sign it for gentoo, and verify the local signature
   add verified binary package host gentoo at https://distfiles.gentoo.org/releases/amd64/binpackages/23.0/x86-64
   fetch the first ebuild repository snapshot with emerge-webrsync
   select profile default/linux/amd64/23.0/systemd

--- a/tests/golden/vm-convert.txt
+++ b/tests/golden/vm-convert.txt
@@ -12,6 +12,7 @@
   create the three autounmask files emerge writes its decisions into, in /gentoo-install.new
   disable inherited binary package host gentoo, in /gentoo-install.new
   run getuto so Portage has a keyring to verify binary packages against, and write dirmngr.conf, in /gentoo-install.new
+  import BB572E0E2D182910 from /usr/share/openpgp-keys/gentoo-release.asc, locally sign it for gentoo, and verify the local signature, in /gentoo-install.new
   add verified binary package host gentoo at https://distfiles.gentoo.org/releases/amd64/binpackages/23.0/x86-64, in /gentoo-install.new
   fetch the first ebuild repository snapshot with emerge-webrsync, in /gentoo-install.new
   select profile default/linux/amd64/23.0/systemd, in /gentoo-install.new

--- a/tests/golden/vm-convert.txt
+++ b/tests/golden/vm-convert.txt
@@ -10,6 +10,7 @@
   write /etc/portage/make.conf with MAKEOPTS, INPUT_DEVICES, ACCEPT_LICENSE, L10N, FEATURES; 2 mirrors in the configured order, 5 appended, in /gentoo-install.new
   configure Portage, wget, curl, git and gpg for direct connection, in /gentoo-install.new
   create the three autounmask files emerge writes its decisions into, in /gentoo-install.new
+  disable inherited binary package host gentoo, in /gentoo-install.new
   run getuto so Portage has a keyring to verify binary packages against, and write dirmngr.conf, in /gentoo-install.new
   add verified binary package host gentoo at https://distfiles.gentoo.org/releases/amd64/binpackages/23.0/x86-64, in /gentoo-install.new
   fetch the first ebuild repository snapshot with emerge-webrsync, in /gentoo-install.new

--- a/tests/golden/vm-desktop.txt
+++ b/tests/golden/vm-desktop.txt
@@ -25,6 +25,7 @@
   write /etc/portage/make.conf with MAKEOPTS, USE, INPUT_DEVICES, ACCEPT_LICENSE, L10N, FEATURES; 2 mirrors in the configured order, 5 appended
   configure Portage, wget, curl, git and gpg for direct connection
   create the three autounmask files emerge writes its decisions into
+  disable inherited binary package host gentoo
   run getuto so Portage has a keyring to verify binary packages against, and write dirmngr.conf
   add verified binary package host gentoo at https://distfiles.gentoo.org/releases/amd64/binpackages/23.0/x86-64
   fetch the first ebuild repository snapshot with emerge-webrsync

--- a/tests/golden/vm-desktop.txt
+++ b/tests/golden/vm-desktop.txt
@@ -27,6 +27,7 @@
   create the three autounmask files emerge writes its decisions into
   disable inherited binary package host gentoo
   run getuto so Portage has a keyring to verify binary packages against, and write dirmngr.conf
+  import BB572E0E2D182910 from /usr/share/openpgp-keys/gentoo-release.asc, locally sign it for gentoo, and verify the local signature
   add verified binary package host gentoo at https://distfiles.gentoo.org/releases/amd64/binpackages/23.0/x86-64
   fetch the first ebuild repository snapshot with emerge-webrsync
   select profile default/linux/amd64/23.0/desktop/plasma/systemd

--- a/tests/golden/vm-f2fs.txt
+++ b/tests/golden/vm-f2fs.txt
@@ -25,6 +25,7 @@
   write /etc/portage/make.conf with MAKEOPTS, INPUT_DEVICES, ACCEPT_LICENSE, L10N, FEATURES; 2 mirrors in the configured order, 5 appended
   configure Portage, wget, curl, git and gpg for direct connection
   create the three autounmask files emerge writes its decisions into
+  disable inherited binary package host gentoo
   run getuto so Portage has a keyring to verify binary packages against, and write dirmngr.conf
   add verified binary package host gentoo at https://distfiles.gentoo.org/releases/amd64/binpackages/23.0/x86-64
   fetch the first ebuild repository snapshot with emerge-webrsync

--- a/tests/golden/vm-f2fs.txt
+++ b/tests/golden/vm-f2fs.txt
@@ -27,6 +27,7 @@
   create the three autounmask files emerge writes its decisions into
   disable inherited binary package host gentoo
   run getuto so Portage has a keyring to verify binary packages against, and write dirmngr.conf
+  import BB572E0E2D182910 from /usr/share/openpgp-keys/gentoo-release.asc, locally sign it for gentoo, and verify the local signature
   add verified binary package host gentoo at https://distfiles.gentoo.org/releases/amd64/binpackages/23.0/x86-64
   fetch the first ebuild repository snapshot with emerge-webrsync
   select profile default/linux/amd64/23.0/systemd

--- a/tests/golden/vm-gnome.txt
+++ b/tests/golden/vm-gnome.txt
@@ -25,6 +25,7 @@
   write /etc/portage/make.conf with MAKEOPTS, USE, INPUT_DEVICES, ACCEPT_LICENSE, L10N, FEATURES; 2 mirrors in the configured order, 5 appended
   configure Portage, wget, curl, git and gpg for direct connection
   create the three autounmask files emerge writes its decisions into
+  disable inherited binary package host gentoo
   run getuto so Portage has a keyring to verify binary packages against, and write dirmngr.conf
   add verified binary package host gentoo at https://distfiles.gentoo.org/releases/amd64/binpackages/23.0/x86-64
   fetch the first ebuild repository snapshot with emerge-webrsync

--- a/tests/golden/vm-gnome.txt
+++ b/tests/golden/vm-gnome.txt
@@ -27,6 +27,7 @@
   create the three autounmask files emerge writes its decisions into
   disable inherited binary package host gentoo
   run getuto so Portage has a keyring to verify binary packages against, and write dirmngr.conf
+  import BB572E0E2D182910 from /usr/share/openpgp-keys/gentoo-release.asc, locally sign it for gentoo, and verify the local signature
   add verified binary package host gentoo at https://distfiles.gentoo.org/releases/amd64/binpackages/23.0/x86-64
   fetch the first ebuild repository snapshot with emerge-webrsync
   select profile default/linux/amd64/23.0/desktop/gnome/systemd

--- a/tests/golden/vm-greetd.txt
+++ b/tests/golden/vm-greetd.txt
@@ -25,6 +25,7 @@
   write /etc/portage/make.conf with MAKEOPTS, USE, INPUT_DEVICES, ACCEPT_LICENSE, L10N, FEATURES; 2 mirrors in the configured order, 5 appended
   configure Portage, wget, curl, git and gpg for direct connection
   create the three autounmask files emerge writes its decisions into
+  disable inherited binary package host gentoo
   run getuto so Portage has a keyring to verify binary packages against, and write dirmngr.conf
   add verified binary package host gentoo at https://distfiles.gentoo.org/releases/amd64/binpackages/23.0/x86-64
   fetch the first ebuild repository snapshot with emerge-webrsync

--- a/tests/golden/vm-greetd.txt
+++ b/tests/golden/vm-greetd.txt
@@ -27,6 +27,7 @@
   create the three autounmask files emerge writes its decisions into
   disable inherited binary package host gentoo
   run getuto so Portage has a keyring to verify binary packages against, and write dirmngr.conf
+  import BB572E0E2D182910 from /usr/share/openpgp-keys/gentoo-release.asc, locally sign it for gentoo, and verify the local signature
   add verified binary package host gentoo at https://distfiles.gentoo.org/releases/amd64/binpackages/23.0/x86-64
   fetch the first ebuild repository snapshot with emerge-webrsync
   select profile default/linux/amd64/23.0/desktop/systemd

--- a/tests/golden/vm-image.txt
+++ b/tests/golden/vm-image.txt
@@ -28,6 +28,7 @@
   create the three autounmask files emerge writes its decisions into
   disable inherited binary package host gentoo
   run getuto so Portage has a keyring to verify binary packages against, and write dirmngr.conf
+  import BB572E0E2D182910 from /usr/share/openpgp-keys/gentoo-release.asc, locally sign it for gentoo, and verify the local signature
   add verified binary package host gentoo at https://distfiles.gentoo.org/releases/amd64/binpackages/23.0/x86-64
   fetch the first ebuild repository snapshot with emerge-webrsync
   select profile default/linux/amd64/23.0/systemd

--- a/tests/golden/vm-image.txt
+++ b/tests/golden/vm-image.txt
@@ -26,6 +26,7 @@
   write /etc/portage/make.conf with MAKEOPTS, INPUT_DEVICES, ACCEPT_LICENSE, L10N, FEATURES; 2 mirrors in the configured order, 5 appended
   configure Portage, wget, curl, git and gpg for direct connection
   create the three autounmask files emerge writes its decisions into
+  disable inherited binary package host gentoo
   run getuto so Portage has a keyring to verify binary packages against, and write dirmngr.conf
   add verified binary package host gentoo at https://distfiles.gentoo.org/releases/amd64/binpackages/23.0/x86-64
   fetch the first ebuild repository snapshot with emerge-webrsync

--- a/tests/golden/vm-luks.txt
+++ b/tests/golden/vm-luks.txt
@@ -34,6 +34,7 @@
   create the three autounmask files emerge writes its decisions into
   disable inherited binary package host gentoo
   run getuto so Portage has a keyring to verify binary packages against, and write dirmngr.conf
+  import BB572E0E2D182910 from /usr/share/openpgp-keys/gentoo-release.asc, locally sign it for gentoo, and verify the local signature
   add verified binary package host gentoo at https://distfiles.gentoo.org/releases/amd64/binpackages/23.0/x86-64
   fetch the first ebuild repository snapshot with emerge-webrsync
   select profile default/linux/amd64/23.0/systemd

--- a/tests/golden/vm-luks.txt
+++ b/tests/golden/vm-luks.txt
@@ -32,6 +32,7 @@
   write /etc/portage/make.conf with MAKEOPTS, INPUT_DEVICES, ACCEPT_LICENSE, L10N, FEATURES; 2 mirrors in the configured order, 5 appended
   configure Portage, wget, curl, git and gpg for direct connection
   create the three autounmask files emerge writes its decisions into
+  disable inherited binary package host gentoo
   run getuto so Portage has a keyring to verify binary packages against, and write dirmngr.conf
   add verified binary package host gentoo at https://distfiles.gentoo.org/releases/amd64/binpackages/23.0/x86-64
   fetch the first ebuild repository snapshot with emerge-webrsync

--- a/tests/golden/vm-lvm.txt
+++ b/tests/golden/vm-lvm.txt
@@ -35,6 +35,7 @@
   create the three autounmask files emerge writes its decisions into
   disable inherited binary package host gentoo
   run getuto so Portage has a keyring to verify binary packages against, and write dirmngr.conf
+  import BB572E0E2D182910 from /usr/share/openpgp-keys/gentoo-release.asc, locally sign it for gentoo, and verify the local signature
   add verified binary package host gentoo at https://distfiles.gentoo.org/releases/amd64/binpackages/23.0/x86-64
   fetch the first ebuild repository snapshot with emerge-webrsync
   select profile default/linux/amd64/23.0

--- a/tests/golden/vm-lvm.txt
+++ b/tests/golden/vm-lvm.txt
@@ -33,6 +33,7 @@
   write /etc/portage/make.conf with MAKEOPTS, INPUT_DEVICES, ACCEPT_LICENSE, L10N, FEATURES; 2 mirrors in the configured order, 5 appended
   configure Portage, wget, curl, git and gpg for direct connection
   create the three autounmask files emerge writes its decisions into
+  disable inherited binary package host gentoo
   run getuto so Portage has a keyring to verify binary packages against, and write dirmngr.conf
   add verified binary package host gentoo at https://distfiles.gentoo.org/releases/amd64/binpackages/23.0/x86-64
   fetch the first ebuild repository snapshot with emerge-webrsync

--- a/tests/golden/vm-mdraid.txt
+++ b/tests/golden/vm-mdraid.txt
@@ -33,6 +33,7 @@
   write /etc/portage/make.conf with MAKEOPTS, INPUT_DEVICES, ACCEPT_LICENSE, L10N, FEATURES; 2 mirrors in the configured order, 5 appended
   configure Portage, wget, curl, git and gpg for direct connection
   create the three autounmask files emerge writes its decisions into
+  disable inherited binary package host gentoo
   run getuto so Portage has a keyring to verify binary packages against, and write dirmngr.conf
   add verified binary package host gentoo at https://distfiles.gentoo.org/releases/amd64/binpackages/23.0/x86-64
   fetch the first ebuild repository snapshot with emerge-webrsync

--- a/tests/golden/vm-mdraid.txt
+++ b/tests/golden/vm-mdraid.txt
@@ -35,6 +35,7 @@
   create the three autounmask files emerge writes its decisions into
   disable inherited binary package host gentoo
   run getuto so Portage has a keyring to verify binary packages against, and write dirmngr.conf
+  import BB572E0E2D182910 from /usr/share/openpgp-keys/gentoo-release.asc, locally sign it for gentoo, and verify the local signature
   add verified binary package host gentoo at https://distfiles.gentoo.org/releases/amd64/binpackages/23.0/x86-64
   fetch the first ebuild repository snapshot with emerge-webrsync
   select profile default/linux/amd64/23.0/systemd

--- a/tests/golden/vm-openrc-desktop.txt
+++ b/tests/golden/vm-openrc-desktop.txt
@@ -25,6 +25,7 @@
   write /etc/portage/make.conf with MAKEOPTS, USE, INPUT_DEVICES, ACCEPT_LICENSE, L10N, FEATURES; 2 mirrors in the configured order, 5 appended
   configure Portage, wget, curl, git and gpg for direct connection
   create the three autounmask files emerge writes its decisions into
+  disable inherited binary package host gentoo
   run getuto so Portage has a keyring to verify binary packages against, and write dirmngr.conf
   add verified binary package host gentoo at https://distfiles.gentoo.org/releases/amd64/binpackages/23.0/x86-64
   fetch the first ebuild repository snapshot with emerge-webrsync

--- a/tests/golden/vm-openrc-desktop.txt
+++ b/tests/golden/vm-openrc-desktop.txt
@@ -27,6 +27,7 @@
   create the three autounmask files emerge writes its decisions into
   disable inherited binary package host gentoo
   run getuto so Portage has a keyring to verify binary packages against, and write dirmngr.conf
+  import BB572E0E2D182910 from /usr/share/openpgp-keys/gentoo-release.asc, locally sign it for gentoo, and verify the local signature
   add verified binary package host gentoo at https://distfiles.gentoo.org/releases/amd64/binpackages/23.0/x86-64
   fetch the first ebuild repository snapshot with emerge-webrsync
   select profile default/linux/amd64/23.0/desktop

--- a/tests/golden/vm-proxy-dead.txt
+++ b/tests/golden/vm-proxy-dead.txt
@@ -28,6 +28,7 @@
   write /etc/portage/make.conf with MAKEOPTS, INPUT_DEVICES, ACCEPT_LICENSE, L10N, http_proxy, https_proxy, ftp_proxy, all_proxy, no_proxy, FETCHCOMMAND, RESUMECOMMAND, RSYNC_PROXY, FEATURES; 2 mirrors in the configured order, 5 appended
   configure Portage, wget, curl, git and gpg for http://127.0.0.1:1 in /etc/wgetrc, /etc/gitconfig, curl-proxy.conf and proxy.toml
   create the three autounmask files emerge writes its decisions into
+  disable inherited binary package host gentoo
   run getuto so Portage has a keyring to verify binary packages against, and write dirmngr.conf
   add verified binary package host gentoo at https://distfiles.gentoo.org/releases/amd64/binpackages/23.0/x86-64
   fetch the first ebuild repository snapshot with emerge-webrsync

--- a/tests/golden/vm-proxy-dead.txt
+++ b/tests/golden/vm-proxy-dead.txt
@@ -30,6 +30,7 @@
   create the three autounmask files emerge writes its decisions into
   disable inherited binary package host gentoo
   run getuto so Portage has a keyring to verify binary packages against, and write dirmngr.conf
+  import BB572E0E2D182910 from /usr/share/openpgp-keys/gentoo-release.asc, locally sign it for gentoo, and verify the local signature
   add verified binary package host gentoo at https://distfiles.gentoo.org/releases/amd64/binpackages/23.0/x86-64
   fetch the first ebuild repository snapshot with emerge-webrsync
   select profile default/linux/amd64/23.0/systemd

--- a/tests/golden/vm-proxy-http.txt
+++ b/tests/golden/vm-proxy-http.txt
@@ -28,6 +28,7 @@
   write /etc/portage/make.conf with MAKEOPTS, INPUT_DEVICES, ACCEPT_LICENSE, L10N, http_proxy, https_proxy, ftp_proxy, all_proxy, no_proxy, FETCHCOMMAND, RESUMECOMMAND, RSYNC_PROXY, FEATURES; 2 mirrors in the configured order, 5 appended
   configure Portage, wget, curl, git and gpg for http://10.0.2.2:3129 in /etc/wgetrc, /etc/gitconfig, curl-proxy.conf and proxy.toml
   create the three autounmask files emerge writes its decisions into
+  disable inherited binary package host gentoo
   run getuto so Portage has a keyring to verify binary packages against, and write dirmngr.conf
   add verified binary package host gentoo at https://distfiles.gentoo.org/releases/amd64/binpackages/23.0/x86-64
   fetch the first ebuild repository snapshot with emerge-webrsync

--- a/tests/golden/vm-proxy-http.txt
+++ b/tests/golden/vm-proxy-http.txt
@@ -30,6 +30,7 @@
   create the three autounmask files emerge writes its decisions into
   disable inherited binary package host gentoo
   run getuto so Portage has a keyring to verify binary packages against, and write dirmngr.conf
+  import BB572E0E2D182910 from /usr/share/openpgp-keys/gentoo-release.asc, locally sign it for gentoo, and verify the local signature
   add verified binary package host gentoo at https://distfiles.gentoo.org/releases/amd64/binpackages/23.0/x86-64
   fetch the first ebuild repository snapshot with emerge-webrsync
   select profile default/linux/amd64/23.0/systemd

--- a/tests/golden/vm-proxy.txt
+++ b/tests/golden/vm-proxy.txt
@@ -30,6 +30,7 @@
   create the three autounmask files emerge writes its decisions into
   disable inherited binary package host gentoo
   run getuto so Portage has a keyring to verify binary packages against, and write dirmngr.conf
+  import BB572E0E2D182910 from /usr/share/openpgp-keys/gentoo-release.asc, locally sign it for gentoo, and verify the local signature
   add verified binary package host gentoo at https://distfiles.gentoo.org/releases/amd64/binpackages/23.0/x86-64
   fetch the first ebuild repository snapshot with emerge-webrsync
   select profile default/linux/amd64/23.0/systemd

--- a/tests/golden/vm-proxy.txt
+++ b/tests/golden/vm-proxy.txt
@@ -28,6 +28,7 @@
   write /etc/portage/make.conf with MAKEOPTS, INPUT_DEVICES, ACCEPT_LICENSE, L10N, all_proxy, no_proxy, FETCHCOMMAND, RESUMECOMMAND, FEATURES; 2 mirrors in the configured order, 5 appended
   configure Portage, wget, curl, git and gpg for socks5h://10.0.2.2:1080 in /etc/wgetrc, /etc/gitconfig, curl-proxy.conf and proxy.toml
   create the three autounmask files emerge writes its decisions into
+  disable inherited binary package host gentoo
   run getuto so Portage has a keyring to verify binary packages against, and write dirmngr.conf
   add verified binary package host gentoo at https://distfiles.gentoo.org/releases/amd64/binpackages/23.0/x86-64
   fetch the first ebuild repository snapshot with emerge-webrsync

--- a/tests/golden/vm-raidz.txt
+++ b/tests/golden/vm-raidz.txt
@@ -37,6 +37,7 @@
   write /etc/portage/make.conf with MAKEOPTS, INPUT_DEVICES, ACCEPT_LICENSE, L10N, FEATURES; 2 mirrors in the configured order, 5 appended
   configure Portage, wget, curl, git and gpg for direct connection
   create the three autounmask files emerge writes its decisions into
+  disable inherited binary package host gentoo
   run getuto so Portage has a keyring to verify binary packages against, and write dirmngr.conf
   add verified binary package host gentoo at https://distfiles.gentoo.org/releases/amd64/binpackages/23.0/x86-64
   fetch the first ebuild repository snapshot with emerge-webrsync

--- a/tests/golden/vm-raidz.txt
+++ b/tests/golden/vm-raidz.txt
@@ -39,6 +39,7 @@
   create the three autounmask files emerge writes its decisions into
   disable inherited binary package host gentoo
   run getuto so Portage has a keyring to verify binary packages against, and write dirmngr.conf
+  import BB572E0E2D182910 from /usr/share/openpgp-keys/gentoo-release.asc, locally sign it for gentoo, and verify the local signature
   add verified binary package host gentoo at https://distfiles.gentoo.org/releases/amd64/binpackages/23.0/x86-64
   fetch the first ebuild repository snapshot with emerge-webrsync
   select profile default/linux/amd64/23.0/systemd

--- a/tests/golden/vm-ram.txt
+++ b/tests/golden/vm-ram.txt
@@ -25,6 +25,7 @@
   write /etc/portage/make.conf with MAKEOPTS, INPUT_DEVICES, ACCEPT_LICENSE, L10N, FEATURES; 2 mirrors in the configured order, 5 appended
   configure Portage, wget, curl, git and gpg for direct connection
   create the three autounmask files emerge writes its decisions into
+  disable inherited binary package host gentoo
   run getuto so Portage has a keyring to verify binary packages against, and write dirmngr.conf
   add verified binary package host gentoo at https://distfiles.gentoo.org/releases/amd64/binpackages/23.0/x86-64
   fetch the first ebuild repository snapshot with emerge-webrsync

--- a/tests/golden/vm-ram.txt
+++ b/tests/golden/vm-ram.txt
@@ -27,6 +27,7 @@
   create the three autounmask files emerge writes its decisions into
   disable inherited binary package host gentoo
   run getuto so Portage has a keyring to verify binary packages against, and write dirmngr.conf
+  import BB572E0E2D182910 from /usr/share/openpgp-keys/gentoo-release.asc, locally sign it for gentoo, and verify the local signature
   add verified binary package host gentoo at https://distfiles.gentoo.org/releases/amd64/binpackages/23.0/x86-64
   fetch the first ebuild repository snapshot with emerge-webrsync
   select profile default/linux/amd64/23.0/systemd

--- a/tests/golden/vm-sdboot.txt
+++ b/tests/golden/vm-sdboot.txt
@@ -25,6 +25,7 @@
   write /etc/portage/make.conf with MAKEOPTS, INPUT_DEVICES, ACCEPT_LICENSE, L10N, FEATURES; 2 mirrors in the configured order, 5 appended
   configure Portage, wget, curl, git and gpg for direct connection
   create the three autounmask files emerge writes its decisions into
+  disable inherited binary package host gentoo
   run getuto so Portage has a keyring to verify binary packages against, and write dirmngr.conf
   add verified binary package host gentoo at https://distfiles.gentoo.org/releases/amd64/binpackages/23.0/x86-64
   fetch the first ebuild repository snapshot with emerge-webrsync

--- a/tests/golden/vm-sdboot.txt
+++ b/tests/golden/vm-sdboot.txt
@@ -27,6 +27,7 @@
   create the three autounmask files emerge writes its decisions into
   disable inherited binary package host gentoo
   run getuto so Portage has a keyring to verify binary packages against, and write dirmngr.conf
+  import BB572E0E2D182910 from /usr/share/openpgp-keys/gentoo-release.asc, locally sign it for gentoo, and verify the local signature
   add verified binary package host gentoo at https://distfiles.gentoo.org/releases/amd64/binpackages/23.0/x86-64
   fetch the first ebuild repository snapshot with emerge-webrsync
   select profile default/linux/amd64/23.0/systemd

--- a/tests/golden/vm-source-kernel.txt
+++ b/tests/golden/vm-source-kernel.txt
@@ -25,6 +25,7 @@
   write /etc/portage/make.conf with MAKEOPTS, INPUT_DEVICES, ACCEPT_LICENSE, L10N, FEATURES; 2 mirrors in the configured order, 5 appended
   configure Portage, wget, curl, git and gpg for direct connection
   create the three autounmask files emerge writes its decisions into
+  disable inherited binary package host gentoo
   run getuto so Portage has a keyring to verify binary packages against, and write dirmngr.conf
   add verified binary package host gentoo at https://distfiles.gentoo.org/releases/amd64/binpackages/23.0/x86-64
   fetch the first ebuild repository snapshot with emerge-webrsync

--- a/tests/golden/vm-source-kernel.txt
+++ b/tests/golden/vm-source-kernel.txt
@@ -27,6 +27,7 @@
   create the three autounmask files emerge writes its decisions into
   disable inherited binary package host gentoo
   run getuto so Portage has a keyring to verify binary packages against, and write dirmngr.conf
+  import BB572E0E2D182910 from /usr/share/openpgp-keys/gentoo-release.asc, locally sign it for gentoo, and verify the local signature
   add verified binary package host gentoo at https://distfiles.gentoo.org/releases/amd64/binpackages/23.0/x86-64
   fetch the first ebuild repository snapshot with emerge-webrsync
   select profile default/linux/amd64/23.0/systemd

--- a/tests/golden/vm-unlock.txt
+++ b/tests/golden/vm-unlock.txt
@@ -35,6 +35,7 @@
   write /etc/portage/make.conf with MAKEOPTS, INPUT_DEVICES, ACCEPT_LICENSE, L10N, FEATURES; 2 mirrors in the configured order, 5 appended
   configure Portage, wget, curl, git and gpg for direct connection
   create the three autounmask files emerge writes its decisions into
+  disable inherited binary package host gentoo
   run getuto so Portage has a keyring to verify binary packages against, and write dirmngr.conf
   add verified binary package host gentoo at https://distfiles.gentoo.org/releases/amd64/binpackages/23.0/x86-64
   fetch the first ebuild repository snapshot with emerge-webrsync

--- a/tests/golden/vm-unlock.txt
+++ b/tests/golden/vm-unlock.txt
@@ -37,6 +37,7 @@
   create the three autounmask files emerge writes its decisions into
   disable inherited binary package host gentoo
   run getuto so Portage has a keyring to verify binary packages against, and write dirmngr.conf
+  import BB572E0E2D182910 from /usr/share/openpgp-keys/gentoo-release.asc, locally sign it for gentoo, and verify the local signature
   add verified binary package host gentoo at https://distfiles.gentoo.org/releases/amd64/binpackages/23.0/x86-64
   fetch the first ebuild repository snapshot with emerge-webrsync
   select profile default/linux/amd64/23.0/systemd

--- a/tests/golden/vm-xfs.txt
+++ b/tests/golden/vm-xfs.txt
@@ -25,6 +25,7 @@
   write /etc/portage/make.conf with MAKEOPTS, INPUT_DEVICES, ACCEPT_LICENSE, L10N, FEATURES; 2 mirrors in the configured order, 5 appended
   configure Portage, wget, curl, git and gpg for direct connection
   create the three autounmask files emerge writes its decisions into
+  disable inherited binary package host gentoo
   run getuto so Portage has a keyring to verify binary packages against, and write dirmngr.conf
   add verified binary package host gentoo at https://distfiles.gentoo.org/releases/amd64/binpackages/23.0/x86-64
   fetch the first ebuild repository snapshot with emerge-webrsync

--- a/tests/golden/vm-xfs.txt
+++ b/tests/golden/vm-xfs.txt
@@ -27,6 +27,7 @@
   create the three autounmask files emerge writes its decisions into
   disable inherited binary package host gentoo
   run getuto so Portage has a keyring to verify binary packages against, and write dirmngr.conf
+  import BB572E0E2D182910 from /usr/share/openpgp-keys/gentoo-release.asc, locally sign it for gentoo, and verify the local signature
   add verified binary package host gentoo at https://distfiles.gentoo.org/releases/amd64/binpackages/23.0/x86-64
   fetch the first ebuild repository snapshot with emerge-webrsync
   select profile default/linux/amd64/23.0/systemd

--- a/tests/golden/vm-zfs-encrypted.txt
+++ b/tests/golden/vm-zfs-encrypted.txt
@@ -31,6 +31,7 @@
   create the three autounmask files emerge writes its decisions into
   disable inherited binary package host gentoo
   run getuto so Portage has a keyring to verify binary packages against, and write dirmngr.conf
+  import BB572E0E2D182910 from /usr/share/openpgp-keys/gentoo-release.asc, locally sign it for gentoo, and verify the local signature
   add verified binary package host gentoo at https://distfiles.gentoo.org/releases/amd64/binpackages/23.0/x86-64
   fetch the first ebuild repository snapshot with emerge-webrsync
   select profile default/linux/amd64/23.0/systemd

--- a/tests/golden/vm-zfs-encrypted.txt
+++ b/tests/golden/vm-zfs-encrypted.txt
@@ -29,6 +29,7 @@
   write /etc/portage/make.conf with MAKEOPTS, INPUT_DEVICES, ACCEPT_LICENSE, L10N, FEATURES; 2 mirrors in the configured order, 5 appended
   configure Portage, wget, curl, git and gpg for direct connection
   create the three autounmask files emerge writes its decisions into
+  disable inherited binary package host gentoo
   run getuto so Portage has a keyring to verify binary packages against, and write dirmngr.conf
   add verified binary package host gentoo at https://distfiles.gentoo.org/releases/amd64/binpackages/23.0/x86-64
   fetch the first ebuild repository snapshot with emerge-webrsync

--- a/tests/golden/vm-zfs-mirror.txt
+++ b/tests/golden/vm-zfs-mirror.txt
@@ -33,6 +33,7 @@
   write /etc/portage/make.conf with MAKEOPTS, INPUT_DEVICES, ACCEPT_LICENSE, L10N, FEATURES; 2 mirrors in the configured order, 5 appended
   configure Portage, wget, curl, git and gpg for direct connection
   create the three autounmask files emerge writes its decisions into
+  disable inherited binary package host gentoo
   run getuto so Portage has a keyring to verify binary packages against, and write dirmngr.conf
   add verified binary package host gentoo at https://distfiles.gentoo.org/releases/amd64/binpackages/23.0/x86-64
   fetch the first ebuild repository snapshot with emerge-webrsync

--- a/tests/golden/vm-zfs-mirror.txt
+++ b/tests/golden/vm-zfs-mirror.txt
@@ -35,6 +35,7 @@
   create the three autounmask files emerge writes its decisions into
   disable inherited binary package host gentoo
   run getuto so Portage has a keyring to verify binary packages against, and write dirmngr.conf
+  import BB572E0E2D182910 from /usr/share/openpgp-keys/gentoo-release.asc, locally sign it for gentoo, and verify the local signature
   add verified binary package host gentoo at https://distfiles.gentoo.org/releases/amd64/binpackages/23.0/x86-64
   fetch the first ebuild repository snapshot with emerge-webrsync
   select profile default/linux/amd64/23.0/systemd

--- a/tests/golden/vm-zfs.txt
+++ b/tests/golden/vm-zfs.txt
@@ -31,6 +31,7 @@
   create the three autounmask files emerge writes its decisions into
   disable inherited binary package host gentoo
   run getuto so Portage has a keyring to verify binary packages against, and write dirmngr.conf
+  import BB572E0E2D182910 from /usr/share/openpgp-keys/gentoo-release.asc, locally sign it for gentoo, and verify the local signature
   add verified binary package host gentoo at https://distfiles.gentoo.org/releases/amd64/binpackages/23.0/x86-64
   fetch the first ebuild repository snapshot with emerge-webrsync
   select profile default/linux/amd64/23.0/systemd

--- a/tests/golden/vm-zfs.txt
+++ b/tests/golden/vm-zfs.txt
@@ -29,6 +29,7 @@
   write /etc/portage/make.conf with MAKEOPTS, INPUT_DEVICES, ACCEPT_LICENSE, L10N, FEATURES; 2 mirrors in the configured order, 5 appended
   configure Portage, wget, curl, git and gpg for direct connection
   create the three autounmask files emerge writes its decisions into
+  disable inherited binary package host gentoo
   run getuto so Portage has a keyring to verify binary packages against, and write dirmngr.conf
   add verified binary package host gentoo at https://distfiles.gentoo.org/releases/amd64/binpackages/23.0/x86-64
   fetch the first ebuild repository snapshot with emerge-webrsync

--- a/tests/golden/vm-zram.txt
+++ b/tests/golden/vm-zram.txt
@@ -25,6 +25,7 @@
   write /etc/portage/make.conf with MAKEOPTS, INPUT_DEVICES, ACCEPT_LICENSE, L10N, FEATURES; 2 mirrors in the configured order, 5 appended
   configure Portage, wget, curl, git and gpg for direct connection
   create the three autounmask files emerge writes its decisions into
+  disable inherited binary package host gentoo
   run getuto so Portage has a keyring to verify binary packages against, and write dirmngr.conf
   add verified binary package host gentoo at https://distfiles.gentoo.org/releases/amd64/binpackages/23.0/x86-64
   fetch the first ebuild repository snapshot with emerge-webrsync

--- a/tests/golden/vm-zram.txt
+++ b/tests/golden/vm-zram.txt
@@ -27,6 +27,7 @@
   create the three autounmask files emerge writes its decisions into
   disable inherited binary package host gentoo
   run getuto so Portage has a keyring to verify binary packages against, and write dirmngr.conf
+  import BB572E0E2D182910 from /usr/share/openpgp-keys/gentoo-release.asc, locally sign it for gentoo, and verify the local signature
   add verified binary package host gentoo at https://distfiles.gentoo.org/releases/amd64/binpackages/23.0/x86-64
   fetch the first ebuild repository snapshot with emerge-webrsync
   select profile default/linux/amd64/23.0/systemd

--- a/tests/golden/zbm-unlock.txt
+++ b/tests/golden/zbm-unlock.txt
@@ -33,6 +33,7 @@
   create the three autounmask files emerge writes its decisions into
   disable inherited binary package host gentoo
   run getuto so Portage has a keyring to verify binary packages against, and write dirmngr.conf
+  import BB572E0E2D182910 from /usr/share/openpgp-keys/gentoo-release.asc, locally sign it for gentoo, and verify the local signature
   add verified binary package host gentoo at https://distfiles.gentoo.org/releases/amd64/binpackages/23.0/x86-64
   fetch the first ebuild repository snapshot with emerge-webrsync
   select profile default/linux/amd64/23.0/systemd

--- a/tests/golden/zbm-unlock.txt
+++ b/tests/golden/zbm-unlock.txt
@@ -31,6 +31,7 @@
   write /etc/portage/make.conf with MAKEOPTS, INPUT_DEVICES, ACCEPT_LICENSE, L10N, FEATURES; 2 mirrors in the configured order, 5 appended
   configure Portage, wget, curl, git and gpg for direct connection
   create the three autounmask files emerge writes its decisions into
+  disable inherited binary package host gentoo
   run getuto so Portage has a keyring to verify binary packages against, and write dirmngr.conf
   add verified binary package host gentoo at https://distfiles.gentoo.org/releases/amd64/binpackages/23.0/x86-64
   fetch the first ebuild repository snapshot with emerge-webrsync

--- a/tests/golden/zfs-zbm.txt
+++ b/tests/golden/zfs-zbm.txt
@@ -33,6 +33,7 @@
   create the three autounmask files emerge writes its decisions into
   disable inherited binary package host gentoo
   run getuto so Portage has a keyring to verify binary packages against, and write dirmngr.conf
+  import BB572E0E2D182910 from /usr/share/openpgp-keys/gentoo-release.asc, locally sign it for gentoo, and verify the local signature
   add verified binary package host gentoo at https://distfiles.gentoo.org/releases/amd64/binpackages/23.0/x86-64
   fetch the first ebuild repository snapshot with emerge-webrsync
   select profile default/linux/amd64/23.0/systemd

--- a/tests/golden/zfs-zbm.txt
+++ b/tests/golden/zfs-zbm.txt
@@ -31,6 +31,7 @@
   write /etc/portage/make.conf with MAKEOPTS, INPUT_DEVICES, ACCEPT_LICENSE, L10N, FEATURES; 2 mirrors in the configured order, 5 appended
   configure Portage, wget, curl, git and gpg for direct connection
   create the three autounmask files emerge writes its decisions into
+  disable inherited binary package host gentoo
   run getuto so Portage has a keyring to verify binary packages against, and write dirmngr.conf
   add verified binary package host gentoo at https://distfiles.gentoo.org/releases/amd64/binpackages/23.0/x86-64
   fetch the first ebuild repository snapshot with emerge-webrsync

--- a/tests/unit/recorder.py
+++ b/tests/unit/recorder.py
@@ -12,11 +12,13 @@ from gentoo_install.plan.operations import CommandOutput
 from collections.abc import Callable
 from dataclasses import dataclass, field
 from pathlib import Path, PurePosixPath
-from typing import Sequence
+from typing import Final, Sequence
 
 from gentoo_install.model.device import DeviceId
 from gentoo_install.model.validate import KernelCeiling
 
+
+FAKE_PORTAGE_TRUST_KEY: Final[str] = "0D83BD4123FE15FE2F7D30E457D1F2DF9E5D8B84"
 
 def _answered(text: str, returncode: int) -> CommandOutput:
     """A reply already carrying an exit code keeps it; a bare string takes the
@@ -41,6 +43,7 @@ class Recorder:
     replies: dict[str, str] = field(default_factory=dict)
     #: Commands whose first word is here raise instead of returning.
     failures: set[str] = field(default_factory=set)
+    locally_signed: set[str] = field(default_factory=set)
     given_up: set[str] = field(default_factory=set)
     #: What the conversion seam was asked to do, rather than doing it.
     swapped: list[tuple[PurePosixPath, tuple[str, ...]]] = field(default_factory=list)
@@ -102,6 +105,16 @@ class Recorder:
             if check:
                 raise CommandFailed(f"{argv[0]} exited 1")
             return _answered(self.replies.get(argv[0], ""), 1)
+        if argv[0] == "gpg" and "--lsign-key" in argv:
+            self.locally_signed.add(argv[-1].upper())
+        if argv[0] == "gpg" and "--with-colons" in argv and "--list-sigs" in argv:
+            target = argv[-1].upper()
+            if target in self.locally_signed:
+                return CommandOutput(
+                    f"sig:::1:0000000000000000:0::::Portage:10l::{FAKE_PORTAGE_TRUST_KEY}:\n",
+                    0,
+                )
+            return CommandOutput("", 0)
         if argv[:3] == ["portageq", "best_visible", "/"]:
             return CommandOutput(f"{argv[-1]}-1\n", 0)
         if argv[:4] == ["portageq", "metadata", "/", "ebuild"]:
@@ -124,6 +137,8 @@ class Recorder:
             return self.files[path]
         if path == PurePosixPath("/var/lib/misc/installkernel"):
             return "date\tsystemd\t6.18.41-gentoo-dist-bin\t/usr/lib/kernel\tcompat\tdracut\tnone\t/boot\tkernel-6.18.41-gentoo-dist-bin\tinitramfs-6.18.41-gentoo-dist-bin.img\tnotset\n"
+        if path == PurePosixPath("/etc/portage/gnupg/mykeyid"):
+            return f"{FAKE_PORTAGE_TRUST_KEY}\n"
         return self.files.get(path, "")
 
     def append(self, path: PurePosixPath, content: str) -> None:

--- a/tests/unit/test_i18n.py
+++ b/tests/unit/test_i18n.py
@@ -524,7 +524,7 @@ REVIEWED_TEMPLATES: frozenset[str] = frozenset(
         "download the newest {} stage3 from {} via {}, verify it against {},"
         " unpack it into the target and write {}",
         "enable {} in the {} runlevel",
-        "import {} from {} and locally sign it for {}",
+        "import {} from {}, locally sign it for {}, and verify the local signature",
         "point repository {} at {}",
         "point repository {} at {}, commit signatures verified",
         "run a script from {} and {} commands once, the first time the system boots",

--- a/tests/unit/test_plan_portage.py
+++ b/tests/unit/test_plan_portage.py
@@ -443,6 +443,24 @@ def test_the_binhost_key_is_signed_after_getuto_creates_the_keyring() -> None:
     signed = next(n for n, argv in enumerate(recorder.in_target) if "--lsign-key" in argv)
     assert getuto < imported < signed
 
+def test_a_deselected_official_binhost_is_removed_before_community_setup() -> None:
+    """The stage3 enables the official host, so enabling only gentoo-zh must
+    first remove its configuration rather than leave an unselected fallback."""
+    installation = with_portage(binhost=Binhost(official=False, community=BinhostChannel.STABLE))
+    recorder = apply_all(installation)
+    official = PurePosixPath("/etc/portage/binrepos.conf/gentoobinhost.conf")
+    community = PurePosixPath("/etc/portage/binrepos.conf/gentoo-zh.conf")
+
+    disabled = ("rm", "--force", "--", str(official))
+    assert disabled in recorder.in_target
+    assert recorder.in_target.index(disabled) < next(
+        index
+        for index, argv in enumerate(recorder.in_target)
+        if argv[-2:] == ("--import", str(portage.GENTOOZH_KEY))
+    )
+    assert official not in recorder.files
+    assert community in recorder.files
+
 
 def test_a_key_that_will_not_sign_takes_its_host_down_with_it() -> None:
     """An imported key stays untrusted until `lsign`, and verification then

--- a/tests/unit/test_plan_portage.py
+++ b/tests/unit/test_plan_portage.py
@@ -448,17 +448,21 @@ def test_a_deselected_official_binhost_is_removed_before_community_setup() -> No
     first remove its configuration rather than leave an unselected fallback."""
     installation = with_portage(binhost=Binhost(official=False, community=BinhostChannel.STABLE))
     recorder = apply_all(installation)
-    official = PurePosixPath("/etc/portage/binrepos.conf/gentoobinhost.conf")
+    official = (
+        PurePosixPath("/etc/portage/binrepos.conf/gentoo.conf"),
+        PurePosixPath("/etc/portage/binrepos.conf/gentoobinhost.conf"),
+    )
     community = PurePosixPath("/etc/portage/binrepos.conf/gentoo-zh.conf")
 
-    disabled = ("rm", "--force", "--", str(official))
-    assert disabled in recorder.in_target
-    assert recorder.in_target.index(disabled) < next(
-        index
-        for index, argv in enumerate(recorder.in_target)
-        if argv[-2:] == ("--import", str(portage.GENTOOZH_KEY))
-    )
-    assert official not in recorder.files
+    for path in official:
+        disabled = ("rm", "--force", "--", str(path))
+        assert disabled in recorder.in_target
+        assert recorder.in_target.index(disabled) < next(
+            index
+            for index, argv in enumerate(recorder.in_target)
+            if argv[-2:] == ("--import", str(portage.GENTOOZH_KEY))
+        )
+        assert path not in recorder.files
     assert community in recorder.files
 
 
@@ -471,7 +475,9 @@ def test_a_key_that_will_not_sign_takes_its_host_down_with_it() -> None:
     installation = with_portage(binhost=Binhost(official=True, community=BinhostChannel.STABLE))
     operations = portage.build(installation, MIRROR)
     imported = next(
-        one for one in operations if isinstance(one, portage.TrustBinhostKey)
+        one
+        for one in operations
+        if isinstance(one, portage.TrustBinhostKey) and one.binhost == "gentoo-zh"
     )
     community = next(
         one
@@ -502,15 +508,67 @@ def test_a_key_that_will_not_sign_takes_its_host_down_with_it() -> None:
     ], working.files
 
 
+def test_an_official_key_without_its_local_signature_falls_back_to_source() -> None:
+    """A successful `getuto` is not sufficient when its local signature is absent."""
+    key = portage.TrustBinhostKey(
+        binhost="gentoo",
+        fingerprint=portage.RELENG_FINGERPRINT,
+        key_path=portage.RELEASE_KEY,
+    )
+    recorder = Recorder()
+    recorder.answering = lambda argv: (
+        CommandOutput("sig:::1:572E0E2D182910:0::::Gentoo:13x::13EBBDBEDE7A12775DFDB1BABB572E0E2D182910:\n", 0)
+        if tuple(argv[-2:]) == ("--list-sigs", portage.RELENG_FINGERPRINT)
+        else None
+    )
+
+    key.apply(recorder)
+
+    assert recorder.degraded(portage.binhost_trust("gentoo"))
+    working = Recorder()
+    key.apply(working)
+    assert not working.degraded(portage.binhost_trust("gentoo"))
+    assert (
+        "gpg",
+        "--homedir",
+        "/etc/portage/gnupg",
+        "--with-colons",
+        "--list-sigs",
+        portage.RELENG_FINGERPRINT,
+    ) in working.in_target
+
+
+def test_the_official_binhost_is_configured_after_its_key_is_trusted() -> None:
+    installation = with_portage(binhost=Binhost(official=True, community=BinhostChannel.OFF))
+    operations = portage.build(installation, MIRROR)
+    trusted = next(
+        operation
+        for operation in operations
+        if isinstance(operation, portage.TrustBinhostKey) and operation.binhost == "gentoo"
+    )
+    configured = next(
+        operation
+        for operation in operations
+        if isinstance(operation, portage.ConfigureBinhost) and operation.name == "gentoo"
+    )
+
+    assert operations.index(trusted) < operations.index(configured)
+    assert PurePosixPath("/etc/portage/binrepos.conf/gentoo.conf") in apply_all(
+        installation
+    ).files
+
+
 def test_the_binhost_is_only_trusted_once_its_key_is() -> None:
     installation = with_portage(binhost=Binhost(official=True, community=BinhostChannel.STABLE))
     operations = portage.build(installation, MIRROR)
-    signed = next(n for n, operation in enumerate(operations) if "locally sign" in operation.describe())
-    # The gentoo-zh host specifically: the official one is trusted by getuto,
-    # which runs before either of them.
+    signed = next(
+        index
+        for index, operation in enumerate(operations)
+        if isinstance(operation, portage.TrustBinhostKey) and operation.binhost == "gentoo-zh"
+    )
     added = next(
-        n
-        for n, operation in enumerate(operations)
+        index
+        for index, operation in enumerate(operations)
         if "binary package host gentoo-zh" in operation.describe()
     )
     assert signed < added
@@ -735,7 +793,7 @@ def test_a_failed_community_key_leaves_the_official_host_alone() -> None:
     )
     written = set(recorder.files)
     assert PurePosixPath("/etc/portage/binrepos.conf/gentoo-zh.conf") not in written
-    assert PurePosixPath("/etc/portage/binrepos.conf/gentoobinhost.conf") in written
+    assert PurePosixPath("/etc/portage/binrepos.conf/gentoo.conf") in written
 
     portage.Emerge(packages=("sys-boot/grub",), summary="install the bootloader").apply(recorder)
     assert "--getbinpkg=y" in next(argv for argv in recorder.in_target if argv[0] == "emerge")


### PR DESCRIPTION
`official = false` added no official `ConfigureBinhost`, and nothing removed what the stage3 ships. A current systemd stage3 carries `/etc/portage/binrepos.conf/gentoo.conf` with `verify-signature = true`, so with a community host enabled — and therefore `FEATURES=getbinpkg` — emerge fetched from the host the operator had deselected. It also broke the fallback rule: a community trust failure could reach an unselected binhost instead of degrading to source.

Both stage3 filenames are removed before any trust operation and `gentoo.conf` is written back only when the official source is trusted. The name was checked by unpacking a current stage3 rather than assumed; the older `gentoobinhost.conf` is handled too.

Official trust previously rested on `getuto` exiting zero. `CLAUDE.md`: a key that exists but is unsigned still fails verification. It now imports, `lsign`s, checks the trustdb and then reads back the local signature with `gpg --with-colons --list-sigs`, degrading the official source to source builds when it is absent — verifying rather than trusting, the shape `GenerateLocales` already uses.

Cluster verification is queued; the first attempt failed on the `PYTHONPATH` defect that was in master at the time and is not counted.