### PR TITLE
vm: read the guest's framebuffer through the monitor

### DIFF
--- a/tests/unit/test_harness.py
+++ b/tests/unit/test_harness.py
@@ -6279,3 +6279,83 @@ def test_the_image_comes_out_of_the_guest_without_its_declared_size(
         monkeypatch.setattr(subprocess_module, "Popen", _pull(0, b""))
         with pytest.raises(RuntimeError, match="came out empty"):
             runner.fetch_image(Path("/dev/null"), 2222, written, into)
+
+
+def _ppm(width: int, height: int, ink: dict[tuple[int, int], bytes]) -> bytes:
+    """A P6 PPM whose named pixels differ from the background."""
+    body = bytearray(b"\x00\x00\x00" * width * height)
+    for (column, line), colour in ink.items():
+        at = (line * width + column) * 3
+        body[at : at + 3] = colour
+    return f"P6\n{width} {height}\n255\n".encode() + bytes(body)
+
+
+def test_the_framebuffer_reader_answers_which_columns_carry_ink(tmp_path: Path) -> None:
+    """The serial console carries the bytes the guest wrote, not what the
+    console made of them. A CJK kernel built with the wrong font size writes
+    the same bytes and draws nothing, and every check this repository has
+    passes on it.
+    """
+    from tests.vm.monitor import TEXT_CELL_HEIGHT, Framebuffer, MonitorError, screendump
+
+    # Two text rows of a narrow screen, with ink in the second row only.
+    width, height = 18, TEXT_CELL_HEIGHT * 2
+    lit = {(column, TEXT_CELL_HEIGHT + 3): b"\xff\xff\xff" for column in (4, 5, 13)}
+    shot = tmp_path / "screen.ppm"
+    shot.write_bytes(_ppm(width, height, lit))
+
+    screen = Framebuffer.read(shot)
+    assert (screen.width, screen.height) == (width, height)
+    assert screen.inked_columns(0) == frozenset()
+    assert screen.inked_columns(1) == frozenset({4, 5, 13})
+    with pytest.raises(MonitorError, match="past the"):
+        screen.inked_columns(2)
+
+    # A truncated dump is refused rather than read as a smaller screen: qemu
+    # creates the file and then writes it, so a race reads a valid header over
+    # a body that is not there yet.
+    short = tmp_path / "short.ppm"
+    short.write_bytes(_ppm(width, height, {})[:-30])
+    with pytest.raises(MonitorError, match="carries"):
+        Framebuffer.read(short)
+
+    # And a file that is not one at all.
+    other = tmp_path / "other.ppm"
+    other.write_bytes(b"P3\n2 2\n255\n0 0 0 0 0 0 0 0 0 0 0 0\n")
+    with pytest.raises(MonitorError, match="not an 8-bit binary PPM"):
+        Framebuffer.read(other)
+
+    assert screendump is not None
+
+
+def test_screendump_reads_a_real_qemu_screen(tmp_path: Path) -> None:
+    """Against qemu itself, because the format is the whole question: this
+    was written after one run measured `P6\\n720 400\\n255\\n` from a live
+    monitor, and a reader built from the documentation would have been
+    checked against nothing."""
+    import shutil
+    import subprocess
+
+    from tests.vm.monitor import TEXT_CELL_HEIGHT, TEXT_CELL_WIDTH, screendump
+
+    qemu = shutil.which("qemu-system-x86_64")
+    if qemu is None:
+        pytest.skip("no qemu-system-x86_64 on this machine")
+    socket_path = tmp_path / "mon.sock"
+    guest = subprocess.Popen(
+        [
+            qemu, "-display", "none", "-m", "128", "-nodefaults", "-vga", "std",
+            "-monitor", f"unix:{socket_path},server,nowait",
+        ],
+        stdout=subprocess.DEVNULL,
+        stderr=subprocess.DEVNULL,
+    )
+    try:
+        screen = screendump(socket_path, tmp_path / "shot.ppm")
+    finally:
+        guest.terminate()
+        guest.wait(timeout=30)
+    # Text mode, in the cells the reader assumes: 80 columns and 25 rows.
+    assert screen.width == 80 * TEXT_CELL_WIDTH, screen.width
+    assert screen.height == 25 * TEXT_CELL_HEIGHT, screen.height
+    assert len(screen.pixels) == screen.width * screen.height * 3

--- a/tests/vm/monitor.py
+++ b/tests/vm/monitor.py
@@ -11,7 +11,9 @@ from __future__ import annotations
 
 import socket
 import time
+from dataclasses import dataclass
 from pathlib import Path
+from typing import Final
 
 #: What `sendkey` calls each character that is not a letter or a digit, on the
 #: US layout its key names are taken from. The whole printable set, not the
@@ -94,6 +96,103 @@ def keys_for(text: str) -> list[str]:
         else:
             raise MonitorError(f"{char!r} has no sendkey name")
     return out
+
+
+#: How long qemu is given to write the framebuffer out. It is a memory copy
+#: and a file write; the wait is for the monitor to get to the command.
+DUMP_PATIENCE: Final[float] = 10.0
+
+#: What VGA text mode gives, measured rather than assumed: `screendump` on a
+#: guest with `-vga std` and nothing booted wrote `P6\n720 400\n255\n`, which
+#: is 80 columns of 9 pixels and 25 rows of 16.
+TEXT_CELL_WIDTH: Final[int] = 9
+TEXT_CELL_HEIGHT: Final[int] = 16
+
+
+@dataclass(frozen=True)
+class Framebuffer:
+    """What the guest is drawing, out of a `screendump` PPM.
+
+    The serial console cannot answer whether a glyph was drawn: it carries the
+    bytes the guest wrote, not what the console made of them. A CJK kernel
+    that builds the wrong font size prints the same bytes and draws nothing,
+    and every check passes.
+    """
+
+    width: int
+    height: int
+    pixels: bytes
+
+    @classmethod
+    def read(cls, path: Path) -> Framebuffer:
+        raw = path.read_bytes()
+        fields: list[bytes] = []
+        at = 0
+        while len(fields) < 4:
+            while at < len(raw) and raw[at : at + 1].isspace():
+                at += 1
+            start = at
+            while at < len(raw) and not raw[at : at + 1].isspace():
+                at += 1
+            if start == at:
+                raise MonitorError(f"{path} ended inside its PPM header")
+            fields.append(raw[start:at])
+        at += 1
+        magic, width, height, depth = fields
+        if magic != b"P6" or depth != b"255":
+            raise MonitorError(f"{path} is not an 8-bit binary PPM: {magic!r} {depth!r}")
+        pixels = raw[at:]
+        wanted = int(width) * int(height) * 3
+        if len(pixels) != wanted:
+            raise MonitorError(
+                f"{path} declares {int(width)}x{int(height)} and carries "
+                f"{len(pixels)} bytes, not {wanted}"
+            )
+        return cls(width=int(width), height=int(height), pixels=pixels)
+
+    def inked_columns(self, row: int) -> frozenset[int]:
+        """Which pixel columns of this text row are not the background.
+
+        The background is whatever the top-left pixel is, so a theme that
+        draws light on dark and one that draws dark on light both answer.
+        """
+        top = row * TEXT_CELL_HEIGHT
+        if top + TEXT_CELL_HEIGHT > self.height:
+            raise MonitorError(f"row {row} is past the {self.height}-pixel screen")
+        background = self.pixels[0:3]
+        found: set[int] = set()
+        for line in range(top, top + TEXT_CELL_HEIGHT):
+            base = line * self.width * 3
+            for column in range(self.width):
+                at = base + column * 3
+                if self.pixels[at : at + 3] != background:
+                    found.add(column)
+        return frozenset(found)
+
+
+def screendump(path: Path, into: Path, patience: float = DUMP_PATIENCE) -> Framebuffer:
+    """Ask qemu for the guest's screen and read it back.
+
+    Measured against a live monitor: the command writes a binary PPM and says
+    nothing useful on the socket, so the file appearing is the answer.
+    """
+    into.unlink(missing_ok=True)
+    sock = connect(path)
+    try:
+        sock.sendall(f"screendump {into}\n".encode())
+    finally:
+        sock.close()
+    deadline = time.monotonic() + patience
+    while time.monotonic() < deadline:
+        # Size as well as existence: qemu creates the file and then writes it,
+        # and a header read between the two is a PPM that ends in its header.
+        if into.exists() and into.stat().st_size > len(b"P6\n0 0\n255\n"):
+            try:
+                return Framebuffer.read(into)
+            except MonitorError:
+                pass
+        time.sleep(0.2)
+    raise MonitorError(f"qemu wrote no readable screen to {into} in {patience:.0f}s")
 
 
 def type_text(path: Path, text: str, pause: float = 0.05) -> None:


### PR DESCRIPTION
`TESTED.md` says CJK text-console rendering is not covered and that `vm-cjk-kernel` does not cover it: that run proves the patched kernel merges and the machine boots, not that a glyph appears. The reason nothing covered it is that the harness had no way to see the screen.

`screendump` does, and its format was measured rather than read about: a live monitor on `-vga std` wrote `P6\n720 400\n255\n`, which is 80 columns of 9 pixels and 25 rows of 16 — so a wide glyph occupies exactly two cells, which is the assertion the next commit can make.

One of the two tests runs against qemu itself and skips where there is none. Three negative controls: always-inked, no size check, and a wrong cell width; all three red.
