### PR TITLE
tui: keep a flag the operator typed and the proposal names

### DIFF
--- a/gentoo_install/tui/packages.py
+++ b/gentoo_install/tui/packages.py
@@ -229,15 +229,22 @@ def derive_effects(
         ),
         networking_changed=after.system.networking is not before.system.networking,
         kept_display_manager=kept_display_manager,
+        # Not what the operator also typed: `desktop_screen` records the
+        # proposal as derived after the flags row has recorded the edit as
+        # theirs, so a value in both was withdrawn by the next desktop change.
         withdrawn_use=tuple(
             one.value
             for one in context.provenance
-            if one.kind is ValueKind.USE_FLAG and one.source is ValueSource.DERIVED
+            if one.kind is ValueKind.USE_FLAG
+            and one.source is ValueSource.DERIVED
+            and not _has_operator(context, ValueKind.USE_FLAG, one.value)
         ),
         withdrawn_video_cards=tuple(
             one.value
             for one in context.provenance
-            if one.kind is ValueKind.VIDEO_CARD and one.source is ValueSource.DERIVED
+            if one.kind is ValueKind.VIDEO_CARD
+            and one.source is ValueSource.DERIVED
+            and not _has_operator(context, ValueKind.VIDEO_CARD, one.value)
         ),
     )
 

--- a/tests/unit/test_tui_app.py
+++ b/tests/unit/test_tui_app.py
@@ -3069,6 +3069,27 @@ def test_an_overlay_the_operator_chose_survives_the_bootloader_choice() -> None:
     assert [one.name for one in after.portage.overlays] == [GENTOO_ZH]
 
 
+def test_a_flag_the_operator_typed_is_not_withdrawn_as_a_proposal() -> None:
+    """The flags row records what was typed as the operator's, and
+    `desktop_screen` then records the proposal as derived -- after it, and
+    from effects computed before it. A value in both carried both sources,
+    and `withdrawn_use` removed it by name on the next desktop change."""
+    from gentoo_install.tui import packages
+    from gentoo_install.tui.context import ValueKind
+
+    at = context()
+    before = config(zfs_root())
+    packages._record_operator(at, ValueKind.USE_FLAG, ["qt6"])
+    packages._record_derived(
+        at, before, packages.Effects(use_flags=("qt6", "wayland"))
+    )
+
+    effects = packages.derive_effects(before, before, at)
+    assert "qt6" not in effects.withdrawn_use, effects.withdrawn_use
+    # And a value only the proposal supplied is still withdrawn.
+    assert "wayland" in effects.withdrawn_use, effects.withdrawn_use
+
+
 def test_a_desktop_chosen_later_does_not_erase_the_overlays_provenance() -> None:
     """`_record_derived` dropped every derived record, so a desktop chosen
     after ZFSBootMenu erased the overlay's and the bootloader could no longer


### PR DESCRIPTION
`settle` pins a confirmed value on purpose, and `desktop_screen` records the proposal as derived so the next desktop change withdraws the last one. The order defeats it: `effects` is computed before `settle`, the flags row inside `settle` records the edit as the operator's, and `_record_derived` then re-marks the proposal from those earlier effects. A value in both carried both sources, and `withdrawn_use` looked only at the derived one.

The withdrawn sets now skip a value the operator also owns. `_has_operator` already held this rule for the network manager; these are the other two fields.