### PR TITLE
cli: hold the kernel's messages while the menu is on screen

### DIFF
--- a/gentoo_install/cli.py
+++ b/gentoo_install/cli.py
@@ -52,6 +52,7 @@ from .tui import app, screens
 from .tui import context as tui_context
 from .tui.curses_screen import CursesScreen, too_small
 from .i18n import Catalog, tag_for
+from .exec.console import kernel_messages_held
 from .model import mirrors, qr, refusals, templates
 from .model.architecture import official_subarch
 from .model.config import (
@@ -1288,7 +1289,10 @@ def _from_menu(
     os.environ.pop("LINES", None)
     os.environ.pop("COLUMNS", None)
     try:
-        finished = curses.wrapper(walk)
+        # The kernel shares this screen on a serial console, and a message
+        # lands in the middle of a panel: held for the walk, restored after.
+        with kernel_messages_held():
+            finished = curses.wrapper(walk)
     except curses.error as error:
         raise errors.PreflightFailed(
             f"the menu needs a terminal and this is not one ({error}); pass --config FILE"

--- a/gentoo_install/exec/console.py
+++ b/gentoo_install/exec/console.py
@@ -1,0 +1,45 @@
+# SPDX-License-Identifier: GPL-2.0-or-later
+"""Keeping the kernel from writing over the interface.
+
+On a serial console the kernel and the menu share one screen. A guest running
+the installer drew `[ 3915.800938] clocksource: Watchdog remote CPU 1 read ti`
+across the middle of a panel: the text is unreadable and an operator cannot
+tell a corrupted screen from a broken installer.
+"""
+
+from __future__ import annotations
+
+from contextlib import contextmanager
+from pathlib import Path
+from typing import Final, Iterator
+
+#: `console_loglevel current default minimum boot`. Only the first decides
+#: what reaches the console; the file takes one number and changes that one.
+PRINTK: Final[Path] = Path("/proc/sys/kernel/printk")
+
+#: `KERN_ALERT` and above, which is what a machine about to stop says. Not 0:
+#: an operator whose disk is failing under the menu should still see it.
+WHILE_DRAWING: Final[str] = "1"
+
+
+@contextmanager
+def kernel_messages_held(printk: Path = PRINTK) -> Iterator[None]:
+    """Lower the console log level for the duration, then put it back.
+
+    Silent when the file is absent or unwritable -- a menu that refuses to
+    open because it could not quieten the kernel is worse than a noisy one --
+    and the level is restored even when the walk raises.
+    """
+    try:
+        before = printk.read_text(encoding="utf-8").split()[0]
+        printk.write_text(f"{WHILE_DRAWING}\n", encoding="utf-8")
+    except (OSError, IndexError):
+        yield
+        return
+    try:
+        yield
+    finally:
+        try:
+            printk.write_text(f"{before}\n", encoding="utf-8")
+        except OSError:
+            pass

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -2573,3 +2573,51 @@ def _probe_with(probe_module: object, runner: object, work: Path) -> RealProbe:
     """A `Probe` built the way `cli.py` builds one, with a fake runner."""
     made = getattr(probe_module, "Probe")
     return cast(RealProbe, made(cast(Any, runner), work))
+
+
+def test_the_kernel_is_quiet_while_the_menu_is_drawn(tmp_path: Path) -> None:
+    """On a serial console the kernel and the menu share one screen.
+
+    A guest drew `[ 3915.800938] clocksource: Watchdog remote CPU 1 read ti`
+    across a panel, which is unreadable and indistinguishable from a broken
+    installer. Only the first field of `/proc/sys/kernel/printk` decides what
+    reaches the console, and it is put back afterwards.
+    """
+    from gentoo_install.exec.console import WHILE_DRAWING, kernel_messages_held
+
+    printk = tmp_path / "printk"
+    printk.write_text("7\t4\t1\t7\n")
+    with kernel_messages_held(printk):
+        assert printk.read_text().split()[0] == WHILE_DRAWING, printk.read_text()
+    assert printk.read_text().split()[0] == "7", printk.read_text()
+
+    # Restored when the walk raises, or a failed install leaves the machine
+    # silent about everything that follows.
+    with pytest.raises(RuntimeError):
+        with kernel_messages_held(printk):
+            raise RuntimeError("the walk stopped")
+    assert printk.read_text().split()[0] == "7", printk.read_text()
+
+    # A machine with no procfs still gets a menu: the file is absent here and
+    # the block runs anyway.
+    ran = False
+    with kernel_messages_held(tmp_path / "absent"):
+        ran = True
+    assert ran
+
+
+def test_the_menu_walk_is_wrapped_in_the_quiet(tmp_path: Path) -> None:
+    """A helper nothing calls leaves every serial console as noisy as before."""
+    import ast
+    import inspect
+    import textwrap
+
+    from gentoo_install import cli
+
+    source = textwrap.dedent(inspect.getsource(cli._from_menu))
+    called = {
+        getattr(node.func, "id", "") or getattr(node.func, "attr", "")
+        for node in ast.walk(ast.parse(source))
+        if isinstance(node, ast.Call)
+    }
+    assert "kernel_messages_held" in called, sorted(called)


### PR DESCRIPTION
Read off a guest while driving the conversion menu: `[ 3915.800938] clocksource: Watchdog remote CPU 1 read ti` was drawn across the middle of the install-mode panel. On a serial console — which is how this installer is run on a server, and how every fixture runs it — the kernel writes to the same screen curses is drawing on.

Nothing in the tree touched `printk`, so every such message has always landed on the menu. The damage is not only cosmetic: a corrupted panel is indistinguishable from a broken installer, and the operator's next move differs.

`kernel_messages_held()` lowers `console_loglevel` to 1 for the walk and puts the previous value back, including when the walk raises — a failed install that left the machine silent about everything afterwards would be worse than the noise. 1 rather than 0, so a machine about to stop still says so under the menu.

Silent when `/proc/sys/kernel/printk` is absent or unwritable: a menu that refuses to open because it could not quieten the kernel is worse than a noisy one.

Only the first of the file's four fields decides what reaches the console, and writing one number changes that one — checked against a real `1	4	1	7`.

Controls: the `with` removed from `_from_menu`, red; the restore replaced by `pass`, red.
