### PR TITLE
bootloader: make the plan agree with what the machine gets

### DIFF
--- a/gentoo_install/plan/bootloader.py
+++ b/gentoo_install/plan/bootloader.py
@@ -162,7 +162,7 @@ class InstallGrub(Operation):
     write_nvram: bool = True
 
     def describe(self) -> str:
-        if self.esp is not None:
+        if self.firmware is Firmware.UEFI and self.esp is not None:
             return f"install GRUB for {self.firmware.value} on the esp at {self.esp}"
         # Every disk, not "the boot disk": the BIOS branch writes a boot sector
         # to the containing disk of each boot device, and a mirrored root has
@@ -253,13 +253,28 @@ class WriteGrubDefaults(Operation):
     keymap: str = ""
 
     def describe(self) -> str:
+        required: list[str] = []
+        if self.luks:
+            containers = ", ".join(str(device) for device in self.luks)
+            required.append(f"rd.luks.uuid from LUKS containers {containers}")
+        if self.arrays:
+            arrays = ", ".join(str(device) for device in self.arrays)
+            required.append(f"rd.md.uuid from arrays {arrays}")
+        if self.keymap:
+            required.append(f"rd.vconsole.keymap={self.keymap}")
         extra = []
         if self.cryptodisk:
             extra.append("cryptodisk enabled")
         if self.serial is not None:
             extra.append(f"its menu on {self.serial[0]}")
         listed = f", {' and '.join(extra)}" if extra else ""
-        return f"write /etc/default/grub with cmdline {' '.join(self.kernel_params) or 'empty'}{listed}"
+        default = " ".join(self.kernel_params) or "empty"
+        needed = " and ".join(required) or "empty"
+        return (
+            "write /etc/default/grub with "
+            f"GRUB_CMDLINE_LINUX_DEFAULT {default} and "
+            f"GRUB_CMDLINE_LINUX {needed}{listed}"
+        )
 
     def apply(self, context: Context) -> None:
         # `GRUB_CMDLINE_LINUX` reaches every entry and `_DEFAULT` only the
@@ -331,12 +346,22 @@ class RequestBootctl(Operation):
 class InstallSystemdBoot(Operation):
     stage: Stage = Stage.BOOTLOADER
     esp: PurePosixPath
+    write_nvram: bool = True
 
     def describe(self) -> str:
-        return f"install systemd-boot on the esp at {self.esp}"
+        entry = (
+            "and request an efi boot entry"
+            if self.write_nvram
+            else "without writing an efi boot entry"
+        )
+        return f"install systemd-boot on the esp at {self.esp} {entry}"
 
     def apply(self, context: Context) -> None:
-        context.run_in_target(["bootctl", f"--esp-path={self.esp}", "install"])
+        command = ["bootctl", f"--esp-path={self.esp}"]
+        if self.write_nvram:
+            _try_the_nvram_entry(context, [*command, "install"])
+        else:
+            context.run_in_target([*command, "--no-variables", "install"])
 
 
 @dataclass(frozen=True, kw_only=True)
@@ -633,7 +658,7 @@ def build(config: InstallConfig) -> list[Operation]:
                 summary="install bootctl",
                 mode=InstallMode.NOREPLACE,
             ),
-            InstallSystemdBoot(esp=esp),
+            InstallSystemdBoot(esp=esp, write_nvram=write_nvram),
             ShowTheBootMenu(esp=esp),
         ]
     elif kind is Bootloader.ZFSBOOTMENU and esp is not None and esp_device is not None:
@@ -833,11 +858,17 @@ def serial_console(config: InstallConfig) -> tuple[str, int] | None:
     for parameter in config.bootloader.kernel_params:
         if not parameter.startswith("console=ttyS"):
             continue
-        port, _, rest = parameter.split("=", 1)[1].partition(",")
+        port, separator, rest = parameter.split("=", 1)[1].partition(",")
+        # `serial8250_console_setup` starts at `int baud = 9600` and parses the
+        # options only when there are any, so a bare `console=ttyS0` is 9600n8.
+        if not separator:
+            return port, 9600
         # The leading run only: `115200n8` names the speed and then the frame
         # format, and taking every digit made that 1152008 baud.
         speed = re.match(r"\d+", rest)
