### PR TITLE
vm: start the proxy a proxy fixture names

### DIFF
--- a/tests/unit/test_harness.py
+++ b/tests/unit/test_harness.py
@@ -759,7 +759,9 @@ def test_an_image_install_is_judged_by_the_image_it_wrote() -> None:
 
     import inspect
 
-    wiring = inspect.getsource(runner._perform)
+    # `_install_and_check`, which is where the work is: `_perform` is the
+    # wrapper that stands a fixture's proxy up around it.
+    wiring = inspect.getsource(runner._install_and_check)
     assert "_reads_an_image(args.install, args.dry_run)" in wiring
 
 
@@ -2773,14 +2775,43 @@ def test_installed_mount_check_handles_swap_and_unprobed_conversion() -> None:
     assert re.search(conversion_check.pattern, "/proc proc proc\n") is None
 
 
-def test_a_proxy_on_the_workstation_must_be_listening_before_the_run() -> None:
-    """The install fails at the stage3 fetch when it is not, and that reads as
-    a defect in the proxy support the fixture exists to prove."""
+def test_the_harness_starts_the_proxy_a_fixture_names_on_this_workstation() -> None:
+    """`vm-proxy` and `vm-proxy-http` were skipped unless somebody had started
+    a proxy by hand, and the cluster cannot run them at all, so the direction
+    an operator on an intranet needs — the proxy works and the install
+    finishes — had never been measured."""
     import socket
     from dataclasses import replace
 
     from gentoo_install.exec.config import load
-    from tests.vm.run import GATEWAY, require_proxy
+    from tests.vm.run import GATEWAY, free_port, proxy_for
+
+    root = Path(__file__).resolve().parents[1]
+    installation = load(root / "fixtures" / "vm-proxy.toml")
+    port = free_port()
+    named = replace(installation, proxy=replace(installation.proxy, host=GATEWAY, port=port))
+
+    def reachable() -> bool:
+        with socket.socket() as probe:
+            probe.settimeout(2.0)
+            return probe.connect_ex(("127.0.0.1", port)) == 0
+
+    assert not reachable()
+    with proxy_for(named):
+        assert reachable(), port
+    # And taken down again: a run that leaves one behind makes the next run's
+    # "already listening" branch true for a proxy nobody is serving.
+    assert not reachable()
+
+
+def test_a_proxy_already_listening_is_left_alone() -> None:
+    """The port is in the fixture rather than chosen here so that an operator
+    can debug against their own proxy; replacing it would take that away."""
+    import socket
+    from dataclasses import replace
+
+    from gentoo_install.exec.config import load
+    from tests.vm.run import GATEWAY, proxy_for
 
     root = Path(__file__).resolve().parents[1]
     installation = load(root / "fixtures" / "vm-proxy.toml")
@@ -2788,42 +2819,35 @@ def test_a_proxy_on_the_workstation_must_be_listening_before_the_run() -> None:
         listener.bind(("127.0.0.1", 0))
         listener.listen(1)
         port = listener.getsockname()[1]
