### PR TITLE
probe: an absent zpool is not a failing zpool

### DIFF
--- a/gentoo_install/exec/probe.py
+++ b/gentoo_install/exec/probe.py
@@ -590,6 +590,11 @@ BOOTED_BY_SYSTEMD_BOOT: Final[re.Pattern[str]] = re.compile(
 )
 
 
+#: What `exec/runner.py` answers for a command it could not run, which is how
+#: "this medium has no `zpool`" is told from "`zpool` ran and failed".
+ABSENT_COMMAND: Final[int] = 127
+
+
 @dataclass
 class Probe:
     """Resolves ids to paths and answers questions about the machine.
@@ -1505,11 +1510,18 @@ class Probe:
         the operator was installing onto.
         """
         listed = self.runner.run(["zpool", "list", "-v", "-H", "-P"], check=False)
-        if listed.returncode != 0:
-            # No pools and no `zpool` are the same answer here: nothing this
-            # command can tell us. `zpool` missing is the common case on a
-            # medium without ZFS, and it is not evidence that a disk is busy.
+        if listed.returncode == ABSENT_COMMAND:
+            # A medium without ZFS has no `zpool`, and that is not evidence
+            # that a disk is busy. The runner answers 127 for a command it
+            # could not run, which is the target's answer rather than this
+            # machine's.
             return False
+        if listed.returncode != 0:
+            # `zpool` present and failing says nothing either way, and this
+            # answered `False` for that too: an imported pool's vdev could
+            # then be repartitioned. `lsblk` and `swapon` in `mounted` both
+            # answer `True` when their command fails, and so does this one.
+            return True
         whole = str(Path(disk).resolve())
         ours = False
         for line in listed.stdout.splitlines():

--- a/tests/unit/test_exec.py
+++ b/tests/unit/test_exec.py
@@ -1762,6 +1762,43 @@ def test_a_disk_holding_an_imported_pool_is_in_use(tmp_path: Path) -> None:
     assert not probe._in_an_imported_pool(f"{tmp_path}/disk2")
 
 
+def test_an_absent_zpool_and_a_failing_zpool_answer_differently(tmp_path: Path) -> None:
+    """`mounted` has three readers and two of them answer `True` when their
+    command fails. This one answered `False` for both "no `zpool` here" and
+    "`zpool` ran and failed", so an imported pool's vdev could be
+    repartitioned whenever the command errored for any other reason."""
+    class Failing(Runner):
+        code: int = 1
+
+        def run(
+            self,
+            argv: Sequence[str],
+            *,
+            check: bool = True,
+            input_text: str | None = None,
+            timeout: float | None = None,
+        ) -> Result:
+            if argv[0] == "zpool":
+                return Result(
+                    argv=tuple(argv), returncode=self.code, stdout="", stderr="", seconds=0.0
+                )
+            return Result(argv=tuple(argv), returncode=0, stdout="", stderr="", seconds=0.0)
+
+    absent = Failing(log=lambda line: None)
+    absent.code = probe_module.ABSENT_COMMAND
+    assert (
+        Probe(runner=absent, work=tmp_path)._in_an_imported_pool(f"{tmp_path}/disk1") is False
+    )
+
+    # `zpool` ran and answered non-zero: nothing is known, so the disk is
+    # treated as in use, the way `lsblk` and `swapon` already are.
+    broken = Failing(log=lambda line: None)
+    broken.code = 1
+    assert (
+        Probe(runner=broken, work=tmp_path)._in_an_imported_pool(f"{tmp_path}/disk1") is True
+    )
+
+
 def test_the_targets_own_half_finished_pool_is_not_somebody_elses_disk(tmp_path: Path) -> None:
     """A run that stopped partway leaves its own pool imported with the install
     target as its altroot. Reading that as a disk in use made the next attempt


### PR DESCRIPTION
`Probe.mounted` has three readers deciding whether a disk is in use: `lsblk` non-zero answers `True`, `swapon` non-zero answers `True`, and `zpool list` non-zero answered `False`. The comment on the third gives a reason that covers only half of it — a medium without ZFS has no `zpool`, and that really is not evidence a disk is busy — but `returncode != 0` folds "not there" together with "ran and failed", which is this repository recurring second defect shape.

The cost is not reversible: the selected disk is a vdev of an imported pool, `lsblk` reports no block-device mountpoint because ZFS datasets have none, `zpool list` fails for some other reason, and preflight authorises repartitioning it.

`exec/runner.py` answers 127 for a command it could not run, which is the target machine answer rather than this one — an existing test already simulates the absent case that way. 127 still answers `False`; every other non-zero now answers `True`.