### PR TITLE
tui: count the layout the image mode discards

### DIFF
--- a/gentoo_install/tui/screens.py
+++ b/gentoo_install/tui/screens.py
@@ -299,7 +299,7 @@ def _answers_this_mode_discards(config: InstallConfig) -> int:
     keypress on it emptied twenty of them, silently. An agent that pressed it
     went back and forth three times looking for what it had lost.
     """
-    return sum(
+    kept = sum(
         1
         for part, blank in (
             ("system", SystemConfig()),
@@ -310,6 +310,13 @@ def _answers_this_mode_discards(config: InstallConfig) -> int:
         )
         if getattr(config, part) != blank
     )
+    # The layout as well, because this mode empties `graph` and `root` too. A
+    # configuration whose only answers are a partition table counted zero and
+    # was discarded without the question, and a hand-built table is the most
+    # laborious thing the menu makes.
+    if config.disk.graph.nodes or config.disk.root:
+        kept += 1
+    return kept
 
 
 def _agrees_to_discard(screen: Screen, context: Context, kept: int) -> bool:

--- a/tests/unit/test_every_row.py
+++ b/tests/unit/test_every_row.py
@@ -396,3 +396,51 @@ def test_an_encrypted_pool_needs_an_initramfs_keymap_too() -> None:
     at.columns = 100
     shown = row.value(config(zfs_root()), at)
     assert "nothing is unlocked at boot" not in shown, shown
+
+
+def test_a_layout_alone_is_still_answers_the_image_mode_discards() -> None:
+    """Choosing to write an image empties `disk.graph` and `disk.root`, and
+    the count that decides whether to ask counted five other groups only.
+
+    A configuration whose only answers are a partition table counted zero, so
+    the question was skipped and the table went without one — the exact thing
+    the count exists to prevent, and a hand-built table is the most laborious
+    thing the menu makes.
+    """
+    from dataclasses import replace as _replace
+
+    from gentoo_install.model.config import (
+        BootloaderConfig,
+        DiskConfig,
+        InstallConfig,
+        KernelConfig,
+        PackagesConfig,
+        PortageConfig,
+        SystemConfig,
+    )
+    from gentoo_install.model.device import DeviceGraph, DeviceId
+    from gentoo_install.tui.screens import _answers_this_mode_discards
+
+    from .layouts import ext4_on_gpt
+
+    bare = InstallConfig(
+        system=SystemConfig(),
+        packages=PackagesConfig(),
+        portage=PortageConfig(),
+        kernel=KernelConfig(),
+        bootloader=BootloaderConfig(),
+        disk=DiskConfig(graph=DeviceGraph.build([]), root=DeviceId("")),
+    )
+    assert _answers_this_mode_discards(bare) == 0, "nothing answered is nothing to lose"
+
+    laid_out = config(ext4_on_gpt())
+    only_disk = _replace(
+        laid_out,
+        system=SystemConfig(),
+        packages=PackagesConfig(),
+        portage=PortageConfig(),
+        kernel=KernelConfig(),
+        bootloader=BootloaderConfig(),
+    )
+    assert only_disk.disk.graph.nodes, only_disk.disk
+    assert _answers_this_mode_discards(only_disk) == 1, _answers_this_mode_discards(only_disk)


### PR DESCRIPTION
`_answers_this_mode_discards` exists because "the row is the first in the list and one keypress on it emptied twenty of them, silently". It counted `system`, `packages`, `portage`, `kernel` and `bootloader`, and the transition it guards also replaces `disk.graph` with an empty graph and `disk.root` with `""`.

So a configuration whose only answers are a partition table counted zero, the question was skipped, and the table went without one — the exact thing the count exists to prevent, on the most laborious thing the menu makes.

Control: the layout clause removed, red.

From a read-only audit agent looking for a displayed value that disagrees with what the installer does.
