### PR TITLE
portage: the check asks the question the merge will ask

### DIFF
--- a/gentoo_install/plan/portage.py
+++ b/gentoo_install/plan/portage.py
@@ -134,6 +134,38 @@ EMERGE_OPTIONS: Final[tuple[str, ...]] = (
     "--autounmask-continue=y",
 )
 
+#: The options that decide what emerge accepts, as against what it prints.
+#: `VerifyPackages` asks whether the merge will succeed, so it has to carry
+#: these: without them the check refused a package set the merge installs by
+#: writing the USE change, and an install stopped at operation 26 of 60.
+AUTOUNMASK: Final[tuple[str, ...]] = tuple(
+    one for one in EMERGE_OPTIONS if one.startswith("--autounmask")
+)
+
+#: How emerge says why it will not proceed, in the order the message is
+#: looked for. Read off a real refusal rather than guessed: the first
+#: non-empty line was `setlocale: unsupported locale setting`, which a chroot
+#: whose locales are not generated yet always prints, and the three lines
+#: beginning `!!!` were mirror download warnings from ten minutes earlier.
+REFUSALS: Final[tuple[str, ...]] = (
+    "Error fetching binhost package info",
+    "necessary to proceed",
+    "there are no ebuilds",
+    "All ebuilds that could satisfy",
+    "has unmet requirements",
+    "Multiple package instances",
+)
+
+
+def why_emerge_refused(output: str) -> str:
+    """The line that explains a refusal, not the first line printed."""
+    lines = [one.strip() for one in output.splitlines() if one.strip()]
+    for line in lines:
+        if any(one in line for one in REFUSALS):
+            return line.removeprefix("!!! ").strip()
+    return lines[-1].removeprefix("!!! ").strip() if lines else "no output"
+
+
 #: What a failed keyring degrades: every host at once, since none of them can
 #: be verified without one.
 BINARY_PACKAGES: Final[str] = "binary packages"
@@ -1450,10 +1482,7 @@ class VerifyPackages(Operation):
         if problems:
             raise ConfigError("; ".join(problems))
 
