### PR TITLE
tui: take back what a choice added

### DIFF
--- a/gentoo_install/tui/context.py
+++ b/gentoo_install/tui/context.py
@@ -52,6 +52,8 @@ class ValueKind(Enum):
     VIDEO_CARD = "video card"
     NETWORKING = "networking"
     DISPLAY_MANAGER = "display manager"
+    OVERLAY = "overlay"
+    COMMUNITY_BINHOST = "community binhost"
 
 
 class ValueSource(Enum):
@@ -438,6 +440,12 @@ TABLE: Final[str] = "table"
 DROP: Final[str] = "drop"
 
 
+#: Named once: this module composes its address, the bootloader screen adds it
+#: and the mirror screen removes it, and a literal in each is a fourth place to
+#: keep the same string right.
+GENTOO_ZH: Final[str] = "gentoo-zh"
+
+
 def with_gentoo_zh(config: InstallConfig) -> PortageConfig:
     """The overlay, cloned from the site already chosen for it.
 
@@ -445,16 +453,52 @@ def with_gentoo_zh(config: InstallConfig) -> PortageConfig:
     table is a second address to update, and the overlay has moved once
     already. A site the operator has not picked yet answers as upstream.
     """
-    if any(overlay.name == "gentoo-zh" for overlay in config.portage.overlays):
+    if any(overlay.name == GENTOO_ZH for overlay in config.portage.overlays):
         return config.portage
     where = mirrors.gentoozh(config.portage.mirrors.gentoo_zh).git
-    added = (*config.portage.overlays, Overlay(name="gentoo-zh", sync_uri=where))
+    added = (*config.portage.overlays, Overlay(name=GENTOO_ZH, sync_uri=where))
     binhost = config.portage.binhost
     if binhost.community is BinhostChannel.OFF:
         # On with the overlay: the host serves what that overlay builds, and
         # `compat.py` is what keeps the two from being set apart.
         binhost = replace(binhost, community=BinhostChannel.STABLE)
     return replace(config.portage, overlays=added, binhost=binhost)
+
+
+def without_gentoo_zh(config: InstallConfig) -> PortageConfig:
+    """The overlay removed, and the binary host that came on with it.
+
+    The mirror of `with_gentoo_zh`, and in one place for the same reason the
+    two are set together there: the community host serves what that overlay
+    builds, so leaving it on refuses the install from a row the operator is
+    not looking at.
+    """
+    kept = tuple(one for one in config.portage.overlays if one.name != GENTOO_ZH)
+    return replace(
+        config.portage,
+        overlays=kept,
+        binhost=replace(config.portage.binhost, community=BinhostChannel.OFF),
+    )
+
+
+def mark_derived(context: "Context", kind: ValueKind, value: str) -> None:
+    """Record that a choice, not the operator, supplied this value."""
+    context.provenance.add(ValueProvenance(kind, value, ValueSource.DERIVED))
+
+
+def was_derived(context: "Context", kind: ValueKind, value: str) -> bool:
+    """Whether a choice supplied this value, so taking that choice back takes
+    the value with it. An operator's own selection has no such record."""
+    return ValueProvenance(kind, value, ValueSource.DERIVED) in context.provenance
+
+
+def forget_derived(context: "Context", kind: ValueKind) -> None:
+    """Drop every derived record of this kind, the choice having been undone."""
+    context.provenance = {
+        one
+        for one in context.provenance
+        if not (one.kind is kind and one.source is ValueSource.DERIVED)
+    }
 
 
 #: What the preflight refuses, read from there rather than written again: the

--- a/gentoo_install/tui/mirror.py
+++ b/gentoo_install/tui/mirror.py
@@ -26,10 +26,15 @@ from .context import (
     Context,
     DONE,
     FieldDescriptor,
+    ValueKind,
     current_menu,
     footer,
+    forget_derived,
+    mark_derived,
     pick,
+    was_derived,
     with_gentoo_zh,
+    without_gentoo_zh,
 )
 from .widgets import Answer, Item, Menu, Outcome, Screen, TextField
 
