### PR TITLE
vm: read one memory rule from both runners

### DIFF
--- a/tests/unit/test_harness.py
+++ b/tests/unit/test_harness.py
@@ -6432,3 +6432,33 @@ def test_a_wide_glyph_is_measured_against_the_same_screens_narrow_row(
     _answer(_screen_with(0, 0))
     with pytest.raises(SystemExit, match="cannot say anything"):
         runner.check_console_glyphs(cast(Any, Console()), cjk, tmp_path / "m", tmp_path / "p")
+
+
+def test_one_rule_says_how_much_memory_a_guest_needs() -> None:
+    """`cluster.py` gave a compiling guest 8192 and `qemu.py` gave every local
+    guest a flat `8G`, so the same question had two answers and the local one
+    did not distinguish a desktop from a binary-package install at all.
+    `vm-gnome` was `Killed` compiling `net-libs/webkit-gtk` at 185 minutes.
+    """
+    from gentoo_install.exec.config import load
+    from tests.vm import cluster, qemu, sizing
+
+    heavy = load(Path("tests/fixtures/vm-gnome.toml"))
+    light = load(Path("tests/fixtures/vm-binpkg.toml"))
+    assert sizing.compiles(heavy) and not sizing.compiles(light)
+    assert sizing.memory_mib(heavy) == sizing.HEAVY_MEMORY_MIB
+    assert sizing.memory_mib(light) == sizing.LIGHT_MEMORY_MIB
+    # Larger, and the reason is a measurement rather than a ratio: eight was
+    # what a compiling guest had when webkit-gtk was killed in one.
+    assert sizing.HEAVY_MEMORY_MIB > 8192, sizing.HEAVY_MEMORY_MIB
+
+    # And both runners read that one rule rather than restating it.
+    assert cluster.HEAVY_MEMORY_MIB == sizing.HEAVY_MEMORY_MIB
+    assert cluster.GUEST_MEMORY_MIB == sizing.LIGHT_MEMORY_MIB
+    assert qemu.VmSpec.memory == f"{sizing.LIGHT_MEMORY_MIB}M", qemu.VmSpec.memory
+    # The local runner asks the rule for every run that installs something:
+    # its default is only for a run with no configuration, such as probing a
+    # medium.
+    source = Path("tests/vm/run.py").read_text()
+    assert "memory_mib(load(" in source, source[:0]
+    assert "memory=wanted_memory" in source, source[:0]

--- a/tests/unit/test_proxmox.py
+++ b/tests/unit/test_proxmox.py
@@ -1907,9 +1907,19 @@ def test_a_guest_that_compiles_is_given_a_whole_node() -> None:
 
 
 def test_a_node_with_one_light_slot_left_is_not_given_a_heavy_guest() -> None:
-    """A heavy guest asks for twice the memory, so a slot list built from the
-    light size does not answer for it."""
-    from tests.vm.cluster import GUEST_MEMORY_MIB, NODE_HEADROOM_BYTES, room_for
+    """A heavy guest asks for more memory, so a slot list built from the light
+    size does not answer for it.
+
+    Both sizes come from `sizing.py` rather than from a ratio spelled here: it
+    said "twice" and stayed true only while heavy was 8192 against 4096, which
+    stopped being so when `vm-gnome` was `Killed` compiling webkit-gtk.
+    """
+    from tests.vm.cluster import (
+        GUEST_MEMORY_MIB,
+        HEAVY_MEMORY_MIB,
+        NODE_HEADROOM_BYTES,
+        room_for,
+    )
     from tests.vm.cluster import fixtures as cluster_fixtures
     from tests.vm.proxmox import Node
 
@@ -1925,11 +1935,12 @@ def test_a_node_with_one_light_slot_left_is_not_given_a_heavy_guest() -> None:
 
     two_slots = Node(
         name="infra-node2",
-        free_bytes=NODE_HEADROOM_BYTES + 2 * GUEST_MEMORY_MIB * 1024**2,
+        free_bytes=NODE_HEADROOM_BYTES + HEAVY_MEMORY_MIB * 1024**2,
         cores=4,
             free_cores=64.0,
     )
     assert room_for(two_slots, heavy)
+    assert HEAVY_MEMORY_MIB > GUEST_MEMORY_MIB, (HEAVY_MEMORY_MIB, GUEST_MEMORY_MIB)
 
 
 def test_a_broken_pipe_is_a_dropped_console_and_not_a_dead_run() -> None:

--- a/tests/vm/cluster.py
+++ b/tests/vm/cluster.py
@@ -48,6 +48,7 @@ from contextlib import contextmanager
 from typing import Final, Iterator, Protocol, TypeVar, cast, Sequence
 
 from .expectations import EXPECTATIONS, Expectation
+from . import sizing
 from .sizing import compiles
 
 from gentoo_install.model.config import Firmware as BootFirmware
@@ -190,8 +191,8 @@ EXTRA_CMDLINE: Final[str] = "console=ttyS0,115200"
 #: with about 6 GiB spare can each take one instead of none: the installer
 #: warns below 5 GiB and builds in `/var/tmp` rather than a tmpfs, which is
 #: slower and correct. Two cores of a node's four leaves it able to answer the
-#: API while a build runs.
-GUEST_MEMORY_MIB: Final[int] = 4096
+#: API while a build runs. The number itself is `sizing.py`'s.
+GUEST_MEMORY_MIB: Final[int] = sizing.LIGHT_MEMORY_MIB
 GUEST_CORES: Final[int] = 2
 TARGET_GIB: Final[int] = 40
 
@@ -199,8 +200,8 @@ TARGET_GIB: Final[int] = 40
 #: is an hour of `emerge` where a binary-package fixture is six minutes, and
 #: giving both the same two cores left the cluster idle while the queue was
 #: deep. A node has four cores, so a heavy guest takes all of them and the
-#: node carries one; the memory is what `MAKEOPTS -j4` needs to link.
-HEAVY_MEMORY_MIB: Final[int] = 8192
+#: node carries one; the memory is `sizing.py`'s, which both runners read.
+HEAVY_MEMORY_MIB: Final[int] = sizing.HEAVY_MEMORY_MIB
 HEAVY_CORES: Final[int] = 4
 
 #: What a compiling guest costs `--limit`, the same number

--- a/tests/vm/qemu.py
+++ b/tests/vm/qemu.py
@@ -13,6 +13,7 @@ from types import TracebackType
 from typing import Final, Self
 
 from .media import Medium
+from .sizing import LIGHT_MEMORY_MIB
 from .results import RESULT_SERIAL
 
 OVMF_CODE = Path("/usr/share/edk2-ovmf/OVMF_CODE_4M.qcow2")
@@ -51,7 +52,11 @@ class VmSpec:
     medium: Medium
     workdir: Path
     firmware: Firmware = Firmware.UEFI
-    memory: str = "8G"
+    #: A flat figure was every local guest's, whatever it installed, while
+    #: `cluster.py` gave a compiling one twice what it gave the rest. Callers
+    #: with a configuration pass `sizing.memory_mib`; this default is for the
+    #: ones that have none, such as probing a medium.
+    memory: str = f"{LIGHT_MEMORY_MIB}M"
     #: MAKEOPTS in the guest is derived from this, so it decides how fast the
     #: packages a fixture compiles are built. Five leaves 32 threads covering
     #: six guests at once.

--- a/tests/vm/run.py
+++ b/tests/vm/run.py
@@ -56,6 +56,7 @@ from .console import (
     SerialConsole,
 )
 from .monitor import TEXT_CELL_WIDTH, screendump, type_text
+from .sizing import LIGHT_MEMORY_MIB, memory_mib
 from .driver import FIND_DRIVER, REPOSITORY, build as build_driver
 from .media import MEDIA, Medium
 from .qemu import Firmware, Vm, VmSpec
@@ -1005,9 +1006,17 @@ def _install_and_check(args: argparse.Namespace, medium: Medium, workdir: Path) 
             seed = SEEDED.get(Path(args.install).stem if args.install else "", ())
             targets = tuple(create_target(path, args.target_size, seed) for path in wanted)
 
+    # From the configuration, not a flat number: `vm-gnome` was `Killed`
+    # compiling webkit-gtk in a guest given what every other one is given.
+    wanted_memory = (
+        f"{memory_mib(load(REPOSITORY / 'tests' / args.install))}M"
+        if args.install
+        else f"{LIGHT_MEMORY_MIB}M"
+    )
     spec = VmSpec(
         medium=medium,
         workdir=workdir,
+        memory=wanted_memory,
         **({"cpus": args.cpus} if args.cpus else {}),
         firmware=Firmware(args.firmware),
         ssh_port=ssh_port,

--- a/tests/vm/sizing.py
+++ b/tests/vm/sizing.py
@@ -12,6 +12,8 @@ no binary host at all.
 
 from __future__ import annotations
 
+from typing import Final
+
 from gentoo_install.model.config import InstallConfig
 from gentoo_install.model.device import ZfsPool
 
@@ -32,3 +34,27 @@ def compiles(config: InstallConfig) -> bool:
     if config.kernel.source.value.endswith("-bin"):
         return bool(config.packages.desktop) or not config.portage.binhost.official
     return True
+
+
+#: What a guest that does not compile is given. Four gibibytes rather than
+#: six, so the three nodes with about 6 GiB spare can each take one instead of
+#: none: the installer warns below 5 GiB and builds in `/var/tmp` rather than
+#: a tmpfs, which is slower and correct.
+LIGHT_MEMORY_MIB: Final[int] = 4096
+
+#: What a guest that compiles is given. Twelve rather than eight: the comment
+#: this replaced said eight "is what `MAKEOPTS -j4` needs to link", and
+#: `vm-gnome` was `Killed` compiling `net-libs/webkit-gtk` at 185 minutes with
+#: exactly that. Two gibibytes a job is the figure the handbook gives, and it
+#: was not enough for that one.
+HEAVY_MEMORY_MIB: Final[int] = 12288
+
+
+def memory_mib(config: InstallConfig) -> int:
+    """How much memory this configuration's guest needs.
+
+    Here rather than in either runner: `cluster.py` gave a compiling guest
+    8192 and `qemu.py` gave every local guest a flat `8G`, so one rule had two
+    spellings and neither was tied to a measurement that held.
+    """
+    return HEAVY_MEMORY_MIB if compiles(config) else LIGHT_MEMORY_MIB


### PR DESCRIPTION
`vm-gnome` failed round fourteen at 185 minutes. The verdict named a boost compile, and the guest's own log names the cause: `Killed`, then `ERROR: net-libs/webkit-gtk-2.52.5-r410::gentoo failed`. The comment beside `HEAVY_MEMORY_MIB` said 8192 "is what `MAKEOPTS -j4` needs to link", and that guest had exactly it.

Same shape as the passphrase loops and the mirror sites: one rule, several readers. `cluster.py` had 8192 for a compiling guest, `qemu.py` had a flat `8G` for every local guest whatever it installed, and `test_proxmox.py` spelled it a third time as "twice the light size" — true only while heavy was 8192 against 4096. All three now read `sizing.py`, which already owned the heavy/light question for `--limit`.

Three negative controls: always-light, the flat local figure back, and heavy back to 8192. All three red — and the first version of this had no test at all, so that control passed green until one was written.
