### PR TITLE
compat: a hash shape is not a hash crypt can produce

### DIFF
--- a/gentoo_install/model/compat.py
+++ b/gentoo_install/model/compat.py
@@ -820,10 +820,28 @@ _MODULAR_CRYPT = re.compile(
 )
 _DES_CRYPT = re.compile(r"^[./0-9A-Za-z]{13}$")
 
+#: How long the digest field is for each scheme whose length is fixed,
+#: measured with `openssl passwd` on one salt. `$6$salt$x` has the shape of a
+#: SHA-512 hash and one character where eighty-six belong, and `crypt(3)`
+#: never produces it: a configuration whose only login carried a truncated
+#: hash passed validation and installed a machine nothing could log in to,
+#: which is what `ROOT_LOCKED` exists to prevent.
+#:
+#: bcrypt, yescrypt and scrypt are absent on purpose. Their digest length is
+#: not a single fixed number, so those three keep the shape check alone rather
+#: than a length guessed at.
+_CRYPT_DIGEST_LENGTH: Final[dict[str, int]] = {"1": 22, "5": 43, "6": 86}
+
 
 def _password_can_authenticate(password_hash: str) -> bool:
-    """Whether the value has a supported crypt(3) hash shape."""
-    return bool(_MODULAR_CRYPT.fullmatch(password_hash) or _DES_CRYPT.fullmatch(password_hash))
+    """Whether the value is a crypt(3) hash something could authenticate against."""
+    if _DES_CRYPT.fullmatch(password_hash):
+        return True
+    if not _MODULAR_CRYPT.fullmatch(password_hash):
+        return False
+    scheme = password_hash.split("$")[1]
+    wanted = _CRYPT_DIGEST_LENGTH.get(scheme)
+    return wanted is None or len(password_hash.rsplit("$", 1)[-1]) == wanted
 
 
 #: The traits `traits_of` reads out of the device graph. An in-place

--- a/tests/unit/test_automatic.py
+++ b/tests/unit/test_automatic.py
@@ -531,7 +531,7 @@ def test_the_account_is_one_form_and_a_wrong_answer_keeps_the_others() -> None:
     assert user.name == "zakk"
     assert user.sudo is True
     assert user.groups == ("plugdev", "kvm")
-    assert user.password_hash == "$6$test$4"
+    assert user.password_hash == "$6$test$" + "4".ljust(86, "a")
 
 
 def test_a_name_useradd_would_refuse_is_refused_on_the_form() -> None:
