### PR TITLE
tui: keep the passphrase a purpose change does not decide

### DIFF
--- a/gentoo_install/data/locale/ja.toml
+++ b/gentoo_install/data/locale/ja.toml
@@ -481,6 +481,7 @@
 "sys-boot/zfsbootmenu is in that overlay and in no other repository, so the emerge fails once the disks have already been partitioned" = "sys-boot/zfsbootmenu はその overlay にしかなく、ディスクを分割した後で emerge が失敗します"
 "the key its packages are signed with comes from that overlay, and without it nothing from the host verifies" = "パッケージの署名鍵はその overlay から提供されるため、鍵がなければその binhost のパッケージを検証できません。"
 "firmware cannot open a container to read the esp" = "ファームウェアは esp を読むときコンテナを開けません"
+"the pool's own encryption covers its members" = "プール自身の暗号化がそのメンバーを含みます"
 "firmware reads the esp itself and cannot open a LUKS container, so an encrypted one never boots" = "ファームウェアは esp を直接読み、LUKS コンテナを開けないため、暗号化した esp は起動しません"
 "Run once at first boot" = "初回起動時の命令"
 "Script address" = "スクリプトのアドレス"

--- a/gentoo_install/data/locale/ko.toml
+++ b/gentoo_install/data/locale/ko.toml
@@ -481,6 +481,7 @@
 "sys-boot/zfsbootmenu is in that overlay and in no other repository, so the emerge fails once the disks have already been partitioned" = "sys-boot/zfsbootmenu 은 그 overlay 에만 있어 디스크를 나눈 뒤에 emerge 가 실패합니다"
 "the key its packages are signed with comes from that overlay, and without it nothing from the host verifies" = "패키지 서명 키는 해당 overlay에서 제공되므로, 키가 없으면 해당 binhost의 패키지를 검증할 수 없습니다."
 "firmware cannot open a container to read the esp" = "펌웨어는 esp 를 읽을 때 컨테이너를 열 수 없습니다"
+"the pool's own encryption covers its members" = "풀 자체의 암호화가 그 구성원을 포함합니다"
 "firmware reads the esp itself and cannot open a LUKS container, so an encrypted one never boots" = "펌웨어는 esp 를 직접 읽으며 LUKS 컨테이너를 열 수 없으므로 암호화된 esp 는 부팅되지 않습니다"
 "Run once at first boot" = "첫 부팅 명령"
 "Script address" = "스크립트 주소"

--- a/gentoo_install/data/locale/zh-CN.toml
+++ b/gentoo_install/data/locale/zh-CN.toml
@@ -482,6 +482,7 @@
 "sys-boot/zfsbootmenu is in that overlay and in no other repository, so the emerge fails once the disks have already been partitioned" = "sys-boot/zfsbootmenu 仅存在于该 overlay；缺少 overlay 时，emerge 会在磁盘分区后失败"
 "the key its packages are signed with comes from that overlay, and without it nothing from the host verifies" = "签名密钥来自该 overlay；缺少该密钥时，binhost 提供的软件包均无法通过验证。"
 "firmware cannot open a container to read the esp" = "固件读 esp 时打不开加密容器"
+"the pool's own encryption covers its members" = "存储池本身的加密涵盖它的成员"
 "firmware reads the esp itself and cannot open a LUKS container, so an encrypted one never boots" = "固件无法打开 LUKS 容器，因此使用加密 esp 的系统无法启动。"
 "Run once at first boot" = "首次开机命令"
 "Script address" = "脚本地址"

--- a/gentoo_install/data/locale/zh-TW.toml
+++ b/gentoo_install/data/locale/zh-TW.toml
@@ -482,6 +482,7 @@
 "sys-boot/zfsbootmenu is in that overlay and in no other repository, so the emerge fails once the disks have already been partitioned" = "sys-boot/zfsbootmenu 僅存在於該 overlay；缺少 overlay 時，emerge 會在磁碟分割後失敗"
 "the key its packages are signed with comes from that overlay, and without it nothing from the host verifies" = "簽章金鑰來自該 overlay；缺少該金鑰時，binhost 提供的套件均無法通過驗證。"
 "firmware cannot open a container to read the esp" = "韌體讀取 esp 時無法開啟加密容器"
