### PR TITLE
portage: getbinpkg follows the host that was written

### DIFF
--- a/gentoo_install/plan/portage.py
+++ b/gentoo_install/plan/portage.py
@@ -455,6 +455,44 @@ class WriteMakeConf(Operation):
         context.write(PurePosixPath("/etc/portage/make.conf"), merge(existing, wanted))
 
 
+@dataclass(frozen=True, kw_only=True)
+class SettleBinhostFeature(Operation):
+    """Make `FEATURES` agree with whether a binary host was configured.
+
+    `WriteMakeConf` writes `getbinpkg` because the configuration asks for a
+    host, and `ConfigureBinhost` finds out six operations later whether there
+    is one this machine can verify -- it returns without writing
+    `binrepos.conf` when there is not. Left alone the installed system says it
+    fetches binary packages and has nothing naming where from.
+
+    A degradation during the merges is a different thing and does not reach
+    here: the host is configured and verified, and one package did not arrive.
+    """
+
+    stage: Stage = Stage.PORTAGE
+    hosts: tuple[str, ...] = ()
+
+    def destinations(self) -> tuple[PurePosixPath, ...]:
+        return (MAKE_CONF,)
+
+    def describe(self) -> str:
+        return (
+            "drop getbinpkg from FEATURES in /etc/portage/make.conf when no "
+            "binary package host was written"
+        )
+
+    def apply(self, context: Context) -> None:
+        existing = context.read(MAKE_CONF)
+        usable = [
+            one
+            for one in self.hosts
+            if not context.degraded(BINARY_PACKAGES)
+            and not context.degraded(binhost_trust(one))
+        ]
+        wanted = existing if usable else _features_without(existing, "getbinpkg")
+        context.write(MAKE_CONF, wanted)
+
+
 class PortageConfigKind(Enum):
     USE = "package.use"
     KEYWORDS = "package.accept_keywords"
@@ -1844,6 +1882,13 @@ def build(
             ),
             ConfigureBinhost(name="gentoo-zh", sync_uri=community_binhost(portage), verify=True),
         ]
+    hosts = tuple(
+        one.name for one in operations if isinstance(one, ConfigureBinhost)
+    )
+    if hosts:
+        # After every `ConfigureBinhost`, because it is their outcome this
+        # reads: `WriteMakeConf` wrote `getbinpkg` before any of them ran.
+        operations.append(SettleBinhostFeature(hosts=hosts))
     return operations
 
 
@@ -1937,6 +1982,27 @@ def _features(config: InstallConfig) -> tuple[str, ...]:
     if config.proxy.enabled and (config.proxy.over_socks or config.proxy.username):
         wanted.append("-userfetch")
     return tuple(wanted)
+
+
+#: The one file `WriteMakeConf` and `ConfigureBinhost` both touch.
+MAKE_CONF: Final[PurePosixPath] = PurePosixPath("/etc/portage/make.conf")
+
+_FEATURES_LINE: Final[re.Pattern[str]] = re.compile(
+    r'^(?P<lead>FEATURES=")(?P<value>[^"]*)(?P<tail>")\n', re.MULTILINE
+)
+
+
+def _features_without(text: str, feature: str) -> str:
+    """`make.conf` with one feature removed from `FEATURES`, and the whole
+    assignment dropped when it was the only one."""
+
+    def rewritten(found: "re.Match[str]") -> str:
+        kept = [one for one in found.group("value").split() if one != feature]
+        if not kept:
+            return ""
+        return f"{found.group('lead')}{' '.join(kept)}{found.group('tail')}\n"
+
+    return _FEATURES_LINE.sub(rewritten, text)
 
 
 def _proxy_endpoint(proxy: ProxyConfig) -> str:

--- a/tests/golden/btrfs-luks.txt
+++ b/tests/golden/btrfs-luks.txt
@@ -47,6 +47,7 @@
   install the key the community binary packages are signed with: emerge sec-keys/openpgp-keys-gentoozh, from source
   import 38A0234EC16AD42E from /usr/share/openpgp-keys/gentoozh.asc, locally sign it for gentoo-zh, and verify the local signature
   write /etc/portage/binrepos.conf/gentoo-zh.conf adding verified binary package host gentoo-zh at https://distfiles.gentoozh.org/binpkgs/x86-64
+  drop getbinpkg from FEATURES in /etc/portage/make.conf when no binary package host was written
   set sys-kernel/installkernel to dracut
   ask for sys-apps/systemd[cryptsetup], which provides the unlock generator
   accept the linux-firmware licence

--- a/tests/golden/mbr-edit.txt
+++ b/tests/golden/mbr-edit.txt
@@ -30,6 +30,7 @@
   install git, which every later repository sync needs: emerge dev-vcs/git
   write /etc/portage/repos.conf/gentoo.conf pointing gentoo at https://github.com/gentoo-mirror/gentoo.git, commit signatures verified
   sync repository gentoo
