### PR TITLE
compat: refuse a vfat label mkfs cannot write

### DIFF
--- a/gentoo_install/model/compat.py
+++ b/gentoo_install/model/compat.py
@@ -512,15 +512,36 @@ class FilesystemLabelUnit(Enum):
         return len(label.encode()) if self is FilesystemLabelUnit.BYTES else len(label)
 
 
+#: What `mkfs.fat` writes a label out of, measured against dosfstools 4.2 on
+#: 2026-08-31 by formatting a throwaway image once per codepoint from 0x20 to
+#: 0x7e. Everything outside it was refused, and so was every non-ASCII
+#: character: a CJK label stops at the CP850 conversion, and even `É`, which
+#: CP850 has, answers `Labels with characters below 0x20 are not allowed`.
+FAT_LABEL_CHARACTERS: Final[frozenset[str]] = frozenset(
+    " !#$%&'()-0123456789@ABCDEFGHIJKLMNOPQRSTUVWXYZ^_`abcdefghijklmnopqrstuvwxyz{}~"
+)
+
+
 @dataclass(frozen=True)
 class FilesystemLabelRule:
     kind: FilesystemType
     maximum: int
     unit: FilesystemLabelUnit
+    #: Empty where the filesystem takes any character. `mkfs` refuses the rest
+    #: after the disks are partitioned, so the set is checked here instead.
+    characters: frozenset[str] = frozenset()
 
     def problem(self, filesystem: Filesystem) -> str | None:
+        if not filesystem.create:
+            return None
+        refused = self._refused(filesystem.label)
+        if refused is not None:
+            return (
+                f"filesystem {filesystem.id} has a {filesystem.kind.value} label "
+                f"holding {refused!r}, which mkfs cannot write into one"
+            )
         length = self.unit.measure(filesystem.label)
-        if not filesystem.create or length <= self.maximum:
+        if length <= self.maximum:
             return None
         return (
             f"filesystem {filesystem.id} has a {filesystem.kind.value} label of {length} "
@@ -528,14 +549,19 @@ class FilesystemLabelRule:
             f"{self.maximum} {self.unit.value}"
         )
 
+    def _refused(self, label: str) -> str | None:
+        if not self.characters:
+            return None
+        return next((one for one in label if one not in self.characters), None)
+
 
 FILESYSTEM_LABEL_RULES: tuple[FilesystemLabelRule, ...] = (
     FilesystemLabelRule(FilesystemType.EXT2, 16, FilesystemLabelUnit.BYTES),
     FilesystemLabelRule(FilesystemType.EXT3, 16, FilesystemLabelUnit.BYTES),
     FilesystemLabelRule(FilesystemType.EXT4, 16, FilesystemLabelUnit.BYTES),
-    # The CJK probe fails during CP850 conversion before length is checked, so
-    # this entry represents only mkfs.fat's independent character-count limit.
-    FilesystemLabelRule(FilesystemType.VFAT, 11, FilesystemLabelUnit.CHARACTERS),
+    FilesystemLabelRule(
+        FilesystemType.VFAT, 11, FilesystemLabelUnit.CHARACTERS, FAT_LABEL_CHARACTERS
+    ),
 )
 
 

--- a/tests/unit/test_validate.py
+++ b/tests/unit/test_validate.py
@@ -1657,3 +1657,37 @@ def test_the_cjk_refusal_reads_the_package_the_install_will_merge() -> None:
 
     assert compat.cjk_kernel_problems(config, elsewhere), "the override names a cjk kernel"
     assert not compat.cjk_kernel_problems(config, AMD64)
+
+
+@pytest.mark.parametrize(
+    "label, refused",
+    [
+        ("GENTOO ESP", False),
+        ("esp_1", False),
+        ("A-B", False),
+        ("\u4e00", True),
+        ("CAF\u00c9", True),
+        ("A.B", True),
+        ("A+B", True),
+    ],
+)
+def test_a_vfat_label_is_refused_unless_mkfs_can_write_it(
+    label: str, refused: bool
+) -> None:
+    """Measured against dosfstools 4.2 on 2026-08-31, one throwaway image per
+    codepoint. `mkfs.vfat -n` stops at the CP850 conversion for a CJK label and
+    answers `Labels with characters below 0x20 are not allowed` for every other
+    non-ASCII one, and the length rule alone let both through to a formatting
+    stage that runs after the disks are partitioned.
+    """
+    nodes = [
+        replace(node, label=label)
+        if isinstance(node, Filesystem) and node.id == i("espfs")
+        else node
+        for node in ext4_on_gpt()
+    ]
+    if not refused:
+        validate(config(nodes))
+        return
+    with pytest.raises(ValidationFailed, match="which mkfs cannot write into one"):
+        validate(config(nodes))


### PR DESCRIPTION
The VFAT rule counted characters and nothing else, so a one-character CJK label passed and `mkfs.vfat -n` failed at the CP850 conversion — in the formatting stage, which runs after the disks are partitioned. The comment above the entry already said the conversion fails before the length is checked; the rule did not act on it.

The accepted set was measured against dosfstools 4.2 by formatting a throwaway image once per codepoint from 0x20 to 0x7e: `` !#$%&'()-0-9@A-Z^_`a-z{}~`` is taken and `"*+,./:;<=>?[\\]|` is refused, along with every non-ASCII character — even `É`, which CP850 has, answers `Labels with characters below 0x20 are not allowed`.

The set lives in `FilesystemLabelRule`, so the one table carries both the length and the characters. Seven cases; the control was run red on four of them.