### PR TITLE
vm: answer a name prompt that comes back

### DIFF
--- a/tests/unit/test_harness.py
+++ b/tests/unit/test_harness.py
@@ -6126,3 +6126,53 @@ def test_an_image_run_hands_its_verdict_a_configuration_not_a_path() -> None:
         # other call site passes a name already bound from it.
         if "REPOSITORY" in written:
             assert "installed_config(" in written, written
+
+
+def test_a_name_prompt_that_comes_back_is_answered_again(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """`vm-zfs-encrypted` failed on an install that had finished: its console
+    held two `cryptzfs login:` banners two seconds apart and no `Password:`.
+    The name prompt turns the echo off with `TCSAFLUSH`, so a name typed into
+    that window is discarded and agetty prints a fresh one. `cluster.py` has
+    handled this since `ext3` lost 33.6 minutes to it; the local console did
+    the sequence once and gave up."""
+    import time
+
+    from tests.vm.console import SerialConsole
+
+    clock = [0.0]
+    monkeypatch.setattr(time, "monotonic", lambda: clock[0])
+
+    class Agetty:
+        """A login that swallows the first name and reprints its prompt."""
+
+        def __init__(self) -> None:
+            self.names = 0
+            self.queue = [b"\r\nlab login: "]
+
+        def recv(self, size: int) -> bytes:
+            clock[0] += 1.0
+            return self.queue.pop(0) if self.queue else b""
+
+        def sendall(self, data: bytes) -> None:
+            typed = data.decode().strip()
+            if typed == "root":
+                self.names += 1
+                # The first name lands in the flush window and is lost.
+                self.queue.append(
+                    b"\r\nlab login: " if self.names == 1 else b"\r\nPassword: "
+                )
+                return
+            self.queue.append(b"\r\n# ")
+
+        def close(self) -> None:
+            return None
+
+        @property
+        def closed(self) -> bool:
+            return False
+
+    guest = Agetty()
+    SerialConsole(cast(Any, guest), BytesIO()).login("root", "install", r"# ")
+    assert guest.names == 2, guest.names

--- a/tests/vm/console.py
+++ b/tests/vm/console.py
@@ -130,6 +130,12 @@ PASSPHRASE_ATTEMPTS: Final[int] = 5
 #: arrives without the guest doing anything.
 ECHO_PATIENCE: Final[float] = 5.0
 
+#: How long a name prompt has to answer with a password prompt. Short,
+#: because `login` prints one at once when it read the name at all: the
+#: whole minute was spent waiting for a prompt agetty had already
+#: replaced with a second `login:`.
+NAME_PATIENCE: Final[float] = 20.0
+
 
 def discarded_by_the_prompt(console: "SerialConsole", answer: str) -> bool:
     """Whether `answer` came back on the console after being typed at a prompt.
@@ -354,10 +360,31 @@ class SerialConsole:
         return plain(said.split(command_done(token).encode())[0])
 
     def login(self, user: str, password: str | None, prompt: str) -> None:
+        """Log in, answering a name prompt that comes back.
+
+        The name prompt turns the echo off with `TCSAFLUSH`, which discards
+        whatever was typed before it: a name sent into that window never
+        reaches `login`, agetty prints a fresh `login:` and no `Password:`
+        ever arrives. `vm-zfs-encrypted` failed on an install that had
+        finished, with two `cryptzfs login:` banners two seconds apart on its
+        console and a machine that was otherwise fine. `cluster.py` has
+        carried the same handling since `ext3` lost 33.6 minutes to it.
+        """
         self.expect(r"login:", timeout=300.0)
-        self.send(user)
+        for attempt in range(PASSPHRASE_ATTEMPTS):
+            self.send(user)
+            if password is None:
+                break
+            try:
+                self.expect(PASSWORD_PROMPT, timeout=NAME_PATIENCE)
+                break
+            except ConsoleTimeout:
+                if attempt + 1 == PASSPHRASE_ATTEMPTS:
+                    raise
+                # The fresh prompt agetty printed, which is already in the
+                # buffer: waiting for a new one would wait for a third.
+                self.expect(r"login:", timeout=NAME_PATIENCE)
         if password is not None:
-            self.expect(PASSWORD_PROMPT, timeout=60.0)
             self.send(password)
         self.expect(prompt, timeout=60.0)
 


### PR DESCRIPTION
`vm-zfs-encrypted` failed locally on an install that had finished: `never matched '[Pp]assword:…', 61s of 60s elapsed`, with two `cryptzfs login:` banners two seconds apart on its console and nothing wrong with the machine.

The name prompt turns the echo off with `TCSAFLUSH`, which discards whatever was typed before it. A name sent into that window never reaches `login`, agetty prints a fresh prompt, and no `Password:` ever arrives. `cluster.py` has handled this since `ext3` lost 33.6 minutes to it; `SerialConsole.login()` ran the sequence once and gave up.

It now retries against the prompt agetty already printed, bounded by `PASSPHRASE_ATTEMPTS`. `NAME_PATIENCE` is twenty seconds rather than sixty: `login` prints the password prompt at once when it read the name at all, so the rest of that minute was spent waiting for a prompt that had already been replaced.

Measured beside it: `vm-zfs` installed, exported and booted locally at the same revision, so the `rpool remains busy` failure from the cluster did not reproduce here.