### PR TITLE
packages: hold a rime schema to the package that ships it

### DIFF
--- a/tests/unit/test_plan.py
+++ b/tests/unit/test_plan.py
@@ -503,11 +503,20 @@ def test_each_rime_schema_is_a_group_the_operator_can_tick() -> None:
     from gentoo_install.plan.build import build
 
     catalog = load_catalog()
+    from gentoo_install.plan.packages import RIME_DATA_PACKAGE
+
     named = {schema for group in catalog.values() for schema in group.schemas}
     assert {"luna_pinyin", "bopomofo", "wubi86", "cangjie5", "jyut6ping3"} <= named
     # One schema per group, so ticking one cannot drag in another.
     for name, group in catalog.items():
         assert len(group.schemas) <= 1, name
+        # And the data package with it. `app-i18n/rime-data` installs the
+        # schema files and nothing else, so a group that names a schema
+        # without it leaves fcitx pointing at an addon that is not on disk and
+        # falling back to `keyboard-us` -- which is how this was found the
+        # first time, and the install exits 0 either way.
+        if group.schemas:
+            assert RIME_DATA_PACKAGE in group.packages, (name, group.packages)
 
     desktop = load(_Path("tests/fixtures/vm-desktop.toml"))
     picked = _replace(


### PR DESCRIPTION
`#1061` catches this at install time by reading the target. This catches it before a machine is built, which is where a data-file edit belongs.

All six rime groups match `app-i18n/rime-data`'s own split today: `bopomofo`, `cangjie5` and `luna_pinyin` come from its default set and carry no `package_use`; `wubi86`, `jyut6ping3` and `pinyin_simp` are in `PKGS_EXTRA` and every one of them sets `USE=extra`. The guard is for the next edit, not for a defect now.
