### PR TITLE
vm: say which counter stopped when a guest stalls

### DIFF
--- a/tests/unit/test_cluster.py
+++ b/tests/unit/test_cluster.py
@@ -26,6 +26,7 @@ from tests.vm.proxmox import (
     ProxmoxError,
     ProxmoxNotFound,
     ProxmoxTransientError,
+    Traffic,
     VMID_FIRST,
     VMID_LAST,
 )
@@ -221,7 +222,7 @@ def test_non_double_memory_reservation_is_admitted_in_exact_bytes(
 
     execution = cluster.Running(
         Guest(),
-        cluster.Watchdog(tmp_path / "odd-sized.log", lambda: (0, 0.0)),
+        cluster.Watchdog(tmp_path / "odd-sized.log", lambda: Traffic(0, 0, 0.0)),
         job.reservation_bytes,
     )
     dispatched = job.dispatch(
@@ -268,7 +269,7 @@ def _timed_wait(
     monkeypatch: pytest.MonkeyPatch,
     tmp_path: Path,
     clock: list[float],
-    counters: Callable[[], tuple[int, float] | None],
+    counters: Callable[[], Traffic | None],
     output_at: float | None = None,
 ) -> tuple[cluster.Reconnecting, cluster.Watchdog]:
     monkeypatch.setattr(time, "monotonic", lambda: clock[0])
@@ -290,9 +291,9 @@ def test_install_wait_continues_when_silent_guest_moves_bytes(
     clock = [0.0]
     traffic = [0]
 
-    def counters() -> tuple[int, float]:
+    def counters() -> Traffic:
         traffic[0] += cluster.QUIET_BYTES * 2
-        return traffic[0], 0.0
+        return Traffic(traffic[0], 0, 0.0)
 
     link, watch = _timed_wait(monkeypatch, tmp_path, clock, counters, output_at=3.0)
     link.wait_for("install", timeout=5.0, idle=2.0, watch=watch)
@@ -305,7 +306,12 @@ def test_install_wait_names_silent_console_and_flat_counters(
     monkeypatch: pytest.MonkeyPatch, tmp_path: Path
 ) -> None:
     clock = [0.0]
-    link, watch = _timed_wait(monkeypatch, tmp_path, clock, lambda: (0, 0.0))
+    # A guest whose network counter sits at a number and whose disk sits at
+    # zero: summed, both shapes read the same and the verdict could not say
+    # which of the two had stopped.
+    link, watch = _timed_wait(
+        monkeypatch, tmp_path, clock, lambda: Traffic(4096, 0, 0.0)
+    )
     watch.log.write_bytes(b"output before the idle window\n")
 
     with pytest.raises(ConsoleTimeout) as raised:
@@ -315,7 +321,8 @@ def test_install_wait_names_silent_console_and_flat_counters(
     assert clock[0] == 2.0
     assert "console was silent" in message
     assert "counters were flat" in message
-    assert "0 -> 0 bytes" in message
+    assert "network 4096 -> 4096" in message, message
+    assert "disk 0 -> 0" in message, message
     # And where, because the cluster's other tenants are not this campaign's:
     # a guest that goes to cpu 0.00 mid-compile is a different finding on a
     # node at 100% than on an idle one, and the verdict was the only record.
@@ -335,9 +342,9 @@ def test_run_ceiling_ends_silent_guest_that_keeps_moving_bytes(
     clock = [0.0]
     readings = [0]
 
-    def counters() -> tuple[int, float]:
+    def counters() -> Traffic:
         readings[0] += 1
-        return readings[0] * cluster.QUIET_BYTES * 2, 0.0
+        return Traffic(readings[0] * cluster.QUIET_BYTES * 2, 0, 0.0)
 
     link, watch = _timed_wait(monkeypatch, tmp_path, clock, counters)
     with pytest.raises(ConsoleTimeout, match="never matched"):
@@ -525,7 +532,7 @@ def test_the_network_is_measured_once_more_after_the_install(
     job = cluster.Job("network", FIXTURES / "mbr-edit.toml")
     held = cluster.Running(
         guest=cast(Any, guest),
-        watch=cluster.Watchdog(log, lambda: (0, 0.0)),
+        watch=cluster.Watchdog(log, lambda: Traffic(0, 0, 0.0)),
         reservation_bytes=0,
         created=True,
     )
@@ -803,7 +810,7 @@ def _held(log: Path, moved: bool, stuck: bool, busy: bool = False) -> object:
     counters = iter(range(0, 10**9, cluster.QUIET_BYTES * 2))
     watch = cluster.Watchdog(
         log=log,
-        counters=(lambda: (next(counters), 0.0)) if busy else (lambda: (0, 0.0)),
+        counters=(lambda: Traffic(next(counters), 0, 0.0)) if busy else (lambda: Traffic(0, 0, 0.0)),
     )
     # One pass so the watchdog has seen the log: the first call always reports
     # growth, from nothing to whatever is there.
@@ -1708,7 +1715,7 @@ def test_a_guest_qemu_calls_running_adds_nothing_to_the_reason(tmp_path: Path) -
     out of a verdict that is cut to length."""
     watch = cluster.Watchdog(
         tmp_path / "install.log",
-        lambda: (0, 0.0),
+        lambda: Traffic(0, 0, 0.0),
         where="infra-node4",
         state=lambda: "running",
     )
@@ -1726,7 +1733,7 @@ def test_a_node_that_will_not_answer_leaves_the_reason_readable(tmp_path: Path) 
         return None
 
     watch = cluster.Watchdog(
-        tmp_path / "install.log", lambda: (0, 0.0), where="infra-node4", load=refusing
+        tmp_path / "install.log", lambda: Traffic(0, 0, 0.0), where="infra-node4", load=refusing
     )
     reason = watch.idle_reason()
     assert reason is not None
@@ -1873,10 +1880,10 @@ def test_a_dropped_console_does_not_end_a_guest_that_is_still_working(
     opened: list[Console] = []
     sampled: list[int] = []
 
-    def counters() -> tuple[int, float] | None:
+    def counters() -> Traffic | None:
         # A guest whose disk keeps growing while its console says nothing.
         sampled.append(len(sampled))
-        return cluster.QUIET_BYTES * 2 * (len(sampled) + 1), 0.0
+        return Traffic(0, cluster.QUIET_BYTES * 2 * (len(sampled) + 1), 0.0)
 
     log = tmp_path / "serial.log"
     log.write_bytes(b"")
@@ -1926,7 +1933,7 @@ def test_a_dropped_console_still_ends_a_guest_that_moves_nothing(tmp_path: Path)
         opened.append(Console())
         return opened[-1]
 
-    still = cluster.Watchdog(log=log, counters=lambda: (0, 0.0))
+    still = cluster.Watchdog(log=log, counters=lambda: Traffic(0, 0, 0.0))
     link = cluster.Reconnecting(open_console, tries=2)
     with pytest.raises(ConsoleClosed):
         link.wait_for("emerge --ask=n @world", timeout=0.0, idle=1.0, watch=still)
@@ -4212,8 +4219,8 @@ def test_a_watchdog_verdict_tells_an_unanswered_state_from_a_running_one(
     a guest qemu had paused on an `io-error` and a hypervisor that did not
     answer produced the same silence — and the two want opposite next steps."""
 
-    def flat() -> tuple[int, float]:
-        return 0, 0.0
+    def flat() -> Traffic:
+        return Traffic(0, 0, 0.0)
 
     def verdict(state: str) -> str:
         watch = cluster.Watchdog(

--- a/tests/unit/test_harness.py
+++ b/tests/unit/test_harness.py
@@ -21,6 +21,7 @@ if TYPE_CHECKING:
 import pytest
 
 from tests.vm.console import passphrase_settle
+from tests.vm.proxmox import Traffic
 from tests.vm.run import verdict
 
 
@@ -1281,7 +1282,7 @@ def test_a_guest_that_could_not_be_removed_keeps_its_slot(
         job = cluster.Job(name, Path(f"tests/fixtures/{name}.toml"))
         execution = cluster.Running(
             Guest(),
-            cluster.Watchdog(Path(f"/nonexistent/{name}.log"), lambda: (0, 0.0)),
+            cluster.Watchdog(Path(f"/nonexistent/{name}.log"), lambda: Traffic(0, 0, 0.0)),
             job.reservation_bytes,
         )
         return job.dispatch(
@@ -1451,8 +1452,8 @@ def test_unknown_telemetry_does_not_make_a_quiet_guest_stuck(tmp_path: Path) -> 
 
     log = tmp_path / "quiet.log"
     log.write_bytes(b"")
-    answers: list[tuple[int, float] | None] = [None] * WATCH_STRIKES + [
-        (10, 0.0)
+    answers: list[Traffic | None] = [None] * WATCH_STRIKES + [
+        Traffic(10, 0, 0.0)
     ] * (WATCH_STRIKES + 1)
     watch = Watchdog(log, lambda: answers.pop(0))
     unknown = [watch.moved() for _ in range(WATCH_STRIKES)]
@@ -2496,7 +2497,7 @@ def test_an_idle_verdict_names_the_counters_before_the_console_tail() -> None:
         "was " + "b'0.1/src/shared/data-fd-util.c [294/2044] compiling'" * 6
     )
     link = cluster.Reconnecting(lambda: _PatternConsole(idle, sent))
-    watch = cluster.Watchdog(log=Path("/nonexistent"), counters=lambda: (0, 0.0))
+    watch = cluster.Watchdog(log=Path("/nonexistent"), counters=lambda: Traffic(0, 0, 0.0))
 
     with pytest.raises(ConsoleTimeout) as raised:
         link.wait_for("sh install.sh", timeout=10.0, idle=1200.0, watch=watch)

--- a/tests/unit/test_proxmox.py
+++ b/tests/unit/test_proxmox.py
@@ -33,6 +33,7 @@ from tests.vm.proxmox import (
     ProxmoxError,
     ProxmoxNotFound,
     ProxmoxTransientError,
+    Traffic,
     _RejectRedirect,
     _line_of_linux,
 )
@@ -668,7 +669,7 @@ def test_the_watchdog_counts_quiet_looks_not_elapsed_time(tmp_path: Path) -> Non
 
     log = tmp_path / "run.log"
     log.write_bytes(b"booting\n")
-    watch = Watchdog(log=log, counters=lambda: (0, 0.0))
+    watch = Watchdog(log=log, counters=lambda: Traffic(0, 0, 0.0))
     # Read into locals: mypy narrows a property and never widens it again,
     # because it cannot see `moved()` changing what `stuck` answers.
     first = (watch.moved(), watch.stuck)
@@ -695,9 +696,9 @@ def test_a_silent_guest_that_is_still_downloading_is_left_alone(tmp_path: Path) 
     log.write_bytes(b"downloading\n")
     moving = [0]
 
-    def counters() -> tuple[int, float]:
+    def counters() -> Traffic:
         moving[0] += QUIET_BYTES * 2
-        return moving[0], 0.0
+        return Traffic(moving[0], 0, 0.0)
 
     watch = Watchdog(log=log, counters=counters)
     looks = [watch.moved() for _ in range(WATCH_STRIKES + 2)]
@@ -718,7 +719,7 @@ def test_a_guest_compiling_in_memory_is_not_read_as_stuck(tmp_path: Path) -> Non
 
     log = tmp_path / "compiling.log"
     log.write_bytes(b"")
-    watch = Watchdog(log=log, counters=lambda: (5_000_000, BUSY_CPU))
+    watch = Watchdog(log=log, counters=lambda: Traffic(5_000_000, 0, BUSY_CPU))
     looks = [watch.moved() for _ in range(WATCH_STRIKES + 2)]
 
     assert looks == [True] * (WATCH_STRIKES + 2), looks
@@ -731,7 +732,7 @@ def test_a_guest_moving_nothing_at_all_is_stuck(tmp_path: Path) -> None:
 
     log = tmp_path / "dead.log"
     log.write_bytes(b"")
-    watch = Watchdog(log=log, counters=lambda: (5_000_000, 0.0))
+    watch = Watchdog(log=log, counters=lambda: Traffic(5_000_000, 0, 0.0))
     quiet = [watch.moved() for _ in range(WATCH_STRIKES + 1)]
     assert quiet[1:] == [False] * WATCH_STRIKES
     assert watch.stuck
@@ -753,7 +754,7 @@ def test_a_stuck_guest_is_stopped_and_not_deleted_by_the_sweep(tmp_path: Path) -
 
     log = tmp_path / "quiet.log"
     log.write_bytes(b"")
-    watch = Watchdog(log=log, counters=lambda: (0, 0.0), strikes=WATCH_STRIKES - 1)
+    watch = Watchdog(log=log, counters=lambda: Traffic(0, 0, 0.0), strikes=WATCH_STRIKES - 1)
     inflight = {
         "vm-zfs": Running(
             guest=Quiet(),
@@ -2273,7 +2274,7 @@ def test_a_reserved_guest_is_not_created_twice_and_is_still_cleaned_up(
     job = Job(name="reserved", fixture=tmp_path / "reserved.toml", iso="minimal.iso")
     execution = Running(
         guest,
-        Watchdog(log=log, counters=lambda: (0, 0.0)),
+        Watchdog(log=log, counters=lambda: Traffic(0, 0, 0.0)),
         job.reservation_bytes,
         created=True,
     )

--- a/tests/vm/cluster.py
+++ b/tests/vm/cluster.py
@@ -101,6 +101,7 @@ from .proxmox import (
     Node,
     ProxmoxError,
     ProxmoxTransientError,
+    Traffic,
     VMID_FIRST,
     VMID_LAST,
     Line,
@@ -518,7 +519,7 @@ class Watchdog:
     """
 
     log: Path
-    counters: Callable[[], tuple[int, float] | None]
+    counters: Callable[[], Traffic | None]
     #: Where the guest is. A verdict that says only `counters were flat` is a
     #: guess about a cluster whose other tenants this campaign does not
     #: control: `static-ip` went to cpu 0.00 mid-compile and the node it was
@@ -538,6 +539,8 @@ class Watchdog:
     _moved: int = field(default=0, init=False)
     _counter_before: int = field(default=0, init=False)
     _counter_after: int = field(default=0, init=False)
+    _network: tuple[int, int] = field(default=(0, 0), init=False)
+    _disk: tuple[int, int] = field(default=(0, 0), init=False)
     _cpu: float = field(default=0.0, init=False)
     #: Consecutive samples the hypervisor would not answer.
     _blind: int = field(default=0, init=False)
@@ -577,9 +580,14 @@ class Watchdog:
             self._blind += 1
             return self._blind < BLIND_SAMPLES
         self._blind = 0
-        moved, self._cpu = traffic
+        moved, self._cpu = traffic.moved, traffic.cpu
         self._counter_before = self._moved
         self._counter_after = moved
+        # Both directions, so a verdict can say which of them stopped. The
+        # first sample has no earlier reading to compare against, so it is its
+        # own predecessor rather than a jump from zero.
+        self._network = (self._network[1] or traffic.network, traffic.network)
+        self._disk = (self._disk[1] or traffic.disk, traffic.disk)
         # Either signal is enough. A compile whose build directory is in RAM
         # writes nothing and answers no network, and `vm-binhost-fallback` was
         # ended for that at 48.8 minutes with grub half built.
@@ -618,7 +626,8 @@ class Watchdog:
                     )
             return (
                 f"counters were flat{node} "
-                f"({self._counter_before} -> {self._counter_after} bytes, "
+                f"(network {self._network[0]} -> {self._network[1]}, "
+                f"disk {self._disk[0]} -> {self._disk[1]}, "
                 f"cpu {self._cpu:.2f}){said}"
             )
 

--- a/tests/vm/proxmox.py
+++ b/tests/vm/proxmox.py
@@ -582,6 +582,27 @@ class GuestSpec:
     nonce: str = ""
 
 
+@dataclass(frozen=True)
+class Traffic:
+    """What a guest moved, kept in the two directions that mean different
+    things. Summed, a stalled guest reads `29577 bytes in 1200s` and nothing
+    says whether that was a network keepalive on a machine whose disk had
+    stopped or the other way round -- which is the whole question about the
+    stalls on this cluster.
+    """
+
+    network: int
+    disk: int
+    cpu: float
+
+    @property
+    def moved(self) -> int:
+        """What the watchdog decides on. Either direction is enough: a compile
+        with its build directory in RAM answers no network and writes nothing
+        to the disk the hypervisor counts."""
+        return self.network + self.disk
+
+
 @dataclass
 class Guest:
     """A machine on the cluster, and the only thing allowed to delete it."""
@@ -732,7 +753,7 @@ class Guest:
         said = status.get("qmpstatus")
         return said if isinstance(said, str) else ""
 
-    def transferred(self) -> tuple[int, float] | None:
+    def transferred(self) -> Traffic | None:
         """Bytes this guest has received and written, and its CPU share.
 
         What the watchdog reads when the console is silent: an install
@@ -745,12 +766,15 @@ class Guest:
             # One unanswered request is not evidence about the guest, and a
             # watchdog that raises here stops the whole schedule.
             return None
-        moved = int(status.get("netin", 0)) + int(status.get("diskwrite", 0))
         # The share of a core the guest is using, from the same reading. A
         # compile whose build directory is in RAM moves no bytes at all:
         # `vm-binhost-fallback` was ended for 7781 bytes in twenty minutes
         # while it was building grub.
-        return moved, float(status.get("cpu", 0.0))
+        return Traffic(
+            network=int(status.get("netin", 0)),
+            disk=int(status.get("diskwrite", 0)),
+            cpu=float(status.get("cpu", 0.0)),
+        )
 
     def running(self) -> bool:
         status = self.api.call("GET", f"/nodes/{self.node}/qemu/{self.vmid}/status/current")


### PR DESCRIPTION
`transferred()` summed `netin` and `diskwrite` into one number, so every stall verdict on this cluster read like `14873894434 -> 14873924011 bytes` and nothing said whether that was a network keepalive on a machine whose disk had stopped or the other way round. That is the open question about the stalls in row 402.

The first sample is also its own predecessor now. It used to compare against zero, so a guest that had never moved printed `0 -> 4096 bytes` and read as one that moved.
