### PR TITLE
Fleet-writable partition sizes, and five defects the media found

### DIFF
--- a/TESTED.md
+++ b/TESTED.md
@@ -93,6 +93,7 @@ a way to pass firmware arguments is available to a non-root API token.
 | `90516741321b` | `vm-proxy` (SOCKS5, password), `vm-proxy-http` | the proxy runs on the host, which a bridged cluster guest cannot reach; each installed 57 operations, 69 packages from a binary host and 46 compiled, and each disk then booted and passed every installed-state check |
 | `f466b89d8206` | `vm-bios-luks` | BIOS serial console; 57 operations, 59 packages from a binary host, 20 compiled, then the disk it wrote booted, unlocked its root and passed every installed-state check |
 | `6ec5d840ff973` | `vm-binpkg`, killed at the stage3 and finished with `--resume` | the cluster has no way to interrupt an install; the resumed run skipped 8 operations an earlier one had recorded as done, reached `[53/53]`, and the disk it wrote booted, mounted its layout and had no failed unit. Zero skipped is a failure there: it would mean the resume repartitioned a disk it had already installed onto |
+| `122d1cf603a85` | `vm-binpkg` plain and `vm-binpkg` killed at the stage3 and finished with `--resume`, in one campaign invocation | the cluster has no way to interrupt an install. Both finished in 5.7 minutes; the resumed one skipped 8 operations an earlier run had recorded as done and installed 58 operations, 30 packages from a binary host and 11 compiled, and each disk then booted and passed every installed-state check. Zero skipped would be a failure: it would mean the resume repartitioned a disk it had already installed onto |
 | `d05e75025c080` | `vm-image` | the same image mode at the revision the campaign runs, through one `--and-boot` invocation: 54 operations, 30 packages from a binary host, 10 compiled, and `losetup -Pf` inside the live medium answered `loop1p1 vfat` and `loop1p2 ext4`. Nothing booted it |
 | `cbd22d88417a6` | `vm-image` | the product is a file on a filesystem this runner mounts on the spare disk, and the cluster has none to offer; 54 operations, 55 packages from a binary host, 12 compiled, then the image was attached with `losetup -Pf` inside the live medium and answered `loop1p1 vfat` and `loop1p2 ext4`, the two filesystems the layout declares. Nothing booted it: reading a file on the guest's own disk is what this record covers |
 
@@ -142,6 +143,19 @@ The negative direction has a revision-tagged cluster run: the `vm-proxy-dead`
 fixture points the proxy at a port where nothing listens and the install stops
 at the stage3 download with `Connection refused`, so a run that reached the
 mirror would show the proxy had been bypassed.
+
+At `122d1cf603a85` both positive directions ran under the campaign rather than
+by hand, against a proxy the harness starts itself: `vm-proxy` (SOCKS5 with a
+password) in 8.9 minutes and `vm-proxy-http` in 8.7 minutes, each installing
+and then booting the disk it wrote and passing every installed-state check.
+Before that revision the run was skipped unless somebody had started a proxy,
+so nothing measured this direction automatically.
+
+What that pair establishes and what it does not: an install finishing does not
+by itself prove the fetches went through the proxy, because QEMU's user-mode
+network also gives the guest a direct route. It is the pair that carries the
+claim — the same configuration stops when the proxy is dead and finishes when
+it answers, and the guest's own `make.conf` names `socks5h://10.0.2.2:1080`.
 
 An HTTP or HTTPS proxy that requires a password cannot check the tree
 snapshot's signature: `emerge-webrsync` hands gemato only the credential-free

--- a/gentoo_install/cli.py
+++ b/gentoo_install/cli.py
@@ -32,12 +32,20 @@ from .exec.probe import (
     BootMethod,
     architecture,
     Probe,
+    probe_capacities,
     probe_storage_facts,
     secure_boot,
 )
 from .exec.runner import Runner
 from .log import Journal
-from .model.device import DeviceGraph, DeviceId, StorageFacts, StorageLayout, ZfsPool
+from .model.device import (
+    DeviceGraph,
+    DeviceId,
+    StorageFacts,
+    StorageLayout,
+    ZfsPool,
+    asks_for_a_share,
+)
 from .model.hardware import HardwareFacts
 from .model.size import Size
 from .tui import app, screens
@@ -509,8 +517,19 @@ def _once(arguments: argparse.Namespace, state: RunState, refused: str) -> int |
             layout = Probe(
                 runner=Runner(log=lambda line: None), work=arguments.work
             ).storage_layout()
+        if arguments.dry_run and asks_for_a_share(config.disk.graph):
+            # A capacity even for a dry run, and only when a share needs one:
+            # a share is a share of the disk, so without it the printed plan
+            # cannot say what `40%` is, and a plan that prints a different
+            # number from the one the install writes is the defect this whole
+            # feature exists to avoid. Gated on the share rather than on the
+            # mode, so a configuration that asks for nothing reads nothing.
+            storage_facts = StorageFacts(
+                capacities=probe_capacities(config.disk.graph, reading)
+            )
         if not arguments.dry_run and config.disk.mode is not DiskMode.DD:
-            # Storage metadata is only required before a real install.
+            # The heavier evidence — mdraid metadata, free extents — is only
+            # required before a real install.
             storage_facts = probe_storage_facts(config, reading)
             # `ld.so --help`, the loader's own answer about this machine.
             loader_v3 = reading.supports_v3()

--- a/gentoo_install/exec/probe.py
+++ b/gentoo_install/exec/probe.py
@@ -26,6 +26,7 @@ from ..model.hardware import CpuVendor, HardwareFacts
 # and `plan/` may not import `exec/`; re-exported here so every caller that
 # asks the probe for the method reads the enum from the same place.
 from ..model.config import BootMethod as BootMethod
+from ..model.size import Size
 from ..model.device import (
     DeviceGraph,
     DeviceId,
@@ -1545,7 +1546,29 @@ def probe_storage_facts(config: InstallConfig, probe: Probe) -> StorageFacts:
         one.id: probe.mdraid_metadata(one.selector) for one in graph.of_type(Existing)
     }
     free = _free_extents(graph, probe)
-    return StorageFacts(mdraid_metadata=metadata, free_extents=free)
+    return StorageFacts(
+        mdraid_metadata=metadata, free_extents=free, capacities=probe_capacities(graph, probe)
+    )
+
+
+def probe_capacities(graph: DeviceGraph, probe: Probe) -> dict[DeviceId, Size]:
+    """What each disk in this layout holds.
+
+    Separate from the rest of the storage evidence because a dry run needs it:
+    a share is a share of the disk, so without a capacity `plan.build()` cannot
+    say what `40%` is and the printed plan would be a different answer from the
+    one the install uses. The heavier evidence — mdraid metadata, free extents
+    — is still only read before a real install.
+    """
+    found: dict[DeviceId, Size] = {}
+    for one in graph.of_type(Existing):
+        try:
+            held = probe.disk_bytes(probe.resolve(one.id, one.selector))
+        except DeviceNotFound:
+            continue
+        if held:
+            found[one.id] = Size(held)
+    return found
 
 
 def _free_extents(graph: DeviceGraph, probe: Probe) -> dict[DeviceId, tuple[Extent, ...]]:

--- a/gentoo_install/model/device.py
+++ b/gentoo_install/model/device.py
@@ -13,12 +13,13 @@ the operation sequence; this module only rejects a graph that cannot be ordered.
 from __future__ import annotations
 
 from dataclasses import dataclass
+from decimal import Decimal
 from enum import Enum
 from pathlib import PurePosixPath
 from types import MappingProxyType
 from typing import Iterable, Mapping, NewType, TypeVar
 
-from ..errors import DeviceCycle, DuplicateDeviceId, UnknownDeviceId
+from ..errors import DeviceCycle, DuplicateDeviceId, InvalidSize, UnknownDeviceId
 from .size import Size
 
 DeviceId = NewType("DeviceId", str)
@@ -171,17 +172,22 @@ class StorageFacts:
 
     mdraid_metadata: Mapping[DeviceId, MdraidMetadataFact]
     free_extents: Mapping[DeviceId, tuple[Extent, ...]]
