### PR TITLE
vm: size a ZFS root as a guest that compiles

### DIFF
--- a/tests/unit/test_cluster.py
+++ b/tests/unit/test_cluster.py
@@ -4175,3 +4175,29 @@ def test_the_encrypted_boot_verdict_says_how_long_and_what_was_on_the_screen(
     assert f"{cluster.BOOT_PATIENCE:.0f}s" in result.refused, result.refused
     # And not the pattern, which is what the truncation used to keep.
     assert "Please enter passphrase" not in result.refused, result.refused
+
+
+def test_a_zfs_root_is_a_heavy_guest_whatever_its_kernel_says() -> None:
+    """`vm-zfs-encrypted` stalled twice mid-compile on the two cores a light
+    guest is given, and its own `install.jsonl` says why: nineteen packages
+    compiled, among them `sys-fs/zfs`, `sys-boot/zfsbootmenu`, its `fzf`,
+    `kexec-tools` and `mbuffer`, and `sys-apps/systemd`. A binary kernel does
+    not spare a ZFS layout, because the module is built against whatever
+    kernel was installed.
+
+    The three assertions before the verdict are the point: every other test
+    for a heavy guest says these are light, so a fixture that later gains a
+    desktop stops covering this case and says so.
+    """
+    from gentoo_install.exec.config import load
+
+    for name in ("vm-zfs", "vm-zfs-encrypted", "vm-zfs-mirror", "vm-raidz"):
+        config = load(FIXTURES / f"{name}.toml")
+        assert config.kernel.source.value.endswith("-bin"), name
+        assert not config.packages.desktop, name
+        assert config.portage.binhost.official, name
+        assert cluster._compiles(config), name
+
+    # And not everything: a plain binary-package install stays light, or the
+    # rule buys nothing and the cluster runs one guest at a time.
+    assert not cluster._compiles(load(FIXTURES / "vm-xfs.toml"))

--- a/tests/unit/test_proxmox.py
+++ b/tests/unit/test_proxmox.py
@@ -1890,13 +1890,16 @@ def test_a_guest_that_compiles_is_given_a_whole_node() -> None:
     from tests.vm.cluster import fixtures as cluster_fixtures
 
     weights = {one.name: one for one in cluster_fixtures(
-        ["vm-binpkg", "vm-zfs", "vm-desktop", "vm-gnome", "ext4-bios"]
+        ["vm-binpkg", "vm-xfs", "vm-zfs", "vm-desktop", "vm-gnome", "ext4-bios"]
     )}
-    for name in ("vm-desktop", "vm-gnome", "ext4-bios"):
+    # `vm-zfs` stood here as a light guest until its own `install.jsonl` was
+    # read: a ZFS root compiles its module, ZFSBootMenu and systemd whatever
+    # the kernel and the binary host say.
+    for name in ("vm-desktop", "vm-gnome", "ext4-bios", "vm-zfs"):
         job = weights[name]
         assert job.heavy, name
         assert (job.cores, job.memory_mib) == (HEAVY_CORES, HEAVY_MEMORY_MIB), name
-    for name in ("vm-binpkg", "vm-zfs"):
+    for name in ("vm-binpkg", "vm-xfs"):
         job = weights[name]
         assert not job.heavy, name
         assert (job.cores, job.memory_mib) == (GUEST_CORES, GUEST_MEMORY_MIB), name

--- a/tests/vm/cluster.py
+++ b/tests/vm/cluster.py
@@ -4488,8 +4488,17 @@ def _sweep_jobs(scheduled: Mapping[str, Job]) -> None:
 
 def _compiles(config: InstallConfig) -> bool:
     """Whether this configuration spends an hour in `emerge` rather than six
-    minutes: a kernel built from source, a desktop, or no binary host at all.
+    minutes: a kernel built from source, a desktop, no binary host at all, or
+    a ZFS root.
+
+    A binary kernel does not spare a ZFS layout: `sys-fs/zfs` builds a module
+    against whatever kernel was installed and no binary host carries one,
+    and ZFSBootMenu is in `gentoo-zh` alone. `vm-zfs-encrypted` reads as
+    light by every other test here and compiled nineteen packages, systemd
+    among them, on the two cores a light guest is given.
     """
+    if config.disk.graph.of_type(ZfsPool):
+        return True
     if config.kernel.source.value.endswith("-bin"):
         return bool(config.packages.desktop) or not config.portage.binhost.official
     return True


### PR DESCRIPTION
`vm-zfs-encrypted` stalled twice at `MARK_24_DONE` with its console silent and `cpu 0.00`, and it is a `dist-bin` kernel with the official binary host on and no desktop — every test `_compiles()` applies says it is light, so it was given two cores and four gibibytes.

Its own `install.jsonl` says otherwise: nineteen packages compiled, among them `sys-fs/zfs`, `sys-boot/zfsbootmenu` with `fzf`, `kexec-tools` and `mbuffer`, `gentoo-kernel-bin`, `pahole`, `linux-firmware`, and `sys-apps/systemd` — the package it stopped inside both times. A binary kernel does not spare a ZFS layout, because the module is built against whatever kernel was installed and no binary host carries one.

Four fixtures move from light to heavy; the two ZFSBootMenu ones were already heavy through their desktop. `test_a_guest_that_compiles_is_given_a_whole_node` used `vm-zfs` as one of its two light examples, so it went red — the example was wrong rather than the assertion, and `vm-zfs` now stands in its heavy list with the reason beside it.