### PR TITLE
probe: a probe that could not run is not an empty answer

### DIFF
--- a/gentoo_install/exec/probe.py
+++ b/gentoo_install/exec/probe.py
@@ -19,7 +19,7 @@ from dataclasses import dataclass, field
 from pathlib import Path
 from typing import ClassVar, Final, Iterable, Mapping
 
-from ..errors import CommandFailed, DeviceNotFound
+from ..errors import CommandFailed, DeviceNotFound, PreflightFailed
 from ..model.config import DiskMode, InstallConfig
 from ..model.hardware import CpuVendor, HardwareFacts
 # Declared in `model/` because `plan/netboot.py` derives operations from it
@@ -222,6 +222,20 @@ UDEV_DIRECTORY_FOR_TAG: Final[dict[str, str]] = {
     "ID": "by-id",
 }
 
+_BLKID_SAFE_CHARACTERS: Final[frozenset[str]] = frozenset(
+    "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz#+-.:=@_"
+)
+
+
+def _blkid_encoded(value: str) -> str:
+    """Encode a tag value as `blkid` writes it for udev."""
+    return "".join(
+        character
+        if not character.isascii() or character in _BLKID_SAFE_CHARACTERS
+        else f"\\x{ord(character):02x}"
+        for character in value
+    )
+
 
 def udev_path_for(selector: str) -> str:
     """A `TAG=value` selector as the path udev keeps for it, or the selector.
@@ -239,7 +253,8 @@ def udev_path_for(selector: str) -> str:
             f"{selector!r} names no identifier this installer knows; "
             f"use one of {', '.join(sorted(UDEV_DIRECTORY_FOR_TAG))} or a path"
         )
-    return f"/dev/disk/{directory}/{value}"
+    # udev links use blkid's hex escapes, so raw labels with separators do not resolve.
+    return f"/dev/disk/{directory}/{_blkid_encoded(value)}"
 
 
 @dataclass(frozen=True)
@@ -269,8 +284,12 @@ def _fstab_we_do_not_manage(esp: str | None, boot: str | None) -> tuple[str, ...
     managed = set(_MANAGED_MOUNTS) | {one for one in (esp, boot) if one}
     try:
         lines = Path("/etc/fstab").read_text(encoding="utf-8").splitlines()
-    except OSError:
+    except FileNotFoundError:
+        # A machine with no fstab carries nothing, which is an answer. One that
+        # has an fstab this cannot open is not, and both returned `()`.
         return ()
+    except OSError as error:
+        raise PreflightFailed(f"/etc/fstab could not be read: {error}") from error
     carried = []
     for line in lines:
         fields = line.split()
@@ -798,8 +817,11 @@ class Probe:
             ["lsblk", "--noheadings", "--nodeps", "--paths", "--output", "NAME,SIZE,TYPE,MODEL"],
             check=False,
         )
+        # A failed inventory must not present the machine as having no install target.
+        if listed.returncode != 0:
+            raise CommandFailed("lsblk could not list disks")
         found: list[ProbedDisk] = []
-        for line in listed.stdout.splitlines() if listed.returncode == 0 else []:
+        for line in listed.stdout.splitlines():
             fields = line.split(maxsplit=3)
             if len(fields) < 3 or fields[2] != "disk":
                 continue
@@ -888,8 +910,9 @@ class Probe:
             ["parted", "--machine", "--script", disk, "unit", "B", "print", "free"],
             check=False,
         )
+        # A failed table read cannot fall back to model-only placement on an edited disk.
         if listed.returncode != 0:
-            raise DeviceNotFound(f"parted could not read the table of {disk}")
+            raise CommandFailed(f"parted could not read the table of {disk}")
         found: list[Extent] = []
         for line in listed.stdout.splitlines():
             fields = line.strip().rstrip(";").split(":")
@@ -1272,9 +1295,18 @@ class Probe:
         would answer `UEFI_GRUB` for a machine GRUB does not manage.
         """
         if _efi_variables():
