### PR TITLE
kernel: name no driver this architecture never built

### DIFF
--- a/gentoo_install/plan/kernel.py
+++ b/gentoo_install/plan/kernel.py
@@ -8,10 +8,11 @@ initramfs that cannot find the root filesystem.
 
 from __future__ import annotations
 
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from pathlib import PurePosixPath
 from typing import Final
 
+from ..model.architecture import DEFAULT_ARCHITECTURE, Architecture
 from ..model.config import Bootloader, InitSystem, InstallConfig, KernelSource
 from ..errors import ConfigError, ConversionUnsupported, NothingToBoot, ValidationFailed
 from ..model import compat
@@ -316,6 +317,20 @@ CLOUD_DRIVERS: Final[tuple[str, ...]] = (
     "gve",
 )
 
+#: The ones Linux builds for x86 alone. `dracut-install` fails its whole `-m`
+#: list when any single name is missing, so naming a Xen frontend on aarch64
+#: leaves a machine whose every initramfs rebuild fails -- including the one a
+#: kernel upgrade triggers. Measured on an aarch64 guest: `modinfo -n
+#: xen_blkfront` finds nothing and the other eleven are present.
+X86_ONLY_DRIVERS: Final[frozenset[str]] = frozenset({"xen_blkfront", "xen_netfront"})
+
+
+def cloud_drivers(row: Architecture = DEFAULT_ARCHITECTURE) -> tuple[str, ...]:
+    """The drivers to name for the machine being installed."""
+    if row.kernel_name in ("x86_64", "i686"):
+        return CLOUD_DRIVERS
+    return tuple(one for one in CLOUD_DRIVERS if one not in X86_ONLY_DRIVERS)
+
 
 @dataclass(frozen=True, kw_only=True)
 class WriteDracutModules(Operation):
@@ -323,7 +338,7 @@ class WriteDracutModules(Operation):
     modules: tuple[str, ...]
     #: Drivers named regardless of what dracut detected. `add_drivers+=` is
     #: dracut's own key for this (`dracut.conf(5)`).
-    drivers: tuple[str, ...] = CLOUD_DRIVERS
+    drivers: tuple[str, ...] = field(default_factory=cloud_drivers)
 
     def describe(self) -> str:
         carried = f"write {DRACUT_MODULES_CONFIG} so dracut carries {', '.join(self.modules)}"

--- a/tests/unit/test_plan_boot.py
+++ b/tests/unit/test_plan_boot.py
@@ -1163,3 +1163,47 @@ def test_openrc_with_systemd_boot_has_a_fixture() -> None:
         if init == "openrc" and kind == "systemd-boot":
             paired.append(fixture.name)
     assert paired, "no fixture pairs openrc with systemd-boot"
+
+
+def test_no_driver_is_named_that_this_architecture_never_built() -> None:
+    """`dracut-install` fails its whole `-m` list when one name is missing.
+
+    The cloud driver list named `xen_blkfront` and `xen_netfront`
+    unconditionally, and Linux builds the Xen frontends for x86 alone. On the
+    aarch64 machine installed with this tree, every initramfs rebuild failed:
+
+        dracut-install: Failed to find module 'xen_blkfront'
+        dracut[E]: FAILED: ... -m virtio_pci ... xen_blkfront ...
+
+    The install itself did not stop, because `installkernel` built that one.
+    A successful install left a machine that could not rebuild its initramfs,
+    which a kernel upgrade needs.
+    """
+    from gentoo_install.model.architecture import AMD64, ARCHITECTURES, architecture_of
+    from gentoo_install.plan.kernel import CLOUD_DRIVERS, X86_ONLY_DRIVERS, cloud_drivers
+
+    on_amd64 = cloud_drivers(AMD64)
+    assert set(X86_ONLY_DRIVERS) <= set(on_amd64), on_amd64
+    assert on_amd64 == CLOUD_DRIVERS
+
+    arm = architecture_of("aarch64")
+    assert arm is not None
+    on_arm = cloud_drivers(arm)
+    assert not set(X86_ONLY_DRIVERS) & set(on_arm), on_arm
+    # And nothing else was dropped: the eleven that exist are still named,
+    # because a provider that attaches the disk differently on the next boot
+    # is what the list is for.
+    assert set(on_arm) == set(CLOUD_DRIVERS) - set(X86_ONLY_DRIVERS)
+
+    # Every row answers, so a new architecture cannot silently take amd64's.
+    for row in ARCHITECTURES:
+        assert cloud_drivers(row), row
+
+
+def test_the_operation_takes_the_drivers_for_this_machine() -> None:
+    """A rule nothing reads leaves every initramfs as broken as before."""
+    from gentoo_install.model.architecture import DEFAULT_ARCHITECTURE
+    from gentoo_install.plan.kernel import WriteDracutModules, cloud_drivers
+
+    written = WriteDracutModules(modules=("crypt",))
+    assert written.drivers == cloud_drivers(DEFAULT_ARCHITECTURE), written.drivers


### PR DESCRIPTION
Measured on the aarch64 machine installed with this tree. Rebuilding its initramfs to change a port:

    dracut-install: Failed to find module 'xen_blkfront'
    dracut[E]: FAILED:  /usr/lib/dracut/dracut-install ... -m virtio_pci virtio_blk ... xen_blkfront xen_netfront ...

`CLOUD_DRIVERS` names thirteen unconditionally, and `dracut-install` fails the whole `-m` list when any single one is missing. Linux builds the Xen frontends for x86 alone: `modinfo -n xen_blkfront` finds nothing there while the other eleven are present.

So that machine could not rebuild its initramfs at all — including the rebuild a kernel upgrade triggers. The install did not notice, because `installkernel` built the first image and the error did not stop it: a successful install left a machine one `emerge sys-kernel/gentoo-kernel-bin` away from an initramfs that no longer matches its kernel.

The list stays unconditional in spirit — the comment above it explains why a provider's name cannot decide, and none of the eleven that exist are dropped. Only the two the architecture never built are removed, through one named table.

Controls: `cloud_drivers` returning the full list regardless of the row, red.

Not covered: no aarch64 fixture exists, so this is held by unit tests and the one machine it was measured on.
