### PR TITLE
tests: separate a home of its own from ZFS in the key check

### DIFF
--- a/tests/fixtures/vm-home-key.toml
+++ b/tests/fixtures/vm-home-key.toml
@@ -1,0 +1,112 @@
+# The same sudo user as `vm-user-key`, on a layout where `/home` is a mount of
+# its own. The pair is the measurement: that one puts `/home` in the root
+# filesystem and its key survives, and the two ZFSBootMenu fixtures put it on a
+# separate dataset and lose it. This holds the separate mount and drops ZFS.
+config_version = 1
+
+[system]
+hostname = "homekeybox"
+timezone = "Asia/Taipei"
+locales = ["en_US.UTF-8", "zh_TW.UTF-8"]
+locale = "zh_TW.UTF-8"
+init = "systemd"
+root_password_hash = "$6$gentooinst$IR3GrdJ862XljQYDqocr4tKniIRDIT.jQNFzIrHE3U75H6B6YSWZoSYoVd5edSHpqaYBdiNfXHCoIPRVgb9lT/"
+sshd = true
+authorized_keys = ["ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIB+85deBslaLOMFw71dx23wo7fFT76GVcEyQS9IdVvvT installer@example"]
+
+[[system.users]]
+name = "zakk"
+sudo = true
+password_hash = "$6$rounds=656000$fixedsaltforthetest$0"
+
+[portage]
+profile = "default/linux/amd64/23.0/systemd"
+makeopts = "-j4"
+
+[portage.binhost]
+official = true
+community = "off"
+
+[kernel]
+source = "dist-bin"
+
+[bootloader]
+kind = "grub"
+firmware = "uefi"
+kernel_params = ["console=ttyS0,115200"]
+
+[disk]
+root = "mnt-root"
+
+[[disk.devices]]
+kind = "existing"
+id = "disk"
+selector = "/dev/disk/by-id/virtio-target0"
+wipe = true
+
+[[disk.devices]]
+kind = "table"
+id = "table"
+disk = "disk"
+table = "gpt"
+
+[[disk.devices]]
+kind = "partition"
+id = "esp"
+table = "table"
+index = 1
+role = "esp"
+size = "512MiB"
+
+[[disk.devices]]
+kind = "partition"
+id = "cryptroot"
+table = "table"
+index = 2
+role = "data"
+
+[[disk.devices]]
+kind = "filesystem"
+id = "espfs"
+device = "esp"
+type = "vfat"
+label = "ESP"
+
+[[disk.devices]]
+kind = "filesystem"
+id = "rootfs"
+device = "cryptroot"
+type = "btrfs"
+
+[[disk.devices]]
+kind = "subvolume"
+id = "sub-root"
+filesystem = "rootfs"
+name = "@"
+
+[[disk.devices]]
+kind = "subvolume"
+id = "sub-home"
+filesystem = "rootfs"
+name = "@home"
+
+[[disk.devices]]
+kind = "mountpoint"
+id = "mnt-root"
+source = "sub-root"
+path = "/"
+options = ["compress=zstd:1"]
+
+[[disk.devices]]
+kind = "mountpoint"
+id = "mnt-home"
+source = "sub-home"
+path = "/home"
+options = ["compress=zstd:1"]
+
+[[disk.devices]]
+kind = "mountpoint"
+id = "mnt-esp"
+source = "espfs"
+path = "/efi"
+options = ["umask=0077"]

