### PR TITLE
vm: a menu that booted itself is worth another boot

### DIFF
--- a/tests/unit/test_cluster.py
+++ b/tests/unit/test_cluster.py
@@ -2968,6 +2968,37 @@ def test_the_silent_console_sentence_is_the_one_the_editor_raises(
     assert cluster.SILENT_EDITOR in str(raised.value)
 
 
+def test_every_sentence_worth_another_boot_is_one_the_menu_raises() -> None:
+    """The retry fired for one sentence and a second recoverable failure went
+    past it: `static-ip` was lost at 0.5 minutes to `the entry booted before
+    its countdown was held`, having passed at 18.2 minutes the round before.
+
+    Read off what the code raises rather than out of its source, and over the
+    whole set rather than the one that was written first.
+    """
+    from tests.vm import cluster, proxmox
+    from tests.vm.proxmox import GrubNotReadable
+
+    class Booting:
+        """A menu whose countdown has already expired."""
+
+        def expect(self, pattern: str, timeout: float) -> bytes:
+            return b"executed automatically in 0s"
+
+        def send_raw(self, keys: str) -> None:
+            return None
+
+        def snapshot(self, seconds: float) -> bytes:
+            return b"Booting `Boot LiveCD (kernel: gentoo)'\r\n"
+
+    with pytest.raises(GrubNotReadable) as raised:
+        proxmox.hold_the_menu(cast(Any, Booting()), timeout=0.5)
+    assert cluster.BOOTED_ITSELF in str(raised.value), raised.value
+    # And the set the retry reads is the one both sentences are in.
+    assert any(one in str(raised.value) for one in cluster.WORTH_ANOTHER_BOOT)
+    assert cluster.SILENT_EDITOR in cluster.WORTH_ANOTHER_BOOT
+
+
 def test_a_reconnect_grant_never_shortens_the_ceiling() -> None:
     """`vm-desktop` was ended at `899s of 898s elapsed` with
     `dev-qt/qtsensors` still compiling, six hours into a run whose ceiling had

--- a/tests/vm/cluster.py
+++ b/tests/vm/cluster.py
@@ -4545,9 +4545,9 @@ def _edit_uefi_cmdline(guest: Guest, link: "Reconnecting") -> None:
         append_to_cmdline(link, EXTRA_CMDLINE)
         return
     except GrubNotReadable as error:
-        if SILENT_EDITOR not in str(error):
+        if not any(one in str(error) for one in WORTH_ANOTHER_BOOT):
             raise
-        print(f"the console said nothing to the editor, booting once more: {error}", flush=True)
+        print(f"the medium's menu was not editable, booting once more: {error}", flush=True)
     guest.reset()
     link.reopen(solicit_prompt=False)
     append_to_cmdline(link, EXTRA_CMDLINE)
@@ -4557,6 +4557,17 @@ def _edit_uefi_cmdline(guest: Guest, link: "Reconnecting") -> None:
 #: the wrong thing. Matched rather than re-derived, so the two sentences
 #: cannot drift apart into a retry that never fires.
 SILENT_EDITOR: Final[str] = "the console delivered"
+
+#: What `hold_the_menu` says when the countdown ran out before the key that
+#: stops it arrived. `static-ip` was lost at 0.5 minutes to this, having
+#: passed the same fixture at 18.2 minutes the round before.
+BOOTED_ITSELF: Final[str] = "booted before its countdown"
+
+#: The failures a fresh boot can answer. A set rather than one constant: the
+#: retry existed for `SILENT_EDITOR` alone and a second recoverable failure
+#: went straight past it, which is the shape this repository keeps hitting --
+#: one rule, one reader, a new instance nobody added.
+WORTH_ANOTHER_BOOT: Final[tuple[str, ...]] = (SILENT_EDITOR, BOOTED_ITSELF)
 
 
 def _edit_bios_cmdline(guest: Guest, link: "Reconnecting") -> None:


### PR DESCRIPTION
`static-ip` failed round seventeen at 0.5 minutes — `the entry booted before its countdown was held` — having passed the same fixture at 18.2 minutes the round before. Its log holds `Booting \`Boot LiveCD (kernel: gentoo)'`, so GRUB really did start the unedited entry, and without the `console=ttyS0` the editor adds there is nothing left to talk to.

A reset-and-retry already existed for this, and fired only for `SILENT_EDITOR`. The comment beside that constant says it is matched rather than re-derived "so the two sentences cannot drift apart into a retry that never fires" — right about spellings, and the set it guards had one member while a second recoverable failure existed. One rule, one reader, a new instance nobody added.

The test drives `hold_the_menu` against a menu whose countdown has expired and reads the sentence off the exception rather than out of the source. Control: the set reduced to one member, red.
