### PR TITLE
tests: add a fixture with a sudo user that carries a key

### DIFF
--- a/tests/fixtures/vm-user-key.toml
+++ b/tests/fixtures/vm-user-key.toml
@@ -1,0 +1,101 @@
+# A sudo user with an authorized key, on a layout where `/home` is part of the
+# root filesystem. Nothing in the matrix had ever read a user's key back:
+# `vm-unlock` carries keys and no user, so its check covered root, and the only
+# fixtures with both are the two ZFSBootMenu ones, where `/home` is a separate
+# dataset. Without a plain layout the cause is confounded three ways.
+config_version = 1
+
+[system]
+hostname = "userkeybox"
+timezone = "UTC"
+locales = ["en_US.UTF-8"]
+locale = "en_US.UTF-8"
+init = "systemd"
+# The desktop brings NetworkManager, so the init's own manager stays off:
+# both claim every interface and the address is whichever won the race.
+networking = "builtin"
+sshd = true
+root_password_hash = "$6$gentooinst$IR3GrdJ862XljQYDqocr4tKniIRDIT.jQNFzIrHE3U75H6B6YSWZoSYoVd5edSHpqaYBdiNfXHCoIPRVgb9lT/"
+authorized_keys = ["ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIB+85deBslaLOMFw71dx23wo7fFT76GVcEyQS9IdVvvT installer@example"]
+
+[[system.users]]
+name = "zakk"
+sudo = true
+password_hash = "$6$rounds=656000$fixedsaltforthetest$0"
+
+[portage]
+profile = "default/linux/amd64/23.0/systemd"
+makeopts = "-j4"
+
+[portage.mirrors]
+region = "global"
+
+[portage.binhost]
+official = true
+community = "off"
+
+[kernel]
+source = "dist-bin"
+
+[bootloader]
+kind = "grub"
+firmware = "uefi"
+kernel_params = ["console=ttyS0,115200"]
+
+[disk]
+root = "mnt-root"
+
+[[disk.devices]]
+kind = "existing"
+id = "disk"
+selector = "/dev/disk/by-id/virtio-target0"
+wipe = true
+
+[[disk.devices]]
+kind = "table"
+id = "table"
+disk = "disk"
+table = "gpt"
+
+[[disk.devices]]
+kind = "partition"
+id = "esp"
+table = "table"
+index = 1
+role = "esp"
+size = "512MiB"
+
+[[disk.devices]]
+kind = "partition"
+id = "rootpart"
+table = "table"
+index = 2
+role = "data"
+
+[[disk.devices]]
+kind = "filesystem"
+id = "espfs"
+device = "esp"
+type = "vfat"
+label = "ESP"
+
+[[disk.devices]]
+kind = "filesystem"
+id = "rootfs"
+device = "rootpart"
+type = "xfs"
+label = "gentoo"
+
+[[disk.devices]]
+kind = "mountpoint"
+id = "mnt-root"
+source = "rootfs"
+path = "/"
+
+[[disk.devices]]
+kind = "mountpoint"
+id = "mnt-esp"
+source = "espfs"
+path = "/efi"
+options = ["umask=0077"]
+