+    #: What each disk holds, as `lsblk` reports it. A share is a share of
+    #: this, so a configuration carrying one cannot be planned without it.
+    capacities: Mapping[DeviceId, Size]
 
     def __init__(
         self,
         *,
         mdraid_metadata: Mapping[DeviceId, MdraidMetadataFact] | None = None,
         free_extents: Mapping[DeviceId, tuple[Extent, ...]] | None = None,
+        capacities: Mapping[DeviceId, Size] | None = None,
     ) -> None:
         object.__setattr__(
             self, "mdraid_metadata", MappingProxyType(dict(mdraid_metadata or {}))
         )
         object.__setattr__(self, "free_extents", MappingProxyType(dict(free_extents or {})))
+        object.__setattr__(self, "capacities", MappingProxyType(dict(capacities or {})))
 
     def metadata_for(self, device: DeviceId) -> MdraidMetadataFact:
         return self.mdraid_metadata.get(device, MdraidMetadataState.UNAVAILABLE)
@@ -205,14 +211,79 @@ class PartitionTable(Node):
         return (self.disk,)
 
 
+def takes_the_rest(partition: "Partition") -> bool:
+    """Whether this partition asks for whatever the others leave.
+
+    Not `size is None`: a partition asking for `40%` also carries no absolute
+    size, and reading the absence as "the rest" made a table with a share and
+    a `rest` on it look like two partitions competing for the same space.
+    """
+    if partition.size is not None:
+        return False
+    return partition.share is None or partition.share.percent is None
+
+
+def asks_for_a_share(graph: "DeviceGraph") -> bool:
+    """Whether any partition here asks for a proportion of its disk.
+
+    What decides whether a run has to read a disk's capacity. A layout of
+    absolute sizes needs none, and reading one anyway makes every dry run
+    depend on evidence it does not use.
+    """
+    return any(
+        one.share is not None and one.share.percent is not None
+        for one in graph.of_type(Partition)
+    )
+
+
+@dataclass(frozen=True)
+class Share:
+    """What a partition asks for when it is not an absolute size.
+
+    `percent` is a share of the table's free space after every absolute
+    partition on it, so `40` beside `60` beside an esp and a swap is a
+    configuration that fits: the two fixed sizes come off first and the rest
+    is split. `None` asks for whatever is left.
+
+    `minimum` and `maximum` are what makes one file serve a fleet: four tenths
+    of a 240 GB disk is 96 GB and four tenths of an 8 TB disk is 3.2 TB, and
+    neither number is what the operator meant on the other machine.
+    """
+
+    percent: Decimal | None = None
+    minimum: Size | None = None
+    maximum: Size | None = None
+
+    def __post_init__(self) -> None:
+        if self.percent is not None and not 0 < self.percent <= 100:
+            raise InvalidSize(f"a share is between 0 and 100 percent, got {self.percent}")
+        if (
+            self.minimum is not None
+            and self.maximum is not None
+            and self.maximum.bytes < self.minimum.bytes
+        ):
+            raise InvalidSize(f"maximum {self.maximum} is below minimum {self.minimum}")
+
+
 @dataclass(frozen=True)
 class Partition(Node):
     table: DeviceId
     index: int
     role: PartitionRole
     #: None means "all remaining space"; only the last partition may use it.
+    #: A `share` says the same thing with bounds, or asks for a proportion.
     size: Size | None
     label: str = ""
+    #: Set instead of `size`, never beside it: two descriptions of one extent
+    #: is a configuration nobody can read back.
+    share: Share | None = None
+
+    def __post_init__(self) -> None:
+        if self.size is not None and self.share is not None:
+            raise InvalidSize(
+                f"partition {self.id} carries both a size and a share; an extent is "
+                "written one way or the other"
+            )
 
     @property
     def inputs(self) -> tuple[DeviceId, ...]:

--- a/gentoo_install/model/parse.py
+++ b/gentoo_install/model/parse.py
@@ -10,9 +10,11 @@ from __future__ import annotations
 
 from enum import Enum
 from pathlib import PurePosixPath
-from typing import Any, Mapping, Sequence, TypeVar
+from typing import Any, Final, Mapping, Sequence, TypeVar
 
-from ..errors import ConfigError
+from decimal import Decimal
+
+from ..errors import ConfigError, InvalidSize
 from . import config as model_config
 from . import sshkey
 from . import templates
