### PR TITLE
vm: run the install where a console hangup cannot reach it

### DIFF
--- a/tests/unit/test_cluster.py
+++ b/tests/unit/test_cluster.py
@@ -5,7 +5,10 @@ from typing import Any, cast
 
 import hashlib
 import io
+import os
 import re
+import signal
+import subprocess
 import time
 import urllib.request
 from collections.abc import Callable
@@ -687,7 +690,12 @@ def test_the_network_is_measured_once_more_after_the_install(
             repeatability[command] = repeatable
 
         def wait_for(
-            self, command: str, timeout: float, idle: float, watch: cluster.Watchdog
+            self,
+            command: str,
+            timeout: float,
+            idle: float,
+            watch: cluster.Watchdog,
+            repeatable: bool = False,
         ) -> None:
             events.append(command)
 
@@ -822,7 +830,7 @@ def test_the_converted_machine_is_read_back_the_same_way(monkeypatch: pytest.Mon
 
     code = inspect.getsource(cluster.convert_and_check)
     assert "boot_and_check(" in code
-    assert "install.sh --config fixtures/" in code
+    assert "detached_install(" in code
     assert "wait_for_network(" in code, "the installed system has to reach a mirror too"
 
 
@@ -3299,7 +3307,7 @@ def test_a_cluster_conversion_writes_and_reads_the_home_marker() -> None:
     # The constant, not a second copy of the path: the local runner writes the
     # same file and reads the same marker.
     written = source.index("HOME_MARKER_PATH")
-    converted = source.index("install.sh")
+    converted = source.index("detached_install(")
     assert written < converted, source
     assert source.index("ETC_MARKER_PATH") < converted, source
     assert "HOME_MARKER_CHECK, ETC_MARKER_CHECK" in source, source
@@ -4668,3 +4676,87 @@ def test_the_resolver_setup_reaches_nsswitch_as_well_as_the_file() -> None:
     # next lookup reads, and a resolver written after the switch was rewritten
     # would still be the one in force.
     assert command.index("resolv.conf") < command.index("nsswitch.conf"), command
+
+
+def test_an_install_outlives_the_shell_that_started_it(tmp_path: Path) -> None:
+    """The console's hangup is what round 30 lost three ZFS guests to.
+
+    `termproxy` dropped inside `emerge sys-apps/systemd` and the reconnect's
+    new `qm terminal` hung up the guest's `ttyS0`, killing the foreground
+    install an hour in. Each console holds a second `starting serial terminal
+    on interface serial0` with a fresh `root@livecd ~ #` under it.
+
+    Run rather than read: the launcher is a shell string, and whether its
+    child leaves the session is not visible in the source.
+    """
+    results = tmp_path / "results"
+    results.mkdir()
+    entry = tmp_path / "install.sh"
+    entry.write_text("i=0\nwhile [ $i -lt 6 ]; do echo line $i; i=$((i+1)); sleep 1; done\nexit 7\n")
+
+    launch = cluster.detached_install("x.toml", results=str(results), entry=str(entry))
+    follow = cluster.follow_install(results=str(results))
+
+    # In a session of its own, then hung up: that is what reaches the guest's
+    # foreground job when `termproxy` drops and `qm terminal` attaches again.
+    shell = subprocess.Popen(
+        ["sh", "-c", f"{launch}; sleep 30"],
+        start_new_session=True,
+        stdout=subprocess.DEVNULL,
+    )
+    time.sleep(2)
+    os.killpg(os.getpgid(shell.pid), signal.SIGHUP)
+    shell.wait(timeout=10)
+
+    first = subprocess.run(["sh", "-c", follow], capture_output=True, text=True, timeout=60)
+    assert "line " in first.stdout, first.stdout
+
+    # Sending the launcher again starts nothing: the install is still running.
+    again = subprocess.run(["sh", "-c", launch], capture_output=True, text=True)
+    assert "install already running" in again.stdout, again.stdout
+
+    # The hangup did not reach it: it ran to its own end and wrote its code.
+    assert (results / "install.rc").read_text().strip() == "7"
+    assert (results / "install.txt").read_text().count("line ") == 6
+    # A follower started after the drop prints what arrived after it attached,
+    # not the log from the top: `install.txt` runs to 294910 lines on a guest.
+    assert "line 0" not in first.stdout, first.stdout
+
+
+def test_a_repeatable_wait_is_sent_again_after_a_reconnect() -> None:
+    """A prompt after a reconnect says the shell was replaced.
+
+    `wait_for` reads one as the command having returned, which is right for a
+    command the reconnect could not have killed and wrong for the follower of
+    a detached install: the follower died with its shell and nothing is
+    printing. `repeatable` sends it again instead.
+    """
+
+    from tests.vm.console import ConsoleClosed
+
+    class Dropping(_MarkerConsole):
+        def __init__(self) -> None:
+            super().__init__(b"", completes=False)
+            self.opens = 0
+
+        def expect(self, pattern: str, timeout: float, idle: float = 0.0) -> bytes:
+            self.patterns.append(pattern)
+            if self.opens < 3:
+                raise ConsoleClosed("dropped")
+            matched = re.search(r"MARK_(\d+)_DONE", pattern)
+            assert matched is not None
+            return f"MARK_{matched.group(1)}_DONE\n".encode()
+
+    console = Dropping()
+
+    def open_console() -> Any:
+        console.opens += 1
+        return console
+
+    link = cluster.Reconnecting(open_console, tries=4)
+    link.wait_for("follow", timeout=60.0, repeatable=True)
+    followers = [one for one in console.sent if "follow" in one]
+    assert len(followers) == 3, console.sent
+    # Not the prompt fallback: a repeatable wait never accepts one, because a
+    # prompt is exactly what a hangup leaves behind.
+    assert not any("root@" in one for one in console.patterns), console.patterns

--- a/tests/unit/test_harness.py
+++ b/tests/unit/test_harness.py
@@ -1535,6 +1535,7 @@ def test_preinstall_console_timeout_is_an_error_with_its_phase(
             timeout: float,
             idle: float = 0.0,
             watch: object | None = None,
+            repeatable: bool = False,
         ) -> None:
             return None
 

--- a/tests/unit/test_proxmox.py
+++ b/tests/unit/test_proxmox.py
@@ -1139,7 +1139,7 @@ def test_the_installer_does_not_start_before_the_guest_has_a_network() -> None:
     from tests.vm import cluster
 
     source = inspect.getsource(cluster.install_one)
-    ran = source.index("install.sh")
+    ran = source.index("detached_install(")
     waited = source.index("wait_for_network")
     assert waited < ran, "the wait has to come before the installer"
 

--- a/tests/vm/cluster.py
+++ b/tests/vm/cluster.py
@@ -2443,11 +2443,10 @@ def install_one(
         stage_passphrases(link, load(job.installed_config or job.fixture))
         link.run(FIND_DRIVER)
         link.run(f"mkdir -p {RESULT_DIR}")
-        # tee, not a redirect: the serial console is the only way to watch a
-        # run that takes half an hour, and it is what the watchdog reads to
-        # tell a slow mirror from a dead guest.
-        # `wait_for`, not `run`: a console dropped mid-install is reopened and
-        # listened to again, never handed the command a second time.
+        # Detached, then followed: the console is the only way to watch a run
+        # that takes half an hour and it is what the watchdog reads, but a
+        # foreground job on `ttyS0` dies of the hangup a dropped `termproxy`
+        # delivers. The follower is repeatable because the install is not it.
         # Again, immediately before the installer: the first measurement is
         # taken a minute earlier and passed on every guest of round 27, whose
         # installers then found no route at all. This one splits that window.
@@ -2466,12 +2465,13 @@ def install_one(
             )
         _note_the_probe(link, "pre-install")
         phase = Phase.INSTALL
+        link.run(detached_install(job.fixture.name), timeout=180.0)
         link.wait_for(
-            f"{{ sh /mnt/driver/install.sh --config fixtures/{job.fixture.name}; "
-            f"echo $? > {RESULT_DIR}/install.rc; }} 2>&1 | tee {RESULT_DIR}/install.txt",
+            follow_install(),
             timeout=RUN_CEILING,
             idle=INSTALL_IDLE,
             watch=watch,
+            repeatable=True,
         )
         # A third time, after the install: a console that still has its routes
         # when the installer saw none puts the loss in the installer's own
@@ -3196,6 +3196,49 @@ def _naming(command: str) -> Iterator[None]:
 INTERRUPT: Final[str] = "\x03"
 
 
+def detached_install(
+    fixture_name: str,
+    *,
+    results: str = RESULT_DIR,
+    entry: str = "/mnt/driver/install.sh",
+) -> str:
+    """The command that starts an install nothing on the console can kill.
+
+    A foreground job on `ttyS0` gets a hangup when `termproxy` drops, and
+    round 30 lost `vm-zfs-encrypted`, `vm-zfs-mirror` and `zfs-zbm` to it an
+    hour in, each inside the same `emerge sys-apps/systemd`: the console holds
+    a second `starting serial terminal on interface serial0` and a fresh
+    `root@livecd ~ #` under it.
+
+    Braced: the console wrapper appends `; printf MARK`, and a bare `&`
+    followed by `;` is a syntax error. Guarded on `install.txt`, so a resend
+    after a reconnect starts nothing a second time.
+    """
+    body = (
+        f"{{ sh {entry} --config fixtures/{fixture_name}; "
+        f"echo $? > {results}/install.rc; }} > {results}/install.txt 2>&1"
+    )
+    return (
+        f"if [ -e {results}/install.txt ]; then echo install already running; "
+        f"else {{ setsid sh -c '{body}' </dev/null >/dev/null 2>&1 & }}; fi"
+    )
+
+
+def follow_install(*, results: str = RESULT_DIR) -> str:
+    """The command that puts a detached install back on the console.
+
+    `-n 0`, so a follower started again after a reconnect prints what has
+    arrived since rather than replaying the 294910 lines `install.txt` holds.
+    The whole file is collected from the guest either way; the console carries
+    it for the watchdog and for a reader.
+    """
+    return (
+        f"tail -n 0 -F {results}/install.txt & follower=$!; "
+        f"while [ ! -e {results}/install.rc ]; do sleep 5; done; "
+        f"sleep 3; kill $follower 2>/dev/null"
+    )
+
+
 class Reconnecting:
     """A console that opens another one when the cluster drops it.
 
@@ -3380,6 +3423,7 @@ class Reconnecting:
         timeout: float,
         idle: float = 0.0,
         watch: Watchdog | None = None,
+        repeatable: bool = False,
     ) -> None:
         """Send a command once and wait for it however long it takes.
 
@@ -3390,6 +3434,10 @@ class Reconnecting:
         command echo starts at a shell prompt. After a reconnect, `reopen`
         requests a fresh prompt, which also proves that the command returned.
 
+        `repeatable` is for a command that owns nothing: the follower of a
+        detached install is sent again, because a prompt after a reconnect
+        says the shell was replaced and not that the install ended.
+
         `idle` is measured from the last byte the guest sent. An install that
         prints for three hours is working and a single ceiling ends it anyway.
         """
@@ -3398,8 +3446,8 @@ class Reconnecting:
 
         def wait_once(deadline: float) -> None:
             nonlocal sent
-            after_reconnect = sent
-            if not sent:
+            after_reconnect = sent and not repeatable
+            if repeatable or not sent:
                 sent = True
                 self.console.send(marked_command(command, token))
             completion = command_done(token)
@@ -4100,12 +4148,13 @@ def convert_and_check(
     link.run(f"printf '%s\\n' {ETC_MARKER} > {ETC_MARKER_PATH}")
     link.run(FIND_DRIVER)
     link.run(f"mkdir -p {RESULT_DIR}")
+    link.run(detached_install(fixture.name), timeout=180.0)
     link.wait_for(
-        f"{{ sh /mnt/driver/install.sh --config fixtures/{fixture.name}; "
-        f"echo $? > {RESULT_DIR}/install.rc; }} 2>&1 | tee {RESULT_DIR}/install.txt",
+        follow_install(),
         timeout=RUN_CEILING,
         idle=INSTALL_IDLE,
         watch=watch,
+        repeatable=True,
     )
     files = collect(guest, link, log)
     # Prefixed: the names are the same as the install that produced this


### PR DESCRIPTION
Round 30 lost `vm-zfs-encrypted`, `vm-zfs-mirror` and `zfs-zbm` at 64 minutes each, all inside `emerge sys-apps/systemd`. Each console holds a second `starting serial terminal on interface serial0` with a clean `root@livecd ~ #` under it: `termproxy` dropped, the reconnect attached a new `qm terminal`, and the hangup that delivered to the guest killed the foreground job.

`detached_install()` starts the install in a session of its own writing to `install.txt`, and `follow_install()` puts it back on the console with `tail -n 0 -F` for the watchdog and for a reader. Because the install no longer belongs to that shell, the follower is repeatable, so `wait_for` gained `repeatable`: it resends after a reconnect instead of reading a prompt as the command having returned — a prompt is exactly what a hangup leaves behind.

The test sends a real SIGHUP to the process group rather than reading the strings. Both controls were run red.