### PR TITLE
vm: dispatch a conversion to the runner that can perform one

### DIFF
--- a/tests/unit/test_harness.py
+++ b/tests/unit/test_harness.py
@@ -154,13 +154,6 @@ NOT_IN_THE_CAMPAIGN: Final[frozenset[str]] = frozenset(
         # medium the campaign boots, because the machine under test has to
         # have a bootloader of its own to arm.
         "vm-ram.toml",
-        # A conversion converts a running system, and the cluster runs it as
-        # the second phase of a pair: install an ordinary machine, then
-        # convert that. The local campaign has no pairing, so it ran the
-        # fixture against a seeded cloud image whose root filesystem holds
-        # 3 GiB free, and the installer refused with exit 2 — correctly, and
-        # the verdict read `FAIL`.
-        "vm-convert.toml",
         # The only fixture that configures a static address, and the interface
         # it has to pin is the cluster's: a local guest presents `enp0s2` where
         # the cluster presents `ens18`, so `[Match] Name=ens18` matches nothing
@@ -5946,3 +5939,31 @@ def test_both_runners_read_one_answer_for_how_heavy_a_guest_is() -> None:
         job = cluster_fixtures([stem])[0]
         assert job.heavy == (local[stem].weight > 1), stem
         assert job.heavy == bool(local[stem].cpus), stem
+
+
+def test_a_conversion_is_dispatched_to_the_runner_that_can_perform_one() -> None:
+    """`vm-convert` was run through `tests/vm/run.py`, which boots the
+    installation medium against a blank disk. A conversion has to convert a
+    machine that is already running, so it met a seeded cloud image whose root
+    filesystem holds 3 GiB free and the installer refused with exit 2. The
+    refusal was right; the dispatch was not.
+
+    Derived from `DiskMode.IN_PLACE` rather than named, which is how
+    `cluster.py` decides the same thing.
+    """
+    from tests.vm.campaign import STAGES, Run
+
+    conversion = Run("fixtures/vm-convert.toml")
+    assert conversion.converts
+    assert conversion.argv()[1:3] == ["-m", "tests.vm.convert"]
+    # The image, because no installation medium is booted: a name carrying
+    # `official-minimal-uefi` would name two things this run does not have.
+    assert conversion.name == "fedora-vm-convert", conversion.name
+
+    plain = Run("fixtures/vm-xfs.toml")
+    assert not plain.converts
+    assert plain.argv()[1:3] == ["-m", "tests.vm.run"]
+
+    # And it is in the campaign again, which is the point of the change.
+    named = {Path(one.config).stem for stage in STAGES.values() for one in stage}
+    assert "vm-convert" in named

--- a/tests/vm/campaign.py
+++ b/tests/vm/campaign.py
@@ -26,6 +26,7 @@ from pathlib import Path
 from typing import Callable, Final, Sequence
 
 from gentoo_install.exec.config import load
+from gentoo_install.model.config import DiskMode
 
 from .driver import REPOSITORY, revision
 from .expectations import EXPECTATIONS, Expectation
@@ -120,6 +121,22 @@ class Run:
     #: is not an install that boots, and that is the whole question.
     boot: bool = True
 
+    #: Which cloud image a conversion is run against. Ignored by every other
+    #: run, which boots the installation medium instead.
+    image: str = "fedora"
+
+    @property
+    def converts(self) -> bool:
+        """Whether this run converts a machine in place rather than installing
+        onto a blank disk.
+
+        `tests/vm/convert.py` is what does that here: it boots a cloud image,
+        hands it the driver CD and converts what is already running. Dispatched
+        through `tests/vm/run.py` instead, the fixture met a seeded image whose
+        root filesystem holds 3 GiB free and the installer refused with exit 2.
+        """
+        return load(FIXTURE_ROOT / self.config).disk.mode is DiskMode.IN_PLACE
+
     @property
     def compiles(self) -> bool:
         """Whether this run spends its time in `emerge` rather than on the
@@ -145,13 +162,23 @@ class Run:
     @property
     def name(self) -> str:
         how = INTERRUPTED_SUFFIX if self.interrupt else ""
-        return f"{self.medium}-{self.firmware}-{Path(self.config).stem}{how}"
+        # A conversion names the image it converts: no installation medium is
+        # booted, so `official-minimal-uefi` would name two things this run
+        # does not have.
+        where = self.image if self.converts else f"{self.medium}-{self.firmware}"
+        return f"{where}-{Path(self.config).stem}{how}"
 
     @property
     def expectation(self) -> Expectation | None:
         return EXPECTATIONS.get(Path(self.config).stem)
 
     def argv(self) -> list[str]:
+        if self.converts:
+            return [
+                sys.executable, "-m", "tests.vm.convert",
+                "--image", self.image,
+                "--config", self.config,
+            ]
         argv = [
             sys.executable, "-m", "tests.vm.run",
             "--medium", self.medium,
@@ -192,6 +219,10 @@ STAGES: Final[dict[str, tuple[Run, ...]]] = {
         Run("fixtures/btrfs-luks.toml"),
         Run("fixtures/ext4-bios.toml", firmware="bios"),
         Run("fixtures/vm-cjk-kernel.toml"),
+        # Run by `tests/vm/convert.py` rather than `run.py`: it boots a
+        # cloud image and converts what is already running, which is the
+        # only thing a conversion can be measured against.
+        Run("fixtures/vm-convert.toml"),
         # The four nothing had ever installed: the only untested filesystem, a
         # desktop on openrc, GNOME at all, and btrfs subvolumes without LUKS
         # wrapped round them.


### PR DESCRIPTION
The earlier note said the fix was to teach `Run` to express the cluster's install-then-convert pair. It is not: `tests/vm/convert.py` already exists and is the committed local way to do this — it takes a cloud image, boots it, hands it the driver CD and converts the system that is running. All three images are still in `lab/vm/cloud/`.

What was missing is the dispatch. `vm-convert.toml` went to `tests/vm/run.py`, which boots the installation medium against a blank disk, so the fixture met a seeded image whose root filesystem holds 3 GiB free and the installer refused with exit 2. The refusal was right and the verdict read `FAIL`.

`Run.converts` derives from `DiskMode.IN_PLACE`, which is how `cluster.py` decides the same thing, and `argv()` follows it. The run is named for the image it converts: no installation medium is booted, so `official-minimal-uefi` named two things it does not have. `vm-convert.toml` leaves `NOT_IN_THE_CAMPAIGN`.