@@ -50,6 +52,7 @@ from .config import (
     User,
 )
 from .device import (
+    Share,
     DeviceGraph,
     DeviceId,
     Existing,
@@ -74,6 +77,11 @@ from .device import (
     ZfsTopology,
 )
 from .size import Size
+
+#: How a partition asks for whatever the others leave. Spelled out rather
+#: than left as an omitted key: a partition with no `size` reads like one
+#: whose size was forgotten, and it is a decision.
+REST: Final[str] = "rest"
 
 E = TypeVar("E", bound=Enum)
 
@@ -454,15 +462,58 @@ def _indexes(raw: Mapping[str, Any], key: str, at: str) -> tuple[int, ...]:
 
 
 def _partition(raw: Mapping[str, Any], at: str) -> Node:
-    _reject_unknown(raw, at, {"kind", "id", "table", "index", "role", "size", "label"})
+    _reject_unknown(
+        raw, at, {"kind", "id", "table", "index", "role", "size", "label", "min", "max"}
+    )
+    absolute, share = _extent(raw, at)
     return Partition(
         id=_id(raw, at),
         table=_ref(raw, "table", at),
         index=_int(raw, "index", at, required=True),
         role=_enum(raw, "role", at, PartitionRole, PartitionRole.DATA),
-        size=_size(raw, "size", at),
+        size=absolute,
         label=_str(raw, "label", at, ""),
+        share=share,
     )
+
+
+def _extent(raw: Mapping[str, Any], at: str) -> tuple[Size | None, Share | None]:
+    """How much of the table this partition asks for.
+
+    Three spellings and one field: `"20G"` is an absolute size, `"40%"` is a
+    share of what the absolute ones leave, and `"rest"` is whatever remains.
+    An omitted `size` still means `rest`, because every configuration written
+    before this existed says it that way.
+
+    `min` and `max` bound a share and are refused beside an absolute size:
+    one extent described by three numbers is one nobody can read back.
+    """
+    written = _get(raw, "size", at, required=False)
+    lowest = _size(raw, "min", at)
+    highest = _size(raw, "max", at)
+    bounded = lowest is not None or highest is not None
+    if written is not None and not isinstance(written, str):
+        raise ConfigError(
+            f'{_at("size", at)} must be a size literal such as "512MiB", a share such '
+            f'as "40%", or "rest"'
+        )
+    if written is not None and not written.endswith("%") and written != REST:
+        if bounded:
+            raise ConfigError(
+                f"{_at('size', at)} is an absolute size, so `min` and `max` say nothing "
+                "it does not already say; bound a share or a rest instead"
+            )
+        return Size.parse(written), None
+    percent: Decimal | None = None
+    if written is not None and written.endswith("%"):
+        try:
+            percent = Decimal(written[:-1])
+        except ArithmeticError as error:
+            raise ConfigError(f"{_at('size', at)}: {written!r} is not a share") from error
+    try:
+        return None, Share(percent=percent, minimum=lowest, maximum=highest)
+    except InvalidSize as error:
+        raise ConfigError(f"{_at('size', at)}: {error}") from error
 
 
 def _luks(raw: Mapping[str, Any], at: str) -> Node:

--- a/gentoo_install/model/serialise.py
+++ b/gentoo_install/model/serialise.py
@@ -19,6 +19,7 @@ from . import config as model_config
 from .config import InstallConfig, ProxyConfig
 from .templates import Choice
 from .device import (
+    Share,
     Existing,
     Filesystem,
     LogicalVolume,
@@ -34,6 +35,7 @@ from .device import (
     ZfsDataset,
     ZfsPool,
 )
+from .parse import REST
 from .size import Size
 
 #: The `kind` each node is written as, mirroring `parse._NODES`. A node class
@@ -57,6 +59,15 @@ KINDS: Final[dict[type[Node], str]] = {
 #: Where a field name and its key in the file differ. `Filesystem.kind` is the
 #: one case: the node discriminator already claims `kind`.
 RENAMED: Final[dict[tuple[type[Node], str], str]] = {(Filesystem, "kind"): "type"}
+
+#: Fields the writer spells as more than one key. `Partition.share` is the
+#: one case: a share and an absolute size answer the same question, so they
+#: share the `size` key, and the bounds are two keys beside it. Declared
+#: rather than special-cased in the test, or the next field that expands
+#: escapes the check that every emitted key is one the parser accepts.
+SPELLED_AS: Final[dict[tuple[type[Node], str], frozenset[str]]] = {
+    (Partition, "share"): frozenset({"size", "min", "max"}),
+}
 
 #: Fields whose value is replaced when the configuration is published. A crypt
 #: hash is not the password, but it is what an offline attack starts from, and
@@ -188,8 +199,27 @@ def _disk(config: InstallConfig) -> list[str]:
                 held == field.default or held == _empty(field.default_factory)
             ):
                 continue
+            if isinstance(held, Share):
+                lines += _share(held)
+                continue
             named = RENAMED.get((type(node), field.name), field.name)
             lines.append(f"{named} = {_value(held)}")
+    return lines
+
+
+def _share(held: Share) -> list[str]:
+    """A share as the one `size` key that reads it back, plus its bounds.
+
+    `rest` rather than an omitted `size`: a partition with no size reads like
+    one whose size was forgotten, and it is a decision. The parser still
+    accepts the omission, so a file written before this stays valid.
+    """
+    written = f"{held.percent}%" if held.percent is not None else REST
+    lines = [f'size = "{written}"']
+    if held.minimum is not None:
+        lines.append(f'min = "{held.minimum}"')
+    if held.maximum is not None:
+        lines.append(f'max = "{held.maximum}"')
     return lines
 
 def _value(held: Any) -> str:

--- a/gentoo_install/model/validate.py
+++ b/gentoo_install/model/validate.py
@@ -30,6 +30,7 @@ from .config import (
     SystemConfig,
 )
 from .device import (
+    takes_the_rest,
     DeviceGraph,
     DeviceId,
     Existing,
@@ -802,7 +803,7 @@ def _partition_size_problems(graph: DeviceGraph, table: PartitionTable) -> list[
     for one in partitions:
         if one.size is not None and one.size.bytes <= 0:
             problems.append(f"partition {one.id} on {table.id} is {one.size}")
-    unsized = [one for one in partitions if one.size is None]
+    unsized = [one for one in partitions if takes_the_rest(one)]
     if len(unsized) > 1:
         problems.append(
             f"{len(unsized)} partitions on {table.id} take the rest of the disk; "

--- a/gentoo_install/plan/disk.py
+++ b/gentoo_install/plan/disk.py
@@ -42,7 +42,7 @@ from ..model.device import (
     ZfsPool,
     ZfsTopology,
 )
-from ..model.size import DEFAULT_ALIGNMENT, Size
+from ..model.size import DEFAULT_ALIGNMENT, SectorSize, Size
 from .mounts import ResolvedMount, resolve_mounts
 from .operations import CommandOutput, Context, Operation, Stage, answered
 
@@ -1295,7 +1295,7 @@ def _operations_for(
                 table_kind=table.table,
                 index=node.index,
                 role=node.role,
-                size=node.size,
+                size=resolve_share(graph, node, storage_facts),
                 label=node.label,
                 start=_start_of(graph, node, storage_facts),
                 limit=_extent_end_of(graph, node, storage_facts),
@@ -1390,6 +1390,82 @@ def _dataset_mountpoint(graph: DeviceGraph, dataset: DeviceId) -> PurePosixPath 
         if mount.source == dataset:
             return mount.path
     return None
+
+
+def resolve_share(
+    graph: DeviceGraph, partition: Partition, facts: StorageFacts
+) -> Size | None:
+    """The bytes this partition asks for, with any share worked out.
+
+    A share is a share of what the table can hand out after every absolute
+    size on it, so `40%` beside `60%` beside an esp and a swap is a layout
+    that fits. `None` still means the rest, which is what `sgdisk` is told.
+
+    Resolved here rather than at `apply()` so that `describe()` prints the
+    number the run will use: a `--dry-run` that says `40%` and an install that
+    writes 96 GiB are two different answers to one question.
+
+    The usable space comes from `Size.usable_for_partitions`, the same
+    function `exec/preflight.py` checks fixed sizes against. Its own docstring
+    says why: answered separately, an operator was told their sizes fitted and
+    the install refused them an hour later.
+    """
+    if partition.share is None:
+        return partition.size
+    if partition.share.percent is None:
+        return _bounded(None, partition)
+    table = _expect(graph, partition.table, PartitionTable)
+    base = share_base(graph, table, facts)
+    if base is None:
+        raise InvalidLayout(
+            f"{partition.id} asks for {partition.share.percent}% of "
+            f"{table.disk}, and this machine did not report that disk's size"
+        )
+    wanted = Size(int(base.bytes * partition.share.percent / 100)).align_down()
+    return _bounded(wanted, partition)
+
+
+def share_base(
+    graph: DeviceGraph, table: PartitionTable, facts: StorageFacts
+) -> Size | None:
+    """What a share on this table is a share of, or `None` when unknown.
+
+    Every absolute size comes off first. A share is then what is left, which
+    is how an operator describes it: the esp and the swap take their fixed
+    sizes and the rest is split.
+    """
+    capacity = facts.capacities.get(table.disk)
+    if capacity is None:
+        return None
+    usable = capacity.usable_for_partitions(
+        table.table is TableType.GPT, SectorSize(512)
+    )
+    fixed = sum(
+        one.size.bytes
+        for one in graph.of_type(Partition)
+        if one.table == table.id and one.size is not None
+    )
+    return Size(max(0, usable.bytes - fixed))
+
+
+def _bounded(wanted: Size | None, partition: Partition) -> Size | None:
+    """A share clamped by its own bounds, or refused when it cannot be met.
+
+    Never quietly raised to the minimum: the space that would come from is
+    another partition's, and moving it silently is how a layout stops adding
+    up without anybody being told.
+    """
+    share = partition.share
+    assert share is not None
+    if wanted is None:
+        return None
+    if share.minimum is not None and wanted < share.minimum:
+        raise InvalidLayout(
+            f"{partition.id} works out to {wanted}, below the {share.minimum} it asks for"
+        )
+    if share.maximum is not None and share.maximum < wanted:
+        return share.maximum
+    return wanted
 
 
 def _start_of(

--- a/gentoo_install/tui/screens.py
+++ b/gentoo_install/tui/screens.py
@@ -112,8 +112,20 @@ def _rebuild(config: InstallConfig, context: Context) -> InstallConfig:
     table with a whole-disk graph carrying `wipe`, which is the operator's data
     destroyed by opening an unrelated row.
     """
-    graph, root = manual.build(context.layout) if context.manual else build(context.choice)
-    return replace(config, disk=DiskConfig(graph=graph, root=root))
+    if context.manual:
+        graph, root = manual.build(context.layout)
+        # Cleared, not left behind: a layout the operator has taken over by
+        # hand is no longer the template it started from, and writing
+        # `[disk.simple]` beside it would export a file that installs
+        # something else.
+        return replace(config, disk=DiskConfig(graph=graph, root=root, simple=None))
+    graph, root = build(context.choice)
+    # Kept, so the export is the four lines the operator answered rather than
+    # the sixty the graph takes to say the same thing. `serialise.py` writes
+    # `[disk.simple]` when this is set and the graph otherwise; it is never
+    # inferred back from the shape, because `table = "gpt"` written out and
+    # `table` omitted produce the same graph from two different answers.
+    return replace(config, disk=DiskConfig(graph=graph, root=root, simple=context.choice))
 
 
 #: What each mode does, in the operator's terms rather than the enum's.

--- a/tests/fixtures/vm-shares.toml
+++ b/tests/fixtures/vm-shares.toml
@@ -1,0 +1,120 @@
+# One file for a fleet of unlike disks. The esp takes a fixed size and the two
+# shares split what it leaves, so 40 and 60 add up to a layout that fits rather
+# than one that has to be written as 39 and 59.
+#
+# The bounds are what make it serve both a small disk and a large one: four
+# tenths of a 240 GB disk is 96 GB and four tenths of an 8 TB disk is 3.2 TB,
+# and neither is what the operator meant on the other machine.
+#
+# The root hash below is `install`, produced by `openssl passwd -6`.
+config_version = 1
+
+[system]
+hostname = "fleetbox"
+timezone = "UTC"
+locales = ["en_US.UTF-8"]
+locale = "en_US.UTF-8"
+init = "systemd"
+networking = "builtin"
+sshd = true
+root_password_hash = "$6$gentooinst$IR3GrdJ862XljQYDqocr4tKniIRDIT.jQNFzIrHE3U75H6B6YSWZoSYoVd5edSHpqaYBdiNfXHCoIPRVgb9lT/"
+
+[portage]
+profile = "default/linux/amd64/23.0/systemd"
+makeopts = "-j4"
+
+[portage.mirrors]
+region = "global"
+
+[portage.binhost]
+official = true
+community = "off"
+
+[kernel]
+source = "dist-bin"
+
+[bootloader]
+kind = "grub"
+firmware = "uefi"
+kernel_params = ["console=ttyS0,115200"]
+[disk]
+root = "mnt-root"
+
+[[disk.devices]]
+kind = "existing"
+id = "disk"
+selector = "/dev/disk/by-id/virtio-target0"
+wipe = true
+
+[[disk.devices]]
+kind = "table"
+id = "table"
+disk = "disk"
+table = "gpt"
+
+[[disk.devices]]
+kind = "partition"
+id = "esp"
+table = "table"
+index = 1
+role = "esp"
+size = "512MiB"
+
+[[disk.devices]]
+kind = "partition"
+id = "rootpart"
+table = "table"
+index = 2
+role = "data"
+size = "40%"
+min = "20GiB"
+max = "300GiB"
+
+[[disk.devices]]
+kind = "partition"
+id = "homepart"
+table = "table"
+index = 3
+role = "data"
+size = "rest"
+min = "10GiB"
+
+[[disk.devices]]
+kind = "filesystem"
+id = "espfs"
+device = "esp"
+type = "vfat"
+label = "ESP"
+
+[[disk.devices]]
+kind = "filesystem"
+id = "rootfs"
+device = "rootpart"
+type = "ext4"
+label = "gentoo"
+
+[[disk.devices]]
+kind = "filesystem"
+id = "homefs"
+device = "homepart"
+type = "ext4"
+label = "home"
+
+[[disk.devices]]
+kind = "mountpoint"
+id = "mnt-root"
+source = "rootfs"
+path = "/"
+
+[[disk.devices]]
+kind = "mountpoint"
+id = "mnt-esp"
+source = "espfs"
+path = "/efi"
+options = ["umask=0077"]
+
+[[disk.devices]]
+kind = "mountpoint"
+id = "mnt-home"
+source = "homefs"
+path = "/home"

--- a/tests/golden/test_golden.py
+++ b/tests/golden/test_golden.py
@@ -29,7 +29,7 @@ from gentoo_install.plan import netboot
 from gentoo_install.plan.build import build
 from gentoo_install.plan.render import render
 
-from ..unit.layouts import running_layout
+from ..unit.layouts import facts_for, running_layout
 
 HERE = Path(__file__).resolve().parent
 FIXTURES = HERE.parent / "fixtures"
@@ -109,7 +109,14 @@ def plan_of(installation: InstallConfig) -> str:
     gives the conversion a golden file at all: without it `build` raises and
     the fixture had none while every other fixture had one."""
     layout = running_layout() if installation.disk.mode is DiskMode.IN_PLACE else None
-    return render(build(installation, load_catalog(), layout=layout))
+    return render(
+        build(
+            installation,
+            load_catalog(),
+            layout=layout,
+            storage_facts=facts_for(installation),
+        )
+    )
 
 
 def plan_text(name: str) -> str:

--- a/tests/golden/vm-shares.txt
+++ b/tests/golden/vm-shares.txt
@@ -1,0 +1,80 @@
+[partition]
+  release anything a previous run of this configuration left mounted or open
+  wipe existing signatures from disk
+  create a gpt partition table on disk as table
+  create partition 1 on disk as esp in the gpt table: esp, 512MiB
+  create partition 2 on disk as rootpart in the gpt table: data, 209509MiB
+  create partition 3 on disk as homepart in the gpt table: data, the rest of the disk
+  reread the partition table of disk and wait for its nodes
+
+[format]
+  make a vfat filesystem on esp as espfs labelled ESP
+  make a ext4 filesystem on homepart as homefs labelled home
+  make a ext4 filesystem on rootpart as rootfs labelled gentoo
+
+[mount]
+  mount rootpart at /
+  mount esp at /efi with umask=0077
+  mount homepart at /home
+
+[stage3]
+  download the newest systemd stage3 from https://distfiles.gentoo.org directly, verify it against BB572E0E2D182910, unpack it into the target and write /etc/gentoo-install/proxy.toml
+
+[chroot]
+  mount transient proc, sys, dev and run filesystems into the target
+  seed the target's resolv.conf from the install medium
+
+[portage]
+  write /etc/portage/make.conf with MAKEOPTS, INPUT_DEVICES, ACCEPT_LICENSE, L10N, FEATURES; 2 mirrors in the configured order, 5 appended
+  configure Portage, wget, curl, git and gpg for direct connection
+  create /etc/portage/package.use/zz-autounmask, /etc/portage/package.accept_keywords/zz-autounmask, /etc/portage/package.license/zz-autounmask, which emerge writes its decisions into
+  disable inherited binary package host gentoo
+  run getuto so Portage has a keyring to verify binary packages against, and write dirmngr.conf
+  import BB572E0E2D182910 from /usr/share/openpgp-keys/gentoo-release.asc, locally sign it for gentoo, and verify the local signature
+  write /etc/portage/binrepos.conf/gentoo.conf adding verified binary package host gentoo at https://distfiles.gentoo.org/releases/amd64/binpackages/23.0/x86-64
+  fetch the first ebuild repository snapshot with emerge-webrsync
+  select profile default/linux/amd64/23.0/systemd
+  install git, which every later repository sync needs: emerge dev-vcs/git
+  write /etc/portage/repos.conf/gentoo.conf pointing gentoo at https://github.com/gentoo-mirror/gentoo.git, commit signatures verified
+  sync repository gentoo
+  set sys-kernel/installkernel to dracut
+  accept the linux-firmware licence
+  resolve net-misc/openssh sys-process/cronie sys-kernel/installkernel sys-kernel/dracut sys-kernel/linux-firmware sys-fs/dosfstools sys-fs/e2fsprogs sys-kernel/gentoo-kernel-bin sys-boot/grub sys-boot/efibootmgr together before installing the requested packages
+
+[system]
+  write /etc/locale.gen with locales en_US.UTF-8 and verify them
+  set the system locale to en_US.UTF-8 in /etc/locale.conf
+  set the timezone to UTC
+  set the console keymap to us and its font to default8x16 in /etc/vconsole.conf
+  set the hostname to fleetbox in /etc/hostname and /etc/hosts
+  give the target its own machine id with systemd-machine-id-setup
+  write /etc/fstab with UUID from rootpart / ext4 defaults 0 1, UUID from esp /efi vfat defaults,umask=0077 0 2, UUID from homepart /home ext4 defaults 0 2
+  treat the hardware clock as UTC in /etc/adjtime
+  set the root password
+  install sshd: emerge net-misc/openssh
+  ssh password login: off, root: off, in 50-gentoo-install.conf
+  enable sshd at boot
+  generate the ssh host keys
+  write /etc/systemd/network/20-wired.network for the wired interfaces with DHCP and DNS -
+  enable systemd-networkd at boot
+  enable systemd-resolved at boot
+  install cron: emerge sys-process/cronie
+  enable cronie at boot
+
+[kernel]
+  install the hook that puts a kernel in /boot: emerge sys-kernel/installkernel
+  install the initramfs builder and firmware: emerge sys-kernel/dracut sys-kernel/linux-firmware
+  install the storage tools: emerge sys-fs/dosfstools sys-fs/e2fsprogs
+  install the kernel: emerge sys-kernel/gentoo-kernel-bin
+  rebuild the initramfs from sys-kernel/gentoo-kernel-bin with the modules written above
+  check the installkernel payload names existing kernel files
+
+[bootloader]
+  install the bootloader: emerge sys-boot/grub sys-boot/efibootmgr
+  write /etc/default/grub with cmdline console=ttyS0,115200, its menu on ttyS0
+  install GRUB for uefi on the esp at /efi
+
+[finish]
+  point /etc/resolv.conf at systemd-resolved rather than the install medium's
+  delete the downloaded stage3 from /var/cache/gentoo-install
+  unmount everything under the target

--- a/tests/unit/layouts.py
+++ b/tests/unit/layouts.py
@@ -7,6 +7,8 @@ it changes and nothing else.
 
 from __future__ import annotations
 
+from typing import Final
+
 from pathlib import PurePosixPath
 
 from gentoo_install.model.config import (
@@ -31,10 +33,12 @@ from gentoo_install.model.device import (
     Partition,
     PartitionRole,
     PartitionTable,
+    StorageFacts,
     StorageLayout,
     TableType,
     ZfsDataset,
     ZfsPool,
+    asks_for_a_share,
 )
 from gentoo_install.model.size import Size
 
@@ -121,6 +125,31 @@ def config(nodes: list[Node] | None = None) -> InstallConfig:
         # An empty hash locks root, and `compat` refuses a system nothing can
         # log into. Every layout here is meant to be installable.
         system=SystemConfig(root_password_hash="$6$gentooinst$IR3GrdJ862XljQYDqocr4tKniIRDIT.jQNFzIrHE3U75H6B6YSWZoSYoVd5edSHpqaYBdiNfXHCoIPRVgb9lT/"),
+    )
+
+
+#: The disk every test pretends a share is a share of. A share cannot be
+#: worked out without a capacity, so a fixture carrying one has no plan at
+#: all without this — the same reason `running_layout()` stands in for the
+#: conversion's machine. Stated rather than probed, because a golden file has
+#: to say the same thing on every machine that regenerates it.
+STAND_IN_CAPACITY: Final[Size] = Size.parse("512GiB")
+
+
+def facts_for(installation: InstallConfig) -> StorageFacts:
+    """The storage evidence a fixture needs to be planned at all.
+
+    Empty unless something asks for a share: a layout of absolute sizes is
+    planned from the file alone, and handing it a capacity it does not read
+    would hide a plan that had started to need one.
+    """
+    if not asks_for_a_share(installation.disk.graph):
+        return StorageFacts()
+    return StorageFacts(
+        capacities={
+            one.id: STAND_IN_CAPACITY
+            for one in installation.disk.graph.of_type(Existing)
+        }
     )
 
 

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -2396,3 +2396,29 @@ def test_every_named_error_has_an_exit_code_somebody_chose(
         code = main(["--config", str(FIXTURES / "btrfs-luks.toml"), "--dry-run"])
         capsys.readouterr()
         assert code == EXIT_FOR_ERROR[name], (name, code, EXIT_FOR_ERROR[name])
+
+
+def test_a_dry_run_reads_a_capacity_only_when_a_share_needs_one() -> None:
+    """A share is a share of the disk, so a dry run that cannot read the
+    capacity prints a different number from the one the install writes. A
+    layout of absolute sizes needs none, and reading one anyway made every dry
+    run depend on evidence it does not use: the first version asked a probe
+    double for `disk_bytes` and `ext4-bios` exited 4."""
+    import tomllib
+
+    from gentoo_install.model.device import asks_for_a_share
+    from gentoo_install.model.parse import parse
+
+    plain = load(FIXTURES / "ext4-bios.toml")
+    assert not asks_for_a_share(plain.disk.graph)
+
+    base = (FIXTURES / "vm-xfs.toml").read_text()
+    anchor = 'kind = "partition"\nid = "rootpart"\ntable = "table"\nindex = 2\nrole = "data"'
+    assert base.count(anchor) == 1
+    shared = parse(tomllib.loads(base.replace(anchor, f'{anchor}\nsize = "40%"')))
+    assert asks_for_a_share(shared.disk.graph)
+
+    # `rest` is not a share of anything: it is whatever is left, which needs
+    # no capacity to describe, so it must not drag a probe in behind it.
+    rested = parse(tomllib.loads(base.replace(anchor, f'{anchor}\nsize = "rest"')))
+    assert not asks_for_a_share(rested.disk.graph)

--- a/tests/unit/test_cluster.py
+++ b/tests/unit/test_cluster.py
@@ -4234,3 +4234,36 @@ def test_a_watchdog_verdict_tells_an_unanswered_state_from_a_running_one(
     # And a guest that is genuinely running says nothing extra: a clause on
     # every verdict is a clause nobody reads.
     assert "qemu calls the guest" not in verdict("running")
+
+
+def test_the_cluster_limit_counts_weight_rather_than_guests() -> None:
+    """Four guests at `--limit 4` meant four compiling ones, and `vm-raidz`
+    and `vm-cjk-kernel` both stalled mid-`emerge` with their nodes at 0%. The
+    same two finished at a limit of two: 64.5m and 20.0m. Memory and cores are
+    reserved per node already; this is the whole-cluster ceiling those cannot
+    express, and `campaign.py` has charged its own machine this way all along.
+    """
+    from tests.vm.campaign import COMPILING_WEIGHT as LOCAL_WEIGHT
+    from tests.vm.cluster import COMPILING_WEIGHT, fixtures
+
+    heavy, light = fixtures(["vm-raidz", "vm-binpkg"])
+    assert heavy.heavy and not light.heavy, (heavy.name, light.name)
+    assert (heavy.weight, light.weight) == (COMPILING_WEIGHT, 1)
+    # One number, both runners: a second table is how the two came to
+    # disagree about nine fixtures in the first place.
+    assert COMPILING_WEIGHT == LOCAL_WEIGHT
+
+    # And the schedule really spends it that way, read off the same
+    # arithmetic the dispatch loop uses.
+    from tests.vm.cluster import slots_within
+    from tests.vm.proxmox import Node
+
+    free = [Node(name=f"infra-node{n}", free_bytes=0, cores=4, free_cores=4.0) for n in range(6)]
+    assert len(slots_within(4, list(free), [])) == 4
+    # One compiling guest already out there leaves two, not three: counting
+    # guests is what put four of them on at once.
+    assert len(slots_within(4, list(free), [heavy])) == 2
+    assert len(slots_within(4, list(free), [light])) == 3
+    assert slots_within(4, list(free), [heavy, heavy]) == []
+    # Zero is "ask the cluster what fits", not "nothing fits".
+    assert len(slots_within(0, list(free), [heavy, heavy])) == len(free)

--- a/tests/unit/test_harness.py
+++ b/tests/unit/test_harness.py
@@ -145,10 +145,13 @@ def test_every_configuration_the_campaign_names_exists() -> None:
 #: in without anybody noticing, which is what this check exists to stop.
 NOT_IN_THE_CAMPAIGN: Final[frozenset[str]] = frozenset(
     {
-        # An image install writes a file rather than the guest's own disk, and
-        # what has to boot is that file attached as a second disk. Nothing in
-        # `tests/vm/campaign.py` boots a file yet.
-        "vm-image.toml",
+        # A share is a share of the disk, and every guest here is given the
+        # same 40 GiB target, so this fixture would measure one capacity and
+        # prove nothing about the arithmetic it exists for. What it does prove
+        # is checked without a guest: `tests/golden/vm-shares.txt` carries the
+        # resolved bytes, and `tests/unit/test_plan_disk.py` runs the same
+        # configuration against two very different disks.
+        "vm-shares.toml",
         # What the memory environment is asked to install once it comes up.
         # `tests/vm/ram.py` runs it against a cloud image rather than the
         # medium the campaign boots, because the machine under test has to
@@ -6066,3 +6069,60 @@ def _through_socks(port: int, name: str, secret: str, target: int) -> bytes | No
                 break
             seen += chunk
         return seen.partition(b"\r\n\r\n")[2]
+
+
+def test_the_image_install_is_in_the_campaign_and_is_not_booted() -> None:
+    """`vm-image` was in neither runner: the cluster refuses it because it
+    cannot give the guest a filesystem to write the image onto, and the
+    campaign excluded it because nothing here boots a file. So the only
+    installation mode that produces a file rather than a disk was never run
+    end to end at all.
+
+    `check_image` reads the partitions and filesystems out of the file, which
+    is what a verdict for this mode can honestly assert; booting it is a
+    separate gap with its own row.
+    """
+    from tests.vm.campaign import STAGES
+
+    named = {Path(one.config).stem: one for stage in STAGES.values() for one in stage}
+    image = named.get("vm-image")
+    assert image is not None, sorted(named)
+    assert not image.boot, "the target disk carries the scratch filesystem, not a system"
+    assert "--and-boot" not in image.argv(), image.argv()
+    # And every other run still boots, or this field becomes a way to make a
+    # red run green.
+    assert all(one.boot for name, one in named.items() if name != "vm-image")
+
+
+def test_an_image_run_hands_its_verdict_a_configuration_not_a_path() -> None:
+    """Every image run died on `'PosixPath' object has no attribute 'disk'`.
+    `check_expected` took an `InstallConfig` from `#1015` onward and this call
+    site kept passing the fixture's path; `argparse.Namespace` makes
+    `args.install` `Any`, so the expression built from it was `Any` too and
+    mypy strict had nothing to say. Nothing in either runner's list carried
+    the image mode, so nothing ran into it.
+    """
+    import ast
+
+    source = Path("tests/vm/run.py").read_text()
+    tree = ast.parse(source)
+    inside = next(
+        node
+        for node in ast.walk(tree)
+        if isinstance(node, ast.FunctionDef) and node.name == "_install_and_check"
+    )
+    assertions = [
+        keyword.value
+        for node in ast.walk(inside)
+        if isinstance(node, ast.Call)
+        for keyword in node.keywords
+        if keyword.arg == "assertions"
+    ]
+    assert assertions, "the image verdict lost its assertions argument"
+    for value in assertions:
+        written = ast.unparse(value)
+        # A path only ever reaches this argument through `installed_config`,
+        # which is what turns it into the configuration the run installs. The
+        # other call site passes a name already bound from it.
+        if "REPOSITORY" in written:
+            assert "installed_config(" in written, written

--- a/tests/unit/test_media.py
+++ b/tests/unit/test_media.py
@@ -48,3 +48,51 @@ def test_replacing_an_iso_with_preserved_metadata_re_extracts_its_boot_files(
     kernel, initrd = medium.boot_files()
     assert len(extracted) == 2, "a changed ISO was served from the cache"
     assert (kernel.read_bytes(), initrd.read_bytes()) == (second, second)
+
+
+def test_every_medium_names_a_volume_label_the_iso_actually_carries() -> None:
+    """`GENTOO_CJK` carried `Gentoo-CJK-amd64-20260809` while its file name
+    said `20260820`: the label is date-stamped by the build, so repinning the
+    ISO and leaving the label behind gives a medium that boots and is then
+    refused for being the wrong one. Read out of the file rather than assumed,
+    and skipped for a medium whose ISO is not downloaded — that is the
+    workstation missing a file, not a defect in the table."""
+    from tests.vm.media import MEDIA
+
+    checked = 0
+    for medium in MEDIA.values():
+        if not medium.volume_label or not medium.iso.is_file():
+            continue
+        with medium.iso.open("rb") as image:
+            # The primary volume descriptor starts at sector 16 and its
+            # volume identifier is 32 bytes at offset 40 inside it.
+            image.seek(32768 + 40)
+            carried = image.read(32).decode("ascii", "replace").rstrip()
+        assert carried == medium.volume_label, (medium.name, carried, medium.volume_label)
+        checked += 1
+    if not checked:
+        pytest.skip("no medium's ISO is downloaded here")
+
+
+def test_every_command_a_fixture_needs_has_an_alpine_package_named_for_it() -> None:
+    """`apk add` takes the whole list or none of it. `ALPINE_PACKAGE_FOR_COMMAND`
+    fell back to the command's own name, so `cat`, `dd`, `mkdir`, `sleep`,
+    `test`, `install`, `truncate`, `dmsetup` and `vgchange` were handed to apk
+    as package names; it answered `cat (no such package)` and refused the
+    transaction, python3 included. The run then failed two steps later with
+    `this installer needs python 3.11 or newer; found: none`, which names
+    neither apk nor the table.
+    """
+    from tests.vm.media import ALPINE_PACKAGE_FOR_COMMAND, _alpine_packages, _fixture_commands
+
+    commands = _fixture_commands()
+    assert commands, "no fixture asked for a command"
+    unnamed = sorted(one for one in commands if one not in ALPINE_PACKAGE_FOR_COMMAND)
+    assert not unnamed, unnamed
+
+    # And an unlisted one is refused rather than passed through, or the table
+    # goes stale again the next time a fixture needs a new tool.
+    from tests.vm.media import MediaError
+
+    with pytest.raises(MediaError, match="no Alpine package is named"):
+        _alpine_packages([*commands, "a-command-nothing-provides"])

--- a/tests/unit/test_plan.py
+++ b/tests/unit/test_plan.py
@@ -40,7 +40,7 @@ from gentoo_install.plan.packages import Catalog, Group
 from gentoo_install.plan.portage import Emerge
 from gentoo_install.plan.render import render, summarise
 
-from .layouts import config, ext4_on_gpt, i, running_layout, zfs_root
+from .layouts import config, ext4_on_gpt, facts_for, i, running_layout, zfs_root
 from .recorder import Recorder
 
 FIXTURES = Path(__file__).resolve().parents[1] / "fixtures"
@@ -258,7 +258,7 @@ def test_every_operation_describes_itself_in_one_line() -> None:
         # A conversion derives its whole plan from the running machine, so the
         # fixture alone is not enough to build one.
         layout = running_layout() if installation.disk.mode is DiskMode.IN_PLACE else None
-        for operation in build(installation, load_catalog(), layout=layout):
+        for operation in build(installation, load_catalog(), layout=layout, storage_facts=facts_for(installation)):
             described = operation.describe()
             assert described and "\n" not in described, f"{type(operation).__name__} in {path.name}"
 

--- a/tests/unit/test_plan_disk.py
+++ b/tests/unit/test_plan_disk.py
@@ -1419,3 +1419,89 @@ def test_rereading_a_table_updates_it_as_well_as_asking() -> None:
     # Undeclared on purpose, like `partprobe`: it runs with `check=False`
     # and `Probe.wait_for` scans for the node when it is absent.
     assert "partx" not in RereadPartitionTable.host_commands
+
+
+def _with_root_extent(body: str) -> InstallConfig:
+    """`vm-xfs` with its root partition asking for something else."""
+    import tomllib
+
+    from gentoo_install.model.parse import parse
+
+    base = Path("tests/fixtures/vm-xfs.toml").read_text()
+    anchor = 'kind = "partition"\nid = "rootpart"\ntable = "table"\nindex = 2\nrole = "data"'
+    assert base.count(anchor) == 1
+    return parse(tomllib.loads(base.replace(anchor, f"{anchor}\n{body}")))
+
+
+def _resolved(body: str, capacity: str) -> Size | None:
+    from gentoo_install.model.device import DeviceId, StorageFacts
+    from gentoo_install.plan.disk import resolve_share
+
+    from gentoo_install.model.device import Partition
+
+    config = _with_root_extent(body)
+    facts = StorageFacts(
+        capacities={DeviceId("disk"): Size.parse(capacity)} if capacity else {}
+    )
+    root = config.disk.graph.nodes[DeviceId("rootpart")]
+    assert isinstance(root, Partition)
+    return resolve_share(config.disk.graph, root, facts)
+
+
+def test_a_share_is_of_what_the_fixed_sizes_leave_and_its_bounds_hold() -> None:
+    """One file for a fleet of unlike disks is the whole point: four tenths of
+    a 240 GB disk and four tenths of an 8 TB disk are both wrong on the other
+    machine, and the bounds are what make one configuration serve both.
+
+    The base is what `Size.usable_for_partitions` answers minus every absolute
+    size on the table — the esp here — so `40%` beside `60%` beside an esp is
+    a layout that fits. Counting the whole disk instead would refuse it.
+    """
+    small = _resolved('size = "40%"', "240G")
+    large = _resolved('size = "40%"', "8T")
+    assert small is not None and large is not None
+    assert small < large, (small, large)
+
+    # The ceiling catches the large disk and leaves the small one alone.
+    bounded = 'size = "40%"\nmin = "30G"\nmax = "100G"'
+    assert _resolved(bounded, "240G") == small
+    assert _resolved(bounded, "8T") == Size.parse("100G")
+
+    # The esp comes off the base first, asserted against the arithmetic rather
+    # than against a looser bound: every candidate base is smaller than the
+    # raw capacity, so `share < 40% of capacity` passes whether or not the
+    # fixed sizes were subtracted, and a control that removed the subtraction
+    # stayed green.
+    from gentoo_install.model.size import SectorSize
+
+    usable = Size.parse("240G").usable_for_partitions(True, SectorSize(512))
+    esp = Size.parse("512MiB")
+    assert small == Size(int((usable.bytes - esp.bytes) * 40 / 100)).align_down()
+    assert small != Size(int(usable.bytes * 40 / 100)).align_down()
+
+    # Aligned, because a partition that starts mid-unit is one `parted` moves.
+    assert small.is_aligned(), small
+
+    # And the other two spellings still mean what they meant.
+    assert _resolved('size = "rest"', "240G") is None
+    assert _resolved('size = "20G"', "240G") == Size.parse("20G")
+
+
+def test_a_share_below_its_floor_is_refused_rather_than_raised() -> None:
+    """Raising it to the minimum takes the space from another partition, and
+    a layout that stops adding up without anybody being told is the failure
+    this whole feature exists to avoid."""
+    from gentoo_install.errors import InvalidLayout
+
+    with pytest.raises(InvalidLayout, match="below the"):
+        _resolved('size = "1%"\nmin = "30G"', "240G")
+
+
+def test_a_share_on_a_disk_of_unknown_size_says_so() -> None:
+    """A dry run on a machine that has no such disk cannot work out what 40%
+    is, and inventing a number would make the printed plan a different answer
+    from the one the install uses."""
+    from gentoo_install.errors import InvalidLayout
+
+    with pytest.raises(InvalidLayout, match="did not report"):
+        _resolved('size = "40%"', "")

--- a/tests/unit/test_plan_system.py
+++ b/tests/unit/test_plan_system.py
@@ -38,7 +38,7 @@ from gentoo_install.model.device import (
 from gentoo_install.plan import bootloader, disk, mounts, system
 from gentoo_install.plan.portage import Emerge
 
-from .layouts import config, ext4_on_gpt, i
+from .layouts import config, ext4_on_gpt, facts_for, i
 from .recorder import Recorder
 
 #: What `locale -a` answers for the default set, so a test that is not
@@ -238,7 +238,7 @@ def test_runtime_mounts_and_fstab_share_resolved_graph_meaning(
 
     runtime = [
         operation
-        for operation in disk.build(installation)
+        for operation in disk.build(installation, facts_for(installation))
         if isinstance(operation, (disk.Mount, disk.MountZfsDataset))
     ]
     entries = system.fstab_entries(installation)
@@ -1547,7 +1547,7 @@ def test_every_derived_destination_is_named_by_the_description() -> None:
                 )
             )
         for installation in variants:
-            for operation in build(installation, catalog):
+            for operation in build(installation, catalog, storage_facts=facts_for(installation)):
                 named = getattr(operation, "destinations", None)
                 if named is None:
                     continue
@@ -1593,7 +1593,7 @@ def test_every_operation_that_names_a_file_writes_exactly_the_files_it_named() -
                 )
             )
         for installation in variants:
-            for operation in build(installation, catalog):
+            for operation in build(installation, catalog, storage_facts=facts_for(installation)):
                 named = getattr(operation, "destinations", None)
                 if named is None:
                     continue

--- a/tests/unit/test_serialise.py
+++ b/tests/unit/test_serialise.py
@@ -288,7 +288,7 @@ def test_every_node_field_the_writer_emits_is_a_key_its_parser_accepts() -> None
     from dataclasses import fields
 
     from gentoo_install.model import parse as parse_module
-    from gentoo_install.model.serialise import KINDS, RENAMED
+    from gentoo_install.model.serialise import KINDS, RENAMED, SPELLED_AS
 
     source = ast.parse(inspect.getsource(parse_module))
     accepted: dict[str, set[str]] = {}
@@ -317,5 +317,14 @@ def test_every_node_field_the_writer_emits_is_a_key_its_parser_accepts() -> None
     for held, kind in KINDS.items():
         keys = accepted.get(builders[kind])
         assert keys is not None, (kind, builders[kind])
-        written = {RENAMED.get((held, one.name), one.name) for one in fields(held)}
+        written: set[str] = set()
+        for one in fields(held):
+            written |= SPELLED_AS.get(
+                (held, one.name), frozenset({RENAMED.get((held, one.name), one.name)})
+            )
         assert written <= keys, (kind, sorted(written - keys))
+    # And every declared expansion is for a field that exists, so a renamed
+    # field leaves a stale entry that quietly excuses nothing.
+    for (held, name), spelled in SPELLED_AS.items():
+        assert name in {one.name for one in fields(held)}, (held.__name__, name)
+        assert spelled, (held.__name__, name)

--- a/tests/unit/test_tui_app.py
+++ b/tests/unit/test_tui_app.py
@@ -4262,3 +4262,43 @@ def test_the_install_row_derives_a_conversion_from_the_machine(
 
     with pytest.raises(ConversionUnsupported, match="layout was not read"):
         real_build(converted, load_catalog())
+
+
+def test_the_interface_exports_the_answers_it_was_given_not_the_graph() -> None:
+    """`vm-xfs` — one disk, one esp, one xfs root, the commonest layout there
+    is — exports as sixty lines of device graph. The four-line `[disk.simple]`
+    form covers it, and `DiskConfig.simple` is what tells the writer to use
+    it: the shape is never inferred back, because `table = "gpt"` written out
+    and `table` omitted produce the same graph from two different answers.
+
+    Nothing set it, so every export was the long form and the short one was
+    reachable only by somebody who already knew it existed.
+    """
+    from gentoo_install.model.serialise import to_toml
+    from gentoo_install.tui import screens
+
+    at = context()
+    assert not at.manual, "this case is about the template path"
+    templated = screens._rebuild(config(), at)
+    assert templated.disk.simple is not None
+
+    written = to_toml(templated)
+    assert "[disk.simple]" in written, written
+    assert "[[disk.devices]]" not in written, written
+    # And it reads back as the same installation, which is the whole point of
+    # saving one: an unattended second run, not a record of what was chosen.
+    assert load_toml(written).disk.graph.nodes.keys() == templated.disk.graph.nodes.keys()
+
+    # Taken over by hand, the template is no longer what the operator means.
+    at.manual = True
+    by_hand = screens._rebuild(config(), at)
+    assert by_hand.disk.simple is None
+    assert "[disk.simple]" not in to_toml(by_hand)
+
+
+def load_toml(text: str) -> InstallConfig:
+    import tomllib
+
+    from gentoo_install.model.parse import parse
+
+    return parse(tomllib.loads(text))

--- a/tests/vm/campaign.py
+++ b/tests/vm/campaign.py
@@ -219,6 +219,11 @@ STAGES: Final[dict[str, tuple[Run, ...]]] = {
         Run("fixtures/btrfs-luks.toml"),
         Run("fixtures/ext4-bios.toml", firmware="bios"),
         Run("fixtures/vm-cjk-kernel.toml"),
+        # `boot=False`: the product is a file on the scratch filesystem
+        # this runner mounts, and the target disk carries that
+        # filesystem rather than an installed system. `check_image`
+        # reads the partitions and filesystems out of the file itself.
+        Run("fixtures/vm-image.toml", boot=False),
         # Run by `tests/vm/convert.py` rather than `run.py`: it boots a
         # cloud image and converts what is already running, which is the
         # only thing a conversion can be measured against.

--- a/tests/vm/cluster.py
+++ b/tests/vm/cluster.py
@@ -201,6 +201,10 @@ TARGET_GIB: Final[int] = 40
 HEAVY_MEMORY_MIB: Final[int] = 8192
 HEAVY_CORES: Final[int] = 4
 
+#: What a compiling guest costs `--limit`, the same number
+#: `campaign.py` charges its own machine.
+COMPILING_WEIGHT: Final[int] = 2
+
 #: Left free on every node whatever else is scheduled. A node with nothing
 #: spare stops answering, and this cluster runs other people's machines.
 NODE_HEADROOM_BYTES: Final[int] = 2 * 1024**3
@@ -380,6 +384,18 @@ class Job:
     @property
     def cores(self) -> int:
         return HEAVY_CORES if self.heavy else GUEST_CORES
+
+    @property
+    def weight(self) -> int:
+        """What this costs `--limit`, in the same units `campaign.CAPACITY`
+        counts.
+
+        Counting guests let four compiling ones onto the cluster at once and
+        two of them stalled mid-`emerge` with their nodes at 0%; the same two
+        finished at a limit of two. Memory and cores are already reserved per
+        node, and this is the whole-cluster ceiling those cannot express.
+        """
+        return COMPILING_WEIGHT if self.heavy else 1
 
     @property
     def collected(self) -> bool:
@@ -1860,6 +1876,18 @@ def _reserved_bytes(scheduled: Mapping[str, Job]) -> Counter[str]:
     return held
 
 
+def slots_within(limit: int, slots: list[Node], running: Sequence[Job]) -> list[Node]:
+    """The slots the whole-cluster ceiling still allows, in weight units.
+
+    Named rather than inline so that a test reads the same arithmetic the
+    schedule does: counting guests here admitted four compiling ones and two
+    of them stalled.
+    """
+    if not limit:
+        return slots
+    return slots[: max(0, limit - sum(job.weight for job in running))]
+
+
 def _reserved_cores(scheduled: Mapping[str, Job]) -> Counter[str]:
     held: Counter[str] = Counter()
     for job in scheduled.values():
@@ -2665,8 +2693,7 @@ def run(
                 # that genuinely has nowhere to run.
                 print(f"the cluster's capacity could not be read: {error}", flush=True)
                 slots = []
-            if limit:
-                slots = slots[: max(0, limit - len(running))]
+            slots = slots_within(limit, slots, running)
             if waiting and not running and not slots:
                 now = time.monotonic()
                 if capacity_since is None:
@@ -4601,7 +4628,14 @@ def main(argv: list[str] | None = None) -> int:
             raise argparse.ArgumentTypeError("--limit cannot be negative")
         return limit
 
-    parser.add_argument("--limit", type=nonnegative, default=0, help="how many guests at once")
+    parser.add_argument(
+        "--limit",
+        type=nonnegative,
+        default=0,
+        help="how much of the cluster to use at once, in the units `Job.weight` counts: "
+        "a guest that compiles is worth two and every other one is worth one, so `4` is "
+        "four binary-package installs or two compiling ones",
+    )
     parser.add_argument("--workdir", type=Path, default=WORKROOT)
     parser.add_argument(
         "--site",

--- a/tests/vm/media.py
+++ b/tests/vm/media.py
@@ -126,9 +126,21 @@ def _extract(iso: Path, files: dict[str, Path]) -> None:
 #: until a run failed on a path nobody had moved.
 ISO_CACHE = CACHE / "iso"
 
-#: Alpine packages for executables whose names differ. An empty package means
-#: the base image already supplies the command.
+#: The Alpine package for every executable a fixture needs. An empty package
+#: means the base image already supplies the command, which on Alpine means
+#: busybox.
+#:
+#: Every command, with no fallback to its own name: `.get(command, command)`
+#: made an unlisted command into a package name, `apk add` refused the whole
+#: list with `cat (no such package)`, and the run failed two steps later with
+#: `this installer needs python 3.11 or newer; found: none` — python3 was in
+#: the same atomic transaction. Nine of the twenty-six that fell through were
+#: not packages at all; the other seventeen worked by luck.
+#:
+#: Checked against `APKINDEX` from `v3.24/{main,community}` on 2026-08-25
+#: rather than remembered.
 ALPINE_PACKAGE_FOR_COMMAND: Final[dict[str, str]] = {
+    "blkid": "blkid",
     "blockdev": "util-linux-misc",
     "btrfs": "btrfs-progs",
     "chroot": "coreutils",
@@ -149,6 +161,31 @@ ALPINE_PACKAGE_FOR_COMMAND: Final[dict[str, str]] = {
     "udevadm": "eudev",
     "vgcreate": "lvm2",
     "zpool": "zfs",
+    "cat": "",
+    "cryptsetup": "cryptsetup",
+    "dd": "",
+    "dmsetup": "device-mapper",
+    "findmnt": "findmnt",
+    "gpg": "gpg",
+    "gpg-agent": "gpg-agent",
+    "gzip": "gzip",
+    "install": "",
+    "losetup": "losetup",
+    "lsblk": "lsblk",
+    "mdadm": "mdadm",
+    "mkdir": "",
+    "mount": "mount",
+    "parted": "parted",
+    "sgdisk": "sgdisk",
+    "sleep": "",
+    "tar": "tar",
+    "test": "",
+    "truncate": "",
+    "umount": "umount",
+    "vgchange": "lvm2",
+    "wipefs": "wipefs",
+    "xz": "xz",
+    "zfs": "zfs",
 }
 
 
@@ -161,10 +198,19 @@ def _fixture_commands() -> frozenset[str]:
 
 
 def _alpine_packages(commands: Iterable[str]) -> tuple[str, ...]:
-    packages = {
-        ALPINE_PACKAGE_FOR_COMMAND.get(command, command)
-        for command in commands
-    }
+    """The packages that supply these commands, refusing any it cannot name.
+
+    No fallback to the command's own name: `apk` takes the whole list or none
+    of it, so one command that is not a package name loses python3 as well and
+    the run fails at the installer rather than here.
+    """
+    unknown = sorted(one for one in commands if one not in ALPINE_PACKAGE_FOR_COMMAND)
+    if unknown:
+        raise MediaError(
+            "no Alpine package is named for " + ", ".join(unknown)
+            + "; add each to ALPINE_PACKAGE_FOR_COMMAND, empty when busybox supplies it"
+        )
+    packages = {ALPINE_PACKAGE_FOR_COMMAND[command] for command in commands}
     return tuple(sorted(package for package in packages if package))
 
 
@@ -172,7 +218,7 @@ ALPINE_PACKAGES: Final[tuple[str, ...]] = ("python3", *_alpine_packages(_fixture
 
 GIGOS = Medium(
     name="gigos",
-    iso=ISO_CACHE / "gig-os-20260807.iso",
+    iso=ISO_CACHE / "gig-os-20260818.iso",
     volume_label="Gig-OS",
     kernel_in_iso="/boot/kernel",
     initrd_in_iso="/boot/initrd",
@@ -205,8 +251,8 @@ OFFICIAL_MINIMAL = Medium(
 
 GENTOO_CJK = Medium(
     name="gentoo-cjk",
-    iso=ISO_CACHE / "install-amd64-cjk-minimal-20260809T143052Z.iso",
-    volume_label="Gentoo-CJK-amd64-20260809",
+    iso=ISO_CACHE / "install-amd64-cjk-minimal-20260820T064553Z.iso",
+    volume_label="Gentoo-CJK-amd64-20260820",
     kernel_in_iso="/boot/gentoo",
     initrd_in_iso="/boot/gentoo.igz",
     root_prompt=r"livecd ~ #",

--- a/tests/vm/run.py
+++ b/tests/vm/run.py
@@ -976,7 +976,12 @@ def _install_and_check(args: argparse.Namespace, medium: Medium, workdir: Path) 
         result_disk,
         keep=args.keep,
         assertions=(
-            REPOSITORY / "tests" / args.install
+            # The configuration this run installs, not the path to it:
+            # `check_expected` takes an `InstallConfig` and a `Path` reached
+            # it here, so every image run died on `'PosixPath' object has no
+            # attribute 'disk'`. `argparse.Namespace` makes `args.install`
+            # `Any`, so the whole expression was `Any` and mypy said nothing.
+            installed_config(REPOSITORY / "tests" / args.install, key)
             if _reads_an_image(args.install, args.dry_run)
             else None
         ),


### PR DESCRIPTION
Six changes, each its own commit.

`disk`: a partition can ask for `40%` with `min`/`max`, or `rest`, beside the absolute sizes it already took. One file then serves unlike disks: four tenths of 240 GB is 96 GB and of 8 TB is 3.2 TB, and the bounds are what make both right. The share is of what the fixed sizes leave, so `esp` + `swap` + `40%` + `60%` is a layout that fits rather than one written as 39 and 59. disko special-cases only `100%` and archinstall has no proportion at all, so this is new rather than copied. Resolved in `plan/` from the disk's capacity, so `describe()` prints the bytes the install writes.

`tui`: the export was sixty lines of device graph for the commonest layout. `DiskConfig.simple` is what selects the four-line form and nothing set it, though `context.choice` was in hand on the line above.

`vm`: `--limit` now spends weight, because four guests at four meant four compiling ones and two stalled. The Alpine package table names every command a fixture needs and refuses an unnamed one, checked against `APKINDEX` — the old fallback handed `cat` to apk, which refused the transaction and took python3 with it. The image mode is in the campaign, which is how its verdict was found taking a path where it wants an `InstallConfig`.

`TESTED.md` gains the proxy pair and the resume run, with what each does and does not establish.