### PR TITLE
vm: have the unlock session name the pools it can see

### DIFF
--- a/tests/unit/test_harness.py
+++ b/tests/unit/test_harness.py
@@ -61,7 +61,10 @@ def test_remote_unlock_replaces_fixture_values_without_mutating_fixture() -> Non
         ("vm-unlock.toml", "unlock", None),
         (
             "zbm-unlock.toml",
-            "zfs load-key -a",
+            # The pools first: `zfs load-key -a` succeeds with nothing to do
+            # when the pool is not imported, so the proof was the first thing
+            # to notice and said only `dataset does not exist`.
+            "echo pools=$(zpool list -H -o name | tr '\\n' ',') && zfs load-key -a",
             "zfs get -H -o value keystatus zpcala/ROOT/gentoo/root",
         ),
     ],

--- a/tests/vm/run.py
+++ b/tests/vm/run.py
@@ -389,7 +389,15 @@ def remote_unlock_commands(installation: InstallConfig) -> tuple[str, str | None
         if not isinstance(pool, ZfsPool):
             raise RuntimeError("ZFSBootMenu root dataset has no configured pool")
         full_name = f"{pool.name}/{dataset.name}"
-        return "zfs load-key -a", f"zfs get -H -o value keystatus {full_name}"
+        # The pools first, and read-only: `zfs load-key -a` loads keys for
+        # what is imported and succeeds with nothing to do when the pool is
+        # not, so the proof was the first thing to notice and it reported
+        # `dataset does not exist`, which names neither the pool nor whether
+        # anything was imported at all.
+        return (
+            f"echo pools=$(zpool list -H -o name | tr '\\n' ',') && zfs load-key -a",
+            f"zfs get -H -o value keystatus {full_name}",
+        )
     return "unlock", None
 
 


### PR DESCRIPTION
With #1024 in, `zbm-unlock` finally said something: `ssh exited 1 and said "cannot open 'zpcala/ROOT/gentoo/root': dataset does not exist"`. Rows 360 and 363 have been shelved for a long time on messages that said only that a port went unanswered.

`zfs load-key -a` acts on imported pools and succeeds with nothing to do when there are none, so the proof command was the first thing to notice anything wrong — and `dataset does not exist` names neither the pool nor whether the session had one at all.

The command now prints `pools=` from `zpool list -H -o name` before loading keys. Read-only, so it changes nothing the fixture tests, and the next failure message carries the environment instead of a symptom of it.