### PR TITLE
portage: name the three autounmask files in the dry-run

### DIFF
--- a/gentoo_install/data/locale/ja.toml
+++ b/gentoo_install/data/locale/ja.toml
@@ -655,7 +655,7 @@
 "write /etc/portage/make.conf with {}; {} mirrors in the configured order, {} appended" = "{} を含む /etc/portage/make.conf を書き込み、{} 個のミラーを設定順にし、{} 個を追加"
 "write /etc/portage/make.conf with {}; {} mirrors in the configured order" = "{} を含む /etc/portage/make.conf を書き込み、{} 個のミラーを設定順にする"
 "write {}" = "{} を書き込む"
-"create the three autounmask files emerge writes its decisions into" = "emerge が判断を書き込む三つの autounmask ファイルを作成"
+"create {}, which emerge writes its decisions into" = "{} を作成し、emerge の判断をそこに書き込ませる"
 "point repository {} at {}, commit signatures verified" = "リポジトリー {} を {} に向け、コミット署名を検証"
 "point repository {} at {}" = "リポジトリー {} を {} に向ける"
 "configure repository {} to sync with emerge-webrsync" = "リポジトリー {} を emerge-webrsync で同期するよう設定"

--- a/gentoo_install/data/locale/ko.toml
+++ b/gentoo_install/data/locale/ko.toml
@@ -655,7 +655,7 @@
 "write /etc/portage/make.conf with {}; {} mirrors in the configured order, {} appended" = "{}를 포함한 /etc/portage/make.conf를 작성하고 {}개 미러를 설정순으로 정렬하며 {}개를 추가"
 "write /etc/portage/make.conf with {}; {} mirrors in the configured order" = "{}를 포함한 /etc/portage/make.conf를 작성하고 {}개 미러를 설정순으로 정렬"
 "write {}" = "{} 작성"
-"create the three autounmask files emerge writes its decisions into" = "emerge가 결정을 기록하는 세 개의 autounmask 파일 생성"
+"create {}, which emerge writes its decisions into" = "{} 생성: emerge가 결정을 여기에 작성"
 "point repository {} at {}, commit signatures verified" = "저장소 {}를 {}로 지정하고 커밋 서명 검증"
 "point repository {} at {}" = "저장소 {}를 {}로 지정"
 "configure repository {} to sync with emerge-webrsync" = "저장소 {}가 emerge-webrsync로 동기화되도록 구성"

--- a/gentoo_install/data/locale/zh-CN.toml
+++ b/gentoo_install/data/locale/zh-CN.toml
@@ -656,7 +656,7 @@
 "write /etc/portage/make.conf with {}; {} mirrors in the configured order, {} appended" = "写入 /etc/portage/make.conf，包含 {}；{} 个镜像按配置顺序，追加 {} 个"
 "write /etc/portage/make.conf with {}; {} mirrors in the configured order" = "写入 /etc/portage/make.conf，包含 {}；{} 个镜像按配置顺序"
 "write {}" = "写入 {}"
-"create the three autounmask files emerge writes its decisions into" = "创建 emerge 写入决定的三个 autounmask 文件"
+"create {}, which emerge writes its decisions into" = "创建 {}，emerge 会把它的决定写进去"
 "point repository {} at {}, commit signatures verified" = "将仓库 {} 指向 {}，验证提交签名"
 "point repository {} at {}" = "将仓库 {} 指向 {}"
 "configure repository {} to sync with emerge-webrsync" = "配置仓库 {} 使用 emerge-webrsync 同步"

--- a/gentoo_install/data/locale/zh-TW.toml
+++ b/gentoo_install/data/locale/zh-TW.toml
@@ -656,7 +656,7 @@
 "write /etc/portage/make.conf with {}; {} mirrors in the configured order, {} appended" = "寫入含有 {} 的 /etc/portage/make.conf；{} 個鏡像依設定順序，另加 {} 個"
 "write /etc/portage/make.conf with {}; {} mirrors in the configured order" = "寫入含有 {} 的 /etc/portage/make.conf；{} 個鏡像依設定順序"
 "write {}" = "寫入 {}"
-"create the three autounmask files emerge writes its decisions into" = "建立 emerge 寫入決定的三個 autounmask 檔案"
+"create {}, which emerge writes its decisions into" = "建立 {}，emerge 會把它的決定寫進去"
 "point repository {} at {}, commit signatures verified" = "將套件庫 {} 指向 {}，並驗證提交簽章"
 "point repository {} at {}" = "將套件庫 {} 指向 {}"
 "configure repository {} to sync with emerge-webrsync" = "設定套件庫 {} 使用 emerge-webrsync 同步"

--- a/gentoo_install/plan/portage.py
+++ b/gentoo_install/plan/portage.py
@@ -458,12 +458,17 @@ def merge(existing: str, wanted: Sequence[tuple[str, str]]) -> str:
 class CreateAutounmaskFiles(Operation):
     stage: Stage = Stage.PORTAGE
 
+    def destinations(self) -> tuple[PurePosixPath, ...]:
+        return tuple(PurePosixPath(one) for one in AUTOUNMASK_FILES)
+
     def describe_parts(self) -> tuple[str, tuple[str, ...]]:
-        return "create the three autounmask files emerge writes its decisions into", ()
+        return "create {}, which emerge writes its decisions into", (
+            ", ".join(str(one) for one in self.destinations()),
+        )
 
     def apply(self, context: Context) -> None:
