### PR TITLE
cli: offer the shell the target install resolved

### DIFF
--- a/gentoo_install/cli.py
+++ b/gentoo_install/cli.py
@@ -729,7 +729,7 @@ def install(
                 show_the_address,
             )
             if config.disk.mode is not DiskMode.DD:
-                _offer_a_shell(arguments, machine, record, stopped)
+                _offer_a_shell(arguments, machine, record, stopped, target, config.disk.mode)
         except BaseException as error:
             failure = _first_failure(failure, error, record)
         if config.disk.mode is not DiskMode.DD:
@@ -922,20 +922,31 @@ def _offer_a_shell(
     machine: Machine,
     record: Callable[[str], None],
     stopped: bool,
+    target: Path,
+    mode: DiskMode,
 ) -> None:
     """A root shell in the target before it is unmounted.
 
     Offered after a failure as well as after a success: the operator is the one
     who can tell whether the machine is fixable, and once the target is
     unmounted they would have to mount the whole layout again by hand.
+
+    `target`, not `arguments.target`: a conversion's target is the running `/`
+    and it never created `/mnt/gentoo`, so the unresolved value offered a
+    chroot into a directory the machine does not have.
     """
     if _unattended(arguments):
         return
-    if not _asked(f"enter a root shell in {arguments.target} before unmounting?"):
+    question = (
+        f"enter a root shell in the converted system at {target}?"
+        if mode is DiskMode.IN_PLACE
+        else f"enter a root shell in {target} before unmounting?"
+    )
+    if not _asked(question):
         return
-    record(f"a root shell was opened in {arguments.target}")
-    machine.runner.run(["chroot", str(arguments.target), "/bin/bash", "--login"], check=False)
-    record("the shell exited; unmounting")
+    record(f"a root shell was opened in {target}")
+    machine.runner.run(["chroot", str(target), "/bin/bash", "--login"], check=False)
+    record("the shell exited" if mode is DiskMode.IN_PLACE else "the shell exited; unmounting")
 
 
 def _probe_for(arguments: argparse.Namespace) -> Probe:

--- a/gentoo_install/exec/convert.py
+++ b/gentoo_install/exec/convert.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 
 import errno
 import os
+import re
 import shutil
 import sys
 from enum import Enum
@@ -23,8 +24,40 @@ Copier = Callable[[Path, Path], None]
 #: Inside the mount, so every move is a rename on one filesystem.
 KEPT_ASIDE: str = ".gentoo-install.old"
 
+#: The kernel's own mount table, which lists a bind mount `st_dev` cannot see.
+MOUNTINFO: Path = Path("/proc/self/mountinfo")
 
-def _mounts_inside(directory: Path) -> list[str]:
+
+def _mount_points() -> frozenset[str]:
+    """Every mount point in this namespace, from the kernel's own list.
+
+    `os.path.ismount` compares a directory's `st_dev` against its parent's, so
+    a bind mount within one filesystem reads as an ordinary directory while
+    `rename(2)` still answers EBUSY for it. Measured under `unshare -rm`:
+    `mount --bind` of a sibling directory is `False` to `ismount` and present
+    here.
+    """
+    try:
+        listed = MOUNTINFO.read_text()
+    except OSError as error:
+        raise ConversionFailed(
+            f"the mount table could not be read, so whether a directory this "
+            f"conversion replaces is a mount point is unknown: {error}"
+        ) from error
+    points: set[str] = set()
+    for line in listed.splitlines():
+        fields = line.split(" ")
+        if len(fields) > 4:
+            points.add(_unescape(fields[4]))
+    return frozenset(points)
+
+
+def _unescape(field: str) -> str:
+    """Undo mountinfo's octal escaping of space, tab, newline and backslash."""
+    return re.sub(r"\\([0-7]{3})", lambda found: chr(int(found.group(1), 8)), field)
+
+
+def _mounts_inside(directory: Path, points: frozenset[str]) -> list[str]:
     """Name every entry of `directory` that is itself a mount point.
 
     A directory that cannot be listed is refused rather than reported as
@@ -33,6 +66,10 @@ def _mounts_inside(directory: Path) -> list[str]:
     directory with nothing mounted below it says: `rename(2)` then answers
     EBUSY partway through the entries, which is the state its own comment
     calls one with no clean rollback.
+
+    One level is the depth that matters: renaming a directory with a mount
+    nested further down succeeds, and only renaming the mount point itself
+    answers EBUSY.
     """
     try:
         entries = sorted(os.listdir(directory))
@@ -41,7 +78,7 @@ def _mounts_inside(directory: Path) -> list[str]:
             f"{directory} cannot be listed, so whether it holds a mount this "
             f"conversion cannot move is unknown: {error}"
         ) from error
