### PR TITLE
vm: read past what the terminal added, not what the program wrote

### DIFF
--- a/tests/unit/test_harness.py
+++ b/tests/unit/test_harness.py
@@ -5470,3 +5470,26 @@ def test_the_usage_examples_name_a_path_the_runner_can_load() -> None:
     assert examples, said
     for one in examples:
         assert (room / one).is_file(), (one, str(room / one))
+
+
+def test_a_reader_removes_the_colour_systemctl_writes_to_a_terminal() -> None:
+    """A serial console is a terminal, so `systemctl` colours its answer and
+    `enabled` arrives wrapped in SGR. The bounded patterns anchor on `$`, so a
+    cluster run failed its `network` check while the console showed the line."""
+    import re
+
+    from tests.vm.console import plain
+    from tests.vm.installed import checks
+
+    from .layouts import config, ext4_on_gpt
+
+    said = (
+        b"\r\nsystemd-networkd.service                "
+        b"\x1b[0;1;32menabled\x1b[0m\x1b[0;1;32m \x1b[0m\x1b[0;1;32menabled \x1b[0m\r\n"
+    )
+    assert b"\x1b" not in plain(said), plain(said)
+    network = [one for one in checks(config(ext4_on_gpt())) if one.name == "network"]
+    if network:
+        pattern = network[0].pattern.encode()
+        assert re.search(pattern, said) is None, "the raw bytes must not match"
+        assert re.search(pattern, plain(said)) is not None, plain(said)

--- a/tests/vm/cluster.py
+++ b/tests/vm/cluster.py
@@ -76,6 +76,7 @@ from .console import (
     command_begin,
     command_done,
     marked_command,
+    plain,
 )
 from .driver import (
     FIND_DRIVER,
@@ -3201,7 +3202,7 @@ class Reconnecting:
             # them `\r\n`, so a pattern anchored with `$` matches nothing at
             # all. `btrfs-luks` was failed at 130.3 minutes for an
             # `inputmethod` check whose three lines were on the console.
-            return said.split(command_done(token).encode())[0].replace(b"\r", b"")
+            return plain(said.split(command_done(token).encode())[0])
 
         return self._with_reconnect(
             timeout, collect_once, retry_timeout=_marker_lost

--- a/tests/vm/console.py
+++ b/tests/vm/console.py
@@ -24,6 +24,24 @@ _BEGIN_TEXT = "MARK_{token}_BEGIN"
 _DONE_TEXT = "MARK_{token}_DONE"
 
 
+#: SGR colour, which `systemctl` writes because a serial console is a terminal:
+#: `enabled` arrives as `\x1b[0;1;32menabled\x1b[0m`, and an anchored pattern
+#: cannot reach the end of that line. Removed where the carriage returns are,
+#: because the reason is the same one.
+ANSI: Final[re.Pattern[bytes]] = re.compile(rb"\x1b\[[0-9;?]*[ -/]*[@-~]")
+
+
+def plain(said: bytes) -> bytes:
+    """`said` as the program wrote it, without what the terminal added.
+
+    Carriage returns, SGR colour, and the trailing spaces column alignment
+    leaves: `systemctl` answers `enabled enabled ` with a space before the
+    newline, and a pattern anchored on `$` cannot reach past it either.
+    """
+    without = ANSI.sub(b"", said.replace(b"\r", b""))
+    return b"\n".join(line.rstrip() for line in without.split(b"\n"))
+
+
 def marked_command(command: str, token: int) -> str:
     """Wrap a command with markers that cannot match its echoed input."""
     return (
@@ -297,7 +315,7 @@ class SerialConsole:
         # Without the carriage returns, for the reason the cluster's own reader
         # gives: a serial line ends every one of them `\r\n`, and `convert.py`
         # applies the same `installed.py` patterns, four of which anchor on `$`.
-        return said.split(command_done(token).encode())[0].replace(b"\r", b"")
+        return plain(said.split(command_done(token).encode())[0])
 
     def login(self, user: str, password: str | None, prompt: str) -> None:
         self.expect(r"login:", timeout=300.0)


### PR DESCRIPTION
Anchoring the installed-state patterns to whole lines was right, and it made every byte the terminal adds part of correctness. A cluster `vm-luks` failed its `network` check while the verdict's own output showed the line, because a serial console is a terminal: `systemctl` answered `\x1b[0;1;32menabled\x1b[0m\x1b[0;1;32m \x1b[0m\x1b[0;1;32menabled \x1b[0m`. The colour and the trailing space from column alignment both sit between `enabled` and `$`.

One `plain()` in `console.py` now removes the three things the terminal adds — carriage returns, SGR, and per-line trailing whitespace — and both readers use it. The test carries the real bytes from that guest's log.

Worth recording how it was found: the verdict printed the output, and reading it off the screen and retyping it produced a pattern that matched, because the terminal had already eaten the escapes. `od -c` on the log showed them.