-        for path in AUTOUNMASK_FILES:
-            context.write(PurePosixPath(path), "")
+        for path in self.destinations():
+            context.write(path, "")
 
 
 @dataclass(frozen=True, kw_only=True)

--- a/tests/golden/btrfs-luks.txt
+++ b/tests/golden/btrfs-luks.txt
@@ -31,7 +31,7 @@
 [portage]
   write /etc/portage/make.conf with COMMON_FLAGS, CFLAGS, CXXFLAGS, FCFLAGS, FFLAGS, MAKEOPTS, USE, VIDEO_CARDS, INPUT_DEVICES, ACCEPT_LICENSE, L10N, FEATURES; 23 mirrors fastest first, measured, 5 appended
   configure Portage, wget, curl, git and gpg for direct connection
-  create the three autounmask files emerge writes its decisions into
+  create /etc/portage/package.use/zz-autounmask, /etc/portage/package.accept_keywords/zz-autounmask, /etc/portage/package.license/zz-autounmask, which emerge writes its decisions into
   disable inherited binary package host gentoo
   run getuto so Portage has a keyring to verify binary packages against, and write dirmngr.conf
   import BB572E0E2D182910 from /usr/share/openpgp-keys/gentoo-release.asc, locally sign it for gentoo, and verify the local signature

--- a/tests/golden/ext2.txt
+++ b/tests/golden/ext2.txt
@@ -23,7 +23,7 @@
 [portage]
   write /etc/portage/make.conf with MAKEOPTS, INPUT_DEVICES, ACCEPT_LICENSE, L10N; 2 mirrors in the configured order, 5 appended
   configure Portage, wget, curl, git and gpg for direct connection
-  create the three autounmask files emerge writes its decisions into
+  create /etc/portage/package.use/zz-autounmask, /etc/portage/package.accept_keywords/zz-autounmask, /etc/portage/package.license/zz-autounmask, which emerge writes its decisions into
   disable inherited binary package host gentoo
   fetch the first ebuild repository snapshot with emerge-webrsync
   select profile default/linux/amd64/23.0

--- a/tests/golden/ext3.txt
+++ b/tests/golden/ext3.txt
@@ -23,7 +23,7 @@
 [portage]
   write /etc/portage/make.conf with MAKEOPTS, INPUT_DEVICES, ACCEPT_LICENSE, L10N; 2 mirrors in the configured order, 5 appended
   configure Portage, wget, curl, git and gpg for direct connection
-  create the three autounmask files emerge writes its decisions into
+  create /etc/portage/package.use/zz-autounmask, /etc/portage/package.accept_keywords/zz-autounmask, /etc/portage/package.license/zz-autounmask, which emerge writes its decisions into
   disable inherited binary package host gentoo
   fetch the first ebuild repository snapshot with emerge-webrsync
   select profile default/linux/amd64/23.0

--- a/tests/golden/ext4-bios.txt
+++ b/tests/golden/ext4-bios.txt
@@ -23,7 +23,7 @@
 [portage]
   write /etc/portage/make.conf with MAKEOPTS, INPUT_DEVICES, ACCEPT_LICENSE, L10N; 2 mirrors in the configured order, 5 appended
   configure Portage, wget, curl, git and gpg for direct connection
-  create the three autounmask files emerge writes its decisions into
+  create /etc/portage/package.use/zz-autounmask, /etc/portage/package.accept_keywords/zz-autounmask, /etc/portage/package.license/zz-autounmask, which emerge writes its decisions into
   disable inherited binary package host gentoo
   fetch the first ebuild repository snapshot with emerge-webrsync
   select profile default/linux/amd64/23.0

--- a/tests/golden/mbr-edit.txt
+++ b/tests/golden/mbr-edit.txt
@@ -20,7 +20,7 @@
 [portage]
   write /etc/portage/make.conf with MAKEOPTS, INPUT_DEVICES, ACCEPT_LICENSE, L10N, FEATURES; 2 mirrors in the configured order, 5 appended
   configure Portage, wget, curl, git and gpg for direct connection
-  create the three autounmask files emerge writes its decisions into
+  create /etc/portage/package.use/zz-autounmask, /etc/portage/package.accept_keywords/zz-autounmask, /etc/portage/package.license/zz-autounmask, which emerge writes its decisions into
   disable inherited binary package host gentoo
   run getuto so Portage has a keyring to verify binary packages against, and write dirmngr.conf
   import BB572E0E2D182910 from /usr/share/openpgp-keys/gentoo-release.asc, locally sign it for gentoo, and verify the local signature

--- a/tests/golden/openrc-sdboot.txt
+++ b/tests/golden/openrc-sdboot.txt
@@ -24,7 +24,7 @@
 [portage]
   write /etc/portage/make.conf with MAKEOPTS, INPUT_DEVICES, ACCEPT_LICENSE, L10N, FEATURES; 2 mirrors in the configured order, 5 appended
   configure Portage, wget, curl, git and gpg for direct connection
-  create the three autounmask files emerge writes its decisions into
+  create /etc/portage/package.use/zz-autounmask, /etc/portage/package.accept_keywords/zz-autounmask, /etc/portage/package.license/zz-autounmask, which emerge writes its decisions into
   disable inherited binary package host gentoo
   run getuto so Portage has a keyring to verify binary packages against, and write dirmngr.conf
   import BB572E0E2D182910 from /usr/share/openpgp-keys/gentoo-release.asc, locally sign it for gentoo, and verify the local signature

