### PR TITLE
manual: refuse a kept row the graph can only overwrite

### DIFF
--- a/gentoo_install/data/locale/ja.toml
+++ b/gentoo_install/data/locale/ja.toml
@@ -399,6 +399,8 @@
 "delete" = "削除"
 "create" = "新規"
 "left alone, data and all" = "そのまま。データも残る"
+"an array is created, never assembled, so a member cannot be kept" = "アレイは作成のみで既存のものを組み立てないため、メンバーは保持できません"
+"a pool is created, never imported, so a member cannot be kept" = "プールは作成のみで既存のものをインポートしないため、メンバーは保持できません"
 "kept in the table, given a new filesystem" = "表には残し、ファイルシステムを作り直す"
 "removed from the table, data and all" = "表から削除。データも消える"
 "not on the disk yet" = "ディスクにまだない"

--- a/gentoo_install/data/locale/ko.toml
+++ b/gentoo_install/data/locale/ko.toml
@@ -399,6 +399,8 @@
 "delete" = "삭제"
 "create" = "생성"
 "left alone, data and all" = "그대로 두며 데이터도 유지"
+"an array is created, never assembled, so a member cannot be kept" = "배열은 생성만 하고 기존 배열을 조립하지 않으므로 구성원을 유지할 수 없습니다"
+"a pool is created, never imported, so a member cannot be kept" = "풀은 생성만 하고 기존 풀을 가져오지 않으므로 구성원을 유지할 수 없습니다"
 "kept in the table, given a new filesystem" = "표에 남기고 파일시스템을 새로 만듦"
 "removed from the table, data and all" = "표에서 제거하며 데이터도 사라짐"
 "not on the disk yet" = "디스크에 아직 없음"

--- a/gentoo_install/data/locale/zh-CN.toml
+++ b/gentoo_install/data/locale/zh-CN.toml
@@ -399,6 +399,8 @@
 "delete" = "删除"
 "create" = "创建"
 "left alone, data and all" = "原封不动，数据保留"
+"an array is created, never assembled, so a member cannot be kept" = "阵列只会创建，不会组装已有的，所以成员无法保留"
+"a pool is created, never imported, so a member cannot be kept" = "存储池只会创建，不会导入已有的，所以成员无法保留"
 "kept in the table, given a new filesystem" = "留在分区表，重建文件系统"
 "removed from the table, data and all" = "从分区表移除，数据一并消失"
 "not on the disk yet" = "尚未创建"

--- a/gentoo_install/data/locale/zh-TW.toml
+++ b/gentoo_install/data/locale/zh-TW.toml
@@ -399,6 +399,8 @@
 "delete" = "刪除"
 "create" = "建立"
 "left alone, data and all" = "原封不動，資料保留"
+"an array is created, never assembled, so a member cannot be kept" = "陣列只會建立，不會組裝既有的，所以成員無法保留"
+"a pool is created, never imported, so a member cannot be kept" = "儲存池只會建立，不會匯入既有的，所以成員無法保留"
 "kept in the table, given a new filesystem" = "留在分割表，重建檔案系統"
 "removed from the table, data and all" = "從分割表移除，資料一併消失"
 "not on the disk yet" = "尚未建立"

--- a/gentoo_install/model/manual.py
+++ b/gentoo_install/model/manual.py
@@ -13,6 +13,7 @@ from enum import Enum
 from pathlib import PurePosixPath
 from typing import Final
 
