### PR TITLE
convert: a copied entry is undone by removing it

### DIFF
--- a/gentoo_install/exec/convert.py
+++ b/gentoo_install/exec/convert.py
@@ -123,12 +123,25 @@ def _replace_contents(destination: Path, staged: Path, copy: Copier) -> None:
 
 
 def _restore_contents(destination: Path, staged: Path) -> None:
-    """Undo `_replace_contents` when a later directory fails."""
+    """Undo `_replace_contents` when a later directory fails.
+
+    Entries that arrived across a filesystem boundary are removed rather than
+    renamed back. `_replace_contents` reaches `copy()` only after `rename`
+    answered `EXDEV`, and renaming the same entry the other way is that move
+    again: it raised, the caller recorded the error and left the directory
+    half replaced, which on `/usr` is a machine that does not boot. A copy
+    leaves the staged original in place, so removing the copy is the undo.
+    """
     aside = destination / KEPT_ASIDE
     for name in sorted(os.listdir(destination)):
         if name == KEPT_ASIDE:
             continue
-        os.rename(destination / name, staged / name)
+        try:
+            os.rename(destination / name, staged / name)
+        except OSError as error:
+            if error.errno != errno.EXDEV:
+                raise
+            _remove(destination / name)
     for name in sorted(os.listdir(aside)):
         os.rename(aside / name, destination / name)
     os.rmdir(aside)

--- a/tests/unit/test_convert.py
+++ b/tests/unit/test_convert.py
@@ -494,3 +494,77 @@ def test_a_directory_that_cannot_be_listed_is_not_reported_as_empty(
     not_a_directory.write_text("")
     with _pytest.raises(ConversionFailed):
         _mounts_inside(not_a_directory)
+
+
+def test_a_copied_entry_is_undone_by_removing_it(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The later rollback renamed back what only a copy could bring in.
+
+    `_replace_contents` reaches `copy()` only after `rename` answered `EXDEV`,
+    and `_restore_contents` then renamed the same entry the other way: the
+    same cross-device move, which raises. `convert` records the error and
+    leaves the directory half replaced, and on `/usr` that is a machine that
+    does not boot.
+    """
+    import errno
+    import os
+
+    from gentoo_install.exec.convert import KEPT_ASIDE, _restore_contents
+
+    destination = tmp_path / "var"
+    staged = tmp_path / "staging" / "var"
+    aside = destination / KEPT_ASIDE
+    for one in (destination, staged, aside):
+        one.mkdir(parents=True)
+    # What the machine looks like after `_replace_contents`: the original
+    # entry held aside, the staged one copied in, and the staged original
+    # still present because a copy does not consume it.
+    (aside / "old").write_text("the machine's own")
+    (destination / "new").write_text("from the stage3")
+    (staged / "new").write_text("from the stage3")
+
+    real_rename = os.rename
+
+    def crossing(source: "str | Path", target: "str | Path") -> None:
+        # Only the direction that leaves the mount: an entry moving out of the
+        # destination into the staging root. Putting the held-aside original
+        # back is a rename inside the mount and still works.
+        if str(source).startswith(str(destination)) and KEPT_ASIDE not in str(source):
+            raise OSError(errno.EXDEV, "Invalid cross-device link")
+        real_rename(source, target)
+
+    monkeypatch.setattr(os, "rename", crossing)
+    _restore_contents(destination, staged)
+
+    # The machine's own entry is back and the copy is gone.
+    assert (destination / "old").read_text() == "the machine's own"
+    assert not (destination / "new").exists()
+    # The staged copy is untouched, so a later attempt still has it.
+    assert (staged / "new").read_text() == "from the stage3"
+    assert not aside.exists()
+
+
+def test_a_rollback_still_raises_for_anything_but_a_crossing(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Only `EXDEV` means the entry arrived by copy; a busy one is a failure."""
+    import errno
+    import os
+
+    from gentoo_install.exec.convert import KEPT_ASIDE, _restore_contents
+
+    destination = tmp_path / "var"
+    staged = tmp_path / "staging" / "var"
+    (destination / KEPT_ASIDE).mkdir(parents=True)
+    staged.mkdir(parents=True)
+    (destination / "new").write_text("")
+
+    def busy(source: "str | Path", target: "str | Path") -> None:
+        del source, target
+        raise OSError(errno.EBUSY, "Device or resource busy")
+
+    monkeypatch.setattr(os, "rename", busy)
+    with pytest.raises(OSError) as raised:
+        _restore_contents(destination, staged)
+    assert raised.value.errno == errno.EBUSY


### PR DESCRIPTION
The severe finding from the conversion audit, checked against the source before acting.

`_replace_contents` reaches `copy()` only after `rename` answered `EXDEV` — a mount point replaced by content, which is why the function exists. It records each entry as `RENAMED` or `COPIED`, and its own immediate rollback honours the distinction.

`_restore_contents`, the rollback used when a *later* directory fails, renamed every entry back unconditionally. For a copied entry that is the same cross-device move that forced the copy, so it raises; `convert` records the error and moves on, leaving the directory half replaced. On `/usr` or `/var` that is a machine that does not boot, reached from the path that exists to put the machine back.

A copy leaves the staged original in place, so removing the copy is the undo — the same thing the immediate rollback does. Only `EXDEV`: a busy entry still raises, and a test holds that.

The test drives `_restore_contents` with `os.rename` failing in the one direction that crosses, and checks all three outcomes — the machine's own entry back, the copy gone, the staged original still there for a later attempt.

Control: the `EXDEV` branch removed, red.

Three claims from that audit remain: two readers of "mounts below a directory" (recursive against direct children), the destination mount state read twice for different decisions, and `plan/convert.py`'s first staging-mount query mapping command failure to an empty set.
