### PR TITLE
tests: a half-open console breaks instead of reading empty

### DIFF
--- a/tests/unit/test_harness.py
+++ b/tests/unit/test_harness.py
@@ -6530,3 +6530,63 @@ def test_a_gap_between_chunks_is_not_the_end_of_the_draw() -> None:
     grid = Screen(lines=5, columns=20)
     shown = _settled(grid, TornConsole())
     assert "-j1" in shown, shown
+
+
+def test_a_console_socket_asks_whether_its_peer_is_still_there() -> None:
+    """`read()` answers empty for an idle console and for a dead one alike.
+
+    A half-open connection whose peer vanished without a FIN reads empty for
+    ever, which is exactly what an idle guest looks like, and four stalled
+    guests were read as the installer hanging. Keepalive makes the kernel
+    break the second one, and `read()` already turns that `OSError` into a
+    closed console with a reason.
+
+    Measured against a real socket rather than a double: these are the values
+    the kernel kept, not the values that were passed.
+    """
+    import socket
+
+    from tests.vm import websocket
+
+    listener = socket.socket()
+    listener.bind(("127.0.0.1", 0))
+    listener.listen(1)
+    talking = socket.create_connection(listener.getsockname())
+    try:
+        assert talking.getsockopt(socket.SOL_SOCKET, socket.SO_KEEPALIVE) == 0
+        websocket.keep_asking(talking)
+        assert talking.getsockopt(socket.SOL_SOCKET, socket.SO_KEEPALIVE) == 1
+        assert (
+            talking.getsockopt(socket.IPPROTO_TCP, socket.TCP_KEEPIDLE)
+            == websocket.SILENCE_BEFORE_PROBING
+        )
+        assert (
+            talking.getsockopt(socket.IPPROTO_TCP, socket.TCP_KEEPINTVL)
+            == websocket.BETWEEN_PROBES
+        )
+        assert (
+            talking.getsockopt(socket.IPPROTO_TCP, socket.TCP_KEEPCNT)
+            == websocket.PROBES_BEFORE_GIVING_UP
+        )
+    finally:
+        talking.close()
+        listener.close()
+
+
+def test_the_console_connection_is_the_one_that_gets_keepalive() -> None:
+    """`connect` must call it, not only export it: a helper nothing reaches
+    leaves every real console exactly as ambiguous as before."""
+    import ast
+    import inspect
+
+    from tests.vm import websocket
+
+    import textwrap
+
+    source = textwrap.dedent(inspect.getsource(websocket.WebSocket.connect))
+    called = {
+        getattr(node.func, "id", "") or getattr(node.func, "attr", "")
+        for node in ast.walk(ast.parse(source))
+        if isinstance(node, ast.Call)
+    }
+    assert "keep_asking" in called, sorted(called)

--- a/tests/unit/test_proxmox.py
+++ b/tests/unit/test_proxmox.py
@@ -589,6 +589,12 @@ def test_the_handshake_accept_must_match_the_key_that_was_sent(
     class Raw:
         def __init__(self) -> None:
             self.closed = False
+            #: What `keep_asking` set, so the double answers the same calls the
+            #: real socket does rather than only the ones this test reads.
+            self.options: list[tuple[int, int, int]] = []
+
+        def setsockopt(self, level: int, option: int, value: int) -> None:
+            self.options.append((level, option, value))
 
         def close(self) -> None:
             self.closed = True

--- a/tests/vm/websocket.py
+++ b/tests/vm/websocket.py
@@ -37,6 +37,34 @@ class WebSocketError(Exception):
     """The handshake failed, or the peer sent something this client cannot read."""
 
 
+#: How long a console may be silent before the kernel starts probing it, and
+#: how many probes at what spacing decide it is gone. A guest is legitimately
+#: silent for minutes at a time, so this measures the connection rather than
+#: the guest: the probes are TCP, and the node answers them whether or not
+#: anything is being typed.
+SILENCE_BEFORE_PROBING: Final[int] = 30
+BETWEEN_PROBES: Final[int] = 10
+PROBES_BEFORE_GIVING_UP: Final[int] = 3
+
+
+def keep_asking(sock: socket.socket) -> None:
+    """Ask the kernel to notice a peer that went away without saying so.
+
+    `read()` answers empty both for an idle console and for a half-open
+    connection whose peer is gone with no FIN, and nothing above can tell
+    those apart: four stalled guests were diagnosed for days as the installer
+    hanging. With keepalive the second one breaks the socket instead, and the
+    `OSError` branch in `read()` already reports it with a reason.
+
+    Not a websocket ping: that needs the server to answer, and this needs
+    nothing from it.
+    """
+    sock.setsockopt(socket.SOL_SOCKET, socket.SO_KEEPALIVE, 1)
+    sock.setsockopt(socket.IPPROTO_TCP, socket.TCP_KEEPIDLE, SILENCE_BEFORE_PROBING)
+    sock.setsockopt(socket.IPPROTO_TCP, socket.TCP_KEEPINTVL, BETWEEN_PROBES)
+    sock.setsockopt(socket.IPPROTO_TCP, socket.TCP_KEEPCNT, PROBES_BEFORE_GIVING_UP)
+
+
 def _client_frame(payload: bytes, opcode: int) -> bytes:
     """One masked frame. A client always masks; a server never does."""
     mask = os.urandom(4)
@@ -106,6 +134,7 @@ class WebSocket:
         secure: ssl.SSLSocket | None = None
         try:
             raw = socket.create_connection((host, port), timeout=timeout)
+            keep_asking(raw)
             secure = (context or ssl.create_default_context()).wrap_socket(
                 raw, server_hostname=host
             )


### PR DESCRIPTION
Task row 428. `WebSocket.read()` returns empty bytes when no frame completed, and its own comment says empty is the ordinary state of an idle console — which is true, and is also what a connection whose peer is gone returns for ever. Nothing above the socket can tell those apart, and row 402's stalled guests were diagnosed for days as the installer hanging, on evidence that could not distinguish the two.

The row proposed a websocket ping. This uses TCP keepalive instead, because a ping needs the server to answer and this needs nothing from it: the kernel probes after 30 s of silence, three probes 10 s apart, and a peer that is gone breaks the socket. `read()`'s `except OSError` branch already turns that into a closed console carrying a reason, so nothing above changes.

Measuring the connection rather than the guest is what makes the timings safe: a guest is legitimately silent for the eleven minutes it spends fetching a stage3, while the node answers TCP probes throughout.

The first test reads the options back off a real loopback socket, so it holds what the kernel kept rather than what was passed, and asserts keepalive is off beforehand. The second holds that `connect` calls the helper — a helper nothing reaches leaves every console as ambiguous as before. The socket double in `test_proxmox.py` grew the `setsockopt` the real socket takes rather than the code being made tolerant of a socket that ignores it.

Controls: the helper setting nothing, red; `connect` not calling it, red.