+  drop getbinpkg from FEATURES in /etc/portage/make.conf when no binary package host was written
   set sys-kernel/installkernel to dracut
   accept the linux-firmware licence
   resolve net-misc/netifrc net-misc/dhcpcd app-admin/sysklogd sys-process/cronie sys-kernel/installkernel sys-kernel/dracut sys-kernel/linux-firmware sys-fs/e2fsprogs sys-kernel/gentoo-kernel-bin sys-boot/grub together before installing the requested packages

--- a/tests/golden/openrc-sdboot.txt
+++ b/tests/golden/openrc-sdboot.txt
@@ -34,6 +34,7 @@
   install git, which every later repository sync needs: emerge dev-vcs/git
   write /etc/portage/repos.conf/gentoo.conf pointing gentoo at https://github.com/gentoo-mirror/gentoo.git, commit signatures verified
   sync repository gentoo
+  drop getbinpkg from FEATURES in /etc/portage/make.conf when no binary package host was written
   set sys-kernel/installkernel to dracut systemd systemd-boot
   accept the linux-firmware licence
   ask for sys-apps/systemd-utils[boot,kernel-install], which is what provides bootctl

--- a/tests/golden/static-ip.txt
+++ b/tests/golden/static-ip.txt
@@ -34,6 +34,7 @@
   install git, which every later repository sync needs: emerge dev-vcs/git
   write /etc/portage/repos.conf/gentoo.conf pointing gentoo at https://github.com/gentoo-mirror/gentoo.git, commit signatures verified
   sync repository gentoo
+  drop getbinpkg from FEATURES in /etc/portage/make.conf when no binary package host was written
   set sys-kernel/installkernel to dracut
   accept the linux-firmware licence
   resolve sys-process/cronie sys-kernel/installkernel sys-kernel/dracut sys-kernel/linux-firmware sys-fs/dosfstools sys-fs/e2fsprogs sys-kernel/gentoo-kernel-bin sys-boot/grub sys-boot/efibootmgr together before installing the requested packages

--- a/tests/golden/vm-binhost-fallback.txt
+++ b/tests/golden/vm-binhost-fallback.txt
@@ -32,6 +32,7 @@
   fetch the first ebuild repository snapshot with emerge-webrsync
   select profile default/linux/amd64/23.0/systemd
   write /etc/portage/repos.conf/gentoo.conf so repository gentoo syncs with emerge-webrsync
+  drop getbinpkg from FEATURES in /etc/portage/make.conf when no binary package host was written
   set sys-kernel/installkernel to dracut
   accept the linux-firmware licence
   resolve net-misc/openssh sys-process/cronie sys-kernel/installkernel sys-kernel/dracut sys-kernel/linux-firmware sys-fs/dosfstools sys-fs/e2fsprogs sys-kernel/gentoo-kernel-bin sys-boot/grub sys-boot/efibootmgr together before installing the requested packages

--- a/tests/golden/vm-binpkg.txt
+++ b/tests/golden/vm-binpkg.txt
@@ -34,6 +34,7 @@
   install git, which every later repository sync needs: emerge dev-vcs/git
   write /etc/portage/repos.conf/gentoo.conf pointing gentoo at https://github.com/gentoo-mirror/gentoo.git, commit signatures verified
   sync repository gentoo
+  drop getbinpkg from FEATURES in /etc/portage/make.conf when no binary package host was written
   set sys-kernel/installkernel to dracut
   accept the linux-firmware licence
   resolve net-misc/openssh sys-process/cronie sys-kernel/installkernel sys-kernel/dracut sys-kernel/linux-firmware sys-fs/dosfstools sys-fs/e2fsprogs sys-kernel/gentoo-kernel-bin sys-boot/grub sys-boot/efibootmgr together before installing the requested packages

--- a/tests/golden/vm-bios-luks.txt
+++ b/tests/golden/vm-bios-luks.txt
@@ -37,6 +37,7 @@
   install git, which every later repository sync needs: emerge dev-vcs/git
   write /etc/portage/repos.conf/gentoo.conf pointing gentoo at https://github.com/gentoo-mirror/gentoo.git, commit signatures verified
   sync repository gentoo
+  drop getbinpkg from FEATURES in /etc/portage/make.conf when no binary package host was written
   set sys-kernel/installkernel to dracut
   accept the linux-firmware licence
   resolve net-misc/netifrc net-misc/dhcpcd app-admin/sysklogd sys-process/cronie sys-kernel/installkernel sys-kernel/dracut sys-kernel/linux-firmware sys-fs/cryptsetup sys-fs/e2fsprogs sys-kernel/gentoo-kernel-bin sys-boot/grub together before installing the requested packages

