### PR TITLE
plan: name the authorized_keys paths the dry-run writes

### DIFF
--- a/gentoo_install/data/locale/ja.toml
+++ b/gentoo_install/data/locale/ja.toml
@@ -624,7 +624,7 @@
 "write {} for the wired interfaces with DHCP and DNS {}" = "{} に書き込む：有線インターフェースは DHCP、DNS {}"
 "write {} for {} with DHCP" = "{} に書き込む：インターフェース {} は DHCP"
 "enable net.{} so netifrc applies the static address" = "net.{} を有効にして netifrc に静的アドレスを適用させる"
-"write {} into authorized_keys for {}" = "{} を {} の authorized_keys に書き込む"
+"write {} into {}" = "{} を {} に書き込む"
 "ssh password login: on, root: on, in 50-gentoo-install.conf" = "SSH パスワードログイン：有効、root：有効（50-gentoo-install.conf）"
 "ssh password login: on, root: off, in 50-gentoo-install.conf" = "SSH パスワードログイン：有効、root：無効（50-gentoo-install.conf）"
 "ssh password login: off, root: on, in 50-gentoo-install.conf" = "SSH パスワードログイン：無効、root：有効（50-gentoo-install.conf）"

--- a/gentoo_install/data/locale/ko.toml
+++ b/gentoo_install/data/locale/ko.toml
@@ -624,7 +624,7 @@
 "write {} for the wired interfaces with DHCP and DNS {}" = "{} 작성: 유선 인터페이스, DHCP, DNS {}"
 "write {} for {} with DHCP" = "{} 작성: 인터페이스 {}, DHCP"
 "enable net.{} so netifrc applies the static address" = "net.{}를 활성화하여 netifrc가 고정 주소를 적용하게 함"
-"write {} into authorized_keys for {}" = "{}를 {}의 authorized_keys에 작성"
+"write {} into {}" = "{}를 {}에 작성"
 "ssh password login: on, root: on, in 50-gentoo-install.conf" = "SSH 비밀번호 로그인: 켬, root: 켬 (50-gentoo-install.conf)"
 "ssh password login: on, root: off, in 50-gentoo-install.conf" = "SSH 비밀번호 로그인: 켬, root: 끔 (50-gentoo-install.conf)"
 "ssh password login: off, root: on, in 50-gentoo-install.conf" = "SSH 비밀번호 로그인: 끔, root: 켬 (50-gentoo-install.conf)"

--- a/gentoo_install/data/locale/zh-CN.toml
+++ b/gentoo_install/data/locale/zh-CN.toml
@@ -625,7 +625,7 @@
 "write {} for the wired interfaces with DHCP and DNS {}" = "写入 {}；有线接口使用 DHCP，DNS {}"
 "write {} for {} with DHCP" = "写入 {}；接口 {} 使用 DHCP"
 "enable net.{} so netifrc applies the static address" = "启用 net.{}，让 netifrc 应用静态地址"
-"write {} into authorized_keys for {}" = "将 {} 写入 {} 的 authorized_keys"
+"write {} into {}" = "将 {} 写入 {}"
 "ssh password login: on, root: on, in 50-gentoo-install.conf" = "SSH 密码登录：开启；root：开启，写入 50-gentoo-install.conf"
 "ssh password login: on, root: off, in 50-gentoo-install.conf" = "SSH 密码登录：开启；root：关闭，写入 50-gentoo-install.conf"
 "ssh password login: off, root: on, in 50-gentoo-install.conf" = "SSH 密码登录：关闭；root：开启，写入 50-gentoo-install.conf"

--- a/gentoo_install/data/locale/zh-TW.toml
+++ b/gentoo_install/data/locale/zh-TW.toml
@@ -625,7 +625,7 @@
 "write {} for the wired interfaces with DHCP and DNS {}" = "寫入 {}；有線網路介面使用 DHCP，DNS {}"
 "write {} for {} with DHCP" = "寫入 {}；介面 {} 使用 DHCP"
 "enable net.{} so netifrc applies the static address" = "啟用 net.{}，讓 netifrc 套用靜態位址"
-"write {} into authorized_keys for {}" = "將 {} 寫入 {} 的 authorized_keys"
+"write {} into {}" = "將 {} 寫入 {}"
 "ssh password login: on, root: on, in 50-gentoo-install.conf" = "SSH 密碼登入：開啟；root：開啟，寫入 50-gentoo-install.conf"
 "ssh password login: on, root: off, in 50-gentoo-install.conf" = "SSH 密碼登入：開啟；root：關閉，寫入 50-gentoo-install.conf"
 "ssh password login: off, root: on, in 50-gentoo-install.conf" = "SSH 密碼登入：關閉；root：開啟，寫入 50-gentoo-install.conf"

