### PR TITLE
parse: an empty value is not the key being absent

### DIFF
--- a/gentoo_install/model/parse.py
+++ b/gentoo_install/model/parse.py
@@ -413,12 +413,29 @@ def _choice(raw: Any, at: str) -> templates.Choice:
         disk=_str(raw, "disk", at, required=True),
         layout=layout,
         firmware=_enum(raw, "firmware", at, Firmware, Firmware.UEFI),
-        table=_enum(raw, "table", at, TableType, None) if raw.get("table") else None,
+        # `in raw`, not truthiness: an explicit `table = ""` was read as the
+        # key being absent, while the graph reader answers `expected one of` for
+        # the same value. One spelling of a key cannot mean two things.
+        table=_enum(raw, "table", at, TableType, None) if "table" in raw else None,
         filesystem=_enum(raw, "filesystem", at, FilesystemType, FilesystemType.XFS),
         swap=_size(raw, "swap", at),
         passphrase_file=_str(raw, "passphrase_file", at),
-        pool=_str(raw, "pool", at) or "rpool",
+        pool=_pool(raw, at),
     )
+
+
+def _pool(raw: Mapping[str, Any], at: str) -> str:
+    """The pool name, refusing an empty one rather than substituting.
+
+    `_str(...) or "rpool"` read `pool = ""` as the key being absent, so a
+    configuration that says the pool has no name installed one called `rpool`.
+    """
+    if "pool" not in raw:
+        return templates.Choice(disk="").pool
+    named = _str(raw, "pool", at)
+    if not named:
+        raise ConfigError(f"{_at('pool', at)} is empty; name the pool or leave the key out")
+    return named
 
 
 def _node(raw: Mapping[str, Any], at: str) -> Node:

--- a/tests/unit/test_parse.py
+++ b/tests/unit/test_parse.py
@@ -541,3 +541,34 @@ def test_a_simple_disk_refuses_a_key_it_does_not_know() -> None:
 
     with pytest.raises(ConfigError, match="filesystems"):
         parse(raw)
+
+
+@pytest.mark.parametrize(
+    "key, value, said",
+    [
+        ("table", '""', "expected one of"),
+        ("pool", '""', "is empty"),
+    ],
+)
+def test_an_empty_value_is_not_the_key_being_absent(
+    key: str, value: str, said: str
+) -> None:
+    """`raw.get(key)` and `_str(...) or default` both read an explicit empty
+    string as the key not being there, while the graph reader answers
+    `expected one of` for the same value. A configuration that says the table
+    has no type installed a GPT one, and one that says the pool has no name
+    installed `rpool`."""
+    raw = tomllib.loads(
+        f'[disk.simple]\ndisk = "/dev/sda"\nlayout = "whole-disk-zfs"\n{key} = {value}\n'
+    )
+    with pytest.raises(ConfigError, match=said):
+        parse(raw)
+
+
+def test_a_key_left_out_still_takes_the_default() -> None:
+    without = parse(
+        tomllib.loads('[disk.simple]\ndisk = "/dev/sda"\nlayout = "whole-disk-zfs"\n')
+    )
+    assert without.disk.simple is not None
+    assert without.disk.simple.table is None
+    assert without.disk.simple.pool == "rpool"


### PR DESCRIPTION
`table=_enum(...) if raw.get("table") else None` and `pool=_str(...) or "rpool"` both read an explicitly written empty string as the key not being there. A configuration saying the table has no type installed a GPT one; a configuration saying the pool has no name installed `rpool`. The graph reader spells the same key the same way and answers `expected one of` for `table = ""`, so one key had two meanings depending on which section it appeared in.

`table` now tests `"table" in raw`. `pool` goes through `_pool()`, which takes the default when the key is absent and refuses an empty one naming both ways out. The default is read from `templates.Choice`, not written a second time.

Three tests: both refusals and one that leaves the keys out and checks the defaults still apply. Both controls were run red.