### PR TITLE
vm: let a campaign survive a failed driver-CD tidy-up

### DIFF
--- a/tests/unit/test_cluster.py
+++ b/tests/unit/test_cluster.py
@@ -20,7 +20,15 @@ from tests.vm import cluster
 
 FIXTURES = Path(__file__).resolve().parents[1] / "fixtures"
 from tests.vm.console import ConsoleTimeout, SerialConsole, command_done
-from tests.vm.proxmox import Api, Node, ProxmoxError, ProxmoxNotFound, VMID_FIRST, VMID_LAST
+from tests.vm.proxmox import (
+    Api,
+    Node,
+    ProxmoxError,
+    ProxmoxNotFound,
+    ProxmoxTransientError,
+    VMID_FIRST,
+    VMID_LAST,
+)
 
 
 class WorkerFailure(Exception):
@@ -4032,3 +4040,38 @@ def test_a_campaign_names_the_guests_an_earlier_one_left_behind() -> None:
 
     assert cluster.orphan_report(cast(Any, Listing([running, resolver]))) == []
     assert cluster.orphan_report(cast(Any, Listing(ProxmoxError("no answer")))) == []
+
+
+def test_a_transient_failure_while_tidying_does_not_end_the_campaign(
+    tmp_path: Path,
+) -> None:
+    """A campaign on 2026-08-24 ended with no verdicts at all: an SSL handshake
+    failed inside `stale_drivers`, which only removes old driver CDs, and the
+    error came out of the scheduler. Six guests had been built and deleted and
+    nothing was said about any of them."""
+    from tests.vm.cluster import place_driver
+
+    class Tidying:
+        def __init__(self) -> None:
+            self.placed: list[str] = []
+
+        def stale_drivers(self, node: str, keep: str, older_than: float) -> list[str]:
+            raise ProxmoxTransientError("GET /nodes/n/storage/local/content did not answer")
+
+        def isos(self, node: str) -> list[str]:
+            return ["driver.iso"]
+
+        def remove_iso(self, node: str, name: str) -> str:
+            return ""
+
+        def upload_iso(self, node: str, path: Path, name: str) -> str:
+            self.placed.append(name)
+            return ""
+
+    api = Tidying()
+    trust = tmp_path / "trust"
+    driver = tmp_path / "driver.iso"
+    driver.write_bytes(b"cd")
+
+    # The point is that this returns rather than raising.
+    place_driver(cast(Any, api), "infra-node2", trust, driver, "driver.iso")

--- a/tests/vm/cluster.py
+++ b/tests/vm/cluster.py
@@ -834,7 +834,16 @@ def prepare(
 
 def place_driver(api: Api, node: str, trust: Path, driver_path: Path, driver: str) -> None:
     """Put one driver CD on a node's `local` storage, replacing a stale copy."""
-    for stale in api.stale_drivers(node, driver, DRIVER_KEPT_SECONDS):
+    # Best-effort: an old driver CD left on a node costs disk and nothing
+    # else, and a transient API failure here ended a whole campaign with no
+    # verdicts at all on 2026-08-24 — six guests built, deleted, and nothing
+    # said about any of them.
+    try:
+        stale_drivers = api.stale_drivers(node, driver, DRIVER_KEPT_SECONDS)
+    except ProxmoxTransientError as error:
+        print(f"stale drivers on {node} could not be listed: {error}", file=sys.stderr)
+        stale_drivers = []
+    for stale in stale_drivers:
         reason = api.remove_iso(node, stale)
         if reason:
             print(f"{stale} stayed on {node}: {reason}", file=sys.stderr)


### PR DESCRIPTION
A cluster round ended `rc=1` with no verdicts at all and every guest already deleted. The last line was `ProxmoxTransientError: GET /nodes/infra-node2/storage/local/content?content=iso did not answer` — raised inside `place_driver`'s call to `stale_drivers`, whose only job is deleting driver CDs that are past their keep time.

The exception class is named `ProxmoxTransientError`. It declares itself transient and was then not treated as transient at this call site, so one handshake cost six guests' worth of results.

Listing failures print a line and the tidy-up is skipped. An old CD left behind costs disk; a lost round costs an hour. Removing the guard turns the test red with the same exception.