### PR TITLE
tests: hold the screen walk to every screen it reaches

### DIFF
--- a/tests/unit/test_no_english_on_a_translated_screen.py
+++ b/tests/unit/test_no_english_on_a_translated_screen.py
@@ -34,7 +34,9 @@ def test_no_screen_draws_an_english_sentence_in_a_chinese_menu() -> None:
     at.tag = "zh-TW"
     installation = config()
     found: dict[str, set[str]] = {}
+    refused: dict[str, str] = {}
     drawn = 0
+    walked = 0
     for name, screen_function in sorted(vars(screens).items()):
         if not name.endswith("_screen") or not callable(screen_function):
             continue
@@ -44,6 +46,7 @@ def test_no_screen_draws_an_english_sentence_in_a_chinese_menu() -> None:
             continue
         if parameters[:1] != ["screen"]:
             continue
+        walked += 1
         display = FakeScreen(keys=["\x1b"] * 40, lines=40, columns=120)
         answered: Any = None
         try:
@@ -51,9 +54,8 @@ def test_no_screen_draws_an_english_sentence_in_a_chinese_menu() -> None:
                 answered = screen_function(display, installation, at)
             else:
                 answered = screen_function(display, at)
-        except Exception:
-            # A screen this configuration cannot open is not this test's
-            # subject; the ones it can open are, and there are many.
+        except Exception as error:
+            refused[name] = f"{type(error).__name__}: {error}"
             continue
         del answered
         drawn += 1
@@ -63,9 +65,11 @@ def test_no_screen_draws_an_english_sentence_in_a_chinese_menu() -> None:
                     hit = hit.strip()
                     if len(hit) > 12 and not any(one in hit for one in NOT_PROSE):
                         found.setdefault(name, set()).add(hit)
-    # The count guards the walk itself: a signature change that stops matching
-    # every screen would leave this passing with nothing rendered.
-    assert drawn >= 8, drawn
+    # Every screen this configuration reaches is drawn, so a screen that stops
+    # opening is a hole in the check above rather than a screen out of scope:
+    # the floor this assertion replaced was 8 against 49 that draw today.
+    assert refused == {}, refused
+    assert drawn == walked, (drawn, walked)
     assert found == {}, {name: sorted(hits) for name, hits in found.items()}
 
 


### PR DESCRIPTION
`test_no_screen_draws_an_english_sentence_in_a_chinese_menu` renders every screen in Traditional Chinese and refuses English sentences. Two things weakened it: `except Exception: continue` dropped any screen that would not open, and the guard on the walk was `drawn >= 8`.

Measured on this revision: 49 screens match the signature and all 49 draw, none refuse. So the floor was six times below reality and the exemption was carrying nothing — 41 screens could have stopped rendering with the check still green, which is the failure the test was written to prevent (`#840` found two English lines in a screenshot that every unit test passed).

It now records the screen and the exception that refused, requires none to refuse, and requires the drawn count to equal the walked count. A screen that legitimately cannot open under this configuration becomes a named decision rather than an invisible hole. Control: `raise RuntimeError` at the top of `disk_screen`, red, with the name and the exception in the message.

GitHub Actions is in a major outage, so both gates were run locally: `mypy=0`, `pytest=0`.