--- a/tests/golden/vm-home-key.txt
+++ b/tests/golden/vm-home-key.txt
@@ -1,0 +1,85 @@
+[partition]
+  release anything a previous run of this configuration left mounted or open
+  wipe existing signatures from disk
+  create a gpt partition table on disk as table
+  create partition 1 on disk as esp in the gpt table: esp, 512MiB
+  create partition 2 on disk as cryptroot in the gpt table: data, the rest of the disk
+  reread the partition table of disk and wait for its nodes
+
+[format]
+  make a vfat filesystem on esp as espfs labelled ESP
+  make a btrfs filesystem on cryptroot as rootfs
+  create btrfs subvolume @home on cryptroot as sub-home
+  create btrfs subvolume @ on cryptroot as sub-root
+
+[mount]
+  mount cryptroot at / with compress=zstd:1,subvol=@
+  mount esp at /efi with umask=0077
+  mount cryptroot at /home with compress=zstd:1,subvol=@home
+
+[stage3]
+  download the newest systemd stage3 from https://distfiles.gentoo.org directly, verify it against BB572E0E2D182910, unpack it into the target and write /etc/gentoo-install/proxy.toml
+
+[chroot]
+  mount transient proc, sys, dev and run filesystems into the target
+  seed the target's resolv.conf from the install medium
+
+[portage]
+  write /etc/portage/make.conf with MAKEOPTS, INPUT_DEVICES, ACCEPT_LICENSE, L10N, FEATURES; 2 mirrors in the configured order, 5 appended
+  configure Portage, wget, curl, git and gpg for direct connection
+  create /etc/portage/package.use/zz-autounmask, /etc/portage/package.accept_keywords/zz-autounmask, /etc/portage/package.license/zz-autounmask, which emerge writes its decisions into
+  disable inherited binary package host gentoo
+  run getuto so Portage has a keyring to verify binary packages against, and write dirmngr.conf
+  import BB572E0E2D182910 from /usr/share/openpgp-keys/gentoo-release.asc, locally sign it for gentoo, and verify the local signature
+  write /etc/portage/binrepos.conf/gentoo.conf adding verified binary package host gentoo at https://distfiles.gentoo.org/releases/amd64/binpackages/23.0/x86-64
+  fetch the first ebuild repository snapshot with emerge-webrsync
+  select profile default/linux/amd64/23.0/systemd
+  install git, which every later repository sync needs: emerge dev-vcs/git
+  write /etc/portage/repos.conf/gentoo.conf pointing gentoo at https://github.com/gentoo-mirror/gentoo.git, commit signatures verified
+  sync repository gentoo
+  set sys-kernel/installkernel to dracut
+  accept the linux-firmware licence
+  resolve app-admin/sudo net-misc/openssh sys-process/cronie sys-kernel/installkernel sys-kernel/dracut sys-kernel/linux-firmware sys-fs/btrfs-progs sys-fs/dosfstools sys-kernel/gentoo-kernel-bin sys-boot/grub sys-boot/efibootmgr together before installing the requested packages
+
+[system]
+  write /etc/locale.gen with locales en_US.UTF-8, zh_TW.UTF-8 and verify them
+  set the system locale to zh_TW.UTF-8 in /etc/locale.conf
+  set the timezone to Asia/Taipei
+  set the console keymap to us and its font to default8x16 in /etc/vconsole.conf
+  set the hostname to homekeybox in /etc/hostname and /etc/hosts
+  give the target its own machine id with systemd-machine-id-setup
+  write /etc/fstab with UUID from cryptroot / btrfs defaults,compress=zstd:1,subvol=@ 0 1, UUID from esp /efi vfat defaults,umask=0077 0 2, UUID from cryptroot /home btrfs defaults,compress=zstd:1,subvol=@home 0 2
+  treat the hardware clock as UTC in /etc/adjtime
+  create user zakk in users, wheel, audio, video, render, usb, input with a password
+  write SHA256:wBQUIpTF0DPsPEUeafUC1YRHr0N0LIdt+LtbxepvlkQ into /home/zakk/.ssh/authorized_keys
+  set the root password
+  install sudo: emerge app-admin/sudo
+  let the wheel group run sudo, with a password, in /etc/sudoers.d/10-wheel
+  install sshd: emerge net-misc/openssh
+  ssh password login: off, root: off, in 50-gentoo-install.conf
+  enable sshd at boot
+  generate the ssh host keys
+  write /etc/systemd/network/20-wired.network for the wired interfaces with DHCP and DNS -
+  enable systemd-networkd at boot
+  enable systemd-resolved at boot
+  install cron: emerge sys-process/cronie
+  enable cronie at boot
+
+[kernel]
+  install the hook that puts a kernel in /boot: emerge sys-kernel/installkernel
+  install the initramfs builder and firmware: emerge sys-kernel/dracut sys-kernel/linux-firmware
+  install the storage tools: emerge sys-fs/btrfs-progs sys-fs/dosfstools
+  install the kernel: emerge sys-kernel/gentoo-kernel-bin
+  write /etc/dracut.conf.d/10-gentoo-install.conf so dracut carries btrfs, and 13 cloud bus drivers whatever it detects
+  rebuild the initramfs from sys-kernel/gentoo-kernel-bin with the modules written above
+  check the installkernel payload names existing kernel files
+
+[bootloader]
+  install the bootloader: emerge sys-boot/grub sys-boot/efibootmgr
+  write /etc/default/grub with cmdline console=ttyS0,115200, its menu on ttyS0
+  install GRUB for uefi on the esp at /efi
+
+[finish]
+  point /etc/resolv.conf at systemd-resolved rather than the install medium's
+  delete the downloaded stage3 from /var/cache/gentoo-install
+  unmount everything under the target

