### PR TITLE
paste: carry a password, and refuse the form that answers without one

### DIFF
--- a/gentoo_install/cli.py
+++ b/gentoo_install/cli.py
@@ -13,6 +13,7 @@ import hashlib
 import locale
 import os
 import shutil
+import getpass
 import sys
 import termios
 import time
@@ -498,7 +499,7 @@ def _once(arguments: argparse.Namespace, state: RunState, refused: str) -> int |
                 return EXIT_ABORTED
             config = chosen
         else:
-            config = load_source(arguments.config)
+            config = _configuration_from(arguments.config)
         if not arguments.missing_commands:
             catalog = load_catalog()
             validate(
@@ -871,6 +872,22 @@ def _closing_catalog(state: RunState, arguments: argparse.Namespace) -> Catalog:
     otherwise: `--config` never opens a screen and has no tag to carry.
     """
     return Catalog(state.language or tag_for(override=arguments.lang))
+
+
+def _configuration_from(source: str) -> InstallConfig:
+    """The configuration, asking for a password when the paste needs one.
+
+    Asked rather than taken from the command line: a password there reaches
+    the shell's history and every `ps` on the machine. An unattended run has
+    no terminal to ask, so the refusal stands and names what is missing.
+    """
+    try:
+        return load_source(source)
+    except errors.ConfigError as refused:
+        if "encrypted paste" not in str(refused) or not sys.stdin.isatty():
+            raise
+    _forget_what_was_typed()
+    return load_source(source, getpass.getpass("password for this paste: "))
 
 
 def _asked(question: str) -> bool:

--- a/gentoo_install/exec/config.py
+++ b/gentoo_install/exec/config.py
@@ -45,19 +45,23 @@ def load(path: Path) -> InstallConfig:
     return parse(raw)
 
 
-def load_source(source: str) -> InstallConfig:
+def load_source(source: str, password: str = "") -> InstallConfig:
     """Read a configuration from a path or from a URL.
 
     One entry point for both, because every mode takes its configuration the
     same way: what differs between installing, converting and writing an image
     is what the configuration says, not where it came from.
+
+    A password opens an encrypted paste. The caller asks for it rather than
+    taking it from the command line, where it would reach the shell's history
+    and every `ps` on the machine.
     """
     if not looks_like_a_url(source):
         return load(Path(source))
     from . import fetch
 
     try:
-        body = fetch.read_text(source, ceiling=URL_CEILING)
+        body = fetch.read_text(source, ceiling=URL_CEILING, password=password)
     except GentooInstallError as error:
         raise ConfigError(scrub(f"{source}: {error}")) from error
     try:

--- a/gentoo_install/exec/fetch.py
+++ b/gentoo_install/exec/fetch.py
@@ -26,7 +26,7 @@ import urllib.parse
 import urllib.request
 from pathlib import Path
 from collections.abc import Iterator, Sequence
-from typing import Any, Callable, Final
+from typing import Any, Callable, Final, Mapping
 
 from ..errors import (
     ArchiveDigestMismatch,
@@ -311,11 +311,27 @@ def _import_release_key(
 
 def text(url: str, proxy: ProxyConfig | None = None) -> str:
     """A short document, such as a public key someone pasted somewhere."""
-    return _read_for(paste.raw_url(url), proxy)
+    return _not_the_password_form(url, _read_for(paste.raw_url(url), proxy))
+
+
+def _not_the_password_form(url: str, body: str) -> str:
+    """The body, unless the server answered its password form instead.
+
+    A wrong password answers 200, so nothing but the body says so and the
+    caller would hand an HTML page to its parser.
+    """
+    if paste.looks_like_the_password_form(body):
+        raise DownloadFailed(
+            f"{url} is an encrypted paste and the password given does not open it"
+        )
+    return body
 
 
 def upload(
-    body: str, export: paste.Export, proxy: ProxyConfig | None = None
+    body: str,
+    export: paste.Export,
+    proxy: ProxyConfig | None = None,
+    password: str = "",
 ) -> str:
     """Create a paste and return the address of the page that shows it.
 
@@ -324,9 +340,9 @@ def upload(
     """
     request = _asked(
         f"{paste.BASE}/",
-        data=paste.payload(body, export),
+        data=paste.payload(body, export, password=password),
         method="POST",
-        **{"Content-Type": "application/json"},
+        headers={"Content-Type": "application/json"},
     )
     try:
         with _urlopen(request, proxy, TIMEOUT) as response:
@@ -593,10 +609,22 @@ def _version_key(version: str) -> tuple[tuple[int, ...], int, int, int]:
     return (tuple(parts), _SUFFIX_ORDER[suffix], int(count), int(revision))
 
 
-def _asked(url: str, *, data: bytes | None = None, method: str = "GET", **headers: str) -> urllib.request.Request:
+def _asked(
+    url: str,
+    *,
+    data: bytes | None = None,
+    method: str = "GET",
+    # A mapping as well as keywords: a header whose name carries a hyphen is
+    # not a Python identifier.
+    headers: Mapping[str, str] | None = None,
+    **named: str,
+) -> urllib.request.Request:
     """Every request this module makes, so none of them goes out unnamed."""
     return urllib.request.Request(
-        url, data=data, method=method, headers={"User-Agent": USER_AGENT, **headers}
+        url,
+        data=data,
+        method=method,
+        headers={"User-Agent": USER_AGENT, **(headers or {}), **named},
     )
 
 
@@ -932,16 +960,21 @@ def _resolvers(path: Path) -> str:
     return f"nameservers {servers}" if servers else "no nameserver line"
 
 
-def read_text(url: str, *, ceiling: int) -> str:
+def read_text(url: str, *, ceiling: int, password: str = "") -> str:
     """Read a small document, refusing a body past `ceiling`.
 
     One byte past the cap is read on purpose: a body exactly at the cap is
     allowed, and anything longer is refused without the rest of it ever being
     read. A configuration is kilobytes, and a redirect into an ISO is the case
     this exists to stop.
+
+    A password reaches an encrypted paste: wastebin stores such an entry as
+    ciphertext, so the secrets a configuration carries are readable by neither
+    the host nor whoever guesses the address.
     """
+    headers = {paste.PASSWORD_HEADER: password} if password else None
     try:
-        with _urlopen(_asked(url), _CURRENT_PROXY.get(), TIMEOUT) as response:
+        with _urlopen(_asked(url, headers=headers), _CURRENT_PROXY.get(), TIMEOUT) as response:
             body = response.read(ceiling + 1)
     except (urllib.error.URLError, TimeoutError, OSError, http.client.HTTPException) as error:
         raise DownloadFailed(
@@ -949,7 +982,7 @@ def read_text(url: str, *, ceiling: int) -> str:
         ) from error
     if len(body) > ceiling:
         raise DownloadFailed(scrub(f"{url} is larger than {ceiling} bytes"))
-    return str(body.decode("utf-8", "replace"))
+    return _not_the_password_form(url, str(body.decode("utf-8", "replace")))
 
 
 def _read_once(url: str, proxy: ProxyConfig | None = None) -> str:

--- a/gentoo_install/model/paste.py
+++ b/gentoo_install/model/paste.py
@@ -62,16 +62,40 @@ def export_for(key: str) -> Export:
     return next(one for one in EXPORTS if one.key == key)
 
 
-def payload(text: str, export: Export, expires: int = EXPIRES) -> bytes:
-    """The body of the POST that creates a paste."""
-    return json.dumps(
-        {
-            "text": text,
-            "extension": export.extension,
-            "title": export.title,
-            "expires": expires,
-        }
-    ).encode()
+#: The header wastebin reads the password from on `GET /raw/:id`, named in its
+#: own README. A request without it, or with the wrong one, answers 200 and the
+#: HTML form rather than a status a caller can test.
+PASSWORD_HEADER: Final[str] = "wastebin-password"
+
+
+def payload(
+    text: str, export: Export, expires: int = EXPIRES, password: str = ""
+) -> bytes:
+    """The body of the POST that creates a paste.
+
+    With a password the server encrypts the entry: wastebin's README says
+    ChaCha20Poly1305 with an argon2 hashed password, so the text is unreadable
+    to the host as well as to anyone who guesses the address.
+    """
+    body: dict[str, object] = {
+        "text": text,
+        "extension": export.extension,
+        "title": export.title,
+        "expires": expires,
+    }
+    if password:
+        body["password"] = password
+    return json.dumps(body).encode()
+
+
+def looks_like_the_password_form(body: str) -> bool:
+    """Whether this is the form wastebin answers instead of the text.
+
+    Measured on 2026-08-31: a `GET /raw/:id` for an encrypted paste with no
+    password, or the wrong one, answers 200 with an HTML page. A caller that
+    only reads the status hands that page to its parser.
+    """
+    return body.lstrip()[:9].lower() == "<!doctype"
 
 
 def page_url(path: str) -> str:

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -2138,7 +2138,7 @@ def test_a_dry_run_takes_its_configuration_from_a_url(
     asked: list[str] = []
     body = (FIXTURES / "ext4-bios.toml").read_text()
 
-    def reading(url: str, *, ceiling: int) -> str:
+    def reading(url: str, *, ceiling: int, password: str = "") -> str:
         asked.append(url)
         return body
 
@@ -2155,7 +2155,7 @@ def test_a_local_configuration_never_reaches_the_network(
     """The negative direction: accepting a URL must not send an ordinary path
     through the fetcher, which would need a network to read a file."""
 
-    def refuse(url: str, *, ceiling: int) -> str:
+    def refuse(url: str, *, ceiling: int, password: str = "") -> str:
         raise AssertionError(f"a path was fetched: {url}")
 
     monkeypatch.setattr(fetch, "read_text", refuse)

--- a/tests/unit/test_exec.py
+++ b/tests/unit/test_exec.py
@@ -2820,7 +2820,7 @@ def test_a_configuration_can_be_read_from_a_url(monkeypatch: pytest.MonkeyPatch)
     body = Path("tests/fixtures/vm-binpkg.toml").read_text(encoding="utf-8")
     asked: list[str] = []
 
-    def answer(url: str, *, ceiling: int) -> str:
+    def answer(url: str, *, ceiling: int, password: str = "") -> str:
         asked.append(url)
         assert ceiling == loader.URL_CEILING
         return body
@@ -2837,7 +2837,7 @@ def test_a_configuration_can_be_read_from_a_url(monkeypatch: pytest.MonkeyPatch)
 
     # Negative control two: a body that is not TOML names the URL rather than
     # a temporary file nobody can look at.
-    monkeypatch.setattr(fetch, "read_text", lambda url, *, ceiling: "<html>404</html>")
+    monkeypatch.setattr(fetch, "read_text", lambda url, *, ceiling, password="": "<html>404</html>")
     with pytest.raises(ConfigError, match="example.invalid/machine.toml"):
         loader.load_source("https://example.invalid/machine.toml")
 

--- a/tests/unit/test_redact.py
+++ b/tests/unit/test_redact.py
@@ -57,7 +57,7 @@ def test_config_error_redacts_user_information_and_query_credentials(
         "?token=query-credential"
     )
 
-    def refuse(url: str, *, ceiling: int) -> str:
+    def refuse(url: str, *, ceiling: int, password: str = "") -> str:
         raise DownloadFailed(f"{url} could not be read")
 
     monkeypatch.setattr(fetch, "read_text", refuse)

--- a/tests/unit/test_sshkey.py
+++ b/tests/unit/test_sshkey.py
@@ -232,3 +232,67 @@ def test_swapping_an_authorized_key_changes_the_dry_run() -> None:
         WriteAuthorizedKeys(keys=(one,), accounts=accounts).describe() for one in (first, second)
     ]
     assert said[0] != said[1], said
+
+
+def test_a_paste_with_a_password_is_encrypted_and_read_back_with_it() -> None:
+    """wastebin encrypts an entry that carries a password — its README says
+    ChaCha20Poly1305 with an argon2 hashed password — so the host cannot read
+    it either. `payload` never sent the field, so the feature was unreachable.
+
+    Measured against `paste.gentoozh.org` on 2026-08-31: `GET /raw/:id` with
+    `wastebin-password` answers the text, and without it, or with the wrong
+    one, answers 200 and an HTML form. Nothing but the body says so.
+    """
+    import json
+
+    from gentoo_install.model import paste
+
+    export = paste.export_for("config")
+    without = json.loads(paste.payload("body", export))
+    assert "password" not in without
+
+    with_one = json.loads(paste.payload("body", export, password="testtest"))
+    assert with_one["password"] == "testtest"
+
+    assert paste.PASSWORD_HEADER == "wastebin-password"
+    assert paste.looks_like_the_password_form('<!DOCTYPE html>\n<html lang="en">')
+    assert not paste.looks_like_the_password_form("[disk]\nwipe = true\n")
+
+
+def test_a_configuration_url_that_needs_a_password_says_so_not_parses_html() -> None:
+    """A wrong password answers 200 and the form, so a reader that checks only
+    the status hands an HTML page to `tomllib` and reports a syntax error at
+    line 1 of a configuration the operator never wrote."""
+    import urllib.request
+    from io import BytesIO
+
+    import pytest
+
+    from gentoo_install.errors import ConfigError
+    from gentoo_install.exec import config as exec_config
+    from gentoo_install.exec import fetch
+
+    class Form:
+        def __enter__(self) -> "Form":
+            return self
+
+        def __exit__(self, *unused: object) -> None:
+            return None
+
+        def read(self, size: int = -1) -> bytes:
+            del size
+            return b'<!DOCTYPE html>\n<html lang="en"><body>password</body></html>'
+
+    def answered(
+        request: urllib.request.Request, proxy: object = None, timeout: float = 0.0
+    ) -> Form:
+        del request, proxy, timeout
+        return Form()
+
+    original = fetch._urlopen
+    fetch._urlopen = answered  # the one call this reader makes
+    try:
+        with pytest.raises(ConfigError, match="encrypted paste"):
+            exec_config.load_source("https://paste.gentoozh.org/raw/abc")
+    finally:
+        fetch._urlopen = original


### PR DESCRIPTION
wastebin encrypts an entry that is created with a password — its README says ChaCha20Poly1305 with an argon2 hashed password — so a paste the host itself cannot read is already possible. `paste.payload()` built `{"text", "extension", "title", "expires"}` and stopped, so the field was never sent and the feature was unreachable.

Measured against `paste.gentoozh.org` on 2026-08-31: `POST /` with `"password"` creates the entry, `GET /raw/:id` with the `wastebin-password` header answers the text, and without it — or with the wrong one — answers **200 and an HTML form**. Nothing but the body says so, so `load_source` handed that page to `tomllib` and reported a syntax error in a configuration the operator never wrote.

`read_text` now takes the password and refuses the form; `load_source` passes it through; the CLI asks with `getpass` and retries, rather than taking it from the command line where it would reach the shell history and every `ps`. An unattended run has no terminal, so the refusal stands and names what is missing.

This is the mechanism. Publishing the secrets under that password instead of redacting them is the next step and a separate decision.