### PR TITLE
tui: do not wipe the screen on a resize the terminal can hold

### DIFF
--- a/gentoo_install/tui/curses_screen.py
+++ b/gentoo_install/tui/curses_screen.py
@@ -123,9 +123,9 @@ class CursesScreen:
             if pressed != "KEY_RESIZE" and not too_small(self):
                 return pressed
             curses.update_lines_cols()
-            self._window.erase()
             if not too_small(self):
                 return pressed
+            self._window.erase()
             self._show_too_small()
             if pressed in ("\x1b", "\x03"):
                 return pressed

--- a/tests/unit/test_tui_curses.py
+++ b/tests/unit/test_tui_curses.py
@@ -783,3 +783,69 @@ def test_a_row_opened_before_a_resize_draws_inside_the_new_frame() -> None:
     # box around it were gone.
     assert result["left"].strip().startswith("row"), result
     assert result["title"].startswith("gentoo-install"), result
+
+
+def test_an_accepted_resize_does_not_wipe_the_screen(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Erasing here is what made the frame disappear intermittently.
+
+    `Region` redraws the frame when the screen's size differs from the one it
+    last drew at, and any `size()` call updates that. A resize that erased the
+    window and then found the size already recorded left the frame wiped and
+    nothing to put it back: `test_a_row_opened_before_a_resize_draws_inside_
+    the_new_frame` failed twice in fifteen runs, and once in twenty with the
+    driver's quiet window raised to three seconds, so it was not the harness
+    waiting too little. The caller redraws on `KEY_RESIZE` and `TwoPane.frame`
+    clears the screen itself, so the erase was never what removed stale
+    content.
+    """
+    import curses as curses_module
+
+    from gentoo_install.tui.curses_screen import CursesScreen
+
+    # Only the module-level calls the constructor makes outside a terminal.
+    # The window itself is the fake below, so what is under test -- whether
+    # `key` erases -- is answered by the real code.
+    monkeypatch.setattr(curses_module, "update_lines_cols", lambda: None)
+    monkeypatch.setattr(curses_module, "raw", lambda: None)
+    monkeypatch.setattr(curses_module, "has_colors", lambda: False)
+    monkeypatch.setattr(curses_module, "keyname", lambda key: b"KEY_RESIZE")
+
+    class Window:
+        def __init__(self, size: tuple[int, int], keys: list[int | str]) -> None:
+            self._size = size
+            self._keys = keys
+            self.erased = 0
+
+        def get_wch(self) -> int | str:
+            return self._keys.pop(0)
+
+        def getmaxyx(self) -> tuple[int, int]:
+            return self._size
+
+        def erase(self) -> None:
+            self.erased += 1
+
+        def addstr(self, *args: Any, **rest: Any) -> None:
+            return None
+
+        def refresh(self) -> None:
+            return None
+
+        def clrtoeol(self) -> None:
+            return None
+
+        def nodelay(self, flag: bool) -> None:
+            return None
+
+    resize = curses_module.KEY_RESIZE
+    roomy = Window((40, 120), [resize])
+    assert CursesScreen(roomy).key() == "KEY_RESIZE"
+    assert roomy.erased == 0, "an accepted resize wiped the frame off the screen"
+
+    # A resize that leaves the terminal unusable still erases: the message it
+    # puts up needs the screen to itself, and no frame survives that size.
+    cramped = Window((4, 20), [resize, "\x1b"])
+    assert CursesScreen(cramped).key() == "\x1b"
+    assert cramped.erased >= 1, "the too-small screen was drawn over the old layout"


### PR DESCRIPTION
`test_a_row_opened_before_a_resize_draws_inside_the_new_frame` failed twice in fifteen runs. It was not the harness waiting too little: raising the driver's quiet window from 0.35s to 3s still failed once in twenty, and the failing screen had the right size and region with row 3 blank — the frame gone after three full seconds of silence.

`CursesScreen.key()` erased the window before deciding the new size was usable. `Region` redraws the frame only when `screen.size()` differs from the size it last drew at, and any `size()` call updates that record, so whenever one landed between `update_lines_cols()` and the erase, the erase wiped the frame and the redraw was skipped. That is the intermittency: it depends on where a `size()` call falls.

Nothing needed the erase — the caller redraws on `KEY_RESIZE` and `TwoPane.frame` clears the screen itself. A resize that leaves the terminal too small still erases, because the message it puts up needs the screen to itself.

25 runs of the pty test after the change, no failures. The new unit test drives the real `key()` against a fake window and is red with the erase restored.
