### PR TITLE
convert: read each destination's mount state once

### DIFF
--- a/gentoo_install/exec/convert.py
+++ b/gentoo_install/exec/convert.py
@@ -169,7 +169,11 @@ def convert(
             raise ConversionFailed(f"the staging directory has no {name}")
         if os.path.lexists(old):
             raise ConversionFailed(f"{old} is left from an earlier attempt")
-        if os.path.ismount(destination):
+        # Read once and used twice: the second call decided which replacement
+        # and rollback this entry gets, so a mount appearing between the two
+        # skipped the nested check above and still took the mounted path.
+        mounted = os.path.ismount(destination)
+        if mounted:
             # Counted before anything moves: `rename(2)` answers EBUSY for a
             # mount point, and finding that out halfway through the entries is
             # a state with no clean rollback.
@@ -183,7 +187,7 @@ def convert(
         # merged-usr Debian has no `/lib64` at all, and renaming what is not
         # there fails half way through with the rest already swapped.
         destinations.append(
-            (name, destination, staged, old, os.path.lexists(destination), os.path.ismount(destination))
+            (name, destination, staged, old, os.path.lexists(destination), mounted)
         )
     # Mount points last: replacing one by content is the only step whose
     # rollback touches more than two renames, so nothing else has to be undone

--- a/tests/unit/test_convert.py
+++ b/tests/unit/test_convert.py
@@ -568,3 +568,40 @@ def test_a_rollback_still_raises_for_anything_but_a_crossing(
     with pytest.raises(OSError) as raised:
         _restore_contents(destination, staged)
     assert raised.value.errno == errno.EBUSY
+
+
+def test_the_mount_state_is_read_once_for_each_destination(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Two reads decided two different things about the same directory.
+
+    The first chose whether nested mounts had to be counted; the second, five
+    lines later, chose which replacement and rollback the entry gets. A mount
+    appearing between them skipped the check and still took the mounted path,
+    which is the path the check exists to make safe.
+    """
+    import os
+
+    from gentoo_install.exec import convert as exec_convert
+
+    root = tmp_path / "root"
+    staging = tmp_path / "root" / "gentoo-install.new"
+    for name in ("usr", "var"):
+        (root / name).mkdir(parents=True)
+        (staging / name).mkdir(parents=True)
+
+    asked: list[str] = []
+    real_ismount = os.path.ismount
+
+    def counting(path: "str | Path") -> bool:
+        asked.append(str(path))
+        return real_ismount(path)
+
+    monkeypatch.setattr(os.path, "ismount", counting)
+    exec_convert.convert(
+        staging, ("usr", "var"), copy=lambda source, target: None, root=root
+    )
+
+    for name in ("usr", "var"):
+        destination = str(root / name)
+        assert asked.count(destination) == 1, (destination, asked)


### PR DESCRIPTION
Fourth finding from the conversion audit. `convert` called `os.path.ismount(destination)` twice, five lines apart: the first chose whether nested mounts had to be counted before anything moves, the second was recorded in the tuple that decides which replacement and rollback the entry gets.

A mount appearing between the two reads therefore skipped the check and still took the mounted path — the path that check exists to make safe. Its own comment says what is at stake: `rename(2)` answers EBUSY for a mount point, and finding that out halfway through the entries is a state with no clean rollback.

Read once, used twice now.

The test drives `convert` with `os.path.ismount` counted, and asserts each destination is asked exactly once — a real call count, not a reading of the source. Control: the second call restored, red.

One claim from that audit remains, and it is not small: `_mounts_inside` looks only at immediate children while `plan/convert.py` matches by path prefix, so a mount two levels down — `/var/lib/docker` with `/var/lib` not itself a mount — is invisible to the check above and blocks the rename anyway.
