### PR TITLE
netboot: delete a helper nothing calls

### DIFF
--- a/gentoo_install/plan/netboot.py
+++ b/gentoo_install/plan/netboot.py
@@ -1199,10 +1199,6 @@ def _without_previous(text: str) -> str:
     return before + after.lstrip("\n")
 
 
-def _under(path: PurePosixPath, parent: str) -> bool:
-    return str(path).startswith(parent.rstrip("/") + "/")
-
-
 def _only_image(context: Context, place: PurePosixPath, suffix: str) -> PurePosixPath:
     """The one file of that kind in the directory this plan owns."""
     said = context.run(["ls", "--almost-all", str(place)], check=False)


### PR DESCRIPTION
`_under` in `plan/netboot.py` has one occurrence in the repository, its own definition. `exec/probe.py` has a function of the same name with its own callers, which is what made it look used.

Found by a read-only audit agent. Two of that agent's other three claims did not survive checking: `DECLINES` is called from `tests/vm/ram.py`, and `CJK_SANS_ORDER` is read by a test. The agent had six files and reported "unreachable" from that scope alone.
