### PR TITLE
tui: an encrypted pool prompts at boot, so the keymap row matters

### DIFF
--- a/gentoo_install/tui/settings.py
+++ b/gentoo_install/tui/settings.py
@@ -370,7 +370,14 @@ def _unlock_keymap(config: InstallConfig, context: Context) -> str:
     prompt that will not appear.
     """
     graph = config.disk.graph
-    if not graph.of_type(Luks) and not config.kernel.remote_unlock.enabled:
+    # An encrypted pool as well as a container: `compat._encrypted_pool` says
+    # native ZFS encryption "prompts for a passphrase exactly as a LUKS
+    # container does", and this row told the operator no keyboard mattered
+    # for a prompt that appears.
+    encrypted = graph.of_type(Luks) or any(
+        pool.encrypted for pool in graph.of_type(ZfsPool)
+    )
+    if not encrypted and not config.kernel.remote_unlock.enabled:
         return context.translate("nothing is unlocked at boot")
     chosen = config.system.keymap_initramfs
     if chosen:

--- a/tests/unit/test_every_row.py
+++ b/tests/unit/test_every_row.py
@@ -378,3 +378,21 @@ def test_every_layout_has_a_label_and_only_reuse_keeps_the_disk() -> None:
         assert erases is (member is not Layout.REUSE), (member, shown)
         # And the label is the member's own, not another member's.
         assert member.value in shown or member is Layout.REUSE, (member, shown)
+
+
+def test_an_encrypted_pool_needs_an_initramfs_keymap_too() -> None:
+    """The row said `nothing is unlocked at boot` for an encrypted ZFS root.
+
+    `compat._encrypted_pool` says native ZFS encryption prompts for a
+    passphrase exactly as a LUKS container does, and `zbm-unlock` and
+    `vm-zfs-encrypted` both answer that prompt on a real machine, so the
+    operator was told no keyboard layout mattered for a prompt that appears.
+    Same rule as the encryption row, one reader behind.
+    """
+    from .layouts import zfs_root
+
+    row = next(one for one in every_row() if one.key == "keymap_initramfs")
+    at = context()
+    at.columns = 100
+    shown = row.value(config(zfs_root()), at)
+    assert "nothing is unlocked at boot" not in shown, shown


### PR DESCRIPTION
`compat._encrypted_pool` says native ZFS encryption "prompts for a passphrase exactly as a LUKS container does", and `zbm-unlock` and `vm-zfs-encrypted` answer that prompt on a real machine. `_unlock_keymap` checked only for a LUKS container and remote unlock, so an encrypted ZFS root read `nothing is unlocked at boot` — a keyboard layout dismissed for a prompt that appears, in the one place a wrong layout means the passphrase cannot be typed.

Same rule as `#1078`, one reader behind: that PR moved the encryption row onto `pool.encrypted` and this row was left on its own condition. The class is why the audit was scoped this way.

Control: the pool clause removed, red.
