### PR TITLE
vm: say the exit code when a remote unlock fails

### DIFF
--- a/tests/unit/test_harness.py
+++ b/tests/unit/test_harness.py
@@ -5727,3 +5727,19 @@ def test_the_dataset_check_names_every_dataset_the_configuration_declares() -> N
     assert not re.search(check.pattern, without), check.pattern
     # And not satisfied by the question: the command names no dataset.
     assert not re.search(check.pattern, check.command), check.command
+
+
+def test_a_failed_remote_unlock_says_the_exit_code_and_not_ssh_noise() -> None:
+    """`zbm-unlock` failed on 2026-08-24 with the whole message being
+    `Warning: Permanently added '[127.0.0.1]:52151' (ECDSA) to the list of
+    known hosts.` — ssh's own noise, kept because the report took the last 300
+    characters and there was nothing else. A reader learns from that only that
+    ssh ran."""
+    from tests.vm.run import _without_ssh_noise
+
+    noise = (
+        "Warning: Permanently added '[127.0.0.1]:52151' (ECDSA) to the list of known hosts.\n"
+    )
+    assert _without_ssh_noise(noise) == ""
+    assert _without_ssh_noise(noise + "zfs: no such pool\n") == "zfs: no such pool"
+    assert _without_ssh_noise("zfs: no such pool\n") == "zfs: no such pool"

--- a/tests/vm/run.py
+++ b/tests/vm/run.py
@@ -298,6 +298,16 @@ def wait_for_unlock_daemon(
     raise RuntimeError(f"no ssh daemon on port {port} after {patience:.0f}s: {last}")
 
 
+#: What ssh prints on every session here and what no reader needs to see.
+_SSH_NOISE: Final[re.Pattern[str]] = re.compile(
+    r"^Warning: Permanently added .*to the list of known hosts\.$", re.MULTILINE
+)
+
+
+def _without_ssh_noise(output: str) -> str:
+    return _SSH_NOISE.sub("", output).strip()
+
+
 def try_remote_unlock(key: Path, port: int, installation: InstallConfig) -> str:
     """Answer the empty string when the unlock worked, or why it did not."""
     try:
@@ -344,7 +354,13 @@ def remote_unlock(
         process.communicate()
         raise RuntimeError(f"remote unlock timed out after {timeout:.0f}s") from error
     if process.returncode != 0:
-        raise RuntimeError(f"remote unlock failed: {output.strip()[-300:]}")
+        # The exit code and the output without ssh's own noise: with
+        # `StrictHostKeyChecking=no` every session prints `Permanently added`,
+        # and a message that kept only the last 300 characters showed that
+        # warning and nothing else, which reads as though ssh was the problem.
+        printed = _without_ssh_noise(output)
+        why = repr(printed[-300:]) if printed else "nothing"
+        raise RuntimeError(f"remote unlock: ssh exited {process.returncode} and said {why}")
     if proof is None:
         return "unlocked"
     said = [line.strip() for line in output.splitlines() if line.strip()]


### PR DESCRIPTION
`zbm-unlock` failed today with this as the entire message:

    FAIL remote unlock: remote unlock failed: Warning: Permanently added
    '[127.0.0.1]:52151' (ECDSA) to the list of known hosts.

Nothing there is about the failure. `StrictHostKeyChecking=no` makes ssh print that line every session, the report kept `output.strip()[-300:]`, and the session printed nothing else — so the noise was the whole report.

The message now carries ssh's exit code and drops that warning; when what is left is empty it says so. "ssh exited 255 and said nothing" and "ssh printed an unrelated warning" are different leads, and the old message could only produce the second.

The verification this came from is the other half: `zbm-unlock`'s `authorized keys zakk` check passes on the `canmount` fix, with `600`, `700` and `755`, so both ZFSBootMenu fixtures are covered. The remote unlock itself is rows 360 and 363 and is untouched here.