-        return port, int(speed.group()) if speed else 115200
+        if speed is None:
+            raise ConfigError(f"{parameter!r} needs a decimal baud rate after the comma")
+        return port, int(speed.group())
     return None
 
 

--- a/tests/golden/btrfs-luks.txt
+++ b/tests/golden/btrfs-luks.txt
@@ -94,7 +94,7 @@
 
 [bootloader]
   install the bootloader: emerge sys-boot/grub sys-boot/efibootmgr
-  write /etc/default/grub with cmdline console=ttyS0,115200, cryptodisk enabled and its menu on ttyS0
+  write /etc/default/grub with GRUB_CMDLINE_LINUX_DEFAULT console=ttyS0,115200 and GRUB_CMDLINE_LINUX rd.luks.uuid from LUKS containers cryptroot, cryptodisk enabled and its menu on ttyS0
   install GRUB for uefi on the esp at /efi
 
 [packages]

--- a/tests/golden/ext2.txt
+++ b/tests/golden/ext2.txt
@@ -63,7 +63,7 @@
 
 [bootloader]
   install the bootloader: emerge sys-boot/grub, with no binhost
-  write /etc/default/grub with cmdline console=ttyS0,115200, its menu on ttyS0
+  write /etc/default/grub with GRUB_CMDLINE_LINUX_DEFAULT console=ttyS0,115200 and GRUB_CMDLINE_LINUX empty, its menu on ttyS0
   install GRUB for bios on the disk under disk
 
 [finish]

--- a/tests/golden/ext3.txt
+++ b/tests/golden/ext3.txt
@@ -63,7 +63,7 @@
 
 [bootloader]
   install the bootloader: emerge sys-boot/grub, with no binhost
-  write /etc/default/grub with cmdline console=ttyS0,115200, its menu on ttyS0
+  write /etc/default/grub with GRUB_CMDLINE_LINUX_DEFAULT console=ttyS0,115200 and GRUB_CMDLINE_LINUX empty, its menu on ttyS0
   install GRUB for bios on the disk under disk
 
 [finish]

--- a/tests/golden/ext4-bios.txt
+++ b/tests/golden/ext4-bios.txt
@@ -63,7 +63,7 @@
 
 [bootloader]
   install the bootloader: emerge sys-boot/grub, with no binhost
-  write /etc/default/grub with cmdline console=ttyS0,115200, its menu on ttyS0
+  write /etc/default/grub with GRUB_CMDLINE_LINUX_DEFAULT console=ttyS0,115200 and GRUB_CMDLINE_LINUX empty, its menu on ttyS0
   install GRUB for bios on the disk under disk
 
 [finish]

--- a/tests/golden/mbr-edit.txt
+++ b/tests/golden/mbr-edit.txt
@@ -64,7 +64,7 @@
 
 [bootloader]
   install the bootloader: emerge sys-boot/grub
-  write /etc/default/grub with cmdline console=ttyS0,115200, its menu on ttyS0
+  write /etc/default/grub with GRUB_CMDLINE_LINUX_DEFAULT console=ttyS0,115200 and GRUB_CMDLINE_LINUX empty, its menu on ttyS0
   install GRUB for bios on the disk under disk
 
 [finish]

--- a/tests/golden/openrc-sdboot.txt
+++ b/tests/golden/openrc-sdboot.txt
@@ -70,7 +70,7 @@
 
 [bootloader]
   install bootctl: emerge sys-apps/systemd-utils
-  install systemd-boot on the esp at /boot
+  install systemd-boot on the esp at /boot and request an efi boot entry
   show the boot menu for 5s in /boot/loader/loader.conf
 
 [finish]

