### PR TITLE
plan: describe the disk values that decide whether something is destroyed

### DIFF
--- a/gentoo_install/plan/disk.py
+++ b/gentoo_install/plan/disk.py
@@ -228,7 +228,15 @@ class CreateImage(Operation):
         return False
 
     def describe(self) -> str:
-        return f"create a {self.size} sparse image at {self.image} and attach it as a loop device"
+        if self.wipe:
+            return (
+                f"create a {self.size} sparse image at {self.image}, overwriting an existing image, "
+                "and attach it as a loop device"
+            )
+        return (
+            f"create a {self.size} sparse image at {self.image}, refusing to overwrite an existing "
+            "image, and attach it as a loop device"
+        )
 
     def apply(self, context: Context) -> None:
         attached = context.run(
@@ -378,8 +386,11 @@ class CreatePartition(Operation):
         else:
             extent = "the rest of the disk"
         name = f" labelled {self.label}" if self.label else ""
+        placement = f" in the {self.table_kind.value} table"
+        if self.table_kind is TableType.MBR:
+            placement += f" from {self.start}"
         return (
-            f"create partition {self.index} on {self.disk} as {self.partition}: "
+            f"create partition {self.index} on {self.disk} as {self.partition}{placement}: "
             f"{self.role.value}, {extent}{name}"
         )
 
@@ -480,7 +491,7 @@ class CreateLuks(Operation):
     name: str
 
     def describe(self) -> str:
-        return f"format {self.backing} as LUKS2"
+        return f"format {self.backing} as LUKS2 using the key file for {self.container}"
 
     def apply(self, context: Context) -> None:
         path = context.device_path(self.backing)
@@ -518,7 +529,7 @@ class OpenLuks(Operation):
     name: str
 
     def describe(self) -> str:
-        return f"open {self.backing} as /dev/mapper/{self.name}"
+        return f"open {self.backing} as /dev/mapper/{self.name} using the key file for {self.container}"
 
     @property
     def survives_a_reboot(self) -> bool:

--- a/tests/golden/btrfs-luks.txt
+++ b/tests/golden/btrfs-luks.txt
@@ -2,13 +2,13 @@
   release anything a previous run of this configuration left mounted or open
   wipe existing signatures from disk
   create a gpt partition table on disk as table
-  create partition 1 on disk as esp: esp, 512MiB
-  create partition 2 on disk as cryptroot: data, the rest of the disk
+  create partition 1 on disk as esp in the gpt table: esp, 512MiB
+  create partition 2 on disk as cryptroot in the gpt table: data, the rest of the disk
   reread the partition table of disk and wait for its nodes
 
 [array]
-  format cryptroot as LUKS2
-  open cryptroot as /dev/mapper/root
+  format cryptroot as LUKS2 using the key file for root-luks
+  open cryptroot as /dev/mapper/root using the key file for root-luks
 
 [format]
   make a vfat filesystem on esp as espfs labelled ESP

--- a/tests/golden/ext2.txt
+++ b/tests/golden/ext2.txt
@@ -2,8 +2,8 @@
   release anything a previous run of this configuration left mounted or open
   wipe existing signatures from disk
   create a mbr partition table on disk as table
-  create partition 1 on disk as swappart: swap, 2GiB
-  create partition 2 on disk as rootpart: data, the rest of the disk
+  create partition 1 on disk as swappart in the mbr table from 1MiB: swap, 2GiB
+  create partition 2 on disk as rootpart in the mbr table from 2049MiB: data, the rest of the disk
   reread the partition table of disk and wait for its nodes
 
 [format]

--- a/tests/golden/ext3.txt
+++ b/tests/golden/ext3.txt
@@ -2,8 +2,8 @@
   release anything a previous run of this configuration left mounted or open
   wipe existing signatures from disk
   create a mbr partition table on disk as table
-  create partition 1 on disk as swappart: swap, 2GiB
-  create partition 2 on disk as rootpart: data, the rest of the disk
+  create partition 1 on disk as swappart in the mbr table from 1MiB: swap, 2GiB
+  create partition 2 on disk as rootpart in the mbr table from 2049MiB: data, the rest of the disk
   reread the partition table of disk and wait for its nodes
 
 [format]

--- a/tests/golden/ext4-bios.txt
+++ b/tests/golden/ext4-bios.txt
@@ -2,8 +2,8 @@
   release anything a previous run of this configuration left mounted or open
   wipe existing signatures from disk
   create a mbr partition table on disk as table
-  create partition 1 on disk as swappart: swap, 2GiB
-  create partition 2 on disk as rootpart: data, the rest of the disk
+  create partition 1 on disk as swappart in the mbr table from 1MiB: swap, 2GiB
+  create partition 2 on disk as rootpart in the mbr table from 2049MiB: data, the rest of the disk
   reread the partition table of disk and wait for its nodes
 
 [format]

--- a/tests/golden/mbr-edit.txt
+++ b/tests/golden/mbr-edit.txt
@@ -1,7 +1,7 @@
 [partition]
   release anything a previous run of this configuration left mounted or open
   keep the mbr partition table on disk as table
-  create partition 2 on disk as rootpart: data, 12GiB
+  create partition 2 on disk as rootpart in the mbr table from 1MiB: data, 12GiB
   reread the partition table of disk and wait for its nodes
 
 [format]

--- a/tests/golden/openrc-sdboot.txt
+++ b/tests/golden/openrc-sdboot.txt
@@ -2,8 +2,8 @@
   release anything a previous run of this configuration left mounted or open
   wipe existing signatures from disk
   create a gpt partition table on disk as table
-  create partition 1 on disk as esp: esp, 1GiB
-  create partition 2 on disk as rootpart: data, the rest of the disk
+  create partition 1 on disk as esp in the gpt table: esp, 1GiB
+  create partition 2 on disk as rootpart in the gpt table: data, the rest of the disk
   reread the partition table of disk and wait for its nodes
 
 [format]

--- a/tests/golden/static-ip.txt
+++ b/tests/golden/static-ip.txt
@@ -2,8 +2,8 @@
   release anything a previous run of this configuration left mounted or open
   wipe existing signatures from disk
   create a gpt partition table on disk as table
-  create partition 1 on disk as esp: esp, 512MiB
-  create partition 2 on disk as rootpart: data, the rest of the disk
+  create partition 1 on disk as esp in the gpt table: esp, 512MiB
+  create partition 2 on disk as rootpart in the gpt table: data, the rest of the disk
   reread the partition table of disk and wait for its nodes
 
 [format]

--- a/tests/golden/vm-binhost-fallback.txt
+++ b/tests/golden/vm-binhost-fallback.txt
@@ -2,8 +2,8 @@
   release anything a previous run of this configuration left mounted or open
   wipe existing signatures from disk
   create a gpt partition table on disk as table
-  create partition 1 on disk as esp: esp, 512MiB
-  create partition 2 on disk as rootpart: data, the rest of the disk
+  create partition 1 on disk as esp in the gpt table: esp, 512MiB
+  create partition 2 on disk as rootpart in the gpt table: data, the rest of the disk
   reread the partition table of disk and wait for its nodes
 
 [format]

--- a/tests/golden/vm-binpkg.txt
+++ b/tests/golden/vm-binpkg.txt
@@ -2,8 +2,8 @@
   release anything a previous run of this configuration left mounted or open
   wipe existing signatures from disk
   create a gpt partition table on disk as table
-  create partition 1 on disk as esp: esp, 512MiB
-  create partition 2 on disk as rootpart: data, the rest of the disk
+  create partition 1 on disk as esp in the gpt table: esp, 512MiB
+  create partition 2 on disk as rootpart in the gpt table: data, the rest of the disk
   reread the partition table of disk and wait for its nodes
 
 [format]

--- a/tests/golden/vm-bios-luks.txt
+++ b/tests/golden/vm-bios-luks.txt
@@ -2,13 +2,13 @@
   release anything a previous run of this configuration left mounted or open
   wipe existing signatures from disk
   create a mbr partition table on disk as table
-  create partition 1 on disk as swappart: swap, 2GiB
-  create partition 2 on disk as rootpart: data, the rest of the disk
+  create partition 1 on disk as swappart in the mbr table from 1MiB: swap, 2GiB
+  create partition 2 on disk as rootpart in the mbr table from 2049MiB: data, the rest of the disk
   reread the partition table of disk and wait for its nodes
 
 [array]
-  format rootpart as LUKS2
-  open rootpart as /dev/mapper/root
+  format rootpart as LUKS2 using the key file for root-luks
+  open rootpart as /dev/mapper/root using the key file for root-luks
 
 [format]
   make swap on swappart as swap

--- a/tests/golden/vm-bios.txt
+++ b/tests/golden/vm-bios.txt
@@ -2,8 +2,8 @@
   release anything a previous run of this configuration left mounted or open
   wipe existing signatures from disk
   create a mbr partition table on disk as table
-  create partition 1 on disk as swappart: swap, 2GiB
-  create partition 2 on disk as rootpart: data, the rest of the disk
+  create partition 1 on disk as swappart in the mbr table from 1MiB: swap, 2GiB
+  create partition 2 on disk as rootpart in the mbr table from 2049MiB: data, the rest of the disk
   reread the partition table of disk and wait for its nodes
 
 [format]

--- a/tests/golden/vm-btrfs.txt
+++ b/tests/golden/vm-btrfs.txt
@@ -2,8 +2,8 @@
   release anything a previous run of this configuration left mounted or open
   wipe existing signatures from disk
   create a gpt partition table on disk as table
-  create partition 1 on disk as esp: esp, 512MiB
-  create partition 2 on disk as cryptroot: data, the rest of the disk
+  create partition 1 on disk as esp in the gpt table: esp, 512MiB
+  create partition 2 on disk as cryptroot in the gpt table: data, the rest of the disk
   reread the partition table of disk and wait for its nodes
 
 [format]

--- a/tests/golden/vm-cjk-kernel.txt
+++ b/tests/golden/vm-cjk-kernel.txt
@@ -2,8 +2,8 @@
   release anything a previous run of this configuration left mounted or open
   wipe existing signatures from disk
   create a gpt partition table on disk as table
-  create partition 1 on disk as esp: esp, 512MiB
-  create partition 2 on disk as rootpart: data, the rest of the disk
+  create partition 1 on disk as esp in the gpt table: esp, 512MiB
+  create partition 2 on disk as rootpart in the gpt table: data, the rest of the disk
   reread the partition table of disk and wait for its nodes
 
 [format]

--- a/tests/golden/vm-desktop.txt
+++ b/tests/golden/vm-desktop.txt
@@ -2,8 +2,8 @@
   release anything a previous run of this configuration left mounted or open
   wipe existing signatures from disk
   create a gpt partition table on disk as table
-  create partition 1 on disk as esp: esp, 512MiB
-  create partition 2 on disk as rootpart: data, the rest of the disk
+  create partition 1 on disk as esp in the gpt table: esp, 512MiB
+  create partition 2 on disk as rootpart in the gpt table: data, the rest of the disk
   reread the partition table of disk and wait for its nodes
 
 [format]

--- a/tests/golden/vm-f2fs.txt
+++ b/tests/golden/vm-f2fs.txt
@@ -2,8 +2,8 @@
   release anything a previous run of this configuration left mounted or open
   wipe existing signatures from disk
   create a gpt partition table on disk as table
-  create partition 1 on disk as esp: esp, 512MiB
-  create partition 2 on disk as rootpart: data, the rest of the disk
+  create partition 1 on disk as esp in the gpt table: esp, 512MiB
+  create partition 2 on disk as rootpart in the gpt table: data, the rest of the disk
   reread the partition table of disk and wait for its nodes
 
 [format]

--- a/tests/golden/vm-gnome.txt
+++ b/tests/golden/vm-gnome.txt
@@ -2,8 +2,8 @@
   release anything a previous run of this configuration left mounted or open
   wipe existing signatures from disk
   create a gpt partition table on disk as table
-  create partition 1 on disk as esp: esp, 512MiB
-  create partition 2 on disk as rootpart: data, the rest of the disk
+  create partition 1 on disk as esp in the gpt table: esp, 512MiB
+  create partition 2 on disk as rootpart in the gpt table: data, the rest of the disk
   reread the partition table of disk and wait for its nodes
 
 [format]

--- a/tests/golden/vm-greetd.txt
+++ b/tests/golden/vm-greetd.txt
@@ -2,8 +2,8 @@
   release anything a previous run of this configuration left mounted or open
   wipe existing signatures from disk
   create a gpt partition table on disk as table
-  create partition 1 on disk as esp: esp, 512MiB
-  create partition 2 on disk as rootpart: data, the rest of the disk
+  create partition 1 on disk as esp in the gpt table: esp, 512MiB
+  create partition 2 on disk as rootpart in the gpt table: data, the rest of the disk
   reread the partition table of disk and wait for its nodes
 
 [format]

--- a/tests/golden/vm-image.txt
+++ b/tests/golden/vm-image.txt
@@ -1,10 +1,10 @@
 [partition]
-  create a 20GiB sparse image at /mnt/scratch/target.raw and attach it as a loop device
+  create a 20GiB sparse image at /mnt/scratch/target.raw, overwriting an existing image, and attach it as a loop device
   release anything a previous run of this configuration left mounted or open
   wipe existing signatures from disk
   create a gpt partition table on disk as table
-  create partition 1 on disk as esp: esp, 512MiB
-  create partition 2 on disk as rootpart: data, the rest of the disk
+  create partition 1 on disk as esp in the gpt table: esp, 512MiB
+  create partition 2 on disk as rootpart in the gpt table: data, the rest of the disk
   reread the partition table of disk and wait for its nodes
 
 [format]

--- a/tests/golden/vm-luks.txt
+++ b/tests/golden/vm-luks.txt
@@ -2,13 +2,13 @@
   release anything a previous run of this configuration left mounted or open
   wipe existing signatures from disk
   create a gpt partition table on disk as table
-  create partition 1 on disk as esp: esp, 512MiB
-  create partition 2 on disk as cryptroot: data, the rest of the disk
+  create partition 1 on disk as esp in the gpt table: esp, 512MiB
+  create partition 2 on disk as cryptroot in the gpt table: data, the rest of the disk
   reread the partition table of disk and wait for its nodes
 
 [array]
-  format cryptroot as LUKS2
-  open cryptroot as /dev/mapper/root
+  format cryptroot as LUKS2 using the key file for root-luks
+  open cryptroot as /dev/mapper/root using the key file for root-luks
 
 [format]
   make a vfat filesystem on esp as espfs labelled ESP

--- a/tests/golden/vm-lvm.txt
+++ b/tests/golden/vm-lvm.txt
@@ -2,8 +2,8 @@
   release anything a previous run of this configuration left mounted or open
   wipe existing signatures from disk
   create a gpt partition table on disk as table
-  create partition 1 on disk as esp: esp, 512MiB
-  create partition 2 on disk as pv: lvm, the rest of the disk
+  create partition 1 on disk as esp in the gpt table: esp, 512MiB
+  create partition 2 on disk as pv in the gpt table: lvm, the rest of the disk
   reread the partition table of disk and wait for its nodes
 
 [array]

--- a/tests/golden/vm-mdraid.txt
+++ b/tests/golden/vm-mdraid.txt
@@ -4,9 +4,9 @@
   wipe existing signatures from disk1
   create a gpt partition table on disk0 as table0
   create a gpt partition table on disk1 as table1
-  create partition 1 on disk0 as esp: esp, 512MiB
-  create partition 1 on disk1 as member1: raid, the rest of the disk
-  create partition 2 on disk0 as member0: raid, the rest of the disk
+  create partition 1 on disk0 as esp in the gpt table: esp, 512MiB
+  create partition 1 on disk1 as member1 in the gpt table: raid, the rest of the disk
+  create partition 2 on disk0 as member0 in the gpt table: raid, the rest of the disk
   reread the partition table of disk0 and wait for its nodes
   reread the partition table of disk1 and wait for its nodes
 

--- a/tests/golden/vm-openrc-desktop.txt
+++ b/tests/golden/vm-openrc-desktop.txt
@@ -2,8 +2,8 @@
   release anything a previous run of this configuration left mounted or open
   wipe existing signatures from disk
   create a gpt partition table on disk as table
-  create partition 1 on disk as esp: esp, 512MiB
-  create partition 2 on disk as rootpart: data, the rest of the disk
+  create partition 1 on disk as esp in the gpt table: esp, 512MiB
+  create partition 2 on disk as rootpart in the gpt table: data, the rest of the disk
   reread the partition table of disk and wait for its nodes
 
 [format]

--- a/tests/golden/vm-proxy-dead.txt
+++ b/tests/golden/vm-proxy-dead.txt
@@ -2,8 +2,8 @@
   release anything a previous run of this configuration left mounted or open
   wipe existing signatures from disk
   create a gpt partition table on disk as table
-  create partition 1 on disk as esp: esp, 512MiB
-  create partition 2 on disk as cryptroot: data, the rest of the disk
+  create partition 1 on disk as esp in the gpt table: esp, 512MiB
+  create partition 2 on disk as cryptroot in the gpt table: data, the rest of the disk
   reread the partition table of disk and wait for its nodes
 
 [format]

--- a/tests/golden/vm-proxy-http.txt
+++ b/tests/golden/vm-proxy-http.txt
@@ -2,8 +2,8 @@
   release anything a previous run of this configuration left mounted or open
   wipe existing signatures from disk
   create a gpt partition table on disk as table
-  create partition 1 on disk as esp: esp, 512MiB
-  create partition 2 on disk as cryptroot: data, the rest of the disk
+  create partition 1 on disk as esp in the gpt table: esp, 512MiB
+  create partition 2 on disk as cryptroot in the gpt table: data, the rest of the disk
   reread the partition table of disk and wait for its nodes
 
 [format]

--- a/tests/golden/vm-proxy.txt
+++ b/tests/golden/vm-proxy.txt
@@ -2,8 +2,8 @@
   release anything a previous run of this configuration left mounted or open
   wipe existing signatures from disk
   create a gpt partition table on disk as table
-  create partition 1 on disk as esp: esp, 512MiB
-  create partition 2 on disk as cryptroot: data, the rest of the disk
+  create partition 1 on disk as esp in the gpt table: esp, 512MiB
+  create partition 2 on disk as cryptroot in the gpt table: data, the rest of the disk
   reread the partition table of disk and wait for its nodes
 
 [format]

--- a/tests/golden/vm-raidz.txt
+++ b/tests/golden/vm-raidz.txt
@@ -6,10 +6,10 @@
   create a gpt partition table on disk as table
   create a gpt partition table on disk2 as table2
   create a gpt partition table on disk3 as table3
-  create partition 1 on disk as esp: esp, 512MiB
-  create partition 1 on disk2 as poolpart2: zfs, the rest of the disk
-  create partition 1 on disk3 as poolpart3: zfs, the rest of the disk
-  create partition 2 on disk as poolpart: data, the rest of the disk
+  create partition 1 on disk as esp in the gpt table: esp, 512MiB
+  create partition 1 on disk2 as poolpart2 in the gpt table: zfs, the rest of the disk
+  create partition 1 on disk3 as poolpart3 in the gpt table: zfs, the rest of the disk
+  create partition 2 on disk as poolpart in the gpt table: data, the rest of the disk
   reread the partition table of disk and wait for its nodes
   reread the partition table of disk2 and wait for its nodes
   reread the partition table of disk3 and wait for its nodes

--- a/tests/golden/vm-ram.txt
+++ b/tests/golden/vm-ram.txt
@@ -2,8 +2,8 @@
   release anything a previous run of this configuration left mounted or open
   wipe existing signatures from disk
   create a gpt partition table on disk as table
-  create partition 1 on disk as esp: esp, 512MiB
-  create partition 2 on disk as rootpart: data, the rest of the disk
+  create partition 1 on disk as esp in the gpt table: esp, 512MiB
+  create partition 2 on disk as rootpart in the gpt table: data, the rest of the disk
   reread the partition table of disk and wait for its nodes
 
 [format]

--- a/tests/golden/vm-sdboot.txt
+++ b/tests/golden/vm-sdboot.txt
@@ -2,8 +2,8 @@
   release anything a previous run of this configuration left mounted or open
   wipe existing signatures from disk
   create a gpt partition table on disk as table
-  create partition 1 on disk as esp: esp, 1GiB
-  create partition 2 on disk as rootpart: data, the rest of the disk
+  create partition 1 on disk as esp in the gpt table: esp, 1GiB
+  create partition 2 on disk as rootpart in the gpt table: data, the rest of the disk
   reread the partition table of disk and wait for its nodes
 
 [format]

--- a/tests/golden/vm-source-kernel.txt
+++ b/tests/golden/vm-source-kernel.txt
@@ -2,8 +2,8 @@
   release anything a previous run of this configuration left mounted or open
   wipe existing signatures from disk
   create a gpt partition table on disk as table
-  create partition 1 on disk as esp: esp, 512MiB
-  create partition 2 on disk as rootpart: data, the rest of the disk
+  create partition 1 on disk as esp in the gpt table: esp, 512MiB
+  create partition 2 on disk as rootpart in the gpt table: data, the rest of the disk
   reread the partition table of disk and wait for its nodes
 
 [format]

--- a/tests/golden/vm-unlock.txt
+++ b/tests/golden/vm-unlock.txt
@@ -2,14 +2,14 @@
   release anything a previous run of this configuration left mounted or open
   wipe existing signatures from disk
   create a gpt partition table on disk as table
-  create partition 1 on disk as esp: esp, 512MiB
-  create partition 2 on disk as boot: data, 1GiB
-  create partition 3 on disk as cryptroot: data, the rest of the disk
+  create partition 1 on disk as esp in the gpt table: esp, 512MiB
+  create partition 2 on disk as boot in the gpt table: data, 1GiB
+  create partition 3 on disk as cryptroot in the gpt table: data, the rest of the disk
   reread the partition table of disk and wait for its nodes
 
 [array]
-  format cryptroot as LUKS2
-  open cryptroot as /dev/mapper/root
+  format cryptroot as LUKS2 using the key file for root-luks
+  open cryptroot as /dev/mapper/root using the key file for root-luks
 
 [format]
   make a ext4 filesystem on boot as bootfs labelled BOOT

--- a/tests/golden/vm-xfs.txt
+++ b/tests/golden/vm-xfs.txt
@@ -2,8 +2,8 @@
   release anything a previous run of this configuration left mounted or open
   wipe existing signatures from disk
   create a gpt partition table on disk as table
-  create partition 1 on disk as esp: esp, 512MiB
-  create partition 2 on disk as rootpart: data, the rest of the disk
+  create partition 1 on disk as esp in the gpt table: esp, 512MiB
+  create partition 2 on disk as rootpart in the gpt table: data, the rest of the disk
   reread the partition table of disk and wait for its nodes
 
 [format]

--- a/tests/golden/vm-zfs-encrypted.txt
+++ b/tests/golden/vm-zfs-encrypted.txt
@@ -2,8 +2,8 @@
   release anything a previous run of this configuration left mounted or open
   wipe existing signatures from disk
   create a gpt partition table on disk as table
-  create partition 1 on disk as esp: esp, 512MiB
-  create partition 2 on disk as poolpart: data, the rest of the disk
+  create partition 1 on disk as esp in the gpt table: esp, 512MiB
+  create partition 2 on disk as poolpart in the gpt table: data, the rest of the disk
   reread the partition table of disk and wait for its nodes
 
 [format]

--- a/tests/golden/vm-zfs-mirror.txt
+++ b/tests/golden/vm-zfs-mirror.txt
@@ -4,9 +4,9 @@
   wipe existing signatures from disk2
   create a gpt partition table on disk as table
   create a gpt partition table on disk2 as table2
-  create partition 1 on disk as esp: esp, 512MiB
-  create partition 1 on disk2 as poolpart2: zfs, the rest of the disk
-  create partition 2 on disk as poolpart: data, the rest of the disk
+  create partition 1 on disk as esp in the gpt table: esp, 512MiB
+  create partition 1 on disk2 as poolpart2 in the gpt table: zfs, the rest of the disk
+  create partition 2 on disk as poolpart in the gpt table: data, the rest of the disk
   reread the partition table of disk and wait for its nodes
   reread the partition table of disk2 and wait for its nodes
 

--- a/tests/golden/vm-zfs.txt
+++ b/tests/golden/vm-zfs.txt
@@ -2,8 +2,8 @@
   release anything a previous run of this configuration left mounted or open
   wipe existing signatures from disk
   create a gpt partition table on disk as table
-  create partition 1 on disk as esp: esp, 512MiB
-  create partition 2 on disk as poolpart: data, the rest of the disk
+  create partition 1 on disk as esp in the gpt table: esp, 512MiB
+  create partition 2 on disk as poolpart in the gpt table: data, the rest of the disk
   reread the partition table of disk and wait for its nodes
 
 [format]

--- a/tests/golden/vm-zram.txt
+++ b/tests/golden/vm-zram.txt
@@ -2,8 +2,8 @@
   release anything a previous run of this configuration left mounted or open
   wipe existing signatures from disk
   create a gpt partition table on disk as table
-  create partition 1 on disk as esp: esp, 512MiB
-  create partition 2 on disk as rootpart: data, the rest of the disk
+  create partition 1 on disk as esp in the gpt table: esp, 512MiB
+  create partition 2 on disk as rootpart in the gpt table: data, the rest of the disk
   reread the partition table of disk and wait for its nodes
 
 [format]

--- a/tests/golden/zbm-unlock.txt
+++ b/tests/golden/zbm-unlock.txt
@@ -2,8 +2,8 @@
   release anything a previous run of this configuration left mounted or open
   wipe existing signatures from disk
   create a gpt partition table on disk as table
-  create partition 1 on disk as esp: esp, 512MiB
-  create partition 2 on disk as poolpart: data, the rest of the disk
+  create partition 1 on disk as esp in the gpt table: esp, 512MiB
+  create partition 2 on disk as poolpart in the gpt table: data, the rest of the disk
   reread the partition table of disk and wait for its nodes
 
 [format]

--- a/tests/golden/zfs-zbm.txt
+++ b/tests/golden/zfs-zbm.txt
@@ -2,8 +2,8 @@
   release anything a previous run of this configuration left mounted or open
   wipe existing signatures from disk
   create a gpt partition table on disk as table
-  create partition 1 on disk as esp: esp, 512MiB
-  create partition 2 on disk as poolpart: data, the rest of the disk
+  create partition 1 on disk as esp in the gpt table: esp, 512MiB
+  create partition 2 on disk as poolpart in the gpt table: data, the rest of the disk
   reread the partition table of disk and wait for its nodes
 
 [format]

--- a/tests/unit/test_plan_disk.py
+++ b/tests/unit/test_plan_disk.py
@@ -40,6 +40,7 @@ from gentoo_install.exec.config import load
 from gentoo_install.model.size import Size
 from gentoo_install.plan import disk, system
 from gentoo_install.plan.operations import Stage
+from gentoo_install.plan.render import render
 
 from .layouts import config, ext4_on_gpt, i, zfs_root
 from .recorder import Recorder
@@ -120,6 +121,11 @@ def test_an_image_refuses_an_existing_file_unless_wipe_is_enabled() -> None:
     ]
     assert recorder.device_path(i("disk")) == "/dev/loop7"
     assert "loop device" in create.describe()
