### PR TITLE
vm: answer a boot passphrase after its prompt has settled

### DIFF
--- a/tests/unit/test_harness.py
+++ b/tests/unit/test_harness.py
@@ -6132,3 +6132,35 @@ def test_no_run_path_spells_out_the_login_sequence_itself() -> None:
     # And it does reach the shared one, by whichever of the two entries suits
     # a caller that has already read the prompt.
     assert re.search(r"console\.(login|answer_login)\(", source), source[:0]
+
+
+def test_a_boot_passphrase_is_answered_after_the_prompt_has_settled(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """`vm-zfs-encrypted` failed locally three times running with its answer
+    echoed on its own line and never taken, and passed on the cluster, where a
+    websocket adds a delay a unix socket does not. Answering three seconds
+    later made the same fixture install and boot. The prompt is printed before
+    its reader is ready, so the wait is the fix and repeating was not: six
+    sends made the line read `install-diskinstall-disk…`."""
+    import time
+
+    from tests.vm import run as runner
+    from tests.vm.console import PROMPT_SETTLE
+
+    waited: list[float] = []
+    monkeypatch.setattr(time, "sleep", lambda seconds: waited.append(seconds))
+
+    source = Path("tests/vm/run.py").read_text()
+    # The wait is before the send, not after it: after is a wait for nothing.
+    passphrase = source.index("console.send(DISK_PASSPHRASE)")
+    settle = source.rindex("time.sleep(PROMPT_SETTLE)", 0, passphrase)
+    assert "\n" in source[settle:passphrase], source[settle:passphrase]
+    assert source.count("time.sleep(PROMPT_SETTLE)") == 1, source.count(
+        "time.sleep(PROMPT_SETTLE)"
+    )
+    assert PROMPT_SETTLE > 0, PROMPT_SETTLE
+    # The name, not a re-export: `run.py` imports it from `console.py`, and
+    # asserting on the attribute makes mypy read it as a module export.
+    assert "PROMPT_SETTLE" in source, source[:0]
+    assert runner.unlock_and_login is not None

--- a/tests/vm/console.py
+++ b/tests/vm/console.py
@@ -128,6 +128,15 @@ PASSPHRASE_ATTEMPTS: Final[int] = 5
 #: replaced with a second `login:`.
 NAME_PATIENCE: Final[float] = 20.0
 
+#: How long a boot-time passphrase prompt is given to start reading
+#: before it is answered. ZFSBootMenu prints its prompt and sets the
+#: terminal up after it: locally `vm-zfs-encrypted` failed three times
+#: running, with the answer echoed on its own line and never taken,
+#: and the same fixture passed on the cluster, where a websocket adds
+#: the delay this does. Measured rather than derived — three seconds
+#: is what worked, and it costs one wait per run.
+PROMPT_SETTLE: Final[float] = 3.0
+
 class Channel(Protocol):
     """What a console needs of its transport, and nothing more.
 

--- a/tests/vm/run.py
+++ b/tests/vm/run.py
@@ -51,6 +51,7 @@ from .console import (
     DISK_PASSPHRASE,
     PASSPHRASE_ATTEMPTS,
     PASSPHRASE_PROMPT,
+    PROMPT_SETTLE,
     SerialConsole,
 )
 from .monitor import type_text
@@ -517,10 +518,12 @@ def unlock_and_login(
             # failure, not the one in hand.
             console.answer_login("root", INSTALLED_PASSWORD, r"# ")
             return "console"
-        # Sent once. Answering again on an echo was tried and made it worse:
-        # ZFSBootMenu echoed every one of six sends on its own line and
-        # accepted none, so the retry turned one wrong answer into a line
-        # reading `install-diskinstall-disk…`. The echo is not a race here.
+        # Answered a moment late, and only once. Retrying on the echo was
+        # tried first and made it worse: ZFSBootMenu took none of six sends
+        # and the line became `install-diskinstall-disk…`. The prompt is
+        # printed before its reader is ready, so the fix is to wait, not to
+        # repeat.
+        time.sleep(PROMPT_SETTLE)
         console.send(DISK_PASSPHRASE)
     raise SystemExit("the disk kept asking for a passphrase; it is not the one installed")
 


### PR DESCRIPTION
`vm-zfs-encrypted` failed locally three runs in a row with its answer echoed on
its own line and never taken. Two candidates were ruled out before anything was
changed:

- Not the line ending. `cluster.Reconnecting.respond()` ends in the same
  `console.send(line)`, so both runners put identical bytes on the wire.
- Not the fixture. The same one passed on the cluster in round seven, `ok 76.5m`.

So the difference is the environment, and the experiment was one line: wait
three seconds before answering, change nothing else. It installed and booted
first time.

ZFSBootMenu prints its prompt and sets the terminal up after it. The cluster
reaches the console through a websocket, which supplies that gap; a local unix
socket does not, so the answer lands in the window and is echoed rather than
read.

`PROMPT_SETTLE` is measured, not derived — three seconds is what worked, and it
costs one wait per run. The test asserts the wait is before the send and that
there is exactly one of them: a wait that drifts after the send is a wait for
nothing, and nothing about the run would look different.

This replaces the retry from earlier tonight, which had the right intuition
about a window and the wrong remedy.
