### PR TITLE
vm: keep an interrupted run out of the plain run's work directory

### DIFF
--- a/tests/unit/test_harness.py
+++ b/tests/unit/test_harness.py
@@ -5790,3 +5790,32 @@ def test_only_reaches_every_run_of_a_fixture() -> None:
     assert "official-minimal-uefi-vm-binpkg" in names, names
     assert "official-minimal-uefi-vm-binpkg-interrupted" in names, names
     assert any(one.interrupt for one in chosen), names
+
+
+def test_an_interrupted_run_does_not_share_a_work_directory() -> None:
+    """`--only vm-binpkg` now selects the plain run and the `--interrupt` one,
+    and they collided: the work directory took the fixture stem and not the
+    suffix `Run.name` carries, so the second reported `LOCK` at 0.0m without
+    ever starting."""
+    import ast
+    import inspect
+
+    from tests.vm import run as runner
+    from tests.vm.campaign import Run
+
+    plain = Run("fixtures/vm-binpkg.toml")
+    interrupted = Run("fixtures/vm-binpkg.toml", interrupt=True)
+    assert plain.name != interrupted.name, plain.name
+    assert interrupted.name.endswith(runner.INTERRUPTED_SUFFIX), interrupted.name
+
+    # And the work directory is built from the same constant, so the two
+    # names cannot drift apart again.
+    source = inspect.getsource(runner.main)
+    assigned = [
+        ast.unparse(node.value)
+        for node in ast.walk(ast.parse(source))
+        if isinstance(node, ast.Assign)
+        and any(isinstance(one, ast.Name) and one.id == "workdir" for one in node.targets)
+    ]
+    assert assigned, "main no longer assigns workdir"
+    assert all("INTERRUPTED_SUFFIX" in one for one in assigned), assigned

--- a/tests/vm/campaign.py
+++ b/tests/vm/campaign.py
@@ -28,6 +28,7 @@ from typing import Callable, Final, Sequence
 from .driver import revision
 from .expectations import EXPECTATIONS, Expectation
 from .media import MISSING_PRECONDITION
+from .run import INTERRUPTED_SUFFIX
 
 WORKROOT: Final[Path] = Path.home() / "code/gentoo-install/lab/vm/runs"
 LOGS: Final[Path] = Path.home() / "code/gentoo-install/lab/vm/campaign"
@@ -118,7 +119,7 @@ class Run:
 
     @property
     def name(self) -> str:
-        how = "-interrupted" if self.interrupt else ""
+        how = INTERRUPTED_SUFFIX if self.interrupt else ""
         return f"{self.medium}-{self.firmware}-{Path(self.config).stem}{how}"
 
     @property

--- a/tests/vm/run.py
+++ b/tests/vm/run.py
@@ -58,6 +58,10 @@ from .results import collect_command, create_disk, read_disk
 from .installed import checks, stage_passphrase_commands
 
 WORKROOT = Path.home() / "code/gentoo-install/lab/vm/runs"
+
+#: What a run killed partway and finished with `--resume` is called, in both
+#: its work directory and `campaign.Run.name`.
+INTERRUPTED_SUFFIX: Final[str] = "-interrupted"
 #: Big enough for a stage3, a desktop and the swap a fixture may ask for.
 DEFAULT_TARGET_SIZE = "40G"
 #: Slirp reads the host's `/etc/resolv.conf` once at startup, so a host that
@@ -803,7 +807,10 @@ def main(argv: list[str] | None = None) -> int:
             )
             return 1
     variant = Path(args.install).stem if args.install else "probe"
-    workdir = WORKROOT / f"{medium.name}-{args.firmware}-{variant}"
+    # The suffix `campaign.Run.name` uses, because the two have to agree: the
+    # plain and the interrupted run of one fixture shared a work directory,
+    # and asking for both at once made the second report `LOCK` at 0.0m.
+    workdir = WORKROOT / f"{medium.name}-{args.firmware}-{variant}{INTERRUPTED_SUFFIX if args.interrupt else ''}"
     workdir.mkdir(parents=True, exist_ok=True)
     # The medium too: a rolling release keeps its filename, so a result
     # that names only the medium does not say which build it booted.


### PR DESCRIPTION
With #1030 in, `--only vm-binpkg` selects all eight runs, and the first thing that produced was `LOCK official-minimal-uefi-vm-binpkg-interrupted 0.0m` — another run holding the work directory.

`Run.name` appends `-interrupted`; `run.py` built `WORKROOT / f"{medium}-{firmware}-{variant}"` from the fixture stem alone. The two runs of one fixture therefore shared a directory, which could not show before because only one of them was reachable.

One `INTERRUPTED_SUFFIX`, read by both. The test compares the names and also reads `main()` to confirm the work directory is built from that constant — comparing names alone would pass with the same string written out twice. Dropping the suffix fails with the old expression.