### PR TITLE
system: the runner asks about the service the plan enables

### DIFF
--- a/gentoo_install/plan/system.py
+++ b/gentoo_install/plan/system.py
@@ -834,7 +834,7 @@ class LinkNetifrcService(Operation):
         return "enable net.{} so netifrc applies the static address", (self.interface,)
 
     def apply(self, context: Context) -> None:
-        service = f"net.{self.interface}"
+        service = netifrc_service(self.interface)
         context.run_in_target(
             ["ln", "--symbolic", "--force", "net.lo", f"/etc/init.d/{service}"]
         )
@@ -1639,10 +1639,27 @@ def _logging(system: SystemConfig) -> list[Operation]:
     return operations
 
 
+def netifrc_service(interface: str) -> str:
+    """The service netifrc runs for one interface, as `LinkNetifrcService`
+    names it. One spelling, because the runner checks for what the plan
+    enabled."""
+    return f"net.{interface}"
+
+
 def _network_service(system: SystemConfig) -> str:
-    """The VM runner reports this name without building the whole plan."""
-    services = NETWORK_BACKENDS[system.networking].for_init(system.init).services
-    return services[0].value if services else ""
+    """The VM runner reports this name without building the whole plan.
+
+    Through `services_for`, not `.services`: an openrc machine with a static
+    address enables `net.<interface>` and this answered `dhcpcd`, so the check
+    asked about a service the plan never enables.
+    """
+    requirements = NETWORK_BACKENDS[system.networking].for_init(system.init)
+    services = requirements.services_for(static=bool(system.addresses))
+    if not services:
+        return ""
+    if services[0] is NetworkService.NETIFRC_INTERFACE:
+        return netifrc_service(system.interface) if system.interface else ""
+    return str(services[0].value)
 
 
 def _set_password(context: Context, user: str, password_hash: str) -> None:

--- a/tests/unit/test_plan_system.py
+++ b/tests/unit/test_plan_system.py
@@ -1647,3 +1647,37 @@ def test_a_link_listing_that_failed_says_so_before_matching_by_name() -> None:
     working = _linked()
     _wired().apply(working)
     assert not working.degraded(system.MAC_MATCH)
+
+
+def test_the_service_the_runner_checks_is_one_the_plan_enables() -> None:
+    """`tests/vm/installed.py` asks the installed machine whether that service
+    is enabled. The helper read `.services` while the plan reads
+    `services_for(static=...)`, so an openrc machine given a static address
+    enabled `net.<interface>` and the check asked about `dhcpcd`. No fixture
+    combines openrc with a static address, which is why it never failed.
+    """
+    from gentoo_install.model.config import InitSystem, Networking, SystemConfig
+    from gentoo_install.plan.system import _network_service
+
+    for init in (InitSystem.SYSTEMD, InitSystem.OPENRC):
+        for addresses in ((), ("192.0.2.10/24",)):
+            settings = SystemConfig(
+                init=init,
+                networking=Networking.BUILTIN,
+                interface="eth0",
+                addresses=addresses,
+                gateways=("192.0.2.1",) if addresses else (),
+                dns=("192.0.2.53",) if addresses else (),
+            )
+            named = _network_service(settings)
+            assert named, (init, addresses)
+
+            planned = system.build(replace(config(), system=settings))
+            enabled = {
+                one.service for one in planned if isinstance(one, system.EnableService)
+            } | {
+                system.netifrc_service(one.interface)
+                for one in planned
+                if isinstance(one, system.LinkNetifrcService)
+            }
+            assert named in enabled, (init, addresses, named, sorted(enabled))


### PR DESCRIPTION
`_network_service` read `NETWORK_BACKENDS[...].for_init(init).services` while `build()` reads `services_for(static=bool(addresses))`. An openrc machine given a static address enables `net.<interface>` through `LinkNetifrcService`, and `tests/vm/installed.py` asked the installed machine whether `dhcpcd` was enabled.

The check has never failed, because no fixture combines openrc with a static address — `static-ip.toml` is systemd and every openrc fixture uses DHCP. That gap is `docs/tasks.md` 461.

`netifrc_service(interface)` is now the one spelling, read by `LinkNetifrcService.apply` as well. The test does not restate a service name: it takes `_network_service`'s answer and requires it to be in the set of services `system.build()` actually enables, across systemd/openrc and DHCP/static. The control was run red.