### PR TITLE
vm: a guest at a prompt is not a stall

### DIFF
--- a/tests/unit/test_cluster.py
+++ b/tests/unit/test_cluster.py
@@ -443,6 +443,66 @@ def test_the_proxys_own_greeting_is_not_the_guest_speaking(
     assert "wrote nothing" in message, message
 
 
+def test_a_guest_at_a_prompt_is_not_reported_as_a_stall(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """`vm-cjk-kernel` printed `MARK_21_BEGIN`, stopped mid-compiler-line, and
+    answered `root@livecd ~ #` when the poke asked at 178.9 minutes.
+
+    The guest never stopped: its command ended and the console stopped
+    delivering, so the marker went into a connection nobody was receiving on.
+    Counted as a stall it kept row 402 looking like one defect when it is two,
+    which is what made it take fifteen rounds.
+    """
+    clock = [0.0]
+    prompt = _Talkative(clock, b"\x1b[?2004l\x1b[?2004hroot@livecd ~ # ")
+    monkeypatch.setattr(time, "monotonic", lambda: clock[0])
+    serial = SerialConsole(TimedChannel(clock), BytesIO())
+    opened = [0]
+
+    def _open() -> SerialConsole:
+        opened[0] += 1
+        # Silent when read, talking only after the poke's newline: the shell
+        # redraws its prompt when something is typed at it.
+        return serial if opened[0] == 1 else SerialConsole(_Quiet(clock, prompt), BytesIO())
+
+    link = cluster.Reconnecting(_open)
+    watch = cluster.Watchdog(
+        tmp_path / "install.log", lambda: Traffic(4096, 0, 0.0), where="infra-node5"
+    )
+    watch.log.write_bytes(b"output before the idle window\n")
+
+    with pytest.raises(ConsoleTimeout) as raised:
+        link.wait_for("install", timeout=5.0, idle=2.0, watch=watch)
+
+    message = str(raised.value)
+    assert "at a shell prompt" in message, message
+    assert "the console stopped delivering" in message, message
+
+
+class _Quiet:
+    """Silent until something is written to it, then whatever it was given."""
+
+    def __init__(self, clock: list[float], after: object) -> None:
+        self._clock = clock
+        self._after = after
+        self._written = False
+
+    def recv(self, size: int) -> bytes:
+        self._clock[0] += 1.0
+        return cast(Any, self._after).recv(size) if self._written else b""
+
+    def sendall(self, data: bytes) -> None:
+        self._written = True
+
+    def close(self) -> None:
+        return None
+
+    @property
+    def closed(self) -> bool:
+        return False
+
+
 def test_run_ceiling_ends_silent_guest_that_keeps_moving_bytes(
     monkeypatch: pytest.MonkeyPatch, tmp_path: Path
 ) -> None:

--- a/tests/vm/cluster.py
+++ b/tests/vm/cluster.py
@@ -3192,6 +3192,17 @@ class Reconnecting:
         except (ConsoleClosed, ProxmoxError) as error:
             return f"a new console could not be opened: {error}"
         if woken:
+            # A prompt is a different failure from a stall and was being
+            # counted as one: `vm-cjk-kernel` printed `MARK_21_BEGIN`, stopped
+            # mid-compiler-line, and answered `root@livecd ~ #` when poked at
+            # 178.9 minutes. The guest never stopped -- the console stopped
+            # delivering, and the marker was printed into a connection nobody
+            # was receiving on.
+            if re.search(_ANY_ROOT_PROMPT.rstrip(), woken.decode("utf-8", "replace")):
+                return (
+                    "the guest is at a shell prompt, so its command ended and "
+                    "the console stopped delivering rather than the guest stopping"
+                )
             return f"a new console said nothing until it was asked, then {woken[-POKE_BYTES:]!r}"
         # Whether the proxy answered is the difference between a console that
         # is gone and a guest that has stopped, and both look like silence.


### PR DESCRIPTION
The poke from `#1065`, with the banner stripped by `#1074`, answered for the second time and named the failure: `a new console said nothing until it was asked, then b'root@livecd ~ #'`. The guest's log shows `MARK_21_BEGIN`, output ending mid-compiler-command-line during `sys-boot/grub-2.14-r5`, then a bracketed-paste toggle and a fresh prompt — a shell redrawing itself.

So the guest never stopped. Its command ended and the console stopped delivering, and `MARK_21_DONE` went into a connection nothing was receiving on. The connection is not dead either: keepalives never failed, the proxy accepts a new session, and the new session gets output.

That is the shape row 159 recorded and parked for want of a reproduction with evidence. Reported as `counters were flat` it looked like row 402's stall, which is part of why that row took fifteen rounds — one row was two defects.

Control: the prompt test disabled, red.