--- a/tests/golden/vm-bios.txt
+++ b/tests/golden/vm-bios.txt
@@ -33,6 +33,7 @@
   install git, which every later repository sync needs: emerge dev-vcs/git
   write /etc/portage/repos.conf/gentoo.conf pointing gentoo at https://github.com/gentoo-mirror/gentoo.git, commit signatures verified
   sync repository gentoo
+  drop getbinpkg from FEATURES in /etc/portage/make.conf when no binary package host was written
   set sys-kernel/installkernel to dracut
   accept the linux-firmware licence
   resolve net-misc/netifrc net-misc/dhcpcd app-admin/sysklogd sys-process/cronie sys-kernel/installkernel sys-kernel/dracut sys-kernel/linux-firmware sys-fs/e2fsprogs sys-kernel/gentoo-kernel-bin sys-boot/grub together before installing the requested packages

--- a/tests/golden/vm-btrfs.txt
+++ b/tests/golden/vm-btrfs.txt
@@ -37,6 +37,7 @@
   install git, which every later repository sync needs: emerge dev-vcs/git
   write /etc/portage/repos.conf/gentoo.conf pointing gentoo at https://github.com/gentoo-mirror/gentoo.git, commit signatures verified
   sync repository gentoo
+  drop getbinpkg from FEATURES in /etc/portage/make.conf when no binary package host was written
   set sys-kernel/installkernel to dracut
   accept the linux-firmware licence
   resolve sys-process/cronie sys-kernel/installkernel sys-kernel/dracut sys-kernel/linux-firmware sys-fs/btrfs-progs sys-fs/dosfstools sys-kernel/gentoo-kernel-bin sys-boot/grub sys-boot/efibootmgr together before installing the requested packages

--- a/tests/golden/vm-cjk-kernel.txt
+++ b/tests/golden/vm-cjk-kernel.txt
@@ -37,6 +37,7 @@
   write /etc/portage/repos.conf/gentoo-zh.conf pointing gentoo-zh at https://github.com/gentoo-zh/overlay.git
   sync repository gentoo-zh, 4 other sites to fall back on
   accept ~amd64 for packages from gentoo-zh only
+  drop getbinpkg from FEATURES in /etc/portage/make.conf when no binary package host was written
   set sys-kernel/installkernel to dracut
   accept the linux-firmware licence
   accept sys-kernel/gentoo-cjk-kernel-bin as testing, with cjk on, writing /etc/portage/package.use/cjk-kernel

--- a/tests/golden/vm-convert.txt
+++ b/tests/golden/vm-convert.txt
@@ -19,6 +19,7 @@
   install git, which every later repository sync needs: emerge dev-vcs/git, in /gentoo-install.new
   write /etc/portage/repos.conf/gentoo.conf pointing gentoo at https://github.com/gentoo-mirror/gentoo.git, commit signatures verified, in /gentoo-install.new
   sync repository gentoo, in /gentoo-install.new
+  drop getbinpkg from FEATURES in /etc/portage/make.conf when no binary package host was written, in /gentoo-install.new
   set sys-kernel/installkernel to dracut, in /gentoo-install.new
   accept the linux-firmware licence, in /gentoo-install.new
   resolve net-misc/openssh sys-process/cronie sys-kernel/installkernel sys-kernel/dracut sys-kernel/linux-firmware sys-fs/dosfstools sys-fs/e2fsprogs sys-kernel/gentoo-kernel-bin sys-boot/grub sys-boot/efibootmgr together before installing the requested packages, in /gentoo-install.new

--- a/tests/golden/vm-desktop.txt
+++ b/tests/golden/vm-desktop.txt
@@ -34,6 +34,7 @@
   install git, which every later repository sync needs: emerge dev-vcs/git
   write /etc/portage/repos.conf/gentoo.conf pointing gentoo at https://github.com/gentoo-mirror/gentoo.git, commit signatures verified
   sync repository gentoo
+  drop getbinpkg from FEATURES in /etc/portage/make.conf when no binary package host was written
   set sys-kernel/installkernel to dracut
   accept the linux-firmware licence
   ask for app-i18n/fcitx-configtool kcm; sys-libs/minizip-ng compat; kde-plasma/kwin lock; kde-plasma/kwin-x11 lock for the plasma group

--- a/tests/golden/vm-f2fs.txt
+++ b/tests/golden/vm-f2fs.txt
@@ -34,6 +34,7 @@
   install git, which every later repository sync needs: emerge dev-vcs/git
   write /etc/portage/repos.conf/gentoo.conf pointing gentoo at https://github.com/gentoo-mirror/gentoo.git, commit signatures verified
   sync repository gentoo
