### PR TITLE
vm: give the encrypted boot verdict its seconds and its screen

### DIFF
--- a/tests/unit/test_cluster.py
+++ b/tests/unit/test_cluster.py
@@ -4108,3 +4108,70 @@ def test_both_runners_read_one_git_state() -> None:
     assert asks_git_status(driver) == 1, "driver.py no longer asks git once"
     assert asks_git_status(cluster) == 0, "cluster.py asks git for itself again"
     assert "git_state" in inspect.getsource(cluster.revision_identity)
+
+
+def test_the_encrypted_boot_verdict_says_how_long_and_what_was_on_the_screen(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """`vm-zfs-encrypted` was failed after 66 minutes with `the encrypted disk
+    asked for nothing and booted nowhere: never matched '<the pattern>'` and
+    nothing else: the verdict was cut to 200 bytes from the front, and
+    `ConsoleTimeout` leads with the pattern, which is 200 bytes on its own. So
+    the one fact it carried is the one already in the source, and whether the
+    guest had waited its whole ceiling or died at second twelve could not be
+    told from the verdict at all."""
+    monkeypatch.setattr(time, "sleep", lambda seconds: None)
+    clock = [0.0]
+    monkeypatch.setattr(time, "monotonic", lambda: clock[0])
+
+    class Booting:
+        """A guest that reaches dracut and then stops, escapes and all."""
+
+        def __init__(self) -> None:
+            self._said = False
+
+        def recv(self, size: int) -> bytes:
+            clock[0] += 1.0
+            if self._said:
+                return b""
+            self._said = True
+            return (
+                b"[\x1b[0;32m  OK  \x1b[0m] Reached target \x1b[0;1;39mZFS pool "
+                b"import target\x1b[0m\r\n         Starting \x1b[0;1;39mdracut "
+                b"pre-mount hook\x1b[0m...\r\n"
+            )
+
+        def sendall(self, data: bytes) -> None:
+            return None
+
+        def close(self) -> None:
+            return None
+
+        @property
+        def closed(self) -> bool:
+            return False
+
+    serial = SerialConsole(cast(Any, Booting()), BytesIO())
+
+    class Watching:
+        def __init__(self) -> None:
+            self.console = serial
+
+        def observe(self, pattern: str, timeout: float, *, solicit: bool = False) -> bytes:
+            return serial.expect(pattern, timeout)
+
+        def respond(self, line: str) -> None:
+            return None
+
+    from gentoo_install.exec.config import load
+
+    installation = load(FIXTURES / "vm-zfs-encrypted.toml")
+    result = cluster._unlock(cast(Any, _Keyboard()), cast(Any, Watching()), installation)
+
+    assert result.refused, result
+    # The screen and the wait, neither of which the reader can get from the
+    # source. `dracut pre-mount` appears in no pattern the wait was built from.
+    assert "dracut pre-mount hook" in result.refused, result.refused
+    assert f"{cluster.BOOT_PATIENCE:.0f}s" in result.refused, result.refused
+    # And not the pattern, which is what the truncation used to keep.
+    assert "Please enter passphrase" not in result.refused, result.refused

--- a/tests/vm/cluster.py
+++ b/tests/vm/cluster.py
@@ -3049,9 +3049,17 @@ def _naming(command: str) -> Iterator[None]:
     try:
         yield
     except ConsoleIdle as error:
-        raise ConsoleIdle(f"{error} while running {_shortened(command)!r}") from error
+        raise ConsoleIdle(
+            f"{error} while running {_shortened(command)!r}",
+            waited=error.waited,
+            seen=error.seen,
+        ) from error
     except ConsoleTimeout as error:
-        raise ConsoleTimeout(f"{error} while running {_shortened(command)!r}") from error
+        raise ConsoleTimeout(
+            f"{error} while running {_shortened(command)!r}",
+            waited=error.waited,
+            seen=error.seen,
+        ) from error
 
 
 #: What clears a half-typed line, including one inside an unclosed quote.
@@ -3226,7 +3234,9 @@ class Reconnecting:
                     # alone filled all 300 of `zbm-unlock`'s, so the round
                     # could not say whether its counters had moved.
                     raise ConsoleTimeout(
-                        f"the console was silent for {idle:.0f}s and {reason}: {error}"
+                        f"the console was silent for {idle:.0f}s and {reason}: {error}",
+                        waited=error.waited,
+                        seen=error.seen,
                     ) from error
 
         self._with_reconnect(timeout, wait_once, watch=watch)
@@ -3770,10 +3780,19 @@ def _unlock(
                 ),
                 timeout=BOOT_PATIENCE,
             )