+    dry_run = render([create])
+    wiping_dry_run = render([wiping])
+    assert "refusing to overwrite an existing image" in dry_run, dry_run
+    assert "overwriting an existing image" in wiping_dry_run, wiping_dry_run
+    assert dry_run != wiping_dry_run
 
     detach = disk.DetachImage(device=i("disk"), image=image)
     assert detach.releases_the_machine
@@ -195,6 +201,31 @@ def test_an_mbr_partition_is_placed_by_offset_because_parted_needs_one() -> None
     assert made[-1][-3:] == ("primary", "513MiB", "100%")
 
 
+def test_partition_table_kind_and_mbr_start_change_the_dry_run() -> None:
+    """`parted` receives an MBR start while `sgdisk` chooses its own position."""
+    partition = disk.CreatePartition(
+        partition=DeviceId("part"),
+        disk=DeviceId("disk"),
+        table_kind=TableType.GPT,
+        index=1,
+        role=PartitionRole.DATA,
+        size=Size.parse("1GiB"),
+        label="",
+        start=Size.parse("1MiB"),
+    )
+    mbr = replace(partition, table_kind=TableType.MBR)
+    later = replace(mbr, start=Size.parse("2MiB"))
+
+    gpt_dry_run = render([partition])
+    mbr_dry_run = render([mbr])
+    later_dry_run = render([later])
+    assert "in the gpt table" in gpt_dry_run, gpt_dry_run
+    assert "in the mbr table from 1MiB" in mbr_dry_run, mbr_dry_run
+    assert "in the mbr table from 2MiB" in later_dry_run, later_dry_run
+    assert gpt_dry_run != mbr_dry_run
+    assert mbr_dry_run != later_dry_run
+
+
 def test_the_kernel_is_asked_to_reread_the_table_before_anything_uses_it() -> None:
     operations = disk.build(config(ext4_on_gpt()))
     reread = [n for n, operation in enumerate(operations) if isinstance(operation, disk.RereadPartitionTable)]