-            said = self.runner.run(["bootctl", "status"], check=False)
-            if said.returncode == 0 and BOOTED_BY_SYSTEMD_BOOT.search(said.stdout):
-                return BootMethod.SYSTEMD_BOOT
+            # A machine without systemd carries no `bootctl`, which is an answer
+            # about the loader. A `bootctl` that is there and fails is not, and
+            # reading that as GRUB armed `grub-reboot` on a systemd-boot machine.
+            if shutil.which("bootctl") is not None:
+                said = self.runner.run(["bootctl", "status"], check=False)
+                if said.returncode != 0:
+                    raise CommandFailed(
+                        "bootctl status could not determine the current boot loader: "
+                        f"{said.stdout.strip()[:200]}"
+                    )
+                if BOOTED_BY_SYSTEMD_BOOT.search(said.stdout):
+                    return BootMethod.SYSTEMD_BOOT
             if shutil.which("efibootmgr") is not None:
                 return BootMethod.UEFI_GRUB
             return BootMethod.NONE
@@ -1326,18 +1358,25 @@ class Probe:
             ],
             check=False,
         )
+        # An unreadable listing must not present an occupied disk as empty.
         if listed.returncode != 0:
-            return ()
+            raise CommandFailed(f"lsblk could not read the partitions of {disk}")
         try:
             document: object = json.loads(listed.stdout)
-        except json.JSONDecodeError:
-            return ()
+        except json.JSONDecodeError as error:
+            raise CommandFailed(
+                f"lsblk could not read the partitions of {disk}: invalid JSON"
+            ) from error
         if not isinstance(document, Mapping):
-            return ()
+            raise CommandFailed(
+                f"lsblk could not read the partitions of {disk}: invalid JSON document"
+            )
         roots = document.get("blockdevices")
-        if not isinstance(roots, list):
-            return ()
-        return tuple(row for root in roots for row in _lsblk_children(root))
+        if not isinstance(roots, list) or len(roots) != 1 or not isinstance(roots[0], Mapping):
+            raise CommandFailed(
+                f"lsblk could not read the partitions of {disk}: invalid JSON document"
+            )
+        return _lsblk_children(roots[0])
 
     def partitions(self, disk: str) -> tuple[tuple[str, str, str], ...]:
         """Display rows retained for callers that have not moved to facts."""
