### PR TITLE
vm: hold each fixture's expected result in one table

### DIFF
--- a/gentoo_install/exec/apply.py
+++ b/gentoo_install/exec/apply.py
@@ -38,6 +38,15 @@ from .probe import Probe
 from .runner import Runner, open_in_target, under
 
 
+def degradation_warning(what: str, reason: str) -> str:
+    """The line a degradation writes to the log.
+
+    A test harness watching a run for a degradation reads this rather than a
+    copy of the wording, so the two cannot drift apart.
+    """
+    return f"WARNING: {what} is unavailable, so {reason}"
+
+
 @dataclass
 class Machine:
     """The live implementation of `plan.operations.Context`."""
@@ -216,7 +225,7 @@ class Machine:
 
     def degrade(self, what: str, reason: str) -> None:
         self.given_up.add(what)
-        self.runner.log(f"WARNING: {what} is unavailable, so {reason}")
+        self.runner.log(degradation_warning(what, reason))
         if self.runner.journal is not None:
             self.runner.journal.degraded(what, reason)
 

--- a/tests/unit/test_cluster.py
+++ b/tests/unit/test_cluster.py
@@ -1284,7 +1284,7 @@ def test_a_fixture_that_passes_by_failing_is_not_recorded_as_a_failure() -> None
         Path(one.config).stem
         for stage in campaign.STAGES.values()
         for one in stage
-        if one.expect_failure
+        if one.expectation is not None and one.expectation.must_stop
     }
     assert failing == set(cluster.EXPECTED_TO_FAIL), (failing, cluster.EXPECTED_TO_FAIL)
 

