### PR TITLE
system: say when the interface is matched by name instead of by MAC

### DIFF
--- a/gentoo_install/plan/system.py
+++ b/gentoo_install/plan/system.py
@@ -53,6 +53,10 @@ CONSOLE_FONTS: Final[dict[ConsoleFontSize, str]] = {
 #: Groups a desktop user needs. `wheel` is what sudo is granted through.
 USER_GROUPS: Final[tuple[str, ...]] = ("users", "wheel", "audio", "video", "render", "usb", "input")
 
+#: What is given up when the links cannot be read. The interface is matched
+#: by name instead, which the target kernel may spell differently.
+MAC_MATCH: Final[str] = "matching the network interface by its MAC"
+
 ROOT = PurePosixPath("/")
 
 
@@ -761,6 +765,14 @@ class WriteNetworkConfig(Operation):
             return ""
         said = context.run(["ip", "-o", "link", "show"], check=False)
         if isinstance(said, CommandOutput) and said.returncode != 0:
+            # Said rather than swallowed: a probe that could not run answers the
+            # same empty string as a MAC two links share, and the name match it
+            # falls back to is the one this docstring records as unreachable.
+            context.degrade(
+                MAC_MATCH,
+                f"the links of this machine could not be read, so {self.interface} is "
+                f"matched by name: {str(said).strip()[:120]}",
+            )
             return ""
         addresses: dict[str, str] = {}
         for line in said.splitlines():

--- a/tests/unit/test_plan_system.py
+++ b/tests/unit/test_plan_system.py
@@ -1616,3 +1616,34 @@ def test_every_operation_that_names_a_file_writes_exactly_the_files_it_named() -
                 )
                 checked += 1
     assert checked > 40, checked
+
+
+def test_a_link_listing_that_failed_says_so_before_matching_by_name() -> None:
+    """A probe that could not run answered the same empty string as a MAC two
+    links share, so the fallback this operation records as unreachable was
+    taken without a word. The name is still written, because there is nothing
+    better to write; the run says what it gave up."""
+    from typing import Sequence
+
+    from gentoo_install.plan.operations import CommandOutput
+
+    class Broken(Recorder):
+        def run(
+            self, argv: Sequence[str], *, check: bool = True, input_text: str | None = None
+        ) -> CommandOutput:
+            self.commands.append(tuple(argv))
+            if argv[0] == "ip":
+                return CommandOutput("ip: command not found", 127)
+            return super().run(argv, check=check, input_text=input_text)
+
+    recorder = Broken()
+    _wired().apply(recorder)
+
+    written = recorder.files[PurePosixPath("/etc/systemd/network/20-wired.network")]
+    assert "Name=eno1" in written, written
+    assert recorder.degraded(system.MAC_MATCH)
+
+    # A listing that answered is not a degradation.
+    working = _linked()
+    _wired().apply(working)
+    assert not working.degraded(system.MAC_MATCH)


### PR DESCRIPTION
The docstring on `_permanent_address` records why a `Name=` match is dangerous: the target's kernel can name the same card differently from the kernel the installer runs under, and a match nothing satisfies leaves the machine with no address and no way in — `reinstall` records a DMIT machine whose Debian normal and cloud kernels named one NIC two ways.

`ip -o link show` failing returned the same empty string as two links sharing a MAC, so that fallback was taken silently. The name is still written, because there is nothing better to write; the run now degrades with what it gave up and why. The control was run red.