### PR TITLE
vm: resolved answers before the file the harness wrote is read

### DIFF
--- a/tests/unit/test_cluster.py
+++ b/tests/unit/test_cluster.py
@@ -4535,3 +4535,33 @@ def test_a_key_already_loaded_is_not_the_initramfs_giving_up() -> None:
     for other in (b"Entering emergency mode", b"Failed to mount /sysroot"):
         assert cluster.initramfs_gave_up(other), other
     assert not cluster.initramfs_gave_up(b"[    3.1] mounting the root")
+
+
+def test_the_resolver_setup_reaches_nsswitch_as_well_as_the_file() -> None:
+    """Writing `/etc/resolv.conf` is not enough on an installed systemd guest.
+
+    Measured on the converted guest: the file held all three servers, two of
+    them answered pings, and `getent hosts distfiles.gentoo.org` still
+    answered 2. `systemd-resolved` was active again -- stopping a
+    socket-activated daemon does not keep it stopped -- and the guest's
+    `hosts: mymachines resolve [!UNAVAIL=return] files myhostname dns` returns
+    whatever `resolve` says, so the `dns` module that reads the file was never
+    reached. Rewriting the line to `files dns` made the same lookup answer 0.
+
+    The whole install after it went by name: the conversion stopped at
+    operation 26 with `<urlopen error [Errno -2] Name or service not known>`.
+    """
+    from tests.vm.cluster import GUEST_RESOLVERS, use_our_resolvers
+
+    command = use_our_resolvers()
+    for one in GUEST_RESOLVERS:
+        assert f"nameserver {one}" in command, command
+    assert "stop systemd-resolved" in command, command
+    # The half that was missing, and the reason it is not enough to stop the
+    # daemon: an active `resolve` module answers before the file is read.
+    assert "nsswitch.conf" in command, command
+    assert "hosts: files dns" in command, command
+    # After the file, not before: the sed and the printf both touch what the
+    # next lookup reads, and a resolver written after the switch was rewritten
+    # would still be the one in force.
+    assert command.index("resolv.conf") < command.index("nsswitch.conf"), command

--- a/tests/vm/cluster.py
+++ b/tests/vm/cluster.py
@@ -1165,11 +1165,20 @@ def use_our_resolvers() -> str:
     # printf wrote through the link and `systemd-resolved` put its own file
     # back. The converted guest reached `10.31.0.254` and `223.5.5.5` and
     # still answered `fail fail fail fail fail` to every lookup.
+    # And `nsswitch.conf` after both: stopping the daemon is not enough,
+    # because `hosts: mymachines resolve [!UNAVAIL=return] files myhostname
+    # dns` returns whatever `resolve` says and only falls through to `dns` --
+    # the module that reads the file above -- when `resolve` is UNAVAIL.
+    # Measured on the converted guest: the file held the three servers, two of
+    # them answered pings, `systemd-resolved` was active again, and
+    # `getent hosts distfiles.gentoo.org` still answered 2. Rewriting the line
+    # to `files dns` made the same lookup answer 0.
     return (
         "systemctl stop systemd-resolved 2>/dev/null; "
         "rc-service systemd-resolved stop 2>/dev/null; "
         "rm -f /etc/resolv.conf; "
-        f"printf '{resolvers}' > /etc/resolv.conf"
+        f"printf '{resolvers}' > /etc/resolv.conf; "
+        "sed -i 's/^hosts:.*/hosts: files dns/' /etc/nsswitch.conf 2>/dev/null"
     )
 
 


### PR DESCRIPTION
The menu-driven conversion stopped at operation 26 of 63 with `<urlopen error [Errno -2] Name or service not known>` fetching the binhost. Everything the harness does to give a guest a resolver had already run.

Measured on that guest afterwards, in this order:

- `/etc/resolv.conf` is a regular file holding all three servers — `use_our_resolvers()` wrote it, and nothing replaced it.
- `REACH 10.31.0.199=down 10.31.0.254=up 223.5.5.5=up` — two of the three answer.
- `systemd-resolved` is `active` again. Stopping a socket-activated daemon does not keep it stopped.
- `getent hosts distfiles.gentoo.org` answers 2.
- `hosts: mymachines resolve [!UNAVAIL=return] files myhostname dns`.

`resolve` is not UNAVAIL while resolved runs, so glibc takes its answer and returns; the `dns` module, the one that reads the file the harness wrote, is never reached. Rewriting the line to `hosts: files dns` made the same lookup answer 0 — measured on the machine before this change was written.

`use_our_resolvers()` already carried a comment about an earlier version of this, where resolved put its own file back through the symlink. That half was fixed by stopping the daemon; this half needed the switch, because the daemon comes back.

Also worth recording, since it cost most of a round: the conversion's failure path deletes `/gentoo-install.new`, so `chroot`-ing into the new root to ask what it held answers 125 and the state that would explain the failure is gone before anyone looks.

Control: the `sed` replaced by `true`, red.