-        detail = next(
-            (line.strip().removeprefix("!!! ") for line in output.splitlines() if line.strip()),
-            "no output",
-        )
+        detail = why_emerge_refused(output)
         requesters = tuple(
             dict.fromkeys(
                 requester for request in self.requests for requester in request.requesters
@@ -1468,7 +1497,8 @@ class VerifyPackages(Operation):
     ) -> CommandOutput:
         without = ("--usepkg=n", "--getbinpkg=n") if source_only else ()
         output = context.run_in_target(
-            ["emerge", "--pretend", "--quiet", *without, "--", *atoms], check=False
+            ["emerge", "--pretend", "--quiet", *AUTOUNMASK, *without, "--", *atoms],
+            check=False,
         )
         if not isinstance(output, CommandOutput):
             raise ConfigError("emerge --pretend returned no exit status")

--- a/tests/unit/test_plan_portage.py
+++ b/tests/unit/test_plan_portage.py
@@ -2976,3 +2976,63 @@ def test_following_this_machine_writes_its_core_count() -> None:
     second = Recorder()
     pinned[0].apply(second)
     assert 'MAKEOPTS="-j4"' in second.files[PurePosixPath("/etc/portage/make.conf")]
+
+
+def test_the_check_asks_the_question_the_merge_will_ask() -> None:
+    """`VerifyPackages` refused a package set the merge installs.
+
+    It ran `emerge --pretend --quiet -- <atoms>` while the merge runs with
+    `--autounmask-use=y --autounmask-write=y --autounmask-continue=y`, so any
+    set needing a USE change was rejected by the guard and accepted by the
+    thing it guards. Measured on a conversion from a server profile with no X:
+    `fcitx-gtk` wants `gtk[X]`, and the install stopped at operation 26 of 60.
+    """
+    import inspect
+
+    from gentoo_install.plan.portage import AUTOUNMASK, EMERGE_OPTIONS, VerifyPackages
+
+    # One table, two readers: every autounmask option the merge carries.
+    assert AUTOUNMASK == tuple(
+        one for one in EMERGE_OPTIONS if one.startswith("--autounmask")
+    )
+    assert AUTOUNMASK, EMERGE_OPTIONS
+
+    resolve = inspect.getsource(VerifyPackages._resolve)
+    assert "AUTOUNMASK" in resolve, resolve
+    # `--verbose` is the merge's alone: the check is quiet.
+    assert "--quiet" in resolve, resolve
+
+
+def test_the_refusal_names_the_line_that_explains_it() -> None:
+    """The message took the first non-empty line, which is never the reason.
+
+    A chroot whose locales are not generated prints `setlocale: unsupported
+    locale setting` before anything else, so every refusal was reported as a
+    locale warning. Taking the first `!!!` line instead is also wrong: in the
+    same log the three of those were mirror download warnings from ten
+    minutes earlier.
+    """
+    from gentoo_install.plan.portage import why_emerge_refused
+
+    measured = (
+        "setlocale: unsupported locale setting\n"
+        "\n"
+        "!!! Couldn't download '.layout.conf.mirror.nyist.edu.cn'. Aborting.\n"
+        "!!! Couldn't download 'openpgp-keys-gentoozh-20260726.asc'. Aborting.\n"
+        "\n"
+        "The following USE changes are necessary to proceed:\n"
+        "# required by app-i18n/fcitx-gtk-5.1.7::gentoo[gtk4]\n"
+        ">=gui-libs/gtk-4.20.4 X\n"
+    )
+    assert why_emerge_refused(measured) == "The following USE changes are necessary to proceed:"
+
+    # A refusal emerge words differently, and the fallback when it words it in
+    # a way this does not know: the last line, not the first.
+    assert "no ebuilds" in why_emerge_refused(
+        "setlocale: unsupported locale setting\n"
+        "emerge: there are no ebuilds to satisfy \"app-misc/absent\".\n"
+    )
+    assert why_emerge_refused("setlocale: bad\nsomething else entirely\n") == (
+        "something else entirely"
+    )
+    assert why_emerge_refused("") == "no output"


### PR DESCRIPTION
Measured on a menu-driven conversion of a guest running a systemd server profile with no X. It stopped at operation 26 of 60:

    ConfigError: emerge --pretend rejected packages requested by the `install cron` operation … : setlocale: unsupported locale setting

Two defects behind one message.

**The guard was stricter than the thing it guards.** `VerifyPackages._resolve` ran `emerge --pretend --quiet -- <atoms>`; the merge runs with `--autounmask-use=y --autounmask-write=y --autounmask-continue=y`. Any set needing a USE change was therefore refused by the check and installed by the merge. Here `app-i18n/fcitx-gtk` wants `gui-libs/gtk[X]`. The amd64 fixtures never hit it because their profiles already carry those flags; a conversion from a server profile is where the two readers diverge. The options now come from `EMERGE_OPTIONS` — one table, both readers — and `--verbose` stays the merge's alone.

`docs/design.md` carries the decision and its cost: `--autounmask-write=y` writes the USE change into the target before the operator confirms. Those three files are created before the first emerge anyway, the merge writes the same content seconds later, and a failed install discards the whole target, so the side effect stays inside it.

**The message named a line that was never the reason.** `detail` took the first non-empty line of emerge's output, and a chroot whose locales are not generated always prints `setlocale: unsupported locale setting` first. Taking the first `!!!` line instead is also wrong — in that same log the three of those were mirror download warnings from ten minutes earlier. `why_emerge_refused` looks for the phrases emerge actually uses, read off the real output, and falls back to the last line rather than the first.

`Error fetching binhost package info` joined that table because an existing test held it: that message is how emerge announces the refusal the degrade-to-source path exists for.

Controls: the autounmask options removed from `_resolve`, red; the phrase search removed from `why_emerge_refused`, red.