+  drop getbinpkg from FEATURES in /etc/portage/make.conf when no binary package host was written
   set sys-kernel/installkernel to dracut
   accept the linux-firmware licence
   resolve net-misc/openssh sys-process/cronie sys-kernel/installkernel sys-kernel/dracut sys-kernel/linux-firmware sys-fs/dosfstools sys-fs/f2fs-tools sys-kernel/gentoo-kernel-bin sys-boot/grub sys-boot/efibootmgr together before installing the requested packages

--- a/tests/golden/vm-gnome.txt
+++ b/tests/golden/vm-gnome.txt
@@ -34,6 +34,7 @@
   install git, which every later repository sync needs: emerge dev-vcs/git
   write /etc/portage/repos.conf/gentoo.conf pointing gentoo at https://github.com/gentoo-mirror/gentoo.git, commit signatures verified
   sync repository gentoo
+  drop getbinpkg from FEATURES in /etc/portage/make.conf when no binary package host was written
   set sys-kernel/installkernel to dracut
   accept the linux-firmware licence
   ask for gnome-base/gdm systemd; sys-auth/pambase systemd for the gdm group

--- a/tests/golden/vm-greetd.txt
+++ b/tests/golden/vm-greetd.txt
@@ -34,6 +34,7 @@
   install git, which every later repository sync needs: emerge dev-vcs/git
   write /etc/portage/repos.conf/gentoo.conf pointing gentoo at https://github.com/gentoo-mirror/gentoo.git, commit signatures verified
   sync repository gentoo
+  drop getbinpkg from FEATURES in /etc/portage/make.conf when no binary package host was written
   set sys-kernel/installkernel to dracut
   accept the linux-firmware licence
   ask for dev-libs/libdbusmenu gtk3 for the xfce group

--- a/tests/golden/vm-home-key.txt
+++ b/tests/golden/vm-home-key.txt
@@ -37,6 +37,7 @@
   install git, which every later repository sync needs: emerge dev-vcs/git
   write /etc/portage/repos.conf/gentoo.conf pointing gentoo at https://github.com/gentoo-mirror/gentoo.git, commit signatures verified
   sync repository gentoo
+  drop getbinpkg from FEATURES in /etc/portage/make.conf when no binary package host was written
   set sys-kernel/installkernel to dracut
   accept the linux-firmware licence
   resolve app-admin/sudo net-misc/openssh sys-process/cronie sys-kernel/installkernel sys-kernel/dracut sys-kernel/linux-firmware sys-fs/btrfs-progs sys-fs/dosfstools sys-kernel/gentoo-kernel-bin sys-boot/grub sys-boot/efibootmgr together before installing the requested packages

--- a/tests/golden/vm-image.txt
+++ b/tests/golden/vm-image.txt
@@ -35,6 +35,7 @@
   install git, which every later repository sync needs: emerge dev-vcs/git
   write /etc/portage/repos.conf/gentoo.conf pointing gentoo at https://github.com/gentoo-mirror/gentoo.git, commit signatures verified
   sync repository gentoo
+  drop getbinpkg from FEATURES in /etc/portage/make.conf when no binary package host was written
   set sys-kernel/installkernel to dracut
   accept the linux-firmware licence
   resolve sys-process/cronie sys-kernel/installkernel sys-kernel/dracut sys-kernel/linux-firmware sys-fs/dosfstools sys-fs/e2fsprogs sys-kernel/gentoo-kernel-bin sys-boot/grub together before installing the requested packages

--- a/tests/golden/vm-luks.txt
+++ b/tests/golden/vm-luks.txt
@@ -41,6 +41,7 @@
   install git, which every later repository sync needs: emerge dev-vcs/git
   write /etc/portage/repos.conf/gentoo.conf pointing gentoo at https://github.com/gentoo-mirror/gentoo.git, commit signatures verified
   sync repository gentoo
+  drop getbinpkg from FEATURES in /etc/portage/make.conf when no binary package host was written
   set sys-kernel/installkernel to dracut
   ask for sys-apps/systemd[cryptsetup], which provides the unlock generator
   accept the linux-firmware licence

--- a/tests/golden/vm-lvm.txt
+++ b/tests/golden/vm-lvm.txt
@@ -42,6 +42,7 @@
   install git, which every later repository sync needs: emerge dev-vcs/git
   write /etc/portage/repos.conf/gentoo.conf pointing gentoo at https://github.com/gentoo-mirror/gentoo.git, commit signatures verified
   sync repository gentoo
+  drop getbinpkg from FEATURES in /etc/portage/make.conf when no binary package host was written
   ask for sys-fs/lvm2[lvm], which dracut needs and the default build lacks
   set sys-kernel/installkernel to dracut
   accept the linux-firmware licence

