### PR TITLE
bootloader: one token names both EFI files

### DIFF
--- a/gentoo_install/model/architecture.py
+++ b/gentoo_install/model/architecture.py
@@ -36,6 +36,11 @@ class Architecture:
     #: in, under `releases/<gentoo_name>/binpackages/<release>/`. A fourth
     #: spelling: amd64's is `x86-64` and arm64's is `arm64`.
     binhost_subarch: str
+    #: How UEFI spells this machine, which names two files: the removable
+    #: media fallback `EFI/BOOT/BOOT<name>.EFI` and systemd's
+    #: `linux<name>.efi.stub`. Read off systemd's own `efi_arch` table in
+    #: `meson.build`, and `BOOTAA64.EFI` measured on an aarch64 machine's esp.
+    efi_name: str
 
 
 #: The row every published path targets today: the stage3, the profile and the
@@ -47,6 +52,7 @@ AMD64: Final[Architecture] = Architecture(
     grub_target="x86_64-efi",
     cpu_flags_variable="CPU_FLAGS_X86",
     binhost_subarch="x86-64",
+        efi_name="x64",
 )
 
 #: Every architecture this installer has a name for. A machine outside it is
@@ -59,6 +65,7 @@ ARCHITECTURES: Final[tuple[Architecture, ...]] = (
         grub_target="arm64-efi",
         cpu_flags_variable="CPU_FLAGS_ARM",
         binhost_subarch="arm64",
+        efi_name="aa64",
     ),
     Architecture(
         kernel_name="i686",
@@ -66,6 +73,7 @@ ARCHITECTURES: Final[tuple[Architecture, ...]] = (
         grub_target="i386-efi",
         cpu_flags_variable="CPU_FLAGS_X86",
         binhost_subarch="i686",
+    efi_name="ia32",
     ),
 )
 

--- a/gentoo_install/plan/bootloader.py
+++ b/gentoo_install/plan/bootloader.py
@@ -94,7 +94,7 @@ EFI_PACKAGE: Final[str] = "sys-boot/efibootmgr"
 #: Where generate-zbm writes, and the path firmware boots with no NVRAM entry.
 #: It names the image after the kernel, so the name is looked up, not assumed.
 ZBM_DIRECTORY: Final[str] = "EFI/zbm"
-FALLBACK_IMAGE: Final[str] = "EFI/BOOT/BOOTX64.EFI"
+FALLBACK_IMAGE: Final[str] = f"EFI/BOOT/BOOT{DEFAULT_ARCHITECTURE.efi_name.upper()}.EFI"
 
 
 @dataclass(frozen=True, kw_only=True)
@@ -497,7 +497,8 @@ class InstallZfsBootMenu(Operation):
             f"  ImageDir: {self.esp}/EFI/zbm\n"
             "  Versions: false\n"
             "  Enabled: true\n"
-            "  Stub: /usr/lib/systemd/boot/efi/linuxx64.efi.stub\n"
+            "  Stub: /usr/lib/systemd/boot/efi/linux"
+            f"{DEFAULT_ARCHITECTURE.efi_name}.efi.stub\n"
             f"{kernel}"
         )
 

--- a/tests/unit/test_plan_boot.py
+++ b/tests/unit/test_plan_boot.py
@@ -1207,3 +1207,54 @@ def test_the_operation_takes_the_drivers_for_this_machine() -> None:
 
     written = WriteDracutModules(modules=("crypt",))
     assert written.drivers == cloud_drivers(DEFAULT_ARCHITECTURE), written.drivers
+
+
+def test_one_token_names_both_efi_files() -> None:
+    """UEFI spells the machine in two file names, and both were `x64`.
+
+    `EFI/BOOT/BOOTX64.EFI` is the removable-media fallback the firmware looks
+    for with no NVRAM entry, and `linuxx64.efi.stub` is what ZFSBootMenu is
+    told to build against. An aarch64 firmware looks for `BOOTAA64.EFI` and
+    that machine ships `linuxaa64.efi.stub`, so both were wrong there and the
+    fallback path was not a fallback at all.
+
+    The token is systemd's own: `efi_arch` in its `meson.build` maps
+    `aarch64` to `aa64`, `x86_64` to `x64` and `x86` to `ia32`. `BOOTAA64.EFI`
+    was also read off a real aarch64 esp.
+    """
+    from gentoo_install.model.architecture import ARCHITECTURES, architecture_of
+    from gentoo_install.plan import bootloader
+
+    named = {row.kernel_name: row.efi_name for row in ARCHITECTURES}
+    assert named == {"x86_64": "x64", "aarch64": "aa64", "i686": "ia32"}, named
+
+    arm = architecture_of("aarch64")
+    assert arm is not None
+    assert f"BOOT{arm.efi_name.upper()}.EFI" == "BOOTAA64.EFI"
+
+    # And the module composes rather than spelling it: the constant follows
+    # whichever machine this is running on.
+    from gentoo_install.model.architecture import DEFAULT_ARCHITECTURE
+
+    assert bootloader.FALLBACK_IMAGE == (
+        f"EFI/BOOT/BOOT{DEFAULT_ARCHITECTURE.efi_name.upper()}.EFI"
+    )
+
+    # No file in the package spells one of the other rows' EFI names, which is
+    # how the second copy came back the last four times.
+    import ast
+    from pathlib import Path
+
+    package = Path(bootloader.__file__).parent.parent
+    others = {
+        row.efi_name for row in ARCHITECTURES if row is not DEFAULT_ARCHITECTURE
+    }
+    for path in sorted(package.rglob("*.py")):
+        if path.name == "architecture.py":
+            continue
+        for node in ast.walk(ast.parse(path.read_text(encoding="utf-8"))):
+            if not isinstance(node, ast.Constant) or not isinstance(node.value, str):
+                continue
+            for one in others:
+                assert f"BOOT{one.upper()}.EFI" not in node.value, f"{path}:{node.lineno}"
+                assert f"linux{one}.efi.stub" not in node.value, f"{path}:{node.lineno}"


### PR DESCRIPTION
From a read-only audit of the architecture assumptions, checked against the source and then against a real machine.

`FALLBACK_IMAGE` was `EFI/BOOT/BOOTX64.EFI` and ZFSBootMenu was configured with `/usr/lib/systemd/boot/efi/linuxx64.efi.stub`. On aarch64 the firmware looks for `BOOTAA64.EFI`, so the fallback copy was not a fallback at all — only the NVRAM entry could find the image — and `generate-zbm` was pointed at a stub that target does not ship.

Both names carry the same token, so the row carries it once. Measured rather than remembered: `BOOTAA64.EFI` is what sits on the aarch64 machine's esp, and the mapping is systemd's own `efi_arch` table in `meson.build` — `aarch64: aa64`, `x86_64: x64`, `x86: ia32`.

The test also refuses any file in the package spelling another row's EFI name, because a second copy is how the architecture came back into a literal the last four times.

Control: the constant written as `BOOTAA64.EFI` instead of composed, red.

Not covered: no ZFS-on-aarch64 run exists, so the stub path is held by the systemd table rather than by a build.