@@ -584,7 +584,7 @@ def test_the_erase_row_is_not_reported_as_a_field_to_fill_in() -> None:
     at.visited.update(one.key for group in settings.SETTINGS for one in (group, *group.rows))
     ready = replace(
         config(ext4_on_gpt()),
-        system=replace(config().system, root_password_hash="$6$t$x"),
+        system=replace(config().system, root_password_hash="$6$t$" + "x" * 86),
         portage=replace(
             config().portage, mirrors=replace(config().portage.mirrors, site="tuna")
         ),

--- a/tests/unit/test_compat.py
+++ b/tests/unit/test_compat.py
@@ -536,6 +536,55 @@ def test_an_authorized_key_needs_a_daemon_and_an_account_that_can_use_it(
     }
 
 
+@pytest.mark.parametrize(
+    "password_hash",
+    [
+        # The shape of a hash and a digest field `crypt(3)` never produces:
+        # SHA-512 is 86 characters, SHA-256 is 43 and MD5 is 22, measured with
+        # `openssl passwd` on one salt. A configuration whose only login
+        # carried one of these installed a machine nothing could log in to.
+        "$6$salt$x",
+        "$6$salt$" + "a" * 85,
+        "$5$salt$" + "a" * 42,
+        "$1$salt$" + "a" * 21,
+    ],
+)
+def test_a_hash_shaped_value_that_crypt_cannot_produce_locks_the_account(
+    password_hash: str,
+) -> None:
+    installation = replace(
+        config(),
+        system=replace(config().system, root_password_hash=password_hash, users=()),
+    )
+    assert (Trait.ROOT_LOCKED, Trait.NO_OTHER_LOGIN) in {
+        (rule.when, rule.excludes) for rule in violations(installation)
+    }
+
+
+@pytest.mark.parametrize(
+    "password_hash",
+    [
+        # Produced by `openssl passwd` on this machine, so the lengths are the
+        # ones `crypt(3)` writes rather than the ones this test assumes.
+        "$6$abcdefgh$D7W7qyozKBT.t6FD3DVYHvADbIO0eSyI4.p20LaEUjro8PqTGYYo"
+        "/EQcuNjhFbzo9Yg5ir1KIEqFY/yJpgFph0",
+        "$5$abcdefgh$sI6g8tHKrJ6RX7w.YoN9B7a/5wK5jYEOMmMnt3tPl0/",
+        "$1$abcdefgh$znAnv9M.XU2pRYfmSs46h/",
+        # yescrypt has no single digest length, so it keeps the shape check
+        # alone rather than a length guessed at.
+        "$y$j9T$MnwtsK.oCEIMSXUvI08eF/$Y0Xn1KAWaEQNyEIQrICLKXpsLLBEGYq4M0EF2NTXVK5",
+    ],
+)
+def test_a_hash_crypt_really_produced_is_a_login(password_hash: str) -> None:
+    installation = replace(
+        config(),
+        system=replace(config().system, root_password_hash=password_hash, users=()),
+    )
+    assert (Trait.ROOT_LOCKED, Trait.NO_OTHER_LOGIN) not in {
+        (rule.when, rule.excludes) for rule in violations(installation)
+    }
+
+
 @pytest.mark.parametrize("password_hash", ["!", "*", "not-a-hash"])
 def test_a_nonempty_root_password_value_must_be_an_authenticating_hash(
     password_hash: str,

--- a/tests/unit/test_plan_system.py
+++ b/tests/unit/test_plan_system.py
@@ -350,7 +350,7 @@ def test_declining_sudo_in_the_menu_keeps_the_account_out_of_wheel() -> None:
         translate=Catalog("en"),
         disks=[("/dev/disk/by-id/virtio-target0", "20 GiB")],
         groups=load_catalog(),
-        hash_password=lambda password: "$6$t$x",
+        hash_password=lambda password: "$6$t$" + "x" * 86,
     )
     # One form: name, the password twice, sudo left unticked, then Done.
     keys = [

--- a/tests/unit/test_random_configurations.py
+++ b/tests/unit/test_random_configurations.py
@@ -134,8 +134,8 @@ def a_configuration() -> InstallConfig:
             console_cjk=cjk and random.random() < 0.7,
             zram=random.choice((None, Size.parse("4GiB"))),
             sshd=random.choice((True, False)),
-            users=random.choice(((), (User(name="zakk", sudo=True, password_hash="$6$t$x"),))),
-            root_password_hash="$6$t$x",
+            users=random.choice(((), (User(name="zakk", sudo=True, password_hash="$6$t$" + "x" * 86),))),
+            root_password_hash="$6$t$" + "x" * 86,
         ),
         portage=PortageConfig(
             profile="default/linux/amd64/23.0"

--- a/tests/unit/test_tui_app.py
+++ b/tests/unit/test_tui_app.py
@@ -83,7 +83,7 @@ def context() -> tui_context.Context:
         translate=Catalog("en"),
         disks=DISKS,
         groups=load_catalog(),
-        hash_password=lambda password: f"$6$test${len(password)}",
+        hash_password=lambda password: "$6$test$" + str(len(password)).ljust(86, "a"),
         stage_passphrase=staged,
         timezones=("UTC", "Asia/Shanghai", "Asia/Taipei", "Europe/London"),
         # The rows that offer a share of memory have nothing to offer at zero,
@@ -260,7 +260,7 @@ def test_install_hands_back_the_configuration() -> None:
     )
     ready = replace(
         config(),
-        system=replace(config().system, root_password_hash="$6$test$x"),
+        system=replace(config().system, root_password_hash="$6$test$" + "x" * 86),
         portage=replace(config().portage, mirrors=replace(config().portage.mirrors, site="osuosl")),
     )
     # The Install row opens the overview: enter leaves the operation list, and
@@ -291,7 +291,7 @@ def test_the_install_row_shows_every_operation_before_it_starts() -> None:
     )
     ready = replace(
         config(),
-        system=replace(config().system, root_password_hash="$6$test$x"),
+        system=replace(config().system, root_password_hash="$6$test$" + "x" * 86),
         portage=replace(config().portage, mirrors=replace(config().portage.mirrors, site="osuosl")),
     )
     # Enter leaves the overview, then No, which returns to the menu.
@@ -2400,7 +2400,7 @@ def test_a_password_is_typed_twice_before_it_is_hashed() -> None:
         "KEY_DOWN", *"first", "\n", "\n",
     ]
     answer = screens.root_password_screen(FakeScreen(keys=keys, lines=24), config(), at)