--- a/gentoo_install/plan/system.py
+++ b/gentoo_install/plan/system.py
@@ -829,10 +829,10 @@ class WriteAuthorizedKeys(Operation):
     def describe_parts(self) -> tuple[str, tuple[str, ...]]:
         # The count alone let one key be swapped for another without a
         # character of the dry-run changing, on the setting that decides who
-        # can log in.
-        who = ", ".join(name for name, _ in self.accounts)
+        # can log in. The paths and not the account names: the paths carry the
+        # names, and an operation that says both says one of them twice.
         keys = ", ".join(fingerprint(key) for key in self.keys) or "-"
-        return "write {} into authorized_keys for {}", (keys, who)
+        return "write {} into {}", (keys, _named(self.destinations()))
 
     def apply(self, context: Context) -> None:
         body = "".join(f"{key}\n" for key in self.keys)

--- a/tests/golden/vm-unlock.txt
+++ b/tests/golden/vm-unlock.txt
@@ -61,7 +61,7 @@
   write /etc/fstab with UUID from root-luks / btrfs defaults,compress=zstd:1,subvol=@ 0 1, UUID from boot /boot ext4 defaults 0 2, UUID from esp /efi vfat defaults,umask=0077 0 2, UUID from root-luks /home btrfs defaults,compress=zstd:1,subvol=@home 0 2
   treat the hardware clock as UTC in /etc/adjtime
   write /etc/crypttab with root UUID from cryptroot luks,x-initrd.attach
-  write SHA256:wBQUIpTF0DPsPEUeafUC1YRHr0N0LIdt+LtbxepvlkQ into authorized_keys for root
+  write SHA256:wBQUIpTF0DPsPEUeafUC1YRHr0N0LIdt+LtbxepvlkQ into /root/.ssh/authorized_keys
   set the root password
   install sshd: emerge net-misc/openssh
   ssh password login: off, root: off, in 50-gentoo-install.conf

--- a/tests/golden/zbm-unlock.txt
+++ b/tests/golden/zbm-unlock.txt
@@ -64,7 +64,7 @@
   write /etc/fstab with UUID from esp /efi vfat defaults,umask=0077 0 2
   treat the hardware clock as UTC in /etc/adjtime
   create user zakk in users, wheel, audio, video, render, usb, input with a password
-  write SHA256:wBQUIpTF0DPsPEUeafUC1YRHr0N0LIdt+LtbxepvlkQ into authorized_keys for root, zakk
+  write SHA256:wBQUIpTF0DPsPEUeafUC1YRHr0N0LIdt+LtbxepvlkQ into /root/.ssh/authorized_keys and /home/zakk/.ssh/authorized_keys
   set the root password
   install sudo: emerge app-admin/sudo
   let the wheel group run sudo, with a password

--- a/tests/golden/zfs-zbm.txt
+++ b/tests/golden/zfs-zbm.txt
@@ -62,7 +62,7 @@
   write /etc/fstab with UUID from esp /efi vfat defaults,umask=0077 0 2
   treat the hardware clock as UTC in /etc/adjtime
   create user zakk in users, wheel, audio, video, render, usb, input with a password
-  write SHA256:wBQUIpTF0DPsPEUeafUC1YRHr0N0LIdt+LtbxepvlkQ into authorized_keys for zakk
+  write SHA256:wBQUIpTF0DPsPEUeafUC1YRHr0N0LIdt+LtbxepvlkQ into /home/zakk/.ssh/authorized_keys
   set the root password
   install sudo: emerge app-admin/sudo
   let the wheel group run sudo, with a password

