### PR TITLE
preflight: refuse BIOS where the architecture has no BIOS platform

### DIFF
--- a/gentoo_install/exec/preflight.py
+++ b/gentoo_install/exec/preflight.py
@@ -516,7 +516,16 @@ def inspect(
     wants_uefi = config.bootloader.firmware is Firmware.UEFI
     if targets_machine_firmware and wants_uefi and not machine.uefi:
         fatal.append(f"the configuration boots by UEFI and this machine booted by BIOS")
-    if targets_machine_firmware and not wants_uefi and machine.uefi:
+    if targets_machine_firmware and not wants_uefi and not installs.bios_target:
+        # Fatal, not the warning below: this is not a machine that could boot
+        # either way. GRUB builds no BIOS platform for this architecture, so
+        # `grub-install` has no target to be given and the install would stop
+        # at the bootloader with the disk already partitioned.
+        fatal.append(
+            f"the configuration boots by BIOS and {installs.gentoo_name} has no "
+            "BIOS platform: GRUB builds none for it"
+        )
+    elif targets_machine_firmware and not wants_uefi and machine.uefi:
         warnings.append("the configuration boots by BIOS on a machine that booted by UEFI")
     if targets_machine_firmware and wants_uefi and not machine.efi_variables:
         # Fatal: `efibootmgr --create` is what the ZFSBootMenu install runs,
@@ -531,7 +540,7 @@ def inspect(
         # firmware then refuse the amd64 executable it was handed.
         fatal.append(
             "this machine booted through 32-bit EFI firmware, which cannot load "
-            "the amd64 EFI executables an amd64 install writes"
+            f"the 64-bit EFI executables a {installs.gentoo_name} install writes"
         )
 
     commands = assess_commands(wanted, machine.commands, machine.versions)

--- a/gentoo_install/model/architecture.py
+++ b/gentoo_install/model/architecture.py
@@ -36,6 +36,10 @@ class Architecture:
     #: in, under `releases/<gentoo_name>/binpackages/<release>/`. A fourth
     #: spelling: amd64's is `x86-64` and arm64's is `arm64`.
     binhost_subarch: str
+    #: `grub-install --target` for a BIOS boot, empty where the architecture
+    #: has no BIOS platform at all. Measured on an aarch64 machine: after a
+    #: GRUB install `/usr/lib/grub/` holds `arm64-efi` and nothing else.
+    bios_target: str
     #: How UEFI spells this machine, which names two files: the removable
     #: media fallback `EFI/BOOT/BOOT<name>.EFI` and systemd's
     #: `linux<name>.efi.stub`. Read off systemd's own `efi_arch` table in
@@ -50,6 +54,7 @@ AMD64: Final[Architecture] = Architecture(
     kernel_name="x86_64",
     gentoo_name="amd64",
     grub_target="x86_64-efi",
+    bios_target="i386-pc",
     cpu_flags_variable="CPU_FLAGS_X86",
     binhost_subarch="x86-64",
         efi_name="x64",
@@ -63,6 +68,7 @@ ARCHITECTURES: Final[tuple[Architecture, ...]] = (
         kernel_name="aarch64",
         gentoo_name="arm64",
         grub_target="arm64-efi",
+        bios_target="",
         cpu_flags_variable="CPU_FLAGS_ARM",
         binhost_subarch="arm64",
         efi_name="aa64",
@@ -71,6 +77,7 @@ ARCHITECTURES: Final[tuple[Architecture, ...]] = (
         kernel_name="i686",
         gentoo_name="x86",
         grub_target="i386-efi",
+        bios_target="i386-pc",
         cpu_flags_variable="CPU_FLAGS_X86",
         binhost_subarch="i686",
     efi_name="ia32",

--- a/gentoo_install/plan/bootloader.py
+++ b/gentoo_install/plan/bootloader.py
@@ -195,7 +195,12 @@ class InstallGrub(Operation):
                     continue
                 installed.add(disk)
                 context.run_in_target(
-                    ["grub-install", *force, "--target=i386-pc", disk]
+                    [
+                        "grub-install",
+                        *force,
+                        f"--target={DEFAULT_ARCHITECTURE.bios_target}",
+                        disk,
+                    ]
                 )
         context.run_in_target(["grub-mkconfig", "--output", "/boot/grub/grub.cfg"])
         # grub-mkconfig exits 0 having found no kernel, and the machine then

--- a/tests/unit/test_exec.py
+++ b/tests/unit/test_exec.py
@@ -3002,3 +3002,67 @@ def test_a_clustered_p_is_still_a_pretend() -> None:
         ["emerge", "-j2", "sys-apps/coreutils"],
     ):
         assert not _pretending(argv), argv
+
+
+def test_bios_is_refused_where_the_architecture_has_no_bios_platform(tmp_path: Path) -> None:
+    """A warning is wrong when the boot method does not exist at all.
+
+    `grub-install --target=i386-pc` is the PC BIOS platform, and GRUB builds
+    no BIOS platform for arm64: after a GRUB install on an aarch64 machine
+    `/usr/lib/grub/` holds `arm64-efi` and nothing else. The check warned and
+    carried on, so the install would have partitioned the disk and stopped at
+    the bootloader with nothing to install.
+    """
+    from gentoo_install.model.architecture import ARCHITECTURES, architecture_of
+
+    named = {row.kernel_name: row.bios_target for row in ARCHITECTURES}
+    assert named["x86_64"] == "i386-pc"
+    assert named["i686"] == "i386-pc"
+    arm = architecture_of("aarch64")
+    assert arm is not None
+    assert arm.bios_target == "", arm
+
+    # Driven, not read: `preflight.inspect` must put the refusal in `fatal`
+    # for a BIOS configuration on an architecture with no BIOS platform. An
+    # earlier version of this test searched the source for the field name and
+    # stayed green when the branch was disabled with `if False and ...`.
+    from dataclasses import replace
+
+    import pytest as _pytest
+
+    from gentoo_install.exec import preflight
+    from gentoo_install.model import architecture
+    from gentoo_install.model.config import Firmware
+
+    bios = config()
+    bios = replace(bios, bootloader=replace(bios.bootloader, firmware=Firmware.BIOS))
+
+    def refusals(row: architecture.Architecture) -> tuple[str, ...]:
+        with _pytest.MonkeyPatch.context() as patched:
+            patched.setattr(preflight, "DEFAULT_ARCHITECTURE", row)
+            return preflight.inspect(bios, described(), probe_of(tmp_path)).fatal
+
+    without = refusals(arm)
+    assert any("no BIOS platform" in one for one in without), without
+
+    with_bios = refusals(architecture.AMD64)
+    assert not any("no BIOS platform" in one for one in with_bios), with_bios
+
+
+def test_the_bios_target_is_not_written_a_second_time() -> None:
+    """`plan/bootloader.py` spelled `i386-pc` beside the row that holds it."""
+    import ast
+    from pathlib import Path
+
+    from gentoo_install.model.architecture import ARCHITECTURES
+    from gentoo_install.plan import bootloader
+
+    package = Path(bootloader.__file__).parent.parent
+    targets = {row.bios_target for row in ARCHITECTURES if row.bios_target}
+    for path in sorted(package.rglob("*.py")):
+        if path.name == "architecture.py":
+            continue
+        for node in ast.walk(ast.parse(path.read_text(encoding="utf-8"))):
+            if isinstance(node, ast.Constant) and isinstance(node.value, str):
+                for one in targets:
+                    assert one not in node.value, f"{path}:{node.lineno} writes {one!r}"


### PR DESCRIPTION
`--target=i386-pc` is the PC BIOS platform. Measured on the aarch64 machine: after a GRUB install, `/usr/lib/grub/` holds `arm64-efi` and nothing else. The check only warned — "the configuration boots by BIOS on a machine that booted by UEFI" — so a BIOS configuration there would have partitioned the disk and stopped at the bootloader with nothing to install.

That warning is right for its own case, a machine that could boot either way. This is a different case and gets a refusal that names the architecture.

`bios_target` joins the row beside `grub_target`, so `plan/bootloader.py` composes the option instead of spelling it, and a test refuses a second spelling anywhere else in the package.

The 32-bit EFI refusal also stopped naming amd64 as the thing being installed; it now names the row.

**Worth recording: my first version of this test could not fail.** It searched `preflight`'s source for `installs.bios_target`, and the control — `if False and targets_machine_firmware and ...` — left that string in place and stayed green. The test now drives `preflight.inspect` with the row patched and reads `report.fatal`, and asserts the amd64 row does *not* produce the refusal. Control against the driven version: red.
