### PR TITLE
model: one place builds a dataset's full name

### DIFF
--- a/gentoo_install/model/device.py
+++ b/gentoo_install/model/device.py
@@ -301,6 +301,17 @@ def mapper_path(name: str) -> str:
     return f"/dev/mapper/{name}"
 
 
+def dataset_name(pool: "ZfsPool", dataset: "ZfsDataset") -> str:
+    """The dataset's full name, which is the pool's and its own.
+
+    Three places built this: `plan/disk.py` for the creation, `plan/mounts.py`
+    for the mount and `plan/bootloader.py` for the root the bootloader names.
+    A convention changed in one of them creates a dataset the others cannot
+    address, and the install would finish and boot nowhere.
+    """
+    return f"{pool.name}/{dataset.name}"
+
+
 def md_path(name: str) -> str:
     """Where `mdadm --create` puts an array. Eight sites across
     `plan/disk.py`, `plan/system.py` and `exec/apply.py` spelled this."""

--- a/gentoo_install/plan/bootloader.py
+++ b/gentoo_install/plan/bootloader.py
@@ -20,6 +20,7 @@ from ..errors import CommandFailed, ConfigError, InvalidLayout, NothingToBoot
 from ..model import compat
 from ..model.config import Bootloader, DiskMode, Firmware, InitSystem, InstallConfig, RemoteUnlock
 from ..model.device import (
+    dataset_name,
     Existing,
     DeviceId,
     Filesystem,
@@ -666,7 +667,7 @@ def boot_facts(config: InstallConfig) -> BootFacts:
         if not isinstance(pool, ZfsPool):
             raise InvalidLayout(f"{source.id} does not refer to a ZFS pool")
         root_device: DeviceId | None = None
-        dataset = f"{pool.name}/{source.name}"
+        dataset = dataset_name(pool, source)
         root_parameters: tuple[str, ...] = ()
         pool_name = pool.name
         pool_dataset = dataset

--- a/gentoo_install/plan/disk.py
+++ b/gentoo_install/plan/disk.py
@@ -16,6 +16,7 @@ from typing import Callable, Final, Protocol, cast
 from ..errors import CommandFailed, ConfigError, GentooInstallError, InvalidLayout
 from ..model.config import DiskMode, InstallConfig
 from ..model.device import (
+    dataset_name,
     md_path,
     mapper_path,
     DeviceGraph,
@@ -1386,7 +1387,7 @@ def _operations_for(
         return [
             CreateDataset(
                 dataset=node.id,
-                name=f"{pool.name}/{node.name}",
+                name=dataset_name(pool, node),
                 mountpoint=_dataset_mountpoint(graph, node.id),
             )
         ]

--- a/gentoo_install/plan/mounts.py
+++ b/gentoo_install/plan/mounts.py
@@ -8,6 +8,7 @@ from pathlib import PurePosixPath
 
 from ..errors import InvalidLayout
 from ..model.device import (
+    dataset_name,
     DeviceGraph,
     DeviceId,
     Filesystem,
@@ -50,7 +51,7 @@ def _resolve_mount(graph: DeviceGraph, mount: Mountpoint) -> ResolvedMount:
             mountpoint=mount.id,
             path=mount.path,
             device=None,
-            dataset=f"{pool.name}/{source.name}",
+            dataset=dataset_name(pool, source),
             filesystem_kind=None,
             subvolume=None,
             options=mount.options,

--- a/tests/unit/test_layers.py
+++ b/tests/unit/test_layers.py
@@ -1207,3 +1207,27 @@ class Example:
     # answers with the last component as well as the unparsed expression.
     names = _written_names(call.args[0], _bindings_in(body, {}))
     assert "locale.conf" in names, sorted(names)
+
+
+def test_one_place_builds_a_dataset_full_name() -> None:
+    """`plan/disk.py` created the dataset, `plan/mounts.py` mounted it and
+    `plan/bootloader.py` named it as the root, and each built
+    `{pool}/{dataset}` itself.
+
+    A convention changed in one of them creates a dataset the others cannot
+    address, and the install finishes and boots nowhere. Same shape as the
+    eight spellings of `/dev/md/{name}`.
+    """
+    import re
+    from pathlib import Path as _Path
+
+    from gentoo_install.model import device
+
+    assert device.dataset_name is not None
+    spelled = {
+        path.as_posix(): re.findall(r'f"\{pool\.name\}/', _Path(path).read_text())
+        for path in sorted(_Path("gentoo_install").rglob("*.py"))
+        if path.name != "device.py"
+    }
+    offenders = {name: hits for name, hits in spelled.items() if hits}
+    assert not offenders, offenders


### PR DESCRIPTION
Three modules built `f"{pool.name}/{source.name}"` independently — the creation, the mount and the root the bootloader names. Changed in one of them, the install creates a dataset the others cannot address and finishes booting nowhere.

Same shape as the eight spellings of `/dev/md/{name}` in `#1083`, and the test is the same kind: only `model/device.py` may spell it, so a fourth site fails rather than being added quietly. Control: the mount site restored to its own f-string, red.

From a read-only audit agent looking for one rule with several spellings.
