### PR TITLE
portage: a USE change the merge writes is not a refusal

### DIFF
--- a/gentoo_install/plan/portage.py
+++ b/gentoo_install/plan/portage.py
@@ -138,9 +138,30 @@ EMERGE_OPTIONS: Final[tuple[str, ...]] = (
 #: `VerifyPackages` asks whether the merge will succeed, so it has to carry
 #: these: without them the check refused a package set the merge installs by
 #: writing the USE change, and an install stopped at operation 26 of 60.
-AUTOUNMASK: Final[tuple[str, ...]] = tuple(
-    one for one in EMERGE_OPTIONS if one.startswith("--autounmask")
-)
+#: What the check adds so emerge computes the USE changes and prints them.
+#: Not the whole set the merge carries: `--autounmask-write` never writes
+#: under `--pretend` -- portage's `depgraph.py` reads
+#: `write_to_file = autounmask_write and not pretend` -- so passing it and
+#: `--autounmask-continue` to a pretend changes what is reported and nothing
+#: else.
+AUTOUNMASK: Final[tuple[str, ...]] = ("--autounmask-use=y",)
+
+#: How emerge announces the one change the merge applies on its own. Only USE:
+#: `--autounmask-license` and `--autounmask=y` are deliberately absent from
+#: `EMERGE_OPTIONS`, so a keyword or licence change is a refusal the merge
+#: would also make.
+USE_CHANGES_NEEDED: Final[str] = "The following USE changes are necessary to proceed"
+
+
+def merge_would_apply(output: str) -> bool:
+    """Whether the merge accepts what this pretend refused.
+
+    The merge runs with `--autounmask-write=y --autounmask-continue=y` and no
+    `--pretend`, so it writes the USE change and carries on. A check that
+    reported this as a refusal was stricter than the thing it guards, and an
+    install stopped at operation 26 of 55 for one `wpa_supplicant dbus`.
+    """
+    return USE_CHANGES_NEEDED in output
 
 #: How emerge says why it will not proceed, in the order the message is
 #: looked for. Read off a real refusal rather than guessed: the first
@@ -1445,6 +1466,10 @@ class VerifyPackages(Operation):
             return
         output = self._without_the_binary_host(context, atoms, output)
         if output.returncode == 0:
+            return
+        if merge_would_apply(str(output)):
+            # The merge writes this one and carries on, so refusing here would
+            # stop an install that works.
             return
 
         problems: list[str] = []

--- a/tests/unit/test_plan_portage.py
+++ b/tests/unit/test_plan_portage.py
@@ -2991,11 +2991,14 @@ def test_the_check_asks_the_question_the_merge_will_ask() -> None:
 
     from gentoo_install.plan.portage import AUTOUNMASK, EMERGE_OPTIONS, VerifyPackages
 
-    # One table, two readers: every autounmask option the merge carries.
-    assert AUTOUNMASK == tuple(
+    # Only what a pretend can act on. This first held every autounmask option
+    # the merge carries, and that premise was wrong: portage's `depgraph.py`
+    # reads `write_to_file = autounmask_write and not pretend`, so the writing
+    # pair does nothing here and the outcome has to be read instead.
+    assert AUTOUNMASK == ("--autounmask-use=y",)
+    assert set(AUTOUNMASK) < {
         one for one in EMERGE_OPTIONS if one.startswith("--autounmask")
-    )
-    assert AUTOUNMASK, EMERGE_OPTIONS
+    }
 
     resolve = inspect.getsource(VerifyPackages._resolve)
     assert "AUTOUNMASK" in resolve, resolve
@@ -3036,3 +3039,95 @@ def test_the_refusal_names_the_line_that_explains_it() -> None:
         "something else entirely"
     )
     assert why_emerge_refused("") == "no output"
