### PR TITLE
compat: mdadm unable to answer is not mdadm saying no

### DIFF
--- a/gentoo_install/data/locale/ja.toml
+++ b/gentoo_install/data/locale/ja.toml
@@ -523,6 +523,8 @@
 "the patched kernel from gentoo-zh" = "gentoo-zh のパッチ適用カーネル"
 "unlocking the root over ssh" = "ssh によるルートの解錠"
 "no authorised ssh key" = "許可された ssh 鍵がない"
+"an esp whose mdraid metadata could not be read" = "mdraid metadata を読み取れなかった esp"
+"mdadm could not say whether the esp is on an array, and only metadata 0.90 and 1.0 leave a member the firmware can read as plain vfat" = "mdadm は esp がアレイ上にあるかどうかを判断できず、メンバーをファームウェアが通常の vfat として読めるのは metadata 0.90 と 1.0 だけです"
 "authorised ssh keys" = "設定済みの ssh 公開鍵"
 "no account sshd will accept a key for" = "sshd が鍵を受け付けるアカウントがありません"
 "every key is written to /root/.ssh/authorized_keys and sshd is given PermitRootLogin no, so none of them can log in: add a user with sudo, or allow root login" = "すべての鍵は /root/.ssh/authorized_keys に書かれ、sshd は PermitRootLogin no に設定されるため、どの鍵でもログインできません。sudo を持つユーザーを追加するか、root ログインを許可してください"

--- a/gentoo_install/data/locale/ko.toml
+++ b/gentoo_install/data/locale/ko.toml
@@ -523,6 +523,8 @@
 "the patched kernel from gentoo-zh" = "gentoo-zh의 패치 적용 커널"
 "unlocking the root over ssh" = "ssh를 통한 루트 잠금 해제"
 "no authorised ssh key" = "승인된 ssh 키 없음"
+"an esp whose mdraid metadata could not be read" = "mdraid metadata를 읽지 못한 esp"
+"mdadm could not say whether the esp is on an array, and only metadata 0.90 and 1.0 leave a member the firmware can read as plain vfat" = "mdadm이 esp가 배열 위에 있는지 판단하지 못했으며, 펌웨어가 구성원을 일반 vfat으로 읽을 수 있는 것은 metadata 0.90과 1.0뿐입니다"
 "authorised ssh keys" = "설정된 ssh 공개 키"
 "no account sshd will accept a key for" = "sshd가 키를 받아들일 계정이 없음"
 "every key is written to /root/.ssh/authorized_keys and sshd is given PermitRootLogin no, so none of them can log in: add a user with sudo, or allow root login" = "모든 키는 /root/.ssh/authorized_keys에 기록되고 sshd는 PermitRootLogin no로 설정되므로 어떤 키로도 로그인할 수 없습니다. sudo 사용자를 추가하거나 root 로그인을 허용하십시오"

--- a/gentoo_install/data/locale/zh-CN.toml
+++ b/gentoo_install/data/locale/zh-CN.toml
@@ -524,6 +524,8 @@
 "the patched kernel from gentoo-zh" = "gentoo-zh 的补丁内核"
 "unlocking the root over ssh" = "通过 ssh 解锁根文件系统"
 "no authorised ssh key" = "没有授权的 ssh 密钥"
+"an esp whose mdraid metadata could not be read" = "mdraid metadata 无法读取的 esp"
+"mdadm could not say whether the esp is on an array, and only metadata 0.90 and 1.0 leave a member the firmware can read as plain vfat" = "mdadm 无法判断 esp 是否位于阵列上，而只有 metadata 0.90 与 1.0 会让成员仍可被固件当成普通 vfat 读取"
 "authorised ssh keys" = "已配置的 ssh 公钥"
 "no account sshd will accept a key for" = "没有 sshd 会接受公钥的账户"
 "every key is written to /root/.ssh/authorized_keys and sshd is given PermitRootLogin no, so none of them can log in: add a user with sudo, or allow root login" = "所有公钥都写入 /root/.ssh/authorized_keys，而 sshd 设为 PermitRootLogin no，因此没有一把能用来登录：请新增一个有 sudo 的用户，或允许 root 登录"

--- a/gentoo_install/data/locale/zh-TW.toml
+++ b/gentoo_install/data/locale/zh-TW.toml
@@ -524,6 +524,8 @@
 "the patched kernel from gentoo-zh" = "gentoo-zh 的補丁核心"
 "unlocking the root over ssh" = "透過 ssh 解鎖根檔案系統"
 "no authorised ssh key" = "沒有授權的 ssh 金鑰"
