### PR TITLE
vm: check the machine against the config the run installed

### DIFF
--- a/tests/unit/test_harness.py
+++ b/tests/unit/test_harness.py
@@ -685,7 +685,7 @@ def test_an_image_install_is_judged_by_the_image_it_wrote() -> None:
     from tests.vm import run as runner
 
     installation = load(Path("tests/fixtures/vm-image.toml"))
-    expectation = runner._from_config(Path("tests/fixtures/vm-image.toml"))
+    expectation = runner._from_config(load(Path("tests/fixtures/vm-image.toml")))
     assert [name for name, _ in expectation] == ["image"]
     pattern = expectation[0][1]
 
@@ -727,14 +727,14 @@ def test_an_image_install_is_judged_by_the_image_it_wrote() -> None:
 
     printed = StringIO()
     with contextlib.redirect_stdout(printed):
-        assert runner.check_expected({"image.txt": real, "install.rc": b"0\n"}, written) == 0
+        assert runner.check_expected({"image.txt": real, "install.rc": b"0\n"}, load(written)) == 0
     # What was read, not what a different mode reads: nothing booted here.
     assert "the image holds every filesystem" in printed.getvalue(), printed.getvalue()
     assert "booted" not in printed.getvalue(), printed.getvalue()
     # The esp alone: the install stopped before it made the root filesystem.
-    assert runner.check_expected({"image.txt": b"loop1\nloop1p1 vfat\n"}, written) != 0
+    assert runner.check_expected({"image.txt": b"loop1\nloop1p1 vfat\n"}, load(written)) != 0
     # And nothing collected at all, which is how the check stayed inert.
-    assert runner.check_expected({}, written) != 0
+    assert runner.check_expected({}, load(written)) != 0
 
     # And the install phase really asks for that verdict: `report` was called
     # with no assertions there, so `image.txt` was collected, printed, and
@@ -1067,7 +1067,7 @@ def test_local_and_cluster_use_the_same_installed_contract() -> None:
         if installation.disk.mode in without_a_machine:
             continue
         expected = [(one.name, one.pattern) for one in checks(installation)]
-        assert _from_config(path) == expected
+        assert _from_config(load(path)) == expected
         assert [(name, pattern) for name, _, pattern in _asked_for(installation)] == expected
 
 
@@ -1186,7 +1186,7 @@ def test_a_single_runner_check_cannot_be_added_without_breaking_parity(
         "_asked_for",
         lambda config: [*original(config), ("sabotage", "true", "^true$")],
     )
