### PR TITLE
tui, plan, exec: say what the code does, and gate the words that say it

### DIFF
--- a/gentoo_install/cli.py
+++ b/gentoo_install/cli.py
@@ -1217,11 +1217,11 @@ def _refuse_a_different_run(
         record("resuming: the journal records no identity, so it is not checked")
         return
     for name, refusal in _RESUME_REFUSALS.items():
-        mine, theirs = identity.get(name, ""), held.get(name, "")
+        now, recorded = identity.get(name, ""), held.get(name, "")
         # An empty value on either side is a machine that cannot answer, and
         # the boot id is the one that can be missing; comparing against it
         # would refuse every resume there.
-        if mine and theirs and mine != theirs:
+        if now and recorded and now != recorded:
             raise ResumeRefused(refusal)
 
 def _refuse_a_resume_with_no_journal(work: Path, resuming: bool) -> None:

--- a/gentoo_install/exec/fetch.py
+++ b/gentoo_install/exec/fetch.py
@@ -262,7 +262,7 @@ def _newest(
     The path, not the bare name. Each entry is `<timestamp>/<name> <size>`,
     and the dated directory is where the file stays; `current-stage3-amd64-*`
     is a symlink that moves when a build is published, and downloading through
-    it answered `404 Not Found` for an archive the pointer had just named.
+    it answered `404 Not Found` for an archive the pointer had named a moment before.
 
     The signature around the entries is not checked here: the DIGESTS file is,
     and it is what decides whether the bytes are the right ones.
@@ -753,7 +753,7 @@ def _over(family: int) -> Iterator[None]:
     guest a second earlier.
 
     Both directions, not only a fall back to IPv4. An IPv6-only machine has no
-    IPv4 route at all, and retrying the family that just failed is no retry.
+    IPv4 route at all, and retrying the family that failed is no retry.
     """
     # One thread at a time: this replaces the process-global resolver and
     # restores what it captured, so two overlapping calls leave the second
@@ -844,11 +844,12 @@ def _interfaces() -> str:
 def _network_namespace() -> str:
     """Whether this process shares the machine's network namespace."""
     try:
-        mine = Path("/proc/self/ns/net").readlink()
-        theirs = Path("/proc/1/ns/net").readlink()
+        process = Path("/proc/self/ns/net").readlink()
+        machine = Path("/proc/1/ns/net").readlink()
     except OSError as error:
         return f"namespace unreadable: {type(error).__name__}"
-    return f"namespace {'shared' if mine == theirs else f'{mine} not {theirs}'}"
+    same = process == machine
+    return f"namespace {'shared' if same else f'{process} not {machine}'}"
 
 
 def _kernel_routes(path: Path) -> str:

--- a/gentoo_install/exec/probe.py
+++ b/gentoo_install/exec/probe.py
@@ -268,18 +268,20 @@ class ProbedPartition:
     device_type: str
 
 
-#: The mount points a conversion writes itself. Every other line of the
+#: The mount points a conversion writes itself. Every other mount of the
 #: running `/etc/fstab` is carried across.
 _MANAGED_MOUNTS: Final[frozenset[str]] = frozenset({"/", "/boot", "/efi", "/boot/efi"})
 
 
 def _fstab_we_do_not_manage(esp: str | None, boot: str | None) -> tuple[str, ...]:
-    """The running fstab's other mounts, verbatim.
+    """The running fstab's other mounts, one line each with trailing space cut.
 
-    `distro2gentoo` copies the whole file across and keeps every mount the
-    machine had. This installer writes `/`, `/boot` and the esp from what it
-    probed, because their identifiers are the ones it just read; the rest —
-    a data partition, swap, a bind mount — is the operator's and is carried.
+    Mounts, not the file: comments and blank lines are dropped, so the
+    converted machine keeps what it mounts and not how the file was laid out.
+    `distro2gentoo` copies the whole file across instead. This installer
+    writes `/`, `/boot` and the esp from what it probed, because it read those
+    identifiers itself; the rest — a data partition, swap, a bind mount — is
+    the operator's and is carried.
     """
     managed = set(_MANAGED_MOUNTS) | {one for one in (esp, boot) if one}
     try:
@@ -1454,7 +1456,7 @@ class Probe:
         """Every partition on the disk now, by number, in bytes.
 
         A table the operator edits rather than rewrites keeps partitions the
-        configuration never names, and their space is claimed just as much as
+        configuration never names, and their space is claimed as much as
         a new partition's.
         """
         found = {
@@ -1562,16 +1564,16 @@ class Probe:
             # answer `True` when their command fails, and so does this one.
             return True
         whole = str(Path(disk).resolve())
-        ours = False
+        ignored = False
         for line in listed.stdout.splitlines():
             if not line.startswith(("\t", " ")):
                 # A pool line. Its last field is the altroot, and `-` when the
                 # pool was imported without one.
                 fields = line.split()
                 where = fields[-1] if fields else "-"
-                ours = bool(ignoring) and where != "-" and _under(where, ignoring)
+                ignored = bool(ignoring) and where != "-" and _under(where, ignoring)
                 continue
-            if ours:
+            if ignored:
                 continue
             for field in line.split():
                 if not field.startswith("/"):

--- a/gentoo_install/model/mirrors.py
+++ b/gentoo_install/model/mirrors.py
@@ -255,9 +255,8 @@ def gentoo_rsync_uri(region: MirrorRegion, preferred: str = "") -> str:
 
 #: Where a mirror keeps the official binary packages, relative to the
 #: distfiles base. Every site that carries the releases tree carries these.
-#: Where a mirror keeps the official binary packages, relative to the
-#: distfiles base. The architecture appears twice in one URL and both come
-#: from the same row: `releases/<gentoo_name>/binpackages/<release>/<subarch>`.
+#: The architecture appears twice in one URL and both come from the same row:
+#: `releases/<gentoo_name>/binpackages/<release>/<subarch>`.
 BINPACKAGES: Final[str] = "releases/{arch}/binpackages/" + PROFILE_RELEASE
 
 

--- a/gentoo_install/plan/convert.py
+++ b/gentoo_install/plan/convert.py
@@ -135,7 +135,7 @@ FSTAB: Final[PurePosixPath] = PurePosixPath("/etc/fstab")
 
 @dataclass(frozen=True, kw_only=True)
 class CarryFstabEntries(Operation):
-    """Append the running machine's other mounts to the fstab just written.
+    """Append the running machine's other mounts to the fstab written above.
 
     A conversion replaces `/etc`, so a data partition, a swap or a bind mount
     the operator had would be gone from the new file: the machine boots and is
@@ -321,7 +321,7 @@ class PopulateBoot(Operation):
     `/boot` is not in the swap: it is a separate mount on many machines and
     holds the esp below it on many more, and `rename` refuses both. Without
     this the converted machine keeps the old distribution's kernels and the
-    one that was just built stays in the staging root.
+    one built by this run stays in the staging root.
     """
 
     stage: Stage = Stage.BOOTLOADER

--- a/gentoo_install/plan/kernel.py
+++ b/gentoo_install/plan/kernel.py
@@ -58,7 +58,7 @@ TEST_ANSWERED: Final[tuple[int, ...]] = (0, 1)
 REMOTE_UNLOCK_PACKAGE: Final[str] = "sys-kernel/dracut-crypt-ssh"
 
 #: Not `crypt-ssh.conf`: `dracut-crypt-ssh` installs a file of exactly that
-#: name, so writing ours there is a CONFIG_PROTECT collision and the merge
+#: name, so writing the installer's there is a CONFIG_PROTECT collision and the merge
 #: leaves the package's copy unapplied as `._cfg0000_crypt-ssh.conf`.
 #: `zz-` and not a digit prefix: dracut sources the directory in lexical order
 #: and the last assignment to a scalar wins, and a digit sorts before every

--- a/gentoo_install/plan/netboot.py
+++ b/gentoo_install/plan/netboot.py
@@ -1101,7 +1101,7 @@ def build(
     ]
     if configuration:
         # After the kernel is placed and before the entry names it: the
-        # appended segment goes on the initramfs that operation just wrote.
+        # appended segment goes on the initramfs that operation wrote.
         operations.append(
             AppendConfiguration(
                 target=target,
@@ -1173,7 +1173,7 @@ def _write_custom(
     # rereading the machine's own configuration works whatever `search` set.
     # `grub-set-default` writes `saved_entry`, which a machine whose
     # configuration says `GRUB_DEFAULT=0` never reads: a `--bypass` guest
-    # rebooted straight into `Booting \'Debian GNU/Linux\'` with our entry
+    # rebooted straight into `Booting \'Debian GNU/Linux\'` with the installer entry
     # selected in `grubenv`. `custom.cfg` is sourced at the end of `grub.cfg`,
     # after its own `set default`, so this assignment is the one that stands.
     chooses = f"set default='{ENTRY_LABEL}'\n" if bypass else ""
@@ -1203,7 +1203,7 @@ def _write_custom(
 
 
 def _without_previous(text: str) -> str:
-    """The file with any earlier entry of ours removed, markers included."""
+    """The file with any earlier entry of this installer removed, markers included."""
     if CUSTOM_BEGIN not in text:
         return text
     before, _, rest = text.partition(CUSTOM_BEGIN)

--- a/gentoo_install/plan/packages.py
+++ b/gentoo_install/plan/packages.py
@@ -827,7 +827,7 @@ RIME_SCHEMA_SUFFIX: Final[str] = ".schema.yaml"
 
 @dataclass(frozen=True, kw_only=True)
 class VerifyRimeSchemas(Operation):
-    """The schemas the profile just named, checked against the target.
+    """The schemas the profile named, checked against the target.
 
     rime ignores a schema that is not on disk and fcitx then falls back to
     `keyboard-us`, so a profile naming one reads as a working install: exit 0,
@@ -1087,7 +1087,7 @@ def _frameworks_behind(chosen: Sequence[Group], catalog: Catalog) -> tuple[Group
 
     `rime` on its own merged `app-i18n/fcitx-rime` and nothing else: no
     `app-i18n/fcitx`, and no `fcitx-gtk` or `fcitx-qt`, so no Gtk or Qt
-    application could reach the engine that had just been installed.
+    application could reach the engine installed beside it.
     """
     have = {group.name for group in chosen}
     wanted: list[Group] = []

--- a/gentoo_install/plan/portage.py
+++ b/gentoo_install/plan/portage.py
@@ -1201,7 +1201,7 @@ class Emerge(Operation):
 
         Every reader of a zero exit, not the first one: a retry that succeeded
         left the run saying it fetches binary packages from a host whose index
-        it had just failed to read.
+        it had failed to read.
         """
         unreadable = _unreadable_index(str(result))
         if unreadable is not None and not context.degraded(BINARY_PACKAGES):
@@ -1822,7 +1822,7 @@ def build(
         # No `dev-vcs/git`: rsync needs none, and the stage3 already has the
         # rsync binary. Signatures are verified per snapshot, not per commit.
         #
-        # No sync here either. `emerge-webrsync` has just placed a signed
+        # No sync here either. `emerge-webrsync` has already placed a signed
         # snapshot, and `SyncRepository` deletes it and fetches the same tree
         # again over rsync. Twelve guests behind one address did that at once
         # and rsync.gentoo.org answered `access denied ... from UNKNOWN`, which

--- a/gentoo_install/plan/system.py
+++ b/gentoo_install/plan/system.py
@@ -780,10 +780,10 @@ class WriteNetworkConfig(Operation):
             found = re.search(r"link/ether ([0-9a-f:]{17})", rest)
             if found:
                 addresses[name.partition("@")[0]] = found.group(1)
-        mine = addresses.get(self.interface, "")
-        if not mine or list(addresses.values()).count(mine) != 1:
+        address = addresses.get(self.interface, "")
+        if not address or list(addresses.values()).count(address) != 1:
             return ""
-        return mine
+        return address
 
     def _networkd(self, address: str = "") -> str:
         if address:

--- a/gentoo_install/tui/context.py
+++ b/gentoo_install/tui/context.py
@@ -200,8 +200,9 @@ class Context:
         #: disk authorised a second one the prompt never named.
         self.confirmed: set[str] = set()
         self.provenance: set[ValueProvenance] = set()
-        # Declared as an annotation and set only by `App`, so a `Context` built
-        # anywhere else answered `settled` with an AttributeError.
+        #: Which settings the operator has opened. Set here rather than by the
+        #: caller: a `Context` built anywhere else answered `settled` with an
+        #: AttributeError.
         self.visited: set[str] = set()
         #: The hand-written partition table, when the layout is manual.
         self.layout = manual.Layout()

--- a/gentoo_install/tui/packages.py
+++ b/gentoo_install/tui/packages.py
@@ -458,7 +458,7 @@ def settle(
     where = effects.editable_row
     named = translate("USE flags") if effects.use_flags else translate("VIDEO_CARDS")
     # Yes first and preselected. Declining cancels the desktop the operator
-    # just chose, and these values are what makes it work rather than extras
+    # chose, and these values are what makes it work rather than extras
     # that come with it, so the cursor starting on `No` offered the refusal as
     # the default answer to a question the choice itself had already implied.
     items = [
@@ -499,7 +499,7 @@ def settle(
         if opened.outcome is Outcome.CANCELLED:
             # Cancelling reaches the application's leave confirmation. Reading
             # it as `keep what was pinned` committed a desktop and a profile
-            # the operator had just refused.
+            # the operator had refused.
             return Answer(Outcome.CANCELLED)
     return Answer(Outcome.CHOSE, pinned)
 
@@ -519,7 +519,7 @@ def _record_derived(context: Context, after: InstallConfig, effects: Effects) ->
     # Only the kinds this proposal owns: it used to drop every derived record,
     # so choosing a desktop after ZFSBootMenu erased the overlay's and taking
     # the bootloader back left an overlay nobody had selected.
-    mine = {
+    owned = {
         ValueKind.USE_FLAG,
         ValueKind.VIDEO_CARD,
         ValueKind.NETWORKING,
@@ -528,7 +528,7 @@ def _record_derived(context: Context, after: InstallConfig, effects: Effects) ->
     context.provenance = {
         one
         for one in context.provenance
-        if not (one.kind in mine and one.source is ValueSource.DERIVED)
+        if not (one.kind in owned and one.source is ValueSource.DERIVED)
     }
     context.provenance.update(
         ValueProvenance(ValueKind.USE_FLAG, value, ValueSource.DERIVED)

--- a/gentoo_install/tui/widgets.py
+++ b/gentoo_install/tui/widgets.py
@@ -242,7 +242,7 @@ class Region:
         size = self.screen.size()
         if size != self._seen:
             # Before the arithmetic, so the rectangle answered is the one the
-            # frame just drew rather than the one it is about to replace.
+            # frame drew rather than the one it is about to replace.
             self._seen = size
             if self.redraw is not None:
                 self.redraw()

--- a/tests/unit/test_layers.py
+++ b/tests/unit/test_layers.py
@@ -387,9 +387,13 @@ def test_no_definition_in_the_package_is_unreachable() -> None:
     assert orphans == [], orphans
 
 
+#: Filler, and the first person. Both lists are in CLAUDE.md; `just` was left
+#: out of this table and fourteen uses of it accumulated behind the gate that
+#: exists to stop them.
 BANNED_WORDS = (
-    "simply", "note that", "basically", "obviously",
+    "simply", "just", "note that", "basically", "obviously",
     "powerful", "robust", "seamlessly", "leverage", "utilize",
+    "we", "our", "ours", "mine",
 )
 
 
@@ -400,10 +404,14 @@ def test_no_source_file_uses_a_banned_filler_word() -> None:
 
     root = Path(__file__).resolve().parents[2]
     pattern = re.compile("|".join(rf"\b{word}\b" for word in BANNED_WORDS), re.IGNORECASE)
+    # Backticks hold literals and tool output, and `parted` says `the closest
+    # location we can manage is 1048kB`. The rule is about this project's own
+    # prose, so what a quoted tool said is not the project saying it.
+    quoted = re.compile(r"`[^`]*`")
     found: list[str] = []
     for path in sorted((root / "gentoo_install").rglob("*.py")):
         for number, line in enumerate(path.read_text().splitlines(), 1):
-            if pattern.search(line):
+            if pattern.search(quoted.sub("", line)):
                 found.append(f"{path.relative_to(root)}:{number} {line.strip()[:60]}")
     assert found == [], found
 


### PR DESCRIPTION
Two comments described behaviour the code does not have.

`_fstab_we_do_not_manage` says the running fstab is carried "verbatim" and that "every other line" is kept; it drops comments, blank lines and short lines, and `rstrip()`s what it keeps. The behaviour is right for a converted machine — it keeps what the machine mounts — and the words were not. `tui/context.py` explains that `visited` is "set only by `App`", pointing at a name no longer in the package, three lines above the line that sets it.

The rest is the rule this repository already holds itself to. `BANNED_WORDS` in `test_layers.py` was missing `just`, which is in CLAUDE.md's list, and fourteen uses had accumulated behind the gate that exists to stop them; the first person had no entry at all. Both are now in the table, so the test is the control for the cleanup beside it — it goes red on the tree before this commit.

The table skips what backticks enclose: `parted` says `the closest location we can manage is 1048kB`, and the rule is about this project's prose, not a quoted tool's.