--- a/tests/golden/vm-user-key.txt
+++ b/tests/golden/vm-user-key.txt
@@ -1,0 +1,81 @@
+[partition]
+  release anything a previous run of this configuration left mounted or open
+  wipe existing signatures from disk
+  create a gpt partition table on disk as table
+  create partition 1 on disk as esp in the gpt table: esp, 512MiB
+  create partition 2 on disk as rootpart in the gpt table: data, the rest of the disk
+  reread the partition table of disk and wait for its nodes
+
+[format]
+  make a vfat filesystem on esp as espfs labelled ESP
+  make a xfs filesystem on rootpart as rootfs labelled gentoo
+
+[mount]
+  mount rootpart at /
+  mount esp at /efi with umask=0077
+
+[stage3]
+  download the newest systemd stage3 from https://distfiles.gentoo.org directly, verify it against BB572E0E2D182910, unpack it into the target and write /etc/gentoo-install/proxy.toml
+
+[chroot]
+  mount transient proc, sys, dev and run filesystems into the target
+  seed the target's resolv.conf from the install medium
+
+[portage]
+  write /etc/portage/make.conf with MAKEOPTS, INPUT_DEVICES, ACCEPT_LICENSE, L10N, FEATURES; 2 mirrors in the configured order, 5 appended
+  configure Portage, wget, curl, git and gpg for direct connection
+  create /etc/portage/package.use/zz-autounmask, /etc/portage/package.accept_keywords/zz-autounmask, /etc/portage/package.license/zz-autounmask, which emerge writes its decisions into
+  disable inherited binary package host gentoo
+  run getuto so Portage has a keyring to verify binary packages against, and write dirmngr.conf
+  import BB572E0E2D182910 from /usr/share/openpgp-keys/gentoo-release.asc, locally sign it for gentoo, and verify the local signature
+  write /etc/portage/binrepos.conf/gentoo.conf adding verified binary package host gentoo at https://distfiles.gentoo.org/releases/amd64/binpackages/23.0/x86-64
+  fetch the first ebuild repository snapshot with emerge-webrsync
+  select profile default/linux/amd64/23.0/systemd
+  install git, which every later repository sync needs: emerge dev-vcs/git
+  write /etc/portage/repos.conf/gentoo.conf pointing gentoo at https://github.com/gentoo-mirror/gentoo.git, commit signatures verified
+  sync repository gentoo
+  set sys-kernel/installkernel to dracut
+  accept the linux-firmware licence
+  resolve app-admin/sudo net-misc/openssh sys-process/cronie sys-kernel/installkernel sys-kernel/dracut sys-kernel/linux-firmware sys-fs/dosfstools sys-fs/xfsprogs sys-kernel/gentoo-kernel-bin sys-boot/grub sys-boot/efibootmgr together before installing the requested packages
+
+[system]
+  write /etc/locale.gen with locales en_US.UTF-8 and verify them
+  set the system locale to en_US.UTF-8 in /etc/locale.conf
+  set the timezone to UTC
+  set the console keymap to us and its font to default8x16 in /etc/vconsole.conf
+  set the hostname to userkeybox in /etc/hostname and /etc/hosts
+  give the target its own machine id with systemd-machine-id-setup
+  write /etc/fstab with UUID from rootpart / xfs defaults 0 1, UUID from esp /efi vfat defaults,umask=0077 0 2
+  treat the hardware clock as UTC in /etc/adjtime
+  create user zakk in users, wheel, audio, video, render, usb, input with a password
+  write SHA256:wBQUIpTF0DPsPEUeafUC1YRHr0N0LIdt+LtbxepvlkQ into /home/zakk/.ssh/authorized_keys
+  set the root password
+  install sudo: emerge app-admin/sudo
+  let the wheel group run sudo, with a password, in /etc/sudoers.d/10-wheel
+  install sshd: emerge net-misc/openssh
+  ssh password login: off, root: off, in 50-gentoo-install.conf
+  enable sshd at boot
+  generate the ssh host keys
+  write /etc/systemd/network/20-wired.network for the wired interfaces with DHCP and DNS -
+  enable systemd-networkd at boot
+  enable systemd-resolved at boot
+  install cron: emerge sys-process/cronie
+  enable cronie at boot
+
+[kernel]
+  install the hook that puts a kernel in /boot: emerge sys-kernel/installkernel
+  install the initramfs builder and firmware: emerge sys-kernel/dracut sys-kernel/linux-firmware
+  install the storage tools: emerge sys-fs/dosfstools sys-fs/xfsprogs
+  install the kernel: emerge sys-kernel/gentoo-kernel-bin
+  rebuild the initramfs from sys-kernel/gentoo-kernel-bin with the modules written above
+  check the installkernel payload names existing kernel files
+
+[bootloader]
+  install the bootloader: emerge sys-boot/grub sys-boot/efibootmgr
+  write /etc/default/grub with cmdline console=ttyS0,115200, its menu on ttyS0
+  install GRUB for uefi on the esp at /efi
+
+[finish]
+  point /etc/resolv.conf at systemd-resolved rather than the install medium's
+  delete the downloaded stage3 from /var/cache/gentoo-install
+  unmount everything under the target

--- a/tests/vm/campaign.py
+++ b/tests/vm/campaign.py
@@ -200,6 +200,10 @@ STAGES: Final[dict[str, tuple[Run, ...]]] = {
         Run("fixtures/vm-convert.toml"),
         Run("fixtures/vm-raidz.toml"),
         Run("fixtures/vm-zram.toml"),
+        # A sudo user's `authorized_keys`, read back off the installed system.
+        # Nothing else in the matrix does: `vm-unlock` has keys and no user,
+        # and the two fixtures that have both put `/home` on its own dataset.
+        Run("fixtures/vm-user-key.toml"),
         Run("fixtures/vm-bios-luks.toml", firmware="bios"),
         # sshd with a key that can reach it, and the initramfs daemon that
         # unlocks the root: `remote_unlock` was off in every other fixture.


### PR DESCRIPTION
`vm-user-key` is `vm-xfs` plus one sudo user and one authorized key, on a layout where `/home` is part of the root filesystem.

Nothing in the matrix had ever read a user's `authorized_keys` back off an installed machine. `vm-unlock` carries keys and no user, so `key_accounts()` returns root and that is what its check covered. The only two fixtures with both a user and keys are `zfs-zbm` and `zbm-unlock`, where the file is missing after boot — and both also put `/home` on its own ZFS dataset and boot through ZFSBootMenu, so the cause is confounded three ways.

This one holds all three constant. It is worth having whatever the answer is: a sudo user with a key is the ordinary headless case, and until now no run had checked that the machine it produces can be logged into.