### PR TITLE
vm: say what --only will run before it runs it

### DIFF
--- a/tests/unit/test_harness.py
+++ b/tests/unit/test_harness.py
@@ -8,6 +8,7 @@ process it drove, so nothing else in the run can notice a failure for it.
 from __future__ import annotations
 
 import re
+from collections.abc import Sequence
 from io import BytesIO
 from pathlib import Path
 from types import SimpleNamespace
@@ -5826,3 +5827,28 @@ def test_an_interrupted_run_does_not_share_a_work_directory() -> None:
     ]
     assert assigned, "main no longer assigns workdir"
     assert all("INTERRUPTED_SUFFIX" in one for one in assigned), assigned
+
+
+def test_every_dispatch_form_says_what_it_will_run_before_it_runs(
+    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """`--only vm-zfs-encrypted` printed nothing at all until the run ended an
+    hour later: its two siblings each announce their round and that branch was
+    written without one. A local round redirected to a file is then a zero-byte
+    file for the whole run, which reads exactly like a launch that failed."""
+    from tests.vm import campaign
+
+    said: list[str] = []
+
+    def announced(runs: Sequence[campaign.Run]) -> list[campaign.Outcome]:
+        said.append(capsys.readouterr().out)
+        return []
+
+    monkeypatch.setattr(campaign, "parallel", announced)
+    monkeypatch.setattr(campaign, "report", lambda done: 0)
+    for argv in (["--only", "vm-xfs"], ["--keep-going"], []):
+        assert campaign.main(argv) == 0, argv
+
+    assert len(said) >= 3, said
+    for spoken in said:
+        assert spoken.strip(), said

--- a/tests/vm/campaign.py
+++ b/tests/vm/campaign.py
@@ -437,7 +437,12 @@ def main(argv: list[str] | None = None) -> int:
     args = parser.parse_args(argv)
     done: list[Outcome] = []
     if args.only:
-        done = list(parallel(named(args.only)))
+        # Named, not counted: `named()` answers with every `Run` carrying the
+        # fixture, so `--only vm-binpkg` is three runs and a reader who is
+        # told `3 runs` cannot tell which three.
+        chosen = named(args.only)
+        print(f"--- {', '.join(one.name for one in chosen)} ({len(chosen)} runs)")
+        done = list(parallel(chosen))
     elif args.keep_going:
         # One pool, not one stage at a time. The stage barrier exists so a
         # failed blocking stage can stop the rest, and `--keep-going` has


### PR DESCRIPTION
A local `campaign --only vm-zfs-encrypted` was six minutes old with `qemu-system` running and its log file still zero bytes. `main()` has three dispatch branches; `--keep-going` and the stage-by-stage one each print a `--- <what> (N runs)` line, and the `--only` branch was written without one. The per-run verdict is only printed when a run ends, so an hour-long round says nothing at all until it is over — which is indistinguishable from a launch that died.

The line names the runs rather than counting them, because `named()` answers with every `Run` carrying the fixture: `--only vm-binpkg` is three of them, and `3 runs` does not say which three.

The test requires all three dispatch forms to have printed something before `parallel()` is called. Removing the new line turns the first form's output into an empty string and it fails.