### PR TITLE
cli: say what --no-shell and --menu actually control

### DIFF
--- a/gentoo_install/cli.py
+++ b/gentoo_install/cli.py
@@ -166,14 +166,21 @@ def parser() -> argparse.ArgumentParser:
     parsed.add_argument(
         "--no-shell",
         action="store_true",
-        help="unmount and exit without offering a root shell in the new system, which is "
-        "what an unattended run wants",
+        # Not only the shell: `_unattended` reads this flag, so it also
+        # answers every closing question, and `mode = "in-place"` in a
+        # configuration file is the authorisation the conversion asks for.
+        help="answer no question and offer no root shell, which is what an unattended "
+        "run wants; --menu says a person is here after all",
     )
     parsed.add_argument(
         "--menu",
         action="store_true",
-        help="a person is driving this console, so open the interface even though "
-        "--no-shell is set; requires a terminal on stdin",
+        # The help said `open the interface`, and `_once` opens it only when
+        # there is no `--config` to apply. With one, this flag says who is at
+        # the keyboard and nothing more.
+        help="a person is driving this console, so keep the questions --no-shell "
+        "would suppress; without --config it also opens the interface. Requires a "
+        "terminal on stdin",
     )
     parsed.add_argument(
         "--skip-preflight",

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -3005,3 +3005,34 @@ def test_a_system_clock_that_could_not_follow_the_rtc_is_reported(
     cli._check_the_clock()
     said = capsys.readouterr().err
     assert "system clock could not be set from the corrected RTC" in said, said
+
+
+def test_the_flag_help_says_what_each_flag_actually_controls() -> None:
+    """`--no-shell` reads as the closing shell alone, and `_unattended` reads
+    it for every question; `--menu` said it opens the interface, and `_once`
+    opens it only when there is no `--config` to apply. An operator who reads
+    the help and passes `--config x --menu` gets no interface."""
+    import argparse
+    import inspect
+
+    parser = cli.parser()
+    help_for = {
+        action.option_strings[0]: (action.help or "")
+        for action in parser._actions
+        if action.option_strings
+    }
+
+    # `--no-shell` reaches `_unattended`, so it decides more than the shell.
+    assert "_unattended" in inspect.getsource(cli._confirmed_swap)
+    assert "no_shell" in inspect.getsource(cli._unattended)
+    assert "no question" in help_for["--no-shell"], help_for["--no-shell"]
+
+    # `--menu` opens the interface only without `--config`.
+    opening = inspect.getsource(cli._once)
+    assert "arguments.config is None" in opening
+    assert "without --config" in help_for["--menu"], help_for["--menu"]
+
+    quiet = argparse.Namespace(menu=False, no_shell=True)
+    driven = argparse.Namespace(menu=True, no_shell=True)
+    assert cli._unattended(quiet)
+    assert not cli._unattended(driven)


### PR DESCRIPTION
The help for `--no-shell` said "unmount and exit without offering a root shell". `_unattended` reads that flag, so it also decides that the in-place conversion is not asked to confirm its replacement list and that no closing question is put to a serial console.

The help for `--menu` said it opens the interface. `_once` opens the interface only when `arguments.config is None`; with a configuration to apply, the flag says a person is at the keyboard and nothing more.

The test reads both help strings against the calls that consume the flags, and was run red against the previous wording.