--- a/tests/golden/static-ip.txt
+++ b/tests/golden/static-ip.txt
@@ -65,7 +65,7 @@
 
 [bootloader]
   install the bootloader: emerge sys-boot/grub sys-boot/efibootmgr
-  write /etc/default/grub with cmdline console=ttyS0,115200, its menu on ttyS0
+  write /etc/default/grub with GRUB_CMDLINE_LINUX_DEFAULT console=ttyS0,115200 and GRUB_CMDLINE_LINUX empty, its menu on ttyS0
   install GRUB for uefi on the esp at /efi
 
 [finish]

--- a/tests/golden/vm-binhost-fallback.txt
+++ b/tests/golden/vm-binhost-fallback.txt
@@ -67,7 +67,7 @@
 
 [bootloader]
   install the bootloader: emerge sys-boot/grub sys-boot/efibootmgr
-  write /etc/default/grub with cmdline console=ttyS0,115200, its menu on ttyS0
+  write /etc/default/grub with GRUB_CMDLINE_LINUX_DEFAULT console=ttyS0,115200 and GRUB_CMDLINE_LINUX empty, its menu on ttyS0
   install GRUB for uefi on the esp at /efi
 
 [finish]

--- a/tests/golden/vm-binpkg.txt
+++ b/tests/golden/vm-binpkg.txt
@@ -69,7 +69,7 @@
 
 [bootloader]
   install the bootloader: emerge sys-boot/grub sys-boot/efibootmgr
-  write /etc/default/grub with cmdline console=ttyS0,115200, its menu on ttyS0
+  write /etc/default/grub with GRUB_CMDLINE_LINUX_DEFAULT console=ttyS0,115200 and GRUB_CMDLINE_LINUX empty, its menu on ttyS0
   install GRUB for uefi on the esp at /efi
 
 [finish]

--- a/tests/golden/vm-bios-luks.txt
+++ b/tests/golden/vm-bios-luks.txt
@@ -73,7 +73,7 @@
 
 [bootloader]
   install the bootloader: emerge sys-boot/grub
-  write /etc/default/grub with cmdline console=ttyS0,115200, cryptodisk enabled and its menu on ttyS0
+  write /etc/default/grub with GRUB_CMDLINE_LINUX_DEFAULT console=ttyS0,115200 and GRUB_CMDLINE_LINUX rd.luks.uuid from LUKS containers rootpart, cryptodisk enabled and its menu on ttyS0
   install GRUB for bios on the disk under disk
 
 [finish]

--- a/tests/golden/vm-bios.txt
+++ b/tests/golden/vm-bios.txt
@@ -67,7 +67,7 @@
 
 [bootloader]
   install the bootloader: emerge sys-boot/grub
-  write /etc/default/grub with cmdline console=ttyS0,115200, its menu on ttyS0
+  write /etc/default/grub with GRUB_CMDLINE_LINUX_DEFAULT console=ttyS0,115200 and GRUB_CMDLINE_LINUX empty, its menu on ttyS0
   install GRUB for bios on the disk under disk
 
 [finish]

--- a/tests/golden/vm-btrfs.txt
+++ b/tests/golden/vm-btrfs.txt
@@ -69,7 +69,7 @@
 
 [bootloader]
   install the bootloader: emerge sys-boot/grub sys-boot/efibootmgr
-  write /etc/default/grub with cmdline console=ttyS0,115200, its menu on ttyS0
+  write /etc/default/grub with GRUB_CMDLINE_LINUX_DEFAULT console=ttyS0,115200 and GRUB_CMDLINE_LINUX empty, its menu on ttyS0
   install GRUB for uefi on the esp at /efi
 
 [finish]

--- a/tests/golden/vm-cjk-kernel.txt
+++ b/tests/golden/vm-cjk-kernel.txt
@@ -70,7 +70,7 @@
 
 [bootloader]
   install the bootloader: emerge sys-boot/grub sys-boot/efibootmgr
