### PR TITLE
model: an omitted extent parses to nothing, not to an empty share

### DIFF
--- a/gentoo_install/model/parse.py
+++ b/gentoo_install/model/parse.py
@@ -504,6 +504,12 @@ def _extent(raw: Mapping[str, Any], at: str) -> tuple[Size | None, Share | None]
                 "it does not already say; bound a share or a rest instead"
             )
         return Size.parse(written), None
+    if written is None and not bounded:
+        # Nothing written is `share=None`, which is what `templates.build`
+        # constructs for the same partition. Answering `Share()` instead made
+        # every template fail export-then-import equality: the two mean the
+        # same to `takes_the_rest` and compare unequal.
+        return None, None
     percent: Decimal | None = None
     if written is not None and written.endswith("%"):
         try:

--- a/tests/unit/test_serialise.py
+++ b/tests/unit/test_serialise.py
@@ -9,11 +9,14 @@ from pathlib import Path
 import pytest
 
 from gentoo_install.exec.config import load
-from gentoo_install.model.config import InstallConfig, Overlay, PortageConfig, ProxyConfig, User
+from gentoo_install.model.config import DiskConfig, InstallConfig, Overlay, PortageConfig, ProxyConfig, User
 from gentoo_install.model.config import ProxyKind
 from gentoo_install.model.device import DeviceGraph, DeviceId, Existing, Node, PartitionTable
 from gentoo_install.model.parse import parse
 from gentoo_install.model.serialise import KINDS, REDACTED, SECRET, to_toml
+from gentoo_install.model import templates
+from gentoo_install.model.templates import Layout
+from gentoo_install.model.config import Firmware
 
 FIXTURES = Path(__file__).resolve().parents[1] / "fixtures"
 
@@ -26,6 +29,32 @@ def _round_trip(config: InstallConfig) -> InstallConfig:
 def test_every_fixture_survives_a_round_trip(path: Path) -> None:
     config = parse(tomllib.loads(path.read_text()))
     assert _round_trip(config) == config
+
+@pytest.mark.parametrize(
+    "layout",
+    [one for one in Layout if one is not Layout.REUSE],
+    ids=lambda one: one.value,
+)
+def test_every_template_the_menu_builds_survives_a_round_trip(layout: Layout) -> None:
+    """The fixtures above all came from TOML, so they agreed by construction:
+    a second parse of what a first parse produced cannot disagree with it.
+
+    What an operator exports is not a fixture. `templates.build` constructs
+    the graph in Python, and its `rootpart` carried `share=None` while an
+    omitted `size` parsed back as an empty `Share` — the same answer to
+    `takes_the_rest` and a different object, so every export-then-import of a
+    menu-built configuration compared unequal.
+    """
+    graph, root = templates.build(
+        templates.Choice(
+            disk="/dev/disk/by-id/virtio-target0",
+            layout=layout,
+            firmware=Firmware.UEFI,
+        )
+    )
+    config = InstallConfig(disk=DiskConfig(graph=graph, root=root))
+    assert _round_trip(config) == config
+
 
 def test_a_dd_configuration_survives_a_round_trip() -> None:
     configuration = parse(


### PR DESCRIPTION
Export a configuration from the menu, import it again, and the result did not equal what was exported. `templates.build` constructs a rest partition with `share=None`; parsing a partition with no `size`, `min` or `max` answered `Share(percent=None, minimum=None, maximum=None)`. Both mean the same to `takes_the_rest`, and they compare unequal — so the identity an operator relies on for a saved configuration did not hold for any of the three templates.

`test_every_fixture_survives_a_round_trip` could not see it: every fixture came from TOML, so a second parse of a first parse's output agrees by construction. The new test parametrises over `Layout` instead, which is what the menu actually builds.

Control: the new branch disabled, three parametrised cases red.

From a read-only audit agent. It described the case as `Partition(size=None, share=None)` and reported it against the fixtures, where it does not reproduce; running the templates through is what showed it.
