### PR TITLE
disk: a failed findmnt is not an unmounted target

### DIFF
--- a/gentoo_install/plan/disk.py
+++ b/gentoo_install/plan/disk.py
@@ -160,6 +160,13 @@ class ReleaseTarget(Operation):
         found = context.run(["findmnt", "--mountpoint", str(path)], check=False)
         if not isinstance(found, CommandOutput):
             raise CommandFailed(f"cannot determine whether {path} is mounted")
+        # 1 is `findmnt` saying the path is not a mountpoint; anything else is
+        # the probe failing, and reading that as unmounted skipped the lazy
+        # unmount and let the wipe run against a target still mounted.
+        if found.returncode not in _FINDMNT_ANSWERED:
+            raise CommandFailed(
+                f"whether {path} is mounted could not be read: {str(found).strip()[:200]}"
+            )
         return found.returncode == 0
 
     def _close(self, context: Context, argv: tuple[str, ...]) -> None:
@@ -1093,7 +1100,16 @@ class UnmountTarget(Operation):
         found = context.run(
             ["findmnt", "--mountpoint", str(context.target)], check=False
         )
-        return isinstance(found, CommandOutput) and found.returncode == 0
+        if not isinstance(found, CommandOutput):
+            raise CommandFailed(
+                f"whether {context.target} is mounted could not be read"
+            )
+        if found.returncode not in _FINDMNT_ANSWERED:
+            raise CommandFailed(
+                f"whether {context.target} is mounted could not be read: "
+                f"{str(found).strip()[:200]}"
+            )
+        return found.returncode == 0
 
     def _unmount_datasets(self, context: Context, pool: str) -> None:
         """Unmount the pool's own datasets, deepest first.
@@ -1587,6 +1603,13 @@ def _expect(graph: DeviceGraph, device: DeviceId, kind: type[T]) -> T:
             f"{device!r} is a {type(node).__name__.lower()} where a {kind.__name__.lower()} is required"
         )
     return node
+
+
+#: `findmnt` answers 0 when the path is a mountpoint and 1 when it is not.
+#: Every other code is the probe failing, which is a different answer: the
+#: rule is written out at `MountFilesystem`, and the two cleanup readers had
+#: it as `returncode == 0`.
+_FINDMNT_ANSWERED: Final[tuple[int, ...]] = (0, 1)
 
 
 def _under(target: PurePosixPath, path: PurePosixPath) -> PurePosixPath:

--- a/tests/unit/test_plan_disk.py
+++ b/tests/unit/test_plan_disk.py
@@ -620,6 +620,52 @@ def test_release_retries_a_busy_container_until_it_closes() -> None:
     assert ("sleep", "5") in recorder.commands
 
 
+def test_a_findmnt_that_failed_is_not_read_as_unmounted() -> None:
+    """`findmnt` answers 1 when the path is not a mountpoint and every other
+    non-zero code when the probe itself failed. `MountFilesystem` writes that
+    rule out and allows `(0, 1)`; both cleanup readers had `returncode == 0`,
+    so a failed probe read as `unmounted`, the lazy unmount was skipped and
+    the wipe ran against a target that was still mounted."""
+
+    class Broken(Recorder):
+        def run(
+            self, argv: Sequence[str], *, check: bool = True, input_text: str | None = None
+        ) -> CommandOutput:
+            if argv[0] == "findmnt":
+                self.commands.append(tuple(argv))
+                return CommandOutput("findmnt: bad usage", 2)
+            if argv[0] == "umount":
+                self.commands.append(tuple(argv))
+                return CommandOutput("", 0)
+            return super().run(argv, check=check, input_text=input_text)
+
+    with pytest.raises(CommandFailed, match="could not be read"):
+        disk.ReleaseTarget(steps=()).apply(Broken())
+
+    with pytest.raises(CommandFailed, match="could not be read"):
+        disk.UnmountTarget(pools=()).apply(Broken())
+
+
+def test_a_findmnt_that_says_not_a_mountpoint_is_still_read_as_unmounted() -> None:
+    """Negative control for the above: exit 1 is `findmnt` answering, not
+    failing, and a run that unmounted everything must not raise on it."""
+
+    class Clean(Recorder):
+        def run(
+            self, argv: Sequence[str], *, check: bool = True, input_text: str | None = None
+        ) -> CommandOutput:
+            if argv[0] == "findmnt":
+                self.commands.append(tuple(argv))
+                return CommandOutput("", 1)
+            if argv[0] == "umount":
+                self.commands.append(tuple(argv))
+                return CommandOutput("", 0)
+            return super().run(argv, check=check, input_text=input_text)
+
+    disk.ReleaseTarget(steps=()).apply(Clean())
+    disk.UnmountTarget(pools=()).apply(Clean())
+
+
 def test_release_accepts_a_missing_container_after_close_fails() -> None:
     class MissingLuks(Recorder):
         def run(


### PR DESCRIPTION
`plan/disk.py` asks `findmnt --mountpoint <path>` in three places. One writes the rule out — exit 1 means the path is not a mountpoint, which is a probe answering rather than failing — and allows `(0, 1)`. The two cleanup readers had `return found.returncode == 0`, so every other non-zero read as unmounted.

`ReleaseTarget` then skips the lazy unmount and lets a later close, wipe or partition run against a target it never proved was released; `UnmountTarget.apply` returns successfully with the target still mounted. Both now answer the way the written rule says, and anything outside `(0, 1)` raises with what the command said.