### PR TITLE
plan, exec: a command that could not run is not an answer

### DIFF
--- a/gentoo_install/exec/apply.py
+++ b/gentoo_install/exec/apply.py
@@ -30,7 +30,7 @@ from ..model.device import (
     VolumeGroup,
 )
 from ..log import Journal
-from ..plan.disk import STAGE3_CACHE
+from ..plan.disk import FINDMNT_ANSWERED, STAGE3_CACHE
 from ..plan.operations import CommandOutput, Operation
 from . import fetch, packages
 from .preflight import SecretStore
@@ -236,7 +236,14 @@ class Machine:
         return what in self.given_up
 
     def is_mounted(self, path: str) -> bool:
-        return self.runner.run(["findmnt", "--mountpoint", path], check=False).returncode == 0
+        # `plan/disk.py` refuses to read a failed probe as unmounted, and this is
+        # the third reader of the same rule rather than a second answer to it.
+        found = self.runner.run(["findmnt", "--mountpoint", path], check=False)
+        if found.returncode not in FINDMNT_ANSWERED:
+            raise CommandFailed(
+                f"whether {path} is mounted could not be read: {found.stdout.strip()[:200]}"
+            )
+        return found.returncode == 0
 
     def swap_directories(
         self,

--- a/gentoo_install/plan/disk.py
+++ b/gentoo_install/plan/disk.py
@@ -163,7 +163,7 @@ class ReleaseTarget(Operation):
         # 1 is `findmnt` saying the path is not a mountpoint; anything else is
         # the probe failing, and reading that as unmounted skipped the lazy
         # unmount and let the wipe run against a target still mounted.
-        if found.returncode not in _FINDMNT_ANSWERED:
+        if found.returncode not in FINDMNT_ANSWERED:
             raise CommandFailed(
                 f"whether {path} is mounted could not be read: {str(found).strip()[:200]}"
             )
@@ -751,6 +751,15 @@ class VerifySubvolume(Operation):
             # the same name is not a subvolume and mounting `subvol=` on it fails
             # at the mount rather than here.
             listed = context.run(["btrfs", "subvolume", "list", str(scratch)], check=False)
+            if not isinstance(listed, CommandOutput):
+                raise CommandFailed(f"cannot list the subvolumes of {self.device}")
+            # A failed listing has no subvolume in it either, so reading the two
+            # as one answer reported a reused subvolume as absent.
+            if listed.returncode != 0:
+                raise CommandFailed(
+                    f"the subvolumes of {self.device} could not be read: "
+                    f"{str(listed).strip()[:200]}"
+                )
             wanted = self.name.lstrip("/")
             if not any(
                 line.rsplit(" path ", 1)[-1].strip() == wanted for line in listed.splitlines()
@@ -1104,7 +1113,7 @@ class UnmountTarget(Operation):
             raise CommandFailed(
                 f"whether {context.target} is mounted could not be read"
             )
-        if found.returncode not in _FINDMNT_ANSWERED:
+        if found.returncode not in FINDMNT_ANSWERED:
             raise CommandFailed(
                 f"whether {context.target} is mounted could not be read: "
                 f"{str(found).strip()[:200]}"
@@ -1609,7 +1618,7 @@ def _expect(graph: DeviceGraph, device: DeviceId, kind: type[T]) -> T:
 #: Every other code is the probe failing, which is a different answer: the
 #: rule is written out at `MountFilesystem`, and the two cleanup readers had
 #: it as `returncode == 0`.
-_FINDMNT_ANSWERED: Final[tuple[int, ...]] = (0, 1)
+FINDMNT_ANSWERED: Final[tuple[int, ...]] = (0, 1)
 
 
 def _under(target: PurePosixPath, path: PurePosixPath) -> PurePosixPath:

--- a/gentoo_install/plan/kernel.py
+++ b/gentoo_install/plan/kernel.py
@@ -14,7 +14,13 @@ from typing import Final
 
 from ..model.architecture import DEFAULT_ARCHITECTURE, Architecture
 from ..model.config import Bootloader, InitSystem, InstallConfig, KernelSource
-from ..errors import ConfigError, ConversionUnsupported, NothingToBoot, ValidationFailed
+from ..errors import (
+    CommandFailed,
+    ConfigError,
+    ConversionUnsupported,
+    NothingToBoot,
+    ValidationFailed,
+)
 from ..model import compat
 from ..model.compat import CJK_KERNELS, KERNEL_PACKAGES
 from ..model.hardware import HardwareFacts
@@ -30,7 +36,7 @@ from ..model.device import (
 )
 from .bootloader import array_parameters, boot_facts, keymap_parameters, luks_parameters
 from .bootloader import GenerateHostId
-from .operations import Context, Operation, Stage
+from .operations import CommandOutput, Context, Operation, Stage
 from .portage import (
     Emerge,
     InstallMode,
@@ -42,6 +48,10 @@ from .bootloader import VerifyPackageUse
 
 #: Filesystems whose driver dracut only includes when asked.
 FILESYSTEM_MODULES: Final[dict[FilesystemType, str]] = {FilesystemType.BTRFS: "btrfs"}
+
+#: `test` answers 0 for true and 1 for false. A chroot that could not run it
+#: answers 126 or 127, which is not an answer about the file.
+TEST_ANSWERED: Final[tuple[int, ...]] = (0, 1)
 
 #: Early unlocking over ssh. It is `~amd64`, and its RDEPEND brings dropbear
 #: and one of the network managers dracut's network module can drive.
@@ -612,7 +622,16 @@ class RequireKernelImage(Operation):
         root, image, initramfs = fields[7], fields[8], fields[9]
         for path in (f"{root}/{image}", f"{root}/{initramfs}"):
             found = context.run_in_target(["test", "-s", path], check=False)
-            if not getattr(found, "returncode", 1) == 0:
+            if not isinstance(found, CommandOutput):
+                raise CommandFailed(f"whether {path} exists could not be read")
+            # `test` answers 1 for absent or empty and nothing else; 126 and 127
+            # are the chroot failing, and reading those as absent named an image
+            # that is there as the reason there is nothing to boot.
+            if found.returncode not in TEST_ANSWERED:
+                raise CommandFailed(
+                    f"whether {path} exists could not be read: {str(found).strip()[:200]}"
+                )
+            if found.returncode != 0:
                 raise NothingToBoot(f"installkernel payload names missing image {path}")
 
 

--- a/tests/unit/test_exec.py
+++ b/tests/unit/test_exec.py
@@ -3138,3 +3138,65 @@ def test_the_bios_target_is_not_written_a_second_time() -> None:
             if isinstance(node, ast.Constant) and isinstance(node.value, str):
                 for one in targets:
                     assert one not in node.value, f"{path}:{node.lineno} writes {one!r}"
+
+
+def test_a_findmnt_that_could_not_run_is_not_read_as_unmounted(tmp_path: Path) -> None:
+    """`plan/disk.py` already refuses to read a failed probe as unmounted. This
+    is the third reader of the same rule, and reading 2 as `not mounted` mounted
+    a second filesystem over one that was already there."""
+    from gentoo_install.plan.disk import Mount
+
+    class Broken(Runner):
+        def __init__(self) -> None:
+            super().__init__(log=lambda line: None)
+
+        def run(
+            self,
+            argv: Sequence[str],
+            *,
+            check: bool = True,
+            input_text: str | None = None,
+            timeout: float | None = None,
+        ) -> Result:
+            return Result(
+                argv=tuple(argv),
+                returncode=2 if argv[0] == "findmnt" else 0,
+                stdout="findmnt: bad usage" if argv[0] == "findmnt" else "",
+                stderr="",
+                seconds=0.0,
+            )
+
+    answering = Broken()
+    machine = apply.Machine(
+        config=config(),
+        runner=answering,
+        probe=Probe(runner=answering, work=tmp_path),
+        work=tmp_path,
+    )
+
+    with pytest.raises(CommandFailed, match="could not be read"):
+        machine.is_mounted("/mnt/gentoo")
+
+
+def test_a_path_component_that_is_a_file_is_not_read_as_an_absent_file(
+    tmp_path: Path,
+) -> None:
+    """`read` answers empty for a file the stage3 has not unpacked yet. A target
+    whose `/etc/portage` is a regular file is broken, and the same empty string
+    would have let `merge` write a make.conf over it."""
+    runner = Runner(log=lambda line: None)
+    machine = apply.Machine(
+        config=config(),
+        runner=runner,
+        probe=Probe(runner=runner, work=tmp_path),
+        work=tmp_path,
+        mountpoint=tmp_path,
+    )
+    (tmp_path / "etc").mkdir()
+    (tmp_path / "etc" / "portage").write_text("not a directory\n")
+
+    from gentoo_install.errors import TargetEscape
+
+    assert machine.read(PurePosixPath("/etc/absent")) == ""
+    with pytest.raises(TargetEscape, match="not a directory in the target"):
+        machine.read(PurePosixPath("/etc/portage/make.conf"))

--- a/tests/unit/test_plan_boot.py
+++ b/tests/unit/test_plan_boot.py
@@ -7,7 +7,12 @@ from typing import Sequence
 
 import pytest
 
-from gentoo_install.errors import ConfigError, NothingToBoot, ValidationFailed
+from gentoo_install.errors import (
+    CommandFailed,
+    ConfigError,
+    NothingToBoot,
+    ValidationFailed,
+)
 
 from gentoo_install.model.config import (
     Bootloader,
@@ -1258,3 +1263,19 @@ def test_one_token_names_both_efi_files() -> None:
             for one in others:
                 assert f"BOOT{one.upper()}.EFI" not in node.value, f"{path}:{node.lineno}"
                 assert f"linux{one}.efi.stub" not in node.value, f"{path}:{node.lineno}"
+
+
+def test_a_test_that_could_not_run_is_not_read_as_a_missing_image() -> None:
+    """`test` answers 1 for absent and nothing else. A chroot that could not run
+    it answers 127, and reading that as absent stopped the install naming an
+    image that is on the disk."""
+    recorder = Recorder(
+        answering=lambda argv: CommandOutput("", 127) if argv[0] == "test" else None
+    )
+    recorder.files[PurePosixPath("/var/lib/misc/installkernel")] = (
+        "date\tsystemd\t6.18.41-gentoo-dist-bin\tx\tcompat\tdracut\tnone\t"
+        "/boot\tvmlinuz\tinitramfs.img\tnotset\n"
+    )
+
+    with pytest.raises(CommandFailed, match="could not be read"):
+        kernel.RequireKernelImage().apply(recorder)

--- a/tests/unit/test_plan_disk.py
+++ b/tests/unit/test_plan_disk.py
@@ -1595,3 +1595,22 @@ def test_a_pool_nothing_will_release_says_what_the_machine_knows(
     # risk of this change is that improving the message turns into forcing
     # the export, which is what the operation refuses to do on purpose.
     assert "-f" not in said, said
+
+
+def test_a_subvolume_listing_that_failed_is_not_read_as_an_absent_subvolume() -> None:
+    """`btrfs subvolume list` answering non-zero produces no line either, so
+    reading the two as one answer named a reused subvolume as missing and sent
+    the operator to look for a subvolume that is there."""
+    recorder = Recorder(
+        answering=lambda argv: (
+            CommandOutput("ERROR: not a btrfs filesystem", 1)
+            if argv[:2] == ["btrfs", "subvolume"]
+            else None
+        )
+    )
+    operation = disk.VerifySubvolume(
+        subvolume=i("root-subvolume"), device=i("root"), name="@"
+    )
+
+    with pytest.raises(CommandFailed, match="could not be read"):
+        operation.apply(recorder)


### PR DESCRIPTION
Three readers gave a failed probe the same value as a negative answer.

`exec/apply.py`'s `is_mounted` read any non-zero `findmnt` as unmounted, while `plan/disk.py` already refuses that with `FINDMNT_ANSWERED`; the constant is now public and there is one table rather than two answers. `VerifySubvolume` ran `btrfs subvolume list` with `check=False` and searched only the output, so a failed listing reported a reused subvolume as absent. `RequireKernelImage` read `test` answering 126 or 127 as a missing image and stopped the install naming a file that is on the disk.

Each of the three has a test that drives the operation, and each control was run red.