### PR TITLE
portage: read a retry the way the first result is read

### DIFF
--- a/gentoo_install/plan/portage.py
+++ b/gentoo_install/plan/portage.py
@@ -1117,18 +1117,14 @@ class Emerge(Operation):
             self._from_source(context)
             return
         if not isinstance(result, CommandOutput) or result.returncode == 0:
-            # A host that answers no index does not fail the emerge: Portage
-            # says so, compiles everything and exits 0. Recorded here or
-            # nowhere, and recorded once, because it says so on every emerge.
-            unreadable = _unreadable_index(str(result))
-            if unreadable is not None and not context.degraded(BINARY_PACKAGES):
-                context.degrade(BINARY_PACKAGES, unreadable)
+            self._note_an_unreadable_index(context, result)
             return
         if (killed := _binhost_killed_emerge(result)) and not context.degraded(
             BINARY_PACKAGES
         ):
             second = context.run_in_target(command, check=False)
             if not isinstance(second, CommandOutput) or second.returncode == 0:
+                self._note_an_unreadable_index(context, second)
                 return
             context.degrade(BINARY_PACKAGES, killed)
             self._from_source(context)
@@ -1136,14 +1132,7 @@ class Emerge(Operation):
         if not _binpkg_failure(str(result)) or context.degraded(BINARY_PACKAGES):
             if self._optional(context, str(result)):
                 return
-            if _ran_out_of_memory(str(result)):
-                raise CommandFailed(
-                    "the compiler was killed because the machine ran out of memory, "
-                    "not because the package is broken: lower the job count in "
-                    "MAKEOPTS or give the machine swap, then resume. "
-                    f"emerge ended with {result.ending}: {worth_reading(str(result))}"
-                )
-            raise CommandFailed(f"emerge ended with {result.ending}: {worth_reading(str(result))}")
+            raise _emerge_failed("emerge", result)
         marker = _binpkg_failure(str(result))
         if (again := self._one_more_binary_try(context, command)) is not None:
             marker = again
@@ -1198,10 +1187,20 @@ class Emerge(Operation):
     def _from_source(self, context: Context) -> None:
         retry_result = context.run_in_target(self._argv(context, source_only=True), check=False)
         if isinstance(retry_result, CommandOutput) and retry_result.returncode != 0:
