### PR TITLE
bootloader: say the ZFSBootMenu cmdline in describe

### DIFF
--- a/gentoo_install/plan/bootloader.py
+++ b/gentoo_install/plan/bootloader.py
@@ -465,7 +465,8 @@ class InstallZfsBootMenu(Operation):
     def describe(self) -> str:
         return (
             f"write {ZBM_CONFIG}, build ZFSBootMenu into {self.esp}/{ZBM_DIRECTORY}, "
-            f"and boot {self.dataset} from it"
+            f"and boot {self.dataset} from it with cmdline "
+            f"{' '.join(self.kernel_params) or 'empty'}"
         )
 
     def _config(self) -> str:

--- a/tests/golden/vm-raidz.txt
+++ b/tests/golden/vm-raidz.txt
@@ -85,7 +85,7 @@
 [bootloader]
   install the bootloader: emerge sys-boot/zfsbootmenu sys-boot/efibootmgr
   install the EFI stub generate-zbm builds around: emerge sys-apps/systemd
-  write /etc/zfsbootmenu/config.yaml, build ZFSBootMenu into /efi/EFI/zbm, and boot rpool/ROOT/gentoo from it
+  write /etc/zfsbootmenu/config.yaml, build ZFSBootMenu into /efi/EFI/zbm, and boot rpool/ROOT/gentoo from it with cmdline console=ttyS0,115200
 
 [packages]
   enable zfs-import-scan.service at boot

--- a/tests/golden/vm-zfs-encrypted.txt
+++ b/tests/golden/vm-zfs-encrypted.txt
@@ -77,7 +77,7 @@
 [bootloader]
   install the bootloader: emerge sys-boot/zfsbootmenu sys-boot/efibootmgr
   install the EFI stub generate-zbm builds around: emerge sys-apps/systemd
-  write /etc/zfsbootmenu/config.yaml, build ZFSBootMenu into /efi/EFI/zbm, and boot rpool/ROOT/gentoo from it
+  write /etc/zfsbootmenu/config.yaml, build ZFSBootMenu into /efi/EFI/zbm, and boot rpool/ROOT/gentoo from it with cmdline console=ttyS0,115200
 
 [packages]
   enable zfs-import-scan.service at boot

--- a/tests/golden/vm-zfs-mirror.txt
+++ b/tests/golden/vm-zfs-mirror.txt
@@ -81,7 +81,7 @@
 [bootloader]
   install the bootloader: emerge sys-boot/zfsbootmenu sys-boot/efibootmgr
   install the EFI stub generate-zbm builds around: emerge sys-apps/systemd
-  write /etc/zfsbootmenu/config.yaml, build ZFSBootMenu into /efi/EFI/zbm, and boot rpool/ROOT/gentoo from it
+  write /etc/zfsbootmenu/config.yaml, build ZFSBootMenu into /efi/EFI/zbm, and boot rpool/ROOT/gentoo from it with cmdline console=ttyS0,115200
 
 [packages]
   enable zfs-import-scan.service at boot

--- a/tests/golden/vm-zfs.txt
+++ b/tests/golden/vm-zfs.txt
@@ -77,7 +77,7 @@
 [bootloader]
   install the bootloader: emerge sys-boot/zfsbootmenu sys-boot/efibootmgr
   install the EFI stub generate-zbm builds around: emerge sys-apps/systemd
-  write /etc/zfsbootmenu/config.yaml, build ZFSBootMenu into /efi/EFI/zbm, and boot rpool/ROOT/gentoo from it
+  write /etc/zfsbootmenu/config.yaml, build ZFSBootMenu into /efi/EFI/zbm, and boot rpool/ROOT/gentoo from it with cmdline console=ttyS0,115200
 
 [packages]
   enable zfs-import-scan.service at boot

