### PR TITLE
tests: pair every desktop fixture with the profile its desktop declares

### DIFF
--- a/tests/fixtures/btrfs-luks.toml
+++ b/tests/fixtures/btrfs-luks.toml
@@ -16,7 +16,7 @@ groups = ["wheel", "video", "render"]
 sudo = true
 
 [portage]
-profile = "default/linux/amd64/23.0/desktop/systemd"
+profile = "default/linux/amd64/23.0/desktop/plasma/systemd"
 keywords = "stable"
 makeopts = "-j4"
 common_flags = "-O2 -pipe -march=x86-64-v3"

--- a/tests/golden/btrfs-luks.txt
+++ b/tests/golden/btrfs-luks.txt
@@ -37,7 +37,7 @@
   import BB572E0E2D182910 from /usr/share/openpgp-keys/gentoo-release.asc, locally sign it for gentoo, and verify the local signature
   write /etc/portage/binrepos.conf/gentoo.conf adding verified binary package host gentoo at https://mirrors.ustc.edu.cn/gentoo/releases/amd64/binpackages/23.0/x86-64
   fetch the first ebuild repository snapshot with emerge-webrsync
-  select profile default/linux/amd64/23.0/desktop/systemd
+  select profile default/linux/amd64/23.0/desktop/plasma/systemd
   install git, which every later repository sync needs: emerge dev-vcs/git
   write /etc/portage/repos.conf/gentoo.conf pointing gentoo at https://mirrors.ustc.edu.cn/gentoo.git, commit signatures verified
   sync repository gentoo, 4 other sites to fall back on

--- a/tests/unit/test_layers.py
+++ b/tests/unit/test_layers.py
@@ -1395,3 +1395,34 @@ def test_no_operation_writes_an_architecture_keyword_it_spelled_itself() -> None
                     if any(one in inner.value for one in spellings):
                         written.append(f"{path.name}:{inner.lineno}: {inner.value!r}")
     assert not written, written
+
+
+def test_every_desktop_fixture_names_the_profile_its_desktop_declares() -> None:
+    """`data/profiles/<desktop>.toml` declares the profile each desktop is
+    built against, and the menu applies it. `btrfs-luks` paired Plasma with the
+    generic `desktop/systemd` profile instead, and it is the fixture that
+    stalled three cluster rounds at `[78/90] install the plasma group` while
+    `vm-desktop`, the other Plasma fixture, passed with `desktop/plasma`.
+    """
+    import tomllib
+
+    from gentoo_install.data import load_catalog
+    from gentoo_install.model.config import InitSystem
+    from gentoo_install.tui.packages import _profile_for, desktop_profiles
+
+    declared = desktop_profiles(load_catalog())
+    wrong: list[str] = []
+    for path in sorted((PACKAGE.parent / "tests" / "fixtures").glob("*.toml")):
+        raw = tomllib.loads(path.read_text())
+        desktop = raw.get("packages", {}).get("desktop", "")
+        profile = raw.get("portage", {}).get("profile", "")
+        if not desktop or not profile or desktop not in declared:
+            continue
+        init = raw.get("system", {}).get("init", "systemd")
+        wanted = _profile_for(
+            declared[desktop],
+            InitSystem.SYSTEMD if init == "systemd" else InitSystem.OPENRC,
+        )
+        if profile != wanted:
+            wrong.append(f"{path.name}: {desktop} has {profile}, not {wanted}")
+    assert wrong == [], wrong


### PR DESCRIPTION
`data/profiles/base/plasma.toml` declares that Plasma is built against `default/linux/amd64/23.0/desktop/plasma`, and the menu applies it. `tests/fixtures/btrfs-luks.toml` selected `desktop = "plasma"` with the generic `default/linux/amd64/23.0/desktop/systemd` instead.

That is the fixture `docs/tasks.md` 447 has been chasing: it stalled in rounds 23 and 24 at `[78/90] install the plasma group`, on different nodes, with identical disk byte counters and no out-of-memory line. The note written then said the difference from `vm-desktop` — the other Plasma fixture, which passes every round — was `cjk-bin` against `dist-bin` and btrfs+LUKS. The profile column was not compared. A generic desktop profile carries different USE defaults, so the plasma group compiles what the plasma profile takes as binaries.

Of the seven fixtures that select a desktop, this was the only mismatch. The new test reads the expected profile from the catalog through `desktop_profiles()` and `_profile_for()` rather than restating it, so a desktop added to `data/profiles/` is covered without touching the test. Control run red.

The next cluster round measures whether this is the whole cause.