### PR TITLE
exec: a clustered -p is still a pretend

### DIFF
--- a/gentoo_install/exec/runner.py
+++ b/gentoo_install/exec/runner.py
@@ -328,7 +328,15 @@ def _pretending(argv: Sequence[str]) -> bool:
     and a package the pretend named and the merge never installed was in the
     record as installed.
     """
-    return any(one in ("--pretend", "-p") for one in argv)
+    for one in argv:
+        if one == "--pretend":
+            return True
+        # `-pv` is the spelling an operator types, and short options cluster:
+        # matching `-p` alone let every combined form through, so a pretend
+        # was journaled as a merge by the commonest way of asking for one.
+        if one.startswith("-") and not one.startswith("--") and "p" in one[1:]:
+            return True
+    return False
 
 
 def _display_argv(argv: Sequence[str]) -> tuple[str, ...]:

--- a/tests/unit/test_exec.py
+++ b/tests/unit/test_exec.py
@@ -2972,3 +2972,33 @@ def test_a_device_that_never_appears_says_what_was_tried() -> None:
     # Either branch is named, and the mdev branch carries the status.
     assert "tried" in said, said
     assert "udev" in said or "mdev=" in said, said
+
+
+def test_a_clustered_p_is_still_a_pretend() -> None:
+    """`emerge -pv` is a pretend, and it was journaled as a merge.
+
+    `_pretending` compared each argument against `-p` exactly, so only the
+    lone spelling was recognised. Short options cluster, and `-pv` is what an
+    operator types: its `[binary]`/`[ebuild]` lines went into the journal as
+    installed packages, which is the doubling the function exists to prevent.
+    """
+    from gentoo_install.exec.runner import _pretending
+
+    for argv in (
+        ["emerge", "--pretend", "sys-apps/coreutils"],
+        ["emerge", "-p", "sys-apps/coreutils"],
+        ["emerge", "-pv", "sys-apps/coreutils"],
+        ["emerge", "-vp", "sys-apps/coreutils"],
+        ["emerge", "-pqv", "sys-apps/coreutils"],
+    ):
+        assert _pretending(argv), argv
+
+    # And a real merge is still a real merge: no `p` outside a cluster, and a
+    # long option that merely contains the letter is not a pretend.
+    for argv in (
+        ["emerge", "sys-apps/coreutils"],
+        ["emerge", "-v", "--getbinpkg", "sys-apps/coreutils"],
+        ["emerge", "--quiet-build=y", "app-portage/cpuid2cpuflags"],
+        ["emerge", "-j2", "sys-apps/coreutils"],
+    ):
+        assert not _pretending(argv), argv


### PR DESCRIPTION
`_pretending` exists because a pretend prints the same `[binary]`/`[ebuild]` lines a merge does, and its docstring records what happened without it: one guest listed 63 packages for the 40 it installed, and a package the pretend named and the merge never installed was recorded as installed.

It compared each argument against `--pretend` or `-p` exactly. Short options cluster, so `emerge -pv` — the spelling an operator actually types, and the one used against a real machine earlier today — was not recognised, and its output went into `install.jsonl` as installed packages. The rule was written; the commonest way of asking for a pretend walked past it.

Any single-dash argument carrying a `p` after the dash is now a pretend. Long options are excluded so `--quiet-build=y` and `--getbinpkg` stay merges, and a value like `-j2` is unaffected.

Found by a read-only audit of the four execution-core files; five of its six claims were checked against the source before this one was acted on.

Control: the cluster branch narrowed back to `one == "-p"`, red.
