### PR TITLE
portage: say that the stage3's own binrepo is disabled now

### DIFF
--- a/gentoo_install/plan/portage.py
+++ b/gentoo_install/plan/portage.py
@@ -942,10 +942,11 @@ class Emerge(Operation):
     repository_bootstrap: bool = False
     mode: InstallMode = InstallMode.NORMAL
     source: SourcePolicy = SourcePolicy.binaries_allowed()
-    #: Whether this run has a binary host at all. The stage3 ships an enabled
-    #: `binrepos.conf` for the official one, so `--getbinpkg=y` reaches it
-    #: even when the configuration turned every host off: `ext2` compiled 48
-    #: packages and fetched 20 from a host it had not asked for.
+    #: Whether this run has a binary host at all, which decides `--getbinpkg`.
+    #: The stage3 ships an enabled `binrepos.conf` for the official one and
+    #: `ext2` once compiled 48 packages while fetching 20 from a host it had
+    #: not asked for; `build()` now schedules `DisableBinhost(name="gentoo")`
+    #: before any emerge, so that host is gone rather than merely unasked for.
     binary_host: bool = True
     #: What to degrade rather than fail, when this emerge is what enables an
     #: optional path. Empty means the install stops, which is right for


### PR DESCRIPTION
The comment on `Emerge.binary_host` said the stage3 ships an enabled `binrepos.conf` "so `--getbinpkg=y` reaches it even when the configuration turned every host off". `build()` appends `DisableBinhost(name="gentoo")` unconditionally, before the `if uses_binhost(portage)` block that restores one, so that host is removed rather than left live. The `ext2` incident that motivated the field is kept, because it is why the field exists.

From a read-only audit agent, and it was the one claim of four that survived checking. Two described past-tense clauses as present claims — the `fallbacks` comment says the stage3 fetch *was* the one step with no second address, and the field it annotates is the fix — and one read "One thread at a time" as an assertion that a lock exists rather than a contract for the caller.
