### PR TITLE
cli: ask every mirror of the region before refusing to start

### DIFF
--- a/gentoo_install/cli.py
+++ b/gentoo_install/cli.py
@@ -1060,17 +1060,34 @@ def _require_network() -> None:
     refused = fetch.why_offline()
     if not refused:
         return
-    if fetch.mirror_online(DEFAULT_MIRROR, DEFAULT_VARIANT):
+    answering = _a_mirror_that_answers()
+    if answering:
         print(
             "warning: packages.gentoo.org did not answer, so the version rows "
-            f"offer only what the keywords allow ({refused})",
+            f"offer only what the keywords allow ({refused}); {answering} answers",
             file=sys.stderr,
         )
         return
     raise errors.PreflightFailed(
-        "this machine reaches neither packages.gentoo.org nor "
-        f"{DEFAULT_MIRROR}, so no install can fetch a stage3: {refused}"
+        "this machine reaches neither packages.gentoo.org nor any mirror this "
+        f"installer offers, so no install can fetch a stage3: {refused}"
     )
+
+
+def _a_mirror_that_answers() -> str:
+    """The name of the first mirror that serves a stage3, or an empty string.
+
+    Every site of the region, not `DEFAULT_MIRROR` alone: a machine in China
+    that cannot reach `distfiles.gentoo.org` was refused at the first screen
+    with USTC one row away, which is the same refusal the comment above records
+    for `packages.gentoo.org`.
+    """
+    if fetch.mirror_online(DEFAULT_MIRROR, DEFAULT_VARIANT):
+        return DEFAULT_MIRROR
+    for site in mirrors.gentoo_sites(_region(fetch.egress_country())):
+        if site.releases and fetch.mirror_online(site.distfiles, DEFAULT_VARIANT):
+            return site.distfiles
+    return ""
 
 
 def _conversion_offer(

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -2791,3 +2791,34 @@ def test_the_menu_walk_is_wrapped_in_the_quiet(tmp_path: Path) -> None:
         if isinstance(node, ast.Call)
     }
     assert "kernel_messages_held" in called, sorted(called)
+
+
+def test_a_mirror_of_the_region_opens_the_menu_when_the_default_one_is_blocked(
+    capsys: pytest.CaptureFixture[str], monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A machine in China reaches USTC and not `distfiles.gentoo.org`, and
+    refusing there stopped an install the first mirror row would have run."""
+    interactive_stdin(monkeypatch)
+    monkeypatch.setattr(os, "geteuid", lambda: 0)
+    online(monkeypatch, False, said="HTTP Error 503")
+    monkeypatch.setattr(fetch, "egress_country", lambda *a, **k: "CN")
+    monkeypatch.setattr(
+        fetch,
+        "mirror_online",
+        lambda mirror, *a, **k: mirror == "https://mirrors.ustc.edu.cn/gentoo",
+    )
+
+    assert cli._a_mirror_that_answers() == "https://mirrors.ustc.edu.cn/gentoo"
+    cli._require_network()
+    assert "mirrors.ustc.edu.cn" in capsys.readouterr().err
+
+
+def test_no_mirror_of_the_region_answering_still_refuses(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    online(monkeypatch, False, said="HTTP Error 503")
+    monkeypatch.setattr(fetch, "egress_country", lambda *a, **k: "CN")
+    monkeypatch.setattr(fetch, "mirror_online", lambda *a, **k: False)
+
+    with pytest.raises(errors.PreflightFailed, match="nor any mirror"):
+        cli._require_network()


### PR DESCRIPTION
The interactive path ran `_require_network()` before the menu derived a region, and that check asked `distfiles.gentoo.org` alone. A machine in China that cannot reach it was refused at the first screen with USTC one row away, which is the same refusal the comment above the check already records for `packages.gentoo.org`.

It now asks the default mirror first, then every site of the region the egress country implies, and names the one that answered. Two tests drive `_require_network()`: one where only USTC answers, one where nothing does. The control was run red.