### PR TITLE
screens: a change of install mode takes back the erase confirmation

### DIFF
--- a/gentoo_install/tui/screens.py
+++ b/gentoo_install/tui/screens.py
@@ -189,6 +189,14 @@ def install_mode_screen(
     mode = answer.unwrap()
     if mode is config.disk.mode:
         return Answer(Outcome.CHOSE, config)
+    # The plan the operator confirmed erasing belongs to the mode they are
+    # leaving. `confirm_screen` skips a selector already in `confirmed`, so a
+    # confirmation given for a partition plan authorised the dd write to the
+    # same disk, which is the mistake the comment above that screen records
+    # for a second disk added in manual partitioning.
+    context.confirmed.clear()
+    context.layout = manual.Layout()
+    context.manual = False
     if mode is DiskMode.IN_PLACE:
         agreed = _confirm_the_swap(screen, context)
         if agreed is not None:

--- a/tests/unit/test_tui_app.py
+++ b/tests/unit/test_tui_app.py
@@ -4733,3 +4733,27 @@ def test_every_key_in_a_fetched_body_is_kept() -> None:
     answer = screens.authorized_keys_screen(FakeScreen(keys=keys), config(), at)
 
     assert answer.unwrap().system.authorized_keys == (GOOD_KEY, second)
+
+
+def test_changing_the_install_mode_takes_back_the_erase_confirmation() -> None:
+    """`confirm_screen` skips a selector already in `context.confirmed`, and
+    the mode screen replaced the configuration without touching it. A
+    confirmation typed for a partition plan on /dev/vda therefore authorised
+    the dd write to /dev/vda, which is the mistake `confirm_screen`'s own
+    comment records for a second disk added in manual partitioning.
+    """
+    at = context()
+    at.image_write_refused = Refusal("")
+    at.conversion_refused = Refusal("the running system cannot be converted")
+    at.confirmed = {"/dev/vda"}
+    at.manual = True
+    at.layout = manual.Layout(disks=[manual.Disk(selector="/dev/vda")])
+
+    # Down to `Write a prepared image`, enter, then agree to discard.
+    screen = FakeScreen(keys=[*down(1), "\n", "KEY_DOWN", "\n"], lines=24, columns=110)
+    answer = screens.install_mode_screen(screen, config(), at)
+
+    assert answer.unwrap().disk.mode is DiskMode.DD
+    assert at.confirmed == set(), at.confirmed
+    assert not at.manual
+    assert not at.layout.disks


### PR DESCRIPTION
`confirm_screen` skips a selector already in `context.confirmed`, and its own comment records why the set exists: "a second disk added in manual partitioning was destroyed under a confirmation that named the first one."

The mode screen replaces the `InstallConfig` — clearing the graph, the root and, for dd, most of the rest — and never touches the context beside it. So confirming the erase of `/dev/vda` for a partition plan, switching to "write a prepared image", and setting the dd destination to `/dev/vda` reaches the confirm screen with that selector already answered. The same carry-over resurrects the abandoned manual layout on the way back: `Context.layout` and `Context.manual` survive a switch that emptied the graph, and pressing Done in the editor rebuilds the old table into the new configuration.

The plan the operator confirmed belongs to the mode they are leaving, so changing mode clears all three.