+
+
+def test_a_use_change_the_merge_writes_is_not_a_refusal() -> None:
+    """Adding the autounmask options to the pretend did not make it pass.
+
+    Portage's `depgraph.py` reads `write_to_file = autounmask_write and not
+    pretend`, so `--autounmask-write` never writes under `--pretend` and
+    `--autounmask-continue` has nothing to continue into. The check therefore
+    has to read the outcome: the merge runs without `--pretend`, writes the
+    change and carries on.
+
+    Measured on a conversion that stopped at operation 26 of 55 for one line:
+
+        The following USE changes are necessary to proceed:
+        # required by net-misc/networkmanager-1.56.0::gentoo[-iwd,wifi]
+        >=net-wireless/wpa_supplicant-2.11-r4 dbus
+    """
+    from gentoo_install.plan.portage import (
+        AUTOUNMASK,
+        EMERGE_OPTIONS,
+        merge_would_apply,
+    )
+
+    measured = (
+        "setlocale: unsupported locale setting\n"
+        "The following USE changes are necessary to proceed:\n"
+        '(see "package.use" in the portage(5) man page for more details)\n'
+        "# required by net-misc/networkmanager-1.56.0::gentoo[-iwd,wifi]\n"
+        ">=net-wireless/wpa_supplicant-2.11-r4 dbus\n"
+    )
+    assert merge_would_apply(measured)
+
+    # A keyword change is not one the merge applies: `--autounmask=y` is
+    # deliberately absent from the merge's options, so this stays a refusal.
+    assert not merge_would_apply(
+        "The following keyword changes are necessary to proceed:\n"
+        "=app-misc/thing-1 ~amd64\n"
+    )
+    assert not merge_would_apply("emerge: there are no ebuilds to satisfy \"x/y\".\n")
+    assert not merge_would_apply("")
+
+    # The check adds only what a pretend can act on, and the merge keeps the
+    # writing pair: passing those to a pretend changes nothing it does.
+    assert AUTOUNMASK == ("--autounmask-use=y",)
+    assert "--autounmask-write=y" in EMERGE_OPTIONS
+    assert "--autounmask-write=y" not in AUTOUNMASK
+
+
+def test_the_check_accepts_a_use_change_rather_than_stopping_the_install() -> None:
+    """The call site, not only the predicate: `apply` must return, not raise.
+
+    An earlier version of this test exercised `merge_would_apply` alone and
+    stayed green with the branch in `apply` disabled.
+    """
+    recorder = Recorder()
+    refused = (
+        "setlocale: unsupported locale setting\n"
+        "The following USE changes are necessary to proceed:\n"
+        "# required by net-misc/networkmanager-1.56.0::gentoo[-iwd,wifi]\n"
+        ">=net-wireless/wpa_supplicant-2.11-r4 dbus\n"
+    )
+
+    def answer(argv: Sequence[str]) -> str | None:
+        if argv[0] != "emerge":
+            return CommandOutput("", 0)
+        return CommandOutput(refused, 1)
+
+    recorder.answering = answer
+    check = portage.VerifyPackages(
+        requests=(
+            portage.PackageRequest(
+                atom="net-misc/networkmanager",
+                requesters=("the `install the network tools` operation",),
+            ),
+        )
+    )
+    # No exception: the merge writes this change and carries on.
+    check.apply(recorder)
+
+    # And a refusal the merge would also make still stops the install.
+    def keyworded(argv: Sequence[str]) -> str | None:
+        if argv[0] != "emerge":
+            return CommandOutput("", 0)
+        return CommandOutput(
+            "The following keyword changes are necessary to proceed:\n"
+            "=net-misc/networkmanager-9 ~amd64\n",
+            1,
+        )
+
+    recorder.answering = keyworded
+    with pytest.raises(ConfigError):
+        check.apply(recorder)


### PR DESCRIPTION
`#1109` was half a fix, and the machine said so: the conversion stopped again at operation 26 of 55, this time for one line.

    The following USE changes are necessary to proceed:
    # required by net-misc/networkmanager-1.56.0::gentoo[-iwd,wifi]
    >=net-wireless/wpa_supplicant-2.11-r4 dbus

The autounmask options *were* being passed to the pretend — the log shows `emerge --pretend --quiet --autounmask-use=y --autounmask-write=y --autounmask-continue=y …` — and it still refused. Portage says why, in `lib/_emerge/depgraph.py`:

    write_to_file = autounmask_write and not pretend

`--autounmask-write` never writes under `--pretend`, so `--autounmask-continue` has nothing to continue into. Passing those two to a check changes what emerge reports and nothing else.

So the check reads the outcome instead. `--autounmask-use=y` stays, because it makes emerge compute and print the change; the announcement `The following USE changes are necessary to proceed` is then treated as acceptance, since the merge runs without `--pretend` and applies it.

Only USE. `--autounmask-license` and `--autounmask=y` are deliberately absent from `EMERGE_OPTIONS`, so a keyword or licence change stays a refusal — the merge would refuse it too.

`#1109`'s test asserted the old premise (`AUTOUNMASK` equals every autounmask option the merge carries). Rewritten with the reason in place rather than deleted.

Controls: the predicate returning `False`, red; the branch in `apply` disabled, red — the second only after a test was added that drives `apply` rather than the predicate alone, which is how the first version of this test stayed green with the branch off.
