### PR TITLE
vm: report a missing precondition as SKIP, not as a failure

### DIFF
--- a/tests/unit/test_harness.py
+++ b/tests/unit/test_harness.py
@@ -5606,3 +5606,26 @@ def test_the_installed_key_check_rejects_a_file_sshd_would_ignore() -> None:
             ("ssh-keygen: /root/.ssh/authorized_keys: No such file\n", "no file at all"),
         ):
             assert not re.search(check.pattern, broken), (check.name, why)
+
+
+def test_a_run_the_workstation_cannot_start_is_not_reported_as_a_failure(
+    tmp_path: Path,
+) -> None:
+    """Two runs ended at 0.0m on 2026-08-24: `vm-proxy-http` because nothing
+    listened on the proxy port, and `vm-binpkg` on the openSUSE medium because
+    that ISO is not downloaded here. Both were printed as FAIL, which sends a
+    reader to the installer for something the workstation is missing."""
+    from tests.vm.campaign import Outcome, Run, mark_for
+    from tests.vm.media import MISSING_PRECONDITION
+
+    run = Run("fixtures/vm-proxy-http.toml")
+    log = tmp_path / "proxy-http.log"
+
+    log.write_text(
+        f"{MISSING_PRECONDITION}http://10.0.2.2:3129 names this workstation, and nothing"
+        " is listening on port 3129; start the proxy before the run\n"
+    )
+    assert mark_for(Outcome(run, 1, 0.0, log)) == "SKIP"
+
+    log.write_text("the install stopped: mkfs refused the device\n")
+    assert mark_for(Outcome(run, 1, 0.0, log)) == "FAIL"

--- a/tests/vm/campaign.py
+++ b/tests/vm/campaign.py
@@ -26,6 +26,7 @@ from pathlib import Path
 from typing import Callable, Final, Sequence
 
 from .expectations import EXPECTATIONS, Expectation
+from .media import MISSING_PRECONDITION
 
 WORKROOT: Final[Path] = Path.home() / "code/gentoo-install/lab/vm/runs"
 LOGS: Final[Path] = Path.home() / "code/gentoo-install/lab/vm/campaign"
@@ -319,6 +320,10 @@ def mark_for(outcome: Outcome) -> str:
         # neither the expected path nor a completed installation.
         return "BYPASS" if outcome.returncode == 0 else "FAIL"
     said = outcome.log.read_text(errors="replace")
+    if MISSING_PRECONDITION in said:
+        # Not a fixture that failed: the workstation is missing an ISO or a
+        # listener, and reporting it as FAIL sends a reader to the installer.
+        return "SKIP"
     if HOST_KILLED in said:
         return "HOST"
     return "LOCK" if ALREADY_RUNNING in said else "FAIL"

--- a/tests/vm/media.py
+++ b/tests/vm/media.py
@@ -12,6 +12,11 @@ from typing import Final, Iterable
 from gentoo_install.exec import preflight
 from gentoo_install.exec.config import load
 
+#: What a run says when the workstation lacks something it needs. Both the
+#: refusals and the campaign's summary read this one string, so a precondition
+#: cannot be reported as a fixture that failed.
+MISSING_PRECONDITION: Final[str] = "this run needs something the workstation has not got: "
+
 CACHE = Path.home() / "code/gentoo-install/lab/vm"
 
 
@@ -91,6 +96,11 @@ def _read(path: Path) -> str:
 
 
 def _sha256(path: Path) -> str:
+    if not path.is_file():
+        # Named rather than a traceback: a workstation without this ISO is a
+        # run that cannot start, and `FileNotFoundError` at the bottom of a
+        # stack reads like the fixture broke.
+        raise SystemExit(f"{MISSING_PRECONDITION}{path} is not there; download it before the run")
     reader = hashlib.sha256()
     with path.open("rb") as handle:
         for block in iter(lambda: handle.read(1 << 20), b""):

--- a/tests/vm/run.py
+++ b/tests/vm/run.py
@@ -52,7 +52,7 @@ from .console import (
 )
 from .monitor import type_text
 from .driver import FIND_DRIVER, REPOSITORY, build as build_driver
-from .media import MEDIA, Medium
+from .media import MEDIA, MISSING_PRECONDITION, Medium
 from .qemu import Firmware, Vm, VmSpec
 from .results import collect_command, create_disk, read_disk
 from .installed import checks, stage_passphrase_commands
@@ -142,8 +142,8 @@ def require_proxy(installation: InstallConfig) -> None:
         probe.settimeout(5.0)
         if probe.connect_ex(("127.0.0.1", parsed.port)) != 0:
             raise SystemExit(
-                f"{url} names this workstation, and nothing is listening on "
-                f"port {parsed.port}; start the proxy before the run"
+                f"{MISSING_PRECONDITION}{url} names this workstation, and nothing is "
+                f"listening on port {parsed.port}; start the proxy before the run"
             )
 
 


### PR DESCRIPTION
Two local runs ended at 0.0m today. `vm-proxy-http` refused with a clear sentence — nothing is listening on port 3129 — and `vm-binpkg` on the openSUSE medium raised `FileNotFoundError` from `_sha256` because that rescue ISO is not downloaded here. The campaign printed `FAIL` for both, the same word it prints when an install breaks.

An unattended loop reading `FAIL` goes to the installer; in both cases the thing to fix was the workstation. One shared `MISSING_PRECONDITION` string now carries both refusals and `mark_for` answers `SKIP` when it sees it. The absent ISO becomes a named refusal rather than a traceback.

Also learned while doing it: `--only vm-binpkg` selects every `Run` carrying that fixture, including the openSUSE one in the media stage. Removing the `SKIP` branch turns the test red with `assert 'FAIL' == 'SKIP'`.