### PR TITLE
model: one spelling for a container's and an array's device path

### DIFF
--- a/gentoo_install/exec/apply.py
+++ b/gentoo_install/exec/apply.py
@@ -153,9 +153,9 @@ class Machine:
         if isinstance(node, Partition):
             return self._partition_path(node)
         if isinstance(node, Luks):
-            return f"/dev/mapper/{node.name}"
+            return node.device_path
         if isinstance(node, MdRaid):
-            return f"/dev/md/{node.name}"
+            return node.device_path
         if isinstance(node, LogicalVolume):
             group = self.config.disk.graph[node.group]
             if isinstance(group, VolumeGroup):

--- a/gentoo_install/model/device.py
+++ b/gentoo_install/model/device.py
@@ -290,6 +290,23 @@ class Partition(Node):
         return (self.table,)
 
 
+def mapper_path(name: str) -> str:
+    """Where `cryptsetup open` puts a container.
+
+    A function rather than a literal at each caller: `plan/disk.py` spelled
+    it, `exec/apply.py` spelled it again, and the operations that open one
+    carry a name rather than the node. A convention changed in one layer
+    opens a container the others cannot find.
+    """
+    return f"/dev/mapper/{name}"
+
+
+def md_path(name: str) -> str:
+    """Where `mdadm --create` puts an array. Eight sites across
+    `plan/disk.py`, `plan/system.py` and `exec/apply.py` spelled this."""
+    return f"/dev/md/{name}"
+
+
 @dataclass(frozen=True)
 class Luks(Node):
     backing: DeviceId
@@ -301,6 +318,10 @@ class Luks(Node):
     @property
     def inputs(self) -> tuple[DeviceId, ...]:
         return (self.backing,)
+
+    @property
+    def device_path(self) -> str:
+        return mapper_path(self.name)
 
 
 @dataclass(frozen=True)
@@ -314,6 +335,10 @@ class MdRaid(Node):
     @property
     def inputs(self) -> tuple[DeviceId, ...]:
         return self.members
+
+    @property
+    def device_path(self) -> str:
+        return md_path(self.name)
 
 
 @dataclass(frozen=True)

--- a/gentoo_install/plan/disk.py
+++ b/gentoo_install/plan/disk.py
@@ -16,6 +16,8 @@ from typing import Callable, Final, Protocol, cast
 from ..errors import CommandFailed, ConfigError, GentooInstallError, InvalidLayout
 from ..model.config import DiskMode, InstallConfig
 from ..model.device import (
+    md_path,
+    mapper_path,
     DeviceGraph,
     DeviceId,
     Existing,
@@ -463,7 +465,7 @@ class CreateMdRaid(Operation):
     def describe(self) -> str:
         members = ", ".join(self.members)
         return (
-            f"create {self.level.value} array /dev/md/{self.name} as {self.array} "
+            f"create {self.level.value} array {md_path(self.name)} as {self.array} "
             f"from {members}, metadata {self.metadata.value}"
         )
 
@@ -472,7 +474,7 @@ class CreateMdRaid(Operation):
             [
                 "mdadm",
                 "--create",
-                f"/dev/md/{self.name}",
+                md_path(self.name),
                 "--run",
                 f"--level={self.level.value}",
                 f"--metadata={self.metadata.value}",
@@ -529,7 +531,7 @@ class OpenLuks(Operation):
     name: str
 
     def describe(self) -> str:
-        return f"open {self.backing} as /dev/mapper/{self.name} using the key file for {self.container}"
+        return f"open {self.backing} as {mapper_path(self.name)} using the key file for {self.container}"
 
     @property
     def survives_a_reboot(self) -> bool:
@@ -563,7 +565,7 @@ class AssembleMdRaid(Operation):
     name: str
 
     def describe(self) -> str:
-        return f"assemble /dev/md/{self.name} from {', '.join(self.members)}"
+        return f"assemble {md_path(self.name)} from {', '.join(self.members)}"
 
     @property
     def survives_a_reboot(self) -> bool:
@@ -571,13 +573,13 @@ class AssembleMdRaid(Operation):
 
     def apply(self, context: Context) -> None:
         listed = context.run(["mdadm", "--detail", "--scan"])
-        if f"/dev/md/{self.name}" in listed:
+        if md_path(self.name) in listed:
             return
         context.run(
             [
                 "mdadm",
                 "--assemble",
-                f"/dev/md/{self.name}",
+                md_path(self.name),
                 *(context.device_path(member) for member in self.members),
             ]
         )
@@ -1261,7 +1263,7 @@ _CLOSE: Final[dict[type[Node], Callable[[Node], tuple[str, ...]]]] = {
     ZfsPool: lambda node: ("zpool", "export", cast(ZfsPool, node).name),
     VolumeGroup: lambda node: ("vgchange", "--activate", "n", cast(VolumeGroup, node).name),
     Luks: lambda node: ("cryptsetup", "close", cast(Luks, node).name),
-    MdRaid: lambda node: ("mdadm", "--stop", f"/dev/md/{cast(MdRaid, node).name}"),
+    MdRaid: lambda node: ("mdadm", "--stop", cast(MdRaid, node).device_path),
 }
 
 

--- a/gentoo_install/plan/system.py
+++ b/gentoo_install/plan/system.py
@@ -989,14 +989,14 @@ class WriteMdadmConf(Operation):
 
     def describe_parts(self) -> tuple[str, tuple[str, ...]]:
         arrays = ", ".join(
-            f"ARRAY /dev/md/{array.name} metadata={array.metadata.value} UUID from {array.id}"
+            f"ARRAY {array.device_path} metadata={array.metadata.value} UUID from {array.id}"
             for array in self.arrays
         )
         return "write /etc/mdadm.conf with {}", (arrays,)
 
     def apply(self, context: Context) -> None:
         definitions = "".join(
-            f"ARRAY /dev/md/{array.name} metadata={array.metadata.value} "
+            f"ARRAY {array.device_path} metadata={array.metadata.value} "
             f"UUID={context.array_uuid(array.id)}\n"
             for array in self.arrays
         )


### PR DESCRIPTION
`plan/disk.py`, `plan/system.py` and `exec/apply.py` each built `/dev/md/{name}` from the node's name, eight sites in all, and `/dev/mapper/{name}` in three. The operations that create and assemble an array carry a name rather than the node, so the rule is a function in `model/device.py` that both the nodes and the operations call.

From a read-only audit agent looking for one rule with several spellings.
