### PR TITLE
model: refuse a pinned kernel version portage cannot be given

### DIFF
--- a/gentoo_install/model/atoms.py
+++ b/gentoo_install/model/atoms.py
@@ -37,6 +37,20 @@ def looks_like_an_atom(text: str) -> bool:
     return bool(_ATOM.match(text))
 
 
+_JUST_A_VERSION: Final[re.Pattern[str]] = re.compile(rf"^{_VERSION}$")
+
+
+def looks_like_a_version(text: str) -> bool:
+    """Whether this is a version and nothing else.
+
+    `plan/portage.py` builds `=package-version` and trims the version back off
+    to name the package in `--usepkg-exclude`, which takes package names and
+    slot atoms only. A version carrying a slot -- `7.1.7-r2:0` -- survives that
+    trim, so emerge answers `Invalid Atom(s)` after the disks are written.
+    """
+    return bool(_JUST_A_VERSION.match(text))
+
+
 def split(text: str) -> tuple[tuple[str, ...], tuple[str, ...]]:
     """The atoms in `text`, and the words that are not atoms."""
     return _split(text, looks_like_an_atom)

--- a/gentoo_install/model/compat.py
+++ b/gentoo_install/model/compat.py
@@ -17,6 +17,7 @@ from enum import Enum
 from pathlib import PurePosixPath
 from typing import Callable, Final, Mapping
 
+from . import atoms
 from .architecture import (
     AMD64,
     ARCHITECTURES,
@@ -414,6 +415,25 @@ def binhost_subarch_problems(
             f"not: `ld.so --help` does not list {V3_SUBARCH} as supported",
         )
     return ()
+
+
+def kernel_version_problems(config: InstallConfig) -> tuple[str, ...]:
+    """Refuse a pinned kernel version that is not a version.
+
+    `plan/kernel.py` builds `={package}-{version}` and `plan/portage.py` trims
+    the version back off to name the package for `--usepkg-exclude`, which
+    takes package names and slot atoms only. Anything after the version --
+    `7.1.7-r2:0` -- survives that trim, and emerge answers `Invalid Atom(s)`
+    with the disks already written.
+    """
+    version = config.kernel.version
+    if not version or atoms.looks_like_a_version(version):
+        return ()
+    return (
+        f"kernel version {version!r} is not a version portage can be given: "
+        "digits, dots, an optional letter, an optional _alpha/_beta/_pre/_rc/_p "
+        "suffix and an optional -rN",
+    )
 
 
 def cjk_kernel_problems(

--- a/gentoo_install/model/validate.py
+++ b/gentoo_install/model/validate.py
@@ -291,6 +291,7 @@ def validate(
         *_repository_name_problems(config),
         *compat.binhost_subarch_problems(config, supports_v3),
         *compat.cjk_kernel_problems(config),
+        *compat.kernel_version_problems(config),
         *compat.mirror_site_problems(config),
     ]
     if problems:

--- a/tests/unit/test_validate.py
+++ b/tests/unit/test_validate.py
@@ -1585,3 +1585,36 @@ def test_a_table_this_run_writes_needs_a_disk_this_run_wipes() -> None:
         if device.get("kind") == "table":
             device["create"] = False
     validate(parse(neither))
+
+
+@pytest.mark.parametrize(
+    "version, refused",
+    [
+        ("7.1.7", False),
+        ("7.1.7-r2", False),
+        ("6.12.47", False),
+        ("7.1.7-r2:0", True),
+        ("latest", True),
+        ("7.1.7::gentoo", True),
+    ],
+)
+def test_a_pinned_kernel_version_has_to_be_one_portage_can_be_given(
+    version: str, refused: bool
+) -> None:
+    """`plan/kernel.py` builds `={package}-{version}` and `plan/portage.py`
+    trims the version back off to name the package for `--usepkg-exclude`,
+    which takes package names and slot atoms only. Anything after the version
+    survives that trim and emerge answers `Invalid Atom(s)` at operation 20 of
+    60, with the disks already written.
+    """
+    from gentoo_install.model.config import KernelConfig, KernelSource
+
+    config = replace(
+        parse(tomllib.loads((FIXTURES / "ext4-bios.toml").read_text())),
+        kernel=KernelConfig(source=KernelSource.DIST_BIN, version=version),
+    )
+    if not refused:
+        validate(config)
+        return
+    with pytest.raises(ValidationFailed, match="is not a version portage"):
+        validate(config)


### PR DESCRIPTION
`kernel.version` was an unrestricted string. `plan/kernel.py` builds `={package}-{version}` from it and `plan/portage.py` trims the version back off with `re.sub(r"-\\d[^-]*(-r\\d+)?$", "", rest)` to name the package for `--usepkg-exclude`, which takes package names and slot atoms only. A version carrying anything after it — `7.1.7-r2:0` — survives that trim, and emerge answers `Invalid Atom(s)` at the merge, with the disks already partitioned and written.

The rule is in `compat.py` and reads `atoms.looks_like_a_version`, whose pattern is the one `atoms.py` already holds for refusing an operatorless versioned atom, taken from portage's own `versions.py`. One version pattern, two readers.

Six parametrised cases; three of them are the control and all three were run red.