+"an esp whose mdraid metadata could not be read" = "mdraid metadata 無法讀取的 esp"
+"mdadm could not say whether the esp is on an array, and only metadata 0.90 and 1.0 leave a member the firmware can read as plain vfat" = "mdadm 無法判斷 esp 是否位於陣列上，而只有 metadata 0.90 與 1.0 會讓成員仍可被韌體當成一般 vfat 讀取"
 "authorised ssh keys" = "已設定的 ssh 公鑰"
 "no account sshd will accept a key for" = "沒有 sshd 會接受公鑰的帳戶"
 "every key is written to /root/.ssh/authorized_keys and sshd is given PermitRootLogin no, so none of them can log in: add a user with sudo, or allow root login" = "所有公鑰都寫進 /root/.ssh/authorized_keys，而 sshd 設為 PermitRootLogin no，因此沒有一把能用來登入：請新增一個有 sudo 的使用者，或允許 root 登入"

--- a/gentoo_install/model/compat.py
+++ b/gentoo_install/model/compat.py
@@ -51,6 +51,7 @@ from .device import (
     Partition,
     PartitionRole,
     PartitionTable,
+    MdraidMetadataState,
     RaidMetadata,
     StorageFacts,
     Swap,
@@ -636,6 +637,7 @@ class Trait(Enum):
     IN_PLACE_CONVERSION = "in-place conversion"
     AUTHORIZED_KEYS = "authorised ssh keys"
     NO_ACCOUNT_A_KEY_CAN_REACH = "no account sshd will accept a key for"
+    ESP_MDRAID_UNREADABLE = "an esp whose mdraid metadata could not be read"
 
 
 @dataclass(frozen=True)
@@ -660,6 +662,12 @@ class Rule:
 
 
 RULES: tuple[Rule, ...] = (
+    Rule(
+        Trait.UEFI_BOOT,
+        Trait.ESP_MDRAID_UNREADABLE,
+        "mdadm could not say whether the esp is on an array, and only metadata "
+        "0.90 and 1.0 leave a member the firmware can read as plain vfat",
+    ),
     Rule(
         Trait.AUTHORIZED_KEYS,
         Trait.NO_ACCOUNT_A_KEY_CAN_REACH,
@@ -867,8 +875,16 @@ def traits_of(
     mounted = esp_mount(graph)
     beneath = {node.id for node in _chain(graph, mounted.id)} if mounted else set()
     for reused in graph.of_type(Existing):
+        if reused.id not in beneath:
+            continue
         metadata = facts.metadata_for(reused.id)
-        if not isinstance(metadata, RaidMetadata) or reused.id not in beneath:
+        # `NOT_PROBED` is a plan built without facts and answers nothing.
+        # `UNAVAILABLE` is mdadm asked and unable to say, which cannot be read
+        # as `ABSENT`: an esp on a 1.2 array boots nothing.
+        if metadata is MdraidMetadataState.UNAVAILABLE:
+            found.add(Trait.ESP_MDRAID_UNREADABLE)
+            continue
+        if not isinstance(metadata, RaidMetadata):
             continue
         found.add(Trait.ESP_ON_MDRAID)
         if metadata.superblock_at_start:

--- a/gentoo_install/model/device.py
+++ b/gentoo_install/model/device.py
@@ -82,8 +82,14 @@ class RaidMetadata(Enum):
 
 
 class MdraidMetadataState(Enum):
-    """Why a reused device has no mdraid metadata version."""
+    """Why a reused device has no mdraid metadata version.
 
+    Three answers, not two: nobody asked, mdadm could not answer, and mdadm
+    answered that this is not an array. A rule that reads the middle one as the
+    last accepted an esp on a 1.2 array, which the firmware cannot read.
+    """
+
+    NOT_PROBED = "not probed"
     UNAVAILABLE = "unavailable"
     ABSENT = "absent"
 
@@ -190,7 +196,7 @@ class StorageFacts:
         object.__setattr__(self, "capacities", MappingProxyType(dict(capacities or {})))
 
     def metadata_for(self, device: DeviceId) -> MdraidMetadataFact:
-        return self.mdraid_metadata.get(device, MdraidMetadataState.UNAVAILABLE)
+        return self.mdraid_metadata.get(device, MdraidMetadataState.NOT_PROBED)
 
 
 @dataclass(frozen=True)

--- a/tests/unit/test_compat.py
+++ b/tests/unit/test_compat.py
@@ -329,7 +329,24 @@ def a_key_no_account_can_use() -> InstallConfig:
     )
 
 
+def an_esp_mdadm_could_not_read() -> InstallConfig:
+    """mdadm asked and unable to answer, which is not the same as answering
+    that the device is no array. Reading the two alike accepted an esp on a
+    1.2 array, which the firmware cannot read as plain vfat."""
+    return config(reused_esp())
+
+
+#: The facts a case needs to reach its rule. Most rules read the graph alone;
+#: these read what the machine answered about a device already on it.
+FACTS_FOR: dict[Callable[[], InstallConfig], StorageFacts] = {
+    an_esp_mdadm_could_not_read: StorageFacts(
+        mdraid_metadata={i("esp"): MdraidMetadataState.UNAVAILABLE}
+    ),
+}
+
+
 CASES: list[tuple[Callable[[], InstallConfig], Trait, Trait]] = [
+    (an_esp_mdadm_could_not_read, Trait.UEFI_BOOT, Trait.ESP_MDRAID_UNREADABLE),
     (a_key_no_account_can_use, Trait.AUTHORIZED_KEYS, Trait.NO_ACCOUNT_A_KEY_CAN_REACH),
     (a_system_nothing_can_log_into, Trait.ROOT_LOCKED, Trait.NO_OTHER_LOGIN),
     (zfs_on_grub, Trait.ROOT_ON_ZFS, Trait.GRUB),
@@ -390,7 +407,8 @@ def test_kernel_cases_cover_the_package_table() -> None:
 def test_each_rule_fires_on_a_configuration_that_breaks_it(
     build: Callable[[], InstallConfig], when: Trait, excludes: Trait
 ) -> None:
-    assert (when, excludes) in {(rule.when, rule.excludes) for rule in violations(build())}
+    found = violations(build(), FACTS_FOR.get(build))
+    assert (when, excludes) in {(rule.when, rule.excludes) for rule in found}
 
 
 @pytest.mark.parametrize("name", ["ext2", "ext3"])
@@ -844,14 +862,22 @@ def test_a_reused_array_under_the_esp_meets_the_firmware_rule() -> None:
         installation,
         StorageFacts(mdraid_metadata={i("esp"): MdraidMetadataState.ABSENT}),
     )
-    unavailable = traits_of(installation, StorageFacts())
+    not_probed = traits_of(installation, StorageFacts())
+    unavailable = traits_of(
+        installation,
+        StorageFacts(mdraid_metadata={i("esp"): MdraidMetadataState.UNAVAILABLE}),
+    )
 
     assert Trait.ESP_ON_MDRAID in at_start
     assert Trait.ESP_MDRAID_SUPERBLOCK_AT_START in at_start
     assert Trait.ESP_ON_MDRAID in at_end
     assert Trait.ESP_MDRAID_SUPERBLOCK_AT_START not in at_end
     assert Trait.ESP_ON_MDRAID not in absent
-    assert Trait.ESP_ON_MDRAID not in unavailable
+    # Nobody asked, so nothing is claimed; mdadm asked and could not say, which
+    # is the answer a rule has to refuse.
+    assert Trait.ESP_ON_MDRAID not in not_probed
+    assert Trait.ESP_MDRAID_UNREADABLE not in not_probed
+    assert Trait.ESP_MDRAID_UNREADABLE in unavailable
 
 
 def test_a_mirror_with_no_ipv6_is_refused_on_an_ipv6_only_machine() -> None:


### PR DESCRIPTION
`MdraidMetadataState`'s docstring says it records why a reused device has no metadata version, and `Probe.mdraid_metadata`'s says a missing command or an unopenable device is `UNAVAILABLE`, which differs from mdadm establishing that the device is not an array. Both layers were right; the esp rule read every non-`RaidMetadata` answer alike, so an esp on a 1.2 array passed validation and the firmware could not read the member as plain vfat.

`metadata_for` used to answer `UNAVAILABLE` for a device nobody had asked about, and a plan built without facts has an empty map — refusing on that would have stopped every reuse install, which is the shape of the regression this same rule caused in `bootctl`. `NOT_PROBED` is the third answer: nobody asked, mdadm could not say, mdadm said no.

`CASES` carries only a config builder, so `FACTS_FOR` supplies the facts for the rules that need them rather than reshaping twenty-odd rows. An existing variable named `unavailable` was in fact empty facts and is now `not_probed`, with the real `UNAVAILABLE` case added beside it. The control was run red.