### PR TITLE
mirrors: refuse a site the chosen region does not offer

### DIFF
--- a/gentoo_install/model/compat.py
+++ b/gentoo_install/model/compat.py
@@ -16,6 +16,7 @@ from enum import Enum
 from pathlib import PurePosixPath
 from typing import Callable, Final, Mapping
 
+from . import mirrors
 from .config import (
     BinhostChannel,
     DiskMode,
@@ -432,6 +433,32 @@ def binhost_subarch_problems(
             "`ld.so --help` does not list x86-64-v3 as supported",
         )
     return ()
+
+
+def mirror_site_problems(config: InstallConfig) -> tuple[str, ...]:
+    """Reject a mirror site the chosen region does not offer.
+
+    `mirrors.gentoo_binhost()` and everything beside it resolve a site key
+    with `next((one for one in sites if one.key == preferred), sites[0])`, so
+    a key the region lacks is silently replaced by the region's first site —
+    for the distfiles, the ebuild repository and the official binary host
+    alike. `vm-binhost-fallback` names `xtom-hk` because its binary package
+    index answers 404 and the run is green only if Portage drops that host;
+    rewritten to `global`, where there is no `xtom-hk`, it installed from
+    `distfiles.gentoo.org` and proved nothing. An operator who picks a mirror
+    and is given another one is owed the same answer.
+    """
+    site = config.portage.mirrors.site
+    if not site:
+        return ()
+    region = config.portage.mirrors.region
+    offered = [one.key for one in mirrors.gentoo_sites(region)]
+    if site in offered:
+        return ()
+    return (
+        f"mirror site {site!r} is not one of region {region.value!r}: "
+        f"{', '.join(sorted(offered))}",
+    )
 
 
 class FilesystemLabelUnit(Enum):

--- a/gentoo_install/model/validate.py
+++ b/gentoo_install/model/validate.py
@@ -288,6 +288,7 @@ def validate(
         *_l10n_problems(config),
         *_repository_name_problems(config),
         *compat.binhost_subarch_problems(config, supports_v3),
+        *compat.mirror_site_problems(config),
     ]
     if problems:
         raise ValidationFailed(

--- a/gentoo_install/tui/screens.py
+++ b/gentoo_install/tui/screens.py
@@ -17,7 +17,7 @@ from typing import Callable, Final, Sequence
 
 from ..i18n import Catalog
 from ..exec import fetch
-from ..model import compat
+from ..model import compat, mirrors
 from ..model.config import (
     BASE_PROFILE,
     SystemConfig,
@@ -2200,6 +2200,17 @@ LANGUAGE_DEFAULTS: Final[dict[str, LanguageDefaults]] = {
 }
 
 
+def _site_kept_in(site: str, region: MirrorRegion) -> str:
+    """The chosen site if the region still offers it, and nothing otherwise.
+
+    Empty takes the region's first, which is what an operator who has not
+    chosen gets; a key the region lacks would take it silently instead.
+    """
+    if site and site in {one.key for one in mirrors.gentoo_sites(region)}:
+        return site
+    return ""
+
+
 def with_language(config: InstallConfig, tag: str) -> InstallConfig:
     """The configuration as the chosen interface language leaves it."""
     chosen = LANGUAGE_DEFAULTS.get(tag)
@@ -2225,7 +2236,14 @@ def with_language(config: InstallConfig, tag: str) -> InstallConfig:
         packages=replace(config.packages, applications=applications),
         portage=replace(
             config.portage,
-            mirrors=replace(config.portage.mirrors, region=chosen.mirror_region),
+            # The site goes with the region, as `_edit_region` already does
+            # it: a key is looked up inside its region, so `tuna` carried into
+            # `global` resolves to `distfiles.gentoo.org` and nothing says so.
+            mirrors=replace(
+                config.portage.mirrors,
+                region=chosen.mirror_region,
+                site=_site_kept_in(config.portage.mirrors.site, chosen.mirror_region),
+            ),
         ),
     )
     if not chosen.cjk_console:

--- a/tests/unit/test_compat.py
+++ b/tests/unit/test_compat.py
@@ -1146,3 +1146,96 @@ def test_a_conversion_is_not_refused_for_an_esp_it_has_not_read_yet() -> None:
     # refused, so the rule above is not "never ask for an esp".
     partitioned = replace(built, disk=replace(built.disk, graph=DeviceGraph.build([])))
     assert compat.Trait.NO_MOUNTED_ESP in compat.traits_of(partitioned)
+
+
+def test_a_mirror_site_the_region_does_not_offer_is_refused() -> None:
+    """`mirrors.gentoo_binhost()` resolves a site key with
+    `next((one for one in sites if one.key == preferred), sites[0])`, so a key
+    the region lacks is replaced by the region's first site and nothing says
+    so. `vm-binhost-fallback` names `xtom-hk` because its binary package index
+    answers 404 and the run is green only if Portage drops that host; rewritten
+    to `global`, where there is no `xtom-hk`, it resolved to
+    `distfiles.gentoo.org` and installed from a working binary host."""
+    from dataclasses import replace
+
+    from gentoo_install.exec.config import load
+    from gentoo_install.model import compat, mirrors
+    from gentoo_install.model.config import MirrorRegion
+
+    config = load(Path("tests/fixtures/vm-binhost-fallback.toml"))
+    assert config.portage.mirrors.site == "xtom-hk", config.portage.mirrors
+    assert not compat.mirror_site_problems(config)
+
+    moved = replace(
+        config,
+        portage=replace(
+            config.portage,
+            mirrors=replace(config.portage.mirrors, region=MirrorRegion.GLOBAL),
+        ),
+    )
+    problems = compat.mirror_site_problems(moved)
+    assert problems and "xtom-hk" in problems[0], problems
+
+    # The silent substitution the rule exists to catch, so the case is not
+    # arguing against a mechanism that was never there.
+    assert mirrors.gentoo_binhost(MirrorRegion.GLOBAL, "xtom-hk") != mirrors.gentoo_binhost(
+        MirrorRegion.CN, "xtom-hk"
+    )
+    assert "xtom" not in mirrors.gentoo_binhost(MirrorRegion.GLOBAL, "xtom-hk")
+
+
+def test_a_fixture_that_keeps_its_site_keeps_its_region(tmp_path: Path) -> None:
+    """The two are one choice: a key is looked up inside its region, so moving
+    the region alone is the same silent substitution by another route.
+
+    Read off the file the harness writes rather than off its source, because
+    what the guest installs from is the file.
+    """
+    from gentoo_install.exec.config import load
+    from gentoo_install.model import compat
+    from gentoo_install.model.config import MirrorRegion, Sync
+    from tests.vm import cluster
+
+    kept, moved = cluster.fixtures(["vm-binhost-fallback", "vm-xfs"])
+    written = cluster.rewrite_fixtures(
+        [kept, moved], tmp_path, MirrorRegion.GLOBAL, Sync.WEBRSYNC, site="osuosl"
+    )
+
+    pinned = load(written / kept.fixture.name).portage.mirrors
+    assert (pinned.region, pinned.site) == (MirrorRegion.CN, "xtom-hk"), pinned
+    assert not compat.mirror_site_problems(load(written / kept.fixture.name))
+
+    ordinary = load(written / moved.fixture.name).portage.mirrors
+    assert (ordinary.region, ordinary.site) == (MirrorRegion.GLOBAL, "osuosl"), ordinary
+
+
+def test_seeding_a_language_drops_a_mirror_site_its_region_lacks() -> None:
+    """The Mirrors screen already clears the site when the region changes;
+    the language seeding replaced the region and left the site behind. An
+    operator who picks `tuna` and then chooses an English profile would fetch
+    everything from `distfiles.gentoo.org` with nothing said."""
+    from dataclasses import replace
+
+    from gentoo_install.model import compat
+    from gentoo_install.model.config import MirrorRegion
+    from gentoo_install.tui import screens
+    from tests.unit.layouts import config as a_config
+
+    chinese = replace(
+        a_config(),
+        portage=replace(
+            a_config().portage,
+            mirrors=replace(
+                a_config().portage.mirrors, region=MirrorRegion.CN, site="tuna"
+            ),
+        ),
+    )
+    assert not compat.mirror_site_problems(chinese)
+
+    # The seeding that moves the region. Whichever language leaves the region
+    # where it was keeps the site, which is the other half of the rule.
+    for tag in sorted(screens.LANGUAGE_DEFAULTS):
+        seeded = screens.with_language(chinese, tag)
+        assert not compat.mirror_site_problems(seeded), (tag, seeded.portage.mirrors)
+        kept = seeded.portage.mirrors.region is MirrorRegion.CN
+        assert bool(seeded.portage.mirrors.site) == kept, (tag, seeded.portage.mirrors)

--- a/tests/unit/test_tui_app.py
+++ b/tests/unit/test_tui_app.py
@@ -261,7 +261,7 @@ def test_install_hands_back_the_configuration() -> None:
     ready = replace(
         config(),
         system=replace(config().system, root_password_hash="$6$test$x"),
-        portage=replace(config().portage, mirrors=replace(config().portage.mirrors, site="tuna")),
+        portage=replace(config().portage, mirrors=replace(config().portage.mirrors, site="osuosl")),
     )
     # The Install row opens the overview: enter leaves the operation list, and
     # the confirmation starts on No, so Yes takes one more key.
@@ -292,7 +292,7 @@ def test_the_install_row_shows_every_operation_before_it_starts() -> None:
     ready = replace(
         config(),
         system=replace(config().system, root_password_hash="$6$test$x"),
-        portage=replace(config().portage, mirrors=replace(config().portage.mirrors, site="tuna")),
+        portage=replace(config().portage, mirrors=replace(config().portage.mirrors, site="osuosl")),
     )
     # Enter leaves the overview, then No, which returns to the menu.
     keys = [*down(len(settings.SETTINGS)), "\n", "\n", "\n", "q", "KEY_DOWN", "\n"]
@@ -2485,7 +2485,7 @@ def test_a_detected_row_has_to_be_opened_and_not_only_filled_in() -> None:
     ready = replace(
         config(),
         system=replace(config().system, root_password_hash="$6$test$x"),
-        portage=replace(config().portage, mirrors=replace(config().portage.mirrors, site="tuna")),
+        portage=replace(config().portage, mirrors=replace(config().portage.mirrors, site="osuosl")),
     )
     # The group itself counts when nothing behind it is required: `Compiler`
     # has a usable value on every row and still has to be looked at.

--- a/tests/vm/cluster.py
+++ b/tests/vm/cluster.py
@@ -1358,6 +1358,7 @@ def rewrite_fixtures(
     ]
     for job, source in wanted:
         config = load(source)
+        keeps_its_site = job.name in KEEPS_ITS_SITE
         # The overlay moves with the region. A `cn` run that still cloned
         # gentoo-zh from github stopped the install after two hundred seconds
         # of `Could not connect to server`, while every other fetch in the same
@@ -1375,8 +1376,12 @@ def rewrite_fixtures(
                 sync=sync,
                 mirrors=replace(
                     config.portage.mirrors,
-                    region=region,
-                    site=config.portage.mirrors.site if job.name in KEEPS_ITS_SITE else site,
+                    # The region moves with the site or not at all: a site key
+                    # is looked up inside its region, and `xtom-hk` under
+                    # `global` resolves to `distfiles.gentoo.org` with nothing
+                    # said. `model/compat.py` refuses that pair now.
+                    region=config.portage.mirrors.region if keeps_its_site else region,
+                    site=config.portage.mirrors.site if keeps_its_site else site,
                     gentoo_zh=chosen,
                     # A replaced list, when one is given: a cache on the
                     # guests' own segment is an address with no name to
@@ -2941,8 +2946,8 @@ def _did_not_stop(name: str, code: bytes, files: Mapping[str, bytes]) -> str:
         )
     return ""
 
-#: Fixtures whose mirror site is the thing under test, so `--site` must not
-#: move it. `vm-binhost-fallback` names `xtom-hk`, whose binary package index
+#: Fixtures whose mirror site is the thing under test, so neither `--site`
+#: nor `--region` may move it: a key is looked up inside its region. `vm-binhost-fallback` names `xtom-hk`, whose binary package index
 #: answers 404, and the run is green only if Portage drops that host and
 #: compiles from source. Rewritten to a working site it installed from a
 #: binhost in 42 minutes and proved nothing.


### PR DESCRIPTION
`mirrors.gentoo_binhost()` and everything beside it resolve a site key with `next((one for one in sites if one.key == preferred), sites[0])`, so a key the region lacks is replaced by the region's first site and nothing says so — for the distfiles, the ebuild repository and the official binary host alike. Measured: `preferred='xtom-hk'` under `global` answers `distfiles.gentoo.org`.

That is why `vm-binhost-fallback` proved nothing on the cluster. It names `xtom-hk` because that site's binary package index answers 404 and the run is green only if Portage drops the host and compiles; the round rewrote the region to `global`, where there is no `xtom-hk`, and it installed from a working binary host instead.

One rule, and every place that moves the region now moves the site with it. `tui/mirror.py`'s `_edit_region` already cleared it. The language seeding in `tui/screens.py` did not, so an operator who picks `tuna` and then chooses an English profile fetched everything from `distfiles.gentoo.org`. `cluster.py` keeps site and region together or moves both.

The seeding test walks every language default and requires the site kept when the region stays and dropped when it moves — asserting only that nothing is refused would pass on clearing it always.