### PR TITLE
packages: verify the rime schema the profile names

### DIFF
--- a/gentoo_install/exec/apply.py
+++ b/gentoo_install/exec/apply.py
@@ -93,6 +93,9 @@ class Machine:
     def target_is_directory(self, path: PurePosixPath) -> bool:
         return packages.target_is_directory(self.mountpoint, path)
 
+    def target_is_file(self, path: PurePosixPath) -> bool:
+        return packages.target_is_file(self.mountpoint, path)
+
     def write(self, path: PurePosixPath, content: str, *, mode: int = 0o644) -> None:
         # Beside it and renamed over, never in place: a run cut short between
         # the truncate and the write leaves a half-written `fstab` or

--- a/gentoo_install/exec/packages.py
+++ b/gentoo_install/exec/packages.py
@@ -4,6 +4,7 @@
 from __future__ import annotations
 
 import os
+import stat
 import re
 
 from pathlib import Path, PurePosixPath
@@ -83,6 +84,20 @@ def installed_package_paths(target: Path, package: str) -> frozenset[PurePosixPa
         except (OSError, TargetEscape) as error:
             raise CommandFailed(f"cannot read {contents_path} for {package}") from error
     return frozenset(paths)
+
+
+def target_is_file(target: Path, path: PurePosixPath) -> bool:
+    """Whether an absolute target path is an existing regular file."""
+    try:
+        handle = open_in_target(target, path, os.O_RDONLY)
+    except (FileNotFoundError, NotADirectoryError, IsADirectoryError):
+        return False
+    except (OSError, TargetEscape) as error:
+        raise CommandFailed(f"cannot inspect target file {path}") from error
+    try:
+        return stat.S_ISREG(os.fstat(handle).st_mode)
+    finally:
+        os.close(handle)
 
 
 def target_is_directory(target: Path, path: PurePosixPath) -> bool:

--- a/gentoo_install/plan/packages.py
+++ b/gentoo_install/plan/packages.py
@@ -142,6 +142,8 @@ class PackageInspection(Protocol):
 
     def target_is_directory(self, path: PurePosixPath) -> bool: ...
 
+    def target_is_file(self, path: PurePosixPath) -> bool: ...
+
 
 def _package_inspection(context: Context, package: str) -> PackageInspection:
     if not isinstance(context, PackageInspection):
@@ -812,6 +814,52 @@ class WriteInputMethodProfile(Operation):
         return f"patch:\n  schema_list:\n{listed}"
 
 
+#: Where rime looks for a schema, and the suffix it reads. Not a guess: the
+#: files `app-i18n/rime-data` lists in its own VDB CONTENTS are exactly
+#: `/usr/share/rime-data/<name>.schema.yaml`.
+RIME_DATA: Final[PurePosixPath] = PurePosixPath("/usr/share/rime-data")
+#: The package the schemas come from, and whose `USE=extra` decides whether
+#: half of them are on disk at all. Named here so the failure points at the
+#: flag rather than at the file.
+RIME_DATA_PACKAGE: Final[str] = "app-i18n/rime-data"
+RIME_SCHEMA_SUFFIX: Final[str] = ".schema.yaml"
+
+
+@dataclass(frozen=True, kw_only=True)
+class VerifyRimeSchemas(Operation):
+    """The schemas the profile just named, checked against the target.
+
+    rime ignores a schema that is not on disk and fcitx then falls back to
+    `keyboard-us`, so a profile naming one reads as a working install: exit 0,
+    a written configuration, and no input method. Half of these schemas come
+    from `app-i18n/rime-data` only with `USE=extra`, so the coupling between a
+    group's `schemas` and its `package_use` is one edit away from silence.
+    """
+
+    stage: Stage = Stage.PACKAGES
+    package: str
+    schemas: tuple[str, ...]
+
+    def describe(self) -> str:
+        return f"verify {self.package} installed {', '.join(self.schemas)}"
+
+    def apply(self, context: Context) -> None:
+        inspection = _package_inspection(context, self.package)
+        missing = tuple(
+            schema
+            for schema in self.schemas
+            if not inspection.target_is_file(
+                RIME_DATA / f"{schema}{RIME_SCHEMA_SUFFIX}"
+            )
+        )
+        if missing:
+            raise CommandFailed(
+                f"the input method profile names {', '.join(missing)}, but "
+                f"{RIME_DATA} holds no such schema. A schema from the extra set "
+                f"needs {self.package} built with USE=extra"
+            )
+
+
 #: Driver groups that cannot be installed together, and why. Two drivers for
 #: the same adapter, not two adapters: `amdgpu` and `radeon` cover different
 #: AMD generations and a machine can hold one card of each, so they are not
@@ -1312,6 +1360,12 @@ def _input_method(config: InstallConfig, chosen: tuple[Group, ...]) -> list[Oper
                 homes=tuple(homes),
             )
         )
+        if schemas:
+            operations.append(
+                VerifyRimeSchemas(
+                    package=RIME_DATA_PACKAGE, schemas=tuple(schemas)
+                )
+            )
     if framework == "ibus" and config.packages.desktop == GNOME_DESKTOP_GROUP:
         sources = tuple(group.input_source for group in chosen if group.input_source)
         if sources:

--- a/tests/golden/btrfs-luks.txt
+++ b/tests/golden/btrfs-luks.txt
@@ -105,6 +105,7 @@
   install the flclash group: emerge net-proxy/flclash-bin
   set XMODIFIERS, QT_IM_MODULES in /etc/environment for fcitx
   configure fcitx with rime and luna_pinyin pinyin_simp for skel, zakk, writing .config/fcitx5/profile, .config/gtk-3.0/settings.ini, .config/gtk-4.0/settings.ini, .local/share/fcitx5/rime/default.custom.yaml under each