@@ -1636,8 +1675,6 @@ def _free_extents(graph: DeviceGraph, probe: Probe) -> dict[DeviceId, tuple[Exte
         disk = graph.nodes.get(table.disk)
         if not isinstance(disk, Existing):
             continue
-        try:
-            found[table.id] = probe.free_extents(probe.resolve(disk.id, disk.selector))
-        except DeviceNotFound:
-            continue
+        # An edited table needs measured gaps; guessing can overwrite retained partitions.
+        found[table.id] = probe.free_extents(probe.resolve(disk.id, disk.selector))
     return found

--- a/gentoo_install/plan/convert.py
+++ b/gentoo_install/plan/convert.py
@@ -473,6 +473,9 @@ def _unsupported_layer(layout: StorageLayout) -> str:
         ("LVM", layout.root_on_lvm),
         ("mdraid", layout.root_on_mdraid),
     ):
+        # A failed block probe is not evidence that the root has no unsupported layer.
+        if present is None:
+            raise ConversionUnsupported("the root block-device stack could not be read")
         if present:
             return name
     return ""

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -20,7 +20,7 @@ from gentoo_install.i18n import Catalog, tag_for
 from gentoo_install.exec import fetch
 from gentoo_install.exec import report
 from gentoo_install.exec.probe import BootMethod, Probe as RealProbe
-from gentoo_install.exec.runner import Runner
+from gentoo_install.exec.runner import Result, Runner
 from gentoo_install.cli import EXIT_CONFIG, EXIT_INTEGRITY, EXIT_OK, EXIT_PREFLIGHT, main
 from gentoo_install.errors import CommandFailed, ConfigError, IntegrityError
 from gentoo_install.model.config import DiskConfig, DiskMode, ImageFormat, MemoryLaunch, MemoryMode
@@ -1936,6 +1936,113 @@ def test_the_conversion_offer_names_the_command_the_reading_needs(
     absent.clear()
     with pytest.raises(AssertionError, match="must not be read"):
         cli._conversion_offer(cast(RealProbe, Probe()))
+
+def test_an_unreadable_fstab_refuses_conversion_before_entries_are_lost(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    from gentoo_install.exec import probe as probe_module
+    from gentoo_install.model import refusals
+
+    class Storage(Runner):
+        def run(
+            self,
+            argv: Sequence[str],
+            *,
+            check: bool = True,
+            input_text: str | None = None,
+            timeout: float | None = None,
+        ) -> Result:
+            if argv[0] == "findmnt":
+                stdout = (
+                    '{"filesystems":[{"target":"/","source":"/dev/vda2",'
+                    '"fstype":"ext4","avail":21474836480}]}'
+                )
+            elif argv[0] == "lsblk":
+                stdout = (
+                    '{"blockdevices":[{"path":"/dev/vda2","type":"part",'
+                    '"pkname":"/dev/vda"},{"path":"/dev/vda","type":"disk"}]}'
+                )
+            else:
+                stdout = "root-uuid\n"
+            return Result(argv=tuple(argv), returncode=0, stdout=stdout, stderr="", seconds=0.0)
+
+    def unreadable(
+        path: Path, encoding: str | None = None, errors: str | None = None
+    ) -> str:
+        raise OSError(f"{path}: permission denied")
+
+    monkeypatch.setattr(probe_module, "EFI_MARKER", tmp_path / "no-efi")
+    monkeypatch.setattr(Path, "read_text", unreadable)
+    monkeypatch.setattr(RealProbe, "live_medium", lambda self: "")
+    monkeypatch.setattr(report, "absent", lambda wanted, probe=None: set())
+
+    _, refused, layout = cli._conversion_offer(
+        RealProbe(runner=Storage(log=lambda line: None), work=tmp_path)
+    )
+
+    assert layout is None
+    assert refused.reason == refusals.CANNOT_READ_THE_SYSTEM
+    assert "/etc/fstab" in refused.detail
+
+    # A machine with no fstab at all carries nothing, which is an answer: only
+    # one this cannot open is a probe that failed.
+    def absent(path: Path, encoding: str | None = None, errors: str | None = None) -> str:
+        raise FileNotFoundError(f"{path}: no such file")
+
+    monkeypatch.setattr(Path, "read_text", absent)
+    _, allowed, read = cli._conversion_offer(
+        RealProbe(runner=Storage(log=lambda line: None), work=tmp_path)
+    )
+    assert read is not None, allowed
+    assert read.carried_fstab == ()
+
+
+def test_an_unreadable_bootctl_status_does_not_build_a_grub_target(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    from gentoo_install.exec import probe as probe_module
+
+    class Failing(Runner):
+        def run(
+            self,
+            argv: Sequence[str],
+            *,
+            check: bool = True,
+            input_text: str | None = None,
+            timeout: float | None = None,
+        ) -> Result:
+            return Result(
+                argv=tuple(argv),
+                returncode=1,
+                stdout="bootctl: failed to read boot loader status\n",
+                stderr="",
+                seconds=0.0,
+            )
+
+    class BootProbe(RealProbe):
+        def storage_layout(self) -> StorageLayout:
+            return StorageLayout(
+                root_device="/dev/vda2",
+                root_filesystem_type="ext4",
+                root_uuid="root-uuid",
+                root_on_lvm=False,
+                root_on_luks=False,
+                root_on_mdraid=False,
+                root_below_device="/dev/vda",
+                boot_device="/dev/vda2",
+                boot_filesystem_type="ext4",
+                boot_same_filesystem=True,
+                esp_device="/dev/vda1",
+                esp_mountpoint="/boot/efi",
+                uefi=True,
+                root_free_bytes=20 * 2**30,
+            )
+
+    monkeypatch.setattr(probe_module, "_efi_variables", lambda: True)
+    monkeypatch.setattr(shutil, "which", lambda name: f"/usr/bin/{name}")
+
+    with pytest.raises(CommandFailed, match="bootctl status"):
+        cli._boot_target(BootProbe(runner=Failing(log=lambda line: None), work=tmp_path))
 
 
 def test_an_unattended_conversion_still_records_that_ssh_stops() -> None:

--- a/tests/unit/test_exec.py
+++ b/tests/unit/test_exec.py
@@ -1988,10 +1988,14 @@ def test_an_edited_table_counts_what_it_keeps(tmp_path: Path) -> None:
             timeout: float | None = None,
         ) -> Result:
             said = ""
-            if argv[0] == "lsblk" and "SIZE" in argv and "PARTN,SIZE" not in argv:
+            if argv[0] == "lsblk" and "--json" in argv:
+                said = (
+                    '{"blockdevices":[{"name":"/dev/null","children":['
+                    f'{{"name":"/dev/null1","partn":1,"size":{18 * 1024**3},'
+                    '"fstype":"ext4","type":"part"}]}]}'
+                )
+            elif argv[0] == "lsblk" and "SIZE" in argv and "PARTN,SIZE" not in argv:
                 said = f"{twenty}\n"
-            elif argv[0] == "lsblk" and "PARTN,SIZE" in argv:
-                said = f"1 {18 * 1024**3}\n"
             return Result(argv=tuple(argv), returncode=0, stdout=said, stderr="", seconds=0.0)
 
     probe = Probe(runner=Answering(log=lambda line: None), work=tmp_path)
@@ -2048,10 +2052,14 @@ def test_removing_a_partition_the_disk_does_not_have_is_refused(tmp_path: Path) 
                 timeout: float | None = None,
             ) -> Result:
                 said = ""
-                if argv[0] == "lsblk" and "SIZE" in argv and "PARTN,SIZE" not in argv:
+                if argv[0] == "lsblk" and "--json" in argv:
+                    said = (
+                        '{"blockdevices":[{"name":"/dev/null","children":['
+                        f'{{"name":"/dev/null1","partn":1,"size":{1024**3},'
+                        '"fstype":"ext4","type":"part"}]}]}'
+                    )
+                elif argv[0] == "lsblk" and "SIZE" in argv and "PARTN,SIZE" not in argv:
                     said = f"{64 * 1024**3}\n"
-                elif argv[0] == "lsblk" and "PARTN,SIZE" in argv:
-                    said = f"1 {1024**3}\n"
                 return Result(argv=tuple(argv), returncode=0, stdout=said, stderr="", seconds=0.0)
 
         probe = Probe(runner=Answering(log=lambda line: None), work=tmp_path)

--- a/tests/unit/test_plan_convert.py
+++ b/tests/unit/test_plan_convert.py
@@ -18,6 +18,9 @@ from gentoo_install.plan.convert import SwapDirectories
 from gentoo_install.plan.operations import Stage
 from gentoo_install.model.config import DiskConfig, DiskMode
 from gentoo_install.errors import ConversionFailed, ConversionUnsupported
+from gentoo_install.exec import probe as probe_module
+from gentoo_install.exec.probe import Probe
+from gentoo_install.exec.runner import Result, Runner
 from gentoo_install.model.device import (
     DeviceGraph,
     DeviceId,
@@ -502,6 +505,48 @@ def test_a_conversion_without_a_layout_is_refused_there_too() -> None:
 
     with pytest.raises(ConversionUnsupported, match="was not read"):
         running_config(_in_place(), None)
+
+def test_an_unreadable_block_listing_refuses_conversion_as_an_unknown_stack(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    class Failing(Runner):
+        def run(
+            self,
+            argv: Sequence[str],
+            *,
+            check: bool = True,
+            input_text: str | None = None,
+            timeout: float | None = None,
+        ) -> Result:
+            if argv[0] == "findmnt":
+                stdout = (
+                    '{"filesystems":[{"target":"/","source":"/dev/vda2",'
+                    '"fstype":"ext4","avail":21474836480}]}'
+                )
+                returncode = 0
+            elif argv[0] == "lsblk":
+                stdout = "lsblk: cannot access block devices\n"
+                returncode = 1
+            else:
+                stdout = "root-uuid\n"
+                returncode = 0
+            return Result(
+                argv=tuple(argv),
+                returncode=returncode,
+                stdout=stdout,
+                stderr="",
+                seconds=0.0,
+            )
+
+    efi = tmp_path / "efi"
+    efi.mkdir()
+    monkeypatch.setattr(probe_module, "EFI_MARKER", efi)
+    monkeypatch.setattr(probe_module, "_fstab_we_do_not_manage", lambda esp, boot: ())
+    layout = Probe(runner=Failing(log=lambda line: None), work=tmp_path).storage_layout()
+
+    assert layout.root_on_luks is None
+    with pytest.raises(ConversionUnsupported, match="block-device stack could not be read"):
+        convert.layout_graph(layout)
 
 
 def test_the_mounts_the_conversion_does_not_manage_are_carried() -> None:

--- a/tests/unit/test_plan_disk.py
+++ b/tests/unit/test_plan_disk.py
@@ -1073,6 +1073,40 @@ def test_a_partition_added_to_an_edited_mbr_goes_after_the_ones_on_the_disk() ->
     assert start.bytes > 1074790399, start
     assert start.is_aligned(), start
 
+def test_an_unreadable_edited_table_does_not_fall_back_to_model_placement(
+    tmp_path: Path,
+) -> None:
+    from gentoo_install.exec.probe import Probe, probe_storage_facts
+    from gentoo_install.exec.runner import Result, Runner
+    from gentoo_install.model.config import DiskConfig
+
+    class Failing(Runner):
+        def run(
+            self,
+            argv: Sequence[str],
+            *,
+            check: bool = True,
+            input_text: str | None = None,
+            timeout: float | None = None,
+        ) -> Result:
+            failed = argv[0] == "parted"
+            return Result(
+                argv=tuple(argv),
+                returncode=1 if failed else 0,
+                stdout="parted: cannot read the partition table\n" if failed else "",
+                stderr="",
+                seconds=0.0,
+            )
+
+    installation = replace(
+        config(),
+        disk=DiskConfig(graph=_edited_mbr(), root=DeviceId("m")),
+    )
+    reader = Probe(runner=Failing(log=lambda line: None), work=tmp_path)
+
+    with pytest.raises(CommandFailed, match="parted could not read the table"):
+        probe_storage_facts(installation, reader)
+
 
 def test_a_partition_that_fits_no_free_extent_is_refused_before_anything_runs() -> None:
     """Refused while the table is unchanged: the removals of the same plan run

--- a/tests/unit/test_probe.py
+++ b/tests/unit/test_probe.py
@@ -6,7 +6,7 @@ from typing import Final, Sequence
 import json
 import pytest
 
-from gentoo_install.errors import DeviceNotFound
+from gentoo_install.errors import CommandFailed, DeviceNotFound
 from gentoo_install.exec import probe
 from gentoo_install.exec.probe import Probe
 from gentoo_install.exec.runner import Result, Runner
@@ -150,6 +150,30 @@ def test_a_disk_probe_keeps_the_kernel_path_that_the_display_tuple_lost(
         setattr(disk, "selector", "/dev/vda")
     assert probe.disks() == (("/dev/disk/by-id/virtio-sample", "64G Sample Disk"),)
 
+def test_an_unreadable_disk_listing_does_not_answer_as_no_install_target(
+    tmp_path: Path,
+) -> None:
+    class Failing(Runner):
+        def run(
+            self,
+            argv: Sequence[str],
+            *,
+            check: bool = True,
+            input_text: str | None = None,
+            timeout: float | None = None,
+        ) -> Result:
+            return Result(
+                argv=tuple(argv),
+                returncode=1,
+                stdout="lsblk: cannot access block devices\n",
+                stderr="",
+                seconds=0.0,
+            )
+
+    with pytest.raises(CommandFailed, match="lsblk could not list disks"):
+        Probe(runner=Failing(log=lambda line: None), work=tmp_path).disks()
+
+
 
 def test_a_partition_probe_keeps_the_exact_size_that_the_display_tuple_lost(
     tmp_path: Path,
@@ -166,6 +190,35 @@ def test_a_partition_probe_keeps_the_exact_size_that_the_display_tuple_lost(
     with pytest.raises(FrozenInstanceError):
         setattr(partition, "size_bytes", 0)
     assert probe.partitions("/dev/vda") == (("/dev/vda1", "16G", "ext4"),)
+
+@pytest.mark.parametrize(
+    ("returncode", "stdout"),
+    ((1, "lsblk: not a block device\n"), (0, "not JSON\n")),
+    ids=("nonzero", "malformed-json"),
+)
+def test_an_unreadable_partition_listing_does_not_answer_as_empty(
+    tmp_path: Path, returncode: int, stdout: str
+) -> None:
+    class Failing(Runner):
+        def run(
+            self,
+            argv: Sequence[str],
+            *,
+            check: bool = True,
+            input_text: str | None = None,
+            timeout: float | None = None,
+        ) -> Result:
+            return Result(
+                argv=tuple(argv),
+                returncode=returncode,
+                stdout=stdout,
+                stderr="",
+                seconds=0.0,
+            )
+
+    with pytest.raises(CommandFailed, match="lsblk could not read the partitions"):
+        Probe(runner=Failing(log=lambda line: None), work=tmp_path).partitions("/dev/vda")
+
 
 
 def test_the_live_medium_is_read_from_the_kernel_command_line(
@@ -435,7 +488,13 @@ def test_a_uefi_machine_without_systemd_boot_uses_efibootmgr(
 
     class NoBootctl(Runner):
         def run(self, argv: Sequence[str], **rest: object) -> Result:
-            return Result(argv=tuple(argv), returncode=1, stdout="", stderr="", seconds=0.0)
+            return Result(
+                argv=tuple(argv),
+                returncode=0,
+                stdout="Current Boot Loader:\n Product: grub\n",
+                stderr="",
+                seconds=0.0,
+            )
 
     method = probe.Probe(runner=NoBootctl(log=lambda line: None), work=tmp_path).boot_method()
 
@@ -891,6 +950,10 @@ def test_a_selector_may_be_spelled_the_way_the_installer_writes_one() -> None:
     assert udev_path_for("PARTUUID=dd") == "/dev/disk/by-partuuid/dd"
     # The tag as `blkid` prints it or as an operator types it.
     assert udev_path_for("partlabel=esp") == "/dev/disk/by-partlabel/esp"
+    assert (
+        udev_path_for("PARTLABEL=Basic data/root")
+        == "/dev/disk/by-partlabel/Basic\\x20data\\x2froot"
+    )
 
     # A path is left exactly as written, including one that already names the
     # directory this would have built.


### PR DESCRIPTION
Seven readers in `exec/probe.py` gave a failed command the value a successful one gives when it finds nothing, and each one has a consequence on a real machine.

`lsblk` failing left `root_on_luks` and its neighbours `None`, and `plan/convert.py`'s `if present: return name` read that as "no unsupported layer", so a conversion ran on a LUKS root it cannot rebuild. `lsblk --json` failing answered an empty tuple, which the disk editor reads as "this disk has no partitions" and seeds with a fresh-layout proposal. A `bootctl status` that could not run reported `UEFI_GRUB` while `efibootmgr` was on PATH, so `grub-reboot` was run on a systemd-boot machine. An unreadable `/etc/fstab` answered as a machine with no carried mounts. `parted print free` failing left a table with no extents and fell back to model-only placement. A whole-disk `lsblk` failing reached the operator as "this machine has no disk to install onto". And `PARTLABEL=root/home` built a path udev does not write: libblkid escapes anything outside `0-9 A-Z a-z #+-.:=@_` as `\\xNN`, keeping valid UTF-8 sequences whole.

Two of these are answers rather than failures and stay that way: a machine with no `bootctl` is not running systemd-boot, and a machine with no `/etc/fstab` carries nothing. Seven controls, run in batches because the two in `test_cli.py` fall past a two-minute timeout when they are run together.