### PR TITLE
tests: a quiet console is not a finished draw

### DIFF
--- a/tests/tui/session.py
+++ b/tests/tui/session.py
@@ -240,10 +240,20 @@ def _settled(grid: "Screen", console: object) -> str:
     """
     read = getattr(console, "read_available")
     deadline = time.monotonic() + SETTLE_LIMIT
+    # Two quiet windows, not one. The console is a websocket to a node, so a
+    # single gap between chunks can be longer than one window and lands in the
+    # middle of a drawn run rather than between two frames: a row that reads
+    # `-j` where the guest wrote `-j1` looks exactly like a defect in the
+    # interface, and three reads in a row showed it.
+    quiet = 0
     while time.monotonic() < deadline:
         arrived = read(SETTLE_QUIET)
         if not arrived:
-            break
+            quiet += 1
+            if quiet == 2:
+                break
+            continue
+        quiet = 0
         grid.feed(arrived)
     return _with_cursor(grid)
 

--- a/tests/unit/test_harness.py
+++ b/tests/unit/test_harness.py
@@ -6503,3 +6503,30 @@ def test_one_rule_says_how_much_memory_a_guest_needs() -> None:
     source = Path("tests/vm/run.py").read_text()
     assert "memory_mib(load(" in source, source[:0]
     assert "memory=wanted_memory" in source, source[:0]
+
+
+def test_a_gap_between_chunks_is_not_the_end_of_the_draw() -> None:
+    """One quiet window ended the read in the middle of a drawn row.
+
+    The console is a websocket to a cluster node, so the gap between two
+    chunks of one repaint can be longer than a window. Reading then returned
+    `-j` for a row the guest had written as `-j1`, which reads as a defect in
+    the interface rather than as half a frame, and it repeated across three
+    reads because the tear is where the network put it, not where the guest is.
+    """
+    from tests.tui.session import _settled
+    from tests.tui.screen import Screen
+
+    class TornConsole:
+        """Delivers one repaint in two chunks with a quiet window between."""
+
+        def __init__(self) -> None:
+            self.answers = [b"\x1b[1;1H  -j", b"", b"1", b"", b""]
+
+        def read_available(self, patience: float) -> bytes:
+            del patience
+            return self.answers.pop(0) if self.answers else b""
+
+    grid = Screen(lines=5, columns=20)
+    shown = _settled(grid, TornConsole())
+    assert "-j1" in shown, shown


### PR DESCRIPTION
`session screen` reported the compile-jobs chooser's second row as `-j`, three reads in a row, while the guest had written `-j1`. That reads as a defect in the interface, and it is not one: moving the cursor off the row and reading twice more returns `-j1` both times.

Traced by separating the two halves. Curses writes it correctly — a pty capture of `makeopts_screen` contains `-j1`, and the guest's own console log contains `\x1b[7;51H\x1b(B\x1b[m  -j1\x1b[35X`. Replaying the whole log through `tests/tui/screen.py` also renders `-j1`, so neither the interface nor the renderer is wrong. What was wrong is when the grid was read: `_settled` returned after a single 250 ms quiet window, and the console is a websocket to a cluster node where the gap between two chunks of one repaint outlasts that. The tear lands wherever the network put it, which is why it repeated instead of moving.

`_settled` now requires two consecutive quiet windows. Its docstring already recorded an earlier torn read — three rows twice and no section headings — so the mechanism was right and the threshold was not.

The test drives `_settled` with a console that hands back a repaint in two chunks with a quiet window between them. Control: one quiet window instead of two, red.

Worth stating plainly: this cost most of a round, and the first two explanations — a clipping bug in the panel, then an off-by-one in the renderer's `ECH` — were both wrong and both plausible.
