### PR TITLE
vm: name the guests an earlier campaign left behind

### DIFF
--- a/tests/unit/test_cluster.py
+++ b/tests/unit/test_cluster.py
@@ -20,7 +20,7 @@ from tests.vm import cluster
 
 FIXTURES = Path(__file__).resolve().parents[1] / "fixtures"
 from tests.vm.console import ConsoleTimeout, SerialConsole, command_done
-from tests.vm.proxmox import Api, Node, ProxmoxNotFound, VMID_FIRST, VMID_LAST
+from tests.vm.proxmox import Api, Node, ProxmoxError, ProxmoxNotFound, VMID_FIRST, VMID_LAST
 
 
 class WorkerFailure(Exception):
@@ -73,6 +73,9 @@ class FakeApi:
             vmid = int(form["vmid"])
             self.created[vmid] = str(form["tags"])
             return "UPID:create"
+        if path.startswith("/cluster/resources"):
+            # The startup orphan report asks; this world has no leftovers.
+            return []
         vmid = int(path.split("/qemu/", 1)[1].split("/", 1)[0])
         if vmid not in self.created:
             raise ProxmoxNotFound(f"VM {vmid} does not exist")
@@ -3987,3 +3990,45 @@ def test_the_probe_records_what_the_lookups_were_asked_with() -> None:
     # Absent is an answer too. A guest with no resolver file at all is the
     # case the lookups cannot distinguish from a resolver that says nothing.
     assert probe.count("printf 'absent'") >= 2, probe
+
+
+def test_a_campaign_names_the_guests_an_earlier_one_left_behind() -> None:
+    """Eight stopped guests held 202 GiB of a 234 GiB pool on 2026-08-24,
+    left by campaigns whose process was killed before their cleanup ran. The
+    next campaign has to say so: nothing else in the run's output distinguishes
+    a pool that is nearly full from one that is filling up."""
+
+    class Listing:
+        def __init__(self, answer: object) -> None:
+            self.answer = answer
+
+        def call(self, method: str, path: str, **form: object) -> object:
+            assert method == "GET" and path.startswith("/cluster/resources")
+            if isinstance(self.answer, Exception):
+                raise self.answer
+            return self.answer
+
+    left = [
+        {"vmid": 9301, "node": "infra-node3", "name": "gi-s1", "status": "stopped",
+         "maxdisk": 40 * 2**30},
+        {"vmid": 9306, "node": "infra-node6", "name": "gi-s8", "status": "stopped",
+         "maxdisk": 40 * 2**30},
+    ]
+    running = {"vmid": 9303, "node": "infra-node1", "name": "gi-static-ip",
+               "status": "running", "maxdisk": 40 * 2**30}
+    # Deliberate infrastructure, and stopped: a leftover sweep that names it
+    # sends somebody to delete the thing the resolvers fall back to.
+    resolver = {"vmid": 9390, "node": "infra-node4", "name": "gi-resolver",
+                "status": "stopped", "maxdisk": 2 * 2**30}
+    others = {"vmid": 120, "node": "infra-node2", "name": "somebody-elses",
+              "status": "stopped", "maxdisk": 100 * 2**30}
+
+    said = cluster.orphan_report(cast(Any, Listing([*left, running, resolver, others])))
+    assert len(said) == 1, said
+    assert "2 stopped guest" in said[0] and "80 GiB" in said[0], said[0]
+    assert "9301 on infra-node3" in said[0] and "9306 on infra-node6" in said[0], said[0]
+    for absent in ("gi-static-ip", "9303", "9390", "120"):
+        assert absent not in said[0], (absent, said[0])
+
+    assert cluster.orphan_report(cast(Any, Listing([running, resolver]))) == []
+    assert cluster.orphan_report(cast(Any, Listing(ProxmoxError("no answer")))) == []

