### PR TITLE
readme: name the architectures that have no record

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -29,6 +29,10 @@ gentoo-install は Linux ライブ環境で動作し、amd64 アーキテクチ�
 
 単体、計画、fixture coverage は実装動作を示しますが、インストール済みシステムの起動を証明しません。[`tests/fixtures/`](tests/fixtures/)は設定モデルを検証するものであり、インストール済みのマシンではありません。記録は未検証の組み合わせを示します。
 
+<!-- fact: verification-architecture -->
+
+`gentoo_install/model/architecture.py` は amd64、arm64、x86 の行を持ち、GRUB のターゲット、`CPU_FLAGS_*` 変数、バイナリホストのサブディレクトリ、EFI 実行ファイル名はその行から組み立てられます。検証済みは amd64 だけです。[`TESTED.md`](TESTED.md)に arm64 と x86 の記録はなく、`tests/vm/` が実行するのは amd64 のみです。
+
 ## 要件
 
 <!-- fact: requirements-runtime -->

--- a/README.ko.md
+++ b/README.ko.md
@@ -29,6 +29,10 @@ gentoo-install은 Linux 라이브 환경에서 실행되어 amd64 아키텍처�
 
 단위, 계획, fixture coverage는 구현 동작을 설명하지만 설치된 시스템의 부팅을 증명하지 않는다.[`tests/fixtures/`](tests/fixtures/)는 구성 모델을 검증하며 설치된 시스템이 아니다. 기록은 미검증 조합을 표시한다.
 
+<!-- fact: verification-architecture -->
+
+`gentoo_install/model/architecture.py`는 amd64, arm64, x86 행을 가지며 GRUB 대상, `CPU_FLAGS_*` 변수, 바이너리 호스트 하위 디렉터리, EFI 실행 파일 이름은 그 행에서 구성된다. 검증된 것은 amd64뿐이다. [`TESTED.md`](TESTED.md)에 arm64와 x86 기록은 없고 `tests/vm/`는 amd64만 실행한다.
+
 ## 요구 사항
 
 <!-- fact: requirements-runtime -->

--- a/README.md
+++ b/README.md
@@ -29,6 +29,10 @@ The implementation covers normal disk installation, storage and boot configurati
 
 Unit, plan and fixture coverage describes implementation behavior; it does not establish that an installed system booted. [`tests/fixtures/`](tests/fixtures/) exercise the configuration model, not an installed machine. The record names unverified combinations.
 
+<!-- fact: verification-architecture -->
+
+`gentoo_install/model/architecture.py` carries rows for amd64, arm64 and x86, and the GRUB target, the `CPU_FLAGS_*` variable, the binary host subdirectory and the EFI executable names are composed from that row. Only amd64 is verified: [`TESTED.md`](TESTED.md) records no arm64 or x86 run, and `tests/vm/` exercises amd64 alone.
+
 ## Requirements
 
 <!-- fact: requirements-runtime -->

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -29,6 +29,10 @@ gentoo-install 在 Linux live 环境中运行，用于安装 amd64 架构的 Gen
 
 单元、计划和 fixture coverage 说明实现行为，不能证明已安装系统已经引导。[`tests/fixtures/`](tests/fixtures/)验证配置模型，不是已安装的机器。记录会列出尚未验证的组合。
 
+<!-- fact: verification-architecture -->
+
+`gentoo_install/model/architecture.py` 带有 amd64、arm64 和 x86 三列，GRUB 目标、`CPU_FLAGS_*` 变量、二进制软件包主机的子目录和 EFI 可执行文件名称都由那一列组成。已验证的只有 amd64：[`TESTED.md`](TESTED.md)没有任何 arm64 或 x86 的记录，`tests/vm/` 也只运行 amd64。
+
 ## 要求
 
 <!-- fact: requirements-runtime -->

--- a/README.zh-TW.md
+++ b/README.zh-TW.md
@@ -29,6 +29,10 @@ gentoo-install 在 Linux live 環境中執行，用於安裝 amd64 架構的 Gen
 
 單元、計畫與 fixture coverage 說明實作行為，不能證明已安裝系統已開機。[`tests/fixtures/`](tests/fixtures/)驗證設定模型，不是已安裝的機器。紀錄會列出尚未驗證的組合。
 
+<!-- fact: verification-architecture -->
+
+`gentoo_install/model/architecture.py` 帶有 amd64、arm64 與 x86 三列，GRUB 目標、`CPU_FLAGS_*` 變數、二進位主機的子目錄與 EFI 執行檔名稱都由那一列組出。已驗證的只有 amd64：[`TESTED.md`](TESTED.md)沒有任何 arm64 或 x86 的紀錄，`tests/vm/` 也只執行 amd64。
+
 ## 需求
 
 <!-- fact: requirements-runtime -->

--- a/tests/unit/test_readme.py
+++ b/tests/unit/test_readme.py
@@ -96,6 +96,7 @@ FACT_UNITS = (
     "identity",
     "capability-summary",
     "verification-scope",
+    "verification-architecture",
     "requirements-runtime",
     "safety-destructive",
     "safety-review-backup",
@@ -188,6 +189,11 @@ def test_readme_facts_preserve_safety_configuration_and_verification_boundaries(
         assert "TESTED.md" in bodies["verification-scope"], name
         assert "tests/fixtures/" in bodies["verification-scope"], name
         assert "`0`" in bodies["verification-scope"], name
+        # An architecture row without a record is implemented, not verified,
+        # and belongs here rather than in the capability list.
+        architecture = bodies["verification-architecture"]
+        for named in ("amd64", "arm64", "x86", "TESTED.md", "tests/vm/"):
+            assert named in architecture, (name, named)
         assert "wipe = true" in bodies["safety-destructive"], name
         assert "dry-run" in bodies["safety-review-backup"], name
         assert "/dev/disk/by-id/" in bodies["safety-review-backup"], name


### PR DESCRIPTION
`gentoo_install/model/architecture.py` carries rows for amd64, arm64 and x86, and the GRUB target, the `CPU_FLAGS_*` variable, the binary host subdirectory and the EFI executable names are all composed from that row. `TESTED.md` records no arm64 or x86 run and `tests/vm/` exercises amd64 alone, so those two were implemented without appearing in either the capability list or the verification boundary — the README rules put an implemented-but-unverified path in the second.

`verification-architecture` joins the fact-unit table, so all five files carry it and a missing or emptied one fails.