+from ..errors import InvalidLayout
 from .config import Firmware
 from .templates import ESP_SIZE
 from .device import (
@@ -143,6 +144,23 @@ class SliceStatus(Enum):
 #: What each status does, as the row says it. Beside the enum rather than in
 #: the screen: a status added here without a sentence is a menu row that reads
 #: as its own key.
+#: Roles whose device the graph can only make, never take over. `MdRaid` and
+#: `ZfsPool` carry no `create` field and `plan/disk.py` has only `mdadm
+#: --create` and `zpool create -f`, so a kept row of one of these promises the
+#: operator its data and overwrites it.
+NOT_KEPT: Final[dict[PartitionRole, str]] = {
+    PartitionRole.RAID: "an array is created, never assembled, so a member cannot be kept",
+    PartitionRole.ZFS: "a pool is created, never imported, so a member cannot be kept",
+}
+
+
+def kept_row_refused(entry: Slice) -> str:
+    """Why this row cannot be left alone, or an empty string when it can."""
+    if entry.status is not SliceStatus.KEEP:
+        return ""
+    return NOT_KEPT.get(entry.role, "")
+
+
 STATUS_REASONS: Final[dict[SliceStatus, str]] = {
     SliceStatus.KEEP: "left alone, data and all",
     SliceStatus.FORMAT: "kept in the table, given a new filesystem",
@@ -434,6 +452,8 @@ def build(layout: Layout) -> tuple[DeviceGraph, DeviceId]:
             if entry.status is SliceStatus.DELETE:
                 # Gone from the table above, so it carries nothing downstream.
                 continue
+            if refused := kept_row_refused(entry):
+                raise InvalidLayout(f"partition {entry.index} of {disk.selector}: {refused}")
             part = DeviceId(f"{prefix}-part{entry.index}")
             if entry.status is SliceStatus.CREATE:
                 nodes.append(

--- a/gentoo_install/tui/partitions.py
+++ b/gentoo_install/tui/partitions.py
@@ -1045,7 +1045,14 @@ def _edit_field_legacy(
             context,
             translate("What happens to it"),
             [
-                Item(label=translate(one.value), value=one, detail=translate(manual.STATUS_REASONS[one]))
+                Item(
+                    label=translate(one.value),
+                    value=one,
+                    detail=translate(manual.STATUS_REASONS[one]),
+                    disabled_because=translate(
+                        manual.kept_row_refused(replace(entry, status=one))
+                    ),
+                )
                 for one in offered
             ],
             entry.status,

--- a/tests/unit/test_i18n.py
+++ b/tests/unit/test_i18n.py
@@ -237,6 +237,12 @@ def in_a_table() -> set[str]:
         one.missing for group in SETTINGS for one in (group, *group.rows) if one.required
     }
     found |= set(STATUS_REASONS.values())
+    # The reason a status is refused is drawn beside it, greyed out. A role
+    # added to the table without a sentence draws an English row in a
+    # translated menu.
+    from gentoo_install.model.manual import NOT_KEPT
+
+    found |= set(NOT_KEPT.values())
     # A mirror is drawn by its own name and where it is, both translated: a
     # Chinese interface listing "Nanjing University" reads half-finished.
     for site in (*GENTOO_SITES, *GENTOOZH_SITES):

--- a/tests/unit/test_tui_partitions.py
+++ b/tests/unit/test_tui_partitions.py
@@ -12,7 +12,7 @@ from typing import Callable, Final, TypeVar
 
 import pytest
 
-from gentoo_install.errors import ValidationFailed
+from gentoo_install.errors import InvalidLayout, ValidationFailed
 from gentoo_install.i18n import Catalog, width
 from gentoo_install.model import manual
 from gentoo_install.model.config import (
@@ -1741,3 +1741,63 @@ def test_the_manual_row_says_where_a_second_disk_goes() -> None:
     screens.layout_screen(screen, config(), opened())
     drawn = "\n".join(screen.frames[0])
     assert "second disk" in drawn
+
+
+@pytest.mark.parametrize(
+    "role, said",
+    [
+        (PartitionRole.RAID, "never assembled"),
+        (PartitionRole.ZFS, "never imported"),
+    ],
+)
+def test_a_kept_array_or_pool_member_is_refused_rather_than_overwritten(
+    role: PartitionRole, said: str
+) -> None:
+    """`keep` is drawn as `left alone, data and all`, and the graph has no
+    operation that assembles an existing array or imports an existing pool:
+    `plan/disk.py` runs `mdadm --create` and `zpool create -f`. The row was
+    built anyway, so a menu promised the operator their data and the install
+    overwrote it.
+    """
+    kept = manual.Layout(
+        disks=[
+            manual.Disk(
+                selector="/dev/vda",
+                slices=[
+                    manual.Slice(
+                        index=1,
+                        role=PartitionRole.ESP,
+                        size=Size.parse("512MiB"),
+                        filesystem=FilesystemType.VFAT,
+                        mountpoint="/efi",
+                    ),
+                    manual.Slice(
+                        index=2,
+                        role=role,
+                        size=None,
+                        status=manual.SliceStatus.KEEP,
+                        selector="/dev/vda2",
+                    ),
+                ],
+            )
+        ]
+    )
+
+    with pytest.raises(InvalidLayout, match=said):
+        manual.build(kept)
+
+    # The same row formatted is the layout this installer can carry out.
+    formatted = replace(
+        kept,
+        disks=[
+            replace(
+                kept.disks[0],
+                slices=[
+                    kept.disks[0].slices[0],
+                    replace(kept.disks[0].slices[1], status=manual.SliceStatus.FORMAT),
+                ],
+            )
+        ],
+    )
+    graph, _ = manual.build(formatted)
+    assert graph.nodes


### PR DESCRIPTION
The status menu draws `keep` as `left alone, data and all`. An ordinary partition honours that — `manual.py` passes `create=entry.status is not SliceStatus.KEEP` to its `Filesystem`. An array member and a pool member did not: `MdRaid` and `ZfsPool` carry no `create` field, and `plan/disk.py` has only `mdadm --create` and `zpool create -f`, so the graph has no operation that assembles an existing array or imports an existing pool. The row was built anyway and the install overwrote what the menu had promised to leave alone.

`manual.NOT_KEPT` is the table; `manual.build()` raises `InvalidLayout` and the status menu greys the choice with the reason, in four catalogs. It refuses rather than silently changing the row to `format`: the operator asked to keep their data, and changing a status for them is deciding not to.

`docs/design.md` carries the decision, written before the code, in the section on reusing existing partitions. Both controls were run red.