### PR TITLE
convert: tell the rollback how each entry arrived

### DIFF
--- a/gentoo_install/exec/convert.py
+++ b/gentoo_install/exec/convert.py
@@ -100,7 +100,9 @@ def _remove(path: Path) -> None:
         path.unlink(missing_ok=True)
 
 
-def _replace_contents(destination: Path, staged: Path, copy: Copier) -> None:
+def _replace_contents(
+    destination: Path, staged: Path, copy: Copier
+) -> list[tuple[str, Arrival]]:
     """Swap what is in a mount point, since the mount point cannot be renamed.
 
     Moving the destination's own entries aside is a `rename(2)` inside the
@@ -157,27 +159,25 @@ def _replace_contents(destination: Path, staged: Path, copy: Copier) -> None:
         raise ConversionFailed(
             f"{destination} could not be replaced by content: {error}"
         ) from error
+    return arrived
 
 
-def _restore_contents(destination: Path, staged: Path) -> None:
+def _restore_contents(
+    destination: Path, staged: Path, arrived: Sequence[tuple[str, Arrival]]
+) -> None:
     """Undo `_replace_contents` when a later directory fails.
 
-    Entries that arrived across a filesystem boundary are removed rather than
-    renamed back. `_replace_contents` reaches `copy()` only after `rename`
-    answered `EXDEV`, and renaming the same entry the other way is that move
-    again: it raised, the caller recorded the error and left the directory
-    half replaced, which on `/usr` is a machine that does not boot. A copy
-    leaves the staged original in place, so removing the copy is the undo.
+    Told how each entry arrived rather than asking again: rederiving it meant
+    trying the reverse `rename` and reading `EXDEV`, and a mount that has gone
+    since answers that rename with success, which moves the underlying entry
+    into staging and leaves the copy on the mount. A copy leaves the staged
+    original in place, so removing the copy is its undo.
     """
     aside = destination / KEPT_ASIDE
-    for name in sorted(os.listdir(destination)):
-        if name == KEPT_ASIDE:
-            continue
-        try:
+    for name, how in reversed(arrived):
+        if how is Arrival.RENAMED:
             os.rename(destination / name, staged / name)
-        except OSError as error:
-            if error.errno != errno.EXDEV:
-                raise
+        else:
             _remove(destination / name)
     for name in sorted(os.listdir(aside)):
         os.rename(aside / name, destination / name)
@@ -233,12 +233,15 @@ def convert(
     destinations.sort(key=lambda entry: entry[5])
 
     swapped: list[tuple[str, Path, Path, Path, bool, bool]] = []
+    #: How each entry of a replaced mount point arrived, so the rollback is
+    #: told rather than asking the filesystem a second time.
+    arrivals: dict[str, list[tuple[str, Arrival]]] = {}
     for entry in destinations:
         name, destination, staged, old, present, mounted = entry
         moved_old = False
         try:
             if mounted:
-                _replace_contents(destination, staged, copy)
+                arrivals[name] = _replace_contents(destination, staged, copy)
             else:
                 if present:
                     os.rename(destination, old)
@@ -261,7 +264,11 @@ def convert(
                 ) = entry_back
                 if was_mounted:
                     try:
-                        _restore_contents(swapped_destination, swapped_staged)
+                        _restore_contents(
+                            swapped_destination,
+                            swapped_staged,
+                            arrivals.get(swapped_name, []),
+                        )
                     except OSError as rollback_error:
                         error.add_note(
                             f"could not restore {swapped_name}: {rollback_error}"

--- a/tests/unit/test_convert.py
+++ b/tests/unit/test_convert.py
@@ -531,18 +531,16 @@ def test_a_directory_that_cannot_be_listed_is_not_reported_as_empty(
 def test_a_copied_entry_is_undone_by_removing_it(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
-    """The later rollback renamed back what only a copy could bring in.
+    """The rollback is told how each entry arrived rather than asking again.
 
-    `_replace_contents` reaches `copy()` only after `rename` answered `EXDEV`,
-    and `_restore_contents` then renamed the same entry the other way: the
-    same cross-device move, which raises. `convert` records the error and
-    leaves the directory half replaced, and on `/usr` that is a machine that
-    does not boot.
+    It used to try the reverse `rename` and read `EXDEV` to decide, so the
+    answer depended on the mount still being there. `convert` records the
+    error and leaves the directory half replaced, and on `/usr` that is a
+    machine that does not boot.
     """