--- a/tests/unit/test_i18n.py
+++ b/tests/unit/test_i18n.py
@@ -548,7 +548,7 @@ REVIEWED_TEMPLATES: frozenset[str] = frozenset(
         "write /etc/portage/make.conf with {}; {} mirrors in the configured order,"
         " {} appended",
         "write /etc/kernel/cmdline with root {}; luks {}; arrays {}; keymap {}; parameters {}",
-        "write {} into authorized_keys for {}",
+        "write {} into {}",
         "write {} with {}",
         "{}: emerge {}",
         "{}: emerge {}, building {} here",

--- a/tests/unit/test_layers.py
+++ b/tests/unit/test_layers.py
@@ -650,6 +650,7 @@ def test_the_dry_run_names_every_file_only_its_owner_may_read() -> None:
     thirty of them still name no file, and that is `docs/tasks.md` row 241.
     """
     private = 0
+    derived_here: set[str] = set()
     for module in _modules("plan"):
         tree = ast.parse(module.read_text(encoding="utf-8"))
         known: dict[str, ast.expr] = {}
@@ -665,6 +666,14 @@ def test_the_dry_run_names_every_file_only_its_owner_may_read() -> None:
             body = {one.name: one for one in cls.body if isinstance(one, ast.FunctionDef)}
             describing = body.get("describe") or body.get("describe_parts")
             if "apply" not in body or describing is None:
+                continue
+            if "destinations" in body:
+                # Its description names the file through
+                # `_named(self.destinations())`, so the source holds `{}`
+                # where the path goes. `test_plan_system.py` renders the plan
+                # and checks the paths are there; counted so a class that
+                # leaves this rule is visible.
+                derived_here.add(cls.name)
                 continue
             said = ast.unparse(describing)
             reachable = _bindings_in(body, known)
@@ -689,6 +698,18 @@ def test_the_dry_run_names_every_file_only_its_owner_may_read() -> None:
                 )
     # The same denominator: twelve writes carry `0600` or `0400` today.
     assert private >= 10, private
+    # Named rather than counted: a class leaving this rule has to be a
+    # decision, and the name is what makes it one.
+    assert derived_here == {
+        "ConfigureConsole",
+        "ConfigureZram",
+        "SelectLocale",
+        "SetHardwareClock",
+        "SetHostname",
+        "WriteAuthorizedKeys",
+        "WriteMachineId",
+        "WriteNetworkConfig",
+    }, sorted(derived_here)
 
 
 def test_the_proxy_endpoint_is_defined_once() -> None:

--- a/tests/unit/test_plan_system.py
+++ b/tests/unit/test_plan_system.py
@@ -1516,6 +1516,48 @@ def test_networkmanager_is_matched_by_mac_too() -> None:
     assert "interface-name" not in written, written
 
 
+def test_every_derived_destination_is_named_by_the_description() -> None:
+    """The source-reading rule in `tests/unit/test_layers.py` cannot see these.
+
+    `describe_parts` returns a template, and the path reaches the text only
+    when `_named(self.destinations())` is formatted into it, so a check that
+    reads the source finds `{}` where the file should be. Rendered here
+    instead: `describe()` has to hold every path `apply()` writes.
+    """
+    from pathlib import Path
+
+    from gentoo_install.data import load_catalog
+    from gentoo_install.exec.config import load
+    from gentoo_install.model.config import DiskMode
+    from gentoo_install.plan.build import build
+
+    catalog = load_catalog()
+    checked = 0
+    for fixture in sorted(Path("tests/fixtures").glob("*.toml")):
+        loaded = load(fixture)
+        if loaded.disk.layout_is_read_from_the_machine:
+            continue
+        variants = [loaded]
+        if loaded.disk.mode is DiskMode.PARTITION and loaded.system.init is InitSystem.SYSTEMD:
+            variants.append(
+                replace(
+                    loaded,
+                    system=replace(loaded.system, init=InitSystem.OPENRC),
+                    portage=replace(loaded.portage, profile="default/linux/amd64/23.0"),
+                )
+            )
+        for installation in variants:
+            for operation in build(installation, catalog):
+                named = getattr(operation, "destinations", None)
+                if named is None:
+                    continue
+                said = operation.describe()
+                for path in named():
+                    assert str(path) in said, (fixture.name, type(operation).__name__, str(path), said)
+                    checked += 1
+    assert checked > 40, checked
+
+
 def test_every_operation_that_names_a_file_writes_exactly_the_files_it_named() -> None:
     """`describe()` and `apply()` read one derivation, so they cannot drift.
 


### PR DESCRIPTION
The source-reading rule in `test_layers.py` cannot see a description that reaches its path through `_named(self.destinations())`: `describe_parts` returns a template, and the source holds `{}` where the file goes. So the eight operations that derive their destinations looked covered by that rule and were not — the eight are named in it now, and a ninth leaving it has to be a decision.

Rendered instead: `test_every_derived_destination_is_named_by_the_description` builds each fixture's plan under both inits and requires `describe()` to hold every path `destinations()` returns. It found one straight away — `WriteAuthorizedKeys` said `into authorized_keys for root` and named neither `/root/.ssh/authorized_keys` nor the sudo user's.

The account names go with it: the paths already carry them, and an operation that prints both prints one of them twice. Control: putting the literal `"authorized_keys"` back as the second argument turns the new rule red.