### PR TITLE
cluster: refuse a layout its target cannot hold

### DIFF
--- a/tests/unit/test_cluster.py
+++ b/tests/unit/test_cluster.py
@@ -1383,6 +1383,45 @@ def test_a_fixture_that_needs_user_mode_networking_is_refused_here() -> None:
     assert cluster.fixtures(["vm-xfs", "zfs-zbm"])
 
 
+def test_a_layout_that_cannot_fit_this_runners_target_is_refused_here() -> None:
+    """Every guest here gets the same `TARGET_GIB`. `vm-shares` asks `40%` of
+    the disk for a root that declares `min = "20GiB"`, which is 16178MiB at
+    that size, so the installer refuses it — correctly — after the round has
+    taken a node and 1.9 minutes.
+
+    The local campaign already names this fixture and its reason, but that is
+    a list only the local runner reads. This refusal is derived from
+    `TARGET_GIB`, so it follows the size this runner gives.
+    """
+    import pytest
+
+    with pytest.raises(SystemExit, match="20GiB"):
+        cluster.fixtures(["vm-shares"])
+
+    # Negative control: the fixtures that fit are still dispatched, including
+    # the one whose layout comes from the machine rather than the file.
+    assert [one.name for one in cluster.fixtures(["vm-xfs", "vm-convert"])] == [
+        "vm-xfs",
+        "vm-convert",
+    ]
+
+
+def test_the_two_runners_agree_on_which_fixtures_a_guest_cannot_run() -> None:
+    """A fixture excluded for a reason that holds on both runners has to be
+    excluded on both. `vm-shares` was named in the local table and dispatched
+    here anyway, which is one rule kept in two places with one of them
+    complete."""
+    import pytest
+
+    from tests.unit.test_harness import NOT_IN_THE_CAMPAIGN
+
+    both: dict[str, str] = {"vm-shares.toml": "20GiB"}
+    assert set(both) <= NOT_IN_THE_CAMPAIGN, sorted(set(both) - NOT_IN_THE_CAMPAIGN)
+    for fixture, said in both.items():
+        with pytest.raises(SystemExit, match=said):
+            cluster.fixtures([fixture.removesuffix(".toml")])
+
+
 def test_the_prompt_after_a_refusal_is_read_before_the_name_is_offered_again(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:

--- a/tests/vm/cluster.py
+++ b/tests/vm/cluster.py
@@ -60,8 +60,13 @@ from gentoo_install.model.config import (
 from gentoo_install.model.device import (
     Existing,
     Luks,
+    Partition,
+    StorageFacts,
     ZfsPool,
 )
+from gentoo_install.errors import InvalidLayout
+from gentoo_install.model.size import Size
+from gentoo_install.plan.disk import resolve_share
 from gentoo_install.model.config import MirrorRegion, Sync
 from gentoo_install.model import mirrors
 from gentoo_install.exec.config import load
@@ -4716,6 +4721,32 @@ def _needs_a_scratch_filesystem(config: InstallConfig) -> str:
     return config.disk.image if config.disk.mode is DiskMode.IMAGE else ""
 
 
+#: Every guest here is given the same `TARGET_GIB`, so a layout whose bounds
+#: cannot be met at that size is refused before a node is taken rather than an
+#: hour later: `vm-shares` asks `40%` of the disk for a root that declares
+#: `min = "20GiB"`, which works out to 16178MiB on 40 GiB, and the installer
+#: exited 1 after 1.9 minutes of cluster time. Derived from `TARGET_GIB` rather
+#: than named, so the refusal follows the size this runner actually gives.
+def _will_not_fit_this_runner(config: InstallConfig) -> str:
+    """Why this layout cannot be resolved at `TARGET_GIB`, or empty."""
+    graph = config.disk.graph
+    facts = StorageFacts(
+        capacities={
+            node.id: Size(TARGET_GIB * 1024**3)
+            for node in graph.nodes.values()
+            if isinstance(node, Existing)
+        }
+    )
+    for node in graph.nodes.values():
+        if not isinstance(node, Partition):
+            continue
+        try:
+            resolve_share(graph, node, facts)
+        except InvalidLayout as refused:
+            return str(refused)
+    return ""
+
+
 def _needs_user_mode_networking(config: InstallConfig) -> str:
     """The address that only the local hypervisor provides, or empty."""
     if not config.proxy.host:
@@ -4747,6 +4778,12 @@ def fixtures(names: list[str]) -> list[Job]:
             raise SystemExit(
                 f"{name} reaches {local_only}, which only qemu's user-mode network "
                 "provides: run it with tests/vm/run.py, not on the cluster"
+            )
+        unfittable = _will_not_fit_this_runner(config)
+        if unfittable:
+            raise SystemExit(
+                f"{name} cannot be laid out on the {TARGET_GIB} GiB target every "
+                f"guest here is given: {unfittable}"
             )
         convert_to: Path | None = None
         if config.disk.mode is DiskMode.IN_PLACE:


### PR DESCRIPTION
The runner already derives two refusals from the configuration — an image mode with no scratch filesystem, a proxy on qemu's user-mode network. A third was missing: every guest here is given the same 40 GiB, and `vm-shares` asks 40% of the disk for a root declaring `min = "20GiB"`, which resolves to 16178MiB. The installer refused it correctly; the waste was dispatching it, 1.9 minutes with a node held.

The local campaign already names that fixture and its reason, but that is a list only the local runner reads. This refusal is derived from `TARGET_GIB` instead, so it follows the size the runner gives and covers any fixture whose bounds cannot be met there.