--- a/tests/golden/vm-mdraid.txt
+++ b/tests/golden/vm-mdraid.txt
@@ -42,6 +42,7 @@
   install git, which every later repository sync needs: emerge dev-vcs/git
   write /etc/portage/repos.conf/gentoo.conf pointing gentoo at https://github.com/gentoo-mirror/gentoo.git, commit signatures verified
   sync repository gentoo
+  drop getbinpkg from FEATURES in /etc/portage/make.conf when no binary package host was written
   set sys-kernel/installkernel to dracut
   accept the linux-firmware licence
   resolve sys-process/cronie sys-kernel/installkernel sys-kernel/dracut sys-kernel/linux-firmware sys-fs/mdadm sys-fs/dosfstools sys-fs/e2fsprogs sys-kernel/gentoo-kernel-bin sys-boot/grub sys-boot/efibootmgr together before installing the requested packages

--- a/tests/golden/vm-openrc-desktop.txt
+++ b/tests/golden/vm-openrc-desktop.txt
@@ -34,6 +34,7 @@
   install git, which every later repository sync needs: emerge dev-vcs/git
   write /etc/portage/repos.conf/gentoo.conf pointing gentoo at https://github.com/gentoo-mirror/gentoo.git, commit signatures verified
   sync repository gentoo
+  drop getbinpkg from FEATURES in /etc/portage/make.conf when no binary package host was written
   set sys-kernel/installkernel to dracut
   accept the linux-firmware licence
   ask for dev-libs/libdbusmenu gtk3 for the xfce group

--- a/tests/golden/vm-proxy-dead.txt
+++ b/tests/golden/vm-proxy-dead.txt
@@ -37,6 +37,7 @@
   install git, which every later repository sync needs: emerge dev-vcs/git
   write /etc/portage/repos.conf/gentoo.conf pointing gentoo at https://github.com/gentoo-mirror/gentoo.git, commit signatures verified
   sync repository gentoo
+  drop getbinpkg from FEATURES in /etc/portage/make.conf when no binary package host was written
   set sys-kernel/installkernel to dracut
   accept the linux-firmware licence
   resolve sys-process/cronie sys-kernel/installkernel sys-kernel/dracut sys-kernel/linux-firmware sys-fs/btrfs-progs sys-fs/dosfstools sys-kernel/gentoo-kernel-bin sys-boot/grub sys-boot/efibootmgr together before installing the requested packages

--- a/tests/golden/vm-proxy-http.txt
+++ b/tests/golden/vm-proxy-http.txt
@@ -37,6 +37,7 @@
   install git, which every later repository sync needs: emerge dev-vcs/git
   write /etc/portage/repos.conf/gentoo.conf pointing gentoo at https://github.com/gentoo-mirror/gentoo.git, commit signatures verified
   sync repository gentoo
+  drop getbinpkg from FEATURES in /etc/portage/make.conf when no binary package host was written
   set sys-kernel/installkernel to dracut
   accept the linux-firmware licence
   resolve sys-process/cronie sys-kernel/installkernel sys-kernel/dracut sys-kernel/linux-firmware sys-fs/btrfs-progs sys-fs/dosfstools sys-kernel/gentoo-kernel-bin sys-boot/grub sys-boot/efibootmgr together before installing the requested packages

--- a/tests/golden/vm-proxy.txt
+++ b/tests/golden/vm-proxy.txt
@@ -37,6 +37,7 @@
   install git, which every later repository sync needs: emerge dev-vcs/git
   write /etc/portage/repos.conf/gentoo.conf pointing gentoo at https://github.com/gentoo-mirror/gentoo.git, commit signatures verified
   sync repository gentoo
+  drop getbinpkg from FEATURES in /etc/portage/make.conf when no binary package host was written
   set sys-kernel/installkernel to dracut
   accept the linux-firmware licence
   resolve sys-process/cronie sys-kernel/installkernel sys-kernel/dracut sys-kernel/linux-firmware sys-fs/btrfs-progs sys-fs/dosfstools sys-kernel/gentoo-kernel-bin sys-boot/grub sys-boot/efibootmgr together before installing the requested packages

--- a/tests/golden/vm-raidz.txt
+++ b/tests/golden/vm-raidz.txt
@@ -49,6 +49,7 @@
   write /etc/portage/repos.conf/gentoo-zh.conf pointing gentoo-zh at https://github.com/gentoo-zh/overlay.git
   sync repository gentoo-zh, 4 other sites to fall back on
   accept ~amd64 for packages from gentoo-zh only
+  drop getbinpkg from FEATURES in /etc/portage/make.conf when no binary package host was written
   set sys-kernel/installkernel to dracut, writing BOOT_ROOT=/boot to /etc/kernel/install.conf.d/50-gentoo-install.conf
   verify kernel version - against the target sys-fs/zfs ceiling
   accept the linux-firmware licence

