### PR TITLE
portage: follow this machine means write its core count

### DIFF
--- a/gentoo_install/plan/portage.py
+++ b/gentoo_install/plan/portage.py
@@ -349,9 +349,15 @@ class WriteMakeConf(Operation):
     #: the overlay's own distfiles, so ranking them together would order one
     #: repository by how fast the other answers.
     appended: tuple[str, ...] = ()
+    #: Whether `MAKEOPTS` is the installing machine's core count, resolved
+    #: here because only `exec` may look at the machine. An empty `makeopts`
+    #: means "follow this machine", and it was written as no `MAKEOPTS` at
+    #: all: a stage3's `make.conf` carries none, `make.globals` carries none
+    #: and no profile sets one, so the target built with a single job.
+    jobs_from_machine: bool = False
 
     def describe_parts(self) -> tuple[str, tuple[str, ...]]:
-        keys = ", ".join(key for key, _ in self.settings)
+        keys = ", ".join(key for key, _ in self._named())
         mirrors = str(len(self.mirrors))
         if self.speed_test:
             if self.appended:
@@ -373,9 +379,19 @@ class WriteMakeConf(Operation):
             (keys, mirrors),
         )
 
+
+    def _named(self) -> tuple[tuple[str, str], ...]:
+        """What the file will hold, for the description. `MAKEOPTS` is named
+        even though its value is not known until apply."""
+        if not self.jobs_from_machine:
+            return self.settings
+        return (*self.settings, ("MAKEOPTS", ""))
+
     def apply(self, context: Context) -> None:
         ranked = context.rank_mirrors(self.mirrors) if self.speed_test else self.mirrors
         wanted = list(self.settings)
+        if self.jobs_from_machine:
+            wanted.append(("MAKEOPTS", f"-j{context.jobs()}"))
         listed = (*ranked, *self.appended)
         # Not written at all when empty: an empty GENTOO_MIRRORS is a shorter
         # list than Portage's own, not the same thing as leaving it alone.
@@ -1567,6 +1583,7 @@ def build(
             mirrors=_distfiles(portage),
             speed_test=portage.mirrors.speed_test,
             appended=_appended_distfiles(portage),
+            jobs_from_machine=not portage.makeopts,
         ),
         WriteProxyClients(proxy=config.proxy),
         CreateAutounmaskFiles(),

--- a/tests/unit/test_plan_portage.py
+++ b/tests/unit/test_plan_portage.py
@@ -1430,9 +1430,9 @@ def test_the_stage3_comes_from_the_mirror_the_operator_chose() -> None:
     """Only `--mirror` was read, so choosing USTC set the mirror for every
     later fetch and still downloaded the stage3 itself, several hundred
     megabytes of it, from `distfiles.gentoo.org`."""
+    from gentoo_install.data import load_catalog
     from dataclasses import replace
 
-    from gentoo_install.data import load_catalog
     from gentoo_install.model.config import MirrorConfig, MirrorRegion
     from gentoo_install.plan.build import DEFAULT_MIRROR, build, stage3_mirror
 
@@ -2936,3 +2936,43 @@ def test_a_build_killed_for_memory_says_so_rather_than_exit_1() -> None:
             packages=("net-libs/webkit-gtk",), summary="install the desktop"
         ).apply(plain)
     assert "ran out of memory" not in str(ordinary.value), ordinary.value
+
+
+def test_following_this_machine_writes_its_core_count() -> None:
+    """The menu stores the machine's own count as an empty `makeopts`, and an
+    empty one wrote no `MAKEOPTS` at all.
+
+    Nothing else supplies one: a stage3 built 2026-08-23 ships a `make.conf`
+    with `COMMON_FLAGS` and no `MAKEOPTS`, `make.globals` has none and no
+    profile sets one, so the target compiled with a single job while the
+    operator had chosen every core. `Context.jobs()` already existed for this
+    and nothing read it.
+    """
+    from dataclasses import replace as _replace
+
+    from gentoo_install.exec.config import load
+
+    chosen = load(Path("tests/fixtures/vm-binpkg.toml"))
+    following = _replace(chosen, portage=_replace(chosen.portage, makeopts=""))
+
+    written = [
+        one
+        for one in portage.build(following, "")
+        if isinstance(one, portage.WriteMakeConf)
+    ]
+    assert written and written[0].jobs_from_machine, written
+    assert "MAKEOPTS" in written[0].describe(), written[0].describe()
+
+    recorder = Recorder()
+    written[0].apply(recorder)
+    made = recorder.files[PurePosixPath("/etc/portage/make.conf")]
+    assert f'MAKEOPTS="-j{recorder.jobs()}"' in made, made
+
+    # And a configuration that names its own jobs is left alone.
+    pinned = [
+        one for one in portage.build(chosen, "") if isinstance(one, portage.WriteMakeConf)
+    ]
+    assert pinned and not pinned[0].jobs_from_machine, pinned
+    second = Recorder()
+    pinned[0].apply(second)
+    assert 'MAKEOPTS="-j4"' in second.files[PurePosixPath("/etc/portage/make.conf")]


### PR DESCRIPTION
`makeopts_screen` stores the preselected row — this machine's core count — as an empty string, so a saved configuration does not force `-j32` onto a four-core laptop. `make_conf()` then wrote no `MAKEOPTS` for an empty value, and nothing else supplies one:

- a stage3 built 2026-08-23 ships `make.conf` with `COMMON_FLAGS` and no `MAKEOPTS`
- `/usr/share/portage/config/make.globals` has none
- no profile `make.defaults` sets one

So the operator chose every core and the target compiled with one job. `Context.jobs()` already existed for exactly this and nothing read it.

`-j$(nproc)` is not the fix: `portage.util.getconfig` stores it literally, and bash does not re-scan an expanded value for command substitution, so `make` would receive the text. The count is resolved at apply time instead, where the installer is running on the machine in question.

Control: the substitution removed, red. No golden changed, because every fixture names its own jobs — which is also why nothing had exercised this path.
