### PR TITLE
screens: record the answer the machine will be given

### DIFF
--- a/gentoo_install/data/locale/ja.toml
+++ b/gentoo_install/data/locale/ja.toml
@@ -184,6 +184,7 @@
 "Fetch from a URL" = "URL から取得"
 "URL of a public key" = "公開鍵の URL"
 "that address returned no key" = "そのアドレスは公開鍵を返しませんでした"
+"{value} is above the sys-fs/zfs ceiling {ceiling}" = "{value} は sys-fs/zfs の上限 {ceiling} を超えています"
 "ssh-ed25519 AAAA... name@host" = "ssh-ed25519 AAAA... name@host"
 "https://example.com/id_ed25519.pub" = "https://example.com/id_ed25519.pub"
 "SSH server" = "SSH サーバー"

--- a/gentoo_install/data/locale/ko.toml
+++ b/gentoo_install/data/locale/ko.toml
@@ -184,6 +184,7 @@
 "Fetch from a URL" = "URL에서 가져오기"
 "URL of a public key" = "공개 키의 URL"
 "that address returned no key" = "그 주소는 공개 키를 반환하지 않았습니다"
+"{value} is above the sys-fs/zfs ceiling {ceiling}" = "{value}: sys-fs/zfs 상한 {ceiling} 초과"
 "ssh-ed25519 AAAA... name@host" = "ssh-ed25519 AAAA... name@host"
 "https://example.com/id_ed25519.pub" = "https://example.com/id_ed25519.pub"
 "SSH server" = "SSH 서버"

--- a/gentoo_install/data/locale/zh-CN.toml
+++ b/gentoo_install/data/locale/zh-CN.toml
@@ -184,6 +184,7 @@
 "Fetch from a URL" = "从 URL 获取"
 "URL of a public key" = "公钥的 URL"
 "that address returned no key" = "该地址未返回公钥"
+"{value} is above the sys-fs/zfs ceiling {ceiling}" = "{value} 高于 sys-fs/zfs 的上限 {ceiling}"
 "ssh-ed25519 AAAA... name@host" = "ssh-ed25519 AAAA... name@host"
 "https://example.com/id_ed25519.pub" = "https://example.com/id_ed25519.pub"
 "SSH server" = "SSH 服务器"

--- a/gentoo_install/data/locale/zh-TW.toml
+++ b/gentoo_install/data/locale/zh-TW.toml
@@ -184,6 +184,7 @@
 "Fetch from a URL" = "從 URL 取得"
 "URL of a public key" = "公鑰的 URL"
 "that address returned no key" = "該位址未回傳公鑰"
+"{value} is above the sys-fs/zfs ceiling {ceiling}" = "{value} 高於 sys-fs/zfs 的上限 {ceiling}"
 "ssh-ed25519 AAAA... name@host" = "ssh-ed25519 AAAA... name@host"
 "https://example.com/id_ed25519.pub" = "https://example.com/id_ed25519.pub"
 "SSH server" = "SSH 伺服器"

--- a/gentoo_install/tui/screens.py
+++ b/gentoo_install/tui/screens.py
@@ -102,6 +102,7 @@ from .widgets import (
     Outcome,
     Screen,
     TextField,
+    TextFieldRejected,
 )
 
 def _rebuild(config: InstallConfig, context: Context) -> InstallConfig:
@@ -946,16 +947,30 @@ def kernel_version_screen(
     ceiling = context.zfs_kernel_max if config.disk.graph.of_type(ZfsPool) else ""
     offered = _within(_while_reading(screen, context, package), ceiling)
     if not offered:
+        def within_the_ceiling(text: str) -> Answer[str] | TextFieldRejected:
+            # The same ceiling `_within` filters the read list by. A typed
+            # version bypassed it, and `sys-fs/zfs` has no module above it, so
+            # the run stopped in the kernel stage with the disks written.
+            literal = text.strip()
+            if not literal or not ceiling or _numeric(literal) <= _numeric(ceiling):
+                return Answer(Outcome.CHOSE, literal)
+            return TextFieldRejected(
+                translate("{value} is above the sys-fs/zfs ceiling {ceiling}").format(
+                    value=literal, ceiling=ceiling
+                ),
+                literal,
+            )
+
         typed = TextField(
             title=f"{package}  {translate('version')}",
             value=config.kernel.version,
             placeholder=translate("empty to leave the version to the keywords"),
             footer=footer(translate),
-        ).run(screen)
+        ).run_validated(screen, within_the_ceiling)
         if not typed.chosen:
             return Answer(typed.outcome)
         return Answer(
-            Outcome.CHOSE, replace(config, kernel=replace(config.kernel, version=typed.unwrap().strip()))
+            Outcome.CHOSE, replace(config, kernel=replace(config.kernel, version=typed.unwrap()))
         )
     # No unpinned row under a ceiling: `MODULES_KERNEL_MAX` only warns, so
     # nothing stops the resolver picking a kernel `sys-fs/zfs` will not build