-    assert [(name, pattern) for name, pattern in run._from_config(path)] != [
+    assert [(name, pattern) for name, pattern in run._from_config(load(path))] != [
         (name, pattern) for name, _, pattern in cluster._asked_for(installation)
     ]
 
@@ -2714,10 +2714,10 @@ def test_a_healthy_init_is_judged_by_the_marker_it_prints() -> None:
     missing = {one.name for one in checks_for_fixture} - written.keys()
     assert not missing, missing
     healthy = {f"{one.name}.txt": written[one.name] for one in checks_for_fixture}
-    assert check_expected(healthy, fixture) == 0
+    assert check_expected(healthy, load(fixture)) == 0
     broken = dict(healthy)
     broken["failed.txt"] = b"cronie.service loaded failed failed\n"
-    assert check_expected(broken, fixture) != 0
+    assert check_expected(broken, load(fixture)) != 0
 
 
 def test_installed_mount_check_requires_every_configured_target() -> None:
@@ -4144,7 +4144,7 @@ def test_memory_runner_boots_the_target_and_reuses_shared_state_checks() -> None
     source = inspect.getsource(ram.run_install)
     assert "boot_installed=True" in source, source
     assert "check_installed(console, installation)" in source, source
-    assert "report(result, keep=True, assertions=configuration)" in source, source
+    assert "report(result, keep=True, assertions=load(configuration))" in source, source
 
 
 class _CdAppearsLate:
@@ -5629,3 +5629,53 @@ def test_a_run_the_workstation_cannot_start_is_not_reported_as_a_failure(
 
     log.write_text("the install stopped: mkfs refused the device\n")
     assert mark_for(Outcome(run, 1, 0.0, log)) == "FAIL"
+
+
+def test_the_installed_checks_read_the_config_the_run_installed(tmp_path: Path) -> None:
+    """A remote-unlock run installs the harness's key, not the operator's.
+
+    `zbm-unlock` failed its authorized-keys check on 2026-08-24 with the file
+    present and its modes right: it held `SHA256:9Y3t23If...`, the run's own
+    key, while the check derived its fingerprint from the fixture on disk.
+    """
+    from gentoo_install.exec.config import load
+    from gentoo_install.model.sshkey import fingerprint
+    from tests.vm.installed import checks
+    from tests.vm.run import installed_config
+
+    fixture = Path("tests/fixtures/zbm-unlock.toml")
+    key = tmp_path / "id_ed25519"
+    key.with_suffix(".pub").write_text(
+        "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIH8w6sgdmfNXN4gVQnnQ"
+        "/5WQiY0oUPrQYr0SPTfnw2ah harness@example\n"
+    )
+
+    written = installed_config(fixture, key)
+    assert written.system.authorized_keys != load(fixture).system.authorized_keys, written
+
+    patterns = "".join(
+        one.pattern for one in checks(written) if one.name.startswith("authorized keys")
+    )
+    assert patterns, [one.name for one in checks(written)]
+    # Escaped, because the check escapes what it puts in its pattern: a
+    # fingerprint holds `+` and `/`.
+    for absent in load(fixture).system.authorized_keys:
+        assert re.escape(fingerprint(absent)) not in patterns, absent
+    for present in written.system.authorized_keys:
+        assert re.escape(fingerprint(present)) in patterns, present
+
+    # The call site, not only the helper: the defect was one `load()` in the
+    # boot branch, and a test that calls `installed_config` itself passes with
+    # that line still there.
+    import ast
+
+    source = (Path(__file__).resolve().parents[1] / "vm" / "run.py").read_text()
+    bound = [
+        ast.unparse(node.value)
+        for node in ast.walk(ast.parse(source))
+        if isinstance(node, ast.Assign)
+        and any(isinstance(one, ast.Name) and one.id == "expected" for one in node.targets)
+    ]
+    assert bound, "the boot branch no longer binds `expected`"
+    for value in bound:
+        assert value.startswith("installed_config("), value

--- a/tests/vm/ram.py
+++ b/tests/vm/ram.py
@@ -370,7 +370,7 @@ def run_install(
             )
             check_installed(console, installation)
             power_off(console, vm)
-        if report(result, keep=True, assertions=configuration) != 0:
+        if report(result, keep=True, assertions=load(configuration)) != 0:
             raise RuntimeError("the installed system failed its shared state checks")
         verified = True
         print(

--- a/tests/vm/run.py
+++ b/tests/vm/run.py
@@ -627,6 +627,19 @@ def run_installer(console: SerialConsole, config: str, extra: str = "") -> None:
     console.run("sync")
 
 
+def installed_config(fixture: Path, key: Path) -> InstallConfig:
+    """The configuration this run installs, which is not the fixture on disk.
+
+    A remote-unlock run replaces the operator's keys with the harness's own,
+    so a check derived from the file reads `/root/.ssh/authorized_keys` and
+    finds a key it never asked for. Both halves read this.
+    """
+    loaded = load(fixture)
+    if not loaded.kernel.remote_unlock.enabled:
+        return loaded
+    return remote_config(loaded, key.with_suffix(".pub").read_text().strip())
+
+
 def install_remote_config(
     console: SerialConsole,
     key: Path,
@@ -637,8 +650,7 @@ def install_remote_config(
     """Publish run-owned remote-unlock values and return the bootstrap path."""
     if not installation.kernel.remote_unlock.enabled:
         return config
-    public_key = key.with_suffix(".pub").read_text().strip()
-    substituted = remote_config(installation, public_key)
+    substituted = installed_config(REPOSITORY / "tests" / config, key)
     remote_path = f"/tmp/{Path(config).name}"
     push_config(key, ssh_port, remote_path, to_toml(substituted))
     return remote_path
@@ -830,7 +842,7 @@ def _perform(args: argparse.Namespace, medium: Medium, workdir: Path) -> int:
     with Vm(spec) as vm:
         with SerialConsole.connect(vm.serial_socket, vm.serial_log) as console:
             if args.boot_installed:
-                expected = load(REPOSITORY / "tests" / args.install)
+                expected = installed_config(REPOSITORY / "tests" / args.install, key)
                 unlocked_remotely = False
                 unlock_failed = ""
                 if expected.kernel.remote_unlock.enabled:
@@ -852,9 +864,7 @@ def _perform(args: argparse.Namespace, medium: Medium, workdir: Path) -> int:
                 print(f"[{time.monotonic() - started:5.1f}s] logged into the installed system ({method})")
                 check_installed(console, expected)
                 power_off(console, vm)
-                code = report(
-                    result_disk, keep=args.keep, assertions=REPOSITORY / "tests" / args.install
-                )
+                code = report(result_disk, keep=args.keep, assertions=expected)
                 if unlock_failed:
                     # The subject of the fixture is the unlock, so a machine
                     # that only came up by console has still failed it.
@@ -948,7 +958,11 @@ def _discard(targets: Sequence[Path], *, keep: bool) -> None:
 
 
 def report(
-    result_disk: Path, *, keep: bool, assertions: Path | None = None, installed: bool = False
+    result_disk: Path,
+    *,
+    keep: bool,
+    assertions: InstallConfig | None = None,
+    installed: bool = False,
 ) -> int:
     results = read_disk(result_disk)
     for name in sorted(results):
@@ -960,9 +974,8 @@ def report(
     return code
 
 
-def _from_config(config: Path) -> list[tuple[str, str]]:
+def _from_config(installation: InstallConfig) -> list[tuple[str, str]]:
     """Return the shared contract in the local result format."""
-    installation = load(config)
     if installation.disk.mode is DiskMode.IMAGE:
         # Nothing booted, so none of the installed-state checks ran: what
         # this mode produces is a file, and `check_image` reads its layout.
@@ -980,7 +993,7 @@ def _image_pattern(installation: InstallConfig) -> str:
 
 
 def verdict(
-    results: dict[str, bytes], assertions: Path | None, *, installed: bool = False
+    results: dict[str, bytes], assertions: InstallConfig | None, *, installed: bool = False
 ) -> int:
     """Turn everything the run left behind into one exit code."""
     code = check_expected(results, assertions) if assertions is not None else 0
@@ -1004,7 +1017,7 @@ def verdict(
     return code
 
 
-def check_expected(results: dict[str, bytes], config: Path) -> int:
+def check_expected(results: dict[str, bytes], config: InstallConfig) -> int:
     """Turn the collected output into a verdict."""
     missing: list[str] = []
     # From the configuration rather than hardcoded: a second fixture installs a
@@ -1015,7 +1028,7 @@ def check_expected(results: dict[str, bytes], config: Path) -> int:
     # while the live medium is still up. Asking for the rest would fail every
     # image run; asking for none of it left the image check inert, collected
     # and printed and never compared.
-    writes_an_image = load(config).disk.mode is DiskMode.IMAGE
+    writes_an_image = config.disk.mode is DiskMode.IMAGE
     installed = [] if writes_an_image else list(EXPECTED)
     for name, pattern in [*installed, *_from_config(config)]:
         text = results.get(f"{name}.txt", b"").decode("utf-8", "replace")


### PR DESCRIPTION
`zbm-unlock` failed its authorized-keys check today with the file present and its modes right. It held `SHA256:9Y3t23If…`, which is the harness's own `vm-test` key: a remote-unlock run installs `remote_config(installation, public_key)`, and the boot phase bound `expected = load(REPOSITORY / "tests" / args.install)` — the fixture on disk.

`installed_config()` is the one derivation of what a run installs, and both the install phase and the boot phase read it. `report` and `check_expected` take the configuration rather than a path, so nothing downstream can reload the fixture either.

The first control for this was green: it called `installed_config` directly, and the defect was one `load()` at the call site. The test now also reads `run.py` and requires every assignment to `expected` to come from `installed_config(`; putting the old line back fails with `load(REPOSITORY / 'tests' / args.install)`.