--- a/tests/golden/static-ip.txt
+++ b/tests/golden/static-ip.txt
@@ -24,7 +24,7 @@
 [portage]
   write /etc/portage/make.conf with MAKEOPTS, INPUT_DEVICES, ACCEPT_LICENSE, L10N, FEATURES; 2 mirrors in the configured order, 5 appended
   configure Portage, wget, curl, git and gpg for direct connection
-  create the three autounmask files emerge writes its decisions into
+  create /etc/portage/package.use/zz-autounmask, /etc/portage/package.accept_keywords/zz-autounmask, /etc/portage/package.license/zz-autounmask, which emerge writes its decisions into
   disable inherited binary package host gentoo
   run getuto so Portage has a keyring to verify binary packages against, and write dirmngr.conf
   import BB572E0E2D182910 from /usr/share/openpgp-keys/gentoo-release.asc, locally sign it for gentoo, and verify the local signature

--- a/tests/golden/vm-binhost-fallback.txt
+++ b/tests/golden/vm-binhost-fallback.txt
@@ -24,7 +24,7 @@
 [portage]
   write /etc/portage/make.conf with MAKEOPTS, INPUT_DEVICES, ACCEPT_LICENSE, L10N, FEATURES; 23 mirrors in the configured order, 5 appended
   configure Portage, wget, curl, git and gpg for direct connection
-  create the three autounmask files emerge writes its decisions into
+  create /etc/portage/package.use/zz-autounmask, /etc/portage/package.accept_keywords/zz-autounmask, /etc/portage/package.license/zz-autounmask, which emerge writes its decisions into
   disable inherited binary package host gentoo
   run getuto so Portage has a keyring to verify binary packages against, and write dirmngr.conf
   import BB572E0E2D182910 from /usr/share/openpgp-keys/gentoo-release.asc, locally sign it for gentoo, and verify the local signature

--- a/tests/golden/vm-binpkg.txt
+++ b/tests/golden/vm-binpkg.txt
@@ -24,7 +24,7 @@
 [portage]
   write /etc/portage/make.conf with MAKEOPTS, INPUT_DEVICES, ACCEPT_LICENSE, L10N, FEATURES; 2 mirrors in the configured order, 5 appended
   configure Portage, wget, curl, git and gpg for direct connection
-  create the three autounmask files emerge writes its decisions into
+  create /etc/portage/package.use/zz-autounmask, /etc/portage/package.accept_keywords/zz-autounmask, /etc/portage/package.license/zz-autounmask, which emerge writes its decisions into
   disable inherited binary package host gentoo
   run getuto so Portage has a keyring to verify binary packages against, and write dirmngr.conf
   import BB572E0E2D182910 from /usr/share/openpgp-keys/gentoo-release.asc, locally sign it for gentoo, and verify the local signature

--- a/tests/golden/vm-bios-luks.txt
+++ b/tests/golden/vm-bios-luks.txt
@@ -27,7 +27,7 @@
 [portage]
   write /etc/portage/make.conf with MAKEOPTS, INPUT_DEVICES, ACCEPT_LICENSE, L10N, FEATURES; 2 mirrors in the configured order, 5 appended
   configure Portage, wget, curl, git and gpg for direct connection
-  create the three autounmask files emerge writes its decisions into
+  create /etc/portage/package.use/zz-autounmask, /etc/portage/package.accept_keywords/zz-autounmask, /etc/portage/package.license/zz-autounmask, which emerge writes its decisions into
   disable inherited binary package host gentoo
   run getuto so Portage has a keyring to verify binary packages against, and write dirmngr.conf
   import BB572E0E2D182910 from /usr/share/openpgp-keys/gentoo-release.asc, locally sign it for gentoo, and verify the local signature

--- a/tests/golden/vm-bios.txt
+++ b/tests/golden/vm-bios.txt
@@ -23,7 +23,7 @@
 [portage]
   write /etc/portage/make.conf with MAKEOPTS, INPUT_DEVICES, ACCEPT_LICENSE, L10N, FEATURES; 2 mirrors in the configured order, 5 appended
   configure Portage, wget, curl, git and gpg for direct connection
-  create the three autounmask files emerge writes its decisions into
+  create /etc/portage/package.use/zz-autounmask, /etc/portage/package.accept_keywords/zz-autounmask, /etc/portage/package.license/zz-autounmask, which emerge writes its decisions into
   disable inherited binary package host gentoo
   run getuto so Portage has a keyring to verify binary packages against, and write dirmngr.conf
   import BB572E0E2D182910 from /usr/share/openpgp-keys/gentoo-release.asc, locally sign it for gentoo, and verify the local signature

--- a/tests/golden/vm-btrfs.txt
+++ b/tests/golden/vm-btrfs.txt
@@ -27,7 +27,7 @@
 [portage]
   write /etc/portage/make.conf with MAKEOPTS, INPUT_DEVICES, ACCEPT_LICENSE, L10N, FEATURES; 2 mirrors in the configured order, 5 appended
   configure Portage, wget, curl, git and gpg for direct connection
