### PR TITLE
validate: refuse a table written onto a disk marked not to wipe

### DIFF
--- a/gentoo_install/model/validate.py
+++ b/gentoo_install/model/validate.py
@@ -255,6 +255,7 @@ def validate(
             *root_size_problems(config),
             *_zfs_kernel_problems(config, zfs_kernel_max),
             *_reuse_problems(config),
+            *_zapped_disk_problems(config),
             *_pool_problems(config),
             *_array_problems(config),
             *(rule.describe() for rule in compat.violations(config, storage_facts)),
@@ -592,6 +593,30 @@ def _reuse_problems(config: InstallConfig) -> list[str]:
             problems.append(
                 f"{filesystem.id} reuses the filesystem on {under.id}, which is marked to be "
                 f"wiped"
+            )
+    return problems
+
+
+def _zapped_disk_problems(config: InstallConfig) -> list[str]:
+    """A table this run writes has to sit on a disk this run wipes.
+
+    `CreatePartitionTable` runs `sgdisk --zap-all` for `create`, which takes
+    every entry with it. A configuration saying `wipe = false` on the disk and
+    `create = true` on its table says both keep this disk and erase its table,
+    and the erase is what happens: the operator reads one thing and the
+    installer does the other, on the one operation that cannot be undone.
+    """
+    graph = config.disk.graph
+    problems: list[str] = []
+    for table in graph.of_type(PartitionTable):
+        if not table.create:
+            continue
+        disk = graph[table.disk]
+        if isinstance(disk, Existing) and not disk.wipe:
+            problems.append(
+                f"{table.id} is created on {disk.id}, which is marked not to be wiped: "
+                f"creating a table runs `sgdisk --zap-all` and takes every partition "
+                f"on it, so set `wipe = true` to say so or `create = false` to keep them"
             )
     return problems
 

--- a/tests/unit/test_validate.py
+++ b/tests/unit/test_validate.py
@@ -1511,3 +1511,46 @@ def test_a_repository_name_is_checked_before_it_reaches_eselect() -> None:
             installation, portage=replace(installation.portage, repositories=("science",))
         )
     )
+
+
+def test_a_table_this_run_writes_needs_a_disk_this_run_wipes() -> None:
+    """`CreatePartitionTable` runs `sgdisk --zap-all` for `create`, and a
+    configuration could say `wipe = false` on the disk and `create = true` on
+    its table.
+
+    Both were accepted, and the erase is what happened: the operator read
+    `wipe = false` and the installer took every partition on the disk. That is
+    the one operation with no way back, so it is refused rather than warned
+    about.
+    """
+    import tomllib
+    from pathlib import Path as _Path
+
+    from gentoo_install.errors import GentooInstallError
+    from gentoo_install.model.parse import parse
+
+    raw = _Path("tests/fixtures/vm-binpkg.toml").read_text()
+    data = tomllib.loads(raw.replace("wipe = true", "wipe = false"))
+    for device in data["disk"]["devices"]:
+        if device.get("kind") == "table":
+            device["create"] = True
+    kept = parse(data)
+
+    with pytest.raises(GentooInstallError) as refused:
+        validate(kept)
+    assert "zap-all" in str(refused.value), refused.value
+    assert "wipe = true" in str(refused.value), refused.value
+
+    # And the two coherent pairs are still accepted: wipe and create together,
+    # and keep and edit together, which is what the manual editor builds.
+    both = tomllib.loads(raw)
+    for device in both["disk"]["devices"]:
+        if device.get("kind") == "table":
+            device["create"] = True
+    validate(parse(both))
+
+    neither = tomllib.loads(raw.replace("wipe = true", "wipe = false"))
+    for device in neither["disk"]["devices"]:
+        if device.get("kind") == "table":
+            device["create"] = False
+    validate(parse(neither))


### PR DESCRIPTION
Measured: `wipe = false` on the disk with `create = true` on its table parses and validates today. `CreatePartitionTable.apply` then runs `sgdisk --zap-all`, which its own comment says "takes every entry with it". The operator reads `wipe = false` and the installer erases the partition table — on the one operation with no way back.

The manual editor never produces that pair, because `manual.py` derives both from `has_existing_slices`. A hand-written configuration can, and `README.md`'s safety section tells the reader that `wipe = true` is what they should be watching for.

Refused rather than warned about. The test also holds the two coherent pairs — wipe and create together, keep and edit together — so the rule cannot be satisfied by refusing everything. Control: the rule unregistered, red.

Reached from a read-only audit agent's claim about `create` being decided in two layers; the layers agree, and following the question to a hand-written configuration is where it went wrong.