-        except (ConsoleTimeout, ConsoleClosed) as error:
+        except ConsoleTimeout as error:
             return UnlockResult(
                 InstalledBootState.WAIT_LOGIN,
-                f"the encrypted disk asked for nothing and booted nowhere: {error}"[:200],
+                (
+                    "the encrypted disk asked for nothing and booted nowhere in "
+                    f"{error.waited:.0f}s; the console held "
+                    f"{error.seen[-INITRAMFS_SCREEN_BYTES:]!r}"
+                )[:VERDICT_BYTES],
+            )
+        except ConsoleClosed as error:
+            return UnlockResult(
+                InstalledBootState.WAIT_LOGIN,
+                f"the encrypted disk closed its console: {error}"[:VERDICT_BYTES],
             )
         if any(one.encode() in said for one in LOGIN_PROMPTS):
             return UnlockResult(InstalledBootState.LOGIN_READY)
@@ -3796,7 +3815,7 @@ def _unlock(
         except ConsoleClosed as error:
             return UnlockResult(
                 InstalledBootState.WAIT_LOGIN,
-                f"the disk passphrase delivery is unknown: {error}"[:200],
+                f"the disk passphrase delivery is unknown: {error}"[:VERDICT_BYTES],
             )
     return UnlockResult(
         InstalledBootState.WAIT_LOGIN,
@@ -3930,7 +3949,7 @@ def boot_and_check(
     try:
         refused = _log_in(link, INSTALLED_PASSWORD)
     except ConsoleClosed as error:
-        return f"installed login response delivery is unknown: {error}"[:200]
+        return f"installed login response delivery is unknown: {error}"[:VERDICT_BYTES]
     if refused:
         return f"{missed_the_prompt}; {refused}"[:VERDICT_BYTES] if missed_the_prompt else refused
 

--- a/tests/vm/console.py
+++ b/tests/vm/console.py
@@ -61,7 +61,18 @@ def command_done(token: int) -> str:
 
 
 class ConsoleTimeout(Exception):
-    """A pattern did not appear on the console within its deadline."""
+    """A pattern did not appear on the console within its deadline.
+
+    `waited` and `seen` are what a verdict needs and the message cannot carry:
+    the message leads with the pattern, which at the encrypted boot is longer
+    than any verdict, so a caller that truncates from the front keeps the one
+    fact its reader already has and drops the two it does not.
+    """
+
+    def __init__(self, message: str, *, waited: float = 0.0, seen: bytes = b"") -> None:
+        super().__init__(message)
+        self.waited = waited
+        self.seen = seen
 
 
 class ConsoleIdle(ConsoleTimeout):
@@ -243,7 +254,9 @@ class SerialConsole:
         )
         raise error(
             f"never matched {pattern!r}, {why}; "
-            f"last output was {strip_ansi(self._buffer)[-600:]!r}"
+            f"last output was {strip_ansi(self._buffer)[-600:]!r}",
+            waited=time.monotonic() - started,
+            seen=strip_ansi(self._buffer),
         )
 
     def send(self, line: str) -> None:


### PR DESCRIPTION
`vm-zfs-encrypted` was failed after 66 minutes with `the encrypted disk asked for nothing and booted nowhere: never matched '<the pattern>'` and nothing after it. `ConsoleTimeout` builds its message pattern first, and that pattern is longer than the 200 bytes the verdict kept, so the only fact it carried is the one already written in the source. Whether the guest had spent its whole ceiling or died at second twelve could not be told from the verdict at all.

`ConsoleTimeout` now carries `waited` and `seen` as attributes, the two places that re-raise it pass them through, and the verdict prints the seconds and the console tail like the `INITRAMFS_GAVE_UP` branch beside it always did. `ConsoleClosed` gets its own branch, because a closed console has no screen to print. Three hand-written `[:200]` truncations now read `VERDICT_BYTES`.

The negative control restores the old verdict and the test fails with the cluster round's string, character for character.