-    assert answer.unwrap().system.root_password_hash == "$6$test$5"
+    assert answer.unwrap().system.root_password_hash == "$6$test$" + "5".ljust(86, "a")
 
     # One form: the two passwords differ, so it redraws with a message and the
     # name is still there. Down to the second field, fix it, then Done.
@@ -2410,7 +2410,7 @@ def test_a_password_is_typed_twice_before_it_is_hashed() -> None:
     ]
     made = screens.user_screen(FakeScreen(keys=account, lines=24, columns=100), config(), at)
     user = made.unwrap().system.users[0]
-    assert user.name == "zakk" and user.password_hash == "$6$test$4"
+    assert user.name == "zakk" and user.password_hash == "$6$test$" + "4".ljust(86, "a")
 
 
 def test_the_keyboard_layout_is_picked_from_what_the_machine_ships() -> None:
@@ -2563,7 +2563,7 @@ def test_a_detected_row_has_to_be_opened_and_not_only_filled_in() -> None:
     at.confirmed = {one.selector for one in compat.destroyed(config().disk.graph)}
     ready = replace(
         config(),
-        system=replace(config().system, root_password_hash="$6$test$x"),
+        system=replace(config().system, root_password_hash="$6$test$" + "x" * 86),
         portage=replace(config().portage, mirrors=replace(config().portage.mirrors, site="osuosl")),
     )
     # The group itself counts when nothing behind it is required: `Compiler`
@@ -3804,7 +3804,7 @@ def test_the_password_fields_are_one_form_the_arrows_move_between() -> None:
         "KEY_DOWN", "\n", "\n",
     ]
     answer = screens.root_password_screen(FakeScreen(keys=keys, lines=24), config(), at)
-    assert answer.unwrap().system.root_password_hash == "$6$test$5"
+    assert answer.unwrap().system.root_password_hash == "$6$test$" + "5".ljust(86, "a")
 
     # Nothing typed leaves the row alone rather than asking for ever.
     away = screens.root_password_screen(
@@ -3865,7 +3865,7 @@ def test_the_conversion_is_not_offered_when_the_machine_refuses_it() -> None:
         translate=Catalog("en"),
         disks=DISKS,
         groups=load_catalog(),
-        hash_password=lambda password: f"$6$test${len(password)}",
+        hash_password=lambda password: "$6$test$" + str(len(password)).ljust(86, "a"),
         conversion_refused=Refusal("this is a live medium (gentoo.iso), so there is no system to replace"),
         running_system="",
     ))
@@ -3881,7 +3881,7 @@ def test_the_conversion_is_not_offered_when_the_machine_refuses_it() -> None:
         translate=Catalog("en"),
         disks=DISKS,
         groups=load_catalog(),
-        hash_password=lambda password: f"$6$test${len(password)}",
+        hash_password=lambda password: "$6$test$" + str(len(password)).ljust(86, "a"),
         conversion_refused=Refusal(""),
         running_system="/dev/vda2 on ext4",
     ))
@@ -3897,7 +3897,7 @@ def test_the_conversion_is_not_offered_when_the_machine_refuses_it() -> None:
         translate=Catalog("en"),
         disks=DISKS,
         groups=load_catalog(),
-        hash_password=lambda password: f"$6$test${len(password)}",
+        hash_password=lambda password: "$6$test$" + str(len(password)).ljust(86, "a"),
     )
     assert blank.conversion_refused, "an unread machine is not a convertible one"
 
@@ -3915,7 +3915,7 @@ def test_choosing_the_conversion_drops_the_device_graph() -> None:
         translate=Catalog("en"),
         disks=DISKS,
         groups=load_catalog(),
-        hash_password=lambda password: f"$6$test${len(password)}",
+        hash_password=lambda password: "$6$test$" + str(len(password)).ljust(86, "a"),
         conversion_refused=Refusal(""),
         running_system="/dev/vda2 on ext4",
     ))
@@ -3959,7 +3959,7 @@ def test_the_swap_screen_names_the_word_it_asks_for() -> None:
         translate=Catalog("en"),
         disks=DISKS,
         groups=load_catalog(),
-        hash_password=lambda password: f"$6$test${len(password)}",
+        hash_password=lambda password: "$6$test$" + str(len(password)).ljust(86, "a"),
         conversion_refused=Refusal(""),
         running_system="/dev/vda2 on ext4",
     ))
@@ -3976,7 +3976,7 @@ def test_dd_mode_is_offered_only_from_a_live_or_memory_environment() -> None:
             translate=Catalog("en"),
             disks=DISKS,
             groups=load_catalog(),
