### PR TITLE
docs: name the fetch path no run has taken

### DIFF
--- a/TESTED.md
+++ b/TESTED.md
@@ -140,14 +140,19 @@ a `volume_label` stamped with the build date, so repinning the ISO without the
 label would have produced a medium that boots and is then refused for being the
 wrong one. Both are read out of the ISO now and a test holds them to it.
 
-What these rows do not cover, and it is larger than a missing record: the
-shipping ISO does not carry this installer. `gig-os-20260818`'s squashfs holds
-381042 entries and not one of them matches `gentoo-install` or `bootstrap.sh`;
-what it does hold is `/usr/bin/calamares` and a `calamares.desktop` on both
-`/etc/skel/Desktop` and `/home/live/Desktop`. Every row above was measured with
-the installer carried in on a second CD the harness builds, which is not how an
-operator reaches it. Packaging it into the ISO beside Calamares is M6 and has
-not started.
+What these rows do not cover: how the installer reaches the medium.
+`gig-os-20260818`'s squashfs holds 381042 entries and not one of them matches
+`gentoo-install` or `bootstrap.sh`; what it does hold is `/usr/bin/calamares`
+and a `calamares.desktop` on both `/etc/skel/Desktop` and `/home/live/Desktop`.
+Every row above was measured with the installer carried in on a second CD the
+harness builds. `README.md` tells an operator to fetch it instead:
+
+    curl -fsSL https://github.com/Zakkaus/gentoo-install/archive/refs/heads/master.tar.gz | tar xz
+
+and no run has ever taken that path. The `packaging/` tree that would put it
+in an ISO beside Calamares exists and is unused; `docs/plan.md` records that
+shipping it there is not a release condition, so this is a gap in the fetch
+path rather than in the milestone.
 
 ### Network modes
 


### PR DESCRIPTION
`#1066` was right about the facts and wrong about what they mean. It said packaging the installer into the ISO "is M6 and has not started", but `docs/plan.md` records M6's acceptance as installing from the minimal ISO, met on 2026-08-24 across five specs, and puts the ISO packaging under "reference for later, not a release condition".

The real gap the squashfs listing exposes is narrower and checkable: every medium row was measured with a second CD the harness builds, while `README.md` tells an operator to run a `curl ... | tar xz`, and no run has ever taken that path.
