### PR TITLE
cli: refuse a resume that has no journal to resume

### DIFF
--- a/gentoo_install/cli.py
+++ b/gentoo_install/cli.py
@@ -677,8 +677,7 @@ def install(
         if arguments.resume:
             resuming = journal.resume()
             _refuse_a_different_run(journal, identity, record)
-            if not resuming:
-                journal.started(**identity)
+            _refuse_a_resume_with_no_journal(arguments.work, resuming)
         else:
             journal.started(**identity)
         finished = completed(journal) if arguments.resume else frozenset()
@@ -1134,6 +1133,25 @@ def _refuse_a_different_run(
         # would refuse every resume there.
         if mine and theirs and mine != theirs:
             raise ResumeRefused(refusal)
+
+def _refuse_a_resume_with_no_journal(work: Path, resuming: bool) -> None:
+    """A resume with nothing to resume is a full install, so it is refused.
+
+    `--resume` says it carries on "instead of partitioning the disk again",
+    and with no journal to read the run started a fresh one, skipped nothing
+    and applied the whole list. The work directory is a tmpfs, so the ordinary
+    way to arrive here is a reboot -- which is exactly when an operator
+    believes a resume is what they asked for.
+    """
+    if resuming:
+        return
+    raise ResumeRefused(
+        f"--resume was given and {work} holds no journal to resume: the work "
+        "directory does not survive a reboot, so this would partition the disk "
+        "again rather than carry on. Run without --resume to install from the "
+        "beginning."
+    )
+
 
 def _from_menu(
     arguments: argparse.Namespace, refused: str = ""

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -2422,3 +2422,30 @@ def test_a_dry_run_reads_a_capacity_only_when_a_share_needs_one() -> None:
     # no capacity to describe, so it must not drag a probe in behind it.
     rested = parse(tomllib.loads(base.replace(anchor, f'{anchor}\nsize = "rest"')))
     assert not asks_for_a_share(rested.disk.graph)
+
+
+def test_a_resume_with_no_journal_refuses_instead_of_partitioning(tmp_path: Path) -> None:
+    """`--resume` says it carries on "instead of partitioning the disk again".
+
+    With nothing to resume the code started a fresh journal, left `finished`
+    empty and applied the whole operation list -- partitioning included. The
+    work directory is a tmpfs, so the ordinary way to arrive here is a reboot,
+    which is exactly when an operator believes a resume is what they asked
+    for.
+    """
+    import pytest as _pytest
+
+    from gentoo_install import cli
+    from gentoo_install.errors import ResumeRefused
+
+    # A journal with entries carries on, which is the whole point of the flag.
+    cli._refuse_a_resume_with_no_journal(tmp_path, True)
+
+    with _pytest.raises(ResumeRefused) as refused:
+        cli._refuse_a_resume_with_no_journal(tmp_path / "run", False)
+    said = str(refused.value)
+    # Both halves, because the operator's next move depends on which is wrong:
+    # the flag they passed, and the directory that turned out to be empty.
+    assert "--resume" in said, said
+    assert str(tmp_path / "run") in said, said
+    assert "partition" in said, said


### PR DESCRIPTION
`--resume`'s help text is "carry on from where a previous run stopped, skipping the operations its journal records as done, instead of partitioning the disk again". When `journal.resume()` found nothing, the code called `journal.started(**identity)`, left `finished` empty and applied the complete operation list — partitioning included.

The work directory is a tmpfs, so the ordinary way to reach that branch is a reboot, which is exactly when an operator believes a resume is what they asked for. The identity checks cannot help: they compare against a journal that is not there.

The refusal names both the flag and the directory that turned out to be empty, because which of the two is wrong decides the operator's next move. Extracted to `_refuse_a_resume_with_no_journal` so the test calls it rather than reading the source. Control: the guard short-circuited, red.

From a read-only audit agent; one of five claims about the entry point, and the one that ends in a partitioned disk.