--- a/tests/golden/vm-ram.txt
+++ b/tests/golden/vm-ram.txt
@@ -34,6 +34,7 @@
   install git, which every later repository sync needs: emerge dev-vcs/git
   write /etc/portage/repos.conf/gentoo.conf pointing gentoo at https://github.com/gentoo-mirror/gentoo.git, commit signatures verified
   sync repository gentoo
+  drop getbinpkg from FEATURES in /etc/portage/make.conf when no binary package host was written
   set sys-kernel/installkernel to dracut
   accept the linux-firmware licence
   resolve net-misc/openssh sys-process/cronie sys-kernel/installkernel sys-kernel/dracut sys-kernel/linux-firmware sys-fs/dosfstools sys-fs/e2fsprogs sys-kernel/gentoo-kernel-bin sys-boot/grub sys-boot/efibootmgr together before installing the requested packages

--- a/tests/golden/vm-sdboot.txt
+++ b/tests/golden/vm-sdboot.txt
@@ -34,6 +34,7 @@
   install git, which every later repository sync needs: emerge dev-vcs/git
   write /etc/portage/repos.conf/gentoo.conf pointing gentoo at https://github.com/gentoo-mirror/gentoo.git, commit signatures verified
   sync repository gentoo
+  drop getbinpkg from FEATURES in /etc/portage/make.conf when no binary package host was written
   set sys-kernel/installkernel to dracut systemd systemd-boot
   accept the linux-firmware licence
   ask for sys-apps/systemd[boot,kernel-install], which is what provides bootctl

--- a/tests/golden/vm-shares.txt
+++ b/tests/golden/vm-shares.txt
@@ -37,6 +37,7 @@
   install git, which every later repository sync needs: emerge dev-vcs/git
   write /etc/portage/repos.conf/gentoo.conf pointing gentoo at https://github.com/gentoo-mirror/gentoo.git, commit signatures verified
   sync repository gentoo
+  drop getbinpkg from FEATURES in /etc/portage/make.conf when no binary package host was written
   set sys-kernel/installkernel to dracut
   accept the linux-firmware licence
   resolve net-misc/openssh sys-process/cronie sys-kernel/installkernel sys-kernel/dracut sys-kernel/linux-firmware sys-fs/dosfstools sys-fs/e2fsprogs sys-kernel/gentoo-kernel-bin sys-boot/grub sys-boot/efibootmgr together before installing the requested packages

--- a/tests/golden/vm-source-kernel.txt
+++ b/tests/golden/vm-source-kernel.txt
@@ -34,6 +34,7 @@
   install git, which every later repository sync needs: emerge dev-vcs/git
   write /etc/portage/repos.conf/gentoo.conf pointing gentoo at https://github.com/gentoo-mirror/gentoo.git, commit signatures verified
   sync repository gentoo
+  drop getbinpkg from FEATURES in /etc/portage/make.conf when no binary package host was written
   set sys-kernel/installkernel to dracut
   accept the linux-firmware licence
   resolve net-misc/openssh sys-process/cronie sys-kernel/installkernel sys-kernel/dracut sys-kernel/linux-firmware sys-fs/dosfstools sys-fs/e2fsprogs sys-kernel/gentoo-kernel sys-boot/grub sys-boot/efibootmgr together before installing the requested packages

--- a/tests/golden/vm-unlock.txt
+++ b/tests/golden/vm-unlock.txt
@@ -44,6 +44,7 @@
   install git, which every later repository sync needs: emerge dev-vcs/git
   write /etc/portage/repos.conf/gentoo.conf pointing gentoo at https://github.com/gentoo-mirror/gentoo.git, commit signatures verified
   sync repository gentoo
+  drop getbinpkg from FEATURES in /etc/portage/make.conf when no binary package host was written
   set sys-kernel/installkernel to dracut
   ask for sys-apps/systemd[cryptsetup], which provides the unlock generator
   accept the linux-firmware licence

--- a/tests/golden/vm-user-key.txt
+++ b/tests/golden/vm-user-key.txt
@@ -34,6 +34,7 @@
   install git, which every later repository sync needs: emerge dev-vcs/git
   write /etc/portage/repos.conf/gentoo.conf pointing gentoo at https://github.com/gentoo-mirror/gentoo.git, commit signatures verified
   sync repository gentoo
+  drop getbinpkg from FEATURES in /etc/portage/make.conf when no binary package host was written
   set sys-kernel/installkernel to dracut
   accept the linux-firmware licence
   resolve app-admin/sudo net-misc/openssh sys-process/cronie sys-kernel/installkernel sys-kernel/dracut sys-kernel/linux-firmware sys-fs/dosfstools sys-fs/xfsprogs sys-kernel/gentoo-kernel-bin sys-boot/grub sys-boot/efibootmgr together before installing the requested packages

