### PR TITLE
docs: the reference and the record disagreed about binhost fallback

### DIFF
--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -478,7 +478,7 @@ path = "/"
 
 ## Binary packages
 
-Binary packages are optional. Disabling them keeps source builds available. The official binhost and the gentoo-zh binhost are separate options with separate trust configuration. No current end-to-end evidence covers an unreachable binhost, a missing signature or an untrusted key; these degradation paths remain unverified.
+Binary packages are optional. Disabling them keeps source builds available. The official binhost and the gentoo-zh binhost are separate options with separate trust configuration. One degradation path has end-to-end evidence: `TESTED.md` records `vm-binhost-fallback` on `e16f57a39199d` installing from source after its host served no package index, with the reason in the journal. That fixture no longer reproduces it — the same host answered on 2026-08-24 — so the path is recorded rather than currently exercised. A missing signature and an untrusted key have no end-to-end evidence and remain unverified.
 
 A verified binhost runs `getuto`, imports its signing key, locally signs that key with `lsign`, and enables signature verification. A failed host, missing signature, or untrusted key degrades that binhost to source compilation and records the reason.
 

--- a/TESTED.md
+++ b/TESTED.md
@@ -410,8 +410,12 @@ with the screen behind it refusing to open, so the install could never start.
 
 greetd desktop sessions and ibus outside GNOME. Binary-host failure
 fallback left this list on `e16f57a39199d`: `vm-binhost-fallback` installed
-against a host whose index answers 404, recorded the degradation and finished
-from source.
+against a host whose index answered 404, recorded the degradation and finished
+from source. **It is back on this list as of `7f55e45a53102`**: the same host
+served packages that day, the run finished with nothing degraded, and the
+check added in `#996` reported it rather than recording an ordinary binary
+package install as coverage. A fixture whose failure is borrowed from the
+outside world stops measuring on a day nobody chooses.
 
 CJK text-console rendering is not covered either, and the `vm-cjk-kernel` row
 above does not cover it: that run establishes that the patched kernel merges,


### PR DESCRIPTION
`TESTED.md` records `vm-binhost-fallback` on `e16f57a39199d`: a real machine whose journal holds one `degraded` event naming the host that served no index, and an install that finished from source. `REFERENCE.md` said no end-to-end evidence covers an unreachable binhost. Both are in the repository and both are factual claims.

The reference now separates the three paths: the unreachable one is recorded, a missing signature and an untrusted key are not. It also says the recorded one no longer reproduces — the same host served packages on 2026-08-24, and tonight's cluster run finished with nothing degraded.

`TESTED.md` puts the fixture back on its uncovered list with the reason, because a fixture whose failure is borrowed from the outside world stops measuring on a day nobody chooses. The check from #996 is what reported it instead of recording an ordinary binary package install as coverage.