### PR TITLE
vm: say when the hypervisor would not name the guest's state

### DIFF
--- a/tests/unit/test_cluster.py
+++ b/tests/unit/test_cluster.py
@@ -4202,3 +4202,35 @@ def test_a_zfs_root_is_a_heavy_guest_whatever_its_kernel_says() -> None:
     # And not everything: a plain binary-package install stays light, or the
     # rule buys nothing and the cluster runs one guest at a time.
     assert not compiles(load(FIXTURES / "vm-xfs.toml"))
+
+
+def test_a_watchdog_verdict_tells_an_unanswered_state_from_a_running_one(
+    tmp_path: Path,
+) -> None:
+    """`vm-raidz` stalled 1200s with `cpu 0.00` on a node at 0% and the verdict
+    carried no word about qemu at all. Only a non-empty answer was reported, so
+    a guest qemu had paused on an `io-error` and a hypervisor that did not
+    answer produced the same silence — and the two want opposite next steps."""
+
+    def flat() -> tuple[int, float]:
+        return 0, 0.0
+
+    def verdict(state: str) -> str:
+        watch = cluster.Watchdog(
+            tmp_path / "install.log",
+            flat,
+            where="infra-node1",
+            load=lambda: 0.0,
+            state=lambda: state,
+        )
+        said = None
+        for _ in range(cluster.WATCH_STRIKES + 2):
+            said = watch.idle_reason()
+        assert said is not None, state
+        return said
+
+    assert "qemu calls the guest io-error" in verdict("io-error")
+    assert "the hypervisor would not say" in verdict("")
+    # And a guest that is genuinely running says nothing extra: a clause on
+    # every verdict is a clause nobody reads.
+    assert "qemu calls the guest" not in verdict("running")

--- a/tests/vm/cluster.py
+++ b/tests/vm/cluster.py
@@ -587,9 +587,18 @@ class Watchdog:
             node = f" on {self.where}" if self.where else ""
             busy = self.load() if self.load is not None else None
             said = "" if busy is None else f", the node itself at {busy * 100:.0f}%"
-            qemu = self.state() if self.state is not None else ""
-            if qemu and qemu != "running":
-                said += f", and qemu calls the guest {qemu}"
+            if self.state is not None:
+                qemu = self.state()
+                # An unanswered call reads exactly like `running` when only a
+                # non-empty answer is reported, and `vm-raidz` stalled for
+                # 1200s with `cpu 0.00` on an idle node and no clause at all:
+                # whether qemu had paused it on an `io-error` could not be
+                # told from the verdict.
+                if qemu != "running":
+                    said += (
+                        ", and qemu calls the guest "
+                        f"{qemu or 'nothing: the hypervisor would not say'}"
+                    )
             return (
                 f"counters were flat{node} "
                 f"({self._counter_before} -> {self._counter_after} bytes, "


### PR DESCRIPTION
`vm-raidz` was ended at 66.6 minutes with its console silent for 1200s, `cpu 0.00`, the node itself at 0% and `sys-apps/systemd` half compiled — and the verdict said nothing about qemu at all. `idle_reason()` reported the state only when it was non-empty and not `running`, so `qmp_state()` failing its API call read exactly like a guest that is running and doing nothing.

Those two want opposite next steps: a guest qemu has paused on an `io-error` is a storage problem on that node, and a guest running with no CPU is a problem inside the guest. An empty answer now says so; `running` still says nothing, because a clause on every verdict is a clause nobody reads.

This does not explain the stall. It is what the next one needs in order to be diagnosable — the same shape as the encrypted-boot verdict earlier tonight, which reported only the pattern it was already given.