-            raise CommandFailed(
-                f"source retry ended with {retry_result.ending}: "
-                f"{worth_reading(str(retry_result))}"
-            )
+            raise _emerge_failed("source retry", retry_result)
+
+    def _note_an_unreadable_index(self, context: Context, result: object) -> None:
+        """A host that answers no index does not fail the emerge: Portage says
+        so, compiles everything and exits 0. Recorded here or nowhere, and
+        recorded once, because it says so on every emerge.
+
+        Every reader of a zero exit, not the first one: a retry that succeeded
+        left the run saying it fetches binary packages from a host whose index
+        it had just failed to read.
+        """
+        unreadable = _unreadable_index(str(result))
+        if unreadable is not None and not context.degraded(BINARY_PACKAGES):
+            context.degrade(BINARY_PACKAGES, unreadable)
 
     def _one_more_binary_try(self, context: Context, command: list[str]) -> str | None:
         """Run the same emerge again, and answer what still names a binary
@@ -1217,6 +1216,7 @@ class Emerge(Operation):
         except CommandFailed as error:
             return _binpkg_failure(str(error)) or str(error).strip()
         if not isinstance(again, CommandOutput) or again.returncode == 0:
+            self._note_an_unreadable_index(context, again)
             return None
         return _binpkg_failure(str(again)) or str(again).strip()
 
@@ -1268,6 +1268,22 @@ _OUT_OF_MEMORY: Final[re.Pattern[str]] = re.compile(
     r"Out of memory: Killed|fatal error: Killed|virtual memory exhausted|"
     r"cc1plus: out of memory|g\+\+: fatal error: Killed"
 )
+
+
+def _emerge_failed(what: str, result: CommandOutput) -> CommandFailed:
+    """The failure a merge deserves, with the one cause an operator can act on.
+
+    `g++: fatal error: Killed` is the machine running out of memory rather than
+    a broken package, and the source retry raised the generic text for it.
+    """
+    if _ran_out_of_memory(str(result)):
+        return CommandFailed(
+            "the compiler was killed because the machine ran out of memory, "
+            "not because the package is broken: lower the job count in "
+            "MAKEOPTS or give the machine swap, then resume. "
+            f"{what} ended with {result.ending}: {worth_reading(str(result))}"
+        )
+    return CommandFailed(f"{what} ended with {result.ending}: {worth_reading(str(result))}")
 
 
 def _ran_out_of_memory(said: str) -> bool:

--- a/tests/unit/test_plan_portage.py
+++ b/tests/unit/test_plan_portage.py
@@ -1090,10 +1090,12 @@ def test_a_failed_emerge_says_why_and_not_what_came_after() -> None:
 
     from gentoo_install.plan import portage as plan_portage
 
-    for source in (
-        inspect.getsource(plan_portage.Emerge.apply),
-        inspect.getsource(plan_portage.Emerge._from_source),
-    ):
+    # One raiser for both, so the source retry cannot answer differently from
+    # the first emerge: it raised the generic text where the first named the
+    # machine running out of memory.
+    for caller in (plan_portage.Emerge.apply, plan_portage.Emerge._from_source):
+        assert "_emerge_failed(" in inspect.getsource(caller), caller.__name__
+    for source in (inspect.getsource(plan_portage._emerge_failed),):
         raised = [one for one in source.split("CommandFailed(") if "ended with" in one]
         assert raised, source
         for block in raised:
@@ -3275,3 +3277,51 @@ def test_the_check_accepts_a_use_change_rather_than_stopping_the_install() -> No
     recorder.answering = keyworded
     with pytest.raises(ConfigError):
         check.apply(recorder)
+
+
+def test_a_retry_that_succeeded_still_records_an_unreadable_index() -> None:
+    """A zero exit does not mean the host answered. The first result was read
+    for that and the retry after a SIGPIPE was not, so a run went on saying it
+    fetches binary packages from a host whose index it had failed to read.
+    """
+    import signal
+
+    class Killed(Recorder):
+        runs: int = 0
+
+        def run_in_target(
+            self, argv: Sequence[str], *, check: bool = True
+        ) -> CommandOutput:
+            self.in_target.append(tuple(argv))
+            self.runs += 1
+            if self.runs == 1:
+                return CommandOutput("", -signal.SIGPIPE)
+            return CommandOutput(BINHOST_TIMED_OUT, 0)
+
+    recorder = Killed()
+    portage.Emerge(packages=("app-editors/vim",), summary="install vim").apply(recorder)
+
+    assert recorder.degraded(portage.BINARY_PACKAGES)
+
+
+def test_a_source_retry_killed_by_the_machine_says_so() -> None:
+    """`_from_source` raised the generic text for the one failure an operator
+    can act on, while the first emerge already named it."""
+    recorder = Recorder()
+
+    def answer(argv: Sequence[str]) -> CommandOutput | None:
+        if "--usepkg=n" in argv:
+            return CommandOutput(
+                "x86_64-pc-linux-gnu-g++: fatal error: Killed\ncompilation terminated.", 1
+            )
+        return CommandOutput(
+            ">>> Emerging binary (1 of 1) sys-libs/zlib-1.3.1::gentoo\n"
+            "Fetching Binary failed for sys-libs/zlib-1.3.1\n",
+            1,
+        )
+
+    recorder.answering = answer
+    with pytest.raises(CommandFailed, match="ran out of memory") as stopped:
+        portage.Emerge(packages=("sys-libs/zlib",), summary="install zlib").apply(recorder)
+    assert "source retry" in str(stopped.value), stopped.value
+    assert "MAKEOPTS" in str(stopped.value), stopped.value


### PR DESCRIPTION
Three places read an emerge that exited zero, and only the first asked whether that zero hid an index the host would not serve. A run that retried after a SIGPIPE, or that succeeded on `_one_more_binary_try`, went on saying it fetches binary packages from a host whose index it had just failed to read. `_note_an_unreadable_index` is now the one reader and all three call it.

`_from_source` raised `source retry ended with exit 1` even when the output held `g++: fatal error: Killed`, which the first emerge already translates into the two things an operator can change. Both raisers go through `_emerge_failed`.

`test_a_failed_emerge_says_why_and_not_what_came_after` inspects the source of the raisers, so it went red and is updated in the same commit: it now asserts both call sites pass through `_emerge_failed` and that `_emerge_failed` uses `worth_reading`. Both new tests had their control run red.