### PR TITLE
tests: hold every operation to naming the files it writes

### DIFF
--- a/gentoo_install/data/locale/ja.toml
+++ b/gentoo_install/data/locale/ja.toml
@@ -651,6 +651,7 @@
 "put the installer, the configuration and {} key(s) in authorized_keys inside the initramfs" = "インストーラー、設定、{} 個の鍵を authorized_keys として initramfs に格納"
 "delete the downloaded archive, now that its two files are out" = "必要な 2 つのファイルを取り出したので、ダウンロードしたアーカイブを削除"
 "write a {} entry for the {} environment" = "{} 用のエントリーを書き込む（{} 環境）"
+"write {}, a {} entry for the {} environment" = "{} を書き込む：{} 用のエントリー、{} 環境"
 "arm one boot into the memory environment with {}" = "{} でメモリー環境への一度きりの起動を設定"
 "replace the default boot entry with the memory environment ({})" = "既定の起動エントリーをメモリー環境に置き換える（{}）"
 "take back the armed boot and delete what it placed" = "設定した起動を取り消し、配置したものを削除"

--- a/gentoo_install/data/locale/ko.toml
+++ b/gentoo_install/data/locale/ko.toml
@@ -651,6 +651,7 @@
 "put the installer, the configuration and {} key(s) in authorized_keys inside the initramfs" = "설치 프로그램, 설정, 키 {}개를 authorized_keys로 initramfs에 넣기"
 "delete the downloaded archive, now that its two files are out" = "필요한 파일 두 개를 꺼냈으므로 내려받은 아카이브 삭제"
 "write a {} entry for the {} environment" = "{} 항목 작성 ({} 환경)"
+"write {}, a {} entry for the {} environment" = "{} 작성: {} 항목, {} 환경"
 "arm one boot into the memory environment with {}" = "{}로 메모리 환경 일회성 부팅 설정"
 "replace the default boot entry with the memory environment ({})" = "기본 부팅 항목을 메모리 환경으로 교체 ({})"
 "take back the armed boot and delete what it placed" = "설정한 부팅을 되돌리고 배치한 파일 삭제"

--- a/gentoo_install/data/locale/zh-CN.toml
+++ b/gentoo_install/data/locale/zh-CN.toml
@@ -652,6 +652,7 @@
 "put the installer, the configuration and {} key(s) in authorized_keys inside the initramfs" = "将安装器、配置文件与 {} 把密钥以 authorized_keys 放进 initramfs"
 "delete the downloaded archive, now that its two files are out" = "需要的两个文件已取出，删除下载的归档"
 "write a {} entry for the {} environment" = "写入 {} 的启动项，用于 {} 环境"
+"write {}, a {} entry for the {} environment" = "写入 {}：{} 的启动项，用于 {} 环境"
 "arm one boot into the memory environment with {}" = "以 {} 预约一次进入内存环境的启动"
 "replace the default boot entry with the memory environment ({})" = "将默认启动项换成内存环境（{}）"
 "take back the armed boot and delete what it placed" = "取消启动预约并删除它放置的文件"

--- a/gentoo_install/data/locale/zh-TW.toml
+++ b/gentoo_install/data/locale/zh-TW.toml
@@ -652,6 +652,7 @@
 "put the installer, the configuration and {} key(s) in authorized_keys inside the initramfs" = "將安裝器、設定檔與 {} 把金鑰以 authorized_keys 放進 initramfs"
 "delete the downloaded archive, now that its two files are out" = "需要的兩個檔案已取出，刪除下載的封存檔"
 "write a {} entry for the {} environment" = "寫入 {} 的開機項目，用於 {} 環境"
+"write {}, a {} entry for the {} environment" = "寫入 {}：{} 的開機項目，用於 {} 環境"
 "arm one boot into the memory environment with {}" = "以 {} 預約一次進入記憶體環境的開機"
 "replace the default boot entry with the memory environment ({})" = "將預設開機項目換成記憶體環境（{}）"
 "take back the armed boot and delete what it placed" = "取消開機預約並刪除它放置的檔案"

