### PR TITLE
vm: spend the cluster budget on the jobs about to start

### DIFF
--- a/tests/unit/test_cluster.py
+++ b/tests/unit/test_cluster.py
@@ -4259,14 +4259,18 @@ def test_the_cluster_limit_counts_weight_rather_than_guests() -> None:
     from tests.vm.proxmox import Node
 
     free = [Node(name=f"infra-node{n}", free_bytes=0, cores=4, free_cores=4.0) for n in range(6)]
-    assert len(slots_within(4, list(free), [])) == 4
-    # One compiling guest already out there leaves two, not three: counting
-    # guests is what put four of them on at once.
-    assert len(slots_within(4, list(free), [heavy])) == 2
-    assert len(slots_within(4, list(free), [light])) == 3
-    assert slots_within(4, list(free), [heavy, heavy]) == []
+    # Four units is four binary-package guests or two compiling ones, and the
+    # budget is spent over the jobs about to start as well as the running
+    # ones: charging only the running ones sent four compiling guests out on
+    # the first pass, which is eight units against a ceiling of four.
+    assert len(slots_within(4, list(free), [], [light] * 6)) == 4
+    assert len(slots_within(4, list(free), [], [heavy] * 6)) == 2
+    # One compiling guest already out there leaves one more, not three.
+    assert len(slots_within(4, list(free), [heavy], [heavy] * 6)) == 1
+    assert len(slots_within(4, list(free), [light], [light] * 6)) == 3
+    assert slots_within(4, list(free), [heavy, heavy], [heavy] * 6) == []
     # Zero is "ask the cluster what fits", not "nothing fits".
-    assert len(slots_within(0, list(free), [heavy, heavy])) == len(free)
+    assert len(slots_within(0, list(free), [heavy, heavy], [heavy] * 6)) == len(free)
 
 
 def test_the_run_ceiling_says_so_rather_than_reporting_its_last_window(

--- a/tests/vm/cluster.py
+++ b/tests/vm/cluster.py
@@ -1876,8 +1876,15 @@ def _reserved_bytes(scheduled: Mapping[str, Job]) -> Counter[str]:
     return held
 
 
-def slots_within(limit: int, slots: list[Node], running: Sequence[Job]) -> list[Node]:
+def slots_within(
+    limit: int, slots: list[Node], running: Sequence[Job], waiting: Sequence[Job]
+) -> list[Node]:
     """The slots the whole-cluster ceiling still allows, in weight units.
+
+    The budget is spent over the jobs about to start as well as the ones
+    already out there. Charging only the running ones left the first pass with
+    an empty cluster and a full list: round twelve dispatched four compiling
+    guests at `--limit 4`, which is eight units against a ceiling of four.
 
     Named rather than inline so that a test reads the same arithmetic the
     schedule does: counting guests here admitted four compiling ones and two
@@ -1885,7 +1892,14 @@ def slots_within(limit: int, slots: list[Node], running: Sequence[Job]) -> list[
     """
     if not limit:
         return slots
-    return slots[: max(0, limit - sum(job.weight for job in running))]
+    spare = limit - sum(job.weight for job in running)
+    allowed = 0
+    for job in waiting:
+        if allowed >= len(slots) or spare < job.weight:
+            break
+        spare -= job.weight
+        allowed += 1
+    return slots[:allowed]
 
 
 def _reserved_cores(scheduled: Mapping[str, Job]) -> Counter[str]:
@@ -2693,7 +2707,7 @@ def run(
                 # that genuinely has nowhere to run.
                 print(f"the cluster's capacity could not be read: {error}", flush=True)
                 slots = []
-            slots = slots_within(limit, slots, running)
+            slots = slots_within(limit, slots, running, waiting)
             if waiting and not running and not slots:
                 now = time.monotonic()
                 if capacity_since is None:


### PR DESCRIPTION
Round twelve put six ZFS fixtures on the cluster, every one of them heavy, and
watched four start at once under `--limit 4` — eight weight units against a
ceiling of four.

`slots_within()` charged the budget only against guests already running. On the
first pass of a round nothing is running, so `limit - 0` let the whole slot list
through and the inner loop dispatched one guest per node without asking again.

The budget is now spent over the jobs about to start as well: walk the waiting
queue in order and hand out a slot only while the remainder covers that job's
weight.

The test missed this for the same reason the code did — every case asked "how
many slots are left when N are already out there", and none asked "how many when
the cluster is empty", which is the state at the start of every round.