@@ -1509,15 +1524,31 @@ def swap_screen(screen: Screen, config: InstallConfig, context: Context) -> Answ
                 else entry
                 for entry in disk.slices
             ]
-        if chosen and not any(entry.role is PartitionRole.SWAP for entry in context.layout.slices):
-            disk = context.layout.disks[0]
-            disk.slices.append(
-                manual.Slice(
-                    index=disk.next_index(),
-                    role=PartitionRole.SWAP,
-                    size=Size.parse(chosen),
-                )
+        if chosen:
+            # Resized as well as added: the second visit set `choice.swap` and
+            # left the slice at the first visit's size, so the machine got the
+            # size the operator had changed away from.
+            wanted = Size.parse(chosen)
+            existing = any(
+                entry.role is PartitionRole.SWAP for entry in context.layout.slices
             )
+            if existing:
+                for disk in context.layout.disks:
+                    disk.slices[:] = [
+                        replace(entry, size=wanted)
+                        if entry.role is PartitionRole.SWAP
+                        else entry
+                        for entry in disk.slices
+                    ]
+            else:
+                disk = context.layout.disks[0]
+                disk.slices.append(
+                    manual.Slice(
+                        index=disk.next_index(),
+                        role=PartitionRole.SWAP,
+                        size=wanted,
+                    )
+                )
         return Answer(Outcome.CHOSE, _from_layout(config, context))
     return Answer(Outcome.CHOSE, _rebuild(config, context))
 
@@ -2636,9 +2667,7 @@ def authorized_keys_screen(
                 Outcome.CHOSE,
                 replace(config, system=replace(config.system, authorized_keys=changed_keys)),
             )
-        added = _ADD_A_KEY[chosen](screen, context)
-        if added:
-            keys.append(added)
+        keys.extend(_ADD_A_KEY[chosen](screen, context))
 
 
 def _key_summary(key: str) -> str:
@@ -2649,7 +2678,7 @@ def _key_summary(key: str) -> str:
     return f"{fields[0]} {comment}".strip()
 
 
-def _type_a_key(screen: Screen, context: Context) -> str:
+def _type_a_key(screen: Screen, context: Context) -> tuple[str, ...]:
     translate = context.translate
     typed = TextField(
         title=translate("Public key"),
@@ -2657,11 +2686,12 @@ def _type_a_key(screen: Screen, context: Context) -> str:
         footer=footer(translate),
     ).run(screen)
     if not typed.chosen:
-        return ""
-    return _checked_key(screen, context, typed.unwrap())
+        return ()
+    checked = _checked_key(screen, context, typed.unwrap())
+    return (checked,) if checked else ()
 
 
-def _paste_a_key(screen: Screen, context: Context) -> str:
+def _paste_a_key(screen: Screen, context: Context) -> tuple[str, ...]:
     """The identifier alone, because the whole address is tedious to copy onto
     a console by hand and the host part never changes."""
     translate = context.translate
@@ -2671,11 +2701,11 @@ def _paste_a_key(screen: Screen, context: Context) -> str:
         footer=footer(translate),
     ).run(screen)
     if not typed.chosen or not typed.unwrap().strip():
-        return ""
-    return _read_a_key(screen, context, paste.url_for(typed.unwrap()))
+        return ()
+    return _read_the_keys(screen, context, paste.url_for(typed.unwrap()))
 
 
-def _fetch_a_key(screen: Screen, context: Context) -> str:
+def _fetch_a_key(screen: Screen, context: Context) -> tuple[str, ...]:
     translate = context.translate
     typed = TextField(
         title=translate("URL of a public key"),
@@ -2683,28 +2713,33 @@ def _fetch_a_key(screen: Screen, context: Context) -> str:
         footer=footer(translate),
     ).run(screen)
     if not typed.chosen or not typed.unwrap().strip():
-        return ""
-    return _read_a_key(screen, context, typed.unwrap().strip())
+        return ()
+    return _read_the_keys(screen, context, typed.unwrap().strip())
 
 
-def _read_a_key(screen: Screen, context: Context, url: str) -> str:
+def _read_the_keys(screen: Screen, context: Context, url: str) -> tuple[str, ...]:
     translate = context.translate
     try:
         body = context.fetch_text(url)
     except GentooInstallError as error:
         say(screen, context, str(error))
-        return ""
+        return ()
     # A paste holding several keys is the normal case for one person's file,
-    # and taking the first line silently would drop the rest.
-    for line in body.splitlines():
-        if line.strip() and not line.lstrip().startswith("#"):
-            return _checked_key(screen, context, line)
-    say(screen, context, translate("that address returned no key"))
-    return ""
+    # and taking the first line silently dropped the rest.
+    found = tuple(
+        checked
+        for line in body.splitlines()
+        if line.strip() and not line.lstrip().startswith("#")
+        for checked in (_checked_key(screen, context, line),)
+        if checked
+    )
+    if not found:
+        say(screen, context, translate("that address returned no key"))
+    return found
 
 
 #: The rows that add a key, in the order the menu lists them.
