### PR TITLE
tui: key the layout row on the member, not on its string

### DIFF
--- a/gentoo_install/tui/settings.py
+++ b/gentoo_install/tui/settings.py
@@ -27,6 +27,7 @@ from ..model.config import (
 )
 from ..model.compat import CJK_KERNELS, KERNEL_PACKAGES
 from ..model import compat, mirrors
+from ..model.templates import Layout
 from ..model.device import (
     DeviceGraph,
     DeviceId,
@@ -477,17 +478,24 @@ def _layout(config: InstallConfig, context: Context) -> str:
         return context.translate("manual, {count} partitions").format(
             count=len(context.layout.slices)
         )
-    if context.choice.layout.value == "whole-disk":
-        layout = context.translate("whole-disk")
-    elif context.choice.layout.value == "whole-disk-btrfs":
-        layout = context.translate("whole-disk-btrfs")
-    elif context.choice.layout.value == "whole-disk-zfs":
-        layout = context.translate("whole-disk-zfs")
-    else:
-        layout = context.translate("reuse")
-    if context.choice.layout.value.startswith("whole-disk"):
-        return f"{layout} ({context.translate('erases the disk')})"
-    return layout
+    # Keyed on the member, not on its string. Spelled out as three `==`
+    # branches and a `startswith`, a fourth whole-disk layout fell to the
+    # `else` and was labelled `reuse` while the prefix test still added
+    # `erases the disk`: the row that decides whether a disk is wiped said
+    # both. A member with no label here raises rather than mislabels, and
+    # `test_every_layout_has_a_label` refuses one before it can.
+    labels = {
+        Layout.WHOLE_DISK: context.translate("whole-disk"),
+        Layout.WHOLE_DISK_BTRFS: context.translate("whole-disk-btrfs"),
+        Layout.WHOLE_DISK_ZFS: context.translate("whole-disk-zfs"),
+        Layout.REUSE: context.translate("reuse"),
+    }
+    layout = labels[context.choice.layout]
+    # Whether it erases is whether it builds a table at all, which is what
+    # `Layout.REUSE` is defined as not doing.
+    if context.choice.layout is Layout.REUSE:
+        return layout
+    return f"{layout} ({context.translate('erases the disk')})"
 
 
 def _template_writes_the_table(config: InstallConfig, context: Context) -> str:

--- a/tests/unit/test_every_row.py
+++ b/tests/unit/test_every_row.py
@@ -349,3 +349,32 @@ def test_an_encrypted_pool_with_no_key_file_still_reads_as_encrypted() -> None:
     at = context()
     at.columns = 100
     assert row.value(installation, at) == "on", row.value(installation, at)
+
+
+def test_every_layout_has_a_label_and_only_reuse_keeps_the_disk() -> None:
+    """The row compared `layout.value` against three strings and then tested
+    `startswith("whole-disk")` for the warning.
+
+    A fourth whole-disk layout would fall to the `else` and be labelled
+    `reuse` while the prefix test still added `erases the disk`, so the row
+    that decides whether a disk is wiped would have said both. Over the enum
+    rather than over the three that exist today: a member added without a
+    label has to fail here, not in front of an operator.
+    """
+    from gentoo_install.model.templates import Layout
+
+    from .layouts import ext4_on_gpt
+
+    row = next(one for one in every_row() if one.key == "layout")
+    installation = config(ext4_on_gpt())
+    for member in Layout:
+        at = context()
+        at.columns = 100
+        at.manual = False
+        at.choice = replace(at.choice, layout=member)
+        shown = row.value(installation, at)
+        assert shown, member
+        erases = "erases the disk" in shown
+        assert erases is (member is not Layout.REUSE), (member, shown)
+        # And the label is the member's own, not another member's.
+        assert member.value in shown or member is Layout.REUSE, (member, shown)


### PR DESCRIPTION
`_layout` compared `context.choice.layout.value` against `"whole-disk"`, `"whole-disk-btrfs"` and `"whole-disk-zfs"`, fell through to `reuse` for anything else, and then decided the warning with `startswith("whole-disk")`. A fourth whole-disk layout gets both halves wrong at once and the operator reads `reuse (erases the disk)` on the row that decides whether their disk is wiped.

Keyed on the member now, so an unlabelled one raises instead of mislabelling, and `test_every_layout_has_a_label_and_only_reuse_keeps_the_disk` iterates `Layout` rather than the three that exist today. Control: a `WHOLE_DISK_XFS` member added, `KeyError`.

The first attempt used `translate(layout.value)` and dropped the literals, which made the keys invisible to `test_the_catalogs_hold_every_string_the_interface_shows` — that scanner reads `translate("...")` literals, and it caught the regression immediately. The literals stay.

From a read-only audit agent; this is the second of its ten claims to survive checking.
