### PR TITLE
compat: refuse a cjktty kernel where gentoo-zh builds none

### DIFF
--- a/gentoo_install/model/compat.py
+++ b/gentoo_install/model/compat.py
@@ -17,7 +17,13 @@ from enum import Enum
 from pathlib import PurePosixPath
 from typing import Callable, Final, Mapping
 
-from .architecture import ARCHITECTURES, V3_SUBARCH
+from .architecture import (
+    AMD64,
+    ARCHITECTURES,
+    DEFAULT_ARCHITECTURE,
+    V3_SUBARCH,
+    Architecture,
+)
 from . import mirrors
 from .config import (
     BinhostChannel,
@@ -396,6 +402,32 @@ def binhost_subarch_problems(
             f"not: `ld.so --help` does not list {V3_SUBARCH} as supported",
         )
     return ()
+
+
+def cjk_kernel_problems(
+    config: InstallConfig, row: Architecture | None = None
+) -> tuple[str, ...]:
+    """Refuse a cjktty kernel where gentoo-zh does not build one.
+
+    The three packages that carry the patch are `~amd64` in that overlay, so
+    another machine choosing one asks for an atom the overlay holds for a
+    different architecture: `emerge` stops with the disk already partitioned.
+    Keyed on `applies_cjktty`, which the table already carries, rather than on
+    a second list of atom names.
+    """
+    # Looked up in the body, not bound as a default: a default argument is
+    # evaluated when the function is defined, so the row could not be varied
+    # and a test that swapped it saw the machine's own.
+    row = row if row is not None else DEFAULT_ARCHITECTURE
+    package = KERNEL_PACKAGES.get(config.kernel.source)
+    if package is None or not package.applies_cjktty:
+        return ()
+    if row.gentoo_name == AMD64.gentoo_name:
+        return ()
+    return (
+        f"{package.atom} carries the cjktty patch, which gentoo-zh builds for "
+        f"{AMD64.gentoo_name} only, and this installs {row.gentoo_name}",
+    )
 
 
 def mirror_site_problems(config: InstallConfig) -> tuple[str, ...]:

--- a/gentoo_install/model/validate.py
+++ b/gentoo_install/model/validate.py
@@ -290,6 +290,7 @@ def validate(
         *_l10n_problems(config),
         *_repository_name_problems(config),
         *compat.binhost_subarch_problems(config, supports_v3),
+        *compat.cjk_kernel_problems(config),
         *compat.mirror_site_problems(config),
     ]
     if problems:

--- a/tests/unit/test_compat.py
+++ b/tests/unit/test_compat.py
@@ -1239,3 +1239,88 @@ def test_seeding_a_language_drops_a_mirror_site_its_region_lacks() -> None:
         assert not compat.mirror_site_problems(seeded), (tag, seeded.portage.mirrors)
         kept = seeded.portage.mirrors.region is MirrorRegion.CN
         assert bool(seeded.portage.mirrors.site) == kept, (tag, seeded.portage.mirrors)
+
+
+def test_a_cjktty_kernel_is_refused_where_gentoo_zh_builds_none() -> None:
+    """The three cjktty packages are `~amd64` in gentoo-zh.
+
+    An aarch64 machine could select one from the menu and reach `emerge` with
+    the disk already partitioned, asking that overlay for an atom it carries
+    for another architecture. Keyed on `applies_cjktty`, the trait the table
+    already holds, so a fourth cjktty package is covered the day it is added.
+    """
+    from dataclasses import replace
+
+    from gentoo_install.model import compat
+    from gentoo_install.model.architecture import AMD64, architecture_of
+    from gentoo_install.model.config import KernelSource
+
+    arm = architecture_of("aarch64")
+    assert arm is not None
+
+    carries = [
+        source
+        for source, package in compat.KERNEL_PACKAGES.items()
+        if package.applies_cjktty
+    ]
+    assert carries, compat.KERNEL_PACKAGES
+
+    base = config()
+    for source in carries:
+        chosen = replace(base, kernel=replace(base.kernel, source=source))
+        refused = compat.cjk_kernel_problems(chosen, arm)
+        assert refused, (source, refused)
+        assert compat.KERNEL_PACKAGES[source].atom in refused[0], refused
+        # And the same choice on amd64 is not refused.
+        assert compat.cjk_kernel_problems(chosen, AMD64) == (), source
+
+    # Every kernel the table offers is covered: the ones without the patch are
+    # accepted on both rows rather than left undecided.
+    for source in KernelSource:
+        chosen = replace(base, kernel=replace(base.kernel, source=source))
+        for row in (AMD64, arm):
+            answered = compat.cjk_kernel_problems(chosen, row)
+            expected = bool(
+                compat.KERNEL_PACKAGES[source].applies_cjktty and row is arm
+            )
+            assert bool(answered) == expected, (source, row.kernel_name, answered)
+
+
+def test_validate_reads_the_cjktty_rule() -> None:
+    """A rule nothing calls refuses nothing, so `validate` names this one.
+
+    The overlay is enabled here: without it a different rule speaks first,
+    and a test that accepted any refusal would pass while this one was never
+    reached.
+    """
+    from dataclasses import replace
+
+    import pytest as _pytest
+
+    from gentoo_install.errors import ValidationFailed
+    from gentoo_install.model import compat, validate
+    from gentoo_install.model.architecture import architecture_of
+    from gentoo_install.model.config import KernelSource, Overlay
+
+    base = config()
+    cjk = replace(
+        base,
+        kernel=replace(base.kernel, source=KernelSource.CJK_BIN),
+        portage=replace(
+            base.portage,
+            overlays=(
+                Overlay(name="gentoo-zh", sync_uri="https://example.invalid/overlay.git"),
+            ),
+        ),
+    )
+    arm = architecture_of("aarch64")
+    assert arm is not None
+
+    # On the row the overlay builds for, this configuration is installable.
+    validate.validate(cjk)
+
+    with _pytest.MonkeyPatch.context() as patched:
+        patched.setattr(compat, "DEFAULT_ARCHITECTURE", arm)
+        with _pytest.raises(ValidationFailed) as refused:
+            validate.validate(cjk)
+    assert "cjktty" in str(refused.value), str(refused.value)


### PR DESCRIPTION
Last of the architecture-assumption findings. `sys-kernel/gentoo-cjk-kernel-bin`, its source sibling and the XanMod build are `~amd64` in gentoo-zh, and nothing stopped another machine from selecting one: the install would partition the disk and then ask that overlay for an atom it carries for a different architecture.

The rule is keyed on `applies_cjktty`, the trait `KERNEL_PACKAGES` already holds, rather than on a second list of atom names — a fourth patched kernel is covered the day it is added. The test walks every member of `KernelSource` and asserts the refusal appears exactly where the trait says it should, on both rows.

The overlay is enabled in the `validate` test on purpose: without it a different rule speaks first, and a test that accepted any refusal would have passed while this one was never reached.

**One thing the test caught that is worth repeating.** The rule first took `row: Architecture = DEFAULT_ARCHITECTURE` as a default argument. A default is evaluated when the function is defined, so patching the module attribute did not change it and the check always read the machine it was running on. The row is resolved in the body now, with the reason beside it.

Also checked and **not** acted on, from the same audit: `ConfigureIntelMicrocode` has no architecture guard, but `needs_intel_microcode` is `cpu_vendor is INTEL and virtual_machine is False`, so no aarch64 machine can reach it. A guard there would be a rule that cannot fire.