--- a/tests/golden/vm-xfs.txt
+++ b/tests/golden/vm-xfs.txt
@@ -34,6 +34,7 @@
   install git, which every later repository sync needs: emerge dev-vcs/git
   write /etc/portage/repos.conf/gentoo.conf pointing gentoo at https://github.com/gentoo-mirror/gentoo.git, commit signatures verified
   sync repository gentoo
+  drop getbinpkg from FEATURES in /etc/portage/make.conf when no binary package host was written
   set sys-kernel/installkernel to dracut
   accept the linux-firmware licence
   resolve net-misc/openssh sys-process/cronie sys-kernel/installkernel sys-kernel/dracut sys-kernel/linux-firmware sys-fs/dosfstools sys-fs/xfsprogs sys-kernel/gentoo-kernel-bin sys-boot/grub sys-boot/efibootmgr together before installing the requested packages

--- a/tests/golden/vm-zfs-encrypted.txt
+++ b/tests/golden/vm-zfs-encrypted.txt
@@ -41,6 +41,7 @@
   write /etc/portage/repos.conf/gentoo-zh.conf pointing gentoo-zh at https://github.com/gentoo-zh/overlay.git
   sync repository gentoo-zh, 4 other sites to fall back on
   accept ~amd64 for packages from gentoo-zh only
+  drop getbinpkg from FEATURES in /etc/portage/make.conf when no binary package host was written
   set sys-kernel/installkernel to dracut, writing BOOT_ROOT=/boot to /etc/kernel/install.conf.d/50-gentoo-install.conf
   verify kernel version - against the target sys-fs/zfs ceiling
   accept the linux-firmware licence

--- a/tests/golden/vm-zfs-mirror.txt
+++ b/tests/golden/vm-zfs-mirror.txt
@@ -45,6 +45,7 @@
   write /etc/portage/repos.conf/gentoo-zh.conf pointing gentoo-zh at https://github.com/gentoo-zh/overlay.git
   sync repository gentoo-zh, 4 other sites to fall back on
   accept ~amd64 for packages from gentoo-zh only
+  drop getbinpkg from FEATURES in /etc/portage/make.conf when no binary package host was written
   set sys-kernel/installkernel to dracut, writing BOOT_ROOT=/boot to /etc/kernel/install.conf.d/50-gentoo-install.conf
   verify kernel version - against the target sys-fs/zfs ceiling
   accept the linux-firmware licence

--- a/tests/golden/vm-zfs.txt
+++ b/tests/golden/vm-zfs.txt
@@ -41,6 +41,7 @@
   write /etc/portage/repos.conf/gentoo-zh.conf pointing gentoo-zh at https://github.com/gentoo-zh/overlay.git
   sync repository gentoo-zh, 4 other sites to fall back on
   accept ~amd64 for packages from gentoo-zh only
+  drop getbinpkg from FEATURES in /etc/portage/make.conf when no binary package host was written
   set sys-kernel/installkernel to dracut, writing BOOT_ROOT=/boot to /etc/kernel/install.conf.d/50-gentoo-install.conf
   verify kernel version - against the target sys-fs/zfs ceiling
   accept the linux-firmware licence

--- a/tests/golden/vm-zram.txt
+++ b/tests/golden/vm-zram.txt
@@ -34,6 +34,7 @@
   install git, which every later repository sync needs: emerge dev-vcs/git
   write /etc/portage/repos.conf/gentoo.conf pointing gentoo at https://github.com/gentoo-mirror/gentoo.git, commit signatures verified
   sync repository gentoo
+  drop getbinpkg from FEATURES in /etc/portage/make.conf when no binary package host was written
   set sys-kernel/installkernel to dracut
   accept the linux-firmware licence
   resolve sys-apps/zram-generator net-misc/openssh sys-process/cronie sys-kernel/installkernel sys-kernel/dracut sys-kernel/linux-firmware sys-fs/dosfstools sys-fs/xfsprogs sys-kernel/gentoo-kernel-bin sys-boot/grub sys-boot/efibootmgr together before installing the requested packages

--- a/tests/golden/zbm-unlock.txt
+++ b/tests/golden/zbm-unlock.txt
@@ -43,6 +43,7 @@
   write /etc/portage/repos.conf/gentoo-zh.conf pointing gentoo-zh at https://mirrors.cernet.edu.cn/gentoo-zh.git
   sync repository gentoo-zh, 4 other sites to fall back on
   accept ~amd64 for packages from gentoo-zh only
