### PR TITLE
convert: one reader for what the machine reports as mounted

### DIFF
--- a/gentoo_install/plan/convert.py
+++ b/gentoo_install/plan/convert.py
@@ -259,17 +259,31 @@ class LeaveStaging(Operation):
     def describe(self) -> str:
         return f"unmount and remove {self.staging}"
 
+    def _every_mount(self, context: Context) -> str:
+        """What the machine reports as mounted, refusing a failed read.
+
+        `findmnt` with no filter lists every mount and exits 0, so a non-zero
+        status is an error rather than an empty answer. One reader treated it
+        as empty and the other as an error: the unmount loop then did nothing
+        and the check after it raised, naming a mount that was never unmounted.
+        """
+        listed = context.run(
+            ["findmnt", "--noheadings", "--list", "--output", "TARGET"], check=False
+        )
+        if isinstance(listed, CommandOutput) and listed.returncode != 0:
+            raise ConversionFailed(
+                f"what is mounted under {self.staging} could not be read: "
+                f"{str(listed).strip()}"
+            )
+        return str(listed)
+
     def _mounted_under(self, context: Context) -> list[str]:
         """Every mount below the staging root, deepest first.
 
         Deepest first because `/gentoo-install.new/dev/pts` has to go before
         `/gentoo-install.new/dev`, and `umount` refuses a busy parent.
         """
-        listed = context.run(
-            ["findmnt", "--noheadings", "--list", "--output", "TARGET"], check=False
-        )
-        if isinstance(listed, CommandOutput) and listed.returncode != 0:
-            return []
+        listed = self._every_mount(context)
         under = f"{self.staging}/"
         found = [
             line.strip()
@@ -284,16 +298,10 @@ class LeaveStaging(Operation):
         # answered `not mounted` and exited 1 while seventeen binds stayed.
         for mounted in self._mounted_under(context):
             context.run(["umount", "--lazy", mounted], check=False)
-        listed = context.run(
-            ["findmnt", "--noheadings", "--list", "--output", "TARGET"], check=False
-        )
-        # `findmnt` with no filter lists every mount and exits 0, so a non-zero
-        # status is an error rather than an empty answer. Reading it as empty
-        # is what lets the `rm` below walk into a `/proc` still bound here.
-        if isinstance(listed, CommandOutput) and listed.returncode != 0:
-            raise ConversionFailed(
-                f"what is mounted under {self.staging} could not be read: {str(listed).strip()}"
-            )
+        # Read again through the same reader: what the `rm` below walks into
+        # depends on this answer, and an unreadable mount table is not an
+        # empty one.
+        listed = self._every_mount(context)
         under = f"{self.staging}/"
         if any(
             line.strip() == str(self.staging) or line.strip().startswith(under)

--- a/tests/unit/test_plan_convert.py
+++ b/tests/unit/test_plan_convert.py
@@ -986,3 +986,56 @@ def test_a_conversion_checks_its_subvolume_rather_than_making_it() -> None:
 
     fresh = Subvolume(id=DeviceId("sub"), filesystem=DeviceId("rootfs"), name="@")
     assert fresh.create
+
+
+def test_an_unreadable_mount_table_is_not_an_empty_one() -> None:
+    """Two readers of one `findmnt`, and only one treated failure as failure.
+
+    `_mounted_under` returned `[]` for a non-zero exit, which is what it
+    returns when nothing is mounted below the staging root, so the unmount
+    loop did nothing. The check after it read the same command, treated the
+    same failure as an error, and raised about a mount that was never
+    unmounted. Both go through one reader now.
+    """
+    import pytest as _pytest
+
+    from gentoo_install.errors import ConversionFailed
+    from gentoo_install.plan import convert as plan_convert
+    from gentoo_install.plan.operations import CommandOutput
+
+    class Refusing:
+        """A machine whose mount table cannot be read."""
+
+        def run(self, argv: object, check: bool = True) -> CommandOutput:
+            del argv, check
+            return CommandOutput("findmnt: cannot read /proc/self/mountinfo", 1)
+
+    removing = plan_convert.LeaveStaging(staging=PurePosixPath("/gentoo-install.new"))
+    with _pytest.raises(ConversionFailed) as refused:
+        removing.apply(cast(Any, Refusing()))
+    assert "could not be read" in str(refused.value), str(refused.value)
+
+    # A readable table with nothing below the staging root still passes, and
+    # the entries below it are returned deepest first.
+    class Reporting:
+        def __init__(self) -> None:
+            self.commands: list[tuple[str, ...]] = []
+
+        def run(self, argv: object, check: bool = True) -> CommandOutput:
+            del check
+            self.commands.append(tuple(str(one) for one in cast(Any, argv)))
+            if tuple(str(one) for one in cast(Any, argv))[0] != "findmnt":
+                return CommandOutput("", 0)
+            if len(self.commands) == 1:
+                return CommandOutput(
+                    "/\n/gentoo-install.new/dev\n/gentoo-install.new/dev/pts\n", 0
+                )
+            return CommandOutput("/\n", 0)
+
+    machine = Reporting()
+    removing.apply(cast(Any, machine))
+    unmounted = [one for one in machine.commands if one[0] == "umount"]
+    assert [one[-1] for one in unmounted] == [
+        "/gentoo-install.new/dev/pts",
+        "/gentoo-install.new/dev",
+    ], unmounted


### PR DESCRIPTION
Third finding from the conversion audit. `LeaveStaging` ran `findmnt --noheadings --list --output TARGET` twice, and the two calls disagreed about what a non-zero exit means.

`_mounted_under` returned `[]` — which is also what it returns when nothing is mounted below the staging root — so the unmount loop did nothing. The check after the loop ran the same command, treated the same failure as an error, and raised about mounts that had never been unmounted. The comment on the second call already said why failure is not emptiness: reading it as empty is what lets the `rm` walk into a `/proc` still bound there.

Both go through `_every_mount` now, which refuses a failed read once, so the two callers cannot drift again.

The test drives `LeaveStaging.apply` rather than the helper: a machine whose mount table cannot be read must raise, and a readable one must unmount the staging binds deepest first, since `umount` refuses a busy parent.

Control: the reader returning `""` on a non-zero exit, red.

Two claims from that audit remain: `_mounts_inside` (direct children) against `plan/convert.py`'s prefix match (recursive) as two readings of "mounts below a directory", and the destination mount state read twice for different decisions.
