### PR TITLE
probe: accept a selector spelled the way the installer writes one

### DIFF
--- a/gentoo_install/exec/probe.py
+++ b/gentoo_install/exec/probe.py
@@ -209,6 +209,39 @@ class ProbedDisk:
     model: str
 
 
+#: The `blkid` tag a `/dev/disk/by-*` directory answers for. Written this way
+#: because the installer writes `UUID=` into fstab, crypttab and the mount
+#: units it generates: a selector spelled the same way is the one an operator
+#: copies back out of the machine, and refusing it made the file speak two
+#: dialects of the same identifier.
+UDEV_DIRECTORY_FOR_TAG: Final[dict[str, str]] = {
+    "UUID": "by-uuid",
+    "LABEL": "by-label",
+    "PARTUUID": "by-partuuid",
+    "PARTLABEL": "by-partlabel",
+    "ID": "by-id",
+}
+
+
+def udev_path_for(selector: str) -> str:
+    """A `TAG=value` selector as the path udev keeps for it, or the selector.
+
+    A tag nothing provides is refused rather than tried as a path: `UUDI=x`
+    would otherwise be looked for as a relative file, and the error would name
+    a missing device instead of a misspelt key.
+    """
+    tag, sign, value = selector.partition("=")
+    if not sign or "/" in tag:
+        return selector
+    directory = UDEV_DIRECTORY_FOR_TAG.get(tag.upper())
+    if directory is None:
+        raise DeviceNotFound(
+            f"{selector!r} names no identifier this installer knows; "
+            f"use one of {', '.join(sorted(UDEV_DIRECTORY_FOR_TAG))} or a path"
+        )
+    return f"/dev/disk/{directory}/{value}"
+
+
 @dataclass(frozen=True)
 class ProbedPartition:
     """Facts read for a device nested below a whole disk."""
@@ -609,7 +642,7 @@ class Probe:
 
     def resolve(self, device: DeviceId, selector: str) -> str:
         """Turn a selector into a path that exists now."""
-        candidate = Path(selector)
+        candidate = Path(udev_path_for(selector))
         if candidate.exists():
             path = str(candidate.resolve())
             self.remember(device, path)

--- a/tests/unit/test_probe.py
+++ b/tests/unit/test_probe.py
@@ -874,3 +874,35 @@ def test_a_machine_running_udev_is_not_sent_to_mdev(
 
     assert ("mdev", "-s") not in asking.asked, asking.asked
     assert ("udevadm", "settle") in asking.asked, asking.asked
+
+
+def test_a_selector_may_be_spelled_the_way_the_installer_writes_one() -> None:
+    """The installer writes `UUID=` into fstab, crypttab and the mount units it
+    generates, and `resolve()` took only a path, so a selector copied back out
+    of a machine this installer made was refused. `/dev/disk/by-uuid/…` worked
+    by accident all along, because udev keeps the symlink and `Path.exists()`
+    is all `resolve()` asked.
+    """
+    from gentoo_install.errors import DeviceNotFound
+    from gentoo_install.exec.probe import UDEV_DIRECTORY_FOR_TAG, udev_path_for
+
+    assert udev_path_for("UUID=abc-123") == "/dev/disk/by-uuid/abc-123"
+    assert udev_path_for("LABEL=gentoo") == "/dev/disk/by-label/gentoo"
+    assert udev_path_for("PARTUUID=dd") == "/dev/disk/by-partuuid/dd"
+    # The tag as `blkid` prints it or as an operator types it.
+    assert udev_path_for("partlabel=esp") == "/dev/disk/by-partlabel/esp"
+
+    # A path is left exactly as written, including one that already names the
+    # directory this would have built.
+    for path in ("/dev/sda", "/dev/disk/by-id/virtio-target0", "target.raw"):
+        assert udev_path_for(path) == path
+
+    # A misspelt tag is refused rather than looked for as a relative file: the
+    # error then names the key rather than a device nobody asked for.
+    with pytest.raises(DeviceNotFound, match="names no identifier"):
+        udev_path_for("UUDI=typo")
+
+    # Every directory named is one udev actually keeps.
+    assert set(UDEV_DIRECTORY_FOR_TAG.values()) <= {
+        "by-uuid", "by-label", "by-partuuid", "by-partlabel", "by-id", "by-path"
+    }


### PR DESCRIPTION
The installed system never depends on a name that moves: fstab, crypttab and the generated mount units all carry `UUID={context.device_uuid(...)}`. Selecting a disk took only a path, so `/dev/disk/by-uuid/…` worked by accident — udev keeps the symlink and `Path.exists()` is all `resolve()` asked — while `UUID=…`, the spelling an operator copies out of a machine this installer made, answered `is not present on this machine`.

`udev_path_for()` translates `UUID=`, `LABEL=`, `PARTUUID=`, `PARTLABEL=` and `ID=` to the directory udev keeps for each, in either case: `blkid` prints the tag upper and an operator types it lower.

A tag that is in no table is refused with the keys that are, rather than tried as a relative path. Otherwise `UUDI=x` reports a missing device when the fault is a misspelt key — the same misdirection that made an Alpine run blame a missing python for an `apk` transaction that had already failed.