### PR TITLE
vm: route every run.py login through the one function

### DIFF
--- a/tests/unit/test_harness.py
+++ b/tests/unit/test_harness.py
@@ -6176,3 +6176,19 @@ def test_a_name_prompt_that_comes_back_is_answered_again(
     guest = Agetty()
     SerialConsole(cast(Any, guest), BytesIO()).login("root", "install", r"# ")
     assert guest.names == 2, guest.names
+
+
+def test_no_run_path_spells_out_the_login_sequence_itself() -> None:
+    """The reprinted-name-prompt fix reached `SerialConsole.login()` and
+    `vm-zfs-encrypted` failed again in exactly the same way, because
+    `unlock_and_login` carried its own copy of the sequence. Six call sites
+    waited for `PASSWORD_PROMPT`; hardening one of them changed nothing for
+    the fixture that had shown the defect.
+    """
+    import re
+
+    source = Path("tests/vm/run.py").read_text()
+    assert "PASSWORD_PROMPT" not in source, "run.py spells the sequence out again"
+    # And it does reach the shared one, by whichever of the two entries suits
+    # a caller that has already read the prompt.
+    assert re.search(r"console\.(login|answer_login)\(", source), source[:0]

--- a/tests/vm/console.py
+++ b/tests/vm/console.py
@@ -371,6 +371,16 @@ class SerialConsole:
         carried the same handling since `ext3` lost 33.6 minutes to it.
         """
         self.expect(r"login:", timeout=300.0)
+        self.answer_login(user, password, prompt)
+
+    def answer_login(self, user: str, password: str | None, prompt: str) -> None:
+        """The same, for a caller that has already read the `login:`.
+
+        Split out because `run.py` waits for the name prompt beside a
+        passphrase one and cannot wait for it twice. Four call sites did this
+        sequence inline; the fix for the reprinted prompt reached one of them
+        and `vm-zfs-encrypted` failed exactly as before.
+        """
         for attempt in range(PASSPHRASE_ATTEMPTS):
             self.send(user)
             if password is None:

--- a/tests/vm/run.py
+++ b/tests/vm/run.py
@@ -51,7 +51,6 @@ from .console import (
     DISK_PASSPHRASE,
     PASSPHRASE_ATTEMPTS,
     PASSPHRASE_PROMPT,
-    PASSWORD_PROMPT,
     SerialConsole,
     discarded_by_the_prompt,
 )
@@ -501,11 +500,7 @@ def unlock_and_login(
         console.login("root", INSTALLED_PASSWORD, r"# ")
         return "console"
     if remote_unlocked:
-        console.expect(r"login:", timeout=300.0)
-        console.send("root")
-        console.expect(PASSWORD_PROMPT, timeout=60.0)
-        console.send(INSTALLED_PASSWORD)
-        console.expect(r"# ", timeout=60.0)
+        console.login("root", INSTALLED_PASSWORD, r"# ")
         return "remote"
     # Bounded: a wrong passphrase makes the prompt come back, and each one
     # re-arms the timeout, so an unbounded loop would never fail.
@@ -518,10 +513,10 @@ def unlock_and_login(
     for _ in range(PASSPHRASE_ATTEMPTS):
         seen = console.expect(rf"{PASSPHRASE_PROMPT}|login:", timeout=300.0)
         if b"login:" in seen:
-            console.send("root")
-            console.expect(PASSWORD_PROMPT, timeout=60.0)
-            console.send(INSTALLED_PASSWORD)
-            console.expect(r"# ", timeout=60.0)
+            # The prompt is already read, so the part after it: waiting for a
+            # second `login:` would wait for the one agetty prints on a
+            # failure, not the one in hand.
+            console.answer_login("root", INSTALLED_PASSWORD, r"# ")
             return "console"
         console.send(DISK_PASSPHRASE)
         # Answered again here rather than at the top of the loop: an answer


### PR DESCRIPTION
The previous change taught `SerialConsole.login()` to answer a name prompt agetty had reprinted. Re-running the fixture that showed the defect failed in exactly the same way: `never matched '[Pp]assword:…', 60s of 60s elapsed`, two `cryptzfs login:` banners a second apart.

Sixty seconds is the tell. `NAME_PATIENCE` is twenty, so the timeout that fired was not in the path that had been fixed. `grep PASSWORD_PROMPT tests/vm/` finds six call sites, and this fixture goes through the copy inside `unlock_and_login`.

`answer_login()` is the part after the prompt, for a caller that has already read it — `unlock_and_login` waits for the name prompt beside a passphrase one and cannot wait for it twice. Both `run.py` sites call it or `login()`, `PASSWORD_PROMPT` no longer appears in `run.py`, and a test holds it that way so the next caller does not write a seventh copy.

Worth stating: the fix and the miss are the same defect class this branch has been closing all evening — one rule, several implementations, and hardening the one you happened to find changes nothing for the case that showed it.