### PR TITLE
kernel: rebuild the initramfs from the atom the merge installed

### DIFF
--- a/gentoo_install/plan/kernel.py
+++ b/gentoo_install/plan/kernel.py
@@ -569,6 +569,9 @@ class RebuildInitramfs(Operation):
     any package that pulls one in, so the image is built again from it."""
 
     stage: Stage = Stage.KERNEL
+    #: The atom the merge used, not the bare package: `dist-kernel` slots by
+    #: version, so with two installed `emerge --config sys-kernel/gentoo-kernel`
+    #: prints both and exits `Please use a specific atom`.
     package: str
 
     def describe(self) -> str:
@@ -844,7 +847,7 @@ def build(config: InstallConfig, hardware: HardwareFacts = HardwareFacts()) -> l
     # is built here.
     if graph.of_type(ZfsPool):
         operations.append(GenerateHostId())
-    operations.append(RebuildInitramfs(package=package))
+    operations.append(RebuildInitramfs(package=atom))
     operations.append(RequireKernelImage())
     return operations
 

--- a/tests/unit/test_plan_boot.py
+++ b/tests/unit/test_plan_boot.py
@@ -1279,3 +1279,29 @@ def test_a_test_that_could_not_run_is_not_read_as_a_missing_image() -> None:
 
     with pytest.raises(CommandFailed, match="could not be read"):
         kernel.RequireKernelImage().apply(recorder)
+
+
+def test_the_initramfs_rebuild_names_the_version_the_merge_installed() -> None:
+    """`dist-kernel` slots by version, so a machine carrying two of them makes
+    `emerge --config sys-kernel/gentoo-kernel` print both and exit `Please use
+    a specific atom` — `action_config` matches the argument against the vdb and
+    refuses more than one hit."""
+    from dataclasses import replace as _replace
+
+    from gentoo_install.model.config import KernelConfig, KernelSource
+    from gentoo_install.plan.kernel import RebuildInitramfs
+
+    pinned = _replace(
+        config(),
+        kernel=KernelConfig(source=KernelSource.DIST_BIN, version="6.12.47"),
+    )
+    operations = kernel.build(pinned)
+    merge = next(
+        one
+        for one in operations
+        if isinstance(one, Emerge) and one.summary.startswith("install the kernel")
+    )
+    rebuild = next(one for one in operations if isinstance(one, RebuildInitramfs))
+
+    assert rebuild.package in merge.packages, (rebuild.package, merge.packages)
+    assert rebuild.package.startswith("="), rebuild.package


### PR DESCRIPTION
The merge runs `=sys-kernel/gentoo-kernel-6.12.47` when a version is pinned, and `RebuildInitramfs` was handed the bare package name. A dist-kernel slots by version, so a machine already carrying another one makes `emerge --config sys-kernel/gentoo-kernel` print both and exit `Please use a specific atom or the --ask option.` — the install stops in the kernel stage.

Portage takes the versioned form: `_emerge/actions.py` gates on `is_valid_package_atom(myfiles[0], allow_repo=True)`, matches the argument against the vdb, and refuses only when more than one installed package matches.

The test does not restate the atom; it requires `RebuildInitramfs.package` to be one of the packages that merge installed, so changing either side alone fails. The control was run red, and the goldens are regenerated in the same commit.