### PR TITLE
model: one row decides both halves of the binhost URL

### DIFF
--- a/gentoo_install/cli.py
+++ b/gentoo_install/cli.py
@@ -53,6 +53,7 @@ from .tui import context as tui_context
 from .tui.curses_screen import CursesScreen, too_small
 from .i18n import Catalog, tag_for
 from .model import mirrors, qr, refusals, templates
+from .model.architecture import official_subarch
 from .model.config import (
     BootloaderConfig,
     Binhost,
@@ -1336,7 +1337,7 @@ def _blank(
         portage=PortageConfig(
             makeopts=f"-j{cores}",
             cpu_flags=cpu_flags,
-            binhost=Binhost(subarch="x86-64-v3" if supports_v3 else "x86-64"),
+            binhost=Binhost(subarch=official_subarch(supports_v3)),
             mirrors=MirrorConfig(region=region, site=mirrors.gentoo_sites(region)[0].key),
         ),
     )

--- a/gentoo_install/model/architecture.py
+++ b/gentoo_install/model/architecture.py
@@ -100,3 +100,23 @@ def architecture_of(kernel_name: str) -> Architecture | None:
         if row.kernel_name == kernel_name:
             return row
     return None
+
+
+#: The one subarchitecture above the row's own, and what a CPU needs for it.
+#: Only amd64 publishes a second: the arm64 releases tree holds one
+#: subarchitecture directory, `arm64`, measured 2026-08-29.
+V3_SUBARCH: Final[str] = "x86-64-v3"
+
+
+def official_subarch(supports_v3: bool) -> str:
+    """Which directory of the official binary host this machine reads.
+
+    The architecture appears twice in that URL and both come from the row.
+    Written as `x86-64` here, an aarch64 machine composed an arm64
+    releases path ending in `/x86-64`, took a 404 and compiled all sixty-three
+    packages from source.
+    """
+    if supports_v3 and DEFAULT_ARCHITECTURE == AMD64:
+        return V3_SUBARCH
+    return DEFAULT_ARCHITECTURE.binhost_subarch
+

--- a/gentoo_install/model/compat.py
+++ b/gentoo_install/model/compat.py
@@ -17,6 +17,7 @@ from enum import Enum
 from pathlib import PurePosixPath
 from typing import Callable, Final, Mapping
 
+from .architecture import ARCHITECTURES, V3_SUBARCH
 from . import mirrors
 from .config import (
     BinhostChannel,
@@ -366,7 +367,9 @@ _CJK_KERNEL_PACKAGES: Final[frozenset[str]] = frozenset(
 #: The official binary hosts this installer knows how to point Portage at.
 #: A subarchitecture outside this set is a refusal rather than a URL composed
 #: from it, because a host that does not exist answers 404 an hour in.
-BINHOST_SUBARCHS: Final[frozenset[str]] = frozenset({"x86-64", "x86-64-v3"})
+BINHOST_SUBARCHS: Final[frozenset[str]] = frozenset(
+    {one.binhost_subarch for one in ARCHITECTURES} | {V3_SUBARCH}
+)
 
 
 def binhost_subarch_problems(
@@ -387,10 +390,10 @@ def binhost_subarch_problems(
         return ()
     if binhost.subarch not in BINHOST_SUBARCHS:
         return (f"official binhost subarch {binhost.subarch!r} is not supported",)
-    if binhost.subarch == "x86-64-v3" and supports_v3 is False:
+    if binhost.subarch == V3_SUBARCH and supports_v3 is False:
         return (
-            "official binhost subarch 'x86-64-v3' needs a CPU this one is not: "
-            "`ld.so --help` does not list x86-64-v3 as supported",
+            f"official binhost subarch {V3_SUBARCH!r} needs a CPU this one is "
+            f"not: `ld.so --help` does not list {V3_SUBARCH} as supported",
         )
     return ()
 

--- a/gentoo_install/model/config.py
+++ b/gentoo_install/model/config.py
@@ -7,6 +7,8 @@ produce the same object, and `plan.build()` accepts nothing else.
 
 from __future__ import annotations
 
+from .architecture import DEFAULT_ARCHITECTURE
+
 from dataclasses import dataclass, field
 from enum import Enum
 from typing import Final, TYPE_CHECKING
@@ -403,7 +405,7 @@ class Binhost:
     #: The official host's subarchitecture. `x86-64-v3` needs AVX2 and the two
     #: are the only ones with a useful number of packages; gentoo-zh builds
     #: `x86-64` only, so this does not touch it.
-    subarch: str = "x86-64"
+    subarch: str = DEFAULT_ARCHITECTURE.binhost_subarch
     community: BinhostChannel = BinhostChannel.OFF
 
 

--- a/gentoo_install/model/mirrors.py
+++ b/gentoo_install/model/mirrors.py
@@ -277,8 +277,14 @@ def gentoozh_for(region: MirrorRegion) -> GentooZhMirror:
     return _GENTOOZH_BY_REGION[region]
 
 
+#: gentoo-zh builds for one machine only, so this is a fact about that host
+#: rather than a parameter of the target: on any other architecture the
+#: community binary host is off, not pointed at a directory it never built.
+GENTOOZH_SUBARCH: Final[str] = "x86-64"
+
+
 def gentoozh_binhost(
-    chosen: GentooZhMirror, subarch: str = "x86-64", unstable: bool = False
+    chosen: GentooZhMirror, subarch: str = GENTOOZH_SUBARCH, unstable: bool = False
 ) -> str:
     """The channel is a different path, not a different keyword file: stable
     builds against the main tree's `amd64`, unstable against `~amd64`

--- a/tests/unit/test_layers.py
+++ b/tests/unit/test_layers.py
@@ -1236,3 +1236,58 @@ def test_one_place_builds_a_dataset_full_name() -> None:
     }
     offenders = {name: hits for name, hits in spelled.items() if hits}
     assert not offenders, offenders
+
+
+def test_one_row_decides_both_halves_of_the_binhost_url() -> None:
+    """The official binary host spells the architecture twice in one URL.
+
+    `releases/<gentoo_name>/binpackages/<release>/<binhost_subarch>`. The first
+    half was parameterised and the second was written as `x86-64`, so an
+    aarch64 machine asked for an arm64 releases path ending in `/x86-64`, took
+    a 404 and compiled all sixty-three packages from source. It installed --
+    the degradation is recorded and falls back to source, which is the design
+    -- so nothing failed and nothing said so either.
+    """
+    import ast
+
+    from gentoo_install.model import architecture, mirrors
+    from gentoo_install.model.config import MirrorRegion
+
+    url = mirrors.gentoo_binhost(MirrorRegion.GLOBAL)
+    row = architecture.DEFAULT_ARCHITECTURE
+    assert f"/{row.gentoo_name}/" in url, url
+    assert url.endswith(f"/{row.binhost_subarch}"), url
+
+    # And nothing outside the table writes a subarchitecture of its own: the
+    # three that did were the dataclass default, the automatic configuration
+    # and the menu's offer, all spelling `x86-64`.
+    # `i686` is both a `uname -m` answer and a binhost directory, so a literal
+    # `i686` is not evidence of a second spelling of the subarchitecture --
+    # `plan/netboot.py` keys Alpine's kernel flavours by the former.
+    kernel_names = {one.kernel_name for one in architecture.ARCHITECTURES}
+    known = {one.binhost_subarch for one in architecture.ARCHITECTURES}
+    known.add(architecture.V3_SUBARCH)
+    known -= kernel_names
+    # Two places outside the table may still name one, and both are named
+    # here rather than exempted by pattern: `mirrors.GENTOOZH_SUBARCH`, a fact
+    # about a host that builds for one machine only, and the menu's own offer.
+    allowed = {
+        PACKAGE / "model" / "architecture.py",
+        PACKAGE / "model" / "mirrors.py",
+        PACKAGE / "tui" / "mirror.py",
+    }
+    for path in sorted(PACKAGE.rglob("*.py")):
+        if path in allowed:
+            continue
+        for node in ast.walk(ast.parse(path.read_text(encoding="utf-8"))):
+            if isinstance(node, ast.Constant) and node.value in known:
+                raise AssertionError(f"{path}:{node.lineno} writes {node.value!r}")
+
+    # And `mirrors.py` names exactly one, the community host's.
+    source = (PACKAGE / "model" / "mirrors.py").read_text(encoding="utf-8")
+    spelled = [
+        node.lineno
+        for node in ast.walk(ast.parse(source))
+        if isinstance(node, ast.Constant) and node.value in known
+    ]
+    assert len(spelled) == 1, spelled


### PR DESCRIPTION
Measured on the aarch64 machine installed tonight. `install.jsonl` recorded the reason, which is why this is a finding rather than a mystery:

    gentoo could not read its package index at
    https://distfiles.gentoo.org/releases/arm64/binpackages/23.0/x86-64:
    HTTP Error 404: Not Found

The first half of that URL came from the architecture row; the second was still the literal. `#1103` parameterised one and left the other, and the install succeeded anyway — the degradation falls back to source with a recorded reason, exactly as designed, so 63 packages compiled and nothing failed.

Five places spelled it: the `Binhost.subarch` dataclass default, the automatic configuration's `"x86-64-v3" if supports_v3 else "x86-64"`, `BINHOST_SUBARCHS` (which would have *refused* `arm64` as unsupported once the others were fixed), the refusal message, and the menu's offer table. `official_subarch()` now derives it, and the accepted set is built from the rows plus `V3_SUBARCH` — the v3 upgrade is amd64's alone.

Measured rather than assumed: `releases/x86/binpackages/23.0/` publishes `i486`, `i686`, `i686-ssemath` and more, so the x86 row's `i686` is a real directory, and `.../x86` is a 404.

`mirrors.GENTOOZH_SUBARCH` keeps its literal under a name that says why: gentoo-zh builds for one machine only, so that is a fact about the host rather than a parameter of the target.

The test holds both halves against the row and refuses a sixth spelling anywhere else, naming its two exemptions instead of matching a pattern. `i686` is excluded from the scan because it is also a `uname -m` answer — `plan/netboot.py` keys Alpine's kernel flavours by that — so a literal `i686` is not evidence of a second spelling. Control: the old expression back in `cli.py`, red.
