### PR TITLE
disk: say what the tools know about a pool that will not export

### DIFF
--- a/TESTED.md
+++ b/TESTED.md
@@ -118,12 +118,23 @@ ZFSBootMenu; the other four use ext4.
 | `alpine-standard-3.24.1`, BIOS, OpenRC, ext4 | `bc8ab3a0edcf` | root shell in 59s; 51 operations, 29 from a binary host, 51 compiled; booted with no failed unit |
 | `install-amd64-minimal-20260816T170110Z`, UEFI, systemd, xfs | `86cca05b314f` | installed `vm-xfs` in one run: 56 operations, 61 packages from a binary host, 12 compiled, then the disk it wrote booted, logged in on the console and passed every installed-state check |
 
-The Gig-OS ISO has no record at a current revision. It runs the installer by
-script, and the medium that covers the same path — the self-built gentoo-cjk
-minimal ISO — was last measured at `b931ef46fc15ed50385f70467f2bfb0a8d1fd154`,
-which this file lists as historical: the installation path changed after it.
-Neither ISO is in `lab/vm/iso/`, so measuring either starts with building or
-fetching one.
+Both target media were measured at `b03f8eafa7501` on 2026-08-25, which is the
+first record either has at a current revision:
+
+| Medium | Fixture | Result |
+|---|---|---|
+| `gig-os-20260818`, UEFI | `vm-binpkg` | 58 operations, 30 packages from a binary host, 11 compiled; the disk it wrote booted, mounted its layout and had no failed unit |
+| `install-amd64-cjk-minimal-20260820T064553Z`, UEFI | `vm-cjk-kernel` | 59 operations, 30 packages from a binary host, 11 compiled; same result |
+
+Both ISOs are in `lab/vm/iso/`, fetched from `iso.gentoozh.org`. `media.py` had
+named files the download site no longer carries — `gig-os-20260807` against
+`20260818`, and a CJK minimal eleven days older — and `GENTOO_CJK` also carried
+a `volume_label` stamped with the build date, so repinning the ISO without the
+label would have produced a medium that boots and is then refused for being the
+wrong one. Both are read out of the ISO now and a test holds them to it.
+
+What these rows do not cover: the Gig-OS ISO also runs the installer by script
+from its own session, and that path has no record.
 
 ### Network modes
 

--- a/gentoo_install/plan/disk.py
+++ b/gentoo_install/plan/disk.py
@@ -1038,6 +1038,11 @@ class DiscardStage3(Operation):
         context.run_in_target(["rm", "--recursive", "--force", f"/{STAGE3_CACHE}"])
 
 
+#: How much of the tool's own words a busy-pool failure carries. The
+#: verdict that reports it is truncated, and a pool's status is longer
+#: than a console line.
+HOLDER_BYTES: Final[int] = 400
+
 RELEASE_TRIES: Final[int] = 6
 RELEASE_PAUSE: Final[float] = 5.0
 
@@ -1142,7 +1147,23 @@ class UnmountTarget(Operation):
         if self._mounted_datasets(context, pool):
             context.run(["zpool", "export", "-f", pool])
             return
-        raise CommandFailed(f"{pool} remains busy after dataset unmount; holder is unknown") from last
+        raise CommandFailed(
+            f"{pool} remains busy after dataset unmount; holder is unknown. "
+            f"`zpool export` said {str(last).strip()[:HOLDER_BYTES]!r}, and the pool "
+            f"reads {self._holders(context, pool)}"
+        ) from last
+
+    def _holders(self, context: Context, pool: str) -> str:
+        """What the machine says about a pool it will not let go of.
+
+        `holder is unknown` was the whole message, so an operator was told the
+        export failed and nothing else: the run that hit it on `vm-zfs` left
+        no way to tell `zed` from a stray mount from a device still open.
+        Read rather than guessed, and `check=False` throughout because this
+        runs while an error is already being raised.
+        """
+        status = context.run(["zpool", "status", "-v", pool], check=False)
+        return str(status).strip()[:HOLDER_BYTES] or "nothing at all"
 
 
 def finish(config: InstallConfig) -> list[Operation]:

--- a/tests/unit/test_plan_disk.py
+++ b/tests/unit/test_plan_disk.py
@@ -1505,3 +1505,47 @@ def test_a_share_on_a_disk_of_unknown_size_says_so() -> None:
 
     with pytest.raises(InvalidLayout, match="did not report"):
         _resolved('size = "40%"', "")
+
+
+def test_a_pool_nothing_will_release_says_what_the_machine_knows(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """`rpool remains busy after dataset unmount; holder is unknown` was the
+    whole message when `vm-zfs` hit it at 62.3 minutes. Refusing to force is
+    right — forcing hides the holder and an unexported pool needs `zpool
+    import -f` on the next boot — but the operator was told the export failed
+    and nothing else, not even what `zpool export` itself had said."""
+    from gentoo_install.errors import CommandFailed
+    from gentoo_install.plan.operations import CommandOutput
+
+    class NeverReleases(Recorder):
+        def run(
+            self, argv: Sequence[str], *, check: bool = True, input_text: str | None = None
+        ) -> CommandOutput:
+            if tuple(argv[:2]) == ("zpool", "export"):
+                raise CommandFailed("zpool export rpool exited 1: pool is busy")
+            if tuple(argv[:2]) == ("zpool", "status"):
+                return CommandOutput("  pool: rpool\n state: ONLINE\n  scan: none\n", 0)
+            if tuple(argv[:2]) == ("zfs", "list"):
+                # Nothing of its own is mounted, which is the branch that
+                # refuses rather than forcing.
+                return CommandOutput("rpool\tno\nrpool/ROOT\tno\n", 0)
+            if argv[0] == "findmnt":
+                return CommandOutput("", 1)
+            return super().run(argv, check=check, input_text=input_text)
+
+    monkeypatch.setattr(disk, "RELEASE_PAUSE", 0.0)
+    with pytest.raises(CommandFailed) as refused:
+        disk.UnmountTarget(pools=("rpool",)).apply(NeverReleases())
+
+    said = str(refused.value)
+    # The classification stays — `holder is unknown` is true and is what
+    # `test_a_pool_busy_with_nothing_mounted_is_named_rather_than_forced`
+    # holds — and the evidence is added beside it.
+    assert "holder is unknown" in said, said
+    assert "pool is busy" in said, said
+    assert "state: ONLINE" in said, said
+    # Still not forced. Asserted here as well as in that test because the
+    # risk of this change is that improving the message turns into forcing
+    # the export, which is what the operation refuses to do on purpose.
+    assert "-f" not in said, said


### PR DESCRIPTION
`vm-zfs` failed at 62.3 minutes with `rpool remains busy after dataset unmount; holder is unknown` and exit 4. Refusing to force is right and stays: forcing hides whatever holds the pool, and an unexported pool needs `zpool import -f` on the next boot, so the failure has to say which case it is.

What it did not do is say anything. `zpool export`'s own words were chained with `from last` and never reached the message. The classification stays — `holder is unknown` is true when nothing of the pool's own is mounted — and `zpool export`'s output and `zpool status -v` are added beside it, both read-only and both `check=False` because this runs while an error is already being raised.

The test asserts the message still contains no `-f`. That duplicates an assertion in the test beside it on purpose: the risk of this particular change is that improving the message turns into forcing the export, which is what the operation declines to do.

This does not explain why the pool was busy. `vm-zfs-encrypted`, `zfs-zbm` and `zbm-unlock` exported through the same sequence in the same rounds, so it is intermittent, and the next occurrence will carry evidence.

Also: both target media now have a record at `b03f8eafa7501`, the first either has had at a current revision.