### PR TITLE
manual: refuse a mount point zfs cannot name a dataset after

### DIFF
--- a/gentoo_install/model/manual.py
+++ b/gentoo_install/model/manual.py
@@ -334,6 +334,30 @@ def dataset_for(mountpoint: str) -> str:
     return ROOT_DATASET if mountpoint == "/" else mountpoint.strip("/").replace("//", "/")
 
 
+#: What a dataset name component may hold, from OpenZFS's own
+#: `zfs_namecheck.c`: `valid_char` takes the alphanumerics plus `-`, `_`, `.`,
+#: `:` and a space, and everything else is `NAME_ERR_INVALCHAR`. `@` is the
+#: snapshot separator, so a mount point holding one names a snapshot to
+#: `zfs create`.
+DATASET_CHARACTERS: Final[frozenset[str]] = frozenset(
+    "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789-_.: "
+)
+
+
+def dataset_name_refused(mountpoint: str) -> str:
+    """Why `zfs create` would refuse the dataset for this mount point."""
+    name = dataset_for(mountpoint)
+    if not name:
+        return ""
+    for component in name.split("/"):
+        if not component:
+            return f"{name} has an empty component"
+        refused = next((one for one in component if one not in DATASET_CHARACTERS), "")
+        if refused:
+            return f"{name} holds {refused!r}, which a dataset name cannot"
+    return ""
+
+
 def _index_of(entry: Slice) -> int:
     """The number the partition has in the table on the disk.
 
@@ -535,11 +559,23 @@ def build(layout: Layout) -> tuple[DeviceGraph, DeviceId]:
                 passphrase_file=layout.passphrase_file,
             )
         )
+        # Names, not ids: `DeviceGraph.build` rejects a duplicate id, and `/`
+        # and `/ROOT/gentoo` both spell `ROOT/gentoo`, so the second
+        # `zfs create` failed on a dataset that already exists.
+        taken: dict[str, str] = {}
         for prefix, entry in datasets:
+            name = dataset_for(entry.mountpoint)
+            if refused := dataset_name_refused(entry.mountpoint):
+                raise InvalidLayout(f"{entry.mountpoint} names a dataset {refused}")
+            if name in taken:
+                raise InvalidLayout(
+                    f"{entry.mountpoint} and {taken[name]} both name the dataset {name}"
+                )
+            taken[name] = entry.mountpoint
             dataset = DeviceId(f"{prefix}-ds{entry.index}")
             mount = DeviceId(f"{prefix}-mnt{entry.index}")
             nodes += [
-                ZfsDataset(id=dataset, pool=DeviceId("pool"), name=dataset_for(entry.mountpoint)),
+                ZfsDataset(id=dataset, pool=DeviceId("pool"), name=name),
                 Mountpoint(id=mount, source=dataset, path=PurePosixPath(entry.mountpoint)),
             ]
             if entry.mountpoint == "/":

--- a/gentoo_install/tui/partitions.py
+++ b/gentoo_install/tui/partitions.py
@@ -865,10 +865,17 @@ class _SliceRule:
 
 
 def _mountpoint_refused(entry: manual.Slice) -> bool:
-    # The two conditions `validate` reads off the built graph, where the
-    # message names a node rather than the field the operator typed into.
-    return bool(entry.mountpoint) and (
-        not entry.mountpoint.startswith("/") or ".." in entry.mountpoint.split("/")
+    # The conditions `validate` reads off the built graph, where the message
+    # names a node rather than the field the operator typed into. A zfs row
+    # carries a third: the mount point becomes the dataset name, and `zfs
+    # create` takes a narrower character set than a path does.
+    if not entry.mountpoint:
+        return False
+    if not entry.mountpoint.startswith("/") or ".." in entry.mountpoint.split("/"):
+        return True
+    return bool(
+        entry.role is PartitionRole.ZFS
+        and manual.dataset_name_refused(entry.mountpoint)
     )
 
 

--- a/tests/unit/test_tui_partitions.py
+++ b/tests/unit/test_tui_partitions.py
@@ -1836,3 +1836,29 @@ def test_reopening_swap_resizes_the_slice_it_already_added() -> None:
     sizes = [entry.size for entry in at.layout.slices if entry.role is PartitionRole.SWAP]
     assert sizes == [Size.parse("8GiB")], sizes
     assert len(answer.unwrap().disk.graph.of_type(Swap)) == 1
+
+
+def test_a_mountpoint_that_cannot_be_a_dataset_name_is_refused() -> None:
+    """A zfs row's mount point becomes the dataset name, and OpenZFS's
+    `valid_char` takes only alphanumerics, `-`, `_`, `.`, `:` and a space —
+    `@` is the snapshot separator, so `/srv/@cache` asks `zfs create` for a
+    snapshot. And `/` and `/ROOT/gentoo` both spell `ROOT/gentoo`, which
+    `DeviceGraph.build` cannot see because it only rejects duplicate ids."""
+    def zfs_row(index: int, mountpoint: str) -> manual.Slice:
+        return manual.Slice(
+            index=index, role=PartitionRole.ZFS, size=None, mountpoint=mountpoint
+        )
+
+    bad_character = one_disk(slices=[zfs_row(1, "/srv/@cache")])
+    with pytest.raises(InvalidLayout, match="cannot"):
+        manual.build(bad_character)
+
+    same_name = one_disk(slices=[zfs_row(1, "/"), zfs_row(2, "/ROOT/gentoo")])
+    with pytest.raises(InvalidLayout, match="both name the dataset"):
+        manual.build(same_name)
+
+    # An ordinary pair still builds.
+    fine = one_disk(slices=[zfs_row(1, "/"), zfs_row(2, "/srv")])
+    graph, root = manual.build(fine)
+    assert root
+    assert {one.name for one in graph.of_type(ZfsDataset)} == {"ROOT/gentoo", "srv"}


### PR DESCRIPTION
A zfs row's mount point becomes the dataset name. OpenZFS' own `module/zcommon/zfs_namecheck.c` defines `valid_char` as the alphanumerics plus `-`, `_`, `.`, `:` and a space, and everything else is `NAME_ERR_INVALCHAR`; `get_dataset_depth` in the same file treats `@` and `#` as the snapshot and bookmark separators. So `/srv/@cache` passed the editor's check — which refuses only a non-absolute path or `..` — and asked `zfs create` for a snapshot, in the format stage, after the disks were written.

`/` and `/ROOT/gentoo` both spell `ROOT/gentoo`. `DeviceGraph.build` cannot see that: it rejects a duplicate `node.id`, and these are two ids carrying one name, so the second `zfs create` failed on a dataset that already exists.

`manual.dataset_name_refused()` is the one rule; `manual.build()` raises `InvalidLayout` and the editor's `_mountpoint_refused` reads the same function, so a zfs row is refused as it is typed. The control was run red.