-  create the three autounmask files emerge writes its decisions into
+  create /etc/portage/package.use/zz-autounmask, /etc/portage/package.accept_keywords/zz-autounmask, /etc/portage/package.license/zz-autounmask, which emerge writes its decisions into
   disable inherited binary package host gentoo
   run getuto so Portage has a keyring to verify binary packages against, and write dirmngr.conf
   import BB572E0E2D182910 from /usr/share/openpgp-keys/gentoo-release.asc, locally sign it for gentoo, and verify the local signature

--- a/tests/golden/vm-cjk-kernel.txt
+++ b/tests/golden/vm-cjk-kernel.txt
@@ -24,7 +24,7 @@
 [portage]
   write /etc/portage/make.conf with MAKEOPTS, INPUT_DEVICES, ACCEPT_LICENSE, L10N, FEATURES; 2 mirrors in the configured order, 5 appended
   configure Portage, wget, curl, git and gpg for direct connection
-  create the three autounmask files emerge writes its decisions into
+  create /etc/portage/package.use/zz-autounmask, /etc/portage/package.accept_keywords/zz-autounmask, /etc/portage/package.license/zz-autounmask, which emerge writes its decisions into
   disable inherited binary package host gentoo
   run getuto so Portage has a keyring to verify binary packages against, and write dirmngr.conf
   import BB572E0E2D182910 from /usr/share/openpgp-keys/gentoo-release.asc, locally sign it for gentoo, and verify the local signature

--- a/tests/golden/vm-convert.txt
+++ b/tests/golden/vm-convert.txt
@@ -9,7 +9,7 @@
 [portage]
   write /etc/portage/make.conf with MAKEOPTS, INPUT_DEVICES, ACCEPT_LICENSE, L10N, FEATURES; 2 mirrors in the configured order, 5 appended, in /gentoo-install.new
   configure Portage, wget, curl, git and gpg for direct connection, in /gentoo-install.new
-  create the three autounmask files emerge writes its decisions into, in /gentoo-install.new
+  create /etc/portage/package.use/zz-autounmask, /etc/portage/package.accept_keywords/zz-autounmask, /etc/portage/package.license/zz-autounmask, which emerge writes its decisions into, in /gentoo-install.new
   disable inherited binary package host gentoo, in /gentoo-install.new
   run getuto so Portage has a keyring to verify binary packages against, and write dirmngr.conf, in /gentoo-install.new
   import BB572E0E2D182910 from /usr/share/openpgp-keys/gentoo-release.asc, locally sign it for gentoo, and verify the local signature, in /gentoo-install.new

--- a/tests/golden/vm-desktop.txt
+++ b/tests/golden/vm-desktop.txt
@@ -24,7 +24,7 @@
 [portage]
   write /etc/portage/make.conf with MAKEOPTS, USE, INPUT_DEVICES, ACCEPT_LICENSE, L10N, FEATURES; 2 mirrors in the configured order, 5 appended
   configure Portage, wget, curl, git and gpg for direct connection
-  create the three autounmask files emerge writes its decisions into
+  create /etc/portage/package.use/zz-autounmask, /etc/portage/package.accept_keywords/zz-autounmask, /etc/portage/package.license/zz-autounmask, which emerge writes its decisions into
   disable inherited binary package host gentoo
   run getuto so Portage has a keyring to verify binary packages against, and write dirmngr.conf
   import BB572E0E2D182910 from /usr/share/openpgp-keys/gentoo-release.asc, locally sign it for gentoo, and verify the local signature

--- a/tests/golden/vm-f2fs.txt
+++ b/tests/golden/vm-f2fs.txt
@@ -24,7 +24,7 @@
 [portage]
   write /etc/portage/make.conf with MAKEOPTS, INPUT_DEVICES, ACCEPT_LICENSE, L10N, FEATURES; 2 mirrors in the configured order, 5 appended
   configure Portage, wget, curl, git and gpg for direct connection
-  create the three autounmask files emerge writes its decisions into
+  create /etc/portage/package.use/zz-autounmask, /etc/portage/package.accept_keywords/zz-autounmask, /etc/portage/package.license/zz-autounmask, which emerge writes its decisions into
   disable inherited binary package host gentoo
   run getuto so Portage has a keyring to verify binary packages against, and write dirmngr.conf
   import BB572E0E2D182910 from /usr/share/openpgp-keys/gentoo-release.asc, locally sign it for gentoo, and verify the local signature

--- a/tests/golden/vm-gnome.txt
+++ b/tests/golden/vm-gnome.txt
@@ -24,7 +24,7 @@
 [portage]
   write /etc/portage/make.conf with MAKEOPTS, USE, INPUT_DEVICES, ACCEPT_LICENSE, L10N, FEATURES; 2 mirrors in the configured order, 5 appended
   configure Portage, wget, curl, git and gpg for direct connection
-  create the three autounmask files emerge writes its decisions into
+  create /etc/portage/package.use/zz-autounmask, /etc/portage/package.accept_keywords/zz-autounmask, /etc/portage/package.license/zz-autounmask, which emerge writes its decisions into
   disable inherited binary package host gentoo
   run getuto so Portage has a keyring to verify binary packages against, and write dirmngr.conf
   import BB572E0E2D182910 from /usr/share/openpgp-keys/gentoo-release.asc, locally sign it for gentoo, and verify the local signature

