### PR TITLE
vm: read one settle rule from every passphrase loop

### DIFF
--- a/tests/unit/test_harness.py
+++ b/tests/unit/test_harness.py
@@ -7,6 +7,7 @@ process it drove, so nothing else in the run can notice a failure for it.
 
 from __future__ import annotations
 
+import ast
 import re
 from collections.abc import Sequence
 from io import BytesIO
@@ -19,6 +20,7 @@ if TYPE_CHECKING:
 
 import pytest
 
+from tests.vm.console import passphrase_settle
 from tests.vm.run import verdict
 
 
@@ -6134,33 +6136,63 @@ def test_no_run_path_spells_out_the_login_sequence_itself() -> None:
     assert re.search(r"console\.(login|answer_login)\(", source), source[:0]
 
 
-def test_a_boot_passphrase_is_answered_after_the_prompt_has_settled(
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    """`vm-zfs-encrypted` failed locally three times running with its answer
-    echoed on its own line and never taken, and passed on the cluster, where a
-    websocket adds a delay a unix socket does not. Answering three seconds
-    later made the same fixture install and boot. The prompt is printed before
-    its reader is ready, so the wait is the fix and repeating was not: six
-    sends made the line read `install-diskinstall-disk…`."""
-    import time
+#: Every function that waits for a boot passphrase prompt and answers it. The
+#: set is named rather than counted so that a loop removed shows up as
+#: loudly as a loop added: a check over whatever it happens to find passes on
+#: a file with nothing in it.
+PASSPHRASE_LOOPS: Final[frozenset[tuple[str, str]]] = frozenset(
+    {
+        ("tests/vm/run.py", "unlock_and_login"),
+        ("tests/vm/cluster.py", "reach_the_login_past_any_passphrase"),
+        ("tests/vm/cluster.py", "_unlock"),
+    }
+)
 
-    from tests.vm import run as runner
-    from tests.vm.console import PROMPT_SETTLE
 
-    waited: list[float] = []
-    monkeypatch.setattr(time, "sleep", lambda seconds: waited.append(seconds))
+def _answers_a_passphrase(function: ast.FunctionDef) -> bool:
+    """Whether this function waits for a passphrase prompt and answers it."""
+    names = {
+        node.id for node in ast.walk(function) if isinstance(node, ast.Name)
+    }
+    return "PASSPHRASE_PROMPT" in names and "DISK_PASSPHRASE" in names
 
-    source = Path("tests/vm/run.py").read_text()
-    # The wait is before the send, not after it: after is a wait for nothing.
-    passphrase = source.index("console.send(DISK_PASSPHRASE)")
-    settle = source.rindex("time.sleep(PROMPT_SETTLE)", 0, passphrase)
-    assert "\n" in source[settle:passphrase], source[settle:passphrase]
-    assert source.count("time.sleep(PROMPT_SETTLE)") == 1, source.count(
-        "time.sleep(PROMPT_SETTLE)"
-    )
-    assert PROMPT_SETTLE > 0, PROMPT_SETTLE
-    # The name, not a re-export: `run.py` imports it from `console.py`, and
-    # asserting on the attribute makes mypy read it as a module export.
-    assert "PROMPT_SETTLE" in source, source[:0]
-    assert runner.unlock_and_login is not None
+
+def test_every_passphrase_loop_reads_the_one_settle_rule() -> None:
+    """Three loops on three transports, and the measurement reached one.
+
+    `PROMPT_SETTLE` was measured because `vm-zfs-encrypted` failed locally
+    three times running with its answer echoed on its own line and never
+    taken. The fix went into `run.py`. The cluster's
+    `reach_the_login_past_any_passphrase` still answered the moment it read
+    the prompt, and `_unlock` still started its settle from zero, so the
+    fixture that showed the defect was measured on a path the fix never
+    reached.
+    """
+    found: set[tuple[str, str]] = set()
+    for path in sorted({one for one, _ in PASSPHRASE_LOOPS}):
+        tree = ast.parse(Path(path).read_text())
+        for function in ast.walk(tree):
+            if not isinstance(function, ast.FunctionDef):
+                continue
+            if not _answers_a_passphrase(function):
+                continue
+            found.add((path, function.name))
+            called = {
+                node.func.id
+                for node in ast.walk(function)
+                if isinstance(node, ast.Call) and isinstance(node.func, ast.Name)
+            }
+            assert "passphrase_settle" in called, (
+                f"{path}:{function.name} answers a passphrase prompt without "
+                "reading the settle rule"
+            )
+    assert found == PASSPHRASE_LOOPS, found ^ PASSPHRASE_LOOPS
+
+
+def test_the_settle_grows_with_every_unanswered_prompt() -> None:
+    """A fixed wait is a guess about a machine whose load is not ours to
+    choose: the three seconds were measured on an idle one, and a prompt
+    answered without effect is evidence that this machine needs longer."""
+    assert passphrase_settle(0) > 0, passphrase_settle(0)
+    assert passphrase_settle(1) > passphrase_settle(0), passphrase_settle(1)
+    assert passphrase_settle(4) > passphrase_settle(3), passphrase_settle(4)

--- a/tests/vm/cluster.py
+++ b/tests/vm/cluster.py
@@ -72,6 +72,7 @@ from .console import (
     PASSPHRASE_ATTEMPTS,
     PASSPHRASE_PROMPT,
     PASSWORD_PROMPT,
+    passphrase_settle,
     ConsoleClosed,
     ConsoleIdle,
     ConsoleTimeout,
@@ -2319,17 +2320,20 @@ def reach_the_login_past_any_passphrase(console: Line) -> None:
     so waiting for `login:` alone spent the whole patience at dracut's prompt
     and reported `s2` as a machine that never booted.
     """
-    for _ in range(PASSPHRASE_ATTEMPTS):
+    seen = b""
+    for answered in range(PASSPHRASE_ATTEMPTS):
         seen = console.expect(f"{PASSPHRASE_PROMPT}|login:", INSTALLED_LOGIN_PATIENCE)
         # What arrived shows a passphrase prompt, rather than what it does not
         # end in: a console that answers the pattern without echoing the text
         # would otherwise be read as an endless passphrase.
         if re.search(PASSPHRASE_PROMPT.encode(), seen) is None:
             return
+        time.sleep(passphrase_settle(answered))
         console.send(DISK_PASSPHRASE)
     raise ProxmoxError(
         f"the installed system asked for a passphrase {PASSPHRASE_ATTEMPTS} "
-        "times and never offered a login"
+        f"times and never offered a login; the console held "
+        f"{seen[-INITRAMFS_SCREEN_BYTES:]!r}"
     )
 
 
@@ -3839,8 +3843,7 @@ def _unlock(
     if not remotely_unlocked and installation.bootloader.firmware is BootFirmware.BIOS:
         time.sleep(GRUB_PROMPT_SECONDS)
         guest.send_keys([*keys_for(DISK_PASSPHRASE), "ret"])
-    settle = PASSWORD_ECHO_OFF_AFTER
-    for _ in range(UNLOCK_TRIES):
+    for answered in range(UNLOCK_TRIES):
         try:
             said = link.observe(
                 "|".join(
@@ -3876,12 +3879,11 @@ def _unlock(
                     f"{said[-INITRAMFS_SCREEN_BYTES:]!r}"
                 )[:VERDICT_BYTES],
             )
-        # The same race the installed system's login lost: the prompt turns
-        # the echo off with `TCSAFLUSH`, which discards whatever was typed
-        # before it. `zbm-unlock` answered twice and ZFSBootMenu said `Key
-        # load error: Incorrect key provided` both times.
-        time.sleep(settle)
-        settle += PASSWORD_ECHO_BACKOFF
+        # The prompt is printed before its reader is ready: `zbm-unlock`
+        # answered twice and ZFSBootMenu said `Key load error: Incorrect key
+        # provided` both times. This started from zero until the local runner
+        # measured the wait that fixes it.
+        time.sleep(passphrase_settle(answered))
         try:
             link.respond(DISK_PASSPHRASE)
         except ConsoleClosed as error:

--- a/tests/vm/console.py
+++ b/tests/vm/console.py
@@ -137,6 +137,23 @@ NAME_PATIENCE: Final[float] = 20.0
 #: is what worked, and it costs one wait per run.
 PROMPT_SETTLE: Final[float] = 3.0
 
+#: Added to that wait for each prompt already answered without effect. A fixed
+#: wait is a guess about a machine whose load is not ours to choose, and the
+#: three seconds above were measured on an idle one.
+PASSPHRASE_BACKOFF: Final[float] = 2.0
+
+
+def passphrase_settle(answered: int) -> float:
+    """How long to wait before answering a boot passphrase prompt.
+
+    The one rule every passphrase loop reads. There are three of them, on
+    three different transports, and the measurement that produced
+    `PROMPT_SETTLE` reached only the one that had failed: the cluster's
+    `reach_the_login_past_any_passphrase` answered the moment it read the
+    prompt and `unlock_and_login` started from zero.
+    """
+    return PROMPT_SETTLE + PASSPHRASE_BACKOFF * answered
+
 class Channel(Protocol):
     """What a console needs of its transport, and nothing more.
 

--- a/tests/vm/run.py
+++ b/tests/vm/run.py
@@ -51,7 +51,7 @@ from .console import (
     DISK_PASSPHRASE,
     PASSPHRASE_ATTEMPTS,
     PASSPHRASE_PROMPT,
-    PROMPT_SETTLE,
+    passphrase_settle,
     SerialConsole,
 )
 from .monitor import type_text
@@ -510,7 +510,7 @@ def unlock_and_login(
         # prompt, which is on the serial port and is waited for below.
         time.sleep(GRUB_PROMPT_SECONDS)
         type_text(monitor, DISK_PASSPHRASE)
-    for _ in range(PASSPHRASE_ATTEMPTS):
+    for answered in range(PASSPHRASE_ATTEMPTS):
         seen = console.expect(rf"{PASSPHRASE_PROMPT}|login:", timeout=300.0)
         if b"login:" in seen:
             # The prompt is already read, so the part after it: waiting for a
@@ -523,7 +523,7 @@ def unlock_and_login(
         # and the line became `install-diskinstall-disk…`. The prompt is
         # printed before its reader is ready, so the fix is to wait, not to
         # repeat.
-        time.sleep(PROMPT_SETTLE)
+        time.sleep(passphrase_settle(answered))
         console.send(DISK_PASSPHRASE)
     raise SystemExit("the disk kept asking for a passphrase; it is not the one installed")
 


### PR DESCRIPTION
The wait `PROMPT_SETTLE` measures reached only `run.py`, so the cluster's `reach_the_login_past_any_passphrase` answered the moment it read the prompt and `_unlock` started its settle from zero.

Closes the third loop of the shape this repository keeps hitting: one rule, several readers, only the bitten one hardened. `test_every_passphrase_loop_reads_the_one_settle_rule` names the three so a fourth cannot be added without reading it.
