### PR TITLE
tui: say a detected value still needs confirming

### DIFF
--- a/gentoo_install/data/locale/ja.toml
+++ b/gentoo_install/data/locale/ja.toml
@@ -442,6 +442,7 @@
 "Yes, and open" = "はい、開く"
 "editable" = "編集できます"
 "required" = "必須"
+"confirm" = "要確認"
 "never opened" = "未確認"
 "User name" = "ユーザー名"
 "empty for root only" = "空欄なら root のみ"

--- a/gentoo_install/data/locale/ko.toml
+++ b/gentoo_install/data/locale/ko.toml
@@ -442,6 +442,7 @@
 "Yes, and open" = "예, 열기"
 "editable" = "편집할 수 있습니다"
 "required" = "필수"
+"confirm" = "확인 필요"
 "never opened" = "열어본 적 없음"
 "User name" = "사용자 이름"
 "empty for root only" = "비우면 root 만"

--- a/gentoo_install/data/locale/zh-CN.toml
+++ b/gentoo_install/data/locale/zh-CN.toml
@@ -443,6 +443,7 @@
 "Yes, and open" = "是，并打开"
 "editable" = "可自行编辑"
 "required" = "必填"
+"confirm" = "待确认"
 "never opened" = "未打开过"
 "User name" = "用户名"
 "empty for root only" = "留空表示只有 root"

--- a/gentoo_install/data/locale/zh-TW.toml
+++ b/gentoo_install/data/locale/zh-TW.toml
@@ -443,6 +443,7 @@
 "Yes, and open" = "是，並開啟"
 "editable" = "可自行編輯"
 "required" = "必填"
+"confirm" = "待確認"
 "never opened" = "未開啟過"
 "User name" = "使用者名稱"
 "empty for root only" = "留空表示只有 root"

--- a/gentoo_install/tui/context.py
+++ b/gentoo_install/tui/context.py
@@ -200,6 +200,9 @@ class Context:
         #: disk authorised a second one the prompt never named.
         self.confirmed: set[str] = set()
         self.provenance: set[ValueProvenance] = set()
+        # Declared as an annotation and set only by `App`, so a `Context` built
+        # anywhere else answered `settled` with an AttributeError.
+        self.visited: set[str] = set()
         #: The hand-written partition table, when the layout is manual.
         self.layout = manual.Layout()
         #: Whether the disk comes from that table rather than a template.

--- a/gentoo_install/tui/settings.py
+++ b/gentoo_install/tui/settings.py
@@ -236,6 +236,12 @@ def shown_value(
         value = context.translate(
             "required" if setting.required and not refused else UNSET
         )
+    elif setting.required and setting.detected and not settled(setting, config, context):
+        # `settled` already refuses a detected value nobody opened, and the
+        # row drew it exactly like an answered one: three operators read
+        # `* Drive  /dev/vda` as done, and pressing the row to clear the star
+        # discarded a hand-written table.
+        value = f"{value} ({context.translate('confirm')})"
     if room is None:
         return value
     # `required` is fitted too: the widest label in the catalog leaves its own

--- a/tests/unit/test_tui_app.py
+++ b/tests/unit/test_tui_app.py
@@ -3247,6 +3247,41 @@ def test_the_short_form_of_a_selector_confirms_the_same_disk() -> None:
     assert at.confirmed == {named}
 
 
+def test_a_detected_value_says_it_still_needs_confirming() -> None:
+    """`settled` refuses a detected value nobody opened, and the row drew it
+    exactly like an answered one. Three operators read `* Drive  /dev/vda` as
+    done, and pressing the row to clear the star discarded a hand-written
+    partition table."""
+    at = context()
+    built = config(zfs_root())
+    row = next(
+        one
+        for group in settings.SETTINGS
+        for one in (group.rows or (group,))
+        if one.key == "disk"
+    )
+    assert row.required and row.detected
+
+    unopened = settings.shown_value(row, built, at)
+    assert unopened.endswith("(confirm)"), unopened
+    assert not settings.settled(row, built, at)
+
+    at.visited.add("disk")
+    opened = settings.shown_value(row, built, at)
+    assert "(confirm)" not in opened, opened
+    assert opened and settings.settled(row, built, at)
+
+    # A row that is required without a detected default says nothing extra:
+    # its value can only have come from the operator.
+    password = next(
+        one
+        for group in settings.SETTINGS
+        for one in (group.rows or (group,))
+        if one.key == "root"
+    )
+    assert password.required and not password.detected
+
+
 def test_a_disk_is_shown_by_its_kernel_name_and_stored_by_its_selector() -> None:
     """The configuration keeps `/dev/disk/by-id/...` because a kernel name is
     assigned at probe time and one saved today installs somewhere else after
@@ -3276,6 +3311,9 @@ def test_a_disk_is_shown_by_its_kernel_name_and_stored_by_its_selector() -> None
         for one in (group.rows or (group,))
         if one.key == "disk"
     )
+    # Opened, so the row is not still asking to be confirmed: this test is
+    # about the kernel name replacing the selector, not about that marker.
+    at.visited.add("disk")
     assert settings.shown_value(row, installation, at) == "/dev/sda"
 
     at.confirmed.clear()


### PR DESCRIPTION
`settled` refuses a detected value nobody opened — "an install that erases a drive nobody looked at is the failure the requirement exists to prevent" — but `shown_value` drew that value exactly like an answered one, so the only difference was the `*`, whose meaning is not on the screen.

Measured twice: three operator agents answered their specs and reported finished while all three machines still listed unanswered rows, and pressing the Drive row to clear its star discarded a hand-written table of three partitions. The row now says the value and that it needs confirming, in words rather than colour.

`Context.visited` was declared as an annotation and set only by `App`, so any `Context` built elsewhere answered `settled` with an `AttributeError`; it is initialised where the other state is.