### PR TITLE
tui: keep the site when the region does not change

### DIFF
--- a/gentoo_install/tui/mirror.py
+++ b/gentoo_install/tui/mirror.py
@@ -286,7 +286,13 @@ def _edit_mirror_region(screen: Screen, context: Context, config: InstallConfig)
     picked = Menu(title=context.translate("Region"), items=[Item(label=one.value, value=one) for one in MirrorRegion], footer=footer(context.translate), current=current.region).run(screen)
     if not picked.chosen:
         return None
-    return replace(config, portage=replace(config.portage, mirrors=replace(current, region=picked.unwrap(), site="")))
+    region = picked.unwrap()
+    # A site belongs to its region, so changing the region drops it. Answering
+    # with the region already selected changes nothing and must not: enter on
+    # that row discarded a site the operator had picked by hand, and `Done`
+    # then wrote the region's first mirror.
+    site = current.site if region is current.region else ""
+    return replace(config, portage=replace(config.portage, mirrors=replace(current, region=region, site=site)))
 
 
 def _edit_mirror_site(screen: Screen, context: Context, config: InstallConfig) -> InstallConfig | None:

--- a/tests/unit/test_automatic.py
+++ b/tests/unit/test_automatic.py
@@ -877,6 +877,46 @@ def test_a_pastebin_that_refuses_leaves_the_overview_standing() -> None:
     assert answer.outcome is Outcome.BACK
 
 
+def test_answering_the_region_row_with_the_same_region_keeps_the_site() -> None:
+    """A site belongs to its region, so changing the region drops it. Enter on
+    the row with that region already selected changes nothing and dropped it
+    anyway, and `Done` then wrote the region's first mirror over a site the
+    operator had picked by hand."""
+    from dataclasses import replace as _replace
+
+    from gentoo_install.model.config import MirrorRegion
+    from tests.unit.fake_screen import FakeScreen
+    from tests.unit.test_tui_app import context
+
+    at = context()
+    start = config(ext4_on_gpt())
+    chosen = _replace(
+        start,
+        portage=_replace(
+            start.portage,
+            mirrors=_replace(
+                start.portage.mirrors, region=MirrorRegion.GLOBAL, site="a-hand-picked-site"
+            ),
+        ),
+    )
+
+    # The cursor opens on the region already selected, so enter answers with it.
+    same = mirror._edit_mirror_region(
+        FakeScreen(keys=["\n"], lines=30, columns=110), at, chosen
+    )
+    assert same is not None
+    assert same.portage.mirrors.region is MirrorRegion.GLOBAL
+    assert same.portage.mirrors.site == "a-hand-picked-site"
+
+    # A different region still drops it: that is what this row is for.
+    moved = mirror._edit_mirror_region(
+        FakeScreen(keys=["KEY_UP", "\n"], lines=30, columns=110), at, chosen
+    )
+    assert moved is not None
+    assert moved.portage.mirrors.region is not MirrorRegion.GLOBAL
+    assert moved.portage.mirrors.site == ""
+
+
 def test_turning_gentoo_zh_off_and_on_keeps_the_channel_that_was_chosen() -> None:
     """`with_gentoo_zh` turns the community host on at `stable`, so an operator
     who had chosen `unstable` was moved to the other channel by turning the


### PR DESCRIPTION
A site belongs to its region, so `_edit_mirror_region` clears it — correctly, and `docs/design.md` says why. It cleared it unconditionally: answering the row with the region already selected changes nothing, and `Done` then wrote the region's first mirror over a site the operator had picked by hand.

The clear now happens when the region actually changes, which is the case the design note describes.