--- a/tests/unit/test_harness.py
+++ b/tests/unit/test_harness.py
@@ -1626,6 +1626,10 @@ def test_zero_cluster_capacity_returns_an_error_after_a_deadline(
         def nodes(self) -> list[Any]:
             return []
 
+        def call(self, method: str, path: str, **form: Any) -> Any:
+            # The startup orphan report asks; an empty cluster has none.
+            return []
+
         def remove_iso(self, node: str, name: str) -> str:
             return ""
 
@@ -1701,6 +1705,9 @@ def test_reconcile_removes_only_an_expired_locally_leased_guest(
             return [("node", 9300), ("node", 9301), ("node", 9302)]
 
         def call(self, method: str, path: str, **form: Any) -> Any:
+            if path.startswith("/cluster/resources"):
+                # The startup orphan report asks; this world has no leftovers.
+                return []
             vmid = int(path.split("/qemu/", 1)[1].split("/", 1)[0])
             if path.endswith("/config"):
                 if self.absent:

--- a/tests/vm/cluster.py
+++ b/tests/vm/cluster.py
@@ -1553,6 +1553,44 @@ def trusted_revision(identity: str) -> bool:
     return bool(identity) and (dirty is None or dirty.group(1) == "0")
 
 
+#: A guest this runner made. `gi-resolver` is deliberate infrastructure and
+#: not a leftover, so it is excluded by name rather than by being running.
+_ORPHAN_NAME: Final[re.Pattern[str]] = re.compile(r"gi-(?!resolver$).+")
+
+
+def orphan_report(api: Api) -> list[str]:
+    """Stopped guests this runner made and did not delete, named so a reader
+    can reclaim them.
+
+    Eight of them held 202 GiB of a 234 GiB pool on 2026-08-24, left by
+    campaigns whose process was killed before their cleanup ran. Reported and
+    not deleted: another campaign's guests carry the same names, and there is
+    nothing here that can tell one runner's leftovers from another's live set.
+    """
+    try:
+        resources = api.call("GET", "/cluster/resources?type=vm")
+    except ProxmoxError:
+        # A listing that fails is not a reason to refuse a campaign; the
+        # schedule's own calls report their failures on their own.
+        return []
+    orphans = [
+        one
+        for one in resources
+        if _ORPHAN_NAME.fullmatch(str(one.get("name", "")))
+        and str(one.get("status", "")) != "running"
+    ]
+    if not orphans:
+        return []
+    held = sum(int(one.get("maxdisk", 0)) for one in orphans) / 2**30
+    named = ", ".join(f"{one['vmid']} on {one['node']}" for one in sorted(
+        orphans, key=lambda one: int(one["vmid"])
+    ))
+    return [
+        f"{len(orphans)} stopped guest(s) from an earlier campaign hold "
+        f"{held:.0f} GiB: {named}"
+    ]
+
+
 def free_slots(
     api: Api,
     placed: Mapping[str, int] | None = None,
@@ -2574,6 +2612,8 @@ def run(
     # is the file a reader opens first, and identifying which revision run109
     # measured meant reading a guest log that a later round had overwritten.
     print(f"installer revision: {revision}", flush=True)
+    for line in orphan_report(api):
+        print(line, flush=True)
     medium, urls, medium_sha512 = current_minimal()
     prepared: set[str] = set()
     # A node whose console proxy went away takes no more guests: three runs on


### PR DESCRIPTION
Starting tonight's campaign found eight stopped `gi-` guests on the cluster holding 202 GiB of a 234 GiB pool, left by earlier campaigns whose process was killed before their cleanup ran. Nothing in a run's output said so; the next campaign would have failed on storage with no explanation.

The sweep reports and does not delete. Another campaign's guests carry the same names, and there is nothing available here that separates one runner's leftovers from another runner's live set — deleting on that basis would end somebody else's run.

`gi-resolver` is excluded by name because it is deliberate infrastructure that happens to be stopped; a sweep that named it would send somebody to delete what the guest resolvers fall back to. Loosening the pattern to `gi-.+` turns the test red with `3 stopped guest(s) … 9390 on infra-node4`.