+"the pool's own encryption covers its members" = "儲存池本身的加密涵蓋它的成員"
 "firmware reads the esp itself and cannot open a LUKS container, so an encrypted one never boots" = "韌體無法開啟 LUKS 容器，因此使用加密 esp 的系統無法開機。"
 "Run once at first boot" = "首次開機指令"
 "Script address" = "腳本位址"

--- a/gentoo_install/tui/partitions.py
+++ b/gentoo_install/tui/partitions.py
@@ -977,11 +977,7 @@ def _slice_field_items(
                     detail=translate("on") if entry.passphrase_file else translate("off"),
                     # Firmware reads the esp itself and cannot open a container,
                     # so an encrypted esp never boots.
-                    disabled_because=(
-                        translate("firmware cannot open a container to read the esp")
-                        if purpose.role is PartitionRole.ESP
-                        else ""
-                    ),
+                    disabled_because=_encryption_refused(purpose, translate),
                 )
             ]
             # Neither member kind: the pool and the array each carry their
@@ -1169,6 +1165,25 @@ _SLICE_FIELDS: tuple[FieldDescriptor[tuple[manual.Slice, manual.Purpose]], ...] 
 )
 
 
+def _encryption_refused(purpose: manual.Purpose, translate: Catalog) -> str:
+    """Why this purpose takes no encryption row, or empty when it takes one.
+
+    A `Purpose` carries no encryption of its own, so this is the only place
+    that decides it. `_apply_purpose` used to clear the passphrase on the way
+    into `zfs` instead, which took an encrypted root away from an operator who
+    passed through that purpose and came back.
+    """
+    if purpose.role is PartitionRole.ESP:
+        # Firmware reads the esp itself and cannot open a container, so an
+        # encrypted esp never boots.
+        return translate("firmware cannot open a container to read the esp")
+    if purpose.role is PartitionRole.ZFS:
+        # `manual.build` reads the pool's own passphrase and puts no LUKS under
+        # a vdev, so a value here would be shown and then ignored.
+        return translate("the pool's own encryption covers its members")
+    return ""
+
+
 def _apply_purpose(entry: manual.Slice, purpose: manual.Purpose) -> manual.Slice:
     """Everything the purpose decides, in one place: picking `swap` has to drop
     the filesystem and the mount point it had as `root`."""
@@ -1177,7 +1192,6 @@ def _apply_purpose(entry: manual.Slice, purpose: manual.Purpose) -> manual.Slice
         role=purpose.role,
         filesystem=entry.filesystem if purpose.chooses_filesystem else purpose.filesystem,
         mountpoint=entry.mountpoint if purpose.asks_mountpoint else purpose.mountpoint,
-        passphrase_file=("" if purpose.role is PartitionRole.ZFS else entry.passphrase_file),
     )
 
 

--- a/tests/unit/test_tui_partitions.py
+++ b/tests/unit/test_tui_partitions.py
@@ -13,7 +13,7 @@ from typing import Callable, Final, TypeVar
 import pytest
 
 from gentoo_install.errors import ValidationFailed
