### PR TITLE
preflight: measure a root that is a whole reused device

### DIFF
--- a/gentoo_install/exec/preflight.py
+++ b/gentoo_install/exec/preflight.py
@@ -424,6 +424,21 @@ def _capacity_problems(config: InstallConfig, probe: Probe) -> list[str]:
                 f"{disk.selector} holds {Size(capacity)} and {table.id} claims "
                 f"{Size(claimed)} in fixed sizes, which does not fit"
             )
+    # Every reused device on the root path, not only the ones a partition
+    # table sits on: a root that is a whole device carries no table, so the
+    # loop above supplied nothing and the size check had nothing to check.
+    if config.disk.mode is not DiskMode.IMAGE:
+        for node in graph.of_type(Existing):
+            if node.id in supplied_root_sizes or graph.nodes.get(node.id) is None:
+                continue
+            if any(table.disk == node.id for table in graph.of_type(PartitionTable)):
+                continue
+            try:
+                measured = probe.disk_bytes(probe.resolve(node.id, node.selector))
+            except DeviceNotFound:
+                continue
+            if measured:
+                supplied_root_sizes[node.id] = Size(measured)
     problems += root_size_problems(config, supplied_root_sizes)
     return problems
 

--- a/tests/unit/test_preflight.py
+++ b/tests/unit/test_preflight.py
@@ -282,3 +282,47 @@ def test_a_conversion_from_a_running_system_is_allowed(tmp_path: Path) -> None:
     )
 
     assert not any("in-place conversion" in one for one in report.fatal)
+
+
+def test_a_reused_whole_device_root_is_measured_too(tmp_path: Path) -> None:
+    """The capacity loop starts at every `PartitionTable`, so a root that is a
+    whole reused device — no table above it — supplied nothing and the size
+    check had nothing to check. An install into 8 GiB runs out during
+    linux-firmware, an hour after the disks were written."""
+    from gentoo_install.model.config import DiskConfig
+    from gentoo_install.model.device import (
+        Existing,
+        Filesystem,
+        FilesystemType,
+        Mountpoint,
+        Node,
+    )
+    from pathlib import PurePosixPath
+
+    nodes: list[Node] = [
+        Existing(id=i("root-device"), selector="/dev/sdb", wipe=False),
+        Filesystem(
+            id=i("rootfs"),
+            device=i("root-device"),
+            kind=FilesystemType.EXT4,
+            create=False,
+        ),
+        Mountpoint(id=i("mnt-root"), source=i("rootfs"), path=PurePosixPath("/")),
+    ]
+    reused = replace(
+        config(),
+        disk=DiskConfig(graph=DeviceGraph.build(nodes), root=i("mnt-root")),
+    )
+
+    class EightGiB(Probe):
+        def resolve(self, device: object, selector: str) -> str:
+            return selector
+
+        def disk_bytes(self, path: str) -> int:
+            return 8 * 2**30
+
+    report = preflight.check(
+        reused, EightGiB(runner=Runner(log=lambda line: None), work=tmp_path), operations=()
+    )
+
+    assert any("carries / and is" in one for one in report.fatal), report.fatal


### PR DESCRIPTION
`_layout_fits` collects capacities with `for table in graph.of_type(PartitionTable)`, so a root that is a whole reused device — no table above it — put nothing into `supplied_root_sizes`, and `root_size_problems` had nothing to check.

`ROOT_MINIMUM` exists because that case was measured: `validate.py` records that an install into 8 GiB runs out during linux-firmware, an hour after the disks were written. The measurement was there and the check could not reach it.

Every reused device on the root path that carries no partition table is now measured with the same `disk_bytes` the disks use. The control was run red.