### PR TITLE
catalog: give MiB back to the value it measures

### DIFF
--- a/gentoo_install/data/locale/ja.toml
+++ b/gentoo_install/data/locale/ja.toml
@@ -656,7 +656,7 @@
 "enable {} at boot" = "起動時に {} を有効化"
 "enable {} in the {} runlevel" = "{} を {} ランレベルで有効化"
 "check that this machine can be told to boot once, {}" = "このマシンに一度だけの起動を指示できるか確認（{}）"
-"check this machine has the {} MiB {} needs" = "このマシンに {} が必要とする {} MiB があるか確認"
+"check this machine has the {} MiB {} needs" = "このマシンに {} MiB があるか確認（{} が必要とする量）"
 "take back anything an earlier run armed" = "以前の実行が設定した一度きりの起動を取り消す"
 "fetch the {} image and verify its checksum" = "{} イメージを取得してチェックサムを検証"
 "unpack the {} kernel and initramfs into {}" = "{} のカーネルと initramfs を {} に展開"

--- a/gentoo_install/data/locale/ko.toml
+++ b/gentoo_install/data/locale/ko.toml
@@ -656,7 +656,7 @@
 "enable {} at boot" = "부팅 시 {} 활성화"
 "enable {} in the {} runlevel" = "{}를 {} 런레벨에서 활성화"
 "check that this machine can be told to boot once, {}" = "이 머신에 일회성 부팅을 지시할 수 있는지 확인 ({})"
-"check this machine has the {} MiB {} needs" = "이 머신에 {}가 필요로 하는 {} MiB가 있는지 확인"
+"check this machine has the {} MiB {} needs" = "이 머신에 {} MiB가 있는지 확인 ({}에 필요한 양)"
 "take back anything an earlier run armed" = "이전 실행이 설정한 일회성 부팅을 되돌림"
 "fetch the {} image and verify its checksum" = "{} 이미지를 가져오고 체크섬 검증"
 "unpack the {} kernel and initramfs into {}" = "{}의 커널과 initramfs를 {}에 풀기"

--- a/gentoo_install/data/locale/zh-CN.toml
+++ b/gentoo_install/data/locale/zh-CN.toml
@@ -657,7 +657,7 @@
 "enable {} at boot" = "在启动时启用 {}"
 "enable {} in the {} runlevel" = "启用 {}，运行级别 {}"
 "check that this machine can be told to boot once, {}" = "检查这台机器能否预约一次启动（{}）"
-"check this machine has the {} MiB {} needs" = "检查这台机器是否有 {} 所需的 {} MiB"
+"check this machine has the {} MiB {} needs" = "检查这台机器有没有 {} MiB（{} 需要的量）"
 "take back anything an earlier run armed" = "取消先前执行留下的启动预约"
 "fetch the {} image and verify its checksum" = "获取 {} 镜像并验证校验和"
 "unpack the {} kernel and initramfs into {}" = "将 {} 的内核与 initramfs 解开到 {}"

--- a/gentoo_install/data/locale/zh-TW.toml
+++ b/gentoo_install/data/locale/zh-TW.toml
@@ -657,7 +657,7 @@
 "enable {} at boot" = "在開機時啟用 {}"
 "enable {} in the {} runlevel" = "啟用 {}，執行階層 {}"
 "check that this machine can be told to boot once, {}" = "檢查這台機器能否預約一次開機（{}）"
-"check this machine has the {} MiB {} needs" = "檢查這台機器是否有 {} 所需的 {} MiB"
+"check this machine has the {} MiB {} needs" = "檢查這台機器有沒有 {} MiB（{} 需要的量）"
 "take back anything an earlier run armed" = "取消先前執行留下的開機預約"
 "fetch the {} image and verify its checksum" = "取得 {} 映像並驗證校驗和"
 "unpack the {} kernel and initramfs into {}" = "將 {} 的核心與 initramfs 解開到 {}"

--- a/tests/unit/test_i18n.py
+++ b/tests/unit/test_i18n.py
@@ -883,3 +883,29 @@ def test_the_compile_jobs_row_says_what_the_plan_will_write() -> None:
 
     pinned = replace(installation, portage=replace(installation.portage, makeopts="-j4"))
     assert settings._makeopts(pinned, at) == "-j4"
+
+
+#: Words that attach to the value in front of them in every language this
+#: interface offers: a unit follows its number, a flag is named as itself.
+#: `REVIEWED_TEMPLATES` says only a reader can judge placeholder order, and it
+#: is right about word order — but it recorded `check this machine has the {}
+#: MiB {} needs` as read while all four catalogs rendered `512 needs --ram
+#: MiB`, so this much of the order is worth checking by machine.
+ANCHORED_UNITS: Final[tuple[str, ...]] = ("MiB", "GiB", "KiB")
+
+
+def test_a_unit_keeps_the_value_it_measures() -> None:
+    """A translation may reorder a sentence; it may not hand `MiB` to the
+    placeholder that carries a command-line flag."""
+    for source in operation_templates():
+        for unit in ANCHORED_UNITS:
+            if f"{{}} {unit}" not in source:
+                continue
+            wanted = source.split(f"{{}} {unit}")[0].count("{}")
+            for tag in sorted(path.stem for path in LOCALES.glob("*.toml")):
+                value = shipped(tag).get(source)
+                if value is None or unit not in value:
+                    continue
+                before = value.split(unit)[0].rstrip()
+                assert before.endswith("{}"), (tag, source, value)
+                assert before.count("{}") - 1 == wanted, (tag, source, value)


### PR DESCRIPTION
`CheckMemory.describe_parts()` supplies `(floor_mib, mode)`. All four catalogs read them the other way round, so `--ram` rendered as the equivalent of "check this machine has the 512 needs --ram MiB" in every language the interface offers.

`"check this machine has the {} MiB {} needs"` is in `REVIEWED_TEMPLATES`, whose comment says the set exists because "a translation that moves them to suit its own word order silently renames them" and lists three earlier instances of exactly this slip. The set records that somebody has read a template's four translations; here it recorded a reading that did not catch four wrong ones.

Word order cannot be checked by machine, but this much of it can: a unit follows the value it measures in every language here. `test_a_unit_keeps_the_value_it_measures` requires the placeholder before `MiB` in a translation to be the same index as in the English. The control was run red.

An audit agent reported this for Japanese and Korean; both Chinese catalogs had it too.