--- a/tests/unit/test_harness.py
+++ b/tests/unit/test_harness.py
@@ -5596,6 +5596,7 @@ def test_the_installed_key_check_rejects_a_file_sshd_would_ignore() -> None:
         f"2048 {printed} root@example (RSA)\n"
         "ACL 600 /root/.ssh/authorized_keys\n"
         "ACL 700 /root/.ssh\n"
+        "ACL 750 /root\n"
     )
     for check in found:
         assert re.search(check.pattern, good), check.name
@@ -5604,6 +5605,8 @@ def test_the_installed_key_check_rejects_a_file_sshd_would_ignore() -> None:
             (good.replace("ACL 700", "ACL 755"), "a world-readable directory"),
             (good.replace(printed[7:20], "Z" * 13), "a different key"),
             ("ssh-keygen: /root/.ssh/authorized_keys: No such file\n", "no file at all"),
+            # The two are different failures and the message has to say which.
+            (good.replace("ACL 750 /root\n", ""), "no home directory either"),
         ):
             assert not re.search(check.pattern, broken), (check.name, why)
 

--- a/tests/vm/campaign.py
+++ b/tests/vm/campaign.py
@@ -204,6 +204,9 @@ STAGES: Final[dict[str, tuple[Run, ...]]] = {
         # Nothing else in the matrix does: `vm-unlock` has keys and no user,
         # and the two fixtures that have both put `/home` on its own dataset.
         Run("fixtures/vm-user-key.toml"),
+        # The same user with `/home` mounted separately: the pair is what
+        # separates a mount of its own from ZFS.
+        Run("fixtures/vm-home-key.toml"),
         Run("fixtures/vm-bios-luks.toml", firmware="bios"),
         # sshd with a key that can reach it, and the initramfs daemon that
         # unlocks the root: `remote_unlock` was off in every other fixture.

--- a/tests/vm/installed.py
+++ b/tests/vm/installed.py
@@ -266,10 +266,14 @@ def checks(installation: InstallConfig) -> tuple[InstalledCheck, ...]:
             ]
             required.append(rf"ACL 600 {re.escape(path)}")
             required.append(rf"ACL 700 {re.escape(home)}/\.ssh")
+            required.append(rf"ACL [0-7]{{3}} {re.escape(home)}$")
             result.append(
                 InstalledCheck(
                     f"authorized keys {name}",
-                    f"ssh-keygen -lf {path}; stat -c 'ACL %a %n' {path} {home}/.ssh",
+                    # The home directory as well as the two below it: a
+                    # missing `.ssh` and a missing `/home/<user>` are different
+                    # failures, and the first message could not tell them apart.
+                    f"ssh-keygen -lf {path}; stat -c 'ACL %a %n' {path} {home}/.ssh {home}",
                     "(?s)" + "".join(f"(?=.*{one})" for one in required),
                     line_boundary_exception="requires every fingerprint and both modes",
                 )


### PR DESCRIPTION
`vm-user-key` passed with `/home` inside the root filesystem. `vm-home-key` is the same sudo user with `/home` as a btrfs `@home` subvolume — a mount of its own — and its key survives too: `mounts.txt` reads `/home /dev/vdb2[/@home] btrfs` and the fingerprint and both modes are there.

So neither "a sudo user's key" nor "a separate /home mount" explains the two ZFSBootMenu fixtures losing the file. Only ZFS is left, and the pair of fixtures is what says so.

The check also stats the home directory now. A missing `.ssh` and a missing `/home/<user>` are different failures and the old message could not tell them apart, so the next `zfs-zbm` verdict will name which one it is.

Building the second fixture nearly wasted the run: `vm-btrfs` has `sshd` off and the check is gated on it, so it would have been green without running. The fixture sets `sshd = true` and the check list was printed before the run started.