### PR TITLE
vm: keep each campaign log under its own revision

### DIFF
--- a/tests/unit/test_harness.py
+++ b/tests/unit/test_harness.py
@@ -5679,3 +5679,19 @@ def test_the_installed_checks_read_the_config_the_run_installed(tmp_path: Path) 
     assert bound, "the boot branch no longer binds `expected`"
     for value in bound:
         assert value.startswith("installed_config("), value
+
+
+def test_a_second_campaign_does_not_write_over_the_first_ones_logs() -> None:
+    """The run that found the missing `authorized_keys` on 2026-08-24 had its
+    install log replaced by the run sent to confirm it, because both wrote
+    `<fixture>.log`. `cluster.py` learned this already and puts the vmid and
+    the driver hash in its own names."""
+    from tests.vm.campaign import _log_for, Run
+    from tests.vm.driver import revision
+
+    named = _log_for(Run("fixtures/vm-luks.toml")).name
+    marker = revision().split()[0]
+    assert marker in named, (named, marker)
+    # `-dirty` survives: a name that drops it reads like a commit.
+    if "dirty" in marker:
+        assert "dirty" in named, named

--- a/tests/vm/campaign.py
+++ b/tests/vm/campaign.py
@@ -25,6 +25,7 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import Callable, Final, Sequence
 
+from .driver import revision
 from .expectations import EXPECTATIONS, Expectation
 from .media import MISSING_PRECONDITION
 
@@ -270,7 +271,12 @@ class Outcome:
 
 
 def _log_for(run: Run) -> Path:
-    return LOGS / f"{run.name}.log"
+    # The revision in the name, because a second campaign otherwise writes over
+    # the log of the first: the run that found the missing `authorized_keys` on
+    # 2026-08-24 had its evidence replaced by the run sent to confirm it.
+    # The whole first word, `-dirty` included: a truncated one turns a run
+    # that proves nothing into a name that reads like a commit.
+    return LOGS / f"{run.name}-{revision().split()[0]}.log"
 
 
 def _failed_outcome(run: Run, started: float, error: Exception) -> Outcome:


### PR DESCRIPTION
Reading back the `zfs-zbm` install log to see whether `/mnt/gentoo/home` was mounted when the keys were written, the file held four lines: the campaign sent to confirm the defect had written over the campaign that found it. `_log_for` was `LOGS / f"{run.name}.log"`.

`cluster.py` learned this already — `guest_log()` carries the vmid and the driver hash, with a comment about two rounds writing the same file. The local half never did.

The whole first word of `revision()` goes in the name, `-dirty` included: truncating it turns a run that proves nothing into a name that reads like a commit. An unattended loop re-runs the same fixture constantly, so an overwrite lands exactly when the evidence matters.