### PR TITLE
tui: selecting the disk already shown is not a change

### DIFF
--- a/gentoo_install/tui/screens.py
+++ b/gentoo_install/tui/screens.py
@@ -394,15 +394,21 @@ def disk_screen(screen: Screen, config: InstallConfig, context: Context) -> Answ
     if not answer.chosen:
         return Answer(answer.outcome)
     picked = answer.unwrap()
+    # Both clears below name the disk being switched away from, so both are
+    # for a change: answering this row with the disk it already shows threw
+    # away a hand-written table of three partitions and left the row less
+    # answered than before.
+    changed = picked != context.choice.disk
     context.choice = replace(context.choice, disk=picked)
-    # `_rebuild` reads the layout rather than the choice when the table was
-    # hand-written, so leaving this behind partitioned the disk the operator
-    # switched away from. The kept rows name partitions of that disk and go too.
-    context.layout = manual.Layout()
-    # Cleared with the disk: the operator typed the name of the one they were
-    # looking at, and carrying that confirmation to another unblocks the
-    # install for a disk nobody agreed to erase.
-    context.confirmed.clear()
+    if changed:
+        # `_rebuild` reads the layout rather than the choice when the table was
+        # hand-written, so leaving this behind partitioned the disk the operator
+        # switched away from. The kept rows name partitions of that disk and go too.
+        context.layout = manual.Layout()
+        # Cleared with the disk: the operator typed the name of the one they were
+        # looking at, and carrying that confirmation to another unblocks the
+        # install for a disk nobody agreed to erase.
+        context.confirmed.clear()
     context.inspect_disk(picked)
     return Answer(Outcome.CHOSE, _rebuild(config, context))
 

--- a/tests/unit/test_tui_app.py
+++ b/tests/unit/test_tui_app.py
@@ -3069,6 +3069,95 @@ def test_an_overlay_the_operator_chose_survives_the_bootloader_choice() -> None:
     assert [one.name for one in after.portage.overlays] == [GENTOO_ZH]
 
 
+def test_answering_the_drive_row_with_the_disk_it_shows_keeps_the_table() -> None:
+    """Driven through the real interface on a guest with a hand-written table
+    of three partitions: the Drive row showed `/dev/vda` and was still marked
+    required, and answering it with that same disk left `partition table:
+    unset`, `manual, 0 partitions` and no partitions at all -- the row less
+    answered than before, and no warning.
+
+    Both clears in `disk_screen` name the disk being switched away from, so
+    both belong to a change.
+    """
+    from gentoo_install.model import manual
+    from gentoo_install.model.device import PartitionRole
+    from gentoo_install.model.size import Size
+    from gentoo_install.tui import screens
+
+    at = context()
+    only = at.disks[0][0]
+    at.choice = replace(at.choice, disk=only)
+    at.confirmed.add(only)
+    at.layout = manual.Layout(
+        disks=[
+            manual.Disk(
+                selector=only,
+                slices=[
+                    manual.Slice(
+                        index=1,
+                        role=PartitionRole.ESP,
+                        size=Size.parse("512MiB"),
+                        mountpoint="/efi",
+                    ),
+                    manual.Slice(
+                        index=2,
+                        role=PartitionRole.DATA,
+                        size=Size.parse("20GiB"),
+                        mountpoint="/",
+                    ),
+                ],
+            )
+        ]
+    )
+
+    screens.disk_screen(FakeScreen(keys=["\n"], lines=24, columns=100), config(), at)
+
+    assert [one.index for one in at.layout.disks[0].slices] == [1, 2], at.layout
+    assert only in at.confirmed, at.confirmed
+
+
+def test_choosing_a_different_disk_still_drops_the_table_and_the_consent() -> None:
+    """Negative control for the above, and the reason both clears exist: the
+    kept rows name partitions of the disk being left, and a confirmation
+    carried across unblocks the install for a disk nobody agreed to erase."""
+    from gentoo_install.model import manual
+    from gentoo_install.model.device import PartitionRole
+    from gentoo_install.model.size import Size
+    from gentoo_install.tui import screens
+
+    at = context()
+    if len(at.disks) < 2:
+        import pytest as _pytest
+
+        _pytest.skip("this fixture offers one disk")
+    first, second = at.disks[0][0], at.disks[1][0]
+    at.choice = replace(at.choice, disk=first)
+    at.confirmed.add(first)
+    at.layout = manual.Layout(
+        disks=[
+            manual.Disk(
+                selector=first,
+                slices=[
+                    manual.Slice(
+                        index=1,
+                        role=PartitionRole.DATA,
+                        size=Size.parse("20GiB"),
+                        mountpoint="/",
+                    )
+                ],
+            )
+        ]
+    )
+
+    screens.disk_screen(
+        FakeScreen(keys=["KEY_DOWN", "\n"], lines=24, columns=100), config(), at
+    )
+
+    assert at.choice.disk == second
+    assert not at.layout.disks or not at.layout.disks[0].slices, at.layout
+    assert first not in at.confirmed, at.confirmed
+
+
 def test_a_flag_the_operator_typed_is_not_withdrawn_as_a_proposal() -> None:
     """The flags row records what was typed as the operator's, and
     `desktop_screen` then records the proposal as derived -- after it, and


### PR DESCRIPTION
Found by driving the real interface on a guest with a hand-written table. The Drive row displays `/dev/vda` and is still marked required, because a detected value is not an answer; answering it with that same disk left `partition table: unset`, `manual, 0 partitions` and no partitions, with no warning — the row less answered than before it was pressed.

`disk_screen` cleared the layout and the erase confirmation unconditionally. Both clears carry a comment naming the disk being switched away from, so both belong to a change; they now happen only when the selection differs.