### PR TITLE
model: refuse input its destination cannot carry

### DIFF
--- a/gentoo_install/i18n.py
+++ b/gentoo_install/i18n.py
@@ -94,6 +94,14 @@ class Catalog:
         for key, value in strings.items():
             if not isinstance(value, str):
                 raise ConfigError(f"{path}: {key} is not a string")
+            control = next(
+                (character for character in value if unicodedata.category(character) == "Cc"),
+                None,
+            )
+            if control is not None:
+                raise ConfigError(
+                    f"{path}: {key} contains control character U+{ord(control):04X}"
+                )
         return {str(key): str(value) for key, value in strings.items()}
 
 

--- a/gentoo_install/model/atoms.py
+++ b/gentoo_install/model/atoms.py
@@ -15,8 +15,21 @@ from typing import Final
 #: `category/name`, with the optional trailing `:slot` and `::repository` that
 #: portage accepts. A leading version operator is deliberately not allowed: it
 #: needs a version too, and the interface asks for a package.
+_CATEGORY: Final[str] = r"[a-z0-9][a-z0-9+._-]*"
+_PACKAGE: Final[str] = r"[a-zA-Z0-9+._-]+"
+#: Portage's own, from `versions.py`, plus its optional revision. A name
+#: ending in one of these is a versioned atom with no operator, which
+#: `isvalidatom` refuses and `emerge --pretend` stops the install over.
+_VERSION: Final[str] = (
+    r"\d+(?:\.\d+)*[a-z]?(?:_(?:pre|p|beta|alpha|rc)\d*)*(?:-r\d+)?"
+)
+#: One optional subslot, the way `slot_re` in portage's `dep/__init__.py`
+#: builds it: `sys-libs/zlib:0/1/2` is an `InvalidAtom` there.
+_SLOT: Final[str] = r":[a-zA-Z0-9+._-]+(?:/[a-zA-Z0-9+._-]+)?"
+_REPOSITORY: Final[str] = r"::[a-zA-Z0-9_-]+"
 _ATOM: Final[re.Pattern[str]] = re.compile(
-    r"^[a-z0-9][a-z0-9+._-]*/[a-zA-Z0-9+._-]+(:[a-zA-Z0-9+._/-]+)?(::[a-zA-Z0-9_-]+)?$"
+    rf"^{_CATEGORY}/(?!{_PACKAGE}-{_VERSION}(?=:|$)){_PACKAGE}"
+    rf"(?:{_SLOT})?(?:{_REPOSITORY})?$"
 )
 
 

--- a/gentoo_install/model/compat.py
+++ b/gentoo_install/model/compat.py
@@ -143,6 +143,18 @@ def port_problem(what: str, port: int) -> str:
     return f"{what} must be between {PORTS.start} and {PORTS.stop - 1}"
 
 
+def curl_config_character_problem(value: str) -> str | None:
+    """The first credential character an unescaped curl config cannot preserve."""
+    for character in value:
+        if ord(character) < 0x20 or ord(character) == 0x7F:
+            return f"control character U+{ord(character):04X}"
+        if character == '"':
+            return "a double quote"
+        if character == "\\":
+            return "a backslash"
+    return None
+
+
 def system_network_problems(system: SystemConfig) -> tuple[InputProblem, ...]:
     """Network values that leave a static system without usable name resolution or routing."""
     addresses = tuple(_parse_ip_interface(one) for one in system.addresses)

--- a/gentoo_install/model/parse.py
+++ b/gentoo_install/model/parse.py
@@ -15,6 +15,7 @@ from typing import Any, Final, Mapping, Sequence, TypeVar
 from decimal import Decimal
 
 from ..errors import ConfigError, InvalidSize
+from . import compat
 from . import config as model_config
 from . import sshkey
 from . import templates
@@ -121,8 +122,9 @@ def _proxy(raw: Mapping[str, Any], at: str) -> ProxyConfig:
     port = _int(raw, "port", at, default.port)
     username = _str(raw, "username", at, default.username)
     password = _str(raw, "password", at, default.password)
