### PR TITLE
probe: the evidence for a live medium is a token

### DIFF
--- a/gentoo_install/exec/probe.py
+++ b/gentoo_install/exec/probe.py
@@ -1210,8 +1210,13 @@ class Probe:
 
         The installer assumed it, and the assumption is what makes running it
         on a machine somebody uses dangerous: nothing said so before the disk
-        screen. Read rather than guessed, because a medium can be anything —
+        screen. Read rather than guessed, because a medium can be anything --
         Alpine, Debian, a Fedora live image.
+
+        One token, not a sentence: this is carried as a `Refusal.detail`,
+        which the menu appends to a translated reason without translating it,
+        so a sentence here put English inside a Chinese line. The callers that
+        want prose build their own around it.
         """
         try:
             cmdline = CMDLINE.read_text(encoding="utf-8")
@@ -1219,7 +1224,7 @@ class Probe:
             cmdline = ""
         for marker in self.LIVE_CMDLINE:
             if marker in cmdline:
-                return f"the kernel command line carries {marker}"
+                return marker
         said = self.runner.run(
             ["findmnt", "--noheadings", "--output", "FSTYPE", "--mountpoint", "/"],
             check=False,
@@ -1228,7 +1233,7 @@ class Probe:
             return ""
         kind = said.stdout.strip()
         if kind in self.LIVE_ROOT_TYPES:
-            return f"the root filesystem is {kind}"
+            return kind
         return ""
 
     def memory_environment(self) -> bool:

--- a/gentoo_install/tui/screens.py
+++ b/gentoo_install/tui/screens.py
@@ -138,8 +138,15 @@ INSTALL_MODES: tuple[tuple[DiskMode, str], ...] = (
 
 def _because(refused: refusals.Refusal, translate: Catalog) -> str:
     """The reason in the operator's language, and what on this machine caused
-    it after it. The detail is a device path or a command name, which is the
-    same word in every language and is not in any catalog."""
+    it after it.
+
+    The detail is never translated, so a producer that puts a sentence there
+    writes English into a translated line: `live_medium()` did, and a guest
+    drew a Chinese refusal ending in `(the kernel command line carries ...)`.
+    A device path, a filesystem type or a comma-joined list of commands is the
+    same word in every language; `str(error)` is not, and is accepted only
+    because an exception message has nowhere else to go.
+    """
     if not refused.detail:
         return translate(refused.reason)
     return f"{translate(refused.reason)} ({refused.detail})"

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -7,7 +7,7 @@ import os
 import shutil
 import sys
 import time
-from typing import Final, Sequence, cast
+from typing import Any, Final, Sequence, cast
 import re
 from dataclasses import replace
 from pathlib import Path
@@ -2523,3 +2523,53 @@ def test_every_session_invocation_asks_for_the_menu() -> None:
     assert len(driven) == 2, driven
     for arguments in driven:
         assert "--menu" in arguments, arguments
+
+
+def test_the_evidence_for_a_live_medium_is_a_token_not_a_sentence(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """`live_medium()` is carried as a `Refusal.detail`, which is not translated.
+
+    The menu draws `translate(reason) + " (" + detail + ")"`, so a sentence
+    here put English inside a translated line: a guest running the interface
+    in Traditional Chinese drew a translated refusal ending in `(the kernel
+    command line carries rd.live.)`. The reason already says what happened;
+    the detail says which marker, and a marker is the same word in every
+    language.
+    """
+    from gentoo_install.exec import probe as probe_module
+
+    class Said:
+        def __init__(self, stdout: str) -> None:
+            self.stdout = stdout
+            self.returncode = 0
+
+    class Runner:
+        def __init__(self, root: str) -> None:
+            self.root = root
+
+        def run(self, argv: list[str], check: bool = True) -> Said:
+            del argv, check
+            return Said(self.root)
+
+    cmdline = tmp_path / "cmdline"
+    monkeypatch.setattr(probe_module, "CMDLINE", cmdline)
+
+    cmdline.write_text("BOOT_IMAGE=/vmlinuz rd.live.image quiet")
+    from_cmdline = _probe_with(probe_module, Runner(""), tmp_path).live_medium()
+    assert from_cmdline == "rd.live.", from_cmdline
+
+    cmdline.write_text("BOOT_IMAGE=/vmlinuz root=/dev/vda2 ro")
+    from_root = _probe_with(probe_module, Runner("overlay"), tmp_path).live_medium()
+    assert from_root == "overlay", from_root
+
+    # The rule, rather than the two values above: a producer that grows a
+    # sentence again is what this is here to refuse.
+    for evidence in (from_cmdline, from_root):
+        assert " " not in evidence, evidence
+
+
+def _probe_with(probe_module: object, runner: object, work: Path) -> RealProbe:
+    """A `Probe` built the way `cli.py` builds one, with a fake runner."""
+    made = getattr(probe_module, "Probe")
+    return cast(RealProbe, made(cast(Any, runner), work))


### PR DESCRIPTION
Read off a guest running the interface in Traditional Chinese: the install-mode screen drew a translated refusal ending in `(the kernel command line carries rd.live.)`.

`_because` builds `translate(reason) + " (" + detail + ")"` and its docstring said the detail is "a device path or a command name, which is the same word in every language". `live_medium()` returned `f"the kernel command line carries {marker}"` or `f"the root filesystem is {kind}"` — prose, and prose in that position is English on a translated line. The reason already says a live medium has no system to replace; the detail only has to say which marker, so it now returns the marker or the filesystem type.

`preflight.py` builds its own English sentence around the value and reads correctly with a token: "this is a live medium (overlay)".

The docstring is corrected rather than left as an aspiration, because a second producer really does put prose there: `Refusal(CANNOT_READ_THE_SYSTEM, str(error))`. An exception message has nowhere else to go, and it is named as the exception rather than pretended away.

Worth noting the change was invisible to the suite — both gates stayed green with the sentence removed, because nothing held the shape of that value. The test now does, and its control is the sentence put back.

The first draft of that test quoted the Chinese screen in its docstring; `test_no_wide_character_is_written_into_code_or_a_data_file` refused it, which is the rule working.
