### PR TITLE
vm: derive how heavy a guest is once for both runners

### DIFF
--- a/tests/unit/test_cluster.py
+++ b/tests/unit/test_cluster.py
@@ -4190,14 +4190,15 @@ def test_a_zfs_root_is_a_heavy_guest_whatever_its_kernel_says() -> None:
     desktop stops covering this case and says so.
     """
     from gentoo_install.exec.config import load
+    from tests.vm.sizing import compiles
 
     for name in ("vm-zfs", "vm-zfs-encrypted", "vm-zfs-mirror", "vm-raidz"):
         config = load(FIXTURES / f"{name}.toml")
         assert config.kernel.source.value.endswith("-bin"), name
         assert not config.packages.desktop, name
         assert config.portage.binhost.official, name
-        assert cluster._compiles(config), name
+        assert compiles(config), name
 
     # And not everything: a plain binary-package install stays light, or the
     # rule buys nothing and the cluster runs one guest at a time.
-    assert not cluster._compiles(load(FIXTURES / "vm-xfs.toml"))
+    assert not compiles(load(FIXTURES / "vm-xfs.toml"))

--- a/tests/unit/test_harness.py
+++ b/tests/unit/test_harness.py
@@ -325,11 +325,19 @@ def test_the_machine_is_packed_by_weight_rather_than_by_count() -> None:
 def test_a_heavier_run_asks_for_the_cores_on_the_command_line() -> None:
     """The guest derives its MAKEOPTS from the vCPU count, so the weight has to
     reach `run.py` rather than only the scheduler."""
-    from tests.vm.campaign import Run
+    from tests.vm.campaign import COMPILING_CPUS, Run
 
-    argv = Run("fixtures/vm-cjk-kernel.toml", weight=2, cpus=10).argv()
-    assert "--cpus" in argv and argv[argv.index("--cpus") + 1] == "10"
-    assert "--cpus" not in Run("fixtures/vm-binpkg.toml").argv()
+    # A fixture that compiles, rather than a hand-set weight: the cores are
+    # derived from the configuration now, so a run that asks for them has to
+    # be one that would.
+    heavy = Run("fixtures/vm-desktop.toml")
+    assert heavy.compiles, heavy.config
+    argv = heavy.argv()
+    assert "--cpus" in argv and argv[argv.index("--cpus") + 1] == str(COMPILING_CPUS)
+
+    light = Run("fixtures/vm-binpkg.toml")
+    assert not light.compiles, light.config
+    assert "--cpus" not in light.argv()
 
 
 def test_every_configuration_the_campaign_runs_reaches_the_serial_port() -> None:
@@ -2956,17 +2964,19 @@ def test_campaign_collects_an_outcome_from_every_worker(
 
     from tests.vm import campaign
 
+    # Real fixture names, because a `Run` reads its own configuration to
+    # decide how heavy it is; what each one installs does not matter here.
     runs = [
-        campaign.Run("fixtures/timeout.toml"),
-        campaign.Run("fixtures/oserror.toml"),
-        campaign.Run("fixtures/complete.toml"),
+        campaign.Run("fixtures/vm-xfs.toml"),
+        campaign.Run("fixtures/vm-lvm.toml"),
+        campaign.Run("fixtures/vm-btrfs.toml"),
     ]
     announced: list[str] = []
 
     def fake_perform(run: campaign.Run) -> campaign.Outcome:
-        if run.config.endswith("timeout.toml"):
+        if run.config.endswith("vm-xfs.toml"):
             raise subprocess.TimeoutExpired(run.argv(), 1.0)
-        if run.config.endswith("oserror.toml"):
+        if run.config.endswith("vm-lvm.toml"):
             raise OSError("could not launch guest")
         return campaign.Outcome(run, 0, 1.0, tmp_path / "complete.log")
 
@@ -5911,3 +5921,28 @@ def test_an_answer_the_passphrase_prompt_discarded_is_answered_again(
 
     assert runner.unlock_and_login(console, installation) == "console"
     assert channel.answers == 2, channel.answers
+
+
+def test_both_runners_read_one_answer_for_how_heavy_a_guest_is() -> None:
+    """The two runners spend the same resource on the same install and each
+    held its own answer: the cluster derived it, the campaign wrote it out per
+    run. Comparing them fixture by fixture gave nine disagreements, every one
+    the local table calling light what the cluster's rule calls heavy — the
+    six ZFS layouts, and the three with no binary host at all."""
+    from tests.vm.campaign import STAGES
+    from tests.vm.cluster import fixtures as cluster_fixtures
+
+    local = {Path(one.config).stem: one for stage in STAGES.values() for one in stage}
+    # Only what the cluster will accept: a fixture it refuses has no answer
+    # there to compare against.
+    shared = sorted(
+        stem
+        for stem in local
+        if stem not in {"vm-proxy", "vm-proxy-http", "vm-image", "static-ip", "vm-convert"}
+    )
+    assert len(shared) > 20, shared
+
+    for stem in shared:
+        job = cluster_fixtures([stem])[0]
+        assert job.heavy == (local[stem].weight > 1), stem
+        assert job.heavy == bool(local[stem].cpus), stem

--- a/tests/vm/campaign.py
+++ b/tests/vm/campaign.py
@@ -25,10 +25,23 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import Callable, Final, Sequence
 
-from .driver import revision
+from gentoo_install.exec.config import load
+
+from .driver import REPOSITORY, revision
 from .expectations import EXPECTATIONS, Expectation
 from .media import MISSING_PRECONDITION
 from .run import INTERRUPTED_SUFFIX
+from .sizing import compiles
+
+#: What a `Run.config` is relative to, the same root the driver CD puts it
+#: under: `fixtures/vm-xfs.toml` names the file `tests/fixtures/vm-xfs.toml`.
+FIXTURE_ROOT: Final[Path] = REPOSITORY / "tests"
+
+#: What a compiling run is given and what it costs. The cores reach the guest
+#: as its MAKEOPTS, and the weight is what keeps three of them on the machine
+#: rather than six.
+COMPILING_CPUS: Final[int] = 10
+COMPILING_WEIGHT: Final[int] = 2
 
 WORKROOT: Final[Path] = Path.home() / "code/gentoo-install/lab/vm/runs"
 LOGS: Final[Path] = Path.home() / "code/gentoo-install/lab/vm/campaign"
@@ -106,16 +119,28 @@ class Run:
     #: Boot what was installed and check it. Always: an install that exits 0
     #: is not an install that boots, and that is the whole question.
     boot: bool = True
-    #: vCPUs, and through the guest's own MAKEOPTS how fast it compiles. Left
-    #: at zero for a run that installs binary packages: more cores do nothing
-    #: for a download, and they would be taken from a run that is compiling.
-    cpus: int = 0
-    #: What this costs the machine, against `CAPACITY`. Two for a run that
-    #: compiles a kernel or a desktop: those saturate their vCPUs for half an
-    #: hour, and packing them beside each other makes every one of them slower
-    #: without finishing any sooner. One for a run that installs binary
-    #: packages, which spends its time on the network and the disk.
-    weight: int = 1
+
+    @property
+    def compiles(self) -> bool:
+        """Whether this run spends its time in `emerge` rather than on the
+        network. Derived rather than written per run, because it was written
+        per run and drifted: nine fixtures were marked light here and answer
+        heavy on the cluster, the six ZFS layouts among them."""
+        return compiles(load(FIXTURE_ROOT / self.config))
+
+    @property
+    def weight(self) -> int:
+        """What this costs the machine, against `CAPACITY`. A compiling run
+        saturates its vCPUs for half an hour, and packing two of them beside
+        each other makes both slower without finishing either sooner."""
+        return COMPILING_WEIGHT if self.compiles else 1
+
+    @property
+    def cpus(self) -> int:
+        """vCPUs, and through the guest's own MAKEOPTS how fast it compiles.
+        Zero for a run that installs binary packages: more cores do nothing
+        for a download and would be taken from a run that is compiling."""
+        return COMPILING_CPUS if self.compiles else 0
 
     @property
     def name(self) -> str:
@@ -148,7 +173,7 @@ STAGES: Final[dict[str, tuple[Run, ...]]] = {
         # The only fixture whose target disk already holds a table; `run.py`
         # seeds it, and the installer keeps partition 1 and adds partition 2.
         Run("fixtures/mbr-edit.toml", firmware="bios"),
-        Run("fixtures/vm-desktop.toml", weight=2, cpus=10),
+        Run("fixtures/vm-desktop.toml"),
         Run("fixtures/vm-zfs.toml"),
     ),
     "matrix": (
@@ -165,7 +190,7 @@ STAGES: Final[dict[str, tuple[Run, ...]]] = {
         Run("fixtures/zfs-zbm.toml"),
         Run("fixtures/zbm-unlock.toml"),
         Run("fixtures/btrfs-luks.toml"),
-        Run("fixtures/ext4-bios.toml", firmware="bios", weight=2, cpus=10),
+        Run("fixtures/ext4-bios.toml", firmware="bios"),
         Run("fixtures/vm-cjk-kernel.toml"),
         # The four nothing had ever installed: the only untested filesystem, a
         # desktop on openrc, GNOME at all, and btrfs subvolumes without LUKS
@@ -181,14 +206,14 @@ STAGES: Final[dict[str, tuple[Run, ...]]] = {
         # is a different path: the configuration, the build, `installkernel`
         # and the initramfs are produced rather than unpacked, and about an
         # hour on four cores, so it gets the weight a desktop gets.
-        Run("fixtures/vm-source-kernel.toml", weight=2, cpus=10),
+        Run("fixtures/vm-source-kernel.toml"),
         # A machine that configures its own address instead of asking for one.
         # The model has carried static addressing since the beginning and no
         # fixture set it, so nothing had ever installed a machine that comes up
         # on an address, a gateway and a resolver it was given. `cluster.py`
         # rewrites the address to the one the scheduler reserved.
-        Run("fixtures/vm-openrc-desktop.toml", weight=2, cpus=10),
-        Run("fixtures/vm-gnome.toml", weight=2, cpus=10),
+        Run("fixtures/vm-openrc-desktop.toml"),
+        Run("fixtures/vm-gnome.toml"),
         # Three more nothing had ever installed: raidz needs a third disk,
         # which no other fixture asks for; zram was set by none of them; and
         # GRUB opening the container itself to read /boot only happens on an
@@ -238,7 +263,7 @@ STAGES: Final[dict[str, tuple[Run, ...]]] = {
         # xfce behind greetd, and the only fixture with a display manager
         # whose configuration the installer rewrites rather than writes: the
         # `command =` line in the file `gui-libs/greetd` installs.
-        Run("fixtures/vm-greetd.toml", weight=2, cpus=10),
+        Run("fixtures/vm-greetd.toml"),
     ),
     # One configuration, six media: this stage tests `bootstrap.sh` and
     # preflight, so the shortest fixture is the right one. Booted like every

--- a/tests/vm/cluster.py
+++ b/tests/vm/cluster.py
@@ -48,6 +48,7 @@ from contextlib import contextmanager
 from typing import Final, Iterator, Protocol, TypeVar, cast, Sequence
 
 from .expectations import EXPECTATIONS, Expectation
+from .sizing import compiles
 
 from gentoo_install.model.config import Firmware as BootFirmware
 from gentoo_install.model.config import (
@@ -4486,24 +4487,6 @@ def _sweep_jobs(scheduled: Mapping[str, Job]) -> None:
     _sweep(inflight)
 
 
-def _compiles(config: InstallConfig) -> bool:
-    """Whether this configuration spends an hour in `emerge` rather than six
-    minutes: a kernel built from source, a desktop, no binary host at all, or
-    a ZFS root.
-
-    A binary kernel does not spare a ZFS layout: `sys-fs/zfs` builds a module
-    against whatever kernel was installed and no binary host carries one,
-    and ZFSBootMenu is in `gentoo-zh` alone. `vm-zfs-encrypted` reads as
-    light by every other test here and compiled nineteen packages, systemd
-    among them, on the two cores a light guest is given.
-    """
-    if config.disk.graph.of_type(ZfsPool):
-        return True
-    if config.kernel.source.value.endswith("-bin"):
-        return bool(config.packages.desktop) or not config.portage.binhost.official
-    return True
-
-
 #: qemu's user-mode network, where `10.0.2.2` is the machine running qemu and
 #: `10.0.2.3` is its resolver. A cluster guest is bridged and has neither, so a
 #: fixture naming one of them can only run under `tests/vm/run.py`. Dispatching
@@ -4567,7 +4550,7 @@ def fixtures(names: list[str]) -> list[Job]:
                 fixture=path,
                 uefi=config.bootloader.firmware.value != "bios",
                 disks=max(1, len(config.disk.graph.of_type(Existing))),
-                heavy=_compiles(config),
+                heavy=compiles(config),
                 remote_unlock=_requests_remote_unlock(path),
                 convert_to=convert_to,
             )

--- a/tests/vm/sizing.py
+++ b/tests/vm/sizing.py
@@ -1,0 +1,34 @@
+# SPDX-License-Identifier: GPL-2.0-or-later
+"""How much of a machine a configuration will want, for both runners.
+
+The two runners spend the same resource on the same install and each held its
+own answer: `cluster.py` derived it from the configuration and `campaign.py`
+wrote it out per run in a table. Comparing them fixture by fixture on
+2026-08-25 gave nine disagreements and every one in the same direction, the
+local table calling light what the cluster's rule calls heavy — the six ZFS
+layouts, which build a module, and `ext2`, `ext3` and `btrfs-luks`, which have
+no binary host at all.
+"""
+
+from __future__ import annotations
+
+from gentoo_install.model.config import InstallConfig
+from gentoo_install.model.device import ZfsPool
+
+
+def compiles(config: InstallConfig) -> bool:
+    """Whether this configuration spends an hour in `emerge` rather than six
+    minutes: a kernel built from source, a desktop, no binary host at all, or
+    a ZFS root.
+
+    A binary kernel does not spare a ZFS layout: `sys-fs/zfs` builds a module
+    against whatever kernel was installed and no binary host carries one, and
+    ZFSBootMenu is in `gentoo-zh` alone. `vm-zfs-encrypted` reads as light by
+    every other test here and compiled nineteen packages, systemd among them,
+    on the two cores a light guest is given.
+    """
+    if config.disk.graph.of_type(ZfsPool):
+        return True
+    if config.kernel.source.value.endswith("-bin"):
+        return bool(config.packages.desktop) or not config.portage.binhost.official
+    return True


### PR DESCRIPTION
Comparing the two runners fixture by fixture gave nine disagreements and every one in the same direction: the local table calls light what the cluster's rule calls heavy. Six are the ZFS layouts, which build a module; `ext2`, `ext3` and `btrfs-luks` have no binary host at all. The local `CAPACITY` is 6, so those nine were packed six at a time on a machine where `earlyoom` signals at 3.6 GiB available and a guest reaches 6.5 GiB.

`compiles()` moves to `tests/vm/sizing.py` and both runners read it. `weight` and `cpus` turn out to be one rule written twice — every `cpus=10` sat beside a `weight=2`, six places to six — so both derive from it and `test_the_machine_is_packed_by_weight_rather_than_by_count` passes unchanged. Fifteen fixtures are heavy locally now instead of six; `CAPACITY` is untouched, so it is still three at once.

One cost worth naming: a `Run` reads its own configuration, so it can no longer name a file that does not exist. A test using `fixtures/timeout.toml` as a label had to take real names. A mistyped fixture now fails at once rather than an hour in.

The negative control narrows the local answer to one fixture; the first shared name fails.