-  write /etc/default/grub with cmdline console=ttyS0,115200, its menu on ttyS0
+  write /etc/default/grub with GRUB_CMDLINE_LINUX_DEFAULT console=ttyS0,115200 and GRUB_CMDLINE_LINUX empty, its menu on ttyS0
   install GRUB for uefi on the esp at /efi
 
 [finish]

--- a/tests/golden/vm-convert.txt
+++ b/tests/golden/vm-convert.txt
@@ -55,7 +55,7 @@
 
 [bootloader]
   install the bootloader: emerge sys-boot/grub sys-boot/efibootmgr, in /gentoo-install.new
-  write /etc/default/grub with cmdline console=ttyS0,115200, its menu on ttyS0, in /gentoo-install.new
+  write /etc/default/grub with GRUB_CMDLINE_LINUX_DEFAULT console=ttyS0,115200 and GRUB_CMDLINE_LINUX empty, its menu on ttyS0, in /gentoo-install.new
   atomically swap /bin, /sbin, /etc, /lib, /lib64, /usr, /var from /gentoo-install.new
   put the kernel from /gentoo-install.new/boot into /boot and drop the old images
   install GRUB for uefi on the esp at /efi

--- a/tests/golden/vm-desktop.txt
+++ b/tests/golden/vm-desktop.txt
@@ -72,7 +72,7 @@
 
 [bootloader]
   install the bootloader: emerge sys-boot/grub sys-boot/efibootmgr
-  write /etc/default/grub with cmdline console=ttyS0,115200, its menu on ttyS0
+  write /etc/default/grub with GRUB_CMDLINE_LINUX_DEFAULT console=ttyS0,115200 and GRUB_CMDLINE_LINUX empty, its menu on ttyS0
   install GRUB for uefi on the esp at /efi
 
 [packages]

--- a/tests/golden/vm-f2fs.txt
+++ b/tests/golden/vm-f2fs.txt
@@ -69,7 +69,7 @@
 
 [bootloader]
   install the bootloader: emerge sys-boot/grub sys-boot/efibootmgr
-  write /etc/default/grub with cmdline console=ttyS0,115200, its menu on ttyS0
+  write /etc/default/grub with GRUB_CMDLINE_LINUX_DEFAULT console=ttyS0,115200 and GRUB_CMDLINE_LINUX empty, its menu on ttyS0
   install GRUB for uefi on the esp at /efi
 
 [finish]

--- a/tests/golden/vm-gnome.txt
+++ b/tests/golden/vm-gnome.txt
@@ -71,7 +71,7 @@
 
 [bootloader]
   install the bootloader: emerge sys-boot/grub sys-boot/efibootmgr
-  write /etc/default/grub with cmdline console=ttyS0,115200, its menu on ttyS0
+  write /etc/default/grub with GRUB_CMDLINE_LINUX_DEFAULT console=ttyS0,115200 and GRUB_CMDLINE_LINUX empty, its menu on ttyS0
   install GRUB for uefi on the esp at /efi
 
 [packages]

--- a/tests/golden/vm-greetd.txt
+++ b/tests/golden/vm-greetd.txt
@@ -71,7 +71,7 @@
 
 [bootloader]
   install the bootloader: emerge sys-boot/grub sys-boot/efibootmgr
-  write /etc/default/grub with cmdline console=ttyS0,115200, its menu on ttyS0
+  write /etc/default/grub with GRUB_CMDLINE_LINUX_DEFAULT console=ttyS0,115200 and GRUB_CMDLINE_LINUX empty, its menu on ttyS0
   install GRUB for uefi on the esp at /efi
 
 [packages]

--- a/tests/golden/vm-home-key.txt
+++ b/tests/golden/vm-home-key.txt
@@ -77,7 +77,7 @@
 
 [bootloader]
   install the bootloader: emerge sys-boot/grub sys-boot/efibootmgr
-  write /etc/default/grub with cmdline console=ttyS0,115200, its menu on ttyS0
+  write /etc/default/grub with GRUB_CMDLINE_LINUX_DEFAULT console=ttyS0,115200 and GRUB_CMDLINE_LINUX empty, its menu on ttyS0
   install GRUB for uefi on the esp at /efi
 
 [finish]