-            hash_password=lambda password: f"$6$test${len(password)}",
+            hash_password=lambda password: "$6$test$" + str(len(password)).ljust(86, "a"),
             conversion_refused=Refusal("the running system was not read"),
         )
     )
@@ -3989,7 +3989,7 @@ def test_dd_mode_is_offered_only_from_a_live_or_memory_environment() -> None:
             translate=Catalog("en"),
             disks=DISKS,
             groups=load_catalog(),
-            hash_password=lambda password: f"$6$test${len(password)}",
+            hash_password=lambda password: "$6$test$" + str(len(password)).ljust(86, "a"),
             conversion_refused=Refusal("the running system was not read"),
             image_write_refused=Refusal(""),
         )
@@ -4463,7 +4463,7 @@ def test_every_row_answers_after_the_conversion_is_confirmed() -> None:
         translate=Catalog("en"),
         disks=DISKS,
         groups=load_catalog(),
-        hash_password=lambda password: f"$6$test${len(password)}",
+        hash_password=lambda password: "$6$test$" + str(len(password)).ljust(86, "a"),
         conversion_refused=Refusal(""),
         running_system="/dev/vda2 on btrfs",
     )
@@ -4502,7 +4502,7 @@ def test_a_conversion_can_reach_its_install_row() -> None:
         translate=Catalog("en"),
         disks=DISKS,
         groups=load_catalog(),
-        hash_password=lambda password: f"$6$test${len(password)}",
+        hash_password=lambda password: "$6$test$" + str(len(password)).ljust(86, "a"),
         conversion_refused=Refusal(""),
         running_system="/dev/vda2 on btrfs",
     ))
@@ -4537,7 +4537,7 @@ def test_a_refused_row_is_not_drawn_as_an_answer_somebody_owes() -> None:
         translate=Catalog("en"),
         disks=DISKS,
         groups=load_catalog(),
-        hash_password=lambda password: f"$6$test${len(password)}",
+        hash_password=lambda password: "$6$test$" + str(len(password)).ljust(86, "a"),
         conversion_refused=Refusal(""),
         running_system="/dev/vda2 on btrfs",
     ))
@@ -4582,7 +4582,7 @@ def test_the_install_row_derives_a_conversion_from_the_machine(
         translate=Catalog("en"),
         disks=DISKS,
         groups=load_catalog(),
-        hash_password=lambda password: f"$6$test${len(password)}",
+        hash_password=lambda password: "$6$test$" + str(len(password)).ljust(86, "a"),
         conversion_refused=Refusal(""),
         running_system="/dev/vda2 on xfs",
         running_layout=reading,
@@ -4599,7 +4599,7 @@ def test_the_install_row_derives_a_conversion_from_the_machine(
     # and never reaches the plan.
     converted = replace(
         converted,
-        system=replace(converted.system, root_password_hash="$6$test$x"),
+        system=replace(converted.system, root_password_hash="$6$test$" + "x" * 86),
         # A mirror chosen rather than detected, the way `Mirrors` is answered.
         portage=replace(
             converted.portage, mirrors=replace(converted.portage.mirrors, site="tuna")

--- a/tests/unit/test_tui_curses.py
+++ b/tests/unit/test_tui_curses.py
@@ -387,7 +387,7 @@ def main(window):
         translate=Catalog("en"),
         disks=[("/dev/disk/by-id/virtio-target0", "40 GiB")],
         groups=load_catalog(),
-        hash_password=lambda password: "$6$test$" + str(len(password)),
+        hash_password=lambda password: "$6$test$" + str(len(password)).ljust(86, "a"),
         timezones=("UTC",),
     ))
     # What an operator does by opening each row and typing the disk name. The


### PR DESCRIPTION
`_password_can_authenticate` checked only the shape of a modular crypt string: a supported scheme identifier and non-empty fields after it. `$6$salt$x` passes, and `crypt(3)` never produces it — the SHA-512 digest field is eighty-six characters.

That is exactly what `ROOT_LOCKED` and `NO_OTHER_LOGIN` exist to prevent: a configuration whose root hash was truncated or mistyped, with no other account and no `authorized_keys`, passed validation, exited `0`, and left a machine with no way in.

The three schemes whose digest length is fixed are in a table, measured with `openssl passwd` on one salt: MD5 22, SHA-256 43, SHA-512 86. bcrypt, yescrypt and scrypt are absent on purpose — their geometry is not one number, so they keep the shape check rather than a length guessed at.

Several test fakes produced `$6$test$4`, a hash of that impossible shape; they now produce a digest of the length `crypt(3)` writes.

Found by one of seventeen parallel reviews.