### PR TITLE
vm: check that the console draws a wide glyph

### DIFF
--- a/tests/unit/test_harness.py
+++ b/tests/unit/test_harness.py
@@ -6359,3 +6359,76 @@ def test_screendump_reads_a_real_qemu_screen(tmp_path: Path) -> None:
     assert screen.width == 80 * TEXT_CELL_WIDTH, screen.width
     assert screen.height == 25 * TEXT_CELL_HEIGHT, screen.height
     assert len(screen.pixels) == screen.width * screen.height * 3
+
+
+def _screen_with(narrow: int, wide: int) -> Any:
+    """A framebuffer whose two top rows carry ink out to these pixels."""
+    from tests.vm.monitor import TEXT_CELL_HEIGHT, Framebuffer
+
+    width, height = 160, TEXT_CELL_HEIGHT * 3
+    body = bytearray(b"\x00\x00\x00" * width * height)
+    for row, reach in ((0, narrow), (1, wide)):
+        for column in range(reach):
+            at = ((row * TEXT_CELL_HEIGHT + 4) * width + column) * 3
+            body[at : at + 3] = b"\xff\xff\xff"
+    return Framebuffer(width=width, height=height, pixels=bytes(body))
+
+
+def test_a_wide_glyph_is_measured_against_the_same_screens_narrow_row(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """One build shipped `CONFIG_FONT_CJK_16x16` alone, printed the text and
+    drew nothing, and every check in this harness passed. The comparison is
+    between two rows of one screen so that nobody has to say how many pixels
+    a glyph should have: the cell size is the font's to choose.
+    """
+    from dataclasses import replace as _replace
+
+    from gentoo_install.exec.config import load
+    from tests.vm import run as runner
+    from tests.vm.monitor import TEXT_CELL_WIDTH
+
+    cjk = load(Path("tests/fixtures/vm-cjk-kernel.toml"))
+    assert cjk.system.console_cjk, "this fixture is the one that asks for it"
+    plain = _replace(cjk, system=_replace(cjk.system, console_cjk=False))
+
+    class Console:
+        def __init__(self) -> None:
+            self.commands: list[str] = []
+
+        def run(self, command: str, timeout: float = 0.0) -> bytes:
+            self.commands.append(command)
+            return b""
+
+    def _answer(screen: Any) -> None:
+        monkeypatch.setattr(runner, "screendump", lambda *args, **rest: screen)
+
+    # A console asked for nothing is not touched at all.
+    quiet = Console()
+    _answer(_screen_with(0, 0))
+    runner.check_console_glyphs(cast(Any, quiet), plain, tmp_path / "m", tmp_path / "p")
+    assert quiet.commands == [], quiet.commands
+
+    # Two cells per wide character: the pair reaches about twice as far.
+    good = Console()
+    _answer(_screen_with(TEXT_CELL_WIDTH * 2, TEXT_CELL_WIDTH * 4))
+    runner.check_console_glyphs(cast(Any, good), cjk, tmp_path / "m", tmp_path / "p")
+    assert any("/dev/tty1" in one for one in good.commands), good.commands
+    assert any("\\033[2J" in one for one in good.commands), good.commands
+
+    # The fallback: the wide pair drawn in single cells, which is what a
+    # kernel with the wrong font size does.
+    _answer(_screen_with(TEXT_CELL_WIDTH * 2, TEXT_CELL_WIDTH * 2))
+    with pytest.raises(SystemExit, match="fell back"):
+        runner.check_console_glyphs(cast(Any, Console()), cjk, tmp_path / "m", tmp_path / "p")
+
+    # Nothing drawn for the wide pair at all.
+    _answer(_screen_with(TEXT_CELL_WIDTH * 2, 0))
+    with pytest.raises(SystemExit, match="drew nothing for the wide pair"):
+        runner.check_console_glyphs(cast(Any, Console()), cjk, tmp_path / "m", tmp_path / "p")
+
+    # And a screen with no ink anywhere says so rather than reporting the
+    # wide pair missing: an empty comparison proves nothing either way.
+    _answer(_screen_with(0, 0))
+    with pytest.raises(SystemExit, match="cannot say anything"):
+        runner.check_console_glyphs(cast(Any, Console()), cjk, tmp_path / "m", tmp_path / "p")

--- a/tests/vm/run.py
+++ b/tests/vm/run.py
@@ -55,7 +55,7 @@ from .console import (
     passphrase_settle,
     SerialConsole,
 )
-from .monitor import type_text
+from .monitor import TEXT_CELL_WIDTH, screendump, type_text
 from .driver import FIND_DRIVER, REPOSITORY, build as build_driver
 from .media import MEDIA, Medium
 from .qemu import Firmware, Vm, VmSpec
@@ -529,6 +529,61 @@ def unlock_and_login(
     raise SystemExit("the disk kept asking for a passphrase; it is not the one installed")
 
 
+#: What is written to the VGA console to ask whether a wide glyph is drawn.
+#: Two narrow characters on one row and two wide ones on the next, so the
+#: answer is a comparison between two rows of the same screen rather than a
+#: threshold: a console that draws neither, and one that draws the wide pair
+#: in single cells, both fail without anyone having to say how many pixels a
+#: glyph should have.
+NARROW_SAMPLE: Final[str] = "AB"
+WIDE_SAMPLE: Final[str] = "\u4e2d\u6587"
+
+#: Which text rows they are written to.
+NARROW_ROW: Final[int] = 0
+WIDE_ROW: Final[int] = 1
+
+
+def check_console_glyphs(
+    console: SerialConsole, installation: InstallConfig, monitor: Path, into: Path
+) -> None:
+    """Whether the console draws a wide glyph, read off the screen.
+
+    The serial line carries the bytes the guest wrote, not what the console
+    made of them, so every check in this harness passes on a kernel that
+    prints the text and draws nothing: one shipped `CONFIG_FONT_CJK_16x16`
+    alone and was found by a human looking at a screen.
+    """
+    if not installation.system.console_cjk:
+        return
+    console.run(
+        f"printf '\\033[2J\\033[H{NARROW_SAMPLE}\\n{WIDE_SAMPLE}\\n' > /dev/tty1"
+    )
+    console.run("sync")
+    screen = screendump(monitor, into)
+    narrow = screen.inked_columns(NARROW_ROW)
+    wide = screen.inked_columns(WIDE_ROW)
+    if not narrow:
+        raise SystemExit(
+            f"the console drew nothing at all for {NARROW_SAMPLE!r}, so this "
+            "check cannot say anything about the wide pair"
+        )
+    if not wide:
+        raise SystemExit(
+            f"the console drew {NARROW_SAMPLE!r} across {max(narrow) + 1} pixels "
+            f"and drew nothing for the wide pair"
+        )
+    # Each wide character takes two cells, so the pair reaches about twice as
+    # far as the narrow pair. Compared against the same screen's own narrow
+    # row rather than against a pixel count, because the cell size is the
+    # font's to choose.
+    if max(wide) + 1 < TEXT_CELL_WIDTH * len(NARROW_SAMPLE) * 2 - TEXT_CELL_WIDTH:
+        raise SystemExit(
+            f"the console drew the wide pair across {max(wide) + 1} pixels and "
+            f"{NARROW_SAMPLE!r} across {max(narrow) + 1}: a wide glyph takes two "
+            "cells, so this console fell back to a narrow one"
+        )
+
+
 def check_installed(console: SerialConsole, installation: InstallConfig) -> None:
     """Assert against the system that was installed, booted from its own disk."""
     console.run(f"mkdir -p {RESULT_DIR}")
@@ -988,6 +1043,9 @@ def _install_and_check(args: argparse.Namespace, medium: Medium, workdir: Path) 
                 )
                 print(f"[{time.monotonic() - started:5.1f}s] logged into the installed system ({method})")
                 check_installed(console, expected)
+                check_console_glyphs(
+                    console, expected, vm.monitor_socket, workdir / "console.ppm"
+                )
                 power_off(console, vm)
                 code = report(
                     result_disk, keep=args.keep, assertions=expected, booted=True


### PR DESCRIPTION
`TESTED.md` says CJK text-console rendering is not covered. This covers it: two narrow characters on one row, two wide ones on the next, one `screendump`, and the wide row has to reach about twice as far.

The comparison is between two rows of the same screen rather than against a pixel count, because the cell size is the font's to choose. A console that draws neither and one that draws the wide pair in single cells both fail, and a screen with no ink anywhere says the check could not answer rather than reporting the wide pair missing.

Three negative controls: no width check, running when the configuration did not ask, and treating a blank screen as an answer. All three red.
