### PR TITLE
packages: own the files it wrote, not the whole home

### DIFF
--- a/gentoo_install/plan/packages.py
+++ b/gentoo_install/plan/packages.py
@@ -754,6 +754,23 @@ class WriteInputMethodEnvironment(Operation):
             context.run_in_target(["env-update"])
 
 
+def _owned_paths(home: PurePosixPath, written: Sequence[PurePosixPath]) -> list[str]:
+    """The written files and the directories between them and the home.
+
+    `context.write` creates a missing parent as root, so the account cannot
+    read its own configuration without them; anything the home already held is
+    left as it was.
+    """
+    paths = {home}
+    for path in written:
+        paths.add(path)
+        parent = path.parent
+        while parent != home and parent != parent.parent:
+            paths.add(parent)
+            parent = parent.parent
+    return [str(one) for one in sorted(paths, key=lambda one: len(one.parts))]
+
+
 @dataclass(frozen=True, kw_only=True)
 class WriteInputMethodProfile(Operation):
     """fcitx starts with no engine configured, so a fresh desktop types latin
@@ -782,16 +799,21 @@ class WriteInputMethodProfile(Operation):
 
     def apply(self, context: Context) -> None:
         for home, owner in self.homes:
-            context.write(home / FCITX_PROFILE, self._profile())
+            written = [home / FCITX_PROFILE]
+            context.write(written[0], self._profile())
             for version in GTK_VERSIONS:
-                context.write(
-                    home / GTK_SETTINGS.format(version=version),
-                    "[Settings]\ngtk-im-module=fcitx\n",
-                )
+                written.append(home / GTK_SETTINGS.format(version=version))
+                context.write(written[-1], "[Settings]\ngtk-im-module=fcitx\n")
             if self.schemas:
-                context.write(home / RIME_CUSTOM, self._rime())
+                written.append(home / RIME_CUSTOM)
+                context.write(written[-1], self._rime())
             if owner:
-                context.run_in_target(["chown", "--recursive", f"{owner}:{owner}", str(home)])
+                # These paths, not the whole home: `--recursive` re-owned every
+                # file a preserved /home already held, so recreating an account
+                # took another one's files with it.
+                context.run_in_target(
+                    ["chown", f"{owner}:{owner}", *_owned_paths(home, written)]
+                )
 
     def _profile(self) -> str:
         """fcitx's own ini. The keyboard is first and the default, so a console

--- a/tests/unit/test_plan.py
+++ b/tests/unit/test_plan.py
@@ -1000,3 +1000,32 @@ def test_the_iwd_backend_asks_for_the_use_flag_that_selects_it() -> None:
             assert [one.lines for one in asked] == [NETWORK_BACKENDS[backend].use], backend
         else:
             assert not asked, backend
+
+
+def test_the_input_method_owns_what_it_wrote_and_not_the_rest_of_the_home() -> None:
+    """It ran `chown --recursive` on the whole home while its description named
+    three configuration files. A reused `/home` with a recreated account
+    therefore handed every retained file to that account, including files
+    another one owned."""
+    from pathlib import PurePosixPath as _P
+
+    from gentoo_install.plan.packages import WriteInputMethodProfile
+
+    home = _P("/home/alice")
+    written = WriteInputMethodProfile(
+        engines=("rime",), schemas=("luna_pinyin",), homes=((home, "alice"),), layout="us"
+    )
+    recorder = Recorder()
+    written.apply(recorder)
+
+    chowned = [argv for argv in recorder.in_target if argv[0] == "chown"]
+    assert len(chowned) == 1, chowned
+    assert "--recursive" not in chowned[0], chowned[0]
+
+    owned = set(chowned[0][2:])
+    assert str(home) in owned
+    for path in recorder.files:
+        assert str(path) in owned, (path, sorted(owned))
+        assert str(path.parent) in owned, (path, sorted(owned))
+    # Nothing outside the home, and nothing the operation did not create.
+    assert all(one.startswith(str(home)) for one in owned), sorted(owned)


### PR DESCRIPTION
`WriteInputMethodProfile.describe()` names the fcitx profile, the GTK settings files and the optional Rime file, "writing ... under each" home. `apply()` then ran `chown --recursive <owner>:<owner> <home>`.

Reusing an existing `/home` and recreating an account is a supported path, and there the recursive change hands every retained file below that home to the new account — including files another account owns. Nothing in the operation preview says so.

It now names the files it wrote and the directories between them and the home, which is what the account needs to read its own configuration, and leaves everything the home already held as it was. The test asserts that every path `apply()` writes is owned, that its parent is owned, that nothing outside the home is, and that `--recursive` is gone; the control was run red.