### PR TITLE
netboot: refuse a half-written entry rather than eating the file

### DIFF
--- a/gentoo_install/plan/netboot.py
+++ b/gentoo_install/plan/netboot.py
@@ -1207,6 +1207,14 @@ def _without_previous(text: str) -> str:
     if CUSTOM_BEGIN not in text:
         return text
     before, _, rest = text.partition(CUSTOM_BEGIN)
+    if CUSTOM_END not in rest:
+        # `partition` answers an empty tail for a marker that is not there, so
+        # an interrupted write took everything after the opening marker with
+        # it, including entries the operator wrote.
+        raise PreflightFailed(
+            f"{CUSTOM_BEGIN} in the GRUB custom configuration has no "
+            f"{CUSTOM_END} after it; remove the partial entry by hand"
+        )
     _, _, after = rest.partition(CUSTOM_END)
     return before + after.lstrip("\n")
 

--- a/tests/unit/test_plan_netboot.py
+++ b/tests/unit/test_plan_netboot.py
@@ -1894,3 +1894,25 @@ def test_the_plan_is_the_one_place_that_decides_the_environment_needs_sshd(
     assert {one.needs_ssh for one in asked} == {wanted}, [
         (type(one).__name__, one.needs_ssh) for one in asked
     ]
+
+
+def test_a_partial_previous_entry_is_refused_rather_than_swallowing_the_file() -> None:
+    """`partition` answers an empty tail for a marker that is not there, so an
+    opening marker with no closing one took everything after it — the
+    operator's own entries included — and wrote the new entry over them."""
+    recorder = _answering()
+    target = _target(BootMethod.BIOS_GRUB)
+    custom = PurePosixPath("/boot/grub/custom.cfg")
+    recorder.files[custom] = (
+        f"menuentry 'theirs' {{ linux /vmlinuz }}\n"
+        f"{netboot.CUSTOM_BEGIN}\n"
+        "menuentry 'ours, half written' {\n"
+        "menuentry 'theirs, after' { linux /other }\n"
+    )
+
+    with pytest.raises(PreflightFailed, match="has no"):
+        netboot.WriteMemoryEntry(
+            mode=MemoryMode.RAM, target=target, launch=_launch()
+        ).apply(recorder)
+
+    assert "theirs, after" in recorder.files[custom]


### PR DESCRIPTION
`_without_previous` checked that `CUSTOM_BEGIN` is in the file and then ran `rest.partition(CUSTOM_END)` unconditionally. `str.partition` answers an empty tail for a separator that is not there, so a `custom.cfg` left by an interrupted write — opening marker, no closing one — lost everything from that marker to the end of the file, including menu entries the operator had written. The new entry was then appended over them.

It now raises `PreflightFailed` naming both markers and asking for the partial entry to be removed by hand: the file belongs to the operator and guessing where their entry begins would be the same mistake.

`test_an_unrelated_custom_entry_is_kept` covers only a file whose markers are both present. The control was run red.