-from gentoo_install.i18n import width
+from gentoo_install.i18n import Catalog, width
 from gentoo_install.model import manual
 from gentoo_install.model.config import (
     Bootloader,
@@ -82,6 +82,80 @@ def opened() -> tui_context.Context:
 
 def index_of(items: list[str], label: str) -> int:
     return items.index(label)
+
+
+def test_a_purpose_that_is_not_zfs_keeps_the_passphrase_it_was_given() -> None:
+    """`Purpose` carries no encryption, so a purpose change must not decide it.
+    Clearing the passphrase on the way into `zfs` took an encrypted root away
+    from an operator who passed through that purpose and came back: the
+    Encryption row read `off` and an empty passphrase is not a refusal, it is
+    a plaintext root.
+    """
+    from gentoo_install.model.device import PartitionRole
+    from gentoo_install.model.size import Size
+    from gentoo_install.tui.partitions import _apply_purpose
+
+    root = next(one for one in manual.PURPOSES if one.key == "root")
+    zfs = next(one for one in manual.PURPOSES if one.key == "zfs")
+    encrypted = manual.Slice(
+        index=1,
+        role=PartitionRole.DATA,
+        size=Size.parse("20GiB"),
+        mountpoint="/",
+        passphrase_file="/run/keys/root",
+    )
+
+    through = _apply_purpose(encrypted, zfs)
+    back = _apply_purpose(through, root)
+    assert back.passphrase_file == "/run/keys/root", (through, back)
+    # The purpose still decides what it owns.
+    assert back.role is root.role and back.mountpoint == root.mountpoint
+
+
+def test_the_encryption_row_is_refused_for_a_pool_member_with_a_reason() -> None:
+    """Measured on `manual.build`: a `zfs` slice with a passphrase and one
+    without produce the same graph, no `Luks` under the vdev either way, so a
+    value there would be shown and ignored. The pool's own passphrase is what
+    `ZfsPool.encrypted` reads."""
+    from gentoo_install.model.device import Luks, PartitionRole
+    from gentoo_install.model.size import Size
+    from gentoo_install.tui.partitions import _encryption_refused
+
+    def graph_for(passphrase: str) -> list[str]:
+        layout = manual.Layout(
+            disks=[
+                manual.Disk(
+                    selector="/dev/disk/by-id/x",
+                    slices=[
+                        manual.Slice(
+                            index=1,
+                            role=PartitionRole.ESP,
+                            size=Size.parse("512MiB"),
+                            filesystem=manual.ESP_FILESYSTEM,
+                            mountpoint="/efi",
+                        ),
+                        manual.Slice(
+                            index=2,
+                            role=PartitionRole.ZFS,
+                            size=None,
+                            passphrase_file=passphrase,
+                        ),
+                    ],
+                )
+            ]
+        )
+        built, _ = manual.build(layout)
+        return [str(one.id) for one in built.nodes.values() if isinstance(one, Luks)]
+
+    assert graph_for("") == graph_for("/run/keys/zfs") == []
+
+    said = Catalog("en")
+    zfs = next(one for one in manual.PURPOSES if one.key == "zfs")
+    esp = next(one for one in manual.PURPOSES if one.key == "esp")
+    root = next(one for one in manual.PURPOSES if one.key == "root")
+    assert _encryption_refused(zfs, said), "a pool member takes no encryption row"
+    assert _encryption_refused(esp, said), "the esp still takes none"
+    assert _encryption_refused(root, said) == "", "an ordinary partition still takes one"
 
 
 def test_the_table_starts_from_something_that_already_boots() -> None:
@@ -436,7 +510,15 @@ def test_exactly_one_pool_encryption_row_is_shown_only_when_a_pool_exists() -> N
     assert rows[0].detail == "on"
 
 
-def test_changing_an_encrypted_partition_to_zfs_drops_its_luks_path() -> None:
+def test_changing_a_partition_to_zfs_keeps_the_luks_path_it_had() -> None:
+    """This asserted the opposite and carried no reason. Measured on
+    `manual.build`: a `zfs` slice with a passphrase and one without produce the
+    same graph, no `Luks` under the vdev either way, so clearing it protected
+    nothing and took an encrypted root away from an operator who passed through
+    the purpose and came back. The row is refused for a pool member instead,
+    which `test_the_encryption_row_is_refused_for_a_pool_member_with_a_reason`
+    holds.
+    """
     entry = manual.Slice(
         index=2,
         role=PartitionRole.DATA,
@@ -448,7 +530,8 @@ def test_changing_an_encrypted_partition_to_zfs_drops_its_luks_path() -> None:
 
     changed = partitions._apply_purpose(entry, manual.purpose_for("zfs"))
 
-    assert changed.passphrase_file == ""
+    assert changed.passphrase_file == "/run/keys/partition"
+    assert changed.role is PartitionRole.ZFS
 
 
 def test_a_field_that_does_not_apply_says_why() -> None:


### PR DESCRIPTION
A `Purpose` carries a role, a mount point and a filesystem; it carries no encryption. `_apply_purpose` cleared `passphrase_file` for `zfs` anyway, so an operator who set an encrypted root, passed through that purpose and came back had the Encryption row read `off` — and an empty passphrase is not a refusal, it is a plaintext root.

Measured on `manual.build`: a `zfs` slice with a passphrase and one without produce the same graph, no `Luks` under the vdev either way, because the pool reads `Layout.passphrase_file`. The clear protected nothing. The encryption row is refused for a pool member instead, with a reason, the way the esp row already is.

The test that pinned the old behaviour carried no reason; it now states this one.