### PR TITLE
preflight: name the firmware, not a filesystem a BIOS machine cannot mount

### DIFF
--- a/gentoo_install/exec/preflight.py
+++ b/gentoo_install/exec/preflight.py
@@ -542,7 +542,17 @@ def inspect(
         )
     elif targets_machine_firmware and not wants_uefi and machine.uefi:
         warnings.append("the configuration boots by BIOS on a machine that booted by UEFI")
-    if targets_machine_firmware and wants_uefi and not machine.efi_variables:
+    if targets_machine_firmware and wants_uefi and not machine.uefi:
+        # A machine that booted by BIOS has no variables to mount, and the
+        # message below sent such an operator looking for efivarfs. The usual
+        # cause is a configuration file with no `firmware` key: the menu takes
+        # that from the machine and the parser defaults it to UEFI.
+        fatal.append(
+            "this machine booted by BIOS and the configuration installs for UEFI: "
+            'set `firmware = "bios"` under `[bootloader]`, or boot the medium '
+            "through UEFI"
+        )
+    elif targets_machine_firmware and wants_uefi and not machine.efi_variables:
         # Fatal: `efibootmgr --create` is what the ZFSBootMenu install runs,
         # and GRUB's `--bootloader-id` entry needs the same. The operator can
         # mount it, so the message says which command.

--- a/tests/unit/test_preflight.py
+++ b/tests/unit/test_preflight.py
@@ -326,3 +326,26 @@ def test_a_reused_whole_device_root_is_measured_too(tmp_path: Path) -> None:
     )
 
     assert any("carries / and is" in one for one in report.fatal), report.fatal
+
+
+def test_a_bios_machine_is_told_why_a_uefi_configuration_refuses(tmp_path: Path) -> None:
+    """`[bootloader] firmware` defaults to UEFI in the parser, while the menu
+    takes it from the machine. A configuration file that leaves the key out,
+    run on a BIOS machine, therefore installs for UEFI — and the refusal told
+    the operator to mount efivarfs, which a BIOS machine does not have."""
+    from gentoo_install.exec.probe import Machine as ProbedMachine
+
+    class Bios(Probe):
+        def machine(
+            self, wanted: frozenset[str] = frozenset(), judged: Iterable[str] = ()
+        ) -> ProbedMachine:
+            return replace(
+                super().machine(wanted, judged), uefi=False, efi_variables=False
+            )
+
+    report = preflight.check(
+        config(), Bios(runner=Runner(log=lambda line: None), work=tmp_path), operations=()
+    )
+
+    assert any("booted by BIOS" in one for one in report.fatal), report.fatal
+    assert not any("efivarfs" in one for one in report.fatal), report.fatal


### PR DESCRIPTION
`cli.py` builds the menu's starting configuration with `firmware=Firmware.UEFI if probe.machine().uefi else Firmware.BIOS`, and says why: the row would otherwise offer an esp and a GPT for a firmware that cannot read either. The parser has no machine to ask, so `BootloaderConfig.firmware` defaults to UEFI and a configuration file that leaves the key out installs for UEFI wherever it runs.

Preflight already refuses that: `wants_uefi and not machine.efi_variables` is fatal, so the disks are not written. But its message tells the operator to `mount -t efivarfs`, and a machine that booted by BIOS has nothing to mount — the remedy it names cannot work.

A machine that did not boot by UEFI is now told so, and told the two ways out. The efivarfs message stays for the case it was written for: a UEFI machine whose variables are not mounted.