### PR TITLE
vm: send a disk passphrase once, because retrying corrupted it

### DIFF
--- a/tests/unit/test_harness.py
+++ b/tests/unit/test_harness.py
@@ -5885,66 +5885,6 @@ def test_every_dispatch_form_says_what_it_will_run_before_it_runs(
     for spoken in said:
         assert spoken.strip(), said
 
-
-def test_an_answer_the_passphrase_prompt_discarded_is_answered_again(
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    """A local `vm-zfs-encrypted` spent its whole 300s ceiling at
-
-        Enter passphrase for 'rpool':install-disk
-
-    with nothing after it. The echo is the proof: the prompt had not yet
-    turned it off, so `TCSAFLUSH` threw the answer away, and ZFSBootMenu
-    prints that prompt once. Waiting for a second one waits for ever."""
-    from gentoo_install.exec.config import load
-    from tests.vm import run as runner
-    from tests.vm.console import DISK_PASSPHRASE, SerialConsole
-
-    import time
-
-    # A clock the reads advance, so a wait for a prompt that is never printed
-    # again ends at its own ceiling rather than holding the suite for 300s.
-    clock = [0.0]
-    monkeypatch.setattr(time, "monotonic", lambda: clock[0])
-
-    class Losing:
-        """A prompt that discards the first answer and echoes it."""
-
-        def __init__(self) -> None:
-            self.answers = 0
-            self.queue = [b"Enter passphrase for 'rpool':"]
-
-        def recv(self, size: int) -> bytes:
-            clock[0] += 1.0
-            return self.queue.pop(0) if self.queue else b""
-
-        def sendall(self, data: bytes) -> None:
-            typed = data.decode().strip()
-            if typed != DISK_PASSPHRASE:
-                self.queue.append(b"# " if typed == "install" else b"Password: ")
-                return
-            self.answers += 1
-            # The first one comes back rather than being read; the second is
-            # taken and the machine goes on to its login.
-            self.queue.append(
-                f"{DISK_PASSPHRASE}\r\n".encode() if self.answers == 1 else b"\r\nlogin: "
-            )
-
-        def close(self) -> None:
-            return None
-
-        @property
-        def closed(self) -> bool:
-            return False
-
-    channel = Losing()
-    console = SerialConsole(cast(Any, channel), BytesIO())
-    installation = load(Path("tests/fixtures/vm-zfs-encrypted.toml"))
-
-    assert runner.unlock_and_login(console, installation) == "console"
-    assert channel.answers == 2, channel.answers
-
-
 def test_both_runners_read_one_answer_for_how_heavy_a_guest_is() -> None:
     """The two runners spend the same resource on the same install and each
     held its own answer: the cluster derived it, the campaign wrote it out per

--- a/tests/vm/console.py
+++ b/tests/vm/console.py
@@ -122,35 +122,11 @@ DISK_PASSPHRASE = "install-disk"
 #: runner at five, so a fifth valid prompt passed one and failed the other.
 PASSPHRASE_ATTEMPTS: Final[int] = 5
 
-#: How long an answer has to come back on the console before it is taken to
-#: have been read rather than discarded. A passphrase prompt turns the echo
-#: off with `TCSAFLUSH`, which throws away whatever was typed before it: an
-#: answer that is echoed never reached the reader, and the prompt is still
-#: waiting. Bounded and short, because the echo is the local terminal's and
-#: arrives without the guest doing anything.
-ECHO_PATIENCE: Final[float] = 5.0
-
 #: How long a name prompt has to answer with a password prompt. Short,
 #: because `login` prints one at once when it read the name at all: the
 #: whole minute was spent waiting for a prompt agetty had already
 #: replaced with a second `login:`.
 NAME_PATIENCE: Final[float] = 20.0
-
-
-def discarded_by_the_prompt(console: "SerialConsole", answer: str) -> bool:
-    """Whether `answer` came back on the console after being typed at a prompt.
-
-    A local `vm-zfs-encrypted` sat at `Enter passphrase for 'rpool':` for its
-    whole 300s ceiling with `install-disk` echoed beside it: the echo proves
-    the prompt had not yet turned it off, so `TCSAFLUSH` discarded the answer
-    and no second prompt was ever going to be printed.
-    """
-    try:
-        console.expect(re.escape(answer), timeout=ECHO_PATIENCE)
-    except ConsoleTimeout:
-        return False
-    return True
-
 
 class Channel(Protocol):
     """What a console needs of its transport, and nothing more.

--- a/tests/vm/run.py
+++ b/tests/vm/run.py
@@ -52,7 +52,6 @@ from .console import (
     PASSPHRASE_ATTEMPTS,
     PASSPHRASE_PROMPT,
     SerialConsole,
-    discarded_by_the_prompt,
 )
 from .monitor import type_text
 from .driver import FIND_DRIVER, REPOSITORY, build as build_driver
@@ -518,14 +517,11 @@ def unlock_and_login(
             # failure, not the one in hand.
             console.answer_login("root", INSTALLED_PASSWORD, r"# ")
             return "console"
+        # Sent once. Answering again on an echo was tried and made it worse:
+        # ZFSBootMenu echoed every one of six sends on its own line and
+        # accepted none, so the retry turned one wrong answer into a line
+        # reading `install-diskinstall-disk…`. The echo is not a race here.
         console.send(DISK_PASSPHRASE)
-        # Answered again here rather than at the top of the loop: an answer
-        # the prompt discarded leaves that same prompt on the screen and
-        # nothing reprints it, so waiting for a second one spends the ceiling.
-        for _ in range(PASSPHRASE_ATTEMPTS):
-            if not discarded_by_the_prompt(console, DISK_PASSPHRASE):
-                break
-            console.send(DISK_PASSPHRASE)
     raise SystemExit("the disk kept asking for a passphrase; it is not the one installed")
 
 


### PR DESCRIPTION
Earlier tonight `unlock_and_login` learned to answer again when it saw its own
passphrase echoed, on the reading that the prompt's `TCSAFLUSH` had discarded
it. The third run of `vm-zfs-encrypted` shows that reading is wrong here — its
console reads:

```
Enter passphrase for 'rpool':install-disk
install-disk
install-disk
install-disk
install-disk
install-disk
```

Six sends, every one echoed, none accepted. If it were the flush race the
second would have been taken. Instead the retry turned one refused answer into
a line reading `install-diskinstall-disk…`, which is a worse thing to diagnose
than the original.

Sent once again, and `discarded_by_the_prompt()` with `ECHO_PATIENCE` and its
test are removed rather than left unused: a helper with no reader reads as a
route that works.

The underlying question is open — ZFSBootMenu prints the prompt and consumes
nothing — and the verdict already carries the console, so the next occurrence
has clean evidence instead of six lines this harness typed.
