### PR TITLE
vm: say when the run's ceiling ended a guest that was working

### DIFF
--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -115,11 +115,40 @@ The paths below are implemented and have automated unit or plan coverage unless 
 | --- | --- | --- |
 | `Existing` | `selector`, `wipe` | Selects a pre-existing device. |
 | `PartitionTable` | `disk`, `table`, `create`, `remove` | Creates or edits a partition table. |
-| `Partition` | `table`, `index`, `role`, `size`, `label` | Defines a partition; final `size` may consume remaining space. |
+| `Partition` | `table`, `index`, `role`, `size`, `label`, `min`, `max` | Defines a partition. `size` is an absolute size, a share such as `"40%"`, or `"rest"`; see the sizes below. |
 | `Luks` | `backing`, `name`, `passphrase_file` | Defines a LUKS container. |
 | `MdRaid` | `members`, `level`, `name`, `metadata` | Defines an mdraid array. |
 | `VolumeGroup` | `members`, `name` | Defines an LVM volume group. |
 | `LogicalVolume` | `group`, `name`, `size` | Defines an LVM logical volume. |
+
+### Partition sizes
+
+`size` takes three forms, and `min` and `max` bound the two that are derived.
+
+| `size` | Meaning |
+| --- | --- |
+| `"20G"` | Exactly that much. `min` and `max` are refused beside it. |
+| `"40%"` | That share of what the table has left after every absolute size on it. |
+| `"rest"` | Whatever the others leave. Only the last partition may ask for it; an omitted `size` means the same and is still accepted. |
+
+A share is of what the fixed sizes leave, so an ESP of `512MiB`, a swap of
+`8G`, a root of `40%` and a home of `60%` describe a disk that fits. `min` and
+`max` are what let one file install a fleet of unlike disks: four tenths of a
+240 GB disk is 96 GB and four tenths of an 8 TB disk is 3.2 TB, and neither is
+what the operator meant on the other machine.
+
+[`tests/fixtures/vm-shares.toml`](tests/fixtures/vm-shares.toml) is a complete
+layout written this way: a fixed ESP, a root at `40%` bounded either side, and
+a home taking the rest. Its disk selector and credentials are for a virtual
+machine and must not be installed unchanged on a real one.
+
+A share below its `min` is refused rather than raised to it: the space would
+come from another partition, and a layout that stops adding up without anybody
+being told is what the bounds exist to prevent. Shares are resolved from the
+disk's own capacity before the plan is built, so `--dry-run` prints the bytes
+the install will write; a machine that does not report the disk's size says so
+rather than printing a number the install would not use.
+
 | `ZfsPool` | `vdevs`, `name`, `topology`, `encrypted`, `passphrase_file` | Defines a ZFS pool. |
 | `ZfsDataset` | `pool`, `name` | Defines a ZFS dataset. |
 | `Filesystem` | `device`, `kind`, `label`, `create` | Formats a device, or verifies it when `create = false`. |

--- a/tests/unit/test_cluster.py
+++ b/tests/unit/test_cluster.py
@@ -4267,3 +4267,42 @@ def test_the_cluster_limit_counts_weight_rather_than_guests() -> None:
     assert slots_within(4, list(free), [heavy, heavy]) == []
     # Zero is "ask the cluster what fits", not "nothing fits".
     assert len(slots_within(0, list(free), [heavy, heavy])) == len(free)
+
+
+def test_the_run_ceiling_says_so_rather_than_reporting_its_last_window(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """`btrfs-luks` was ended at 481.4 minutes with C++ still compiling on its
+    console and the verdict read `never matched 'MARK_26_DONE', 162s of 162s
+    elapsed`. `expect` reports the window it was handed, and the last window
+    before an eight-hour deadline is a few seconds, so a guest that ran out of
+    budget while working reads exactly like a step that hung."""
+    clock = [0.0]
+    monkeypatch.setattr(time, "monotonic", lambda: clock[0])
+
+    class Printing:
+        """A guest that keeps printing and never finishes."""
+
+        def recv(self, size: int) -> bytes:
+            clock[0] += 1.0
+            return b"compiling something\n"
+
+        def sendall(self, data: bytes) -> None:
+            return None
+
+        def close(self) -> None:
+            return None
+
+        @property
+        def closed(self) -> bool:
+            return False
+
+    serial = SerialConsole(cast(Any, Printing()), BytesIO())
+    link = cluster.Reconnecting(lambda: serial)
+    with pytest.raises(ConsoleTimeout) as ended:
+        link.wait_for("install", timeout=30.0, idle=20.0)
+
+    said = str(ended.value)
+    assert "ceiling ended it with the console still printing" in said, said
+    # And what it was printing, so the reader can tell working from wedged.
+    assert "compiling something" in said, said

--- a/tests/vm/cluster.py
+++ b/tests/vm/cluster.py
@@ -3280,6 +3280,22 @@ class Reconnecting:
                         waited=error.waited,
                         seen=error.seen,
                     ) from error
+                except ConsoleTimeout as error:
+                    # The ceiling, not a step that was slow, and after the
+                    # idle branch because `ConsoleIdle` is one of these.
+                    # `expect` reports the window it was given, and the last
+                    # window before an eight-hour deadline is a few seconds:
+                    # `btrfs-luks` was ended at 481.4m compiling C++ and the
+                    # verdict read `162s of 162s elapsed`, which names
+                    # neither the ceiling nor the guest still working.
+                    if _remaining(deadline) > 1.0:
+                        raise
+                    raise ConsoleTimeout(
+                        f"the run's {timeout / 3600:.0f}h ceiling ended it with the "
+                        f"console still printing: {error}",
+                        waited=error.waited,
+                        seen=error.seen,
+                    ) from error
 
         self._with_reconnect(timeout, wait_once, watch=watch)
 


### PR DESCRIPTION
`btrfs-luks` was ended at 481.4 minutes with `never matched 'MARK_26_DONE', 162s of 162s elapsed` and a C++ compile on its console. That 162 seconds is not a timeout anyone chose — it is what was left of the eight-hour `RUN_CEILING`. `expect` reports the window it was handed, so a guest that ran out of budget while working reads exactly like a step that hung.

Two independent readings said it was working: the console was printing, and sampling the hypervisor gave `cpu≈0.6` with 30 MB written in two minutes.

The new branch sits after the `ConsoleIdle` one, because `ConsoleIdle` is a `ConsoleTimeout` and catching the parent first would take the watchdog out of the idle path entirely.

This does not explain why that fixture needs more than eight hours — `official = false` means every package from source — and raising the ceiling for such fixtures is recorded separately rather than folded in here.

Also: `REFERENCE.md` now documents the three forms `size` takes, which nothing outside the model did.