@@ -472,17 +477,13 @@ def _edit_gentoozh(
     picked = answer.unwrap()
     portage = config.portage
     if picked is None:
-        # What required the overlay goes with it: leaving the community binhost
-        # on refuses the install from a row the operator is not looking at.
-        kept = tuple(one for one in portage.overlays if one.name != "gentoo-zh")
-        return replace(
-            config,
-            portage=replace(
-                portage,
-                overlays=kept,
-                binhost=replace(portage.binhost, community=BinhostChannel.OFF),
-            ),
-        )
+        # Recorded before it is lost: `with_gentoo_zh` turns the host back on
+        # at `STABLE`, so an operator who had chosen `UNSTABLE` was quietly
+        # moved to the other channel by turning the overlay off and on again.
+        if portage.binhost.community is not BinhostChannel.OFF:
+            forget_derived(context, ValueKind.COMMUNITY_BINHOST)
+            mark_derived(context, ValueKind.COMMUNITY_BINHOST, portage.binhost.community.value)
+        return replace(config, portage=without_gentoo_zh(config))
     # The overlay is cloned from the chosen site, not from upstream: a mirror
     # picked here and ignored by the sync is the choice doing nothing.
     added = with_gentoo_zh(config)
@@ -490,10 +491,21 @@ def _edit_gentoozh(
         replace(one, sync_uri=mirrors.gentoozh(picked).git) if one.name == "gentoo-zh" else one
         for one in added.overlays
     )
+    binhost = added.binhost
+    for channel in BinhostChannel:
+        if channel is not BinhostChannel.OFF and was_derived(
+            context, ValueKind.COMMUNITY_BINHOST, channel.value
+        ):
+            binhost = replace(binhost, community=channel)
+            forget_derived(context, ValueKind.COMMUNITY_BINHOST)
+            break
     return replace(
         config,
         portage=replace(
-            added, overlays=overlays, mirrors=replace(portage.mirrors, gentoo_zh=picked)
+            added,
+            overlays=overlays,
+            binhost=binhost,
+            mirrors=replace(portage.mirrors, gentoo_zh=picked),
         ),
     )
 

--- a/gentoo_install/tui/packages.py
+++ b/gentoo_install/tui/packages.py
@@ -411,8 +411,19 @@ def _has_operator(context: Context, kind: ValueKind, value: str) -> bool:
 
 def _record_derived(context: Context, after: InstallConfig, effects: Effects) -> None:
     """Replace the previous choice's derived values with the new choice's."""
+    # Only the kinds this proposal owns: it used to drop every derived record,
+    # so choosing a desktop after ZFSBootMenu erased the overlay's and taking
+    # the bootloader back left an overlay nobody had selected.
+    mine = {
+        ValueKind.USE_FLAG,
+        ValueKind.VIDEO_CARD,
+        ValueKind.NETWORKING,
+        ValueKind.DISPLAY_MANAGER,
+    }
     context.provenance = {
-        one for one in context.provenance if one.source is not ValueSource.DERIVED
+        one
+        for one in context.provenance
+        if not (one.kind in mine and one.source is ValueSource.DERIVED)
     }
     context.provenance.update(
         ValueProvenance(ValueKind.USE_FLAG, value, ValueSource.DERIVED)

--- a/gentoo_install/tui/partitions.py
+++ b/gentoo_install/tui/partitions.py
@@ -40,6 +40,8 @@ from ..model.validate import validate
 from ..errors import GentooInstallError, InvalidSize, ValidationFailed
 from .context import (
     Context,
+    GENTOO_ZH,
+    ValueKind,
     answers,
     DONE,
     DROP,
@@ -48,8 +50,12 @@ from .context import (
     TABLE,
     current_menu,
     footer,
+    forget_derived,
+    mark_derived,
     say,
+    was_derived,
     with_gentoo_zh,
+    without_gentoo_zh,
 )
 from .widgets import (
     Answer,
@@ -99,7 +105,18 @@ def _zfs_bootloader(
 
     def apply(kind: Bootloader) -> InstallConfig:
         if kind is Bootloader.SYSTEMD_BOOT:
-            return replace(config, bootloader=replace(config.bootloader, kind=kind))
+            if not was_derived(context, ValueKind.OVERLAY, GENTOO_ZH):
+                # An overlay the operator selected on the Mirrors screen is
+                # theirs, and this choice does not reach across and take it.
+                return replace(config, bootloader=replace(config.bootloader, kind=kind))
+            forget_derived(context, ValueKind.OVERLAY)
+            return replace(
+                config,
+                bootloader=replace(config.bootloader, kind=kind),
+                portage=without_gentoo_zh(config),
+            )
+        if not any(one.name == GENTOO_ZH for one in config.portage.overlays):
+            mark_derived(context, ValueKind.OVERLAY, GENTOO_ZH)
         return replace(
             config,
             bootloader=replace(config.bootloader, kind=kind),

--- a/tests/unit/test_automatic.py
+++ b/tests/unit/test_automatic.py
@@ -877,6 +877,64 @@ def test_a_pastebin_that_refuses_leaves_the_overview_standing() -> None:
     assert answer.outcome is Outcome.BACK
 
 
+def test_turning_gentoo_zh_off_and_on_keeps_the_channel_that_was_chosen() -> None:
+    """`with_gentoo_zh` turns the community host on at `stable`, so an operator
+    who had chosen `unstable` was moved to the other channel by turning the
+    overlay off and on again -- from a row that says nothing about channels.
+    Measured before this fix: `unstable` came back as `stable`."""
+    from dataclasses import replace as _replace
+
+    from gentoo_install.model.config import BinhostChannel
+    from gentoo_install.tui.context import GENTOO_ZH, with_gentoo_zh
+    from tests.unit.fake_screen import FakeScreen
+    from tests.unit.test_tui_app import context
+
+    at = context()
+    start = config(ext4_on_gpt())
+    chosen = _replace(start, portage=with_gentoo_zh(start))
+    chosen = _replace(
+        chosen,
+        portage=_replace(
+            chosen.portage,
+            binhost=_replace(chosen.portage.binhost, community=BinhostChannel.UNSTABLE),
+        ),
+    )
+
+    # The cursor opens on the site already chosen, so it walks up to the
+    # `not used` row at the top before answering.
+    off = mirror._edit_gentoozh(
+        FakeScreen(keys=["KEY_UP"] * 8 + ["\n"], lines=30, columns=110), at, chosen
+    )
+    assert off is not None
+    assert [one.name for one in off.portage.overlays] == []
+    assert off.portage.binhost.community is BinhostChannel.OFF
+
+    back = mirror._edit_gentoozh(
+        FakeScreen(keys=["KEY_DOWN", "\n"], lines=30, columns=110), at, off
+    )
+    assert back is not None
+    assert [one.name for one in back.portage.overlays] == [GENTOO_ZH]
+    assert back.portage.binhost.community is BinhostChannel.UNSTABLE
+
+
+def test_a_first_time_gentoo_zh_choice_still_arrives_at_the_stable_channel() -> None:
+    """Negative control for the above: with nothing recorded, the overlay
+    brings the host on at `stable` exactly as it did before."""
+    from gentoo_install.model.config import BinhostChannel
+    from tests.unit.fake_screen import FakeScreen
+    from tests.unit.test_tui_app import context
+
+    at = context()
+    start = config(ext4_on_gpt())
+    assert start.portage.binhost.community is BinhostChannel.OFF
+
+    chosen = mirror._edit_gentoozh(
+        FakeScreen(keys=["KEY_DOWN", "\n"], lines=30, columns=110), at, start
+    )
+    assert chosen is not None
+    assert chosen.portage.binhost.community is BinhostChannel.STABLE
+
+
 def test_opening_the_mirror_screen_and_changing_nothing_answers_it() -> None:
     """The row is required so nobody installs from a mirror they never looked
     at, and opening the screen is looking at it. Leaving the site unset made

--- a/tests/unit/test_tui_app.py
+++ b/tests/unit/test_tui_app.py
@@ -3025,6 +3025,65 @@ def test_the_zfs_bootloader_prompt_returns_only_installable_answers() -> None:
         validate(answered.unwrap())
 
 
+def test_taking_zfsbootmenu_back_takes_the_overlay_it_added_with_it() -> None:
+    """The screen's own docstring says choosing ZFSBootMenu is consenting to
+    `gentoo-zh`, because adding it silently was the fault it replaced. The
+    reverse half was never written: measured before this fix, ZFSBootMenu then
+    systemd-boot left `gentoo-zh` in the overlays and the community binary
+    host at `stable`, neither of which the operator had selected."""
+    from gentoo_install.tui.context import GENTOO_ZH
+    from gentoo_install.model.config import BinhostChannel
+
+    at = context()
+    start = config(zfs_root())
+    assert not [one for one in start.portage.overlays if one.name == GENTOO_ZH]
+
+    chose = partitions._zfs_bootloader(
+        FakeScreen(keys=["\n"], lines=24, columns=100), start, at
+    ).unwrap()
+    assert [one.name for one in chose.portage.overlays] == [GENTOO_ZH]
+    assert chose.portage.binhost.community is not BinhostChannel.OFF
+
+    took_it_back = partitions._zfs_bootloader(
+        FakeScreen(keys=["KEY_DOWN", "\n"], lines=24, columns=100), chose, at
+    ).unwrap()
+    assert took_it_back.bootloader.kind is Bootloader.SYSTEMD_BOOT
+    assert [one.name for one in took_it_back.portage.overlays] == []
+    assert took_it_back.portage.binhost.community is BinhostChannel.OFF
+
+
+def test_an_overlay_the_operator_chose_survives_the_bootloader_choice() -> None:
+    """Negative control for the above: the reverse half takes back what this
+    screen added, not what the Mirrors screen was told to add."""
+    from gentoo_install.tui.context import GENTOO_ZH, with_gentoo_zh
+    from dataclasses import replace as _replace
+
+    at = context()
+    start = config(zfs_root())
+    theirs = _replace(start, portage=with_gentoo_zh(start))
+    assert [one.name for one in theirs.portage.overlays] == [GENTOO_ZH]
+
+    after = partitions._zfs_bootloader(
+        FakeScreen(keys=["KEY_DOWN", "\n"], lines=24, columns=100), theirs, at
+    ).unwrap()
+    assert [one.name for one in after.portage.overlays] == [GENTOO_ZH]
+
+
+def test_a_desktop_chosen_later_does_not_erase_the_overlays_provenance() -> None:
+    """`_record_derived` dropped every derived record, so a desktop chosen
+    after ZFSBootMenu erased the overlay's and the bootloader could no longer
+    take back what it had added."""
+    from gentoo_install.tui.context import GENTOO_ZH, ValueKind, mark_derived, was_derived
+    from gentoo_install.tui import packages
+
+    at = context()
+    mark_derived(at, ValueKind.OVERLAY, GENTOO_ZH)
+    assert was_derived(at, ValueKind.OVERLAY, GENTOO_ZH)
+
+    packages._record_derived(at, config(zfs_root()), packages.Effects())
+    assert was_derived(at, ValueKind.OVERLAY, GENTOO_ZH)
+
+
 def test_the_erase_field_is_visibly_empty_before_anything_is_typed() -> None:
     """The selector was drawn inside the box as a placeholder, where it is
     indistinguishable from a value already entered: an operator pressed enter


### PR DESCRIPTION
Two screens set a second value when a choice is made and restore nothing when it is taken back. Choosing ZFSBootMenu adds `gentoo-zh` — the screen exists because adding it silently was wrong — and choosing systemd-boot afterwards left the overlay and a community binary host at `stable`, neither of which the operator had selected. Turning `gentoo-zh` off and on again moved an operator who had chosen `unstable` to `stable`, from a row that says nothing about channels.

`ValueKind` gains the two kinds, so what a choice added is taken back and what the operator selected is not. `without_gentoo_zh` puts the overlay and its host in one place, the way `with_gentoo_zh` already sets them together.

`_record_derived` dropped every derived record, so a desktop chosen afterwards erased the overlay's; it now drops only the kinds it owns.