### PR TITLE
plan: describe authorized keys by fingerprint, not by count

### DIFF
--- a/gentoo_install/data/locale/ja.toml
+++ b/gentoo_install/data/locale/ja.toml
@@ -624,7 +624,7 @@
 "write {} for the wired interfaces with DHCP and DNS {}" = "{} に書き込む：有線インターフェースは DHCP、DNS {}"
 "write {} for {} with DHCP" = "{} に書き込む：インターフェース {} は DHCP"
 "enable net.{} so netifrc applies the static address" = "net.{} を有効にして netifrc に静的アドレスを適用させる"
-"write {} ssh key(s) into authorized_keys for {}" = "{} 個の ssh 鍵を {} の authorized_keys に書き込む"
+"write {} into authorized_keys for {}" = "{} を {} の authorized_keys に書き込む"
 "ssh password login: on, root: on, in 50-gentoo-install.conf" = "SSH パスワードログイン：有効、root：有効（50-gentoo-install.conf）"
 "ssh password login: on, root: off, in 50-gentoo-install.conf" = "SSH パスワードログイン：有効、root：無効（50-gentoo-install.conf）"
 "ssh password login: off, root: on, in 50-gentoo-install.conf" = "SSH パスワードログイン：無効、root：有効（50-gentoo-install.conf）"

--- a/gentoo_install/data/locale/ko.toml
+++ b/gentoo_install/data/locale/ko.toml
@@ -624,7 +624,7 @@
 "write {} for the wired interfaces with DHCP and DNS {}" = "{} 작성: 유선 인터페이스, DHCP, DNS {}"
 "write {} for {} with DHCP" = "{} 작성: 인터페이스 {}, DHCP"
 "enable net.{} so netifrc applies the static address" = "net.{}를 활성화하여 netifrc가 고정 주소를 적용하게 함"
-"write {} ssh key(s) into authorized_keys for {}" = "SSH 키 {}개를 {}의 authorized_keys에 작성"
+"write {} into authorized_keys for {}" = "{}를 {}의 authorized_keys에 작성"
 "ssh password login: on, root: on, in 50-gentoo-install.conf" = "SSH 비밀번호 로그인: 켬, root: 켬 (50-gentoo-install.conf)"
 "ssh password login: on, root: off, in 50-gentoo-install.conf" = "SSH 비밀번호 로그인: 켬, root: 끔 (50-gentoo-install.conf)"
 "ssh password login: off, root: on, in 50-gentoo-install.conf" = "SSH 비밀번호 로그인: 끔, root: 켬 (50-gentoo-install.conf)"

--- a/gentoo_install/data/locale/zh-CN.toml
+++ b/gentoo_install/data/locale/zh-CN.toml
@@ -625,7 +625,7 @@
 "write {} for the wired interfaces with DHCP and DNS {}" = "写入 {}；有线接口使用 DHCP，DNS {}"
 "write {} for {} with DHCP" = "写入 {}；接口 {} 使用 DHCP"
 "enable net.{} so netifrc applies the static address" = "启用 net.{}，让 netifrc 应用静态地址"
-"write {} ssh key(s) into authorized_keys for {}" = "将 {} 个 SSH 密钥写入 {} 的 authorized_keys"
+"write {} into authorized_keys for {}" = "将 {} 写入 {} 的 authorized_keys"
 "ssh password login: on, root: on, in 50-gentoo-install.conf" = "SSH 密码登录：开启；root：开启，写入 50-gentoo-install.conf"
 "ssh password login: on, root: off, in 50-gentoo-install.conf" = "SSH 密码登录：开启；root：关闭，写入 50-gentoo-install.conf"
 "ssh password login: off, root: on, in 50-gentoo-install.conf" = "SSH 密码登录：关闭；root：开启，写入 50-gentoo-install.conf"

--- a/gentoo_install/data/locale/zh-TW.toml
+++ b/gentoo_install/data/locale/zh-TW.toml
@@ -625,7 +625,7 @@
 "write {} for the wired interfaces with DHCP and DNS {}" = "寫入 {}；有線網路介面使用 DHCP，DNS {}"
 "write {} for {} with DHCP" = "寫入 {}；介面 {} 使用 DHCP"
 "enable net.{} so netifrc applies the static address" = "啟用 net.{}，讓 netifrc 套用靜態位址"