-        require_proxy(
-            replace(
-                installation,
-                proxy=replace(installation.proxy, host=GATEWAY, port=port),
-            )
+        named = replace(
+            installation, proxy=replace(installation.proxy, host=GATEWAY, port=port)
         )
-    with pytest.raises(SystemExit) as refused:
-        require_proxy(
-            replace(
-                installation,
-                proxy=replace(installation.proxy, host=GATEWAY, port=port),
-            )
-        )
-    assert str(port) in str(refused.value)
+        with proxy_for(named):
+            # Still the test's own listener: a second bind on the same port
+            # would have raised rather than answered.
+            assert listener.getsockname()[1] == port
 
 
-def test_a_proxy_somewhere_else_is_not_checked_against_this_workstation() -> None:
-    """An operator's own intranet proxy is unreachable from here by design, and
-    refusing the run on that would refuse every real configuration."""
+def test_a_proxy_somewhere_else_starts_nothing_on_this_workstation() -> None:
+    """An operator's own intranet proxy is unreachable from here by design,
+    and binding its port here would answer for a machine that is not this
+    one."""
+    import socket
     from dataclasses import replace
 
     from gentoo_install.exec.config import load
-    from tests.vm.run import free_port, require_proxy
+    from tests.vm.run import free_port, proxy_for
 
     root = Path(__file__).resolve().parents[1]
     installation = load(root / "fixtures" / "vm-proxy.toml")
     # A port nothing holds, so dropping the address check would make this
-    # raise. `1080` would not: the workstation runs a proxy there during a
-    # proxy run, and the test would pass for the wrong reason.
+    # bind. `1080` would not: a proxy run holds that one.
     port = free_port()
-    require_proxy(
-        replace(
-            installation,
-            proxy=replace(installation.proxy, host="192.0.2.9", port=port),
-        )
-    )
+    named = replace(installation, proxy=replace(installation.proxy, host="192.0.2.9", port=port))
+    with proxy_for(named):
+        with socket.socket() as probe:
+            probe.settimeout(2.0)
+            assert probe.connect_ex(("127.0.0.1", port)) != 0, port
 
 
 def test_input_method_check_accepts_its_planned_environment() -> None:
@@ -5639,9 +5663,11 @@ def test_a_run_the_workstation_cannot_start_is_not_reported_as_a_failure(
     run = Run("fixtures/vm-proxy-http.toml")
     log = tmp_path / "proxy-http.log"
 
+    # The ISO, because the harness starts the proxy itself now and that
+    # message is gone: a sample nothing can produce stops being a sample.
     log.write_text(
-        f"{MISSING_PRECONDITION}http://10.0.2.2:3129 names this workstation, and nothing"
-        " is listening on port 3129; start the proxy before the run\n"
+        f"{MISSING_PRECONDITION}openSUSE-Leap-15.6-NET-x86_64-Media.iso is not "
+        "downloaded here\n"
     )
     assert mark_for(Outcome(run, 1, 0.0, log)) == "SKIP"
 
@@ -5967,3 +5993,76 @@ def test_a_conversion_is_dispatched_to_the_runner_that_can_perform_one() -> None
     # And it is in the campaign again, which is the point of the change.
     named = {Path(one.config).stem for stage in STAGES.values() for one in stage}
     assert "vm-convert" in named
+
+
+def test_the_proxy_the_harness_runs_carries_a_real_fetch() -> None:
+    """A proxy that accepts a connection and forwards nothing looks exactly
+    like a working one to `require_proxy`'s old probe, which is what the
+    fixtures were waiting on. Both kinds and both directions of the SOCKS
+    credential, against a listener this test runs itself."""
+    import socket
+    import threading
+    import urllib.request
+    from http.server import BaseHTTPRequestHandler, HTTPServer
+
+    from tests.vm.proxy import Credential, serving
+
+    body = b"through the proxy"
+
+    class Answering(BaseHTTPRequestHandler):
+        # The name is `http.server`'s, not a choice.
+        def do_GET(self) -> None:
+            self.send_response(200)
+            self.send_header("Content-Length", str(len(body)))
+            self.end_headers()
+            self.wfile.write(body)
+
+        def log_message(self, *_: object) -> None:
+            return None
+
+    with HTTPServer(("127.0.0.1", 0), Answering) as origin:
+        threading.Thread(target=origin.serve_forever, daemon=True).start()
+        where = f"http://127.0.0.1:{origin.server_address[1]}/"
+
+        with serving("http", 0) as port:
+            opener = urllib.request.build_opener(
+                urllib.request.ProxyHandler({"http": f"http://127.0.0.1:{port}"})
+            )
+            with opener.open(where, timeout=10) as answer:
+                assert answer.read() == body
+
+        with serving("socks5", 0, Credential("installer", "secret")) as port:
+            assert _through_socks(port, "installer", "secret", origin.server_address[1]) == body
+            # The refusal, or the credential is decoration.
+            assert _through_socks(port, "installer", "wrong", origin.server_address[1]) is None
+        origin.shutdown()
+
+
+def _through_socks(port: int, name: str, secret: str, target: int) -> bytes | None:
+    """One SOCKS5 CONNECT to `127.0.0.1:target`, then one HTTP request.
+
+    Hand-written rather than through a library, because the point is what the
+    bytes on the wire are: nothing in the standard library speaks SOCKS5.
+    """
+    import socket
+
+    with socket.create_connection(("127.0.0.1", port), timeout=10) as client:
+        client.sendall(bytes((5, 1, 2)))
+        if client.recv(2) != bytes((5, 2)):
+            return None
+        client.sendall(
+            bytes((1, len(name))) + name.encode() + bytes((len(secret),)) + secret.encode()
+        )
+        if client.recv(2) != bytes((1, 0)):
+            return None
+        client.sendall(bytes((5, 1, 0, 1)) + socket.inet_aton("127.0.0.1") + target.to_bytes(2, "big"))
+        if client.recv(10)[:2] != bytes((5, 0)):
+            return None
+        client.sendall(b"GET / HTTP/1.0\r\nHost: 127.0.0.1\r\n\r\n")
+        seen = b""
+        while True:
+            chunk = client.recv(65536)
+            if not chunk:
+                break
+            seen += chunk
+        return seen.partition(b"\r\n\r\n")[2]

--- a/tests/vm/proxy.py
+++ b/tests/vm/proxy.py
@@ -1,0 +1,281 @@
+# SPDX-License-Identifier: GPL-2.0-or-later
+"""The proxy a proxy fixture needs, started by the harness that needs it.
+
+`vm-proxy` and `vm-proxy-http` are the only fixtures that prove an install
+completes through a proxy, and neither runner could ever run them: the cluster
+refuses them because `10.0.2.2` is qemu's user-mode gateway and exists nowhere
+else, and locally they were skipped unless somebody had started a proxy by
+hand. So the direction that matters to an operator on an intranet — the proxy
+works and the install finishes — had never been measured.
+
+Standard library only, and no configuration file: what the fixture asks for is
+the whole specification.
+"""
+
+from __future__ import annotations
+
+import selectors
+import socket
+import socketserver
+import threading
+from contextlib import contextmanager
+from dataclasses import dataclass
+from typing import Final, Iterator
+from urllib.parse import urlsplit
+
+#: How long a client has to finish its handshake, and how long a stalled
+#: tunnel is carried. A guest fetching a stage3 goes quiet between chunks, so
+#: this bounds the handshake rather than the transfer.
+HANDSHAKE_SECONDS: Final[float] = 30.0
+
+#: What one `recv` takes off either side of a tunnel.
+CHUNK_BYTES: Final[int] = 65536
+
+SOCKS_VERSION: Final[int] = 5
+AUTH_NONE: Final[int] = 0
+AUTH_PASSWORD: Final[int] = 2
+AUTH_UNACCEPTABLE: Final[int] = 0xFF
+COMMAND_CONNECT: Final[int] = 1
+ADDRESS_IPV4: Final[int] = 1
+ADDRESS_DOMAIN: Final[int] = 3
+ADDRESS_IPV6: Final[int] = 4
+REPLY_OK: Final[int] = 0
+REPLY_REFUSED: Final[int] = 5
+REPLY_UNSUPPORTED: Final[int] = 7
+
+
+@dataclass(frozen=True)
+class Credential:
+    """What a client must present, empty when the proxy asks for nothing."""
+
+    username: str = ""
+    password: str = ""
+
+    @property
+    def demanded(self) -> bool:
+        return bool(self.username or self.password)
+
+
+def _pipe(one: socket.socket, other: socket.socket) -> None:
+    """Carry bytes both ways until either side closes.
+
+    One selector rather than two threads: a tunnel that loses its reader
+    thread leaks it for the life of the run, and a fixture opens one per
+    fetch.
+    """
+    one.settimeout(None)
+    other.settimeout(None)
+    with selectors.DefaultSelector() as watching:
+        watching.register(one, selectors.EVENT_READ, other)
+        watching.register(other, selectors.EVENT_READ, one)
+        open_ends = 2
+        while open_ends == 2:
+            for key, _ in watching.select():
+                source = key.fileobj
+                assert isinstance(source, socket.socket)
+                target = key.data
+                try:
+                    chunk = source.recv(CHUNK_BYTES)
+                except OSError:
+                    chunk = b""
+                if not chunk:
+                    open_ends -= 1
+                    break
+                try:
+                    target.sendall(chunk)
+                except OSError:
+                    open_ends -= 1
+                    break
+
+
+def _connect(host: str, port: int) -> socket.socket | None:
+    try:
+        return socket.create_connection((host, port), timeout=HANDSHAKE_SECONDS)
+    except OSError:
+        return None
+
+
+class _Socks5(socketserver.BaseRequestHandler):
+    """One SOCKS5 CONNECT, with RFC 1929 authentication when one is demanded."""
+
+    credential: Credential = Credential()
+
+    def handle(self) -> None:
+        client: socket.socket = self.request
+        client.settimeout(HANDSHAKE_SECONDS)
+        try:
+            if not self._greet(client) or not self._authenticate(client):
+                return
+            upstream = self._requested(client)
+        except OSError:
+            return
+        if upstream is None:
+            return
+        with upstream:
+            _pipe(client, upstream)
+
+    def _greet(self, client: socket.socket) -> bool:
+        head = _exactly(client, 2)
+        if len(head) != 2 or head[0] != SOCKS_VERSION:
+            return False
+        offered = set(_exactly(client, head[1]))
+        wanted = AUTH_PASSWORD if self.credential.demanded else AUTH_NONE
+        if wanted not in offered:
+            client.sendall(bytes((SOCKS_VERSION, AUTH_UNACCEPTABLE)))
+            return False
+        client.sendall(bytes((SOCKS_VERSION, wanted)))
+        return True
+
+    def _authenticate(self, client: socket.socket) -> bool:
+        if not self.credential.demanded:
+            return True
+        version = _exactly(client, 1)
+        if version != b"\x01":
+            return False
+        name = _exactly(client, _exactly(client, 1)[0]).decode(errors="replace")
+        secret = _exactly(client, _exactly(client, 1)[0]).decode(errors="replace")
+        allowed = (name, secret) == (self.credential.username, self.credential.password)
+        client.sendall(bytes((1, 0 if allowed else 1)))
+        return allowed
+
+    def _requested(self, client: socket.socket) -> socket.socket | None:
+        head = _exactly(client, 4)
+        if len(head) != 4 or head[0] != SOCKS_VERSION:
+            return None
+        if head[1] != COMMAND_CONNECT:
+            _refuse(client, REPLY_UNSUPPORTED)
+            return None
+        kind = head[3]
+        if kind == ADDRESS_IPV4:
+            host = socket.inet_ntoa(_exactly(client, 4))
+        elif kind == ADDRESS_DOMAIN:
+            host = _exactly(client, _exactly(client, 1)[0]).decode(errors="replace")
+        elif kind == ADDRESS_IPV6:
+            host = socket.inet_ntop(socket.AF_INET6, _exactly(client, 16))
+        else:
+            _refuse(client, REPLY_UNSUPPORTED)
+            return None
+        port = int.from_bytes(_exactly(client, 2), "big")
+        upstream = _connect(host, port)
+        if upstream is None:
+            _refuse(client, REPLY_REFUSED)
+            return None
+        # The bound address the reply carries is ignored by every client that
+        # only tunnels, so the unspecified one is honest rather than invented.
+        client.sendall(bytes((SOCKS_VERSION, REPLY_OK, 0, ADDRESS_IPV4, 0, 0, 0, 0, 0, 0)))
+        return upstream
+
+
+def _refuse(client: socket.socket, reply: int) -> None:
+    client.sendall(bytes((SOCKS_VERSION, reply, 0, ADDRESS_IPV4, 0, 0, 0, 0, 0, 0)))
+
+
+def _exactly(client: socket.socket, count: int) -> bytes:
+    """Exactly `count` bytes, or fewer when the peer stopped.
+
+    `recv` answers with what has arrived rather than what was asked for, and a
+    handshake read short is a handshake misparsed.
+    """
+    seen = b""
+    while len(seen) < count:
+        chunk = client.recv(count - len(seen))
+        if not chunk:
+            break
+        seen += chunk
+    return seen
+
+
+class _Http(socketserver.BaseRequestHandler):
+    """One HTTP proxy request: `CONNECT` tunnelled, anything else forwarded.
+
+    Both, because a fixture uses both: `emerge-webrsync` hands gemato only
+    `http_proxy` and fetches over plain HTTP with an absolute request target,
+    while a stage3 over https arrives as `CONNECT`.
+    """
+
+    credential: Credential = Credential()
+
+    def handle(self) -> None:
+        client: socket.socket = self.request
+        client.settimeout(HANDSHAKE_SECONDS)
+        try:
+            head = _until_headers(client)
+            if not head:
+                return
+            request_line, _, rest = head.partition(b"\r\n")
+            method, _, remainder = request_line.partition(b" ")
+            target, _, version = remainder.partition(b" ")
+            if method.upper() == b"CONNECT":
+                self._tunnel(client, target.decode(errors="replace"))
+                return
+            self._forward(client, method, target.decode(errors="replace"), version, rest)
+        except OSError:
+            return
+
+    def _tunnel(self, client: socket.socket, authority: str) -> None:
+        host, _, port = authority.rpartition(":")
+        upstream = _connect(host, int(port or 443))
+        if upstream is None:
+            client.sendall(b"HTTP/1.1 502 Bad Gateway\r\n\r\n")
+            return
+        with upstream:
+            client.sendall(b"HTTP/1.1 200 Connection established\r\n\r\n")
+            _pipe(client, upstream)
+
+    def _forward(
+        self, client: socket.socket, method: bytes, target: str, version: bytes, rest: bytes
+    ) -> None:
+        parsed = urlsplit(target)
+        if not parsed.hostname:
+            client.sendall(b"HTTP/1.1 400 Bad Request\r\n\r\n")
+            return
+        upstream = _connect(parsed.hostname, parsed.port or 80)
+        if upstream is None:
+            client.sendall(b"HTTP/1.1 502 Bad Gateway\r\n\r\n")
+            return
+        path = parsed.path or "/"
+        if parsed.query:
+            path = f"{path}?{parsed.query}"
+        with upstream:
+            # The origin form, because a server answering an absolute target
+            # is optional and Portage's mirrors are ordinary web servers.
+            upstream.sendall(b"%s %s %s\r\n%s" % (method, path.encode(), version, rest))
+            _pipe(client, upstream)
+
+
+def _until_headers(client: socket.socket) -> bytes:
+    """The request line and its headers, including the blank line that ends
+    them. The body is left on the socket for the tunnel to carry."""
+    seen = b""
+    while b"\r\n\r\n" not in seen:
+        chunk = client.recv(CHUNK_BYTES)
+        if not chunk:
+            return b""
+        seen += chunk
+    return seen
+
+
+class _Threaded(socketserver.ThreadingTCPServer):
+    allow_reuse_address = True
+    daemon_threads = True
+
+
+@contextmanager
+def serving(kind: str, port: int, credential: Credential = Credential()) -> Iterator[int]:
+    """Run a proxy of `kind` on `port` for the life of the block.
+
+    `port` may be zero, and the port actually bound is what is yielded: a
+    fixture names its own, and a test does not want to.
+    """
+    handlers = {"socks5": _Socks5, "http": _Http}
+    if kind not in handlers:
+        raise ValueError(f"no proxy of kind {kind!r}; have {', '.join(sorted(handlers))}")
+    handler = type(f"_Bound{kind}", (handlers[kind],), {"credential": credential})
+    with _Threaded(("0.0.0.0", port), handler) as server:
+        thread = threading.Thread(target=server.serve_forever, daemon=True)
+        thread.start()
+        try:
+            yield int(server.server_address[1])
+        finally:
+            server.shutdown()
+            thread.join(timeout=HANDSHAKE_SECONDS)

--- a/tests/vm/run.py
+++ b/tests/vm/run.py
@@ -43,6 +43,10 @@ from gentoo_install.exec.config import load
 from gentoo_install.model.serialise import to_toml
 from gentoo_install.model.manual import dataset_for
 
+from contextlib import contextmanager, nullcontext
+from typing import Iterator
+
+from .proxy import Credential, serving
 from .console import (
     DISK_PASSPHRASE,
     PASSPHRASE_ATTEMPTS,
@@ -53,7 +57,7 @@ from .console import (
 )
 from .monitor import type_text
 from .driver import FIND_DRIVER, REPOSITORY, build as build_driver
-from .media import MEDIA, MISSING_PRECONDITION, Medium
+from .media import MEDIA, Medium
 from .qemu import Firmware, Vm, VmSpec
 from .results import collect_command, create_disk, read_disk
 from .installed import checks, stage_passphrase_commands
@@ -130,26 +134,34 @@ def free_port() -> int:
     return port
 
 
-def require_proxy(installation: InstallConfig) -> None:
-    """Refuse a run whose proxy is not listening, before anything is built.
+@contextmanager
+def proxy_for(installation: InstallConfig) -> Iterator[None]:
+    """Run the proxy the fixture asks for, for the life of the run.
 
     A fixture reaches the workstation at qemu's user-mode gateway, which is
-    `127.0.0.1` from here. Without this the install fails at the stage3 fetch
-    and reads exactly like a defect in the proxy support it was meant to prove.
+    `127.0.0.1` from here. Refusing instead meant `vm-proxy` and
+    `vm-proxy-http` were skipped unless somebody had started one by hand, and
+    the cluster cannot run them at all, so the direction an operator on an
+    intranet needs — the proxy works and the install finishes — had never been
+    measured.
+
+    Something already listening is left alone: an operator debugging against
+    their own proxy is why the port is in the fixture rather than chosen here.
     """
     url = installation.proxy.redacted_url
-    if not url:
-        return
-    parsed = urlsplit(url)
-    if parsed.hostname != GATEWAY or parsed.port is None:
+    parsed = urlsplit(url) if url else None
+    if parsed is None or parsed.hostname != GATEWAY or parsed.port is None:
+        yield
         return
     with socket.socket() as probe:
         probe.settimeout(5.0)
-        if probe.connect_ex(("127.0.0.1", parsed.port)) != 0:
-            raise SystemExit(
-                f"{MISSING_PRECONDITION}{url} names this workstation, and nothing is "
-                f"listening on port {parsed.port}; start the proxy before the run"
-            )
+        already = probe.connect_ex(("127.0.0.1", parsed.port)) == 0
+    if already:
+        yield
+        return
+    credential = Credential(installation.proxy.username, installation.proxy.password)
+    with serving(installation.proxy.kind.value, parsed.port, credential):
+        yield
 
 
 def _target_paths(workdir: Path, installation: InstallConfig) -> tuple[Path, ...]:
@@ -838,11 +850,21 @@ def main(argv: list[str] | None = None) -> int:
 
 
 def _perform(args: argparse.Namespace, medium: Medium, workdir: Path) -> int:
+    """Run the guest with whatever the fixture needs standing around it.
+
+    A wrapper rather than a `with` around the body: the body is eighty lines
+    and re-indenting them would bury this one decision in a diff of
+    whitespace.
+    """
+    scope = proxy_for(load(REPOSITORY / "tests" / args.install)) if args.install else nullcontext()
+    with scope:
+        return _install_and_check(args, medium, workdir)
+
+
+def _install_and_check(args: argparse.Namespace, medium: Medium, workdir: Path) -> int:
     ssh_port = args.ssh_port or free_port()
     key = ssh_keypair(workdir)
     requested = load(REPOSITORY / "tests" / args.install) if args.install else None
-    if requested is not None:
-        require_proxy(requested)
     remote_port = (
         free_port() if requested is not None and requested.kernel.remote_unlock.enabled else None
     )


### PR DESCRIPTION
`vm-proxy` and `vm-proxy-http` are the only fixtures that prove an install finishes through a proxy, and neither runner could run them: the cluster refuses them because `10.0.2.2` is qemu's user-mode gateway and exists nowhere else, and locally they answered `SKIP … start the proxy before the run` unless somebody had started one by hand. `vm-proxy-dead` has been running all along, so only the failure direction of the option was ever measured.

`tests/vm/proxy.py` is a SOCKS5 server with RFC 1929 authentication and an HTTP proxy, standard library only. Both HTTP forms, because a fixture uses both: `emerge-webrsync` hands gemato only `http_proxy` and fetches over plain HTTP with an absolute request target, while a stage3 over https arrives as `CONNECT`.

Measured before wiring it in — plain forwarding 200, `CONNECT` 200, SOCKS5 with the credential 200, SOCKS5 with the wrong one refused. The test carries a real fetch through both kinds against a listener it runs itself; a proxy that accepts a connection and forwards nothing passed the old probe, which is what the fixtures were waiting on.

Something already listening is left alone: the port is in the fixture so an operator can debug against their own proxy.