### PR TITLE
vm: keep the static-address fixture off the local campaign

### DIFF
--- a/tests/unit/test_harness.py
+++ b/tests/unit/test_harness.py
@@ -150,12 +150,38 @@ NOT_IN_THE_CAMPAIGN: Final[frozenset[str]] = frozenset(
         # medium the campaign boots, because the machine under test has to
         # have a bootloader of its own to arm.
         "vm-ram.toml",
+        # The only fixture that configures a static address, and the interface
+        # it has to pin is the cluster's: a local guest presents `enp0s2` where
+        # the cluster presents `ens18`, so `[Match] Name=ens18` matches nothing
+        # and networkd applies no address. Measured 2026-08-24 on
+        # `2c9728a81d97e`: the address, route and resolver checks all failed
+        # while `network` passed, and every recorded pass of this fixture is a
+        # cluster run.
+        "static-ip.toml",
         # The dd runner generates its sources, streams each one from the driver
         # CD, and reads the target back; neither target can boot as a system.
         "vm-dd-raw.toml",
         "vm-dd-gz.toml",
     }
 )
+
+
+def test_no_local_run_configures_an_address_the_guest_cannot_match() -> None:
+    """A static address needs the interface named, and the name is decided by
+    the hypervisor's slot layout: `ens18` on the cluster, `enp0s2` under local
+    qemu. A fixture pinning one of them is green on that runner and red on the
+    other for a reason no check reports as an environment mismatch."""
+    from gentoo_install.exec.config import load
+    from tests.vm.campaign import STAGES
+
+    scheduled = {Path(run.config).stem for runs in STAGES.values() for run in runs}
+    configuring = {
+        one.stem
+        for one in sorted(Path("tests/fixtures").glob("*.toml"))
+        if load(one).system.addresses
+    }
+    assert configuring, "a fixture with a static address is what this measures"
+    assert not configuring & scheduled, sorted(configuring & scheduled)
 
 
 def test_the_campaign_covers_every_vm_fixture() -> None:

--- a/tests/vm/campaign.py
+++ b/tests/vm/campaign.py
@@ -184,7 +184,6 @@ STAGES: Final[dict[str, tuple[Run, ...]]] = {
         # fixture set it, so nothing had ever installed a machine that comes up
         # on an address, a gateway and a resolver it was given. `cluster.py`
         # rewrites the address to the one the scheduler reserved.
-        Run("fixtures/static-ip.toml"),
         Run("fixtures/vm-openrc-desktop.toml", weight=2, cpus=10),
         Run("fixtures/vm-gnome.toml", weight=2, cpus=10),
         # Three more nothing had ever installed: raidz needs a third disk,


### PR DESCRIPTION
Run `static-ip` on a local guest and its address, route and resolver checks fail while `network` passes. The cause is one line of the run log: the guest's interface is `enp0s2` and the fixture pins `interface = "ens18"`, which is what the cluster presents. `[Match] Name=ens18` matches nothing, so networkd applies no address and the three checks are right to be red.

The fixture's own header says its addresses are the cluster's segment, and every row in `TESTED.md` naming it is a cluster run — but `campaign.py` scheduled it locally anyway, and nobody had run it there. A fixture that only ever ran in one environment looks identical, on a list, to one that cannot pass in the other.

The rule is derived from the configuration rather than from the name: a fixture with a static address stays off the local campaign, because the interface name comes from the hypervisor's slot layout. Putting `static-ip` back into `STAGES` turns it red with `['static-ip']`.