-"write {} ssh key(s) into authorized_keys for {}" = "將 {} 個 SSH 金鑰寫入 {} 的 authorized_keys"
+"write {} into authorized_keys for {}" = "將 {} 寫入 {} 的 authorized_keys"
 "ssh password login: on, root: on, in 50-gentoo-install.conf" = "SSH 密碼登入：開啟；root：開啟，寫入 50-gentoo-install.conf"
 "ssh password login: on, root: off, in 50-gentoo-install.conf" = "SSH 密碼登入：開啟；root：關閉，寫入 50-gentoo-install.conf"
 "ssh password login: off, root: on, in 50-gentoo-install.conf" = "SSH 密碼登入：關閉；root：開啟，寫入 50-gentoo-install.conf"

--- a/gentoo_install/model/sshkey.py
+++ b/gentoo_install/model/sshkey.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 
 import base64
 import binascii
+import hashlib
 from dataclasses import dataclass
 from enum import Enum, auto
 from typing import Final
@@ -109,6 +110,19 @@ def check(line: str) -> str:
         raise ConfigError("the key body declares a different type from its first field")
     _validate_shape(parts, key_format)
     return " ".join(fields)
+
+
+def fingerprint(line: str) -> str:
+    """The key as `ssh-keygen -l` names it: `SHA256:` and the digest of the
+    wire blob, base64 without padding.
+
+    A hash and not the key: a dry-run reaches `install.jsonl` and any paste an
+    operator sends on, and the comment field of a key carries a username and a
+    hostname.
+    """
+    blob = line.split()[1]
+    digest = hashlib.sha256(base64.b64decode(blob, validate=True)).digest()
+    return "SHA256:" + base64.b64encode(digest).decode().rstrip("=")
 
 
 def _wire(raw: bytes) -> list[bytes]:

--- a/gentoo_install/plan/system.py
+++ b/gentoo_install/plan/system.py
@@ -27,6 +27,7 @@ from ..model.config import (
     User,
 )
 from ..model.size import Size
