### PR TITLE
tui: a derived network manager is undone like the login screen

### DIFF
--- a/gentoo_install/tui/packages.py
+++ b/gentoo_install/tui/packages.py
@@ -21,6 +21,7 @@ from ..model.config import (
     InstallConfig,
     Networking,
     PackagesConfig,
+    SystemConfig,
 )
 from ..plan import automatic as automatic_values
 from ..plan.fonts import CJK_SANS_PREFERENCE, CjkFontconfigLocale, FontCategory
@@ -273,6 +274,16 @@ def _desktop_proposes(
         changed = replace(
             changed,
             packages=replace(changed.packages, display_manager=""),
+        )
+    # The same undo for the network manager, which had only the forward half:
+    # a desktop derived `networkmanager-wpa` and choosing no desktop
+    # afterwards left it, so a converted server carried NetworkManager it was
+    # never asked for. Read off the menu: the network row stayed
+    # `networkmanager-wpa` after the desktop row went back to none.
+    if _has_derived(context, ValueKind.NETWORKING, before.system.networking.value):
+        changed = replace(
+            changed,
+            system=replace(changed.system, networking=SystemConfig().networking),
         )
     if not desktop:
         return changed

--- a/tests/unit/test_tui_widgets.py
+++ b/tests/unit/test_tui_widgets.py
@@ -1423,3 +1423,50 @@ def test_a_detail_too_long_for_one_row_keeps_its_end() -> None:
     TextField(title="name", detail="convert").run(short)
     assert short.frames[-1][2].strip() == "convert", short.frames[-1][:5]
     assert short.frames[-1][3].strip() == "", short.frames[-1][:5]
+
+
+def test_a_derived_network_manager_is_undone_like_the_login_screen() -> None:
+    """Choosing a desktop and then none left NetworkManager behind.
+
+    `_desktop_proposes` cleared a derived display manager before proposing the
+    new one and had no matching step for the network manager, so the forward
+    half ran and the undo did not. Read off the menu on a conversion: the
+    network row stayed `networkmanager-wpa` after the desktop row went back to
+    none, and a converted server would have carried a service nobody asked for.
+    """
+    from dataclasses import replace
+
+    from gentoo_install.model.config import Networking, SystemConfig
+    from gentoo_install.tui.context import ValueKind, ValueProvenance, ValueSource
+    from gentoo_install.tui.packages import _desktop_proposes
+
+    from .test_tui_app import config, context
+
+    at = context()
+    before = config()
+    with_manager = replace(
+        before,
+        system=replace(before.system, networking=Networking.NETWORKMANAGER_WPA),
+    )
+    at.provenance = {
+        ValueProvenance(
+            ValueKind.NETWORKING,
+            Networking.NETWORKMANAGER_WPA.value,
+            ValueSource.DERIVED,
+        )
+    }
+
+    # No desktop: the derived manager goes back to the default.
+    answered = _desktop_proposes(with_manager, with_manager, at, "")
+    assert answered.system.networking == SystemConfig().networking, answered.system
+
+    # The operator's own choice is not touched.
+    at.provenance = {
+        ValueProvenance(
+            ValueKind.NETWORKING,
+            Networking.NETWORKMANAGER_WPA.value,
+            ValueSource.OPERATOR,
+        )
+    }
+    kept = _desktop_proposes(with_manager, with_manager, at, "")
+    assert kept.system.networking == Networking.NETWORKMANAGER_WPA, kept.system


### PR DESCRIPTION
Read off the menu while driving a conversion. The desktop row was set to `console` by mistake and then back to none; the network row stayed `networkmanager-wpa`.

`_desktop_proposes` clears a *derived* display manager before proposing the new one, and had no matching step for the network manager. So the forward half — a desktop implies NetworkManager, since the Plasma and GNOME profiles carry `USE=networkmanager` and nothing moved `system.networking` with it — ran, and the undo did not. A server converted after briefly selecting a desktop would carry a service nobody asked for.

The same `_has_derived` test the display manager uses, so an operator's own choice still stands.

Control: the new branch disabled with `if False and ...`, red.
