### PR TITLE
vm: let --only reach every run carrying a fixture

### DIFF
--- a/tests/unit/test_harness.py
+++ b/tests/unit/test_harness.py
@@ -5775,3 +5775,18 @@ def test_an_untracked_file_does_not_make_a_run_look_dirty(
     assert "uncommitted" not in driver.revision(), driver.revision()
     (tmp_path / "tracked.txt").write_text("two\n")
     assert "1 uncommitted files" in driver.revision(), driver.revision()
+
+
+def test_only_reaches_every_run_of_a_fixture() -> None:
+    """`--only vm-binpkg` reached the openSUSE medium and nothing else: the
+    lookup was a dict keyed by the fixture stem, so of the eight runs carrying
+    that fixture the last one written won. The ordinary run and the
+    `--interrupt` one that exercises `--resume` could not be asked for."""
+    from tests.vm.campaign import named
+
+    chosen = named(["vm-binpkg"])
+    names = [one.name for one in chosen]
+    assert len(names) > 1, names
+    assert "official-minimal-uefi-vm-binpkg" in names, names
+    assert "official-minimal-uefi-vm-binpkg-interrupted" in names, names
+    assert any(one.interrupt for one in chosen), names

--- a/tests/vm/campaign.py
+++ b/tests/vm/campaign.py
@@ -404,11 +404,18 @@ def named(wanted: Sequence[str]) -> list[Run]:
     So that testing four configurations again is this harness with an argument
     rather than a shell loop written for one afternoon and thrown away.
     """
-    by_name = {Path(one.config).stem: one for runs in STAGES.values() for one in runs}
+    # Every `Run` carrying the fixture, not one: a dict keyed by the stem kept
+    # only the last, so `--only vm-binpkg` reached the openSUSE medium and
+    # neither the ordinary run nor the `--interrupt` one that exercises
+    # `--resume` could be asked for at all.
+    by_name: dict[str, list[Run]] = {}
+    for runs in STAGES.values():
+        for one in runs:
+            by_name.setdefault(Path(one.config).stem, []).append(one)
     missing = [one for one in wanted if one not in by_name]
     if missing:
         raise SystemExit(f"no fixture named {', '.join(missing)}; have {', '.join(sorted(by_name))}")
-    return [by_name[one] for one in wanted]
+    return [run for one in wanted for run in by_name[one]]
 
 
 def main(argv: list[str] | None = None) -> int:


### PR DESCRIPTION
`--only vm-binpkg` selected one run and it was the openSUSE medium, which this workstation has no ISO for, so the campaign reported `0/1 passed` after skipping. `named()` built `{stem: run}`, and eight runs carry that fixture — the last one written won.

The two that matter most were unreachable: the ordinary `vm-binpkg` and `Run(..., interrupt=True)`, which is the only exercise `--resume` has.

The lookup maps a stem to a list now. `named(["vm-binpkg"])` answers with all eight and one of them carries `interrupt=True`; restoring the one-to-one mapping fails with `['opensuse-uefi-vm-binpkg']`.

This is the quiet kind: the command did not error, it did less than it was asked, and `0/1 passed` reads like an ordinary failure.