### PR TITLE
disk: create a dataset without mounting it

### DIFF
--- a/gentoo_install/plan/disk.py
+++ b/gentoo_install/plan/disk.py
@@ -876,6 +876,30 @@ class ImportZpool(Operation):
         context.run(["zpool", "import", "-N", "-f", "-R", str(context.target), self.name])
 
 
+def canmount_for(mountpoint: PurePosixPath | None) -> str:
+    """What a dataset's `canmount` is once the install is finished.
+
+    `zfs mount -a` and `zfs-mount-generator` both skip `noauto`, which is
+    wanted for the boot environment and wrong for everything else: a `/home`
+    dataset marked `noauto` came up empty. The values are the ones
+    `calamares-settings-gig`'s `zfs.conf` gives its dataset array.
+    """
+    if mountpoint is None:
+        return "off"
+    return "noauto" if mountpoint == PurePosixPath("/") else "on"
+
+
+def _canmount_at_creation(mountpoint: PurePosixPath | None) -> str:
+    """What it is created with, which is never `on`.
+
+    `zfs create -o canmount=on` mounts the dataset immediately, and the pool's
+    altroot puts a `/home` dataset under the target before the root dataset is
+    mounted over it: the writes then land in the root dataset and the machine
+    boots with an empty `/home`.
+    """
+    return "off" if mountpoint is None else "noauto"
+
+
 @dataclass(frozen=True, kw_only=True)
 class CreateDataset(Operation):
     stage: Stage = Stage.ZFS
@@ -890,16 +914,14 @@ class CreateDataset(Operation):
         return f"create dataset {self.name} as {self.dataset}, mountpoint {where}"
 
     def canmount(self) -> str:
-        """`zfs mount -a` and `zfs-mount-generator` both skip `noauto`, which is
-        wanted for the boot environment and wrong for everything else: a
-        `/home` dataset marked `noauto` came up empty. The values are the ones
-        `calamares-settings-gig`'s `zfs.conf` gives its dataset array."""
-        if self.mountpoint is None:
-            return "off"
-        return "noauto" if self.mountpoint == PurePosixPath("/") else "on"
+        return canmount_for(self.mountpoint)
 
     def apply(self, context: Context) -> None:
         where = str(self.mountpoint) if self.mountpoint is not None else "none"
+        # `noauto` whatever it ends up as: `zfs create -o canmount=on` mounts
+        # the dataset there and then, and the pool's altroot puts `/home`
+        # under the target before the root dataset is mounted over it. The
+        # mount stage sets the real value once it has mounted this in order.
         # -p: a dataset three levels down needs its parents, and the layout
         # names only the leaves it mounts.
         context.run(
@@ -907,7 +929,7 @@ class CreateDataset(Operation):
                 "zfs", "create", "-p",
                 *DATASET_OPTIONS,
                 "-o", f"mountpoint={where}",
-                "-o", f"canmount={self.canmount()}",
+                "-o", f"canmount={_canmount_at_creation(self.mountpoint)}",
                 self.name,
             ]
         )
@@ -994,6 +1016,12 @@ class MountZfsDataset(Operation):
                 return
             context.run(["zfs", "unmount", self.name])
         context.run(["zfs", "mount", self.name])
+        # After the mount, not at creation: `canmount=on` is what makes
+        # `zfs mount -a` bring this dataset up at boot, and setting it here
+        # keeps `zfs create` from mounting it before the root is in place.
+        wanted = canmount_for(self.path)
+        if wanted != "noauto":
+            context.run(["zfs", "set", f"canmount={wanted}", self.name])
 
 @dataclass(frozen=True, kw_only=True)
 class DiscardStage3(Operation):

--- a/tests/unit/test_plan_disk.py
+++ b/tests/unit/test_plan_disk.py
@@ -719,7 +719,7 @@ def test_only_the_boot_environment_is_left_unmounted_at_boot() -> None:
     dataset array of `calamares-settings-gig`'s `zfs.conf`."""
     from pathlib import PurePosixPath
 
-    from gentoo_install.plan.disk import CreateDataset
+    from gentoo_install.plan.disk import CreateDataset, MountZfsDataset
 
     holder = CreateDataset(dataset=i("ds"), name="rpool/ROOT", mountpoint=None)
     root = CreateDataset(dataset=i("ds"), name="rpool/ROOT/gentoo", mountpoint=PurePosixPath("/"))
@@ -728,9 +728,25 @@ def test_only_the_boot_environment_is_left_unmounted_at_boot() -> None:
     )
     assert (holder.canmount(), root.canmount(), home.canmount()) == ("off", "noauto", "on")
 
+    # Created `noauto` whatever it ends up as: `zfs create -o canmount=on`
+    # mounts the dataset immediately, and the pool's altroot puts `/home`
+    # under the target before the root dataset is mounted over it. The writes
+    # then land in the root dataset and the machine boots with an empty
+    # `/home`, which is what `zfs-zbm` did on 2026-08-24.
     recorder = Recorder()
     home.apply(recorder)
-    assert "canmount=on" in recorder.only("zfs", "create")
+    assert "canmount=noauto" in recorder.only("zfs", "create")
+    assert "canmount=on" not in recorder.only("zfs", "create")
+
+    # And the mount stage puts it back, so `zfs mount -a` brings it up at boot.
+    mounting = Recorder()
+    mounting.replies["zfs"] = "no"
+    MountZfsDataset(
+        mountpoint=i("mnt"), name="rpool/ROOT/gentoo/home", path=PurePosixPath("/home")
+    ).apply(mounting)
+    assert ("zfs", "set", "canmount=on", "rpool/ROOT/gentoo/home") in mounting.commands, (
+        mounting.commands
+    )
 
 
 def test_the_downloaded_stage3_does_not_ship_with_the_installed_system() -> None:


### PR DESCRIPTION
`zfs-zbm` installs, boots, and has no `/home/zakk` at all. The `datasets` check added alongside this says why the search kept failing: `zpcala/ROOT/gentoo/home` is present, mounted at `/home`, and 192K — empty.

The install log has the sequence. Step 10 creates the home dataset with `canmount=on`, which mounts it immediately, and the pool carries `-R /mnt/gentoo`, so it lands on `/mnt/gentoo/home`. Step 11 creates the root dataset `noauto`. Step 12 mounts the root at `/mnt/gentoo` — over the home mount. Step 14 asks `zfs get mounted` and is told `yes`, so it leaves it alone. Everything written afterwards goes into the root dataset's `/home` directory, and at boot the home dataset covers it.

That step already tries to detect this with `findmnt --target`, and its own comment records why it cannot: `findmnt` answers with the covered mount's source, so "mounted where it belongs" and "mounted and hidden" give the same answer.

Datasets are created `noauto` now and the mount stage sets the real `canmount` after mounting, in the depth order it already uses. Not `zfs create -u`, which needs a newer OpenZFS than the medium is guaranteed to carry. Restoring the creation value turns the test red.

Unverified: a VM run of `zfs-zbm` against this is running now and the result goes in `TESTED.md` before it counts.