+  drop getbinpkg from FEATURES in /etc/portage/make.conf when no binary package host was written
   set sys-kernel/installkernel to dracut, writing BOOT_ROOT=/boot to /etc/kernel/install.conf.d/50-gentoo-install.conf
   verify kernel version - against the target sys-fs/zfs ceiling
   accept the linux-firmware licence

--- a/tests/golden/zfs-zbm.txt
+++ b/tests/golden/zfs-zbm.txt
@@ -43,6 +43,7 @@
   write /etc/portage/repos.conf/gentoo-zh.conf pointing gentoo-zh at https://mirrors.cernet.edu.cn/gentoo-zh.git
   sync repository gentoo-zh, 4 other sites to fall back on
   accept ~amd64 for packages from gentoo-zh only
+  drop getbinpkg from FEATURES in /etc/portage/make.conf when no binary package host was written
   set sys-kernel/installkernel to dracut, writing BOOT_ROOT=/boot to /etc/kernel/install.conf.d/50-gentoo-install.conf
   verify kernel version - against the target sys-fs/zfs ceiling
   accept the linux-firmware licence

--- a/tests/unit/test_layers.py
+++ b/tests/unit/test_layers.py
@@ -737,6 +737,7 @@ def test_the_dry_run_names_every_file_only_its_owner_may_read() -> None:
         "GenerateLocales",
         "GrantSudo",
         "SelectLocale",
+        "SettleBinhostFeature",
         "SetHardwareClock",
         "SetHostname",
         "WriteAuthorizedKeys",

--- a/tests/unit/test_plan_portage.py
+++ b/tests/unit/test_plan_portage.py
@@ -612,6 +612,46 @@ def test_a_binhost_that_cannot_be_trusted_compiles_instead_of_stopping() -> None
     assert "--usepkg=n" in emerge and "--getbinpkg=y" not in emerge
 
 
+def test_a_host_that_is_not_written_takes_getbinpkg_with_it() -> None:
+    """`WriteMakeConf` writes `FEATURES="getbinpkg"` six operations before
+    `ConfigureBinhost` finds out whether there is a host the machine can
+    verify. When there is not, it returns without writing `binrepos.conf` --
+    and the installed system was left saying it fetches binary packages with
+    nothing naming where from."""
+    recorder = Recorder()
+    recorder.files[portage.MAKE_CONF] = (
+        'MAKEOPTS="-j4"\nFEATURES="getbinpkg"\nUSE="X"\n'
+    )
+    recorder.degrade(portage.BINARY_PACKAGES, "the index could not be read")
+
+    portage.ConfigureBinhost(name="gentoo", sync_uri="https://example/", verify=True).apply(
+        recorder
+    )
+    portage.SettleBinhostFeature(hosts=("gentoo",)).apply(recorder)
+
+    assert PurePosixPath("/etc/portage/binrepos.conf/gentoo.conf") not in recorder.files
+    written = recorder.files[portage.MAKE_CONF]
+    assert "getbinpkg" not in written, written
+    # Only that one feature, and nothing else in the file.
+    assert 'MAKEOPTS="-j4"' in written and 'USE="X"' in written, written
+
+
+def test_a_host_that_is_written_keeps_getbinpkg() -> None:
+    """Negative control: the feature belongs there whenever the host does, and
+    a degradation during the merges does not take it away -- the host is
+    configured and verified, one package simply did not arrive."""
+    recorder = Recorder()
+    recorder.files[portage.MAKE_CONF] = 'FEATURES="getbinpkg"\n'
+
+    portage.ConfigureBinhost(name="gentoo", sync_uri="https://example/", verify=True).apply(
+        recorder
+    )
+    portage.SettleBinhostFeature(hosts=("gentoo",)).apply(recorder)
+
+    assert PurePosixPath("/etc/portage/binrepos.conf/gentoo.conf") in recorder.files
+    assert "getbinpkg" in recorder.files[portage.MAKE_CONF]
+
+
 def test_a_binhost_that_can_be_trusted_is_used() -> None:
     recorder = Recorder()
     portage.PrepareBinhostTrust().apply(recorder)


### PR DESCRIPTION
`WriteMakeConf` is operation 14 and writes `FEATURES="getbinpkg"` because the configuration asks for a binary host. `ConfigureBinhost` is operation 20 and returns without writing `binrepos.conf` when the host cannot be verified — correctly, and its comment says why. The two answer the same question at different times, so a trust failure left the installed system claiming it fetches binary packages with nothing naming where from.

`SettleBinhostFeature` runs after every `ConfigureBinhost` and makes `FEATURES` agree with what they wrote. A degradation during the merges does not reach it: the host is configured and verified there, and one package did not arrive.

Found by one of seventeen parallel reviews. The first attempt put the rewrite inside `ConfigureBinhost`, which broke two repository rules at once — an operation must name every file it writes and write exactly the files it names, and that one only sometimes touches make.conf.