### PR TITLE
vm: give both runners one reading of the git state

### DIFF
--- a/tests/unit/test_cluster.py
+++ b/tests/unit/test_cluster.py
@@ -16,7 +16,7 @@ from typing import Any, cast
 import pytest
 
 from gentoo_install.model.config import MirrorRegion, Sync
-from tests.vm import cluster
+from tests.vm import cluster, driver
 
 FIXTURES = Path(__file__).resolve().parents[1] / "fixtures"
 from tests.vm.console import ConsoleTimeout, SerialConsole, command_done
@@ -1019,6 +1019,7 @@ def test_a_node_that_refuses_a_guest_does_not_end_the_campaign() -> None:
     that were installing."""
     import ast
     import inspect
+    from types import ModuleType
     import textwrap
 
     from tests.vm import proxmox
@@ -4075,3 +4076,35 @@ def test_a_transient_failure_while_tidying_does_not_end_the_campaign(
 
     # The point is that this returns rather than raising.
     place_driver(cast(Any, api), "infra-node2", trust, driver, "driver.iso")
+
+
+def test_both_runners_read_one_git_state() -> None:
+    """`driver.revision()` and `cluster.revision_identity()` each ran their own
+    `git status`, and fixing the untracked-file count in one left the other
+    reporting `dirty=1` for a screenshot."""
+    import ast
+    import inspect
+    from types import ModuleType
+
+    def asks_git_status(module: ModuleType) -> int:
+        """`git status` argv lists, not every `"status"` in the file: the
+        orphan report reads a `status` key out of the API's answer, and a
+        check that counted that would fail for a reason it does not mean."""
+        tree = ast.parse(inspect.getsource(module))
+        found = 0
+        for node in ast.walk(tree):
+            if not isinstance(node, (ast.List, ast.Tuple)):
+                continue
+            words = [
+                one.value
+                for one in node.elts
+                if isinstance(one, ast.Constant) and isinstance(one.value, str)
+            ]
+            if words[:2] == ["git", "status"]:
+                found += 1
+        return found
+
+    # One derivation, in the module that owns it.
+    assert asks_git_status(driver) == 1, "driver.py no longer asks git once"
+    assert asks_git_status(cluster) == 0, "cluster.py asks git for itself again"
+    assert "git_state" in inspect.getsource(cluster.revision_identity)

--- a/tests/vm/cluster.py
+++ b/tests/vm/cluster.py
@@ -81,6 +81,7 @@ from .console import (
     plain,
 )
 from .driver import (
+    git_state,
     FIND_DRIVER,
     NAME_PREFIX as DRIVER_PREFIX,
     build as build_driver,
@@ -1534,18 +1535,11 @@ def _first_selector(installation: InstallConfig) -> str:
 def revision_identity(driver: Path) -> str:
     """Git state and exact driver bytes represented by a campaign outcome."""
 
-    def ask(argv: list[str]) -> str:
-        try:
-            result = subprocess.run(
-                argv, cwd=REPOSITORY, capture_output=True, text=True
-            )
-        except OSError:
-            return ""
-        return result.stdout.strip() if result.returncode == 0 else ""
-
-    described = ask(["git", "describe", "--always", "--dirty"]) or "unknown"
-    changed = len(ask(["git", "status", "--short"]).splitlines())
-    return f"{described} dirty={changed} driver-sha256={driver_digest(driver)}"
+    described, changed = git_state()
+    return (
+        f"{described or 'unknown'} dirty={changed} "
+        f"driver-sha256={driver_digest(driver)}"
+    )
 
 
 def retain_driver(workdir: Path, built: Path) -> Path:

--- a/tests/vm/driver.py
+++ b/tests/vm/driver.py
@@ -111,13 +111,13 @@ exec sh ./bootstrap.sh --no-shell "$@"
 """
 
 
-def revision() -> str:
-    """What the driver CD is about to be built from.
+def git_state() -> tuple[str, int]:
+    """What `git describe` calls the checkout, and how many tracked files differ.
 
-    A campaign that ran while its own tree was being committed to measured
-    twelve different snapshots and could name none of them, so every run says
-    this before it boots anything. `dirty` means the result proves nothing
-    about any commit.
+    Tracked only: an untracked screenshot sitting in the checkout made every
+    run report a change while `git describe --dirty` on the same line said the
+    tree was clean, and both runners read that to decide whether a result
+    counts.
     """
 
     def ask(command: list[str]) -> str:
@@ -131,14 +131,22 @@ def revision() -> str:
 
     described = ask(["git", "describe", "--always", "--dirty"]).strip()
     if not described:
+        return "", 0
+    changed = ask(["git", "status", "--short", "--untracked-files=no"]).splitlines()
+    return described, len(changed)
+
+
+def revision() -> str:
+    """What the driver CD is about to be built from.
+
+    A campaign that ran while its own tree was being committed to measured
+    twelve different snapshots and could name none of them, so every run says
+    this before it boots anything. `dirty` means the result proves nothing
+    about any commit.
+    """
+    described, uncommitted = git_state()
+    if not described:
         return "unknown, not a git checkout"
-    # Tracked changes only: an untracked screenshot sitting in the checkout
-    # made every run say `1 uncommitted files`, which reads as a result that
-    # proves nothing while `git describe --dirty` had already said the tree
-    # was clean.
-    uncommitted = len(
-        ask(["git", "status", "--short", "--untracked-files=no"]).splitlines()
-    )
     return f"{described} ({uncommitted} uncommitted files)" if uncommitted else described
 
 


### PR DESCRIPTION
#1026 stopped an untracked screenshot from being counted as a change in `driver.revision()`. The next cluster round opened with `installer revision: da0df83ad7948 dirty=1` — `cluster.revision_identity()` ran its own `git status` and still counted it.

One `git_state()` in `driver.py` now, read by both. The test pins the shape: exactly one `git status` argv in `driver.py`, none in `cluster.py`.

Its first version counted every `"status"` string constant and failed on the orphan report reading a `status` key out of the API's answer — a red that had nothing to do with what the rule means. It matches the argv now. Putting a `git status` back into `cluster.py` fails with `cluster.py asks git for itself again`.