### PR TITLE
cluster: say how far the installer got and why it stopped

### DIFF
--- a/tests/unit/test_cluster.py
+++ b/tests/unit/test_cluster.py
@@ -1383,6 +1383,69 @@ def test_a_fixture_that_needs_user_mode_networking_is_refused_here() -> None:
     assert cluster.fixtures(["vm-xfs", "zfs-zbm"])
 
 
+def test_a_verdict_says_how_far_the_installer_had_reached(tmp_path: Path) -> None:
+    """A marker names one of this harness's own commands, not an installer
+    operation, and the two were read as the same thing: `btrfs-luks` was
+    reported as `never matched \'MARK_24_DONE\'` with the installer at its own
+    operation 78 of 90, three from the end of its package set.
+
+    Sampled from a kept cluster log, so the shape is the one `exec/apply.py`
+    actually writes.
+    """
+    log = tmp_path / "a-guest.log"
+    log.write_bytes(
+        b"| >>> Emerging (1 of 4) sys-apps/portage\r\n"
+        b"[76/90 0:27:38] [bootloader] write /etc/default/grub with cmdline\r\n"
+        b"[78/90 0:27:55] [packages] install the plasma group: emerge kde-plasma\r\n"
+        b"|  * kwin-6.6.6-1.gpkg.tar MD5 SHA1 size ;-) ...           [ ok ]\r\n"
+    )
+    said = cluster.how_far_it_got(log)
+    assert said.startswith("reached [78/90"), said
+    assert "install the plasma group" in said, said
+
+    # A guest that printed no operation says nothing rather than naming the
+    # last thing a build wrote.
+    quiet = tmp_path / "quiet.log"
+    quiet.write_bytes(b"| >>> Emerging (1 of 4) sys-apps/portage\r\n")
+    assert cluster.how_far_it_got(quiet) == ""
+    assert cluster.how_far_it_got(tmp_path / "never-made") == ""
+
+
+def test_a_run_refused_before_it_started_names_the_reason(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str], monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """`cli.py` writes `the install stopped: ` only once `install()` is running,
+    so a configuration refused before that left the whole verdict at `the
+    installer exited b\'1\'`. The reason was in the file the guest handed back.
+
+    The refusal is produced by `cli.main`, not written here, so a renamed
+    prefix fails this test rather than going quiet in a verdict.
+    """
+    from gentoo_install import cli as real_cli
+    from gentoo_install.cli import EXIT_CONFIG, main
+    from tests.vm.results import LOG_TAIL
+
+    broken = tmp_path / "broken.toml"
+    broken.write_text(
+        (Path(__file__).resolve().parents[1] / "fixtures" / "vm-xfs.toml")
+        .read_text()
+        .replace('locale = "en_US.UTF-8"', 'locale = "zh_CH.UTF-8"')
+    )
+    monkeypatch.setattr(real_cli, "_require_root", lambda arguments: None)
+    monkeypatch.setattr(real_cli, "_check_the_clock", lambda: None)
+    assert main(["--config", str(broken), "--dry-run"]) == EXIT_CONFIG
+    printed = capsys.readouterr().err
+    assert printed.strip(), "the refusal printed nothing"
+
+    reason = cluster._why_it_stopped({LOG_TAIL: printed.encode()})
+    assert "configuration:" in reason, (reason, printed)
+    assert "zh_CH.UTF-8" in reason, reason
+
+    # And a build's own output is still not a reason: that decision is held by
+    # `test_a_stopped_install_says_why` and this must not overturn it.
+    assert cluster._why_it_stopped({LOG_TAIL: b"| >>> Emerging app-i18n/ibus\n"}) == ""
+
+
 def test_a_layout_that_cannot_fit_this_runners_target_is_refused_here() -> None:
     """Every guest here gets the same `TARGET_GIB`. `vm-shares` asks `40%` of
     the disk for a root that declares `min = "20GiB"`, which is 16178MiB at

--- a/tests/vm/cluster.py
+++ b/tests/vm/cluster.py
@@ -87,6 +87,7 @@ from .console import (
     command_done,
     marked_command,
     plain,
+    strip_ansi,
 )
 from .driver import (
     git_state,
@@ -2569,7 +2570,7 @@ def install_one(
             job.name,
             verdict,
             time.monotonic() - started,
-            dropped or str(error)[:OUTCOME_BYTES],
+            how_far_it_got(log) + (dropped or str(error))[:OUTCOME_BYTES],
             log,
             phase=phase,
             revision=revision,
@@ -2983,6 +2984,21 @@ EXPECTED_TO_FAIL: Final[Mapping[str, Expectation]] = MappingProxyType(
 #: `install.txt` meant 294910 lines of build output first.
 INSTALL_STOPPED: Final[str] = "the install stopped: "
 
+#: What `cli.py` prints to stderr when it refuses before `install()` runs, so
+#: that line is never written. Named prefixes rather than the log's last line:
+#: a build's own output is not a reason, and `vm-shares` was failed with
+#: `the installer exited b'1'` and nothing else while `configuration:
+#: rootpart works out to 16178MiB, below the 20GiB it asks for` was in the
+#: file the guest had handed back.
+REFUSED_BEFORE_THE_RUN: Final[tuple[str, ...]] = (
+    "configuration: ",
+    "preflight: ",
+    "conversion: ",
+    "device: ",
+    "work directory: ",
+    "resume: ",
+)
+
 #: How much of that line the verdict keeps.
 REASON_BYTES: Final[int] = 400
 
@@ -2998,6 +3014,15 @@ def _why_it_stopped(files: Mapping[str, bytes]) -> str:
         found = line.find(INSTALL_STOPPED)
         if found >= 0:
             return f": {line[found + len(INSTALL_STOPPED):].strip()[:REASON_BYTES]}"
+    lines = said.splitlines()
+    for index in range(len(lines) - 1, -1, -1):
+        if not lines[index].startswith(REFUSED_BEFORE_THE_RUN):
+            continue
+        # To the end, not that line alone: a validation refusal is a header
+        # and one indented line for each rule it broke, and the header names
+        # none of them.
+        rest = " ".join(one.strip() for one in lines[index:] if one.strip())
+        return f": {rest[:REASON_BYTES]}"
     return ""
 
 
@@ -4240,6 +4265,37 @@ PROXY_DROPPED: Final[re.Pattern[str]] = re.compile(
 
 #: How much of the log's tail carries the reason a console went away.
 PROXY_TAIL_BYTES: Final[int] = 4096
+
+
+#: The line `exec/apply.py` prints before each operation. Read from the log
+#: rather than named in a verdict message: the marker a timeout reports counts
+#: this harness's own commands, and `btrfs-luks` read `never matched
+#: MARK_24_DONE` while the installer had reached its own operation 78 of 90.
+PROGRESS_LINE: Final[re.Pattern[str]] = re.compile(
+    r"^\[\d+/\d+ [0-9:]+\] \[[a-z]+\] [^\r\n]*", re.MULTILINE
+)
+
+#: How far back a progress line is looked for. Larger than the proxy window
+#: above: one `emerge` writes megabytes between two of them.
+PROGRESS_TAIL_BYTES: Final[int] = 8 * 1024 * 1024
+
+
+def how_far_it_got(log: Path) -> str:
+    """The installer's own last progress line, or empty when it printed none.
+
+    A verdict is truncated to a few hundred bytes, so this goes at the front:
+    `never matched 'MARK_24_DONE'` reads like an early failure and that guest
+    was three operations from the end of its package set.
+    """
+    try:
+        with log.open("rb") as reading:
+            reading.seek(0, 2)
+            reading.seek(max(0, reading.tell() - PROGRESS_TAIL_BYTES))
+            tail = strip_ansi(reading.read()).decode("utf-8", "replace")
+    except OSError:
+        return ""
+    found = PROGRESS_LINE.findall(tail)
+    return f"reached {found[-1].strip()}; " if found else ""
 
 
 def console_proxy_dropped(log: Path) -> str:


### PR DESCRIPTION
A verdict is truncated to a few hundred bytes, so what matters has to come first. Two diagnoses this week each cost a round, and both had their answer in a file the harness had already written.

`MARK_n` counts this harness's own commands, not installer operations: `btrfs-luks` read as `never matched 'MARK_24_DONE'` while the installer had reached `[78/90] install the plasma group`. The last `[n/N]` line now leads the detail, and a run that printed no operation says nothing rather than quoting build output.

`cli.py` writes `the install stopped: ` only once `install()` runs, so `vm-shares` was reported as `the installer exited b'1'` with `configuration: rootpart works out to 16178MiB, below the 20GiB it asks for` in the file the guest handed back. Named prefixes, produced by `cli.main` in the test, keep the existing decision that build output is not a reason.