--- a/tests/golden/vm-image.txt
+++ b/tests/golden/vm-image.txt
@@ -66,7 +66,7 @@
 
 [bootloader]
   install the bootloader: emerge sys-boot/grub
-  write /etc/default/grub with cmdline console=ttyS0,115200, its menu on ttyS0
+  write /etc/default/grub with GRUB_CMDLINE_LINUX_DEFAULT console=ttyS0,115200 and GRUB_CMDLINE_LINUX empty, its menu on ttyS0
   install GRUB for uefi on the esp at /efi
 
 [finish]

--- a/tests/golden/vm-luks.txt
+++ b/tests/golden/vm-luks.txt
@@ -76,7 +76,7 @@
 
 [bootloader]
   install the bootloader: emerge sys-boot/grub sys-boot/efibootmgr
-  write /etc/default/grub with cmdline console=ttyS0,115200, cryptodisk enabled and its menu on ttyS0
+  write /etc/default/grub with GRUB_CMDLINE_LINUX_DEFAULT console=ttyS0,115200 and GRUB_CMDLINE_LINUX rd.luks.uuid from LUKS containers cryptroot, cryptodisk enabled and its menu on ttyS0
   install GRUB for uefi on the esp at /efi
 
 [finish]

--- a/tests/golden/vm-lvm.txt
+++ b/tests/golden/vm-lvm.txt
@@ -79,7 +79,7 @@
 
 [bootloader]
   install the bootloader: emerge sys-boot/grub sys-boot/efibootmgr
-  write /etc/default/grub with cmdline console=ttyS0,115200, its menu on ttyS0
+  write /etc/default/grub with GRUB_CMDLINE_LINUX_DEFAULT console=ttyS0,115200 and GRUB_CMDLINE_LINUX empty, its menu on ttyS0
   install GRUB for uefi on the esp at /efi
 
 [packages]

--- a/tests/golden/vm-mdraid.txt
+++ b/tests/golden/vm-mdraid.txt
@@ -75,7 +75,7 @@
 
 [bootloader]
   install the bootloader: emerge sys-boot/grub sys-boot/efibootmgr
-  write /etc/default/grub with cmdline console=ttyS0,115200, its menu on ttyS0
+  write /etc/default/grub with GRUB_CMDLINE_LINUX_DEFAULT console=ttyS0,115200 and GRUB_CMDLINE_LINUX rd.md.uuid from arrays array, its menu on ttyS0
   install GRUB for uefi on the esp at /efi
 
 [finish]

--- a/tests/golden/vm-openrc-desktop.txt
+++ b/tests/golden/vm-openrc-desktop.txt
@@ -75,7 +75,7 @@
 
 [bootloader]
   install the bootloader: emerge sys-boot/grub sys-boot/efibootmgr
-  write /etc/default/grub with cmdline console=ttyS0,115200, its menu on ttyS0
+  write /etc/default/grub with GRUB_CMDLINE_LINUX_DEFAULT console=ttyS0,115200 and GRUB_CMDLINE_LINUX empty, its menu on ttyS0
   install GRUB for uefi on the esp at /efi
 
 [packages]

--- a/tests/golden/vm-proxy-dead.txt
+++ b/tests/golden/vm-proxy-dead.txt
@@ -70,7 +70,7 @@
 
 [bootloader]
   install the bootloader: emerge sys-boot/grub sys-boot/efibootmgr
-  write /etc/default/grub with cmdline console=ttyS0,115200, its menu on ttyS0
+  write /etc/default/grub with GRUB_CMDLINE_LINUX_DEFAULT console=ttyS0,115200 and GRUB_CMDLINE_LINUX empty, its menu on ttyS0
   install GRUB for uefi on the esp at /efi
 
 [finish]

--- a/tests/golden/vm-proxy-http.txt
+++ b/tests/golden/vm-proxy-http.txt
@@ -70,7 +70,7 @@
 
 [bootloader]
   install the bootloader: emerge sys-boot/grub sys-boot/efibootmgr
