### PR TITLE
vm: count only tracked changes in the revision a run reports

### DIFF
--- a/tests/unit/test_harness.py
+++ b/tests/unit/test_harness.py
@@ -5746,3 +5746,32 @@ def test_a_failed_remote_unlock_says_the_exit_code_and_not_ssh_noise() -> None:
     assert _without_ssh_noise(noise) == ""
     assert _without_ssh_noise(noise + "zfs: no such pool\n") == "zfs: no such pool"
     assert _without_ssh_noise("zfs: no such pool\n") == "zfs: no such pool"
+
+
+def test_an_untracked_file_does_not_make_a_run_look_dirty(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Every run said `1 uncommitted files` because a screenshot sat untracked
+    in the checkout, while `git describe --dirty` had already reported the
+    tree clean. `CLAUDE.md` reads that line to decide whether a result counts,
+    so a file the driver cannot contain must not appear in it."""
+    import subprocess
+
+    from tests.vm import driver
+
+    def git(*argv: str) -> None:
+        subprocess.run(["git", *argv], cwd=tmp_path, check=True, capture_output=True)
+
+    git("init", "--quiet")
+    git("config", "user.email", "zakk@gentoozh.org")
+    git("config", "user.name", "Zakk")
+    git("config", "commit.gpgsign", "false")
+    (tmp_path / "tracked.txt").write_text("one\n")
+    git("add", "tracked.txt")
+    git("commit", "--quiet", "-m", "first")
+
+    monkeypatch.setattr(driver, "REPOSITORY", tmp_path)
+    (tmp_path / "screenshot.png").write_bytes(b"")
+    assert "uncommitted" not in driver.revision(), driver.revision()
+    (tmp_path / "tracked.txt").write_text("two\n")
+    assert "1 uncommitted files" in driver.revision(), driver.revision()

--- a/tests/vm/driver.py
+++ b/tests/vm/driver.py
@@ -132,7 +132,13 @@ def revision() -> str:
     described = ask(["git", "describe", "--always", "--dirty"]).strip()
     if not described:
         return "unknown, not a git checkout"
-    uncommitted = len(ask(["git", "status", "--short"]).splitlines())
+    # Tracked changes only: an untracked screenshot sitting in the checkout
+    # made every run say `1 uncommitted files`, which reads as a result that
+    # proves nothing while `git describe --dirty` had already said the tree
+    # was clean.
+    uncommitted = len(
+        ask(["git", "status", "--short", "--untracked-files=no"]).splitlines()
+    )
     return f"{described} ({uncommitted} uncommitted files)" if uncommitted else described
 
 


### PR DESCRIPTION
Every run tonight printed `installer revision: <sha> (1 uncommitted files)` while `git describe --always --dirty` on the same line carried no `-dirty`. The two contradict each other because the count came from `git status --short`, which lists untracked files — here a screenshot sitting in the checkout that the driver CD cannot contain.

`CLAUDE.md` reads that line to decide whether a result counts, so this is a false alarm that throws away good runs. The count uses `--untracked-files=no`; restoring it turns the test red with `644ef6a (1 uncommitted files)`.

Found while chasing something else: the same line was the only reason to doubt a `zbm-unlock` verdict, and doubting it was right for a different reason — that run really had measured a stale tree.