### PR TITLE
portage: name a build the kernel killed for memory

### DIFF
--- a/gentoo_install/plan/portage.py
+++ b/gentoo_install/plan/portage.py
@@ -1026,6 +1026,13 @@ class Emerge(Operation):
         if not _binpkg_failure(str(result)) or context.degraded(BINARY_PACKAGES):
             if self._optional(context, str(result)):
                 return
+            if _ran_out_of_memory(str(result)):
+                raise CommandFailed(
+                    "the compiler was killed because the machine ran out of memory, "
+                    "not because the package is broken: lower the job count in "
+                    "MAKEOPTS or give the machine swap, then resume. "
+                    f"emerge ended with {result.ending}: {worth_reading(str(result))}"
+                )
             raise CommandFailed(f"emerge ended with {result.ending}: {worth_reading(str(result))}")
         marker = _binpkg_failure(str(result))
         if (again := self._one_more_binary_try(context, command)) is not None:
@@ -1111,6 +1118,23 @@ BINHOST_INDEX_FAILURE: Final[str] = "Error fetching binhost package info"
 #: `!!! [gentoo] <urlopen error [Errno -3] Temporary failure in name
 #: resolution>`. Captured, because without it the recorded reason says the
 #: host has no index when the guest could not resolve its name at all.
+#: What the kernel and the compiler say when a build is killed for memory.
+#: `vm-gnome` died compiling `net-libs/webkit-gtk` with four jobs in eight
+#: gibibytes and the installer reported `emerge ended with exit 1`, leaving
+#: the operator to find `Out of memory: Killed ... task=cc1plus` in the log.
+#: Both spellings, because the kernel's line is not always in the emerge
+#: output the installer captured while gcc's always is.
+_OUT_OF_MEMORY: Final[re.Pattern[str]] = re.compile(
+    r"Out of memory: Killed|fatal error: Killed|virtual memory exhausted|"
+    r"cc1plus: out of memory|g\+\+: fatal error: Killed"
+)
+
+
+def _ran_out_of_memory(said: str) -> bool:
+    """Whether this emerge failed because the machine had no memory left."""
+    return _OUT_OF_MEMORY.search(said) is not None
+
+
 _INDEX_UNREADABLE: Final[re.Pattern[str]] = re.compile(
     r"!!! \[(?P<host>[^\]]+)\] "
     + re.escape(BINHOST_INDEX_FAILURE)

--- a/tests/unit/test_plan_portage.py
+++ b/tests/unit/test_plan_portage.py
@@ -2899,3 +2899,40 @@ def test_a_half_finished_clone_is_cleared_before_the_sync_is_retried(
     # double raises instead of recording it, so the pairing is read from the
     # removals rather than from an alternation.
     assert kinds == ["rm", "rm", "sync"], kinds
+
+
+def test_a_build_killed_for_memory_says_so_rather_than_exit_1() -> None:
+    """`vm-gnome` died compiling `net-libs/webkit-gtk` with four jobs in eight
+    gibibytes and the installer said `emerge ended with exit 1`.
+
+    The guest's own log held the answer -- `x86_64-pc-linux-gnu-g++: fatal
+    error: Killed` and `Out of memory: Killed ... task=cc1plus` -- and the
+    operator had to find it. The package is not broken and retrying changes
+    nothing; what changes it is fewer jobs or some swap, so the message says
+    that instead of leaving an exit code.
+    """
+    for said in (
+        "x86_64-pc-linux-gnu-g++: fatal error: Killed\ncompilation terminated.",
+        "Out of memory: Killed process 419676 (cc1plus)",
+        "virtual memory exhausted: Cannot allocate memory",
+    ):
+        recorder = Recorder()
+        recorder.answering = lambda argv, text=said: CommandOutput(text, 1)
+        with pytest.raises(CommandFailed, match="ran out of memory") as stopped:
+            portage.Emerge(
+                packages=("net-libs/webkit-gtk",), summary="install the desktop"
+            ).apply(recorder)
+        # The two things that change the outcome, and the original text: a
+        # message that drops what the compiler said is one nobody can check.
+        assert "MAKEOPTS" in str(stopped.value), stopped.value
+        assert "swap" in str(stopped.value), stopped.value
+        assert "exit 1" in str(stopped.value), stopped.value
+
+    # And an ordinary failure is still an ordinary failure.
+    plain = Recorder()
+    plain.answering = lambda argv: CommandOutput("configure: error: no gtk", 1)
+    with pytest.raises(CommandFailed) as ordinary:
+        portage.Emerge(
+            packages=("net-libs/webkit-gtk",), summary="install the desktop"
+        ).apply(plain)
+    assert "ran out of memory" not in str(ordinary.value), ordinary.value


### PR DESCRIPTION
Measured on the cluster: `vm-gnome` at 8 GiB with `MAKEOPTS=-j4` failed at 185 minutes, and its guest log holds `x86_64-pc-linux-gnu-g++: fatal error: Killed` with `Out of memory: Killed ... task=cc1plus`. The same fixture at 12 GiB is compiling the same ebuild past 280 minutes with no kill at all, so the package is not broken and a retry changes nothing.

What the operator saw was `emerge ended with exit 1`. Now the message names the cause and the two things that change the outcome — fewer jobs or some swap — and keeps the original text, because a message that drops what the compiler said is one nobody can check.

Both spellings are matched: the kernel's line is not always in the output the installer captured, gcc's always is. Control: the branch disabled, red. An ordinary `configure: error` still reports as an ordinary failure.