--- a/tests/golden/zbm-unlock.txt
+++ b/tests/golden/zbm-unlock.txt
@@ -93,7 +93,7 @@
   install the bootloader: emerge sys-boot/zfsbootmenu sys-boot/efibootmgr
   install the EFI stub generate-zbm builds around: emerge sys-apps/systemd
   write /etc/zfsbootmenu/dracut.conf.d/dropbear.conf and /etc/cmdline.d/dracut-network.conf, authorise keys at /etc/dropbear/root_key, and generate dedicated host keys under /etc/dropbear
-  write /etc/zfsbootmenu/config.yaml, build ZFSBootMenu into /efi/EFI/zbm, and boot zpcala/ROOT/gentoo/root from it
+  write /etc/zfsbootmenu/config.yaml, build ZFSBootMenu into /efi/EFI/zbm, and boot zpcala/ROOT/gentoo/root from it with cmdline console=ttyS0,115200 quiet
 
 [packages]
   enable zfs-import-scan.service at boot

--- a/tests/golden/zfs-zbm.txt
+++ b/tests/golden/zfs-zbm.txt
@@ -89,7 +89,7 @@
 [bootloader]
   install the bootloader: emerge sys-boot/zfsbootmenu sys-boot/efibootmgr
   install the EFI stub generate-zbm builds around: emerge sys-apps/systemd
-  write /etc/zfsbootmenu/config.yaml, build ZFSBootMenu into /efi/EFI/zbm, and boot zpcala/ROOT/gentoo/root from it
+  write /etc/zfsbootmenu/config.yaml, build ZFSBootMenu into /efi/EFI/zbm, and boot zpcala/ROOT/gentoo/root from it with cmdline console=ttyS0,115200 quiet
 
 [packages]
   enable zfs-import-scan.service at boot

--- a/tests/unit/test_plan_bootloader.py
+++ b/tests/unit/test_plan_bootloader.py
@@ -597,3 +597,25 @@ def test_an_image_found_beside_an_unreadable_entry_is_still_installed() -> None:
         }
     )
     assert built._image(partial) == "/efi/EFI/zbm/vmlinuz-6.12.EFI"
+
+
+def test_the_zfsbootmenu_describe_changes_with_the_command_line_it_will_set() -> None:
+    """`apply()` sets `org.zfsbootmenu:commandline` and `describe()` said only
+    the config path and the dataset, so a dry run could not show whether the
+    installed system would answer on a serial port. GRUB's own describe has
+    named its cmdline all along; the two disagreed about the same value.
+
+    The parameters are also not the operator's alone: a remote unlock adds
+    its own, so what a dry run hides here is larger than what was configured.
+    """
+    from dataclasses import replace
+
+    operation = zfsbootmenu_operation()
+    assert " ".join(operation.kernel_params) in operation.describe(), operation.describe()
+
+    other = replace(operation, kernel_params=("console=ttyS1,9600", "nomodeset"))
+    assert other.describe() != operation.describe()
+    assert "console=ttyS1,9600 nomodeset" in other.describe(), other.describe()
+
+    empty = replace(operation, kernel_params=())
+    assert "empty" in empty.describe(), empty.describe()


### PR DESCRIPTION
`InstallZfsBootMenu.apply()` runs `zfs set org.zfsbootmenu:commandline=<params>`, and its `describe()` named only the config path, the directory and the dataset. `InstallGrub.describe()` has printed `with cmdline …` all along, so the two disagreed about the same value and a dry run could not show whether the installed system would answer on a serial port.

The six regenerated golden files show the difference was real, not decorative: `vm-zfs-encrypted` reads `console=ttyS0,115200` and `zbm-unlock` reads `console=ttyS0,115200 quiet`. The field is not the operator's alone either — a remote unlock adds its own parameters, so what the dry run hid was larger than what the configuration asked for.

Found while reading why a local `vm-zfs-encrypted` went silent after ZFSBootMenu took its passphrase. That is a separate defect in the harness's typing; the installer sets this property correctly, with `returncode 0` in the run's own log.