### PR TITLE
vm: a key already loaded is not the initramfs giving up

### DIFF
--- a/tests/unit/test_cluster.py
+++ b/tests/unit/test_cluster.py
@@ -4515,3 +4515,23 @@ def test_the_run_ceiling_says_so_rather_than_reporting_its_last_window(
     assert "ceiling ended it with the console still printing" in said, said
     # And what it was printing, so the reader can tell working from wedged.
     assert "compiling something" in said, said
+
+
+def test_a_key_already_loaded_is_not_the_initramfs_giving_up() -> None:
+    """`zbm-unlock` was failed at 142.6 minutes with `Key load error: Key
+    already loaded for 'zpcala'`.
+
+    ZFSBootMenu says that when the key is in place, which is exactly what a
+    successful remote SSH unlock leaves behind — so the fixture whose subject
+    is the remote unlock was failed for performing it. The wrong-key message
+    the codebase already quotes elsewhere is `Key load error: Incorrect key
+    provided`, and that one still counts.
+    """
+    already = b"Enter passphrase for 'zpcala':\r\nKey load error: Key already loaded for 'zpcala'"
+    assert not cluster.initramfs_gave_up(already), already
+
+    wrong = b"Key load error: Incorrect key provided for 'zpcala'"
+    assert cluster.initramfs_gave_up(wrong), wrong
+    for other in (b"Entering emergency mode", b"Failed to mount /sysroot"):
+        assert cluster.initramfs_gave_up(other), other
+    assert not cluster.initramfs_gave_up(b"[    3.1] mounting the root")

--- a/tests/vm/cluster.py
+++ b/tests/vm/cluster.py
@@ -3757,6 +3757,24 @@ INITRAMFS_GAVE_UP: Final[tuple[str, ...]] = (
     "Key load error",
 )
 
+#: The one `Key load error` that is a success. ZFSBootMenu says this when the
+#: key is already in place, which is exactly what a remote SSH unlock leaves
+#: behind: `zbm-unlock` was failed at 142.6 minutes with `Key load error: Key
+#: already loaded for 'zpcala'`, for doing the thing the fixture exists to do.
+KEY_ALREADY_LOADED: Final[str] = "Key already loaded"
+
+
+def initramfs_gave_up(said: bytes) -> bool:
+    """Whether this screen shows the initramfs failing to reach the root.
+
+    One reader, so the exception cannot be applied in one place and forgotten
+    in the other: the pattern that waits for these and the check that reads
+    what arrived are different lines.
+    """
+    if KEY_ALREADY_LOADED.encode() in said:
+        return False
+    return any(one.encode() in said for one in INITRAMFS_GAVE_UP)
+
 #: Enough of the screen to carry the refusal and the prompt above it.
 INITRAMFS_SCREEN_BYTES: Final[int] = 600
 
@@ -3966,7 +3984,7 @@ def _unlock(
             )
         if any(one.encode() in said for one in LOGIN_PROMPTS):
             return UnlockResult(InstalledBootState.LOGIN_READY)
-        if any(one.encode() in said for one in INITRAMFS_GAVE_UP):
+        if initramfs_gave_up(said):
             return UnlockResult(
                 InstalledBootState.WAIT_LOGIN,
                 (


### PR DESCRIPTION
`zbm-unlock` failed round seventeen at 142.6 minutes: `the initramfs did not mount the root; the console held " for 'zpcala':\r\nKey load error"`. The guest's log carries the rest of that line — `Key load error: Key already loaded for 'zpcala'` — which ZFSBootMenu prints when the key is in place. That is precisely what a successful remote SSH unlock leaves behind, so the fixture whose subject is the remote unlock was failed for performing it.

`INITRAMFS_GAVE_UP` matched on the prefix `Key load error`. The wrong-key message this repository already quotes in `_unlock`'s docstring is `Key load error: Incorrect key provided`, and that still counts.

One reader, `initramfs_gave_up()`, because the pattern that waits for these and the check that reads what arrived are different lines and the exception has to hold in both. Control: the exclusion removed, red.
