### PR TITLE
vm: keep the conversion off a campaign that cannot pair it

### DIFF
--- a/tests/unit/test_harness.py
+++ b/tests/unit/test_harness.py
@@ -153,6 +153,13 @@ NOT_IN_THE_CAMPAIGN: Final[frozenset[str]] = frozenset(
         # medium the campaign boots, because the machine under test has to
         # have a bootloader of its own to arm.
         "vm-ram.toml",
+        # A conversion converts a running system, and the cluster runs it as
+        # the second phase of a pair: install an ordinary machine, then
+        # convert that. The local campaign has no pairing, so it ran the
+        # fixture against a seeded cloud image whose root filesystem holds
+        # 3 GiB free, and the installer refused with exit 2 — correctly, and
+        # the verdict read `FAIL`.
+        "vm-convert.toml",
         # The only fixture that configures a static address, and the interface
         # it has to pin is the cluster's: a local guest presents `enp0s2` where
         # the cluster presents `ens18`, so `[Match] Name=ens18` matches nothing

--- a/tests/vm/campaign.py
+++ b/tests/vm/campaign.py
@@ -198,7 +198,6 @@ STAGES: Final[dict[str, tuple[Run, ...]]] = {
         # from staging root to swap to bootloader is exercised on a real
         # system rather than a plan. Two installs one after the other, so it is
         # long rather than heavy: the instantaneous cost is one guest's.
-        Run("fixtures/vm-convert.toml"),
         Run("fixtures/vm-raidz.toml"),
         Run("fixtures/vm-zram.toml"),
         # A sudo user's `authorized_keys`, read back off the installed system.


### PR DESCRIPTION
`vm-convert` failed locally in 0.4m with the installer's own preflight message: `the root filesystem has 3 GiB free and a conversion needs 10: the staged system and the running one are on it at the same time`. That refusal is right, and a real operator in the same position should see exactly that sentence.

It is not what the cluster measures. There a conversion is a two-phase job — `Job.convert_to` installs an ordinary machine and then converts it — and `campaign.Run` has no such field, so the local campaign ran the fixture against a seeded cloud image instead. The cluster's 71.4m `ok` and this 0.4m `FAIL` do not contradict each other; they are not the same experiment.

Excluded with that reason recorded, and row 405 holds the real fix: teach `Run` to express the pair. This is the third fixture the local list carried that the local runner cannot satisfy — `static-ip` needed an interface name, the other media need ISOs, this one needs a system to convert.