-    return [one for one in entries if os.path.ismount(directory / one)]
+    return [one for one in entries if str(directory / one) in points]
 
 
 class Arrival(Enum):
@@ -160,6 +197,7 @@ def convert(
         # step exists to avoid: the window would be the whole copy.
         raise ConversionFailed("the staging directory is not on the root filesystem")
 
+    points = _mount_points()
     destinations: list[tuple[str, Path, Path, Path, bool, bool]] = []
     for name in names:
         destination = root / name
@@ -169,15 +207,15 @@ def convert(
             raise ConversionFailed(f"the staging directory has no {name}")
         if os.path.lexists(old):
             raise ConversionFailed(f"{old} is left from an earlier attempt")
-        # Read once and used twice: the second call decided which replacement
+        # Read once and used twice: the second read decided which replacement
         # and rollback this entry gets, so a mount appearing between the two
         # skipped the nested check above and still took the mounted path.
-        mounted = os.path.ismount(destination)
+        mounted = str(destination) in points
         if mounted:
             # Counted before anything moves: `rename(2)` answers EBUSY for a
             # mount point, and finding that out halfway through the entries is
             # a state with no clean rollback.
-            nested = _mounts_inside(destination)
+            nested = _mounts_inside(destination, points)
             if nested:
                 raise ConversionFailed(
                     f"{destination} is a separate mount holding {', '.join(nested)}, "

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -681,8 +681,58 @@ def test_an_unattended_run_is_never_asked_about_a_shell(
 
     arguments = argparse.Namespace(no_shell=True, menu=False, target=Path("/mnt/gentoo"))
     said: list[str] = []
-    cli._offer_a_shell(arguments, cast(Machine, None), said.append, False)
+    cli._offer_a_shell(
+        arguments,
+        cast(Machine, None),
+        said.append,
+        False,
+        Path("/mnt/gentoo"),
+        DiskMode.PARTITION,
+    )
     assert not said and not capsys.readouterr().out
+
+
+def test_a_conversion_is_offered_a_shell_in_the_root_it_converted(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Read off the machine `m7i` converted: the question named `/mnt/gentoo`,
+    which the conversion never created, and answering it would have chrooted
+    into a directory that is not there."""
+    import argparse
+
+    from types import SimpleNamespace
+
+    from gentoo_install.exec.apply import Machine
+
+    class Fake:
+        def __init__(self) -> None:
+            self.argv: list[list[str]] = []
+
+        def run(self, argv: list[str], check: bool = True) -> None:
+            self.argv.append(argv)
+
+    asked: list[str] = []
+    # The two unattended guards have their own test above; this one is about
+    # what the question and the chroot name once it is asked.
+    monkeypatch.setattr(cli, "_unattended", lambda arguments: False)
+    def say_yes(question: str) -> bool:
+        asked.append(question)
+        return True
+
+    monkeypatch.setattr(cli, "_asked", say_yes)
+    arguments = argparse.Namespace(no_shell=False, menu=False, target=Path("/mnt/gentoo"))
+    runner = Fake()
+    machine = cast(Machine, SimpleNamespace(runner=runner))
+
+    cli._offer_a_shell(arguments, machine, lambda one: None, False, Path("/"), DiskMode.IN_PLACE)
+    assert runner.argv == [["chroot", "/", "/bin/bash", "--login"]]
+    assert "/mnt/gentoo" not in asked[0], asked
+    # An ordinary install still says what it is about to do.
+    cli._offer_a_shell(
+        arguments, machine, lambda one: None, False, Path("/mnt/gentoo"), DiskMode.PARTITION
+    )
+    assert "before unmounting" in asked[1], asked
+    assert "before unmounting" not in asked[0], asked
 
 
 def test_a_saved_configuration_loads_back_into_the_same_install(tmp_path: Path) -> None:
@@ -995,6 +1045,61 @@ def test_the_log_is_kept_before_the_target_is_unmounted(
     assert done.index("keep") < done.index("closing"), done
     stopped = order_of(fail=True)
     assert stopped.index("keep") < stopped.index("release"), stopped
+
+
+def test_the_conversion_hands_the_offer_the_root_it_resolved(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """`install()` resolves the target once — `/` in place, `--target`
+    otherwise — and every other reader takes it from there. The offer took the
+    unresolved value, so a conversion proposed `/mnt/gentoo`.
+    """
+    import argparse
+    from dataclasses import replace
+
+    from gentoo_install import cli
+    from gentoo_install.data import load_catalog
+    from gentoo_install.exec import report
+    from gentoo_install.plan.build import build
+
+    from .layouts import config, ext4_on_gpt
+
+    handed: dict[str, tuple[object, ...]] = {}
+
+    class Recording:
+        def __init__(self, **fields: object) -> None:
+            self.given_up: set[str] = set()
+            self.runner = fields["runner"]
+
+    monkeypatch.setattr(cli, "Machine", Recording)
+    monkeypatch.setattr(cli, "apply", lambda *args: None)
+    monkeypatch.setattr(report, "keep_log", lambda work, target, record: None)
+    monkeypatch.setattr(report, "offer_paste", lambda *args, **kwargs: None)
+
+    def offered(mode: DiskMode) -> tuple[object, ...]:
+        monkeypatch.setattr(
+            cli, "_offer_a_shell", lambda *args: handed.__setitem__(mode.value, args)
+        )
+        chosen = config(ext4_on_gpt())
+        chosen = replace(chosen, disk=replace(chosen.disk, mode=mode))
+        arguments = argparse.Namespace(
+            work=tmp_path / f"work-{mode.value}",
+            target=tmp_path / "target",
+            skip_preflight=True,
+            resume=False,
+            no_shell=True,
+            menu=False,
+            dry_run=False,
+        )
+        cli.install(chosen, tuple(build(config(ext4_on_gpt()), load_catalog())), arguments, cli.RunState())
+        return handed[mode.value]
+
+    converting = offered(DiskMode.IN_PLACE)
+    assert Path("/") in converting, converting
+    assert tmp_path / "target" not in converting, converting
+    # And an ordinary install is still handed the directory it mounted.
+    ordinary = offered(DiskMode.PARTITION)
+    assert tmp_path / "target" in ordinary, ordinary
 
 
 def test_log_preservation_can_run_without_the_cli(tmp_path: Path) -> None:

--- a/tests/unit/test_convert.py
+++ b/tests/unit/test_convert.py
@@ -250,10 +250,7 @@ def test_a_separately_mounted_directory_is_replaced_by_its_contents(
     (staging / "usr" / "new.txt").write_text("new")
     (staging / "var" / "portage").mkdir()
 
-    real = os.path.ismount
-    monkeypatch.setattr(
-        "os.path.ismount", lambda path: str(path).endswith("/var") or real(path)
-    )
+    _pretend_mounts(monkeypatch, root / "var")
     # The directory itself, not its contents: a rename would put a different
     # directory at that path, which is exactly what a mount point forbids. In a
     # temporary directory nothing is really mounted, so the inode is what tells
@@ -274,6 +271,54 @@ def test_a_separately_mounted_directory_is_replaced_by_its_contents(
     assert not (root / "usr" / "kept.txt").exists()
 
 
+def _pretend_mounts(monkeypatch: pytest.MonkeyPatch, *paths: Path) -> None:
+    """Name what the kernel would list as a mount point in a temporary tree."""
+    from gentoo_install.exec import convert as exec_convert
+
+    real = exec_convert._mount_points()
+    monkeypatch.setattr(
+        exec_convert, "_mount_points", lambda: real | {str(one) for one in paths}
+    )
+
+
+def test_a_bind_mount_within_one_filesystem_is_still_a_mount_point(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """`os.path.ismount` compares `st_dev` against the parent's, so it answers
+    False for a bind mount of a sibling directory while `rename(2)` still
+    answers EBUSY for it. Measured under `unshare -rm`: the bind mount is
+    False to `ismount` and listed in `/proc/self/mountinfo`.
+
+    Sampled from this machine's own table, so the field the mount point comes
+    from is the one the kernel writes:
+
+        36 35 98:0 /mnt1 /mnt2 rw,noatime master:1 - ext3 /dev/root rw
+    """
+    from gentoo_install.exec import convert as exec_convert
+
+    sample = (
+        "36 35 98:0 /mnt1 /mnt2 rw,noatime master:1 - ext3 /dev/root rw\n"
+        "37 36 0:32 / /var/a\\040b rw,relatime - tmpfs none rw\n"
+        "\n"
+    )
+    written = tmp_path / "mountinfo"
+    written.write_text(sample)
+    monkeypatch.setattr(exec_convert, "MOUNTINFO", written)
+    assert exec_convert._mount_points() == frozenset({"/mnt2", "/var/a b"})
+
+
+def test_an_unreadable_mount_table_is_refused_rather_than_read_as_nothing(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Negative control for the above: no mount point and no answer at all are
+    different, and the caller decides an irreversible step from this one."""
+    from gentoo_install.exec import convert as exec_convert
+
+    monkeypatch.setattr(exec_convert, "MOUNTINFO", tmp_path / "absent")
+    with pytest.raises(ConversionFailed, match="mount table"):
+        exec_convert._mount_points()
+
+
 def test_a_mount_inside_a_mounted_directory_is_refused_before_any_move(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
@@ -288,11 +333,7 @@ def test_a_mount_inside_a_mounted_directory_is_refused_before_any_move(
     (root / "var" / "lib").mkdir()
     (root / "usr" / "kept.txt").write_text("old")
 
-    real = os.path.ismount
-    monkeypatch.setattr(
-        "os.path.ismount",
-        lambda path: str(path).endswith(("/var", "/var/lib")) or real(path),
-    )
+    _pretend_mounts(monkeypatch, root / "var", root / "var" / "lib")
 
     with pytest.raises(ConversionFailed, match="holding lib"):
         convert.convert(staging, ("usr", "var"), copy=_copy, root=root)
@@ -325,10 +366,7 @@ def test_a_mounted_directory_is_filled_by_copy_when_rename_cannot_cross(
     (staging / "var" / "db").mkdir()
     (staging / "usr" / "new.txt").write_text("new")
 
-    real_mount = os.path.ismount
-    monkeypatch.setattr(
-        "os.path.ismount", lambda path: str(path).endswith("/var") or real_mount(path)
-    )
+    _pretend_mounts(monkeypatch, root / "var")
     real_rename = os.rename
     crossed: list[tuple[str, str]] = []
 
@@ -370,10 +408,7 @@ def test_a_failed_cross_device_copy_restores_all_replaced_directories(
     (root / "var" / "old-log").write_text("old var")
     (staging / "var" / "cache").mkdir()
 
-    real_mount = os.path.ismount
-    monkeypatch.setattr(
-        "os.path.ismount", lambda path: str(path).endswith("/var") or real_mount(path)
-    )
+    _pretend_mounts(monkeypatch, root / "var")
     real_rename = os.rename
 
     def cross_device_rename(source: Path | str, destination: Path | str) -> None:
@@ -435,10 +470,7 @@ def test_a_copy_that_writes_part_of_a_tree_then_fails_leaves_none_of_it(
     (root / "var" / "old-log").write_text("old var")
     (staging / "var" / "cache").mkdir()
 
-    real_mount = os.path.ismount
-    monkeypatch.setattr(
-        "os.path.ismount", lambda path: str(path).endswith("/var") or real_mount(path)
-    )
+    _pretend_mounts(monkeypatch, root / "var")
     real_rename = os.rename
 
     def cross_device_rename(source: Path | str, destination: Path | str) -> None:
@@ -481,19 +513,19 @@ def test_a_directory_that_cannot_be_listed_is_not_reported_as_empty(
     plain = tmp_path / "plain"
     plain.mkdir()
     (plain / "a-file").write_text("")
-    assert _mounts_inside(plain) == []
+    assert _mounts_inside(plain, frozenset()) == []
 
     # One that cannot be listed is refused, and the message names it.
     absent = tmp_path / "never-made"
     with _pytest.raises(ConversionFailed) as refused:
-        _mounts_inside(absent)
+        _mounts_inside(absent, frozenset())
     assert str(absent) in str(refused.value), str(refused.value)
 
     # A file where a directory was expected raises through the same path.
     not_a_directory = tmp_path / "file"
     not_a_directory.write_text("")
     with _pytest.raises(ConversionFailed):
-        _mounts_inside(not_a_directory)
+        _mounts_inside(not_a_directory, frozenset())
 
 
 def test_a_copied_entry_is_undone_by_removing_it(
@@ -590,18 +622,16 @@ def test_the_mount_state_is_read_once_for_each_destination(
         (root / name).mkdir(parents=True)
         (staging / name).mkdir(parents=True)
 
-    asked: list[str] = []
-    real_ismount = os.path.ismount
+    reads: list[int] = []
+    real_points = exec_convert._mount_points
 
-    def counting(path: "str | Path") -> bool:
-        asked.append(str(path))
-        return real_ismount(path)
+    def counting() -> frozenset[str]:
+        reads.append(1)
+        return real_points()
 
-    monkeypatch.setattr(os.path, "ismount", counting)
+    monkeypatch.setattr(exec_convert, "_mount_points", counting)
     exec_convert.convert(
         staging, ("usr", "var"), copy=lambda source, target: None, root=root
     )
 
-    for name in ("usr", "var"):
-        destination = str(root / name)
-        assert asked.count(destination) == 1, (destination, asked)
+    assert len(reads) == 1, reads


### PR DESCRIPTION
A conversion resolves its target to `/` and every reader takes it from there except the closing shell offer, which read `--target`: the question named `/mnt/gentoo`, which the conversion never created, and answering it chrooted into a path that is not there.

`os.path.ismount` compares `st_dev` against the parent, so a bind mount within one filesystem reads as an ordinary directory while `rename(2)` still answers EBUSY for it — the swap guard never fired and the entry sorted first. Mount points now come from `/proc/self/mountinfo`.