### PR TITLE
serialise: a paste must not carry the key file's path

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -26,8 +26,10 @@ by one person: a reply comes when there is one to give.
   under `/run/gentoo-install/keys/` with mode `0600` for the command that
   reads it, and `/run` is a tmpfs, so it does not survive the reboot into the
   installed system. The installer does not delete it before then. `--paste`
-  replaces `password_hash` and `root_password_hash` and drops the proxy
-  username and password, so a published configuration carries neither.
+  replaces `password_hash`, `root_password_hash` and `passphrase_file` and
+  drops the proxy username and password, so a published configuration carries
+  none of them. The key file's path is replaced as well as the hashes: it is
+  not the key, and it still says where key material sits on the machine.
 - **What is verified.** The stage3 is checked against its DIGESTS and its
   OpenPGP signature; the repository snapshot is verified by `emerge-webrsync`;
   binary packages are refused unless their host's key is imported and locally

--- a/gentoo_install/model/serialise.py
+++ b/gentoo_install/model/serialise.py
@@ -74,6 +74,15 @@ SPELLED_AS: Final[dict[tuple[type[Node], str], frozenset[str]]] = {
 #: the pastebin is a public address.
 SECRET: Final[frozenset[str]] = frozenset({"password_hash", "root_password_hash"})
 
+#: Device fields a paste must not carry. Separate from `SECRET`, which means
+#: the password hashes and whose test derives its membership from the model:
+#: this one is a path rather than a hash, and folding the two together would
+#: have made that rule unstatable. It names where key material sits on the
+#: installing machine, and a hand-written configuration points it wherever the
+#: operator keeps keys. `publishing=True` has one caller, the pastebin upload
+#: in `exec/report.py`, so nothing that needs the real path sees the redaction.
+NOT_FOR_A_PASTE: Final[frozenset[str]] = frozenset({"passphrase_file"})
+
 #: What stands in for a secret. Not a valid hash, so a file edited from a
 #: published one locks the account rather than setting a password nobody knows.
 REDACTED: Final[str] = "removed-before-publishing"
@@ -87,7 +96,7 @@ def to_toml(config: InstallConfig, *, publishing: bool = False) -> str:
     lines = [f"{model_config.CONFIG_VERSION_KEY} = {config.config_version}"]
     for name in model_config.PERSISTED_SECTIONS[:-1]:
         lines += _section(name, getattr(config, name), publishing=publishing)
-    lines += _disk(config)
+    lines += _disk(config, publishing=publishing)
     return "\n".join(lines).rstrip("\n") + "\n"
 
 
@@ -170,7 +179,7 @@ def _simple(choice: Choice) -> list[str]:
     return lines
 
 
-def _disk(config: InstallConfig) -> list[str]:
+def _disk(config: InstallConfig, *, publishing: bool = False) -> list[str]:
     disk = config.disk
     lines = ["", "[disk]"]
     for field in fields(disk):
@@ -203,6 +212,9 @@ def _disk(config: InstallConfig) -> list[str]:
                 lines += _share(held)
                 continue
             named = RENAMED.get((type(node), field.name), field.name)
+            if publishing and field.name in NOT_FOR_A_PASTE:
+                lines.append(f"{named} = {_value(REDACTED)}")
+                continue
             lines.append(f"{named} = {_value(held)}")
     return lines
 

--- a/tests/unit/test_project_docs.py
+++ b/tests/unit/test_project_docs.py
@@ -10,7 +10,7 @@ from pathlib import Path
 import pytest
 
 from gentoo_install.model.config import ProxyConfig
-from gentoo_install.model.serialise import SECRET
+from gentoo_install.model.serialise import NOT_FOR_A_PASTE, SECRET
 
 ROOT = Path(__file__).resolve().parents[2]
 
@@ -35,7 +35,9 @@ def test_security_names_what_publishing_actually_removes() -> None:
     said = (ROOT / "SECURITY.md").read_text(encoding="utf-8")
     paragraph = next(part for part in said.split("\n- ") if "--paste" in part)
 
-    for name in SECRET:
+    # Both tables: `NOT_FOR_A_PASTE` was added without a document guard of its
+    # own, which is the same gap the redaction itself was closing.
+    for name in (*SECRET, *NOT_FOR_A_PASTE):
         assert f"`{name}`" in paragraph, name
     dropped = {"username", "password"}
     assert dropped <= {field.name for field in fields(ProxyConfig)}, "the model moved"

--- a/tests/unit/test_serialise.py
+++ b/tests/unit/test_serialise.py
@@ -357,3 +357,31 @@ def test_every_node_field_the_writer_emits_is_a_key_its_parser_accepts() -> None
     for (held, name), spelled in SPELLED_AS.items():
         assert name in {one.name for one in fields(held)}, (held.__name__, name)
         assert spelled, (held.__name__, name)
+
+
+def test_a_published_configuration_redacts_the_key_file_path() -> None:
+    """`_disk` took no `publishing` flag, so the whole device section bypassed
+    the redaction that `_section` applies.
+
+    The field holds a path rather than the key, which is why it looked
+    harmless — but it names where key material sits on the installing machine,
+    and a hand-written configuration points it wherever the operator keeps
+    keys. `publishing=True` has one caller, the pastebin upload in
+    `exec/report.py`, so nothing that needs the real path ever sees this form.
+    """
+    for name in ("vm-luks", "vm-zfs-encrypted"):
+        config = parse(tomllib.loads((FIXTURES / f"{name}.toml").read_text()))
+        saved = to_toml(config)
+        published = to_toml(config, publishing=True)
+
+        held = [one for one in saved.splitlines() if "passphrase_file" in one]
+        assert held, f"{name} carries no key file to redact"
+        assert all("/run/" in one for one in held), held
+
+        gone = [one for one in published.splitlines() if "passphrase_file" in one]
+        assert gone, f"{name} dropped the key rather than redacting it"
+        assert all(REDACTED in one for one in gone), gone
+        assert "/run/gentoo-install-keys" not in published, published
+
+        # The saved form is what an operator keeps, and it has to stay usable.
+        assert REDACTED not in saved, saved


### PR DESCRIPTION
Measured on `vm-luks` and `vm-zfs-encrypted`: `to_toml(publishing=True)` redacted `root_password_hash` and wrote `passphrase_file = "/run/gentoo-install-keys/root"` unchanged, because `_disk()` had no `publishing` parameter and never consulted the table. `publishing=True` has one caller, the pastebin upload in `exec/report.py`, so nothing that needs the real path ever sees the redacted form.

The field is a path rather than the key, which is why it read as harmless. It still says where key material sits on the machine, and a hand-written configuration points it wherever the operator keeps keys.

A separate table rather than an addition to `SECRET`: `SECRET` means the password hashes and `test_every_secret_field_the_model_has_is_in_the_table` derives its membership from the model, so folding a path in made that rule unstatable — it failed immediately, correctly. `SECURITY.md` names the new field, and the document test now reads both tables, because the new one had no document guard of its own, which is the same gap the redaction closes.

Control: the table emptied, red.

From a read-only audit agent. Its claim said "LUKS passphrases"; the model stores only a path, so the finding was real and the wording overstated.
