### PR TITLE
serialise: redact the key file path in both writers, not one

### DIFF
--- a/gentoo_install/model/serialise.py
+++ b/gentoo_install/model/serialise.py
@@ -164,7 +164,7 @@ class _Nothing:
 _NOTHING: Final[_Nothing] = _Nothing()
 
 
-def _simple(choice: Choice) -> list[str]:
+def _simple(choice: Choice, *, publishing: bool = False) -> list[str]:
     """A whole-disk template, with every field the default already covers left
     out: an omitted key reads as `whatever this installer does by default`."""
     against = Choice(disk=choice.disk)
@@ -174,6 +174,9 @@ def _simple(choice: Choice) -> list[str]:
             continue
         held = getattr(choice, field.name)
         if held == getattr(against, field.name):
+            continue
+        if publishing and field.name in NOT_FOR_A_PASTE:
+            lines.append(f"{field.name} = {_value(REDACTED)}")
             continue
         lines.append(f"{field.name} = {_value(held)}")
     return lines
@@ -192,7 +195,12 @@ def _disk(config: InstallConfig, *, publishing: bool = False) -> list[str]:
     if disk.simple is not None:
         # `simple` reconstructs graph and root; writing both is a rejected duplicate.
         # Its eight fields replace the graph's sixty for a hand-edited file.
-        return [*lines, "", "[disk.simple]", *_simple(disk.simple)]
+        return [
+            *lines,
+            "",
+            "[disk.simple]",
+            *_simple(disk.simple, publishing=publishing),
+        ]
     if disk.root:
         lines.append(f"root = {_value(disk.root)}")
     for node in disk.graph.nodes.values():

--- a/tests/unit/test_serialise.py
+++ b/tests/unit/test_serialise.py
@@ -2,7 +2,7 @@
 from __future__ import annotations
 
 import tomllib
-from typing import Iterator, cast
+from typing import Final, Iterator, cast
 from dataclasses import MISSING, fields, is_dataclass, replace
 from pathlib import Path
 
@@ -373,32 +373,60 @@ def test_every_node_field_the_writer_emits_is_a_key_its_parser_accepts() -> None
         assert spelled, (held.__name__, name)
 
 
-def test_a_published_configuration_redacts_the_key_file_path() -> None:
-    """`_disk` took no `publishing` flag, so the whole device section bypassed
-    the redaction that `_section` applies.
+SIMPLE_WITH_A_KEY_FILE: Final[str] = """
+[disk.simple]
+disk = "/dev/sda"
+layout = "whole-disk"
+passphrase_file = "/run/gentoo-install-keys/root.key"
+"""
 
-    The field holds a path rather than the key, which is why it looked
-    harmless — but it names where key material sits on the installing machine,
+
+def _every_configuration_that_names_a_key_file() -> list[tuple[str, InstallConfig]]:
+    """One per writer, found rather than listed.
+
+    `_simple` and the graph loop are two writers of the same field, and the
+    hand-written pair this test used to hold covered only the graph one, which
+    is how `[disk.simple]` published a real key file path for a year.
+    """
+    found = [("[disk.simple]", parse(tomllib.loads(SIMPLE_WITH_A_KEY_FILE)))]
+    for path in sorted(FIXTURES.glob("*.toml")):
+        config = parse(tomllib.loads(path.read_text()))
+        if "passphrase_file" in to_toml(config):
+            found.append((path.stem, config))
+    return found
+
+
+NAMES_A_KEY_FILE: Final[list[tuple[str, InstallConfig]]] = (
+    _every_configuration_that_names_a_key_file()
+)
+
+
+@pytest.mark.parametrize(
+    "name, config", NAMES_A_KEY_FILE, ids=[one for one, _ in NAMES_A_KEY_FILE]
+)
+def test_a_published_configuration_redacts_the_key_file_path(
+    name: str, config: InstallConfig
+) -> None:
+    """The field holds a path rather than the key, which is why it looked
+    harmless -- but it names where key material sits on the installing machine,
     and a hand-written configuration points it wherever the operator keeps
     keys. `publishing=True` has one caller, the pastebin upload in
     `exec/report.py`, so nothing that needs the real path ever sees this form.
     """
-    for name in ("vm-luks", "vm-zfs-encrypted"):
-        config = parse(tomllib.loads((FIXTURES / f"{name}.toml").read_text()))
-        saved = to_toml(config)
-        published = to_toml(config, publishing=True)
+    saved = to_toml(config)
+    published = to_toml(config, publishing=True)
 
-        held = [one for one in saved.splitlines() if "passphrase_file" in one]
-        assert held, f"{name} carries no key file to redact"
-        assert all("/run/" in one for one in held), held
+    held = [one for one in saved.splitlines() if "passphrase_file" in one]
+    assert held, f"{name} carries no key file to redact"
 
-        gone = [one for one in published.splitlines() if "passphrase_file" in one]
-        assert gone, f"{name} dropped the key rather than redacting it"
-        assert all(REDACTED in one for one in gone), gone
-        assert "/run/gentoo-install-keys" not in published, published
+    gone = [one for one in published.splitlines() if "passphrase_file" in one]
+    assert gone, f"{name} dropped the key rather than redacting it"
+    assert all(REDACTED in one for one in gone), gone
+    for line in held:
+        assert line.split("=", 1)[1].strip() not in published, (name, line)
 
-        # The saved form is what an operator keeps, and it has to stay usable.
-        assert REDACTED not in saved, saved
+    # The saved form is what an operator keeps, and it has to stay usable.
+    assert REDACTED not in saved, saved
 
 
 #: A value away from the default for every persisted field no fixture moves.


### PR DESCRIPTION
The redaction that `NOT_FOR_A_PASTE` describes lived in the graph-node loop only. `_disk` returns before it when the configuration holds a `[disk.simple]` layout, and `_simple` took no `publishing` flag, so `publish_config` uploaded the path where key material sits on the installing machine.

The test no longer holds a hand-written pair of fixtures. It finds every configuration whose saved form names a key file, and adds a `[disk.simple]` one built in the test because no fixture uses that writer — which is why the defect survived. Eight cases; the control leaves only the simple one red.