### PR TITLE
vm: answer a passphrase prompt that discarded the answer

### DIFF
--- a/tests/unit/test_harness.py
+++ b/tests/unit/test_harness.py
@@ -5852,3 +5852,62 @@ def test_every_dispatch_form_says_what_it_will_run_before_it_runs(
     assert len(said) >= 3, said
     for spoken in said:
         assert spoken.strip(), said
+
+
+def test_an_answer_the_passphrase_prompt_discarded_is_answered_again(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A local `vm-zfs-encrypted` spent its whole 300s ceiling at
+
+        Enter passphrase for 'rpool':install-disk
+
+    with nothing after it. The echo is the proof: the prompt had not yet
+    turned it off, so `TCSAFLUSH` threw the answer away, and ZFSBootMenu
+    prints that prompt once. Waiting for a second one waits for ever."""
+    from gentoo_install.exec.config import load
+    from tests.vm import run as runner
+    from tests.vm.console import DISK_PASSPHRASE, SerialConsole
+
+    import time
+
+    # A clock the reads advance, so a wait for a prompt that is never printed
+    # again ends at its own ceiling rather than holding the suite for 300s.
+    clock = [0.0]
+    monkeypatch.setattr(time, "monotonic", lambda: clock[0])
+
+    class Losing:
+        """A prompt that discards the first answer and echoes it."""
+
+        def __init__(self) -> None:
+            self.answers = 0
+            self.queue = [b"Enter passphrase for 'rpool':"]
+
+        def recv(self, size: int) -> bytes:
+            clock[0] += 1.0
+            return self.queue.pop(0) if self.queue else b""
+
+        def sendall(self, data: bytes) -> None:
+            typed = data.decode().strip()
+            if typed != DISK_PASSPHRASE:
+                self.queue.append(b"# " if typed == "install" else b"Password: ")
+                return
+            self.answers += 1
+            # The first one comes back rather than being read; the second is
+            # taken and the machine goes on to its login.
+            self.queue.append(
+                f"{DISK_PASSPHRASE}\r\n".encode() if self.answers == 1 else b"\r\nlogin: "
+            )
+
+        def close(self) -> None:
+            return None
+
+        @property
+        def closed(self) -> bool:
+            return False
+
+    channel = Losing()
+    console = SerialConsole(cast(Any, channel), BytesIO())
+    installation = load(Path("tests/fixtures/vm-zfs-encrypted.toml"))
+
+    assert runner.unlock_and_login(console, installation) == "console"
+    assert channel.answers == 2, channel.answers

--- a/tests/vm/console.py
+++ b/tests/vm/console.py
@@ -122,6 +122,29 @@ DISK_PASSPHRASE = "install-disk"
 #: runner at five, so a fifth valid prompt passed one and failed the other.
 PASSPHRASE_ATTEMPTS: Final[int] = 5
 
+#: How long an answer has to come back on the console before it is taken to
+#: have been read rather than discarded. A passphrase prompt turns the echo
+#: off with `TCSAFLUSH`, which throws away whatever was typed before it: an
+#: answer that is echoed never reached the reader, and the prompt is still
+#: waiting. Bounded and short, because the echo is the local terminal's and
+#: arrives without the guest doing anything.
+ECHO_PATIENCE: Final[float] = 5.0
+
+
+def discarded_by_the_prompt(console: "SerialConsole", answer: str) -> bool:
+    """Whether `answer` came back on the console after being typed at a prompt.
+
+    A local `vm-zfs-encrypted` sat at `Enter passphrase for 'rpool':` for its
+    whole 300s ceiling with `install-disk` echoed beside it: the echo proves
+    the prompt had not yet turned it off, so `TCSAFLUSH` discarded the answer
+    and no second prompt was ever going to be printed.
+    """
+    try:
+        console.expect(re.escape(answer), timeout=ECHO_PATIENCE)
+    except ConsoleTimeout:
+        return False
+    return True
+
 
 class Channel(Protocol):
     """What a console needs of its transport, and nothing more.

--- a/tests/vm/run.py
+++ b/tests/vm/run.py
@@ -49,6 +49,7 @@ from .console import (
     PASSPHRASE_PROMPT,
     PASSWORD_PROMPT,
     SerialConsole,
+    discarded_by_the_prompt,
 )
 from .monitor import type_text
 from .driver import FIND_DRIVER, REPOSITORY, build as build_driver
@@ -511,6 +512,13 @@ def unlock_and_login(
             console.expect(r"# ", timeout=60.0)
             return "console"
         console.send(DISK_PASSPHRASE)
+        # Answered again here rather than at the top of the loop: an answer
+        # the prompt discarded leaves that same prompt on the screen and
+        # nothing reprints it, so waiting for a second one spends the ceiling.
+        for _ in range(PASSPHRASE_ATTEMPTS):
+            if not discarded_by_the_prompt(console, DISK_PASSPHRASE):
+                break
+            console.send(DISK_PASSPHRASE)
     raise SystemExit("the disk kept asking for a passphrase; it is not the one installed")
 
 


### PR DESCRIPTION
A local `vm-zfs-encrypted` spent its whole 300s ceiling with a serial log 1219 bytes long that ends `Enter passphrase for 'rpool':install-disk`. The echo is the proof: a passphrase prompt turns the echo off with `TCSAFLUSH`, which throws away whatever was typed before it, so an answer that comes back on the console never reached the reader. ZFSBootMenu prints that prompt once, so the loop's next wait was for a prompt that was never going to appear again.

`discarded_by_the_prompt()` reads the console for the answer it just typed and answers again when it finds it, bounded by `PASSPHRASE_ATTEMPTS`.

Only the local runner changes. The cluster got past ZFSBootMenu's prompt to the system's own dracut prompt in the same round, so its growing settle works there and there is no evidence to act on; `reach_the_login_past_any_passphrase` has the same shape and no evidence either, so it is recorded rather than edited.

The first negative control hung for the real 300 seconds instead of failing, and a timeout is not a red. With a clock the reads advance it fails with the measured string, character for character.