### PR TITLE
vm: read every declared dataset back off the machine

### DIFF
--- a/tests/unit/test_harness.py
+++ b/tests/unit/test_harness.py
@@ -589,6 +589,7 @@ def test_every_installed_check_is_line_bounded_or_names_why_it_is_not() -> None:
         ("greetd config", "requires constraints across greetd config lines"),
         ("inputmethod", "requires the binary and every environment line"),
         ("authorized keys root", "requires every fingerprint and both modes"),
+        ("datasets", "requires one line per configured dataset"),
         ("authorized keys zakk", "requires every fingerprint and both modes"),
     }
     for installation in configurations:
@@ -5698,3 +5699,31 @@ def test_a_second_campaign_does_not_write_over_the_first_ones_logs() -> None:
     # `-dirty` survives: a name that drops it reads like a commit.
     if "dirty" in marker:
         assert "dirty" in named, named
+
+
+def test_the_dataset_check_names_every_dataset_the_configuration_declares() -> None:
+    """A pool whose child dataset is absent, or mounted somewhere else, gives
+    a machine that boots and holds none of what was written into that dataset.
+    `zfs-zbm` lost `/home/zakk` entirely and nothing in the checks read the
+    dataset list back."""
+    import re
+
+    from gentoo_install.exec.config import load
+    from tests.vm.installed import checks
+
+    installation = load(Path("tests/fixtures/zfs-zbm.toml"))
+    found = [one for one in checks(installation) if one.name == "datasets"]
+    assert found, [one.name for one in checks(installation)]
+    check = found[0]
+
+    listed = (
+        "zpcala/ROOT\t96K\tnone\n"
+        "zpcala/ROOT/gentoo\t2.1G\tnone\n"
+        "zpcala/ROOT/gentoo/root\t2.1G\t/\n"
+        "zpcala/ROOT/gentoo/home\t96K\t/home\n"
+    )
+    assert re.search(check.pattern, listed), check.pattern
+    without = listed.replace("zpcala/ROOT/gentoo/home\t96K\t/home\n", "")
+    assert not re.search(check.pattern, without), check.pattern
+    # And not satisfied by the question: the command names no dataset.
+    assert not re.search(check.pattern, check.command), check.command

--- a/tests/vm/installed.py
+++ b/tests/vm/installed.py
@@ -278,6 +278,28 @@ def checks(installation: InstallConfig) -> tuple[InstalledCheck, ...]:
                     line_boundary_exception="requires every fingerprint and both modes",
                 )
             )
+    datasets = tuple(installation.disk.graph.of_type(ZfsDataset))
+    if datasets:
+        # Every dataset the configuration declares, read off the machine with
+        # the mountpoint it declared. A pool whose child dataset is absent, or
+        # mounted somewhere else, produces a system that boots and quietly
+        # holds none of what was written into that dataset.
+        pools = {
+            one.id: one.name for one in installation.disk.graph.of_type(ZfsPool)
+        }
+        declared = [
+            rf"^{re.escape(f'{pools[one.pool]}/{one.name}')}\s"
+            for one in datasets
+            if one.pool in pools
+        ]
+        result.append(
+            InstalledCheck(
+                "datasets",
+                "zfs list -H -o name,used,mountpoint",
+                "(?ms)" + "".join(f"(?=.*{one})" for one in declared),
+                line_boundary_exception="requires one line per configured dataset",
+            )
+        )
     if installation.system.zram is not None:
         # The device the machine brought up, not the file the installer wrote:
         # `zram-generator` and `zram-init` each read a configuration that can


### PR DESCRIPTION
The sharper key check answered the question it was given: on `zfs-zbm` all three `stat` lines say no such file — `authorized_keys`, `.ssh`, and `/home/zakk` itself. `/etc/passwd` carries `zakk:x:1000:1000::/home/zakk:/bin/bash` and `/home` is mounted from `zpcala/ROOT/gentoo/home`, so everything written under `/mnt/gentoo/home` during the install is gone, the home directory `useradd` made included.

Nothing read the dataset list back. The new check runs `zfs list -H -o name,used,mountpoint` and requires a line for each dataset the configuration declares, so the next verdict carries the `used` column — which says whether that dataset is empty or mounted somewhere else.

Worth saying what this cost: the previous plan was to convert the kept image to raw, attach it with `losetup` and import the pool. This kernel has neither `nbd` nor `loop`, so none of that worked, and what actually narrowed the fault was adding one path to a `stat` command.