### PR TITLE
binhost: let its address be overridden

### DIFF
--- a/gentoo_install/model/config.py
+++ b/gentoo_install/model/config.py
@@ -407,6 +407,11 @@ class Binhost:
     #: `x86-64` only, so this does not touch it.
     subarch: str = DEFAULT_ARCHITECTURE.binhost_subarch
     community: BinhostChannel = BinhostChannel.OFF
+    #: The official host's address, when the composed one is not wanted. Empty
+    #: means `mirrors.gentoo_binhost` composes it from the region and site, the
+    #: same shape `mirrors.distfiles` already has: a cache on the machine's own
+    #: segment is an address with no name to resolve.
+    url: str = ""
 
 
 #: The profile release every path in this installer is built against, and the

--- a/gentoo_install/model/parse.py
+++ b/gentoo_install/model/parse.py
@@ -277,12 +277,13 @@ def _remote_unlock(raw: Mapping[str, Any], at: str) -> RemoteUnlock:
 
 
 def _binhost(raw: Mapping[str, Any], at: str) -> Binhost:
-    _reject_unknown(raw, at, {"official", "community", "subarch"})
+    _reject_unknown(raw, at, {"official", "community", "subarch", "url"})
     default = Binhost()
     return Binhost(
         official=_bool(raw, "official", at, default.official),
         community=_enum(raw, "community", at, BinhostChannel, default.community),
         subarch=_str(raw, "subarch", at, default.subarch),
+        url=_str(raw, "url", at, default.url),
     )
 
 

