### PR TITLE
vm: derive the glyph cell from the screen being read

### DIFF
--- a/tests/unit/test_harness.py
+++ b/tests/unit/test_harness.py
@@ -6386,8 +6386,6 @@ def test_a_wide_glyph_is_measured_against_the_same_screens_narrow_row(
 
     from gentoo_install.exec.config import load
     from tests.vm import run as runner
-    from tests.vm.monitor import TEXT_CELL_WIDTH
-
     cjk = load(Path("tests/fixtures/vm-cjk-kernel.toml"))
     assert cjk.system.console_cjk, "this fixture is the one that asks for it"
     plain = _replace(cjk, system=_replace(cjk.system, console_cjk=False))
@@ -6409,21 +6407,24 @@ def test_a_wide_glyph_is_measured_against_the_same_screens_narrow_row(
     runner.check_console_glyphs(cast(Any, quiet), plain, tmp_path / "m", tmp_path / "p")
     assert quiet.commands == [], quiet.commands
 
-    # Two cells per wide character: the pair reaches about twice as far.
+    # Two cells per wide character: the pair reaches about twice as far. The
+    # cell here is 8 rather than `TEXT_CELL_WIDTH`, because that is what the
+    # installed system's framebuffer console actually draws and the check
+    # derives the cell from the screen rather than from the constant.
     good = Console()
-    _answer(_screen_with(TEXT_CELL_WIDTH * 2, TEXT_CELL_WIDTH * 4))
+    _answer(_screen_with(8 * 2, 8 * 4))
     runner.check_console_glyphs(cast(Any, good), cjk, tmp_path / "m", tmp_path / "p")
     assert any("/dev/tty1" in one for one in good.commands), good.commands
     assert any("\\033[2J" in one for one in good.commands), good.commands
 
     # The fallback: the wide pair drawn in single cells, which is what a
     # kernel with the wrong font size does.
-    _answer(_screen_with(TEXT_CELL_WIDTH * 2, TEXT_CELL_WIDTH * 2))
+    _answer(_screen_with(8 * 2, 8 * 2))
     with pytest.raises(SystemExit, match="fell back"):
         runner.check_console_glyphs(cast(Any, Console()), cjk, tmp_path / "m", tmp_path / "p")
 
     # Nothing drawn for the wide pair at all.
-    _answer(_screen_with(TEXT_CELL_WIDTH * 2, 0))
+    _answer(_screen_with(8 * 2, 0))
     with pytest.raises(SystemExit, match="drew nothing for the wide pair"):
         runner.check_console_glyphs(cast(Any, Console()), cjk, tmp_path / "m", tmp_path / "p")
 
@@ -6431,6 +6432,16 @@ def test_a_wide_glyph_is_measured_against_the_same_screens_narrow_row(
     # wide pair missing: an empty comparison proves nothing either way.
     _answer(_screen_with(0, 0))
     with pytest.raises(SystemExit, match="cannot say anything"):
+        runner.check_console_glyphs(cast(Any, Console()), cjk, tmp_path / "m", tmp_path / "p")
+
+    # A wider cell than either mode measured here, to show the threshold moves
+    # with the screen rather than with a constant: a 16-wide cell needs the
+    # wide pair out at 48, and 32 is a narrow fallback at that size even
+    # though it would have passed as a wide pair on an 8-wide cell.
+    _answer(_screen_with(16 * 2, 16 * 4))
+    runner.check_console_glyphs(cast(Any, Console()), cjk, tmp_path / "m", tmp_path / "p")
+    _answer(_screen_with(16 * 2, 16 * 2))
+    with pytest.raises(SystemExit, match="fell back"):
         runner.check_console_glyphs(cast(Any, Console()), cjk, tmp_path / "m", tmp_path / "p")
 
 

--- a/tests/vm/monitor.py
+++ b/tests/vm/monitor.py
@@ -102,11 +102,17 @@ def keys_for(text: str) -> list[str]:
 #: and a file write; the wait is for the monitor to get to the command.
 DUMP_PATIENCE: Final[float] = 10.0
 
-#: What VGA text mode gives, measured rather than assumed: `screendump` on a
-#: guest with `-vga std` and nothing booted wrote `P6\n720 400\n255\n`, which
-#: is 80 columns of 9 pixels and 25 rows of 16.
-TEXT_CELL_WIDTH: Final[int] = 9
+#: The row height every mode measured here uses, because both draw an 8x16
+#: font: VGA text mode on a guest with nothing booted wrote `P6\n720 400\n255\n`
+#: and an installed system came up on a 1280x800 framebuffer console, and 800
+#: and 400 are both whole multiples of this.
 TEXT_CELL_HEIGHT: Final[int] = 16
+
+#: What that VGA text mode gives per column. Only that mode: the same
+#: installed system's framebuffer console draws 8-wide cells, so anything
+#: comparing glyph widths derives the cell from the screen it is reading
+#: rather than from this.
+TEXT_CELL_WIDTH: Final[int] = 9
 
 
 @dataclass(frozen=True)

--- a/tests/vm/run.py
+++ b/tests/vm/run.py
@@ -55,7 +55,7 @@ from .console import (
     passphrase_settle,
     SerialConsole,
 )
-from .monitor import TEXT_CELL_WIDTH, screendump, type_text
+from .monitor import screendump, type_text
 from .sizing import LIGHT_MEMORY_MIB, memory_mib
 from .driver import FIND_DRIVER, REPOSITORY, build as build_driver
 from .media import MEDIA, Medium
@@ -573,15 +573,21 @@ def check_console_glyphs(
             f"the console drew {NARROW_SAMPLE!r} across {max(narrow) + 1} pixels "
             f"and drew nothing for the wide pair"
         )
-    # Each wide character takes two cells, so the pair reaches about twice as
-    # far as the narrow pair. Compared against the same screen's own narrow
-    # row rather than against a pixel count, because the cell size is the
-    # font's to choose.
-    if max(wide) + 1 < TEXT_CELL_WIDTH * len(NARROW_SAMPLE) * 2 - TEXT_CELL_WIDTH:
+    # The cell width comes from the narrow row of this same screen, not from a
+    # constant: `TEXT_CELL_WIDTH` is 9 because that is what VGA text mode gave
+    # a guest with nothing booted, and the installed system came up on a
+    # 1280x800 framebuffer console whose cells are 8 wide. One measurement
+    # covered one input, and the threshold passed here by luck.
+    cell = (max(narrow) + 1) / len(NARROW_SAMPLE)
+    # Two cells per wide character, less one cell of slack for a glyph that
+    # does not ink its last column.
+    wanted = cell * len(WIDE_SAMPLE) * 2 - cell
+    if max(wide) + 1 < wanted:
         raise SystemExit(
             f"the console drew the wide pair across {max(wide) + 1} pixels and "
-            f"{NARROW_SAMPLE!r} across {max(narrow) + 1}: a wide glyph takes two "
-            "cells, so this console fell back to a narrow one"
+            f"{NARROW_SAMPLE!r} across {max(narrow) + 1}, so a cell is {cell:.0f} "
+            f"wide and the pair should reach {wanted:.0f}: this console fell "
+            "back to a narrow glyph"
         )
 
 


### PR DESCRIPTION
The wide-glyph check ran against a real machine for the first time and worked: `AB` reached 15 pixels, the wide pair reached 31, so the CJK console does draw two cells per character — the first measurement of that anywhere in this repository.

It also showed the check was reading a constant that does not apply. `TEXT_CELL_WIDTH` is 9 because `screendump` on `-vga std` with nothing booted wrote `720 400`; the installed system came up on a 1280x800 framebuffer console with 8-wide cells. The threshold was 27 and the reading was 31, so it passed by four pixels of luck. One measurement covered one input.

The cell now comes from the narrow row of the same screen, so the check holds in any display mode. A test at a 16-wide cell shows the threshold moving with the screen: a reading that passes as a wide pair on an 8-wide cell is a narrow fallback there. Control: a hardcoded cell of 8, red.