-  write /etc/default/grub with cmdline console=ttyS0,115200, its menu on ttyS0
+  write /etc/default/grub with GRUB_CMDLINE_LINUX_DEFAULT console=ttyS0,115200 and GRUB_CMDLINE_LINUX empty, its menu on ttyS0
   install GRUB for uefi on the esp at /efi
 
 [finish]

--- a/tests/golden/vm-proxy.txt
+++ b/tests/golden/vm-proxy.txt
@@ -70,7 +70,7 @@
 
 [bootloader]
   install the bootloader: emerge sys-boot/grub sys-boot/efibootmgr
-  write /etc/default/grub with cmdline console=ttyS0,115200, its menu on ttyS0
+  write /etc/default/grub with GRUB_CMDLINE_LINUX_DEFAULT console=ttyS0,115200 and GRUB_CMDLINE_LINUX empty, its menu on ttyS0
   install GRUB for uefi on the esp at /efi
 
 [finish]

--- a/tests/golden/vm-ram.txt
+++ b/tests/golden/vm-ram.txt
@@ -69,7 +69,7 @@
 
 [bootloader]
   install the bootloader: emerge sys-boot/grub sys-boot/efibootmgr
-  write /etc/default/grub with cmdline console=ttyS0,115200, its menu on ttyS0
+  write /etc/default/grub with GRUB_CMDLINE_LINUX_DEFAULT console=ttyS0,115200 and GRUB_CMDLINE_LINUX empty, its menu on ttyS0
   install GRUB for uefi on the esp at /efi
 
 [finish]

--- a/tests/golden/vm-sdboot.txt
+++ b/tests/golden/vm-sdboot.txt
@@ -67,7 +67,7 @@
 
 [bootloader]
   install bootctl: emerge sys-apps/systemd
-  install systemd-boot on the esp at /boot
+  install systemd-boot on the esp at /boot and request an efi boot entry
   show the boot menu for 5s in /boot/loader/loader.conf
 
 [finish]

--- a/tests/golden/vm-shares.txt
+++ b/tests/golden/vm-shares.txt
@@ -72,7 +72,7 @@
 
 [bootloader]
   install the bootloader: emerge sys-boot/grub sys-boot/efibootmgr
-  write /etc/default/grub with cmdline console=ttyS0,115200, its menu on ttyS0
+  write /etc/default/grub with GRUB_CMDLINE_LINUX_DEFAULT console=ttyS0,115200 and GRUB_CMDLINE_LINUX empty, its menu on ttyS0
   install GRUB for uefi on the esp at /efi
 
 [finish]

--- a/tests/golden/vm-source-kernel.txt
+++ b/tests/golden/vm-source-kernel.txt
@@ -69,7 +69,7 @@
 
 [bootloader]
   install the bootloader: emerge sys-boot/grub sys-boot/efibootmgr
-  write /etc/default/grub with cmdline console=ttyS0,115200, its menu on ttyS0
+  write /etc/default/grub with GRUB_CMDLINE_LINUX_DEFAULT console=ttyS0,115200 and GRUB_CMDLINE_LINUX empty, its menu on ttyS0
   install GRUB for uefi on the esp at /efi
 
 [finish]

--- a/tests/golden/vm-unlock.txt
+++ b/tests/golden/vm-unlock.txt
@@ -87,7 +87,7 @@
 
 [bootloader]
   install the bootloader: emerge sys-boot/grub sys-boot/efibootmgr
-  write /etc/default/grub with cmdline rd.neednet=1 ip=192.0.2.10::192.0.2.1:255.255.255.0::eth0:none console=ttyS0,115200, its menu on ttyS0
+  write /etc/default/grub with GRUB_CMDLINE_LINUX_DEFAULT rd.neednet=1 ip=192.0.2.10::192.0.2.1:255.255.255.0::eth0:none console=ttyS0,115200 and GRUB_CMDLINE_LINUX rd.luks.uuid from LUKS containers cryptroot, its menu on ttyS0
   install GRUB for uefi on the esp at /efi
 
 [finish]

