### PR TITLE
tui: read the same encryption fact the rules read

### DIFF
--- a/gentoo_install/tui/settings.py
+++ b/gentoo_install/tui/settings.py
@@ -559,7 +559,10 @@ def _encryption(config: InstallConfig, context: Context) -> str:
     is built from `context.layout`, so the choice said `on` over a layout that
     carried no container and the machine came up unencrypted."""
     graph = config.disk.graph
-    if graph.of_type(Luks) or any(pool.passphrase_file for pool in graph.of_type(ZfsPool)):
+    # `encrypted`, not `passphrase_file`: `validate.py` refuses a file without
+    # the flag and allows the flag without a file, so a pool keyed any other
+    # way is encrypted to every rule in `compat.py` and read as `off` here.
+    if graph.of_type(Luks) or any(pool.encrypted for pool in graph.of_type(ZfsPool)):
         return context.translate("on")
     return context.translate("off")
 

--- a/tests/unit/test_every_row.py
+++ b/tests/unit/test_every_row.py
@@ -321,3 +321,31 @@ def test_no_row_loses_its_value_when_it_is_opened_again() -> None:
             wrong.append(f"{row.key}: chose {chose!r}, reopened as {row.value(again.unwrap(), at)!r}")
     assert not wrong, wrong
     assert walked > 10, walked
+
+
+def test_an_encrypted_pool_with_no_key_file_still_reads_as_encrypted() -> None:
+    """The row asked whether a pool had a `passphrase_file`; every rule in
+    `compat.py` asks whether it is `encrypted`.
+
+    `validate.py` refuses a file without the flag and allows the flag without
+    a file, so a pool keyed any other way is encrypted to the planner and to
+    the compatibility table while the menu said `off` — the operator reads one
+    answer and the install performs the other.
+    """
+    from gentoo_install.model.compat import _encrypted_pool
+    from gentoo_install.model.device import ZfsPool
+
+    from .layouts import zfs_root
+
+    layout = zfs_root()
+    installation = config(layout)
+    pools = installation.disk.graph.of_type(ZfsPool)
+    assert pools and pools[0].encrypted, pools
+    assert not pools[0].passphrase_file, pools[0].passphrase_file
+
+    assert _encrypted_pool(installation.disk.graph, installation.disk.root)
+
+    row = next(one for one in every_row() if one.key == "encryption")
+    at = context()
+    at.columns = 100
+    assert row.value(installation, at) == "on", row.value(installation, at)


### PR DESCRIPTION
`validate.py` refuses a `passphrase_file` without `encrypted` and allows `encrypted` without a file, so a pool keyed any other way is encrypted to `compat._encrypted_pool` and to the planner while the menu read `off`. The operator reads one answer and the install performs the other.

`tests/unit/layouts.py::zfs_root` already builds exactly that pool, so the test needed no new fixture. Control: the old predicate restored, `assert 'off' == 'on'`.

Found by a read-only audit agent looking for one rule with two spellings — the class this repository keeps hitting. Of that agent's first four claims this is the one I could confirm; the others describe divergences whose two sides answer different questions.
