### PR TITLE
vm: ask the console whether it is there before ending a guest

### DIFF
--- a/tests/unit/test_cluster.py
+++ b/tests/unit/test_cluster.py
@@ -318,8 +318,14 @@ def test_install_wait_names_silent_console_and_flat_counters(
         link.wait_for("install", timeout=5.0, idle=2.0, watch=watch)
 
     message = str(raised.value)
-    assert clock[0] == 2.0
+    # Two poke windows after the idle one: a fresh console is opened and read,
+    # then asked. That time is spent only on a guest about to be ended, and it
+    # buys the one fact the counters cannot give.
+    assert clock[0] == 2.0 + 2 * cluster.POKE_PATIENCE, clock[0]
     assert "console was silent" in message
+    # This console answers nothing, which is what a guest that has really
+    # stopped looks like -- and it now says so instead of leaving it open.
+    assert "stayed empty" in message, message
     assert "counters were flat" in message
     assert "network 4096 -> 4096" in message, message
     assert "disk 0 -> 0" in message, message
@@ -334,6 +340,67 @@ def test_install_wait_names_silent_console_and_flat_counters(
     # And what qemu calls it, when that is not `running`: a guest paused by a
     # storage error reads exactly like one that stopped on its own.
     assert "qemu calls the guest io-error" in message, message
+
+
+def test_a_console_that_answers_when_reopened_says_so_in_the_verdict(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """The difference between a guest that stopped and a console that went.
+
+    Five stalls on this cluster read `the console was silent` mid-compile, and
+    the counters cannot separate the two: these guests keep
+    `/var/tmp/portage` in RAM, so `gi-vm-desktop` was measured compiling
+    `fcitx-rime` with both disk counters frozen and `cpu 0.00`. A fresh
+    console that prints at once is a guest that never stopped.
+    """
+    clock = [0.0]
+    talking = _Talkative(clock)
+    monkeypatch.setattr(time, "monotonic", lambda: clock[0])
+    serial = SerialConsole(TimedChannel(clock), BytesIO())
+    # The first console is the silent one the wait gave up on; the one the
+    # poke opens is the guest still printing.
+    opened = [0]
+
+    def _open() -> SerialConsole:
+        opened[0] += 1
+        return serial if opened[0] == 1 else SerialConsole(talking, BytesIO())
+
+    link = cluster.Reconnecting(_open)
+    watch = cluster.Watchdog(
+        tmp_path / "install.log", lambda: Traffic(4096, 0, 0.0), where="infra-node2"
+    )
+    watch.log.write_bytes(b"output before the idle window\n")
+
+    with pytest.raises(ConsoleTimeout) as raised:
+        link.wait_for("install", timeout=5.0, idle=2.0, watch=watch)
+
+    message = str(raised.value)
+    assert "showed" in message and "at once" in message, message
+    assert "still compiling" in message, message
+    # And it never had to be asked, so nothing was written to a guest that is
+    # working: `vm-luks` lost `grub-install` at operation 56 of 56 that way.
+    assert "until it was asked" not in message, message
+
+
+class _Talkative:
+    """A console that prints the moment anything reads it."""
+
+    def __init__(self, clock: list[float]) -> None:
+        self._clock = clock
+
+    def recv(self, size: int) -> bytes:
+        self._clock[0] += 1.0
+        return b"[3/24] still compiling\n"
+
+    def sendall(self, data: bytes) -> None:
+        return None
+
+    def close(self) -> None:
+        return None
+
+    @property
+    def closed(self) -> bool:
+        return False
 
 
 def test_run_ceiling_ends_silent_guest_that_keeps_moving_bytes(

--- a/tests/vm/cluster.py
+++ b/tests/vm/cluster.py
@@ -3162,6 +3162,43 @@ class Reconnecting:
     def to(cls, guest: Guest, log: Path, tries: int = RECONNECT_TRIES) -> Reconnecting:
         return cls(lambda: SerialConsole(guest.console(), log.open("ab")), tries)
 
+    def what_a_fresh_console_says(self) -> str:
+        """Whether the console is still there, asked rather than assumed.
+
+        Every stall on this cluster is `the console was silent` with the last
+        line mid-compile, and the counters cannot tell that from a healthy
+        build: these guests keep `/var/tmp/portage` in RAM, so `gi-vm-desktop`
+        was measured compiling `fcitx-rime` with both disk counters frozen and
+        `cpu 0.00`. What separates the two is whether a new console shows the
+        build still printing, and nothing had ever opened one.
+
+        Passive first, because a live guest mid-compile prints at once. The
+        newline is only for a window that stayed empty, where the guest is
+        being ended either way: `vm-luks` lost `grub-install` at operation 56
+        of 56 to an interrupt sent on a reopen, so nothing is written to a
+        console that has just proved it is alive.
+        """
+        try:
+            self.reopen(solicit_prompt=False)
+            said = self._listen(POKE_PATIENCE)
+            if said:
+                return f"a new console showed {said[-POKE_BYTES:]!r} at once"
+            self.console.send("")
+            woken = self._listen(POKE_PATIENCE)
+        except (ConsoleClosed, ProxmoxError) as error:
+            return f"a new console could not be opened: {error}"
+        if woken:
+            return f"a new console said nothing until it was asked, then {woken[-POKE_BYTES:]!r}"
+        return f"a new console opened and stayed empty for {2 * POKE_PATIENCE:.0f}s"
+
+    def _listen(self, patience: float) -> bytes:
+        """Everything that arrives in this window, looking for nothing."""
+        try:
+            self.console.expect(NEVER_MATCHES, timeout=patience)
+        except ConsoleTimeout as quiet:
+            return quiet.seen
+        return b""
+
     def reopen(self, *, solicit_prompt: bool = True) -> None:
         self._reopens += 1
         if self._reopens > REOPEN_CEILING:
@@ -3303,7 +3340,8 @@ class Reconnecting:
                     # alone filled all 300 of `zbm-unlock`'s, so the round
                     # could not say whether its counters had moved.
                     raise ConsoleTimeout(
-                        f"the console was silent for {idle:.0f}s and {reason}: {error}",
+                        f"the console was silent for {idle:.0f}s and {reason}; "
+                        f"{self.what_a_fresh_console_says()}: {error}",
                         waited=error.waited,
                         seen=error.seen,
                     ) from error
@@ -3571,6 +3609,18 @@ def _name_the_user(link: Reconnecting) -> bool:
 #: no window to wait out; the growth below is kept for the console that proves
 #: otherwise by echoing.
 PASSWORD_ECHO_OFF_AFTER: Final[float] = 0.0
+
+#: A pattern nothing matches, for a read whose point is what arrived rather
+#: than what it was looking for.
+NEVER_MATCHES: Final[str] = "(?!)"
+
+#: How long a fresh console is given to say anything, twice: once passively
+#: and once after a newline. Short, because this runs only on the path that is
+#: about to end the guest.
+POKE_PATIENCE: Final[float] = 20.0
+
+#: How much of what it said the verdict carries.
+POKE_BYTES: Final[int] = 200
 
 #: Added to the settle each time the console proves it lost that race, and how
 #: many of those are absorbed. A fixed wait is a guess about a machine whose


### PR DESCRIPTION
Measured on `gi-vm-desktop` this morning: `cpu 0.00`, `diskwrite` and `diskread` both frozen across 42 seconds, network trickling — the exact shape of the five stalls — while the guest was compiling `fcitx-rime` with a 12 MB log still growing. The guests keep `/var/tmp/portage` in RAM, so a compile moves no disk bytes, and `disk 0 -> 0` is the normal state rather than evidence. `#1059` still adds evidence but it cannot make this distinction, and I said it would.

What separates the two is whether a new console shows the build still printing, and nothing had ever opened one. Passive first, because a live guest mid-compile prints at once; the newline is only for a window that stayed empty, where the guest is being ended either way — `vm-luks` lost `grub-install` at operation 56 of 56 to a write sent on a reopen.

Costs 40s per guest, spent only on the path that ends one.
