### PR TITLE
cli: report a command that failed rather than the one it meant to run

### DIFF
--- a/gentoo_install/cli.py
+++ b/gentoo_install/cli.py
@@ -89,6 +89,11 @@ from .plan.render import render, summarise
 #: and no answer at all, takes the global list.
 CN: Final[str] = "CN"
 
+#: What `chroot` answers for its own failure rather than the command's, from
+#: its `--help`: 125 for chroot itself, 126 for a command that cannot be
+#: invoked, 127 for one that is not there.
+CHROOT_COULD_NOT_START: Final[tuple[int, ...]] = (125, 126, 127)
+
 #: What an operator has to know before a conversion starts, because after it
 #: there is no way to tell them.
 SESSION_IS_THE_LIFELINE: Final[str] = (
@@ -962,8 +967,13 @@ def _offer_a_shell(
     ).format(target=target)
     if not _asked(question):
         return
+    opened = machine.runner.run(["chroot", str(target), "/bin/bash", "--login"], check=False)
+    if opened.returncode in CHROOT_COULD_NOT_START:
+        # Recorded before the run, the log said a shell had opened and exited
+        # on a target where `chroot` never started one.
+        record(f"no root shell could be started in {target}: exit {opened.returncode}")
+        return
     record(f"a root shell was opened in {target}")
-    machine.runner.run(["chroot", str(target), "/bin/bash", "--login"], check=False)
     record("the shell exited" if mode is DiskMode.IN_PLACE else "the shell exited; unmounting")
 
 
@@ -1043,7 +1053,16 @@ def _check_the_clock() -> None:
             file=sys.stderr,
         )
         return
-    runner.run(["hwclock", "--hctosys", "--utc"], check=False)
+    applied = runner.run(["hwclock", "--hctosys", "--utc"], check=False)
+    if applied.returncode != 0:
+        # The same warning as the line above, for the same reason: the RTC now
+        # holds the right time and the system clock does not, so TLS refuses
+        # every mirror and the next message blames the network.
+        print(
+            "warning: the system clock could not be set from the corrected RTC; "
+            f"TLS may refuse every mirror ({applied.stdout.strip()[:80]})",
+            file=sys.stderr,
+        )
 
 
 def _require_network() -> None:

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -759,12 +759,17 @@ def test_a_conversion_is_offered_a_shell_in_the_root_it_converted(
 
     from gentoo_install.exec.apply import Machine
 
+    from gentoo_install.exec.runner import Result
+
     class Fake:
         def __init__(self) -> None:
             self.argv: list[list[str]] = []
 
-        def run(self, argv: list[str], check: bool = True) -> None:
+        # A `Result`, the way the real runner answers: a double returning None
+        # hid the caller that reads the exit code for itself.
+        def run(self, argv: list[str], check: bool = True) -> Result:
             self.argv.append(argv)
+            return Result(argv=tuple(argv), returncode=0, stdout="", stderr="", seconds=0.0)
 
     asked: list[str] = []
     # The two unattended guards have their own test above; this one is about
@@ -2822,3 +2827,74 @@ def test_no_mirror_of_the_region_answering_still_refuses(
 
     with pytest.raises(errors.PreflightFailed, match="nor any mirror"):
         cli._require_network()
+
+
+def test_a_shell_that_never_started_is_not_recorded_as_one_that_opened(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Both lines were written around an unchecked `chroot`, so a target whose
+    `/bin/bash` is not there recorded a shell that opened and exited."""
+    import argparse
+    from types import SimpleNamespace
+
+    from gentoo_install.exec.apply import Machine
+    from gentoo_install.exec.runner import Result
+
+    interactive_stdin(monkeypatch)
+    monkeypatch.setattr(cli, "_asked", lambda question: True)
+
+    def run_a_shell(code: int) -> list[str]:
+        said: list[str] = []
+        runner = SimpleNamespace(
+            run=lambda argv, **kwargs: Result(
+                argv=tuple(argv), returncode=code, stdout="", stderr="", seconds=0.0
+            )
+        )
+        cli._offer_a_shell(
+            argparse.Namespace(no_shell=False, menu=False, target=Path("/mnt/gentoo"), lang=""),
+            cast(Machine, SimpleNamespace(runner=runner)),
+            said.append,
+            False,
+            Path("/mnt/gentoo"),
+            DiskMode.PARTITION,
+            Catalog("en"),
+        )
+        return said
+
+    refused = run_a_shell(127)
+    assert any("no root shell could be started" in one for one in refused), refused
+    assert not any("was opened" in one for one in refused), refused
+
+    # A shell the operator ended with a non-zero status still opened.
+    ordinary = run_a_shell(1)
+    assert any("was opened" in one for one in ordinary), ordinary
+    assert any("the shell exited" in one for one in ordinary), ordinary
+
+
+def test_a_system_clock_that_could_not_follow_the_rtc_is_reported(
+    capsys: pytest.CaptureFixture[str], monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The `--set` failure is warned about because TLS then refuses every
+    mirror. `--hctosys` failing leaves exactly that state, and its result was
+    discarded."""
+    import time
+
+    from gentoo_install.exec.runner import Result, Runner
+
+    # A stamp two days out, so the correction runs at all.
+    monkeypatch.setattr(fetch, "network_time", lambda: time.time() + 172800)
+
+    def running(self: Runner, argv: Sequence[str], **kwargs: object) -> Result:
+        failed = "--hctosys" in argv
+        return Result(
+            argv=tuple(argv),
+            returncode=1 if failed else 0,
+            stdout="hwclock: cannot set the system clock" if failed else "",
+            stderr="",
+            seconds=0.0,
+        )
+
+    monkeypatch.setattr(Runner, "run", running)
+    cli._check_the_clock()
+    said = capsys.readouterr().err
+    assert "system clock could not be set from the corrected RTC" in said, said


### PR DESCRIPTION
`_offer_a_shell` wrote `a root shell was opened in {target}` before running `chroot` and `the shell exited` after it, with nothing reading the result in between: a target whose `/bin/bash` is not there recorded a shell that opened and exited. `chroot --help` lists 125, 126 and 127 as its own failures and everything else as the command's exit status; that distinction is quoted from the tool rather than measured, because an unprivileged `chroot` answers 125 for all of them on this machine.

`_check_the_clock` warns at length when `hwclock --set` fails — busybox has no `--set`, and every HTTPS request then fails on a not-yet-valid certificate while the next message blames the network. It then discarded the result of `hwclock --hctosys`, which leaves exactly that state.

One existing double was exposed by the change and is fixed in the same commit: its `run` returned `None`, which is the shape that hides every caller reading an exit code. Both controls were run red.