### PR TITLE
vm: read the authorized_keys back off the installed machine

### DIFF
--- a/tests/unit/test_harness.py
+++ b/tests/unit/test_harness.py
@@ -588,6 +588,8 @@ def test_every_installed_check_is_line_bounded_or_names_why_it_is_not() -> None:
         ("greetd service", "requires default service and process lines"),
         ("greetd config", "requires constraints across greetd config lines"),
         ("inputmethod", "requires the binary and every environment line"),
+        ("authorized keys root", "requires every fingerprint and both modes"),
+        ("authorized keys zakk", "requires every fingerprint and both modes"),
     }
     for installation in configurations:
         for check in checks(installation):
@@ -5565,3 +5567,35 @@ def test_a_reader_removes_the_colour_systemctl_writes_to_a_terminal() -> None:
         pattern = network[0].pattern.encode()
         assert re.search(pattern, said) is None, "the raw bytes must not match"
         assert re.search(pattern, plain(said)) is not None, plain(said)
+
+
+def test_the_installed_key_check_rejects_a_file_sshd_would_ignore() -> None:
+    """The file that decides who can log in was never read back: the plan said
+    it was written and no check opened it. sshd ignores an `authorized_keys`
+    that is group or world writable and says so only in its own log, so the
+    modes are as much of the answer as the key is."""
+    import re
+
+    from gentoo_install.exec.config import load
+    from gentoo_install.model.sshkey import fingerprint
+    from tests.vm.installed import checks
+
+    installation = load(Path("tests/fixtures/vm-unlock.toml"))
+    found = [one for one in checks(installation) if one.name.startswith("authorized keys")]
+    assert found, [one.name for one in checks(installation)]
+
+    printed = fingerprint(installation.system.authorized_keys[0])
+    good = (
+        f"2048 {printed} root@example (RSA)\n"
+        "ACL 600 /root/.ssh/authorized_keys\n"
+        "ACL 700 /root/.ssh\n"
+    )
+    for check in found:
+        assert re.search(check.pattern, good), check.name
+        for broken, why in (
+            (good.replace("ACL 600", "ACL 644"), "a world-readable file"),
+            (good.replace("ACL 700", "ACL 755"), "a world-readable directory"),
+            (good.replace(printed[7:20], "Z" * 13), "a different key"),
+            ("ssh-keygen: /root/.ssh/authorized_keys: No such file\n", "no file at all"),
+        ):
+            assert not re.search(check.pattern, broken), (check.name, why)

--- a/tests/vm/installed.py
+++ b/tests/vm/installed.py
@@ -28,7 +28,9 @@ from gentoo_install.model.device import (
 )
 from gentoo_install.plan.mounts import ResolvedMount, resolve_mounts
 from gentoo_install.plan.packages import ENVIRONMENT_FILE, input_environment
+from gentoo_install.model.sshkey import fingerprint
 from gentoo_install.plan.system import _network_service as network_service
+from gentoo_install.plan.system import key_accounts
 from gentoo_install.plan.system import _sshd_service as sshd_service
 
 from .console import DISK_PASSPHRASE
@@ -245,6 +247,31 @@ def checks(installation: InstallConfig) -> tuple[InstalledCheck, ...]:
                     "sshd",
                     "rc-update show default",
                     rf"(?m)^[ \t]*{sshd_service()}[ \t]*\|[ \t]*default$",
+                )
+            )
+    if installation.system.authorized_keys and installation.system.sshd:
+        # The file that decides who can log in, read back from the machine
+        # rather than assumed from the plan. `ssh-keygen -l` computes the
+        # fingerprint on the guest, so the answer cannot come from the echo of
+        # the question, and `stat` answers with the modes sshd requires:
+        # sshd ignores an `authorized_keys` group or world writable, and says
+        # so only in its own log.
+        for name, home in key_accounts(
+            installation.system, installation.kernel.remote_unlock.enabled
+        ):
+            path = f"{home}/.ssh/authorized_keys"
+            required = [
+                re.escape(fingerprint(key))
+                for key in installation.system.authorized_keys
+            ]
+            required.append(rf"ACL 600 {re.escape(path)}")
+            required.append(rf"ACL 700 {re.escape(home)}/\.ssh")
+            result.append(
+                InstalledCheck(
+                    f"authorized keys {name}",
+                    f"ssh-keygen -lf {path}; stat -c 'ACL %a %n' {path} {home}/.ssh",
+                    "(?s)" + "".join(f"(?=.*{one})" for one in required),
+                    line_boundary_exception="requires every fingerprint and both modes",
                 )
             )
     if installation.system.zram is not None:


### PR DESCRIPTION
`tests/vm/installed.py` had no check that touched `authorized_keys` on the installed system. The two key-related checks it does carry look at the ZFSBootMenu image's acl and at the remote-unlock flow; neither opens the file the booted machine authenticates against.

The check asks for values the guest computes rather than repeating the question back: `ssh-keygen -lf` produces the fingerprint there, and `stat -c 'ACL %a %n'` produces the modes. The modes are as much of the answer as the key — sshd ignores an `authorized_keys` that is group or world writable and says so only in its own log.

Written and then run before being believed, which is how the first version was caught: `fingerprint()` already carries the `SHA256:` prefix and the pattern asked for `SHA256:SHA256:`, so it could never have matched. It now accepts a correct answer and rejects a 644 file, a 755 directory, a different key and a missing file; loosening the mode to `ACL [0-9]+` turns the unit test red.