### PR TITLE
tui: the compile jobs row names the machine, not the stage3

### DIFF
--- a/gentoo_install/data/locale/ja.toml
+++ b/gentoo_install/data/locale/ja.toml
@@ -378,7 +378,6 @@
 "a reused layout writes no table" = "構成を流用する場合はパーティションテーブルを書かない"
 "none detected" = "検出なし"
 "this machine" = "このマシン"
-"stage3 default" = "stage3 の既定値"
 "baseline" = "ベースライン"
 "what the profile sets, and what a binary host builds" = "profile が決める設定で、binhost も同じ設定でビルドします"
 "Encryption is a field of each partition, under Partitions." = "暗号化は「パーティション」画面にある各パーティションの項目です。"

--- a/gentoo_install/data/locale/ko.toml
+++ b/gentoo_install/data/locale/ko.toml
@@ -378,7 +378,6 @@
 "a reused layout writes no table" = "기존 구성을 재사용하면 파티션 테이블을 쓰지 않음"
 "none detected" = "감지 없음"
 "this machine" = "이 기기"
-"stage3 default" = "stage3 기본값"
 "baseline" = "기준선"
 "what the profile sets, and what a binary host builds" = "profile이 정하는 설정이며 binhost 도 같은 설정으로 빌드합니다"
 "Encryption is a field of each partition, under Partitions." = '암호화는 "파티션" 화면의 각 파티션에 있는 항목입니다.'

--- a/gentoo_install/data/locale/zh-CN.toml
+++ b/gentoo_install/data/locale/zh-CN.toml
@@ -378,7 +378,6 @@
 "a reused layout writes no table" = "沿用既有分区不写分区表"
 "none detected" = "未检测到"
 "this machine" = "本机"
-"stage3 default" = "stage3 默认值"
 "baseline" = "基线"
 "what the profile sets, and what a binary host builds" = "profile 决定，binhost 也照同一组设置构建"
 "Encryption is a field of each partition, under Partitions." = "加密是各分区的字段，在分区那一页设置。"

--- a/gentoo_install/data/locale/zh-TW.toml
+++ b/gentoo_install/data/locale/zh-TW.toml
@@ -378,7 +378,6 @@
 "a reused layout writes no table" = "沿用既有分割區不寫分割表"
 "none detected" = "未偵測到"
 "this machine" = "本機"
-"stage3 default" = "stage3 預設值"
 "baseline" = "基線"
 "what the profile sets, and what a binary host builds" = "profile 決定，binhost 也照同一組設定建置"
 "Encryption is a field of each partition, under Partitions." = "加密是各分割區的欄位；設定位置為分割區頁面。"

--- a/gentoo_install/tui/settings.py
+++ b/gentoo_install/tui/settings.py
@@ -705,7 +705,10 @@ def _license(config: InstallConfig, context: Context) -> str:
 def _makeopts(config: InstallConfig, context: Context) -> str:
     if config.portage.makeopts:
         return config.portage.makeopts
-    return context.translate("stage3 default")
+    # Not the stage3's value: `plan.portage` passes `jobs_from_machine` when
+    # this is empty and writes the target's own core count, so the row said
+    # the opposite of what the install does. Same words as the chooser's row.
+    return context.translate("this machine's core count")
 
 
 def _cflags(config: InstallConfig, context: Context) -> str:

--- a/tests/unit/test_i18n.py
+++ b/tests/unit/test_i18n.py
@@ -839,3 +839,33 @@ def test_the_password_form_shows_the_catalog_word_for_done() -> None:
     drawn = "\n".join(line for frame in display.frames for line in frame)
     assert "Done" not in drawn, drawn
     assert at.translate("Done") in drawn, drawn
+
+
+def test_the_compile_jobs_row_says_what_the_plan_will_write() -> None:
+    """An empty `makeopts` means the target's own core count, not the stage3's.
+
+    `plan.portage` passes `jobs_from_machine=not portage.makeopts` and writes
+    `-j` with the machine's cores, while the row read `stage3 default`: the
+    menu named the opposite of what the install does. Found by reading the
+    screen on a guest, where choosing the preselected row changed the summary
+    to a value that row does not produce.
+    """
+    from dataclasses import replace
+
+    from gentoo_install.i18n import Catalog
+    from gentoo_install.tui import settings
+
+    from .test_tui_app import config, context
+
+    at = context()
+    at.translate = Catalog("zh-TW")
+    installation = config()
+    unpinned = replace(
+        installation, portage=replace(installation.portage, makeopts="")
+    )
+    said = settings._makeopts(unpinned, at)
+    assert said == at.translate("this machine's core count"), said
+    assert said != at.translate("stage3 default"), said
+
+    pinned = replace(installation, portage=replace(installation.portage, makeopts="-j4"))
+    assert settings._makeopts(pinned, at) == "-j4"

--- a/tests/unit/test_tui_app.py
+++ b/tests/unit/test_tui_app.py
@@ -1967,12 +1967,18 @@ def test_the_console_font_is_a_row_and_the_size_with_no_cjk_says_why() -> None:
     assert chosen.unwrap().system.console_font is ConsoleFontSize.SIZE_16X32
 
 
-def test_empty_makeopts_summary_names_the_stage3_default() -> None:
-    """An empty value is preserved by the plan, so its summary must say stage3 default."""
+def test_empty_makeopts_summary_names_the_machine_it_installs_onto() -> None:
+    """An empty value is resolved by the plan, so its summary says whose cores.
+
+    This test held the opposite until now, and its own docstring carried the
+    premise that stopped being true: `#1086` made `plan.portage` pass
+    `jobs_from_machine` for an empty value and write the target's core count,
+    while the row still read `stage3 default`.
+    """
     at = context()
     empty = config()
     setting = next(one for group in settings.SETTINGS for one in group.rows if one.key == "makeopts")
-    assert settings.shown_value(setting, empty, at) == "stage3 default"
+    assert settings.shown_value(setting, empty, at) == "this machine's core count"
 
 
 def test_console_font_is_available_for_standard_kernel_without_console_cjk() -> None:


### PR DESCRIPTION
Driving the menu on guest `m7c`, selecting the preselected row of the compile-jobs chooser — labelled `-j2` with the note `本機核心數` — changed the summary to `stage3 預設值`. Those are different things, and the summary was the wrong one.

`#1086` made an empty `makeopts` mean the target's own core count: `plan.portage` builds `WriteMakeConf(jobs_from_machine=not portage.makeopts, ...)` and resolves `-j{context.jobs()}` when the operation is applied. The TUI was not revisited, so `_makeopts` still rendered an empty value as `stage3 default` and told the operator the stage3's value would be kept.

The summary now reuses the chooser's own key, `this machine's core count`, so the row and the option that produces it read the same. `stage3 default` is removed from all four catalogs because nothing shows it any more — the bidirectional catalog test refuses a stale key, which is how that came up. The `(stage3 default)` suffix on the compiler-flags row is a separate key and is still correct: an empty `cflags` really is preserved.

`test_empty_makeopts_summary_names_the_stage3_default` asserted the old behaviour, and its docstring carried the premise that stopped being true — "an empty value is preserved by the plan". Rewritten rather than deleted, with the reason in place.

Control: putting the old key back at the call site, red.
