### PR TITLE
compat: name the kernel package the install will merge

### DIFF
--- a/gentoo_install/model/compat.py
+++ b/gentoo_install/model/compat.py
@@ -434,6 +434,19 @@ def kernel_version_problems(config: InstallConfig) -> tuple[str, ...]:
         "digits, dots, an optional letter, an optional _alpha/_beta/_pre/_rc/_p "
         "suffix and an optional -rN",
     )
+def kernel_package_name(config: InstallConfig) -> str:
+    """The bare `category/name` of the kernel this install will merge.
+
+    The override first, because `plan/kernel.py` merges
+    `config.kernel.package or KERNEL_PACKAGES[source].atom` and a rule reading
+    only the source decides for a package the install is not installing. The
+    trailing `*` is stripped as well: `=sys-kernel/gentoo-sources-6.12*` is a
+    form portage takes, and leaving it on walked past the `-sources` refusal.
+    """
+    atom = config.kernel.package or KERNEL_PACKAGES[config.kernel.source].atom
+    bare = atom.lstrip("=<>~!").split(":", 1)[0]
+    bare = re.sub(r"-r\d+\*?$", "", bare)
+    return re.sub(r"-\d[\w.]*\*?$", "", bare)
 
 
 def cjk_kernel_problems(
@@ -451,13 +464,16 @@ def cjk_kernel_problems(
     # evaluated when the function is defined, so the row could not be varied
     # and a test that swapped it saw the machine's own.
     row = row if row is not None else DEFAULT_ARCHITECTURE
-    package = KERNEL_PACKAGES.get(config.kernel.source)
-    if package is None or not package.applies_cjktty:
+    # The package this install merges, not the one its source names: an
+    # override naming a cjk atom took the architecture refusal past this rule
+    # while the trait reader below saw it.
+    name = kernel_package_name(config)
+    if name not in _CJK_KERNEL_PACKAGES:
         return ()
     if row.gentoo_name == AMD64.gentoo_name:
         return ()
     return (
-        f"{package.atom} carries the cjktty patch, which gentoo-zh builds for "
+        f"{name} carries the cjktty patch, which gentoo-zh builds for "
         f"{AMD64.gentoo_name} only, and this installs {row.gentoo_name}",
     )
 
@@ -833,11 +849,7 @@ def traits_of(
             and _encrypted_pool(graph, config.disk.root)
         ):
             found.add(Trait.NATIVE_ZFS_SYSTEM_INITRAMFS)
-    package = config.kernel.package or KERNEL_PACKAGES[config.kernel.source].atom
-    package_name = package.lstrip("=<>~!").split(":", 1)[0]
-    package_name = re.sub(r"-r\d+$", "", package_name)
-    package_name = re.sub(r"-\d[\w.]*$", "", package_name)
-    if package_name in _CJK_KERNEL_PACKAGES:
+    if kernel_package_name(config) in _CJK_KERNEL_PACKAGES:
         found.add(Trait.CJK_KERNEL)
     else:
         found.add(Trait.KERNEL_WITHOUT_CJKTTY)

--- a/gentoo_install/model/validate.py
+++ b/gentoo_install/model/validate.py
@@ -624,22 +624,11 @@ def _zapped_disk_problems(config: InstallConfig) -> list[str]:
     return problems
 
 
-def _package_name(atom: str) -> str:
-    """`=cat/pkg-1.2:3` reduced to `cat/pkg`.
-
-    Checked on the name, not the atom: a version or a slot otherwise walks past
-    a rule that exists to stop an unbuildable kernel.
-    """
-    bare = atom.lstrip("=<>~!").split(":", 1)[0]
-    bare = re.sub(r"-r\d+$", "", bare)
-    return re.sub(r"-\d[\w.]*$", "", bare)
-
-
 def _kernel_package_problems(config: InstallConfig) -> list[str]:
     """The installer configures and compiles no kernel of its own, so a
     `-sources` package would unpack a tree that nothing ever builds and leave
     the bootloader pointing at a `/boot` with no kernel in it."""
-    package = _package_name(config.kernel.package)
+    package = compat.kernel_package_name(config) if config.kernel.package else ""
     if package and package.endswith("-sources"):
         return [
             f"{package} installs a source tree and no kernel; name a dist-kernel "

--- a/tests/unit/test_validate.py
+++ b/tests/unit/test_validate.py
@@ -1618,3 +1618,42 @@ def test_a_pinned_kernel_version_has_to_be_one_portage_can_be_given(
         return
     with pytest.raises(ValidationFailed, match="is not a version portage"):
         validate(config)
+
+
+@pytest.mark.parametrize(
+    "package",
+    ["sys-kernel/gentoo-sources", "=sys-kernel/gentoo-sources-6.12*"],
+)
+def test_a_sources_package_is_refused_in_every_atom_form(package: str) -> None:
+    """The trim read `-\\d[\\w.]*$`, and `=cat/pkg-6.12*` ends in an asterisk, so
+    the name kept its version and the `-sources` refusal did not fire. Portage
+    takes that form, and the installer builds no kernel of its own, so the
+    machine finished with a source tree and an empty `/boot`."""
+    from gentoo_install.model.config import KernelConfig, KernelSource
+
+    config = replace(
+        parse(tomllib.loads((FIXTURES / "ext4-bios.toml").read_text())),
+        kernel=KernelConfig(source=KernelSource.DIST_BIN, package=package),
+    )
+    with pytest.raises(ValidationFailed, match="installs a source tree"):
+        validate(config)
+
+
+def test_the_cjk_refusal_reads_the_package_the_install_will_merge() -> None:
+    """`cjk_kernel_problems` keyed on `kernel.source` while the trait beside it
+    keyed on `kernel.package or ...`. An override naming a cjktty atom took the
+    architecture refusal past the rule, and `emerge` then stopped with the disk
+    already partitioned."""
+    from gentoo_install.model.architecture import ARCHITECTURES, AMD64
+    from gentoo_install.model.config import KernelConfig, KernelSource
+
+    elsewhere = next(one for one in ARCHITECTURES if one.gentoo_name != AMD64.gentoo_name)
+    config = replace(
+        parse(tomllib.loads((FIXTURES / "ext4-bios.toml").read_text())),
+        kernel=KernelConfig(
+            source=KernelSource.DIST_BIN, package="sys-kernel/gentoo-cjk-kernel-bin"
+        ),
+    )
+
+    assert compat.cjk_kernel_problems(config, elsewhere), "the override names a cjk kernel"
+    assert not compat.cjk_kernel_problems(config, AMD64)


### PR DESCRIPTION
Two readers decided from `kernel.package` and one from `kernel.source`. `cjk_kernel_problems` was the one reading the source, so a non-amd64 install whose `kernel.package` names a cjktty atom took the architecture refusal past the rule — and `plan/kernel.py` merges the override, so emerge stopped with the disk already partitioned.

The trim from atom to bare name existed three times over: `validate._package_name` and two more lines in `compat.py`, all with `-\\d[\\w.]*$`, which does not strip the `*` in `=sys-kernel/gentoo-sources-6.12*`. Portage takes that form, so the `-sources` refusal never fired and the install finished with a source tree and an empty `/boot`. One `compat.kernel_package_name(config)` now, reading the override first and stripping the asterisk.

Both controls were run red.