### PR TITLE
model: compose every published path from the machine's row

### DIFF
--- a/gentoo_install/exec/fetch.py
+++ b/gentoo_install/exec/fetch.py
@@ -38,11 +38,12 @@ from ..errors import (
 from ..redact import scrub
 from ..model import paste
 from ..model.validate import KernelCeiling
+from ..model.architecture import DEFAULT_ARCHITECTURE
 from ..model.config import ProxyConfig
 from .probe import RELEASE_KEY
 from .runner import Runner
 
-STAGE3_PATH: Final[str] = "releases/amd64/autobuilds"
+STAGE3_PATH: Final[str] = f"releases/{DEFAULT_ARCHITECTURE.gentoo_name}/autobuilds"
 TIMEOUT: Final[float] = 60.0
 
 #: Sent on every request. `paste.gentoozh.org` answers 403 to the agent urllib
@@ -265,7 +266,7 @@ def _newest(
     The signature around the entries is not checked here: the DIGESTS file is,
     and it is what decides whether the bytes are the right ones.
     """
-    pointer = f"{builds}/latest-stage3-amd64-{variant}.txt"
+    pointer = f"{builds}/latest-stage3-{DEFAULT_ARCHITECTURE.gentoo_name}-{variant}.txt"
     paths: list[str] = []
     for line in _read_patiently(pointer, proxy).splitlines():
         said = line.strip()
@@ -465,7 +466,8 @@ def why_mirror_unreachable(
     mirror: str, variant: str, proxy: ProxyConfig | None = None
 ) -> str:
     """Empty when the mirror answers, and why it did not otherwise."""
-    url = f"{mirror.rstrip('/')}/{STAGE3_PATH}/latest-stage3-amd64-{variant}.txt"
+    stage3 = f"latest-stage3-{DEFAULT_ARCHITECTURE.gentoo_name}-{variant}.txt"
+    url = f"{mirror.rstrip('/')}/{STAGE3_PATH}/{stage3}"
     return why_unreachable(url) if proxy is None else why_unreachable(url, proxy)
 
 

--- a/gentoo_install/exec/preflight.py
+++ b/gentoo_install/exec/preflight.py
@@ -14,6 +14,7 @@ from typing import AbstractSet, Final, Iterable, Mapping
 
 from ..errors import DeviceNotFound, PreflightFailed
 from ..model import compat
+from ..model.architecture import DEFAULT_ARCHITECTURE
 from ..model.config import DiskMode, Firmware, InstallConfig
 from ..model.device import (
     DeviceGraph,
@@ -505,7 +506,7 @@ def inspect(
     # The row rather than the literal: `uname -m` and Gentoo spell the same
     # architecture differently, and the message has to name the one the
     # configuration targets rather than the one this file was written for.
-    installs = compat.DEFAULT_ARCHITECTURE
+    installs = DEFAULT_ARCHITECTURE
     if config.disk.mode is not DiskMode.DD and machine.architecture != installs.kernel_name:
         fatal.append(
             f"this build installs {installs.gentoo_name} and the machine reports "

--- a/gentoo_install/model/architecture.py
+++ b/gentoo_install/model/architecture.py
@@ -1,0 +1,102 @@
+# SPDX-License-Identifier: GPL-2.0-or-later
+"""Which machine an install targets, under each of the names something spells it.
+
+Its own module rather than part of `compat.py`: `mirrors.py` composes a URL
+from the row and `compat.py` reads `mirrors.py`, so holding the row in
+`compat.py` is a cycle.
+"""
+
+from __future__ import annotations
+
+import platform
+from dataclasses import dataclass
+from typing import Final
+
+@dataclass(frozen=True, kw_only=True)
+class Architecture:
+    """One target architecture, under each of the names something spells it.
+
+    Ecosystems name the same architecture differently, the way `fma` and
+    `fma3` do: `uname -m` answers `x86_64` and Gentoo's `profiles/arch.list`
+    says `amd64`. Holding the pair together is what lets a site compare a row
+    instead of a literal. Keyword-only, because both fields are strings that
+    read the same way round, so a swapped row would pass every gate.
+    """
+
+    #: What `uname -m` answers on a machine of this kind.
+    kernel_name: str
+    #: The line of `profiles/arch.list`, which is also the keyword.
+    gentoo_name: str
+    #: `grub-install --target`. GRUB spells the same machine a third way.
+    grub_target: str
+    #: Which `CPU_FLAGS_*` `make.conf` takes. Writing the x86 one on an arm64
+    #: machine sets a variable no ebuild reads.
+    cpu_flags_variable: str
+    #: The directory the official binary host keeps this machine's packages
+    #: in, under `releases/<gentoo_name>/binpackages/<release>/`. A fourth
+    #: spelling: amd64's is `x86-64` and arm64's is `arm64`.
+    binhost_subarch: str
+
+
+#: The row every published path targets today: the stage3, the profile and the
+#: official binary host are all fetched for it. Named so that the default is
+#: this row rather than whichever one the table happens to list first.
+AMD64: Final[Architecture] = Architecture(
+    kernel_name="x86_64",
+    gentoo_name="amd64",
+    grub_target="x86_64-efi",
+    cpu_flags_variable="CPU_FLAGS_X86",
+    binhost_subarch="x86-64",
+)
+
+#: Every architecture this installer has a name for. A machine outside it is
+#: refused by name rather than sent to a URL composed from a guess.
+ARCHITECTURES: Final[tuple[Architecture, ...]] = (
+    AMD64,
+    Architecture(
+        kernel_name="aarch64",
+        gentoo_name="arm64",
+        grub_target="arm64-efi",
+        cpu_flags_variable="CPU_FLAGS_ARM",
+        binhost_subarch="arm64",
+    ),
+    Architecture(
+        kernel_name="i686",
+        gentoo_name="x86",
+        grub_target="i386-efi",
+        cpu_flags_variable="CPU_FLAGS_X86",
+        binhost_subarch="i686",
+    ),
+)
+
+def _machine_row() -> Architecture:
+    """The row for the machine this installer is running on.
+
+    Every published path is composed for one architecture -- the stage3, the
+    profile, the binary host, `grub-install --target` -- and the installer
+    installs for the machine it runs on. Naming that machine here is what the
+    constant always meant; it was written as `AMD64` because that was the only
+    machine anyone had run it on.
+
+    An architecture with no row falls back to amd64 rather than composing a
+    URL from a guess: `preflight` then refuses by name, which is a message an
+    operator can act on.
+    """
+    running = platform.machine()
+    for row in ARCHITECTURES:
+        if row.kernel_name == running:
+            return row
+    return AMD64
+
+
+#: What an installation targets. Read from the machine rather than written in,
+#: because a cross-architecture install is not a thing this installer does.
+DEFAULT_ARCHITECTURE: Final[Architecture] = _machine_row()
+
+
+def architecture_of(kernel_name: str) -> Architecture | None:
+    """The row a machine reporting `kernel_name` belongs to, if there is one."""
+    for row in ARCHITECTURES:
+        if row.kernel_name == kernel_name:
+            return row
+    return None

--- a/gentoo_install/model/compat.py
+++ b/gentoo_install/model/compat.py
@@ -9,6 +9,7 @@ once and read twice.
 
 from __future__ import annotations
 
+
 import ipaddress
 import re
 from dataclasses import dataclass
@@ -359,48 +360,7 @@ _CJK_KERNEL_PACKAGES: Final[frozenset[str]] = frozenset(
 )
 
 
-@dataclass(frozen=True, kw_only=True)
-class Architecture:
-    """One target architecture, under each of the names something spells it.
 
-    Ecosystems name the same architecture differently, the way `fma` and
-    `fma3` do: `uname -m` answers `x86_64` and Gentoo's `profiles/arch.list`
-    says `amd64`. Holding the pair together is what lets a site compare a row
-    instead of a literal. Keyword-only, because both fields are strings that
-    read the same way round, so a swapped row would pass every gate.
-    """
-
-    #: What `uname -m` answers on a machine of this kind.
-    kernel_name: str
-    #: The line of `profiles/arch.list`, which is also the keyword.
-    gentoo_name: str
-
-
-#: The row every published path targets today: the stage3, the profile and the
-#: official binary host are all fetched for it. Named so that the default is
-#: this row rather than whichever one the table happens to list first.
-AMD64: Final[Architecture] = Architecture(kernel_name="x86_64", gentoo_name="amd64")
-
-#: Every architecture this installer has a name for. A machine outside it is
-#: refused by name rather than sent to a URL composed from a guess.
-ARCHITECTURES: Final[tuple[Architecture, ...]] = (
-    AMD64,
-    Architecture(kernel_name="aarch64", gentoo_name="arm64"),
-    Architecture(kernel_name="i686", gentoo_name="x86"),
-)
-
-#: What an installation targets when its configuration says nothing. Only
-#: amd64 is installed today; the others are named so that the sites that
-#: decide can compare a row rather than a literal.
-DEFAULT_ARCHITECTURE: Final[Architecture] = AMD64
-
-
-def architecture_of(kernel_name: str) -> Architecture | None:
-    """The row a machine reporting `kernel_name` belongs to, if there is one."""
-    for row in ARCHITECTURES:
-        if row.kernel_name == kernel_name:
-            return row
-    return None
 
 
 #: The official binary hosts this installer knows how to point Portage at.

--- a/gentoo_install/model/mirrors.py
+++ b/gentoo_install/model/mirrors.py
@@ -12,6 +12,7 @@ from __future__ import annotations
 from dataclasses import dataclass
 from typing import Final
 
+from .architecture import DEFAULT_ARCHITECTURE
 from .config import PROFILE_RELEASE, GentooZhMirror, MirrorRegion
 
 
@@ -243,14 +244,18 @@ def gentoo_rsync_uri(region: MirrorRegion, preferred: str = "") -> str:
 
 #: Where a mirror keeps the official binary packages, relative to the
 #: distfiles base. Every site that carries the releases tree carries these.
-BINPACKAGES: Final[str] = f"releases/amd64/binpackages/{PROFILE_RELEASE}"
+#: Where a mirror keeps the official binary packages, relative to the
+#: distfiles base. The architecture appears twice in one URL and both come
+#: from the same row: `releases/<gentoo_name>/binpackages/<release>/<subarch>`.
+BINPACKAGES: Final[str] = "releases/{arch}/binpackages/" + PROFILE_RELEASE
 
 
-def gentoo_binhost(region: MirrorRegion, preferred: str = "", subarch: str = "x86-64") -> str:
+def gentoo_binhost(region: MirrorRegion, preferred: str = "", subarch: str = "") -> str:
     """The official binary packages, from the same site as the distfiles."""
     sites = gentoo_sites(region)
     chosen = next((site for site in sites if site.key == preferred), sites[0])
-    return f"{chosen.distfiles}/{BINPACKAGES}/{subarch}"
+    within = BINPACKAGES.format(arch=DEFAULT_ARCHITECTURE.gentoo_name)
+    return f"{chosen.distfiles}/{within}/{subarch or DEFAULT_ARCHITECTURE.binhost_subarch}"
 
 
 def gentoozh(chosen: GentooZhMirror) -> Site:

--- a/gentoo_install/plan/bootloader.py
+++ b/gentoo_install/plan/bootloader.py
@@ -18,6 +18,7 @@ from typing import Final
 
 from ..errors import CommandFailed, ConfigError, InvalidLayout, NothingToBoot
 from ..model import compat
+from ..model.architecture import DEFAULT_ARCHITECTURE
 from ..model.config import Bootloader, DiskMode, Firmware, InitSystem, InstallConfig, RemoteUnlock
 from ..model.device import (
     dataset_name,
@@ -174,7 +175,12 @@ class InstallGrub(Operation):
     def apply(self, context: Context) -> None:
         force = ["--force"] if self.force else []
         if self.firmware is Firmware.UEFI and self.esp is not None:
-            efi = ["grub-install", *force, "--target=x86_64-efi", f"--efi-directory={self.esp}"]
+            efi = [
+                "grub-install",
+                *force,
+                f"--target={DEFAULT_ARCHITECTURE.grub_target}",
+                f"--efi-directory={self.esp}",
+            ]
             # The removable-media path first, because it is the one that boots
             # without an NVRAM entry: firmware that loses its entry, and every
             # firmware that never had one, boots only that.

--- a/gentoo_install/plan/netboot.py
+++ b/gentoo_install/plan/netboot.py
@@ -17,7 +17,7 @@ from pathlib import PurePosixPath
 from typing import Final
 
 from ..errors import DownloadFailed, PreflightFailed
-from ..model.compat import ARCHITECTURES, architecture_of
+from ..model.architecture import ARCHITECTURES, architecture_of
 from ..model.config import BootMethod, MemoryLaunch, MemoryMode, MirrorRegion
 from .operations import CommandOutput, Context, Operation, Stage
 
@@ -82,8 +82,19 @@ ALPINE_REPOSITORY: Final[str] = "{base}/latest-stable/main"
 #: composes an aarch64 URL and the modloop is the one built beside the kernel
 #: that will be running.
 ALPINE_MODLOOP: Final[str] = (
-    "{base}/latest-stable/releases/{architecture}/netboot-{version}/modloop-lts"
+    "{base}/latest-stable/releases/{architecture}/netboot-{version}/modloop-{flavour}"
 )
+
+#: Which kernel Alpine builds for each architecture. Not one word everywhere:
+#: `alpine-netboot-3.24.1-aarch64.tar.gz` holds `virt` and `rpi` and no `lts`
+#: at all, measured 2026-08-29, so an aarch64 run composing `vmlinuz-lts`
+#: extracts nothing. `virt` is the one built for a machine with no hardware of
+#: its own, which is every cloud instance this arms.
+ALPINE_FLAVOUR: Final[dict[str, str]] = {
+    "x86_64": "lts",
+    "i686": "lts",
+    "aarch64": "virt",
+}
 
 #: What Alpine names a netboot archive. `netboot/` beside it holds whatever
 #: release is newest, so pinning the version keeps `modules/$(uname -r)` inside
@@ -418,9 +429,10 @@ class PlaceMemoryKernel(Operation):
                 )
             return
         archive = _only_image(context, STAGING, ".tar.gz")
+        flavour = _alpine_flavour(archive)
         for member, name in (
-            ("boot/vmlinuz-lts", "kernel"),
-            ("boot/initramfs-lts", "initramfs"),
+            (f"boot/vmlinuz-{flavour}", "kernel"),
+            (f"boot/initramfs-{flavour}", "initramfs"),
         ):
             context.run(
                 [
@@ -1242,7 +1254,34 @@ def _alpine_modloop(
             f"{archive.name} is not named as an Alpine netboot archive, so the "
             "modloop its kernel needs cannot be composed from it"
         )
-    return ALPINE_MODLOOP.format(base=ALPINE_MIRRORS[region], **named.groupdict())
+    return ALPINE_MODLOOP.format(
+        base=ALPINE_MIRRORS[region],
+        flavour=_alpine_flavour(archive),
+        **named.groupdict(),
+    )
+
+
+def _alpine_flavour(archive: PurePosixPath) -> str:
+    """Which kernel to take out of this netboot archive.
+
+    The architecture is in the archive's own name, so the flavour is derived
+    from what was downloaded rather than from what the machine says it is.
+    """
+    named = ALPINE_ARCHIVE.match(archive.name)
+    if named is None:
+        raise DownloadFailed(
+            f"{archive.name} is not named as an Alpine netboot archive, so the "
+            "kernel inside it cannot be named either"
+        )
+    architecture = named.group("architecture")
+    flavour = ALPINE_FLAVOUR.get(architecture)
+    if flavour is None:
+        known = ", ".join(sorted(ALPINE_FLAVOUR))
+        raise DownloadFailed(
+            f"Alpine builds no known netboot kernel for {architecture}; "
+            f"the architectures this can arm are {known}"
+        )
+    return flavour
 
 
 def _volume_label(context: Context, image: PurePosixPath) -> str:

--- a/gentoo_install/plan/portage.py
+++ b/gentoo_install/plan/portage.py
@@ -19,6 +19,7 @@ from typing import Final, Sequence
 
 from ..errors import CommandFailed, ConfigError
 from ..model import mirrors
+from ..model.architecture import DEFAULT_ARCHITECTURE
 from ..model.config import (
     BinhostChannel,
     InitSystem,
@@ -1785,7 +1786,9 @@ def make_conf(
     if wanted:
         settings.append(("USE", " ".join(wanted)))
     if portage.cpu_flags:
-        settings.append(("CPU_FLAGS_X86", " ".join(portage.cpu_flags)))
+        settings.append(
+            (DEFAULT_ARCHITECTURE.cpu_flags_variable, " ".join(portage.cpu_flags))
+        )
     wanted_cards = video_cards or portage.video_cards
     if wanted_cards:
         settings.append(("VIDEO_CARDS", " ".join(wanted_cards)))

--- a/tests/unit/test_layers.py
+++ b/tests/unit/test_layers.py
@@ -932,7 +932,7 @@ def test_one_table_decides_what_an_architecture_is_called() -> None:
     spell an architecture drifted apart."""
     import ast
 
-    from gentoo_install.model.compat import ARCHITECTURES
+    from gentoo_install.model.architecture import ARCHITECTURES
 
     pairs = {(one.kernel_name, one.gentoo_name) for one in ARCHITECTURES}
     assert ("x86_64", "amd64") in pairs
@@ -941,7 +941,7 @@ def test_one_table_decides_what_an_architecture_is_called() -> None:
     # the second table this exists to prevent. One file is exempt, by path: a
     # basename exempted every future `plan/compat.py` from the rule too.
     for path in sorted(PACKAGE.rglob("*.py")):
-        if path == PACKAGE / "model" / "compat.py":
+        if path == PACKAGE / "model" / "architecture.py":
             continue
         text = path.read_text()
         for kernel_name, gentoo_name in pairs:
@@ -964,13 +964,18 @@ def test_the_default_architecture_is_pinned_by_name_not_by_row_order() -> None:
     and refuse x86_64, while the stage3 and profile paths still fetch amd64."""
     import ast
 
-    from gentoo_install.model import compat
+    import platform
 
-    assert compat.DEFAULT_ARCHITECTURE.kernel_name == "x86_64"
-    assert compat.DEFAULT_ARCHITECTURE.gentoo_name == "amd64"
+    from gentoo_install.model import architecture as compat
+
+    # The machine's own row, not the first one in the table. On a machine the
+    # table has no row for it falls back to amd64, and `preflight` refuses by
+    # name rather than a URL being composed from a guess.
+    expected = compat.architecture_of(platform.machine()) or compat.AMD64
+    assert compat.DEFAULT_ARCHITECTURE == expected
     assert compat.DEFAULT_ARCHITECTURE in compat.ARCHITECTURES
 
-    source = (PACKAGE / "model" / "compat.py").read_text()
+    source = (PACKAGE / "model" / "architecture.py").read_text()
     assigned = [
         node.value
         for node in ast.walk(ast.parse(source))
@@ -993,7 +998,7 @@ def test_an_architecture_row_cannot_be_written_with_its_names_swapped() -> None:
 
     import pytest
 
-    from gentoo_install.model.compat import Architecture
+    from gentoo_install.model.architecture import Architecture
 
     # Called through a name mypy cannot resolve to the constructor, so the
     # rejection this pins is the runtime one and not a silenced type error.

--- a/tests/unit/test_plan_netboot.py
+++ b/tests/unit/test_plan_netboot.py
@@ -1168,7 +1168,7 @@ def test_every_architecture_this_maps_is_one_gentoo_names() -> None:
     `install-amd64-…`: two ecosystems naming the same machine, the way `fma`
     and `fma3` do. A name Gentoo does not use finds no asset and the failure
     reads as a missing release."""
-    from gentoo_install.model.compat import ARCHITECTURES
+    from gentoo_install.model.architecture import ARCHITECTURES
 
     named = {one.gentoo_name for one in ARCHITECTURES}
     assert named <= GENTOO_ARCH_NAMES, sorted(named - GENTOO_ARCH_NAMES)


### PR DESCRIPTION
Groundwork for installing onto an aarch64 machine. The architecture table already held `aarch64/arm64`, and `preflight` already compared a row rather than a literal, but every published path was written for amd64: `releases/amd64/autobuilds`, `latest-stage3-amd64-*`, `releases/amd64/binpackages/…/x86-64`, `--target=x86_64-efi`, and `CPU_FLAGS_X86`. The binhost URL spells the architecture twice and only the second was a parameter.

The row now carries `grub_target`, `cpu_flags_variable` and `binhost_subarch` beside the two names, and the five sites read it. `DEFAULT_ARCHITECTURE` is matched from `platform.machine()`, falling back to amd64 when the table has no row, so `preflight` refuses by name rather than a URL being composed from a guess — the constant said amd64 because amd64 was the only machine it had run on, not because the installer cross-compiles.

The table moved to `model/architecture.py`: `mirrors.py` composes a URL from it and `compat.py` imports `mirrors.py`, so keeping it in `compat.py` is an import cycle. `compat.py` re-exports nothing; the four readers import the new module.

`plan/netboot.py` gained the same fix one layer down. Alpine names its kernels per architecture — `alpine-netboot-3.24.1-aarch64.tar.gz` carries `virt` and `rpi` and no `lts` at all, measured today — so an aarch64 run extracting `boot/vmlinuz-lts` got nothing. The flavour is derived from the architecture in the archive's own name.

Measured while checking: that archive's `initramfs-virt` is 9385851 bytes, 3 mod 4, the same misalignment as x86_64's `initramfs-lts`. The padding step is unconditional, so it already covers this.

`docs/design.md` gained the section before the code. `test_layers.py`'s three guards moved with the table rather than being weakened: the one-table exemption is still by path, and the default is still pinned by name rather than by row order — now against the machine's row instead of a constant.