--- a/tests/unit/test_harness.py
+++ b/tests/unit/test_harness.py
@@ -150,11 +150,6 @@ NOT_IN_THE_CAMPAIGN: Final[frozenset[str]] = frozenset(
         # medium the campaign boots, because the machine under test has to
         # have a bootloader of its own to arm.
         "vm-ram.toml",
-        # A binary host that answers 404 and an install that has to compile
-        # instead. Green here would mean nothing: telling that apart from an
-        # ordinary install needs the `degraded` event in `install.jsonl`, and
-        # `cluster.MUST_DEGRADE` is the only runner that reads it.
-        "vm-binhost-fallback.toml",
         # The dd runner generates its sources, streams each one from the driver
         # CD, and reads the target back; neither target can boot as a system.
         "vm-dd-raw.toml",
@@ -168,6 +163,7 @@ def test_the_campaign_covers_every_vm_fixture() -> None:
     matrix is that the list cannot quietly fall behind."""
     from tests.vm.campaign import STAGES
     from tests.vm.cluster import MUST_DEGRADE
+    from tests.vm.expectations import EXPECTATIONS
 
     root = Path(__file__).resolve().parents[1]
     named = {Path(run.config).name for runs in STAGES.values() for run in runs}
@@ -175,9 +171,10 @@ def test_the_campaign_covers_every_vm_fixture() -> None:
     assert available - named == NOT_IN_THE_CAMPAIGN, sorted(
         (available - named) ^ NOT_IN_THE_CAMPAIGN
     )
-    # The reason `vm-binhost-fallback` is excused, held where it can fail: the
-    # cluster is the only runner that can tell its pass from an ordinary one.
+    # Both runners can now tell its pass from an ordinary install: the cluster
+    # reads the `degraded` event, the campaign reads the line it writes.
     assert "vm-binhost-fallback" in MUST_DEGRADE
+    assert EXPECTATIONS["vm-binhost-fallback"].marker
 
 
 def test_every_fixture_names_a_disk_the_harness_creates() -> None:
@@ -2817,10 +2814,9 @@ def test_no_input_method_asks_for_no_environment() -> None:
 def test_a_fixture_meant_to_fail_proves_its_failure_path(tmp_path: Path) -> None:
     """`vm-proxy-dead` succeeds only after its dead proxy refuses the stage3
     download; another non-zero result proves no such thing."""
-    from tests.vm.campaign import ExpectedFailure, Outcome, Run, mark_for
+    from tests.vm.campaign import Outcome, Run, mark_for
 
-    expected = ExpectedFailure(returncode=1, signal="Connection refused")
-    dead = Run("fixtures/vm-proxy-dead.toml", expect_failure=expected)
+    dead = Run("fixtures/vm-proxy-dead.toml")
     log = tmp_path / "proxy-dead.log"
     log.write_text("the stage3 could not be fetched: [Errno 111] Connection refused\n")
 
@@ -2838,21 +2834,71 @@ def test_a_fixture_meant_to_fail_proves_its_failure_path(tmp_path: Path) -> None
     assert not Outcome(ordinary, 4, 1.0, log).passed
 
 
+def test_neither_runner_keeps_its_own_copy_of_an_expectation() -> None:
+    """One table, two readers. `Connection refused` was written in three
+    places, and the two runners disagreed on the exit code beside it: the
+    campaign wanted `1` and the cluster `b"4"`, and nothing compared them."""
+    import ast
+
+    from tests.vm.expectations import EXPECTATIONS
+
+    wanted = [one.says for one in EXPECTATIONS.values() if one.says]
+    assert wanted, "an empty set of markers would make this assert nothing"
+
+    here = Path(__file__).resolve().parents[1] / "vm"
+    for runner in ("campaign.py", "cluster.py", "run.py"):
+        tree = ast.parse((here / runner).read_text())
+        docstrings = {
+            id(node.body[0].value)
+            for node in ast.walk(tree)
+            if isinstance(node, (ast.Module, ast.ClassDef, ast.FunctionDef))
+            and node.body
+            and isinstance(node.body[0], ast.Expr)
+            and isinstance(node.body[0].value, ast.Constant)
+            and isinstance(node.body[0].value.value, str)
+        }
+        literals = [
+            node.value
+            for node in ast.walk(tree)
+            if isinstance(node, ast.Constant)
+            and isinstance(node.value, str)
+            and id(node) not in docstrings
+        ]
+        for says in wanted:
+            held = [one for one in literals if says in one]
+            assert not held, (runner, says, held)
+
+
+def test_a_fixture_that_has_to_degrade_is_not_green_when_it_did_not(tmp_path: Path) -> None:
+    """`vm-binhost-fallback` finishes and boots whether or not its binary host
+    ever failed, so the exit code cannot tell the two apart. The day the host
+    answers again this run has to go red rather than quietly stop covering the
+    degradation it exists to measure."""
+    from gentoo_install.exec.apply import degradation_warning
+    from gentoo_install.plan.portage import BINARY_PACKAGES
+    from tests.vm.campaign import Outcome, Run
+
+    fallback = Run("fixtures/vm-binhost-fallback.toml")
+    log = tmp_path / "fallback.log"
+
+    log.write_text("the install finished\n")
+    assert not Outcome(fallback, 0, 1.0, log).passed
+
+    log.write_text(degradation_warning(BINARY_PACKAGES, "the index answered 404") + "\n")
+    assert Outcome(fallback, 0, 1.0, log).passed
+    assert not Outcome(fallback, 4, 1.0, log).passed
+
+
 def test_the_campaign_expects_exactly_the_fixtures_that_cannot_finish() -> None:
-    """A second fixture marked this way would be a fixture nobody notices
-    failing, so the set is named here as well as there."""
-    from tests.vm.campaign import ExpectedFailure, STAGES
+    """An expectation naming a fixture the campaign never runs is a rule that
+    cannot fire, and it reads as coverage."""
+    from tests.vm.campaign import STAGES
+    from tests.vm.expectations import EXPECTATIONS
 
-    expected = {
-        Path(run.config).stem: run.expect_failure
-        for runs in STAGES.values()
-        for run in runs
-        if run.expect_failure is not None
-    }
+    scheduled = {Path(run.config).stem for runs in STAGES.values() for run in runs}
 
-    assert expected == {
-        "vm-proxy-dead": ExpectedFailure(returncode=1, signal="Connection refused")
-    }
+    assert set(EXPECTATIONS) <= scheduled, set(EXPECTATIONS) - scheduled
+    assert {name for name, one in EXPECTATIONS.items() if one.must_stop} == {"vm-proxy-dead"}
 
 
 def test_campaign_collects_an_outcome_from_every_worker(

--- a/tests/vm/campaign.py
+++ b/tests/vm/campaign.py
@@ -25,6 +25,8 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import Callable, Final, Sequence
 
+from .expectations import EXPECTATIONS, Expectation
+
 WORKROOT: Final[Path] = Path.home() / "code/gentoo-install/lab/vm/runs"
 LOGS: Final[Path] = Path.home() / "code/gentoo-install/lab/vm/campaign"
 
@@ -90,14 +92,6 @@ TIMEOUT: Final[float] = 5400.0
 
 
 @dataclass(frozen=True)
-class ExpectedFailure:
-    """Exit result that proves a negative fixture reached its failure path."""
-
-    returncode: int
-    signal: str
-
-
-@dataclass(frozen=True)
 class Run:
     """One invocation of `tests.vm.run`."""
 
@@ -113,8 +107,6 @@ class Run:
     #: at zero for a run that installs binary packages: more cores do nothing
     #: for a download, and they would be taken from a run that is compiling.
     cpus: int = 0
-    #: The result that proves a negative fixture exercised the path it names.
-    expect_failure: ExpectedFailure | None = None
     #: What this costs the machine, against `CAPACITY`. Two for a run that
     #: compiles a kernel or a desktop: those saturate their vCPUs for half an
     #: hour, and packing them beside each other makes every one of them slower
@@ -126,6 +118,10 @@ class Run:
     def name(self) -> str:
         how = "-interrupted" if self.interrupt else ""
         return f"{self.medium}-{self.firmware}-{Path(self.config).stem}{how}"
+
+    @property
+    def expectation(self) -> Expectation | None:
+        return EXPECTATIONS.get(Path(self.config).stem)
 
     def argv(self) -> list[str]:
         argv = [
@@ -209,10 +205,12 @@ STAGES: Final[dict[str, tuple[Run, ...]]] = {
         # The proxy pointed at a port nothing listens on: a run that reaches
         # the mirror proves something bypassed it, so this one is expected to
         # fail at the stage3 download and its failure is the result.
-        Run(
-            "fixtures/vm-proxy-dead.toml",
-            expect_failure=ExpectedFailure(1, "Connection refused"),
-        ),  # see cluster.EXPECTED_TO_FAIL
+        Run("fixtures/vm-proxy-dead.toml"),  # see expectations.EXPECTATIONS
+        # The binary host it names answers 404, so the run has to give binary
+        # packages up and finish from source. `EXPECTATIONS` is what makes the
+        # console say so; without it the run is green whether or not the host
+        # ever failed.
+        Run("fixtures/vm-binhost-fallback.toml"),
         # The direction that matters to an operator on an intranet, and the one
         # nothing covered: the proxy answers and the install completes through
         # it. It needs a SOCKS5 listener on the workstation, so `run.py` refuses
@@ -255,7 +253,7 @@ class Outcome:
 
     @property
     def passed(self) -> bool:
-        expected = self.run.expect_failure
+        expected = self.run.expectation
         if self.error is not None:
             return False
         if expected is None:
@@ -264,7 +262,11 @@ class Outcome:
             said = self.log.read_text(errors="replace")
         except OSError:
             return False
-        return self.returncode == expected.returncode and expected.signal in said
+        if expected.marker not in said:
+            return False
+        if not expected.must_stop:
+            return self.returncode == 0
+        return self.returncode == expected.runner_returncode
 
 
 def _log_for(run: Run) -> Path:
@@ -313,7 +315,7 @@ def mark_for(outcome: Outcome) -> str:
         return "ok  "
     if outcome.error is not None:
         return "FAIL"
-    if outcome.run.expect_failure is not None:
+    if (expected := outcome.run.expectation) is not None and expected.must_stop:
         # A clean exit proves the proxy was bypassed; another failure proved
         # neither the expected path nor a completed installation.
         return "BYPASS" if outcome.returncode == 0 else "FAIL"

--- a/tests/vm/cluster.py
+++ b/tests/vm/cluster.py
@@ -47,6 +47,8 @@ from types import MappingProxyType
 from contextlib import contextmanager
 from typing import Final, Iterator, Protocol, TypeVar, cast, Sequence
 
+from .expectations import EXPECTATIONS, Expectation
+
 from gentoo_install.model.config import Firmware as BootFirmware
 from gentoo_install.model.config import (
     DiskMode,
@@ -2837,8 +2839,10 @@ def _remaining(deadline: float) -> float:
 #: bypassed the proxy, and a syntax error, a refused preflight or a failed
 #: disk stops the install just as non-zero. Measured on a passing run:
 #: `install.rc` held `4` and `Connection refused` appeared 26 times.
-EXPECTED_TO_FAIL: Final[Mapping[str, tuple[bytes, str]]] = MappingProxyType(
-    {"vm-proxy-dead": (b"4", "Connection refused")}
+#: The fixtures whose install has to stop, read from the one table both
+#: runners share rather than named a second time here.
+EXPECTED_TO_FAIL: Final[Mapping[str, Expectation]] = MappingProxyType(
+    {name: one for name, one in EXPECTATIONS.items() if one.must_stop}
 )
 
 
@@ -2874,7 +2878,8 @@ def _did_not_stop(name: str, code: bytes, files: Mapping[str, bytes]) -> str:
     code and the reason, because the local runner has checked both since it
     was written and the cluster checked neither.
     """
-    wanted, marker = EXPECTED_TO_FAIL[name]
+    expected = EXPECTED_TO_FAIL[name]
+    wanted, marker = expected.installer_returncode, expected.marker
     if not code:
         return "the install was supposed to stop and wrote no exit code"
     if code == b"0":
@@ -2904,7 +2909,7 @@ KEEPS_ITS_SITE: Final[frozenset[str]] = frozenset({"vm-binhost-fallback"})
 #: this the fixture is green when the install merely finished, which it does
 #: whether or not the host it names ever failed.
 MUST_DEGRADE: Final[Mapping[str, str]] = MappingProxyType(
-    {"vm-binhost-fallback": BINARY_PACKAGES}
+    {name: one.degrades for name, one in EXPECTATIONS.items() if one.degrades}
 )
 
 

--- a/tests/vm/expectations.py
+++ b/tests/vm/expectations.py
@@ -1,0 +1,65 @@
+# SPDX-License-Identifier: GPL-2.0-or-later
+"""What each fixture's run has to produce, for both runners.
+
+The two runners read different evidence for the same fact: `campaign.py` sees
+`tests/vm/run.py`'s exit code and the console, `cluster.py` reads the
+installer's own exit code and `install.jsonl`. Holding the answer in each of
+them let `vm-proxy-dead` carry `1` in one table and `b"4"` in another, put a
+third copy of `Connection refused` in the unit tests, and left the local runner
+with no notion of a fixture that has to degrade.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from types import MappingProxyType
+from typing import Final, Mapping
+
+from gentoo_install.exec.apply import degradation_warning
+from gentoo_install.plan.portage import BINARY_PACKAGES
+
+
+@dataclass(frozen=True)
+class Expectation:
+    """One fixture's required result."""
+
+    #: What `install.jsonl` must record the run giving up, empty when the run
+    #: has to finish with nothing degraded.
+    degrades: str = ""
+    #: Text the console must carry, for a fixture whose evidence is not a
+    #: degradation. A run whose log lacks it did not reach the path the
+    #: fixture exists to measure.
+    says: str = ""
+    #: What `tests/vm/run.py` exits when the install stops as intended, or
+    #: `None` when the fixture has to install and boot.
+    runner_returncode: int | None = None
+    #: What `cli.py` recorded as its own exit code, as the cluster collects it.
+    installer_returncode: bytes = b""
+
+    @property
+    def must_stop(self) -> bool:
+        return self.runner_returncode is not None
+
+    @property
+    def marker(self) -> str:
+        """What a console reader looks for. Derived from `degrades` rather than
+        written beside it, so the wording cannot drift from what `degrade()`
+        writes."""
+        if self.degrades:
+            return degradation_warning(self.degrades, "")
+        return self.says
+
+
+EXPECTATIONS: Final[Mapping[str, Expectation]] = MappingProxyType(
+    {
+        # The proxy points at a port nothing listens on, so a run that reaches
+        # the mirror proves something bypassed it.
+        "vm-proxy-dead": Expectation(
+            says="Connection refused", runner_returncode=1, installer_returncode=b"4"
+        ),
+        # The fixture's binary host answered 404 for its index on 2026-08-18.
+        # The day it answers again this run stops covering the degradation and
+        # becomes an ordinary binary package install, which no exit code shows.
+        "vm-binhost-fallback": Expectation(degrades=BINARY_PACKAGES),
+    }
+)


### PR DESCRIPTION
`Connection refused` was written in `campaign.ExpectedFailure`, `cluster.EXPECTED_TO_FAIL` and a third time in the unit tests, and the first two disagreed on the exit code beside it: `1` against `b"4"`. Both are right — one reads `tests/vm/run.py`'s exit, the other `cli.py`'s own — but nothing compared them, so a disagreement and two kinds of evidence looked identical.

`tests/vm/expectations.py` is now the one table and each runner reads the column it can see. That closes the gap `NOT_IN_THE_CAMPAIGN` recorded: `vm-binhost-fallback` was excused locally because only the cluster read the `degraded` event, and the local runner now reads the warning line instead — derived from `degrade()`'s own format, not copied.

Controls: removing the marker check turns two tests red; a `"Connection refused"` literal put back into `campaign.py` turns the shape test red. That test parses with `ast` and looks only at code literals, because two comments in `cluster.py` describe this history and a text match would read them as the duplication.