+  verify app-i18n/rime-data installed luna_pinyin, pinyin_simp
   verify app-i18n/fcitx installed /usr/share/applications/fcitx5-wayland-launcher.desktop
   set /etc/xdg/kwinrc so the Wayland session starts /usr/share/applications/fcitx5-wayland-launcher.desktop
   enable /etc/fonts/conf.d/70-noto-cjk.conf

--- a/tests/golden/vm-desktop.txt
+++ b/tests/golden/vm-desktop.txt
@@ -84,6 +84,7 @@
   enable pipewire.socket, pipewire-pulse.socket, wireplumber.service for every user
   set XMODIFIERS, QT_IM_MODULES in /etc/environment for fcitx
   configure fcitx with rime and luna_pinyin pinyin_simp for skel, writing .config/fcitx5/profile, .config/gtk-3.0/settings.ini, .config/gtk-4.0/settings.ini, .local/share/fcitx5/rime/default.custom.yaml under each
+  verify app-i18n/rime-data installed luna_pinyin, pinyin_simp
   verify app-i18n/fcitx installed /usr/share/applications/fcitx5-wayland-launcher.desktop
   set /etc/xdg/kwinrc so the Wayland session starts /usr/share/applications/fcitx5-wayland-launcher.desktop
 

--- a/tests/unit/test_packages.py
+++ b/tests/unit/test_packages.py
@@ -336,6 +336,7 @@ class PackageRecorder(Recorder):
         self.package_paths: dict[str, frozenset[PurePosixPath]] = {}
         self.help: dict[str, str] = {}
         self.directories: set[PurePosixPath] = set()
+        self.regular_files: set[PurePosixPath] = set()
 
     def installed_package_paths(self, package: str) -> frozenset[PurePosixPath]:
         return self.package_paths.get(package, frozenset())
@@ -345,6 +346,9 @@ class PackageRecorder(Recorder):
 
     def target_is_directory(self, path: PurePosixPath) -> bool:
         return path in self.directories
+
+    def target_is_file(self, path: PurePosixPath) -> bool:
+        return path in self.regular_files
 
 
 def test_greetd_update_preserves_package_owned_defaults() -> None:
@@ -603,3 +607,53 @@ def test_a_group_fragment_declaring_half_of_the_pair_is_refused_at_import() -> N
 
     with pytest.raises(ConfigError, match="WriteForGroup declares no directory, verb"):
         plan_packages.WriteForGroup(group="chat", lines=("one",))
+
+
+def test_a_rime_schema_the_profile_names_must_be_on_disk() -> None:
+    """rime ignores a schema that is not there and fcitx falls back to
+    `keyboard-us`, so a profile naming one reads as a working install: exit 0,
+    a written configuration, and no input method. Half of these come from
+    `app-i18n/rime-data` only with `USE=extra`, so the coupling between a
+    group's `schemas` and its `package_use` is one edit away from silence.
+    """
+    check = plan_packages.VerifyRimeSchemas(
+        package="app-i18n/rime-data", schemas=("luna_pinyin", "pinyin_simp")
+    )
+    assert "luna_pinyin, pinyin_simp" in check.describe(), check.describe()
+
+    recorder = PackageRecorder()
+    recorder.regular_files = {
+        plan_packages.RIME_DATA / f"{one}.schema.yaml"
+        for one in ("luna_pinyin", "pinyin_simp")
+    }
+    check.apply(recorder)
+
+    # The one the extra set carries, missing: that is what a dropped
+    # `package_use` looks like, and it has to stop the install.
+    recorder.regular_files.discard(plan_packages.RIME_DATA / "pinyin_simp.schema.yaml")
+    with pytest.raises(CommandFailed, match="pinyin_simp"):
+        check.apply(recorder)
+
+
+def test_every_rime_group_has_its_schemas_verified() -> None:
+    """The check is derived from the profile it follows, not from a second
+    list: a group whose schemas nobody verifies is the shape this repository
+    keeps hitting."""
+    installation = config()
+    selected = replace(
+        installation,
+        packages=replace(
+            installation.packages,
+            desktop="plasma",
+            applications=("fcitx5", "rime", "rime-simplified"),
+        ),
+    )
+    operations = plan_packages.build(selected, load_catalog())
+    written = [
+        one for one in operations if isinstance(one, plan_packages.WriteInputMethodProfile)
+    ]
+    checked = [
+        one for one in operations if isinstance(one, plan_packages.VerifyRimeSchemas)
+    ]
+    assert written and written[0].schemas, written
+    assert [one.schemas for one in checked] == [written[0].schemas], (written, checked)


### PR DESCRIPTION
The installer writes `rime_custom.yaml` naming schemas and `profile` naming engines, and nothing read either back. rime ignores a schema that is not on disk and fcitx then falls back to `keyboard-us`, so the install exits 0 with a written configuration and no input method — the failure mode `rime-simplified.toml` already records in a comment.

Half the schemas come from `app-i18n/rime-data` only with `USE=extra`, so the coupling between a group's `schemas` and its `package_use` was one edit away from silence.

Scoped to schemas. The engine names in the profile map to `/usr/share/fcitx5/inputmethod/<name>.conf`, confirmed for `rime` and `mcbopomofo` on a real machine and for nothing else, so that half waits for evidence per engine.

Unverified: the round now on the cluster is pinned before this commit, so `vm-desktop` has not run the check yet.