--- a/tests/golden/vm-greetd.txt
+++ b/tests/golden/vm-greetd.txt
@@ -24,7 +24,7 @@
 [portage]
   write /etc/portage/make.conf with MAKEOPTS, USE, INPUT_DEVICES, ACCEPT_LICENSE, L10N, FEATURES; 2 mirrors in the configured order, 5 appended
   configure Portage, wget, curl, git and gpg for direct connection
-  create the three autounmask files emerge writes its decisions into
+  create /etc/portage/package.use/zz-autounmask, /etc/portage/package.accept_keywords/zz-autounmask, /etc/portage/package.license/zz-autounmask, which emerge writes its decisions into
   disable inherited binary package host gentoo
   run getuto so Portage has a keyring to verify binary packages against, and write dirmngr.conf
   import BB572E0E2D182910 from /usr/share/openpgp-keys/gentoo-release.asc, locally sign it for gentoo, and verify the local signature

--- a/tests/golden/vm-image.txt
+++ b/tests/golden/vm-image.txt
@@ -25,7 +25,7 @@
 [portage]
   write /etc/portage/make.conf with MAKEOPTS, INPUT_DEVICES, ACCEPT_LICENSE, L10N, FEATURES; 2 mirrors in the configured order, 5 appended
   configure Portage, wget, curl, git and gpg for direct connection
-  create the three autounmask files emerge writes its decisions into
+  create /etc/portage/package.use/zz-autounmask, /etc/portage/package.accept_keywords/zz-autounmask, /etc/portage/package.license/zz-autounmask, which emerge writes its decisions into
   disable inherited binary package host gentoo
   run getuto so Portage has a keyring to verify binary packages against, and write dirmngr.conf
   import BB572E0E2D182910 from /usr/share/openpgp-keys/gentoo-release.asc, locally sign it for gentoo, and verify the local signature

--- a/tests/golden/vm-luks.txt
+++ b/tests/golden/vm-luks.txt
@@ -31,7 +31,7 @@
 [portage]
   write /etc/portage/make.conf with MAKEOPTS, INPUT_DEVICES, ACCEPT_LICENSE, L10N, FEATURES; 2 mirrors in the configured order, 5 appended
   configure Portage, wget, curl, git and gpg for direct connection
-  create the three autounmask files emerge writes its decisions into
+  create /etc/portage/package.use/zz-autounmask, /etc/portage/package.accept_keywords/zz-autounmask, /etc/portage/package.license/zz-autounmask, which emerge writes its decisions into
   disable inherited binary package host gentoo
   run getuto so Portage has a keyring to verify binary packages against, and write dirmngr.conf
   import BB572E0E2D182910 from /usr/share/openpgp-keys/gentoo-release.asc, locally sign it for gentoo, and verify the local signature

--- a/tests/golden/vm-lvm.txt
+++ b/tests/golden/vm-lvm.txt
@@ -32,7 +32,7 @@
 [portage]
   write /etc/portage/make.conf with MAKEOPTS, INPUT_DEVICES, ACCEPT_LICENSE, L10N, FEATURES; 2 mirrors in the configured order, 5 appended
   configure Portage, wget, curl, git and gpg for direct connection
-  create the three autounmask files emerge writes its decisions into
+  create /etc/portage/package.use/zz-autounmask, /etc/portage/package.accept_keywords/zz-autounmask, /etc/portage/package.license/zz-autounmask, which emerge writes its decisions into
   disable inherited binary package host gentoo
   run getuto so Portage has a keyring to verify binary packages against, and write dirmngr.conf
   import BB572E0E2D182910 from /usr/share/openpgp-keys/gentoo-release.asc, locally sign it for gentoo, and verify the local signature

--- a/tests/golden/vm-mdraid.txt
+++ b/tests/golden/vm-mdraid.txt
@@ -32,7 +32,7 @@
 [portage]
   write /etc/portage/make.conf with MAKEOPTS, INPUT_DEVICES, ACCEPT_LICENSE, L10N, FEATURES; 2 mirrors in the configured order, 5 appended
   configure Portage, wget, curl, git and gpg for direct connection
-  create the three autounmask files emerge writes its decisions into
+  create /etc/portage/package.use/zz-autounmask, /etc/portage/package.accept_keywords/zz-autounmask, /etc/portage/package.license/zz-autounmask, which emerge writes its decisions into
   disable inherited binary package host gentoo
   run getuto so Portage has a keyring to verify binary packages against, and write dirmngr.conf
   import BB572E0E2D182910 from /usr/share/openpgp-keys/gentoo-release.asc, locally sign it for gentoo, and verify the local signature

--- a/tests/golden/vm-openrc-desktop.txt
+++ b/tests/golden/vm-openrc-desktop.txt
@@ -24,7 +24,7 @@
 [portage]
   write /etc/portage/make.conf with MAKEOPTS, USE, INPUT_DEVICES, ACCEPT_LICENSE, L10N, FEATURES; 2 mirrors in the configured order, 5 appended
   configure Portage, wget, curl, git and gpg for direct connection
-  create the three autounmask files emerge writes its decisions into
+  create /etc/portage/package.use/zz-autounmask, /etc/portage/package.accept_keywords/zz-autounmask, /etc/portage/package.license/zz-autounmask, which emerge writes its decisions into
   disable inherited binary package host gentoo
   run getuto so Portage has a keyring to verify binary packages against, and write dirmngr.conf
   import BB572E0E2D182910 from /usr/share/openpgp-keys/gentoo-release.asc, locally sign it for gentoo, and verify the local signature