+from ..model.sshkey import fingerprint
 from ..model.device import (
     MdRaid,
     Node,
@@ -822,14 +823,21 @@ class WriteAuthorizedKeys(Operation):
     #: happen.
     accounts: tuple[tuple[str, str], ...]
 
+    def destinations(self) -> tuple[PurePosixPath, ...]:
+        return tuple(PurePosixPath(f"{home}/.ssh/authorized_keys") for _, home in self.accounts)
+
     def describe_parts(self) -> tuple[str, tuple[str, ...]]:
+        # The count alone let one key be swapped for another without a
+        # character of the dry-run changing, on the setting that decides who
+        # can log in.
         who = ", ".join(name for name, _ in self.accounts)
-        return "write {} ssh key(s) into authorized_keys for {}", (str(len(self.keys)), who)
+        keys = ", ".join(fingerprint(key) for key in self.keys) or "-"
+        return "write {} into authorized_keys for {}", (keys, who)
 
     def apply(self, context: Context) -> None:
         body = "".join(f"{key}\n" for key in self.keys)
-        for name, home in self.accounts:
-            context.write(PurePosixPath(f"{home}/.ssh/authorized_keys"), body, mode=0o600)
+        for path, (name, home) in zip(self.destinations(), self.accounts):
+            context.write(path, body, mode=0o600)
             context.run_in_target(["chmod", "700", f"{home}/.ssh"])
             if name != "root":
                 context.run_in_target(["chown", "-R", f"{name}:{name}", f"{home}/.ssh"])

--- a/tests/golden/vm-unlock.txt
+++ b/tests/golden/vm-unlock.txt
@@ -61,7 +61,7 @@
   write /etc/fstab with UUID from root-luks / btrfs defaults,compress=zstd:1,subvol=@ 0 1, UUID from boot /boot ext4 defaults 0 2, UUID from esp /efi vfat defaults,umask=0077 0 2, UUID from root-luks /home btrfs defaults,compress=zstd:1,subvol=@home 0 2
   treat the hardware clock as UTC in /etc/adjtime
   write /etc/crypttab with root UUID from cryptroot luks,x-initrd.attach
-  write 1 ssh key(s) into authorized_keys for root
+  write SHA256:wBQUIpTF0DPsPEUeafUC1YRHr0N0LIdt+LtbxepvlkQ into authorized_keys for root
   set the root password
   install sshd: emerge net-misc/openssh
   ssh password login: off, root: off, in 50-gentoo-install.conf

--- a/tests/golden/zbm-unlock.txt
+++ b/tests/golden/zbm-unlock.txt
@@ -64,7 +64,7 @@
   write /etc/fstab with UUID from esp /efi vfat defaults,umask=0077 0 2
   treat the hardware clock as UTC in /etc/adjtime
   create user zakk in users, wheel, audio, video, render, usb, input with a password
-  write 1 ssh key(s) into authorized_keys for root, zakk
+  write SHA256:wBQUIpTF0DPsPEUeafUC1YRHr0N0LIdt+LtbxepvlkQ into authorized_keys for root, zakk
   set the root password
   install sudo: emerge app-admin/sudo
   let the wheel group run sudo, with a password

--- a/tests/golden/zfs-zbm.txt
+++ b/tests/golden/zfs-zbm.txt
@@ -62,7 +62,7 @@
   write /etc/fstab with UUID from esp /efi vfat defaults,umask=0077 0 2
   treat the hardware clock as UTC in /etc/adjtime
   create user zakk in users, wheel, audio, video, render, usb, input with a password
-  write 1 ssh key(s) into authorized_keys for zakk
+  write SHA256:wBQUIpTF0DPsPEUeafUC1YRHr0N0LIdt+LtbxepvlkQ into authorized_keys for zakk
   set the root password
   install sudo: emerge app-admin/sudo
   let the wheel group run sudo, with a password

--- a/tests/unit/test_i18n.py
+++ b/tests/unit/test_i18n.py
@@ -548,7 +548,7 @@ REVIEWED_TEMPLATES: frozenset[str] = frozenset(
         "write /etc/portage/make.conf with {}; {} mirrors in the configured order,"
         " {} appended",
         "write /etc/kernel/cmdline with root {}; luks {}; arrays {}; keymap {}; parameters {}",
-        "write {} ssh key(s) into authorized_keys for {}",
+        "write {} into authorized_keys for {}",
         "write {} with {}",
         "{}: emerge {}",
         "{}: emerge {}, building {} here",

--- a/tests/unit/test_layers.py
+++ b/tests/unit/test_layers.py
@@ -529,6 +529,46 @@ def test_every_operation_still_has_to_say_what_it_does() -> None:
     assert len(found) > 60, len(found)
 
 
+def _bindings_in(
+    body: Mapping[str, ast.FunctionDef], known: Mapping[str, ast.expr]
+) -> dict[str, ast.expr]:
+    """Every name `apply()` binds to something a path can be read out of.
+
+    `destinations()` is where an operation derives the paths both halves read,
+    so a write through one of its results resolves to that method rather than
+    to the loop variable that carried it.
+    """
+    reachable = dict(known)
+    derived = body.get("destinations")
+    for step in ast.walk(body["apply"]):
+        if isinstance(step, ast.Assign) and step.value is not None:
+            reachable.update(
+                {one.id: step.value for one in step.targets if isinstance(one, ast.Name)}
+            )
+        elif derived is not None and isinstance(step, (ast.For, ast.Assign)):
+            source = step.iter if isinstance(step, ast.For) else step.value
+            if source is not None and "destinations()" in ast.unparse(source):
+                target = step.target if isinstance(step, ast.For) else step.targets[0]
+                reachable.update(
+                    {
+                        one.id: ast.Constant(_destination_text(derived))
+                        for one in ast.walk(target)
+                        if isinstance(one, ast.Name)
+                    }
+                )
+    return reachable
+
+
+def _destination_text(derived: ast.FunctionDef) -> str:
+    """The path literals `destinations()` returns, as one string a description
+    can be searched against."""
+    return " ".join(
+        node.value
+        for node in ast.walk(derived)
+        if isinstance(node, ast.Constant) and isinstance(node.value, str)
+    )
+
+
 def _written_names(expr: ast.expr, known: Mapping[str, ast.expr]) -> set[str]:
     """What a reader of `describe()` could recognise the written path by: the
     expression itself, any module constant it names, and the last component of
@@ -580,12 +620,7 @@ def test_every_operation_names_the_files_it_writes() -> None:
             if "apply" not in body or "describe" not in body:
                 continue
             said = ast.unparse(body["describe"])
-            reachable = dict(known)
-            for step in ast.walk(body["apply"]):
-                if isinstance(step, ast.Assign) and step.value is not None:
-                    reachable.update(
-                        {one.id: step.value for one in step.targets if isinstance(one, ast.Name)}
-                    )
+            reachable = _bindings_in(body, known)
             for call in ast.walk(body["apply"]):
                 if not isinstance(call, ast.Call) or not isinstance(call.func, ast.Attribute):
                     continue
@@ -632,12 +667,7 @@ def test_the_dry_run_names_every_file_only_its_owner_may_read() -> None:
             if "apply" not in body or describing is None:
                 continue
             said = ast.unparse(describing)
-            reachable = dict(known)
-            for step in ast.walk(body["apply"]):
-                if isinstance(step, ast.Assign) and step.value is not None:
-                    reachable.update(
-                        {one.id: step.value for one in step.targets if isinstance(one, ast.Name)}
-                    )
+            reachable = _bindings_in(body, known)
             for call in ast.walk(body["apply"]):
                 if not isinstance(call, ast.Call) or not isinstance(call.func, ast.Attribute):
                     continue

--- a/tests/unit/test_sshkey.py
+++ b/tests/unit/test_sshkey.py
@@ -181,3 +181,54 @@ def test_a_refused_key_is_not_quoted_back() -> None:
     # rule above cannot be met by a message that carries nothing at all.
     with pytest.raises(ConfigError, match="ssh-ed25519"):
         sshkey.check("ssh-rsa2 AAAA")
+
+
+def test_the_fingerprint_is_the_one_ssh_keygen_prints() -> None:
+    """Both samples and both answers were read from `ssh-keygen -lf` on
+    2026-08-24. Hashing the base64 text rather than the wire blob, or leaving
+    the base64 padding on, produces a plausible string that no other tool
+    agrees with."""
+    from gentoo_install.model.sshkey import fingerprint
+
+    ed25519 = (
+        "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIA9Q0PGF+/PUkbS6MTwK5Q5dqJE0"
+        "+t0drU7HR0nzv7qb sample@example"
+    )
+    rsa = (
+        "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQDdlHUHRweaoLfv6h0VgfHTmQSXzxJMZZS7Ia4a3dP8"
+        "I6ixYDosr01D5sRQQIZnmmXrrL9KXcHzCmmBnUwpLgZxW9ZyPLIcnImkXFt9nVbzlC/QPXp7bk1wT9ZN"
+        "25I4PQAD1FyNmLBREHNUv10c+szitxacK/37S+WGachteiZ5PfWuR/ktDIIaaSeFfwE4XORC3Jh0vJYJ"
+        "aBT1D7r78UaeAjX/jcHnuK31QeE8ntrtxQdtMVcLl5MVbKmYmaH2JwcXM2zDi2K/CFyayfDv3s+RDuHp"
+        "kCZM1SU1sMduklNplaI5BpW6w1T4LMSKY/4EgWAYdFmvAG58P42qB8M3r9oV sample@example"
+    )
+
+    assert fingerprint(ed25519) == "SHA256:LblrAMoRSX1FbTHC09p0i3CyohVjuqZlCFA7p+iMV5A"
+    assert fingerprint(rsa) == "SHA256:wlGCUednI5pRuDPDzpbdstjVq3awqyOcFoTpDAdIxbE"
+    # The comment carries a username and a hostname; the fingerprint is the
+    # same key with a different one.
+    assert fingerprint(ed25519.replace("sample@example", "someone@elsewhere")) == fingerprint(
+        ed25519
+    )
+
+
+def test_swapping_an_authorized_key_changes_the_dry_run() -> None:
+    """The description was the number of keys, so replacing the key that
+    decides who can log in moved not one character of it."""
+    from gentoo_install.model.sshkey import fingerprint
+    from gentoo_install.plan.system import WriteAuthorizedKeys
+
+    first = (
+        "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIA9Q0PGF+/PUkbS6MTwK5Q5dqJE0"
+        "+t0drU7HR0nzv7qb sample@example"
+    )
+    second = (
+        "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIH8w6sgdmfNXN4gVQnnQ"
+        "/5WQiY0oUPrQYr0SPTfnw2ah other@example"
+    )
+    assert fingerprint(first) != fingerprint(second)
+
+    accounts = (("root", "/root"),)
+    said = [
+        WriteAuthorizedKeys(keys=(one,), accounts=accounts).describe() for one in (first, second)
+    ]
+    assert said[0] != said[1], said


### PR DESCRIPTION
The description was `{n} ssh key(s)`, so replacing the key that decides who can log in left the dry-run byte for byte identical. Measured both ways: with two different keys the old form gives one string twice, the new one gives two.

`model/sshkey.py` grows `fingerprint()`, which hashes the decoded wire blob and strips the base64 padding — the form `ssh-keygen -lf` prints. Hashing the base64 text instead, or leaving the padding on, yields a plausible string no other tool agrees with, so both sample answers in the test were read from `ssh-keygen` rather than derived. The key's trailing comment carries a username and a hostname; a fingerprint does not.

`test_the_dry_run_names_every_file_only_its_owner_may_read` resolved the written path through assignments only, so a write through `destinations()` reached it as the bare name `path`. Both AST tests now share one `_bindings_in`; pointing `destinations()` at `.ssh/somewhere_else` turns the check red.