--- a/tests/golden/vm-user-key.txt
+++ b/tests/golden/vm-user-key.txt
@@ -73,7 +73,7 @@
 
 [bootloader]
   install the bootloader: emerge sys-boot/grub sys-boot/efibootmgr
-  write /etc/default/grub with cmdline console=ttyS0,115200, its menu on ttyS0
+  write /etc/default/grub with GRUB_CMDLINE_LINUX_DEFAULT console=ttyS0,115200 and GRUB_CMDLINE_LINUX empty, its menu on ttyS0
   install GRUB for uefi on the esp at /efi
 
 [finish]

--- a/tests/golden/vm-xfs.txt
+++ b/tests/golden/vm-xfs.txt
@@ -69,7 +69,7 @@
 
 [bootloader]
   install the bootloader: emerge sys-boot/grub sys-boot/efibootmgr
-  write /etc/default/grub with cmdline console=ttyS0,115200, its menu on ttyS0
+  write /etc/default/grub with GRUB_CMDLINE_LINUX_DEFAULT console=ttyS0,115200 and GRUB_CMDLINE_LINUX empty, its menu on ttyS0
   install GRUB for uefi on the esp at /efi
 
 [finish]

--- a/tests/golden/vm-zram.txt
+++ b/tests/golden/vm-zram.txt
@@ -71,7 +71,7 @@
 
 [bootloader]
   install the bootloader: emerge sys-boot/grub sys-boot/efibootmgr
-  write /etc/default/grub with cmdline console=ttyS0,115200, its menu on ttyS0
+  write /etc/default/grub with GRUB_CMDLINE_LINUX_DEFAULT console=ttyS0,115200 and GRUB_CMDLINE_LINUX empty, its menu on ttyS0
   install GRUB for uefi on the esp at /efi
 
 [finish]

--- a/tests/unit/test_plan_bootloader.py
+++ b/tests/unit/test_plan_bootloader.py
@@ -8,6 +8,7 @@ from pathlib import Path, PurePosixPath
 from typing import Sequence, cast
 
 from gentoo_install.exec.config import load
+from gentoo_install.model.architecture import DEFAULT_ARCHITECTURE
 from gentoo_install.model.config import (
     Bootloader, BootloaderConfig, DiskMode, Firmware, InstallConfig, RemoteUnlock
 )
@@ -619,3 +620,117 @@ def test_the_zfsbootmenu_describe_changes_with_the_command_line_it_will_set() ->
 
     empty = replace(operation, kernel_params=())
     assert "empty" in empty.describe(), empty.describe()