--- a/gentoo_install/plan/portage.py
+++ b/gentoo_install/plan/portage.py
@@ -1703,7 +1703,8 @@ def build(
             ),
             ConfigureBinhost(
                 name="gentoo",
-                sync_uri=mirrors.gentoo_binhost(
+                sync_uri=portage.binhost.url
+                or mirrors.gentoo_binhost(
                     portage.mirrors.region, portage.mirrors.site, portage.binhost.subarch
                 ),
                 verify=True,

--- a/tests/unit/test_cluster.py
+++ b/tests/unit/test_cluster.py
@@ -125,6 +125,7 @@ def _rewrite(
     site: str = "",
     unlock_addresses: object = None,
     distfiles: str = "",
+    binhost: str = "",
 ) -> Path:
     return into
 

--- a/tests/unit/test_harness.py
+++ b/tests/unit/test_harness.py
@@ -1689,7 +1689,7 @@ def test_zero_cluster_capacity_returns_an_error_after_a_deadline(
     monkeypatch.setattr(
         cluster,
         "rewrite_fixtures",
-        lambda jobs, into, region, sync, public_key="", site="", unlock_addresses=None, distfiles="": into,
+        lambda jobs, into, region, sync, public_key="", site="", unlock_addresses=None, distfiles="", binhost="": into,
     )
 
     def build(path: Path, **kwargs: object) -> Path:

--- a/tests/unit/test_plan_portage.py
+++ b/tests/unit/test_plan_portage.py
@@ -2137,6 +2137,40 @@ def test_a_binary_that_downloads_on_the_second_try_compiles_nothing() -> None:
     assert not recorder.degraded(portage.BINARY_PACKAGES)
 
 
+def test_an_overridden_binhost_address_is_the_one_configured() -> None:
+    """`mirrors.distfiles` already replaces the distfile address for a cache on
+    the machine's own segment; the binary host had no such field, so a round
+    measured whatever `distfiles.gentoo.org` did that evening -- one run lost
+    481.5 minutes to it and two more degraded to source."""
+    from dataclasses import replace
+
+    from gentoo_install.model.config import Binhost
+    from tests.unit.layouts import config, ext4_on_gpt
+
+    here = "http://10.31.0.2/gentoo/releases/amd64/binpackages/23.0/x86-64"
+    built = config(ext4_on_gpt())
+    composed = [
+        one
+        for one in portage.build(built, "https://distfiles.gentoo.org")
+        if isinstance(one, portage.ConfigureBinhost) and one.name == "gentoo"
+    ]
+    assert composed and composed[0].sync_uri.startswith("https://"), composed
+
+    overridden = replace(
+        built,
+        portage=replace(built.portage, binhost=replace(built.portage.binhost, url=here)),
+    )
+    named = [
+        one
+        for one in portage.build(overridden, "https://distfiles.gentoo.org")
+        if isinstance(one, portage.ConfigureBinhost) and one.name == "gentoo"
+    ]
+    assert named and named[0].sync_uri == here, named
+    # Still verified: the mirror carries the official packages, so the release
+    # key is the same one.
+    assert named[0].verify
+
+
 #: Verbatim from `vm-gnome-9301-69777bdafc.log`, which reached the run's 8h
 #: ceiling at 481.5 minutes with the console still printing.
 GNOME_TLS_DROPPED = """>>> Emerging binary (39 of 227) net-print/cups-pk-helper-0.2.7-r1::gentoo

--- a/tests/unit/test_serialise.py
+++ b/tests/unit/test_serialise.py
@@ -408,6 +408,7 @@ def test_a_published_configuration_redacts_the_key_file_path() -> None:
 #: unknown key while every fixture round trip stayed green.
 NON_DEFAULT: "dict[tuple[type, str], object]" = {
     (Binhost, "subarch"): "arm64",
+    (Binhost, "url"): "http://10.31.0.2/gentoo/releases/amd64/binpackages/23.0/x86-64",
     (FirstBoot, "commands"): ("emerge --info",),
     (FirstBoot, "url"): "https://example.test/first-boot.sh",
     (KernelConfig, "dracut_modules"): ("crypt", "lvm"),

--- a/tests/vm/cluster.py
+++ b/tests/vm/cluster.py
@@ -1382,6 +1382,7 @@ def rewrite_fixtures(
     site: str = "",
     unlock_addresses: Mapping[str, str] | None = None,
     distfiles: str = "",
+    binhost: str = "",
 ) -> Path:
     """Write each fixture out again with its mirror region, site and sync.
 
@@ -1440,6 +1441,12 @@ def rewrite_fixtures(
                     # thirty rounds died of.
                     distfiles=(distfiles,) if distfiles else config.portage.mirrors.distfiles,
                 ),
+                # Beside `distfiles`, for the reason written there: an evening
+                # of `distfiles.gentoo.org` answering three different ways cost
+                # one run 481.5 minutes and degraded two more to source.
+                binhost=replace(config.portage.binhost, url=binhost)
+                if binhost
+                else config.portage.binhost,
                 overlays=tuple(
                     replace(overlay, sync_uri=where)
                     if overlay.name == "gentoo-zh"
@@ -2662,6 +2669,7 @@ def run(
     sync: Sync = Sync.RSYNC,
     site: str = "",
     distfiles: str = "",
+    binhost: str = "",
     skip_nodes: Sequence[str] = (),
     allow_nodes: Sequence[str] = (),
 ) -> list[Outcome]:
@@ -2693,7 +2701,15 @@ def run(
         for job in jobs
     }
     rewritten = rewrite_fixtures(
-        jobs, fixture_dir, region, sync, public_key, site, unlock_addresses, distfiles
+        jobs,
+        fixture_dir,
+        region,
+        sync,
+        public_key,
+        site,
+        unlock_addresses,
+        distfiles,
+        binhost,
     )
     # Rebuilt rather than mutated: `Job` is frozen so that a scheduler state
     # change is always a new object.
@@ -4931,6 +4947,14 @@ def main(argv: list[str] | None = None) -> int:
         ),
     )
     parser.add_argument(
+        "--binhost",
+        default="",
+        help=(
+            "replace the official binary host with this one address, so a round "
+            "measures the installer rather than what the upstream mirror did"
+        ),
+    )
+    parser.add_argument(
         "--region",
         choices=[one.value for one in MirrorRegion],
         default=MirrorRegion.GLOBAL.value,
@@ -4968,6 +4992,7 @@ def main(argv: list[str] | None = None) -> int:
         Sync(args.sync),
         args.site,
         args.distfiles,
+        args.binhost,
         args.skip_node,
         args.allow_node,
     )


### PR DESCRIPTION
`mirrors.distfiles` already replaces the distfile address, and its comment says why: a cache on the guests own segment is an address with no name to resolve, which is the class of failure the first thirty rounds died of. The binary host had no such field, so every round measured whatever the upstream mirror did that evening.

Three different failures from `distfiles.gentoo.org` in one evening: a `.gpkg.tar` answering `Unable to establish SSL connection.` twice (`vm-gnome`, 227 packages rebuilt from source, 481.5 minutes, the run ceiling ended it), an unreadable package index (`btrfs-luks`, the whole path degraded), and three guests whose disk byte counter did not move for 1200 seconds. The degradations are all correct; measuring the mirror is not the point of a round.

`Binhost.url` is empty by default and the address is composed from the region and site as before. The mirror on the cluster segment already serves `releases/amd64/binpackages/23.0/x86-64/Packages`, and those are the official packages, so `verify-signature` still checks against the release key.