@@ -214,6 +245,7 @@ def test_partition_table_waits_for_device_events_before_formatting() -> None:
 
     assert recorder.device_event_settles == 1
 
+
 def test_luks_is_formatted_with_argon2id_and_opened_from_the_same_key_file() -> None:
     nodes: list[Node] = [node for node in ext4_on_gpt() if node.id != i("rootfs")]
     nodes += [
@@ -226,6 +258,25 @@ def test_luks_is_formatted_with_argon2id_and_opened_from_the_same_key_file() -> 
     assert "--pbkdf" in formatted and formatted[formatted.index("--pbkdf") + 1] == "argon2id"
     assert "--type" in formatted and "luks2" in formatted
     assert formatted[formatted.index("--key-file") + 1] == opened[opened.index("--key-file") + 1]
+
+
+def test_luks_container_changes_the_dry_run() -> None:
+    """`cryptsetup` reads the key file selected by the container id."""
+    formatting = disk.CreateLuks(
+        container=DeviceId("cryptroot"), backing=DeviceId("rootpart"), name="cryptroot"
+    )
+    opening = disk.OpenLuks(
+        container=DeviceId("cryptroot"), backing=DeviceId("rootpart"), name="cryptroot"
+    )
+    alternate_formatting = replace(formatting, container=DeviceId("cryptdata"))
+    alternate_opening = replace(opening, container=DeviceId("cryptdata"))
+
+    formatting_dry_run = render([formatting])
+    opening_dry_run = render([opening])
+    assert "key file for cryptroot" in formatting_dry_run, formatting_dry_run
+    assert "key file for cryptroot" in opening_dry_run, opening_dry_run
+    assert formatting_dry_run != render([alternate_formatting])
+    assert opening_dry_run != render([alternate_opening])
 
 
 def test_an_array_is_created_with_the_metadata_the_layout_asked_for() -> None:


### PR DESCRIPTION
An operator reads the dry run and decides whether to continue, and three values that change what happens to something already on the disk were not in it. `CreateImage.wipe` decides whether an existing image is refused or overwritten and the line always said the image would be created. `CreatePartition.table_kind` selects `sgdisk` or `parted`, and the MBR branch also uses `start`. `CreateLuks.container` and `OpenLuks.container` select the key file handed to `cryptsetup`.

Measured both ways, which is the point rather than a formality: before this change the five `render()` outputs were identical whichever value was set; after it all five differ. 37 golden files move with it, in the same commit.

This is the first of the three categories in `docs/design.md`'s `describe() 要說出哪些值`; the other two are separate work. `plan/disk.py` is one of the areas unit tests do not verify — the report names the `apply()` branches still unexercised by a guest.