+
+
+@pytest.mark.parametrize(
+    "fixture",
+    ("tests/fixtures/vm-btrfs.toml", "tests/fixtures/zbm-unlock.toml"),
+)
+def test_serial_console_uses_kernel_default_or_rejects_garbage(fixture: str) -> None:
+    from gentoo_install.errors import ConfigError
+
+    installation = load(Path(fixture))
+    no_speed = replace(
+        installation,
+        bootloader=replace(installation.bootloader, kernel_params=("console=ttyS0",)),
+    )
+    operations = bootloader.build(no_speed)
+    serial = next(
+        operation.serial
+        for operation in operations
+        if isinstance(
+            operation, (bootloader.WriteGrubDefaults, bootloader.InstallZfsBootMenu)
+        )
+    )
+    assert serial == ("ttyS0", 9600)
+
+    malformed = replace(
+        no_speed,
+        bootloader=replace(no_speed.bootloader, kernel_params=("console=ttyS0,garbage",)),
+    )
+    with pytest.raises(ConfigError, match="decimal baud rate"):
+        bootloader.build(malformed)
+
+
+def test_systemd_boot_image_skips_nvram_and_firmware_failure_degrades() -> None:
+    installation = load(Path("tests/fixtures/vm-sdboot.toml"))
+    image = replace(
+        installation,
+        disk=replace(
+            installation.disk,
+            mode=DiskMode.IMAGE,
+            image="/var/tmp/target.raw",
+            size=Size.parse("20GiB"),
+        ),
+    )
+    image_operations = bootloader.build(image)
+    image_bootctl = next(
+        operation
+        for operation in image_operations
+        if isinstance(operation, bootloader.InstallSystemdBoot)
+    )
+    assert not image_bootctl.write_nvram
+    assert "without writing an efi boot entry" in image_bootctl.describe()
+
+    image_recorder = Recorder()
+    image_bootctl.apply(image_recorder)
+    assert "--no-variables" in image_recorder.only("bootctl")
+
+    bootctl = next(
+        operation
+        for operation in bootloader.build(installation)
+        if isinstance(operation, bootloader.InstallSystemdBoot)
+    )
+    assert bootctl.write_nvram
+    refused = Recorder(failures={"bootctl"})
+    bootctl.apply(refused)
+    assert refused.degraded(bootloader.NVRAM_ENTRY)
+
+
+def test_grub_description_names_context_resolved_luks_parameters() -> None:
+    installation = load(Path("tests/fixtures/vm-luks.toml"))
+    without_configured_params = replace(
+        installation,
+        bootloader=replace(installation.bootloader, kernel_params=()),
+    )
+    operations = bootloader.build(without_configured_params)
+    defaults = next(
+        operation
+        for operation in operations
+        if isinstance(operation, bootloader.WriteGrubDefaults)
+    )
+    said = defaults.describe()
+    assert "GRUB_CMDLINE_LINUX_DEFAULT empty" in said
+    assert "rd.luks.uuid" in said
+    assert "cryptroot" in said
+
+    recorder = Recorder()
+    defaults.apply(recorder)
+    written = recorder.files[PurePosixPath("/etc/default/grub")]
+    assert 'GRUB_CMDLINE_LINUX="rd.luks.uuid=uuid-of-cryptroot"' in written
+    assert "uuid-of-cryptroot" not in said
+
+
+def test_bios_grub_description_uses_disk_path_despite_mounted_esp() -> None:
+    installation = load(Path("tests/fixtures/vm-btrfs.toml"))
+    bios = replace(
+        installation,
+        bootloader=BootloaderConfig(kind=Bootloader.GRUB, firmware=Firmware.BIOS),
+    )
+    operations = bootloader.build(bios)
+    grub = next(
+        operation
+        for operation in operations
+        if isinstance(operation, bootloader.InstallGrub)
+    )
+    assert grub.esp == PurePosixPath("/efi")
+    said = grub.describe()
+    assert "/efi" not in said
+    assert "bios" in said
+    assert "disk" in said
+
+    recorder = Recorder(replies={"grep": "1"})
+    grub.apply(recorder)
+    assert recorder.argv_starting(
+        "grub-install", f"--target={DEFAULT_ARCHITECTURE.bios_target}"
+    ) == (("grub-install", "--target=i386-pc", "/dev/vda"),)


### PR DESCRIPTION
Four readers in `plan/bootloader.py` disagreed with what the operation gives the machine.

`InstallGrub.describe()` named the esp whenever one was mounted, while `apply()` takes the UEFI branch only for `Firmware.UEFI`, so a BIOS install said `/boot/efi` and wrote the MBR. `WriteGrubDefaults.describe()` reported `cmdline empty` for a config with no kernel parameters while writing `GRUB_CMDLINE_LINUX="rd.luks.uuid=..."`. `InstallSystemdBoot` ignored `write_nvram`, so building a disk image wrote an EFI boot entry into the building machine — GRUB and ZFSBootMenu already honour it and degrade on refusal. `console=ttyS0` with no speed configured the menu at 115200; `serial8250_console_setup` starts at `int baud = 9600` and parses options only when there are any.

Each of the four has a test that builds a config, calls `bootloader.build()` and asserts on the operation list; each control was run red. Goldens regenerated in the same commit.