### PR TITLE
convert: a directory that cannot be listed is not an empty one

### DIFF
--- a/gentoo_install/exec/convert.py
+++ b/gentoo_install/exec/convert.py
@@ -25,11 +25,22 @@ KEPT_ASIDE: str = ".gentoo-install.old"
 
 
 def _mounts_inside(directory: Path) -> list[str]:
-    """Name every entry of `directory` that is itself a mount point."""
+    """Name every entry of `directory` that is itself a mount point.
+
+    A directory that cannot be listed is refused rather than reported as
+    holding nothing. The caller decides from this answer whether the rename
+    is safe, and `[]` from an `OSError` said exactly what `[]` from a
+    directory with nothing mounted below it says: `rename(2)` then answers
+    EBUSY partway through the entries, which is the state its own comment
+    calls one with no clean rollback.
+    """
     try:
         entries = sorted(os.listdir(directory))
-    except OSError:
-        return []
+    except OSError as error:
+        raise ConversionFailed(
+            f"{directory} cannot be listed, so whether it holds a mount this "
+            f"conversion cannot move is unknown: {error}"
+        ) from error
     return [one for one in entries if os.path.ismount(directory / one)]
 
 

--- a/tests/unit/test_convert.py
+++ b/tests/unit/test_convert.py
@@ -459,3 +459,38 @@ def test_a_copy_that_writes_part_of_a_tree_then_fails_leaves_none_of_it(
     assert not (root / "var" / "cache").exists(), sorted(
         one.name for one in (root / "var").iterdir()
     )
+
+
+def test_a_directory_that_cannot_be_listed_is_not_reported_as_empty(
+    tmp_path: Path,
+) -> None:
+    """The guard on the irreversible step could not tell safe from unreadable.
+
+    `_mounts_inside` returned `[]` for a directory with nothing mounted below
+    it and `[]` for one whose listing raised, and the caller uses that answer
+    to decide the rename may proceed. Its own comment says why that matters:
+    `rename(2)` answers EBUSY for a mount point, and finding that out halfway
+    through the entries is a state with no clean rollback.
+    """
+    import pytest as _pytest
+
+    from gentoo_install.errors import ConversionFailed
+    from gentoo_install.exec.convert import _mounts_inside
+
+    # A directory with nothing mounted below it still answers empty.
+    plain = tmp_path / "plain"
+    plain.mkdir()
+    (plain / "a-file").write_text("")
+    assert _mounts_inside(plain) == []
+
+    # One that cannot be listed is refused, and the message names it.
+    absent = tmp_path / "never-made"
+    with _pytest.raises(ConversionFailed) as refused:
+        _mounts_inside(absent)
+    assert str(absent) in str(refused.value), str(refused.value)
+
+    # A file where a directory was expected raises through the same path.
+    not_a_directory = tmp_path / "file"
+    not_a_directory.write_text("")
+    with _pytest.raises(ConversionFailed):
+        _mounts_inside(not_a_directory)


### PR DESCRIPTION
From a read-only audit of the conversion path, checked against the source before acting.

`_mounts_inside` swallowed `OSError` and returned `[]`, which is exactly what it returns for a directory with nothing mounted below it. The caller uses that answer to decide the irreversible step may proceed, and the comment beside it already states the cost:

    # Counted before anything moves: `rename(2)` answers EBUSY for a
    # mount point, and finding that out halfway through the entries is
    # a state with no clean rollback.

So the guard written to keep the machine out of an unrecoverable state passed a directory it could not read. It now refuses, naming the directory and the error, because "I could not look" is not "there is nothing there".

The test drives the function on three real inputs — a directory with a plain file in it, a path that does not exist, and a file where a directory was expected — rather than reading the source. Control: the `except OSError: return []` restored, red.

Four other claims from the same audit are recorded and not yet acted on; the rollback one (`_restore_contents` renaming back across a filesystem boundary after an `EXDEV` copy) is the severe one and needs its own change.