-    if any(ord(char) < 0x20 or ord(char) == 0x7F for char in password):
-        raise ConfigError(f"{_at('password', at)} contains control characters")
+    for field, value in (("username", username), ("password", password)):
+        if refused := compat.curl_config_character_problem(value):
+            raise ConfigError(f"{_at(field, at)} contains {refused}")
     if host and any(char.isspace() for char in host):
         raise ConfigError(f"{_at('host', at)} must not contain spaces")
     if port < 0 or port > 65535:

--- a/gentoo_install/model/validate.py
+++ b/gentoo_install/model/validate.py
@@ -403,8 +403,9 @@ def _proxy_problems(config: InstallConfig) -> list[str]:
         return [refused]
     if any(char.isspace() for char in proxy.host):
         return ["proxy host must not contain spaces"]
-    if any(ord(char) < 0x20 or ord(char) == 0x7F for char in proxy.password):
-        return ["proxy password contains control characters"]
+    for field, value in (("username", proxy.username), ("password", proxy.password)):
+        if character_problem := compat.curl_config_character_problem(value):
+            return [f"proxy {field} contains {character_problem}"]
     if any(not item.strip() or any(char.isspace() for char in item) for item in proxy.bypass):
         return ["proxy bypass hosts must be non-empty host names"]
     return []

--- a/tests/unit/test_i18n.py
+++ b/tests/unit/test_i18n.py
@@ -66,6 +66,12 @@ def test_a_broken_catalog_is_named_rather_than_ignored(tmp_path: Path) -> None:
         Catalog("xx", tmp_path)("Disks")
 
 
+def test_a_catalog_value_with_a_control_character_names_its_key(tmp_path: Path) -> None:
+    (tmp_path / "xx.toml").write_text('[strings]\nDisks = "broken\\nline"\n')
+    with pytest.raises(ConfigError, match="Disks.*control character"):
+        Catalog("xx", tmp_path)("Disks")
+
+
 def test_every_shipped_catalog_translates_the_same_keys() -> None:
     """A key in one catalog and not the other is a screen that changes language
     halfway down."""

--- a/tests/unit/test_parse.py
+++ b/tests/unit/test_parse.py
@@ -2,6 +2,7 @@
 from __future__ import annotations
 
 import tomllib
+import re
 from pathlib import Path
 from typing import Any
 
@@ -172,10 +173,28 @@ def test_proxy_kind_rejects_unsupported_values(scheme: str) -> None:
         parse(raw)
 
 
-def test_proxy_password_rejects_control_characters() -> None:
+@pytest.mark.parametrize(
+    ("field", "value", "character"),
+    (
+        ("username", 'operator"quote', "double quote"),
+        ("username", r"operator\slash", "backslash"),
+        ("username", "operator\ncontrol", "control character U+000A"),
+        ("password", 'p"q', "double quote"),
+        ("password", r"password\slash", "backslash"),
+        ("password", "password\ncontrol", "control character U+000A"),
+    ),
+)
+def test_proxy_credentials_reject_curl_config_characters(
+    field: str, value: str, character: str
+) -> None:
     raw = fixture()
-    raw["proxy"] = {"kind": "http", "host": "proxy.example", "port": 8080, "password": "bad\npass"}
-    with pytest.raises(ConfigError, match="password.*control"):
+    raw["proxy"] = {
+        "kind": "http",
+        "host": "proxy.example",
+        "port": 8080,
+        field: value,
+    }
+    with pytest.raises(ConfigError, match=rf"{field}.*{re.escape(character)}"):
         parse(raw)
 
 

--- a/tests/unit/test_tui_app.py
+++ b/tests/unit/test_tui_app.py
@@ -364,6 +364,37 @@ def test_invalid_extra_package_dialog_cancellation_reaches_caller() -> None:
     assert answer.outcome is Outcome.CANCELLED
 
 
