### PR TITLE
exec: answer absence from a target probe instead of raising

### DIFF
--- a/gentoo_install/exec/packages.py
+++ b/gentoo_install/exec/packages.py
@@ -86,13 +86,31 @@ def installed_package_paths(target: Path, package: str) -> frozenset[PurePosixPa
     return frozenset(paths)
 
 
+def _is_absent(error: TargetEscape) -> bool:
+    """Whether this escape is a component that is not there.
+
+    `open_in_target` opens each component itself, so a directory missing on
+    the way arrives as `TargetEscape`, and a probe that re-raised it answered
+    `cannot inspect` for a package that is not installed at all -- where the
+    caller has the message that names the reason. `ENOENT` only: measured on
+    this kernel, `O_NOFOLLOW | O_DIRECTORY` answers `ENOTDIR` for a symlink
+    out of the target and `ENOENT` for a missing name, so taking both would
+    turn the escape this function exists to catch into a quiet `False`.
+    """
+    return isinstance(error.__cause__, FileNotFoundError)
+
+
 def target_is_file(target: Path, path: PurePosixPath) -> bool:
     """Whether an absolute target path is an existing regular file."""
     try:
         handle = open_in_target(target, path, os.O_RDONLY)
     except (FileNotFoundError, NotADirectoryError, IsADirectoryError):
         return False
-    except (OSError, TargetEscape) as error:
+    except TargetEscape as error:
+        if _is_absent(error):
+            return False
+        raise CommandFailed(f"cannot inspect target file {path}") from error
+    except OSError as error:
         raise CommandFailed(f"cannot inspect target file {path}") from error
     try:
         return stat.S_ISREG(os.fstat(handle).st_mode)
@@ -106,7 +124,11 @@ def target_is_directory(target: Path, path: PurePosixPath) -> bool:
         handle = open_in_target(target, path, os.O_RDONLY | os.O_DIRECTORY)
     except (FileNotFoundError, NotADirectoryError):
         return False
-    except (OSError, TargetEscape) as error:
+    except TargetEscape as error:
+        if _is_absent(error):
+            return False
+        raise CommandFailed(f"cannot inspect target directory {path}") from error
+    except OSError as error:
         raise CommandFailed(f"cannot inspect target directory {path}") from error
     os.close(handle)
     return True

--- a/tests/unit/test_packages.py
+++ b/tests/unit/test_packages.py
@@ -657,3 +657,44 @@ def test_every_rime_group_has_its_schemas_verified() -> None:
     ]
     assert written and written[0].schemas, written
     assert [one.schemas for one in checked] == [written[0].schemas], (written, checked)
+
+
+def test_the_target_probes_answer_absence_without_hiding_an_escape(
+    tmp_path: Path,
+) -> None:
+    """Neither probe had a test, and the check that reads them cannot fail
+    if they always answer the same thing.
+
+    The distinction is measured rather than assumed: `O_NOFOLLOW |
+    O_DIRECTORY` answers `ENOTDIR` for a symlink out of the target and
+    `ENOENT` for a name that is not there, so a first version of this that
+    took both turned a symlink escape into a quiet `False`.
+    """
+    from gentoo_install.exec.packages import target_is_directory, target_is_file
+
+    target = tmp_path / "target"
+    (target / "usr/share/rime-data").mkdir(parents=True)
+    (target / "usr/share/rime-data/luna_pinyin.schema.yaml").write_text("x")
+    outside = tmp_path / "outside"
+    outside.mkdir()
+    (target / "usr/escape").symlink_to(outside, target_is_directory=True)
+
+    schema = PurePosixPath("/usr/share/rime-data/luna_pinyin.schema.yaml")
+    assert target_is_file(target, schema)
+    # Absent, in both the shapes an uninstalled package produces: the file
+    # gone, and the directory that would hold it gone with it.
+    assert not target_is_file(
+        target, PurePosixPath("/usr/share/rime-data/pinyin_simp.schema.yaml")
+    )
+    assert not target_is_file(
+        target, PurePosixPath("/usr/share/nothing-here/pinyin_simp.schema.yaml")
+    )
+    # A directory is not a file, and a file is not a directory.
+    assert not target_is_file(target, PurePosixPath("/usr/share/rime-data"))
+    assert target_is_directory(target, PurePosixPath("/usr/share/rime-data"))
+    assert not target_is_directory(target, schema)
+
+    # And a symlink out of the target is still refused rather than answered.
+    for probe in (target_is_file, target_is_directory):
+        with pytest.raises(CommandFailed, match="cannot inspect"):
+            probe(target, PurePosixPath("/usr/escape/anything"))


### PR DESCRIPTION
`VerifyRimeSchemas` says which schema is missing and that `app-i18n/rime-data` needs `USE=extra`. That message never reached an operator whose `rime-data` was absent entirely, because the missing directory raised `cannot inspect target file` from the probe first. `VerifySessionDirectories` had the same shape.

`ENOENT` only, and that is measured rather than assumed: `O_NOFOLLOW | O_DIRECTORY` answers `ENOTDIR` for a symlink out of the target and `ENOENT` for a name that is not there. A first version of this took both and turned the escape the function exists to catch into a quiet `False`; the test now holds that apart, and fails on that version.

Neither probe had a test before this.