--- a/tests/golden/vm-proxy-dead.txt
+++ b/tests/golden/vm-proxy-dead.txt
@@ -27,7 +27,7 @@
 [portage]
   write /etc/portage/make.conf with MAKEOPTS, INPUT_DEVICES, ACCEPT_LICENSE, L10N, http_proxy, https_proxy, ftp_proxy, all_proxy, no_proxy, FETCHCOMMAND, RESUMECOMMAND, RSYNC_PROXY, FEATURES; 2 mirrors in the configured order, 5 appended
   configure Portage, wget, curl, git and gpg for http://127.0.0.1:1 in /etc/wgetrc, /etc/gitconfig, curl-proxy.conf and proxy.toml
-  create the three autounmask files emerge writes its decisions into
+  create /etc/portage/package.use/zz-autounmask, /etc/portage/package.accept_keywords/zz-autounmask, /etc/portage/package.license/zz-autounmask, which emerge writes its decisions into
   disable inherited binary package host gentoo
   run getuto so Portage has a keyring to verify binary packages against, and write dirmngr.conf
   import BB572E0E2D182910 from /usr/share/openpgp-keys/gentoo-release.asc, locally sign it for gentoo, and verify the local signature

--- a/tests/golden/vm-proxy-http.txt
+++ b/tests/golden/vm-proxy-http.txt
@@ -27,7 +27,7 @@
 [portage]
   write /etc/portage/make.conf with MAKEOPTS, INPUT_DEVICES, ACCEPT_LICENSE, L10N, http_proxy, https_proxy, ftp_proxy, all_proxy, no_proxy, FETCHCOMMAND, RESUMECOMMAND, RSYNC_PROXY, FEATURES; 2 mirrors in the configured order, 5 appended
   configure Portage, wget, curl, git and gpg for http://10.0.2.2:3129 in /etc/wgetrc, /etc/gitconfig, curl-proxy.conf and proxy.toml
-  create the three autounmask files emerge writes its decisions into
+  create /etc/portage/package.use/zz-autounmask, /etc/portage/package.accept_keywords/zz-autounmask, /etc/portage/package.license/zz-autounmask, which emerge writes its decisions into
   disable inherited binary package host gentoo
   run getuto so Portage has a keyring to verify binary packages against, and write dirmngr.conf
   import BB572E0E2D182910 from /usr/share/openpgp-keys/gentoo-release.asc, locally sign it for gentoo, and verify the local signature

--- a/tests/golden/vm-proxy.txt
+++ b/tests/golden/vm-proxy.txt
@@ -27,7 +27,7 @@
 [portage]
   write /etc/portage/make.conf with MAKEOPTS, INPUT_DEVICES, ACCEPT_LICENSE, L10N, all_proxy, no_proxy, FETCHCOMMAND, RESUMECOMMAND, FEATURES; 2 mirrors in the configured order, 5 appended
   configure Portage, wget, curl, git and gpg for socks5h://10.0.2.2:1080 in /etc/wgetrc, /etc/gitconfig, curl-proxy.conf and proxy.toml
-  create the three autounmask files emerge writes its decisions into
+  create /etc/portage/package.use/zz-autounmask, /etc/portage/package.accept_keywords/zz-autounmask, /etc/portage/package.license/zz-autounmask, which emerge writes its decisions into
   disable inherited binary package host gentoo
   run getuto so Portage has a keyring to verify binary packages against, and write dirmngr.conf
   import BB572E0E2D182910 from /usr/share/openpgp-keys/gentoo-release.asc, locally sign it for gentoo, and verify the local signature

--- a/tests/golden/vm-raidz.txt
+++ b/tests/golden/vm-raidz.txt
@@ -36,7 +36,7 @@
 [portage]
   write /etc/portage/make.conf with MAKEOPTS, INPUT_DEVICES, ACCEPT_LICENSE, L10N, FEATURES; 2 mirrors in the configured order, 5 appended
   configure Portage, wget, curl, git and gpg for direct connection
-  create the three autounmask files emerge writes its decisions into
+  create /etc/portage/package.use/zz-autounmask, /etc/portage/package.accept_keywords/zz-autounmask, /etc/portage/package.license/zz-autounmask, which emerge writes its decisions into
   disable inherited binary package host gentoo
   run getuto so Portage has a keyring to verify binary packages against, and write dirmngr.conf
   import BB572E0E2D182910 from /usr/share/openpgp-keys/gentoo-release.asc, locally sign it for gentoo, and verify the local signature

--- a/tests/golden/vm-ram.txt
+++ b/tests/golden/vm-ram.txt
@@ -24,7 +24,7 @@
 [portage]
   write /etc/portage/make.conf with MAKEOPTS, INPUT_DEVICES, ACCEPT_LICENSE, L10N, FEATURES; 2 mirrors in the configured order, 5 appended
   configure Portage, wget, curl, git and gpg for direct connection
-  create the three autounmask files emerge writes its decisions into
+  create /etc/portage/package.use/zz-autounmask, /etc/portage/package.accept_keywords/zz-autounmask, /etc/portage/package.license/zz-autounmask, which emerge writes its decisions into
   disable inherited binary package host gentoo
   run getuto so Portage has a keyring to verify binary packages against, and write dirmngr.conf
   import BB572E0E2D182910 from /usr/share/openpgp-keys/gentoo-release.asc, locally sign it for gentoo, and verify the local signature

