### PR TITLE
credits: record what was taken and bind the ledger

### DIFF
--- a/CREDITS.md
+++ b/CREDITS.md
@@ -6,15 +6,17 @@ that a reader can find the original and its terms.
 
 ## Derived code
 
-Nothing yet. Every line in this repository was written for it.
-
 A derivation is recorded here in the same commit that introduces it, one row
 per file, naming the source project, the file it came from and what was taken.
 The file itself carries the same statement in a comment at the top, because a
 reader of that file cannot be assumed to have read this one.
 
+None of it is installed: the ebuild installs `gentoo_install/` and the one
+derivation below is under `tests/`, which no package carries.
+
 | File here | Source project | Source file | Licence | Taken |
 |---|---|---|---|---|
+| `tests/vm/cluster.py` | [shadow](https://github.com/shadow-maint/shadow) | `po/zh_TW.po`, `po/zh_CN.po` | BSD GPL-2 | The wordings `login` prints when it refuses a password, so a harness driving a Chinese console recognises a refusal instead of waiting out its budget |
 
 ## Projects read for behaviour
 
@@ -30,6 +32,7 @@ somewhere and the reader deserves to know where.
 | [archinstall](https://github.com/archlinux/archinstall) | GPL-3 | Menu structure and configuration schema layering |
 | [catalyst](https://github.com/gentoo/catalyst) | GPL-2 | How a Gentoo installation medium is built |
 | [releng](https://gitweb.gentoo.org/proj/releng.git/) | — | What the official install CD contains |
+| [bin456789/reinstall](https://github.com/bin456789/reinstall) | MIT | What a cloud image's GRUB needs before it will take an added entry |
 
 `archinstall` is GPL-3. The `or later` clause makes taking code from it lawful,
 and a release that carries any of it is distributed under GPL-3 rather than

--- a/gentoo_install/model/manual.py
+++ b/gentoo_install/model/manual.py
@@ -112,9 +112,12 @@ def purpose_of(entry: Slice) -> Purpose:
 class SliceStatus(Enum):
     """What happens to one row of the table.
 
-    Taken from `archinstall`'s `ModificationStatus`. Two exclusive modes could
-    not say "keep the Windows partition, reformat the root, delete the rest,
-    add a swap", and that is the ordinary case rather than an exotic one.
+    Four states rather than two, which `archinstall` had already found with
+    its `ModificationStatus`: two exclusive modes could not say "keep the
+    Windows partition, reformat the root, delete the rest, add a swap", and
+    that is the ordinary case rather than an exotic one. The shape is the
+    lesson; none of its code is here, and `CREDITS.md` lists that project
+    among the ones read for behaviour.
     """
 
     #: Already there and untouched. Mounted if it names a mount point.

--- a/tests/unit/test_layers.py
+++ b/tests/unit/test_layers.py
@@ -1291,3 +1291,69 @@ def test_one_row_decides_both_halves_of_the_binhost_url() -> None:
         if isinstance(node, ast.Constant) and node.value in known
     ]
     assert len(spelled) == 1, spelled
+
+def test_every_named_source_is_in_the_ledger() -> None:
+    """`CREDITS.md` said "Nothing yet. Every line in this repository was
+    written for it." while `tests/vm/cluster.py` said `Taken from shadow's own
+    po/zh_TW.po` and `model/manual.py` named `archinstall`. Nothing checked the
+    two against each other, so the ledger drifted from the tree it is the
+    ledger for -- and which outside project a file names is what decides the
+    licence a release goes out under.
+    """
+    import re
+
+    root = Path(__file__).resolve().parents[2]
+    credits = (root / "CREDITS.md").read_text()
+
+    def rows(after: str) -> list[list[str]]:
+        block = credits.split(after, 1)[1]
+        found = []
+        for line in block.splitlines():
+            if line.startswith("## "):
+                break
+            if not line.startswith("|") or set(line) <= set("|- "):
+                continue
+            if line.startswith("| File here") or line.startswith("| Project"):
+                continue
+            found.append([cell.strip() for cell in line.strip("|").split("|")])
+        return found
+
+    derived = rows("## Derived code")
+    read = rows("## Projects read for behaviour")
+    assert read, "the ledger names no project at all"
+
+    def named(cell: str) -> str:
+        inside = re.search(r"\[([^\]]+)\]", cell)
+        return (inside.group(1) if inside else cell).strip("`")
+
+    # Every derived row names a file that exists and says so itself.
+    for row in derived:
+        here = root / row[0].strip("`")
+        assert here.is_file(), row
+        project = named(row[1]).split("/")[-1]
+        assert project in here.read_text(), (row[0], project)
+
+    # And every outside project a file names as a source is mentioned in the
+    # ledger. The vocabulary is not taken from the ledger itself: a row
+    # deleted from it would then delete the check with it.
+    fixtures = {one.stem for one in (root / "tests" / "fixtures").glob("*.toml")}
+    #: Words that follow `Taken from` inside a sentence about this repository.
+    ORDINARY = {"the", "what", "its", "their", "this", "that", "one", "each"}
+    taken = re.compile(r"(?:Taken|Adapted|Copied) from `?([A-Za-z0-9][A-Za-z0-9_./-]*)")
+    outside: dict[str, str] = {}
+    for path in sorted((root / "gentoo_install").rglob("*.py")) + sorted(
+        (root / "tests").rglob("*.py")
+    ):
+        # Not this file: it quotes the wordings it looks for, so scanning it
+        # reports its own docstring.
+        if path == Path(__file__).resolve():
+            continue
+        for found in taken.finditer(path.read_text()):
+            name = found.group(1)
+            if name in ORDINARY or name in fixtures or "." in name.split("/")[0]:
+                continue
+            outside.setdefault(name, str(path.relative_to(root)))
+
+    assert outside, "the scan found no named source at all, so it holds nothing"
+    for name, where in sorted(outside.items()):
+        assert name in credits, (where, name)

--- a/tests/unit/test_plan_netboot.py
+++ b/tests/unit/test_plan_netboot.py
@@ -918,7 +918,8 @@ def _custom(recorder: Recorder) -> str:
 
 
 def test_the_entry_carries_what_a_cloud_image_grub_needs() -> None:
-    """Taken from `bin456789/reinstall`, which arms the same kind of machine:
+    """What `bin456789/reinstall` had already found out about the same kind of
+    machine, listed in `CREDITS.md` among the projects read for behaviour:
     an image with a GRUB password refuses an entry that is not
     `--unrestricted`, Fedora's EFI GRUB has no `all_video` loaded, an LVM
     `/boot` needs its module, and a `/boot` inside a btrfs subvolume resolves


### PR DESCRIPTION
`CREDITS.md` said "Nothing yet. Every line in this repository was written for it." while three files named an outside project, and nothing checked the two against each other. Which project a file names is what decides the licence a release goes out under, so this had to be settled before a tag.

`model/manual.py` said `Taken from archinstall's ModificationStatus`, but what is there is four enum members and a reason for having four states rather than two — no archinstall code, and the ledger already lists that project among the ones read for behaviour. The wording was wrong, not the licence: the release stays GPL-2-or-later.

`tests/vm/cluster.py` really did take the wordings `login` prints from shadow's own `po/zh_TW.po` and `po/zh_CN.po`, so that is a derived-code row — BSD GPL-2, compatible, and under `tests/`, which the ebuild does not install. `bin456789/reinstall` joins the projects read for behaviour.

`test_every_named_source_is_in_the_ledger` binds the two from now on. Its vocabulary is deliberately not taken from the ledger: the first version derived it from there, so deleting a row deleted the check with it and the control stayed green.