-_ADD_A_KEY: Final[tuple[Callable[[Screen, "Context"], str], ...]] = (
+_ADD_A_KEY: Final[tuple[Callable[[Screen, "Context"], tuple[str, ...]], ...]] = (
     lambda screen, context: _type_a_key(screen, context),
     lambda screen, context: _paste_a_key(screen, context),
     lambda screen, context: _fetch_a_key(screen, context),

--- a/tests/unit/test_tui_app.py
+++ b/tests/unit/test_tui_app.py
@@ -4697,3 +4697,39 @@ def load_toml(text: str) -> InstallConfig:
     from gentoo_install.model.parse import parse
 
     return parse(tomllib.loads(text))
+
+
+def test_a_typed_kernel_version_is_held_to_the_same_zfs_ceiling_as_the_list() -> None:
+    """`_within` drops a version above `MODULES_KERNEL_MAX` from the list, and
+    the field that replaces the list on a medium with no repository stored
+    whatever was typed. The run then reached the kernel stage, with the disks
+    written, and stopped there."""
+    at = context()
+    at.kernel_versions = lambda atom: ()
+    at.zfs_kernel_max = "7.0"
+    on_zfs = config(zfs_root())
+
+    refused = FakeScreen(keys=[*"7.1.7", "\n", "\x1b"], lines=20, columns=100)
+    answer = screens.kernel_version_screen(refused, on_zfs, at)
+    assert not answer.chosen
+    assert any("7.0" in line for frame in refused.frames for line in frame)
+
+    accepted = FakeScreen(keys=[*"6.18.43", "\n"], lines=20, columns=100)
+    assert (
+        screens.kernel_version_screen(accepted, on_zfs, at).unwrap().kernel.version
+        == "6.18.43"
+    )
+
+
+def test_every_key_in_a_fetched_body_is_kept() -> None:
+    """The comment above the reader says a file holding several keys is the
+    normal case and that taking the first would drop the rest; it took the
+    first. One person's `authorized_keys` reached the target with one key."""
+    at = context()
+    second = GOOD_KEY.rsplit(" ", 1)[0] + " bob@host"
+
+    at.fetch_text = lambda url: f"# mine\n{GOOD_KEY}\n\n{second}\n"
+    keys = [*down(2), "\n", *"https://example.com/keys", "\n", *down(5), "\n"]
+    answer = screens.authorized_keys_screen(FakeScreen(keys=keys), config(), at)
+
+    assert answer.unwrap().system.authorized_keys == (GOOD_KEY, second)

--- a/tests/unit/test_tui_partitions.py
+++ b/tests/unit/test_tui_partitions.py
@@ -1801,3 +1801,38 @@ def test_a_kept_array_or_pool_member_is_refused_rather_than_overwritten(
     )
     graph, _ = manual.build(formatted)
     assert graph.nodes
+def test_reopening_swap_resizes_the_slice_it_already_added() -> None:
+    """The screen recorded the new size in `context.choice` and added a slice
+    only when there was none, so a second visit left the first visit's
+    partition and the machine got the size the operator had changed away from.
+    """
+    from gentoo_install.model.device import Swap
+
+    at = opened()
+    at.layout = one_disk(
+        slices=[
+            manual.Slice(
+                index=1,
+                role=PartitionRole.ESP,
+                size=Size.parse("512MiB"),
+                filesystem=FilesystemType.VFAT,
+                mountpoint="/efi",
+            ),
+            manual.Slice(
+                index=2,
+                role=PartitionRole.DATA,
+                size=None,
+                filesystem=FilesystemType.EXT4,
+                mountpoint="/",
+            ),
+        ]
+    )
+
+    screens.swap_screen(FakeScreen(keys=["KEY_DOWN", "\n"]), config(), at)
+    sizes = [entry.size for entry in at.layout.slices if entry.role is PartitionRole.SWAP]
+    assert sizes == [Size.parse("4GiB")], sizes
+
+    answer = screens.swap_screen(FakeScreen(keys=[*["KEY_DOWN"] * 2, "\n"]), config(), at)
+    sizes = [entry.size for entry in at.layout.slices if entry.role is PartitionRole.SWAP]
+    assert sizes == [Size.parse("8GiB")], sizes
+    assert len(answer.unwrap().disk.graph.of_type(Swap)) == 1


### PR DESCRIPTION
Three screens stored something the install could not carry out.

`kernel_version_screen` filters the read list by `MODULES_KERNEL_MAX`, and the text field that replaces the list on a medium with no repository stored whatever was typed. A ZFS root then reached the kernel stage — after the disks were written — and stopped there. The field validates against the same ceiling.

`_read_a_key` carried the comment "A paste holding several keys is the normal case for one person's file, and taking the first line silently would drop the rest", directly above a `return` on the first line. The comment was right and the code was not; the reader is now `_read_the_keys` and every adder answers a tuple.

`swap_screen` added a slice only when there was none, so a second visit recorded the new size in `context.choice` and left the partition at the first visit's size.

Each of the three has a test that feeds the screen keys and reads the resulting configuration or layout; each control was run red.