+def test_extra_package_screen_rejects_operatorless_versioned_atom() -> None:
+    base = config()
+    permissive = replace(base, portage=replace(base.portage, accept_license=("*",)))
+    rejected = tui_packages.extra_packages_screen(
+        FakeScreen(keys=[*"sys-apps/portage-3.0.64", "\n", "q"]), permissive, context()
+    )
+    assert rejected.outcome is Outcome.CANCELLED
+
+    # No leading operator either, which is the decision already written above
+    # the pattern: an operator needs a version and this screen asks for a
+    # package.
+    with_operator = tui_packages.extra_packages_screen(
+        FakeScreen(keys=[*">=sys-apps/portage-3.0.64", "\n", "q"]), permissive, context()
+    )
+    assert with_operator.outcome is Outcome.CANCELLED
+
+
+def test_extra_package_screen_rejects_multiple_slot_separators() -> None:
+    base = config()
+    permissive = replace(base, portage=replace(base.portage, accept_license=("*",)))
+    rejected = tui_packages.extra_packages_screen(
+        FakeScreen(keys=[*"sys-libs/zlib:0/1/2", "\n", "q"]), permissive, context()
+    )
+    assert rejected.outcome is Outcome.CANCELLED
+
+    accepted = tui_packages.extra_packages_screen(
+        FakeScreen(keys=[*"sys-libs/zlib:0/1", "\n"]), permissive, context()
+    )
+    assert accepted.unwrap().packages.extra == ("sys-libs/zlib:0/1",)
+
+
 def test_timezone_back_reopens_area_and_escape_leaves_both() -> None:
     changed = screens.timezone_screen(
         FakeScreen(keys=["\n", "KEY_LEFT", "KEY_DOWN", "\n", "\n"]),

--- a/tests/unit/test_validate.py
+++ b/tests/unit/test_validate.py
@@ -2,6 +2,7 @@
 from __future__ import annotations
 
 import ipaddress
+import re
 import tomllib
 from dataclasses import FrozenInstanceError, replace
 from pathlib import Path, PurePosixPath
@@ -239,6 +240,36 @@ def test_a_broken_proxy_is_refused_in_dd_mode_too() -> None:
         proxy=ProxyConfig(kind=ProxyKind.HTTP, host="proxy.example", port=3128),
     )
     validate(working)
+
+
+@pytest.mark.parametrize(
+    ("username", "password", "field", "character"),
+    (
+        ('operator"quote', "", "username", "double quote"),
+        (r"operator\slash", "", "username", "backslash"),
+        ("operator\ncontrol", "", "username", "control character U+000A"),
+        ("", 'p"q', "password", "double quote"),
+        ("", r"password\slash", "password", "backslash"),
+        ("", "password\ncontrol", "password", "control character U+000A"),
+    ),
+)
+def test_proxy_credentials_reject_curl_config_characters(
+    username: str, password: str, field: str, character: str
+) -> None:
+    from gentoo_install.model.config import ProxyConfig, ProxyKind
+
+    broken = replace(
+        config(),
+        proxy=ProxyConfig(
+            kind=ProxyKind.HTTP,
+            host="proxy.example",
+            port=3128,
+            username=username,
+            password=password,
+        ),
+    )
+    with pytest.raises(ValidationFailed, match=rf"{field}.*{re.escape(character)}"):
+        validate(broken)
 
 
 def test_the_profile_probe_reads_current_amd64_paths(tmp_path: Path) -> None:


### PR DESCRIPTION
Three values passed the screen that typed them and stopped something an hour later.

`atoms.py` accepted `sys-apps/portage-3.0.64` and `sys-libs/zlib:0/1/2`; portage answers `InvalidAtom` for both, so the install reached `VerifyPackages` and stopped there. The version pattern is portage's own from `versions.py`, and the slot allows the one optional subslot `slot_re` builds. A leading operator stays refused, which is the decision already written above the pattern.

`compat.py` gains the one rule for what a curl config line can carry, read by both `parse.py` and `validate.py`: `password = 'p"q'` was written unescaped into `proxy-user` and curl parsed it as `p`.

`i18n.py` refuses a catalog value holding a control character, naming the key: such a value reached `curses.addstr` and broke the frame.

Each of the four has a test that drives the real call point, and each control was run red.