-    import errno
-    import os
+    del monkeypatch
 
-    from gentoo_install.exec.convert import KEPT_ASIDE, _restore_contents
+    from gentoo_install.exec.convert import KEPT_ASIDE, Arrival, _restore_contents
 
     destination = tmp_path / "var"
     staged = tmp_path / "staging" / "var"
@@ -553,27 +551,23 @@ def test_a_copied_entry_is_undone_by_removing_it(
     # entry held aside, the staged one copied in, and the staged original
     # still present because a copy does not consume it.
     (aside / "old").write_text("the machine's own")
-    (destination / "new").write_text("from the stage3")
-    (staged / "new").write_text("from the stage3")
+    # The copy is half written, which is the hazard `_replace_contents` records
+    # when it puts the entry on the list before calling `copy`.
+    (destination / "new").write_text("from the stage3, half")
+    (staged / "new").write_text("from the stage3, whole")
 
-    real_rename = os.rename
-
-    def crossing(source: "str | Path", target: "str | Path") -> None:
-        # Only the direction that leaves the mount: an entry moving out of the
-        # destination into the staging root. Putting the held-aside original
-        # back is a rename inside the mount and still works.
-        if str(source).startswith(str(destination)) and KEPT_ASIDE not in str(source):
-            raise OSError(errno.EXDEV, "Invalid cross-device link")
-        real_rename(source, target)
-
-    monkeypatch.setattr(os, "rename", crossing)
-    _restore_contents(destination, staged)
+    # `rename` works throughout: the mount the copy crossed is gone by the time
+    # the rollback runs, which is exactly when rederiving the answer gives the
+    # wrong one. The old code renamed the underlying entry into staging and
+    # left the copy behind.
+    _restore_contents(destination, staged, [("new", Arrival.COPIED)])
 
     # The machine's own entry is back and the copy is gone.
     assert (destination / "old").read_text() == "the machine's own"
     assert not (destination / "new").exists()
-    # The staged copy is untouched, so a later attempt still has it.
-    assert (staged / "new").read_text() == "from the stage3"
+    # The staged original is untouched, so a later attempt still has it. The
+    # rollback used to rename the half-written copy over it.
+    assert (staged / "new").read_text() == "from the stage3, whole"
     assert not aside.exists()
 
 
@@ -584,7 +578,7 @@ def test_a_rollback_still_raises_for_anything_but_a_crossing(
     import errno
     import os
 
-    from gentoo_install.exec.convert import KEPT_ASIDE, _restore_contents
+    from gentoo_install.exec.convert import KEPT_ASIDE, Arrival, _restore_contents
 
     destination = tmp_path / "var"
     staged = tmp_path / "staging" / "var"
@@ -598,7 +592,7 @@ def test_a_rollback_still_raises_for_anything_but_a_crossing(
 
     monkeypatch.setattr(os, "rename", busy)
     with pytest.raises(OSError) as raised:
-        _restore_contents(destination, staged)
+        _restore_contents(destination, staged, [("new", Arrival.RENAMED)])
     assert raised.value.errno == errno.EBUSY
 
 


### PR DESCRIPTION
`_replace_contents` records how every entry got there — `Arrival.RENAMED` or `Arrival.COPIED` — and threw the list away. `_restore_contents` rederived it by attempting the reverse `rename` and reading `EXDEV`, so its answer depended on the mount still being there.

When it is not, the reverse rename succeeds: the entry underneath moves into the staging root, over the original, and the half-written copy stays on the mount. `_replace_contents` records the entry before calling `copy` precisely because a copy can write part of a tree and then fail, so the case is one the file already knows about — the rollback just could not see it.

`_replace_contents` now returns the record, `convert()` keeps it per swapped destination, and `_restore_contents` undoes exactly what happened.

The first version of the test did not distinguish the two implementations, because the copy and the staged original held the same bytes and the reverse rename replaced one with an identical file. Making the copy half-written is what separates them, and that is the real hazard. The control was run red.