--- a/tests/golden/vm-sdboot.txt
+++ b/tests/golden/vm-sdboot.txt
@@ -24,7 +24,7 @@
 [portage]
   write /etc/portage/make.conf with MAKEOPTS, INPUT_DEVICES, ACCEPT_LICENSE, L10N, FEATURES; 2 mirrors in the configured order, 5 appended
   configure Portage, wget, curl, git and gpg for direct connection
-  create the three autounmask files emerge writes its decisions into
+  create /etc/portage/package.use/zz-autounmask, /etc/portage/package.accept_keywords/zz-autounmask, /etc/portage/package.license/zz-autounmask, which emerge writes its decisions into
   disable inherited binary package host gentoo
   run getuto so Portage has a keyring to verify binary packages against, and write dirmngr.conf
   import BB572E0E2D182910 from /usr/share/openpgp-keys/gentoo-release.asc, locally sign it for gentoo, and verify the local signature

--- a/tests/golden/vm-source-kernel.txt
+++ b/tests/golden/vm-source-kernel.txt
@@ -24,7 +24,7 @@
 [portage]
   write /etc/portage/make.conf with MAKEOPTS, INPUT_DEVICES, ACCEPT_LICENSE, L10N, FEATURES; 2 mirrors in the configured order, 5 appended
   configure Portage, wget, curl, git and gpg for direct connection
-  create the three autounmask files emerge writes its decisions into
+  create /etc/portage/package.use/zz-autounmask, /etc/portage/package.accept_keywords/zz-autounmask, /etc/portage/package.license/zz-autounmask, which emerge writes its decisions into
   disable inherited binary package host gentoo
   run getuto so Portage has a keyring to verify binary packages against, and write dirmngr.conf
   import BB572E0E2D182910 from /usr/share/openpgp-keys/gentoo-release.asc, locally sign it for gentoo, and verify the local signature

--- a/tests/golden/vm-unlock.txt
+++ b/tests/golden/vm-unlock.txt
@@ -34,7 +34,7 @@
 [portage]
   write /etc/portage/make.conf with MAKEOPTS, INPUT_DEVICES, ACCEPT_LICENSE, L10N, FEATURES; 2 mirrors in the configured order, 5 appended
   configure Portage, wget, curl, git and gpg for direct connection
-  create the three autounmask files emerge writes its decisions into
+  create /etc/portage/package.use/zz-autounmask, /etc/portage/package.accept_keywords/zz-autounmask, /etc/portage/package.license/zz-autounmask, which emerge writes its decisions into
   disable inherited binary package host gentoo
   run getuto so Portage has a keyring to verify binary packages against, and write dirmngr.conf
   import BB572E0E2D182910 from /usr/share/openpgp-keys/gentoo-release.asc, locally sign it for gentoo, and verify the local signature

--- a/tests/golden/vm-xfs.txt
+++ b/tests/golden/vm-xfs.txt
@@ -24,7 +24,7 @@
 [portage]
   write /etc/portage/make.conf with MAKEOPTS, INPUT_DEVICES, ACCEPT_LICENSE, L10N, FEATURES; 2 mirrors in the configured order, 5 appended
   configure Portage, wget, curl, git and gpg for direct connection
-  create the three autounmask files emerge writes its decisions into
+  create /etc/portage/package.use/zz-autounmask, /etc/portage/package.accept_keywords/zz-autounmask, /etc/portage/package.license/zz-autounmask, which emerge writes its decisions into
   disable inherited binary package host gentoo
   run getuto so Portage has a keyring to verify binary packages against, and write dirmngr.conf
   import BB572E0E2D182910 from /usr/share/openpgp-keys/gentoo-release.asc, locally sign it for gentoo, and verify the local signature

--- a/tests/golden/vm-zfs-encrypted.txt
+++ b/tests/golden/vm-zfs-encrypted.txt
@@ -28,7 +28,7 @@
 [portage]
   write /etc/portage/make.conf with MAKEOPTS, INPUT_DEVICES, ACCEPT_LICENSE, L10N, FEATURES; 2 mirrors in the configured order, 5 appended
   configure Portage, wget, curl, git and gpg for direct connection
-  create the three autounmask files emerge writes its decisions into
+  create /etc/portage/package.use/zz-autounmask, /etc/portage/package.accept_keywords/zz-autounmask, /etc/portage/package.license/zz-autounmask, which emerge writes its decisions into
   disable inherited binary package host gentoo
   run getuto so Portage has a keyring to verify binary packages against, and write dirmngr.conf
   import BB572E0E2D182910 from /usr/share/openpgp-keys/gentoo-release.asc, locally sign it for gentoo, and verify the local signature

--- a/tests/golden/vm-zfs-mirror.txt
+++ b/tests/golden/vm-zfs-mirror.txt
@@ -32,7 +32,7 @@
 [portage]
   write /etc/portage/make.conf with MAKEOPTS, INPUT_DEVICES, ACCEPT_LICENSE, L10N, FEATURES; 2 mirrors in the configured order, 5 appended
   configure Portage, wget, curl, git and gpg for direct connection