--- a/gentoo_install/plan/netboot.py
+++ b/gentoo_install/plan/netboot.py
@@ -913,8 +913,27 @@ class WriteMemoryEntry(Operation):
         """
         return self.access or bool(self.launch.ssh_key) or bool(self.launch.root_password)
 
+    def destinations(self) -> tuple[PurePosixPath, ...]:
+        # Only the systemd-boot entry: the GRUB branch delegates to
+        # `_write_custom`, and a file another path writes is named by that one.
+        if self.target.method is not BootMethod.SYSTEMD_BOOT:
+            return ()
+        return (
+            PurePosixPath(str(self.target.esp_mountpoint))
+            / "loader"
+            / "entries"
+            / f"{PLACE}.conf",
+        )
+
     def describe_parts(self) -> tuple[str, tuple[str, ...]]:
-        return "write a {} entry for the {} environment", (
+        written = self.destinations()
+        if not written:
+            return "write a {} entry for the {} environment", (
+                self.target.method.value,
+                self.mode.value,
+            )
+        return "write {}, a {} entry for the {} environment", (
+            str(written[0]),
             self.target.method.value,
             self.mode.value,
         )
@@ -929,13 +948,8 @@ class WriteMemoryEntry(Operation):
                 f"initrd  /{PLACE}/initramfs\n"
                 f"options {cmdline}\n"
             )
-            context.write(
-                PurePosixPath(str(self.target.esp_mountpoint))
-                / "loader"
-                / "entries"
-                / f"{PLACE}.conf",
-                entry,
-            )
+            (path,) = self.destinations()
+            context.write(path, entry)
             return
         # Both GRUBs read their own `custom.cfg`, and a UEFI one is reached
         # by `--bootnext` into GRUB rather than into the entry directly.

--- a/tests/golden/memory-bypass.txt
+++ b/tests/golden/memory-bypass.txt
@@ -8,5 +8,5 @@
 
 [bootloader]
   unpack the ram kernel and initramfs into /boot/efi/gentoo-install-ram
-  write a systemd-boot entry for the ram environment
+  write /boot/efi/loader/entries/gentoo-install-ram.conf, a systemd-boot entry for the ram environment
   replace the default boot entry with the memory environment (systemd-boot)

--- a/tests/golden/memory-lowram.txt
+++ b/tests/golden/memory-lowram.txt
@@ -8,6 +8,6 @@
 
 [bootloader]
   unpack the lowram kernel and initramfs into /boot/efi/gentoo-install-ram
-  write a systemd-boot entry for the lowram environment
+  write /boot/efi/loader/entries/gentoo-install-ram.conf, a systemd-boot entry for the lowram environment
   delete the downloaded archive, now that its two files are out
   arm one boot into the memory environment with systemd-boot

--- a/tests/golden/memory-ram.txt
+++ b/tests/golden/memory-ram.txt
@@ -8,5 +8,5 @@
 
 [bootloader]
   unpack the ram kernel and initramfs into /boot/efi/gentoo-install-ram
-  write a systemd-boot entry for the ram environment
+  write /boot/efi/loader/entries/gentoo-install-ram.conf, a systemd-boot entry for the ram environment
   arm one boot into the memory environment with systemd-boot

--- a/tests/unit/test_i18n.py
+++ b/tests/unit/test_i18n.py
@@ -547,6 +547,7 @@ REVIEWED_TEMPLATES: frozenset[str] = frozenset(
         "check this machine has the {} MiB {} needs",
         "unpack the {} kernel and initramfs into {}",
         "write a {} entry for the {} environment",
+        "write {}, a {} entry for the {} environment",
         "set the system locale to {} in {}",
         "start a login on {} at {} baud",
         "stream the {} image {} onto {}",

--- a/tests/unit/test_layers.py
+++ b/tests/unit/test_layers.py
@@ -595,6 +595,14 @@ def _written_names(expr: ast.expr, known: Mapping[str, ast.expr]) -> set[str]:
     return {one for one in found if one}
 
 
+#: Operations whose writes go into the directory that becomes the cpio
+#: appended to the initramfs, not onto the installed system. Named rather than
+#: detected: the paths derive from `self.target.place`, and a rule that
+#: recognised that by its shape would also excuse a real target path built the
+#: same way.
+STAGED: Final[frozenset[str]] = frozenset({"AppendConfiguration"})
+
+
 def test_every_operation_names_the_files_it_writes() -> None:
     """`--dry-run` prints `describe()` for the same operations `apply()` runs,
     so a file named by neither is a file an operator learns about by finding it
@@ -609,6 +617,7 @@ def test_every_operation_names_the_files_it_writes() -> None:
     of them and the check would pass having compared nothing.
     """
     read = 0
+    staged = 0
     for module in _modules("plan"):
         tree = ast.parse(module.read_text(encoding="utf-8"))
         known: dict[str, ast.expr] = {}
@@ -622,14 +631,27 @@ def test_every_operation_names_the_files_it_writes() -> None:
                 )
         for cls in (one for one in ast.walk(tree) if isinstance(one, ast.ClassDef)):
             body = {one.name: one for one in cls.body if isinstance(one, ast.FunctionDef)}
-            if "apply" not in body or "describe" not in body:
+            describing = body.get("describe") or body.get("describe_parts")
+            if "apply" not in body or describing is None:
                 continue
-            said = ast.unparse(body["describe"])
+            if "destinations" in body:
+                # Its path reaches the text through `_named(self.destinations())`,
+                # so the source holds `{}` where the filename goes.
+                # `test_plan_system.py` renders the plan and checks it there.
+                continue
+            said = ast.unparse(describing)
             reachable = _bindings_in(body, known)
             for call in ast.walk(body["apply"]):
                 if not isinstance(call, ast.Call) or not isinstance(call.func, ast.Attribute):
                     continue
                 if call.func.attr != "write" or not call.args:
+                    continue
+                if cls.name in STAGED:
+                    # Not a file on the installed system: these land in the
+                    # directory that becomes the appended cpio, and what an
+                    # operator needs to know is what goes into the initramfs,
+                    # which the description says.
+                    staged += 1
                     continue
                 read += 1
                 names = _written_names(call.args[0], reachable)
@@ -720,6 +742,7 @@ def test_the_dry_run_names_every_file_only_its_owner_may_read() -> None:
         "WriteAuthorizedKeys",
         "WriteFirstBoot",
         "WriteMachineId",
+        "WriteMemoryEntry",
         "WriteNetworkConfig",
         "WriteProxyEnvironment",
     }, sorted(derived_here)


### PR DESCRIPTION
Row 241. `test_every_operation_names_the_files_it_writes` required `describe`, and almost every operation now returns `describe_parts` instead, so the rule had quietly stopped applying to them — 27 of 56 `context.write` calls named a file their description did not.

Nine operations were fixed over the previous PRs; the ones that derive their path through `destinations()` are covered by the rendered rule in `test_plan_system.py`, since the source holds `{}` where the filename goes. `WriteMemoryEntry` is the last one that named nothing, and it now prints the ESP entry it writes.

`AppendConfiguration`'s five writes are exempt by name. They land in the directory that becomes the cpio appended to the initramfs, not on the installed system, and the description already says what goes in there. `STAGED` names the class rather than recognising the shape, because a rule that excused `self.target.place` by shape would also excuse a real target path built the same way. Emptying it turns the check red at `netboot.py:595`.