### PR TITLE
tests: derive which functions translate an argument

### DIFF
--- a/gentoo_install/data/locale/ja.toml
+++ b/gentoo_install/data/locale/ja.toml
@@ -163,6 +163,7 @@
 "every license" = "すべてのライセンス"
 "Compile jobs" = "コンパイルの並列数"
 "this machine's core count" = "このマシンのコア数"
+"Compiler" = "コンパイラ"
 "Compiler flags" = "コンパイラフラグ"
 "what the stage3 already has" = "stage3 の設定をそのまま使う"
 "binary packages match" = "バイナリパッケージと一致します"

--- a/gentoo_install/data/locale/ko.toml
+++ b/gentoo_install/data/locale/ko.toml
@@ -163,6 +163,7 @@
 "every license" = "모든 라이선스"
 "Compile jobs" = "컴파일 병렬 수"
 "this machine's core count" = "이 컴퓨터의 코어 수"
+"Compiler" = "컴파일러"
 "Compiler flags" = "컴파일러 플래그"
 "what the stage3 already has" = "stage3 설정을 그대로 사용"
 "binary packages match" = "바이너리 패키지가 일치합니다"

--- a/gentoo_install/data/locale/zh-CN.toml
+++ b/gentoo_install/data/locale/zh-CN.toml
@@ -163,6 +163,7 @@
 "every license" = "全部许可"
 "Compile jobs" = "编译并行数"
 "this machine's core count" = "本机核心数"
+"Compiler" = "编译器"
 "Compiler flags" = "编译器标志"
 "what the stage3 already has" = "沿用 stage3 设置"
 "binary packages match" = "可使用匹配的二进制软件包"

--- a/gentoo_install/data/locale/zh-TW.toml
+++ b/gentoo_install/data/locale/zh-TW.toml
@@ -163,6 +163,7 @@
 "every license" = "全部授權"
 "Compile jobs" = "編譯並行數"
 "this machine's core count" = "本機核心數"
+"Compiler" = "編譯器"
 "Compiler flags" = "編譯器旗標"
 "what the stage3 already has" = "沿用 stage3 設定"
 "binary packages match" = "可使用相符的二進位套件"

--- a/tests/unit/test_i18n.py
+++ b/tests/unit/test_i18n.py
@@ -279,8 +279,13 @@ def displayed() -> set[str]:
 
     found = in_a_table()
     found |= operation_templates()
-    for module in Path(tui.__file__).parent.parent.rglob("*.py"):
-        for node in ast.walk(ast.parse(module.read_text(encoding="utf-8"))):
+    trees = {
+        module: ast.parse(module.read_text(encoding="utf-8"))
+        for module in Path(tui.__file__).parent.parent.rglob("*.py")
+    }
+    carriers = _translates_a_parameter(trees.values())
+    for tree in trees.values():
+        for node in ast.walk(tree):
             if not isinstance(node, ast.Call):
                 continue
             called = getattr(node.func, "id", "") or getattr(node.func, "attr", "")
@@ -288,23 +293,51 @@ def displayed() -> set[str]:
                 node.args[0], ast.Constant
             ):
                 found.add(str(node.args[0].value))
+            # `Setting("cflags", "Compiler flags", ...)`: a dataclass field,
+            # translated by whoever draws the row rather than in a body here,
+            # so it cannot be derived the way the carriers below are.
             if called == "Setting" and len(node.args) > 1:
                 if isinstance(node.args[1], ast.Constant):
                     found.add(str(node.args[1].value))
-            # `footer(translate, "Start writing to the disks")`: the string
-            # names what enter does on that screen and is translated inside.
-            if called == "footer" and len(node.args) > 1:
-                if isinstance(node.args[1], ast.Constant):
-                    found.add(str(node.args[1].value))
-            # `_consent_screen(screen, config, context, "Font configuration",
-            # summary)`: its fourth argument is the title and it calls
-            # `translate(title)` itself. Without this the collector could not
-            # see that title at all, so `Font configuration` drew in English
-            # on four translated screens and this test stayed green.
-            if called == "_consent_screen" and len(node.args) > 3:
-                if isinstance(node.args[3], ast.Constant):
-                    found.add(str(node.args[3].value))
+            for position in carriers.get(called, ()):
+                if len(node.args) <= position:
+                    continue
+                carried = node.args[position]
+                if isinstance(carried, ast.Constant):
+                    found.add(str(carried.value))
     return found
+
+
+def _translates_a_parameter(trees: object) -> dict[str, set[int]]:
+    """Functions that hand one of their own parameters to `translate`.
+
+    Derived, not listed: the list was written by hand and missed one three
+    times. `footer` and `_consent_screen` were added after each miss drew
+    English on a translated screen, and `nested` was still absent, which is
+    why the group title `Compiler` reached four screens untranslated and was
+    not even a catalog key.
+    """
+    import ast as _ast
+    from typing import Iterable, cast
+
+    carriers: dict[str, set[int]] = {}
+    for tree in cast("Iterable[_ast.Module]", trees):
+        for function in _ast.walk(tree):
+            if not isinstance(function, (_ast.FunctionDef, _ast.AsyncFunctionDef)):
+                continue
+            names = [one.arg for one in function.args.args]
+            for node in _ast.walk(function):
+                if not isinstance(node, _ast.Call):
+                    continue
+                called = getattr(node.func, "id", "") or getattr(node.func, "attr", "")
+                if called not in {"translate", "_translate"} or not node.args:
+                    continue
+                argument = node.args[0]
+                if isinstance(argument, _ast.Name) and argument.id in names:
+                    carriers.setdefault(function.name, set()).add(
+                        names.index(argument.id)
+                    )
+    return carriers
 
 
 def test_the_catalogs_hold_every_string_the_interface_shows() -> None:


### PR DESCRIPTION
`Compiler` was drawn in English at the top of the make.conf screen on guest `m7c`, with every row under it in Chinese. Nine of the ten `nested(...)` group titles are catalog keys; the tenth was never added, and nothing noticed.

`displayed()` collects source strings by walking for calls, and it carried a hand-written list of the functions that translate an argument rather than a literal: `translate`, `Setting`, `footer`, `_consent_screen`. The comment on `_consent_screen` records the previous time this was missed (`Font configuration`, four screens). `nested` was never added, so its title was invisible to the check that exists to find exactly this.

The list is now derived: any function whose body passes one of its own parameters to `translate` is a carrier, and the argument at that position is collected at every call site. That finds six where the list had two — `nested`, `_one_group`, `pick` and `_array_descriptor` were all uncovered. Sweeping with the derived set reports exactly one string missing from the catalogs, `Compiler`, added here in all four with `編譯器` / `编译器` / `コンパイラ` / `컴파일러`.

`Setting` stays explicit, with a comment saying why: its label is a dataclass field translated by whoever draws the row, not a parameter translated in a body, so it cannot be derived the same way.

Controls: removing the new key, red naming `Compiler`; emptying the derived carrier map, red.