-  create the three autounmask files emerge writes its decisions into
+  create /etc/portage/package.use/zz-autounmask, /etc/portage/package.accept_keywords/zz-autounmask, /etc/portage/package.license/zz-autounmask, which emerge writes its decisions into
   disable inherited binary package host gentoo
   run getuto so Portage has a keyring to verify binary packages against, and write dirmngr.conf
   import BB572E0E2D182910 from /usr/share/openpgp-keys/gentoo-release.asc, locally sign it for gentoo, and verify the local signature

--- a/tests/golden/vm-zfs.txt
+++ b/tests/golden/vm-zfs.txt
@@ -28,7 +28,7 @@
 [portage]
   write /etc/portage/make.conf with MAKEOPTS, INPUT_DEVICES, ACCEPT_LICENSE, L10N, FEATURES; 2 mirrors in the configured order, 5 appended
   configure Portage, wget, curl, git and gpg for direct connection
-  create the three autounmask files emerge writes its decisions into
+  create /etc/portage/package.use/zz-autounmask, /etc/portage/package.accept_keywords/zz-autounmask, /etc/portage/package.license/zz-autounmask, which emerge writes its decisions into
   disable inherited binary package host gentoo
   run getuto so Portage has a keyring to verify binary packages against, and write dirmngr.conf
   import BB572E0E2D182910 from /usr/share/openpgp-keys/gentoo-release.asc, locally sign it for gentoo, and verify the local signature

--- a/tests/golden/vm-zram.txt
+++ b/tests/golden/vm-zram.txt
@@ -24,7 +24,7 @@
 [portage]
   write /etc/portage/make.conf with MAKEOPTS, INPUT_DEVICES, ACCEPT_LICENSE, L10N, FEATURES; 2 mirrors in the configured order, 5 appended
   configure Portage, wget, curl, git and gpg for direct connection
-  create the three autounmask files emerge writes its decisions into
+  create /etc/portage/package.use/zz-autounmask, /etc/portage/package.accept_keywords/zz-autounmask, /etc/portage/package.license/zz-autounmask, which emerge writes its decisions into
   disable inherited binary package host gentoo
   run getuto so Portage has a keyring to verify binary packages against, and write dirmngr.conf
   import BB572E0E2D182910 from /usr/share/openpgp-keys/gentoo-release.asc, locally sign it for gentoo, and verify the local signature

--- a/tests/golden/zbm-unlock.txt
+++ b/tests/golden/zbm-unlock.txt
@@ -30,7 +30,7 @@
 [portage]
   write /etc/portage/make.conf with MAKEOPTS, INPUT_DEVICES, ACCEPT_LICENSE, L10N, FEATURES; 2 mirrors in the configured order, 5 appended
   configure Portage, wget, curl, git and gpg for direct connection
-  create the three autounmask files emerge writes its decisions into
+  create /etc/portage/package.use/zz-autounmask, /etc/portage/package.accept_keywords/zz-autounmask, /etc/portage/package.license/zz-autounmask, which emerge writes its decisions into
   disable inherited binary package host gentoo
   run getuto so Portage has a keyring to verify binary packages against, and write dirmngr.conf
   import BB572E0E2D182910 from /usr/share/openpgp-keys/gentoo-release.asc, locally sign it for gentoo, and verify the local signature

--- a/tests/golden/zfs-zbm.txt
+++ b/tests/golden/zfs-zbm.txt
@@ -30,7 +30,7 @@
 [portage]
   write /etc/portage/make.conf with MAKEOPTS, INPUT_DEVICES, ACCEPT_LICENSE, L10N, FEATURES; 2 mirrors in the configured order, 5 appended
   configure Portage, wget, curl, git and gpg for direct connection
-  create the three autounmask files emerge writes its decisions into
+  create /etc/portage/package.use/zz-autounmask, /etc/portage/package.accept_keywords/zz-autounmask, /etc/portage/package.license/zz-autounmask, which emerge writes its decisions into
   disable inherited binary package host gentoo
   run getuto so Portage has a keyring to verify binary packages against, and write dirmngr.conf
   import BB572E0E2D182910 from /usr/share/openpgp-keys/gentoo-release.asc, locally sign it for gentoo, and verify the local signature

--- a/tests/unit/test_layers.py
+++ b/tests/unit/test_layers.py
@@ -707,6 +707,7 @@ def test_the_dry_run_names_every_file_only_its_owner_may_read() -> None:
     # decision, and the name is what makes it one.
     assert derived_here == {
         "ConfigureConsole",
+        "CreateAutounmaskFiles",
         "ConfigureZram",
         "GenerateLocales",
         "GrantSudo",


### PR DESCRIPTION
`create the three autounmask files emerge writes its decisions into` counts them and names none. They are `/etc/portage/package.use/zz-autounmask`, `/etc/portage/package.accept_keywords/zz-autounmask` and `/etc/portage/package.license/zz-autounmask`, and an operator reading a dry-run to decide whether to proceed learns which by finding them afterwards.

Derived through `destinations()` like the others, so the rendered rule covers it. Putting `"the three autounmask files"` back as the argument turns that rule red on `/etc/portage/package.use/zz-autounmask`.

The remaining entries in row 241 are a different shape: `ConfigureRepository` and `ConfigureBinhost` write `/etc/portage/repos.conf/<name>.conf` and their descriptions already print `<name>`, so the path is determined by what they say. That distinction needs a place to be recorded before those are touched.