### PR TITLE
bootloader: name the fallback ZFSBootMenu overwrites

### DIFF
--- a/gentoo_install/plan/bootloader.py
+++ b/gentoo_install/plan/bootloader.py
@@ -500,10 +500,13 @@ class InstallZfsBootMenu(Operation):
     serial: tuple[str, int] | None
 
     def describe(self) -> str:
+        # The fallback is named because `apply` overwrites it: firmware that
+        # drops an NVRAM entry starts the removable-media path instead, and on
+        # a reused esp that file belongs to whatever was installed before.
         return (
             f"write {ZBM_CONFIG}, build ZFSBootMenu into {self.esp}/{ZBM_DIRECTORY}, "
-            f"and boot {self.dataset} from it with cmdline "
-            f"{' '.join(self.kernel_params) or 'empty'}"
+            f"copy it over {self.esp}/{FALLBACK_IMAGE}, and boot {self.dataset} "
+            f"from it with cmdline {' '.join(self.kernel_params) or 'empty'}"
         )
 
     def _config(self) -> str:

--- a/tests/golden/vm-raidz.txt
+++ b/tests/golden/vm-raidz.txt
@@ -86,7 +86,7 @@
 [bootloader]
   install the bootloader: emerge sys-boot/zfsbootmenu sys-boot/efibootmgr
   install the EFI stub generate-zbm builds around: emerge sys-apps/systemd
-  write /etc/zfsbootmenu/config.yaml, build ZFSBootMenu into /efi/EFI/zbm, and boot rpool/ROOT/gentoo from it with cmdline console=ttyS0,115200
+  write /etc/zfsbootmenu/config.yaml, build ZFSBootMenu into /efi/EFI/zbm, copy it over /efi/EFI/BOOT/BOOTX64.EFI, and boot rpool/ROOT/gentoo from it with cmdline console=ttyS0,115200
 
 [packages]
   enable zfs-import-scan.service at boot

--- a/tests/golden/vm-zfs-encrypted.txt
+++ b/tests/golden/vm-zfs-encrypted.txt
@@ -78,7 +78,7 @@
 [bootloader]
   install the bootloader: emerge sys-boot/zfsbootmenu sys-boot/efibootmgr
   install the EFI stub generate-zbm builds around: emerge sys-apps/systemd
-  write /etc/zfsbootmenu/config.yaml, build ZFSBootMenu into /efi/EFI/zbm, and boot rpool/ROOT/gentoo from it with cmdline console=ttyS0,115200
+  write /etc/zfsbootmenu/config.yaml, build ZFSBootMenu into /efi/EFI/zbm, copy it over /efi/EFI/BOOT/BOOTX64.EFI, and boot rpool/ROOT/gentoo from it with cmdline console=ttyS0,115200
 
 [packages]
   enable zfs-import-scan.service at boot

--- a/tests/golden/vm-zfs-mirror.txt
+++ b/tests/golden/vm-zfs-mirror.txt
@@ -82,7 +82,7 @@
 [bootloader]
   install the bootloader: emerge sys-boot/zfsbootmenu sys-boot/efibootmgr
   install the EFI stub generate-zbm builds around: emerge sys-apps/systemd
-  write /etc/zfsbootmenu/config.yaml, build ZFSBootMenu into /efi/EFI/zbm, and boot rpool/ROOT/gentoo from it with cmdline console=ttyS0,115200
+  write /etc/zfsbootmenu/config.yaml, build ZFSBootMenu into /efi/EFI/zbm, copy it over /efi/EFI/BOOT/BOOTX64.EFI, and boot rpool/ROOT/gentoo from it with cmdline console=ttyS0,115200
 
 [packages]
   enable zfs-import-scan.service at boot

--- a/tests/golden/vm-zfs.txt
+++ b/tests/golden/vm-zfs.txt
@@ -78,7 +78,7 @@
 [bootloader]
   install the bootloader: emerge sys-boot/zfsbootmenu sys-boot/efibootmgr
   install the EFI stub generate-zbm builds around: emerge sys-apps/systemd
-  write /etc/zfsbootmenu/config.yaml, build ZFSBootMenu into /efi/EFI/zbm, and boot rpool/ROOT/gentoo from it with cmdline console=ttyS0,115200
+  write /etc/zfsbootmenu/config.yaml, build ZFSBootMenu into /efi/EFI/zbm, copy it over /efi/EFI/BOOT/BOOTX64.EFI, and boot rpool/ROOT/gentoo from it with cmdline console=ttyS0,115200
 
 [packages]
   enable zfs-import-scan.service at boot

--- a/tests/golden/zbm-unlock.txt
+++ b/tests/golden/zbm-unlock.txt
@@ -94,7 +94,7 @@
   install the bootloader: emerge sys-boot/zfsbootmenu sys-boot/efibootmgr
   install the EFI stub generate-zbm builds around: emerge sys-apps/systemd
   write /etc/zfsbootmenu/dracut.conf.d/dropbear.conf and /etc/cmdline.d/dracut-network.conf, authorise keys at /etc/dropbear/root_key, and generate dedicated host keys under /etc/dropbear
-  write /etc/zfsbootmenu/config.yaml, build ZFSBootMenu into /efi/EFI/zbm, and boot zpcala/ROOT/gentoo/root from it with cmdline console=ttyS0,115200 quiet
+  write /etc/zfsbootmenu/config.yaml, build ZFSBootMenu into /efi/EFI/zbm, copy it over /efi/EFI/BOOT/BOOTX64.EFI, and boot zpcala/ROOT/gentoo/root from it with cmdline console=ttyS0,115200 quiet
 
 [packages]
   enable zfs-import-scan.service at boot

--- a/tests/golden/zfs-zbm.txt
+++ b/tests/golden/zfs-zbm.txt
@@ -90,7 +90,7 @@
 [bootloader]
   install the bootloader: emerge sys-boot/zfsbootmenu sys-boot/efibootmgr
   install the EFI stub generate-zbm builds around: emerge sys-apps/systemd
-  write /etc/zfsbootmenu/config.yaml, build ZFSBootMenu into /efi/EFI/zbm, and boot zpcala/ROOT/gentoo/root from it with cmdline console=ttyS0,115200 quiet
+  write /etc/zfsbootmenu/config.yaml, build ZFSBootMenu into /efi/EFI/zbm, copy it over /efi/EFI/BOOT/BOOTX64.EFI, and boot zpcala/ROOT/gentoo/root from it with cmdline console=ttyS0,115200 quiet
 
 [packages]
   enable zfs-import-scan.service at boot

--- a/tests/unit/test_plan_bootloader.py
+++ b/tests/unit/test_plan_bootloader.py
@@ -734,3 +734,25 @@ def test_bios_grub_description_uses_disk_path_despite_mounted_esp() -> None:
     assert recorder.argv_starting(
         "grub-install", f"--target={DEFAULT_ARCHITECTURE.bios_target}"
     ) == (("grub-install", "--target=i386-pc", "/dev/vda"),)
+
+
+def test_the_zbm_description_names_the_fallback_it_overwrites() -> None:
+    """`apply` copies the generated image over the removable-media path.
+
+    `EFI/BOOT/BOOTX64.EFI` is what firmware that dropped its NVRAM entry
+    starts, and on a reused esp it belongs to whatever was installed there
+    before. The description said the image was built under `EFI/zbm` and
+    stopped, so a dry-run never showed the one write that replaces another
+    system's loader.
+    """
+    operation = zfsbootmenu_operation()
+    written = Recorder(replies={"find": "/efi/EFI/zbm/vmlinuz.EFI\n"})
+    operation.apply(written)
+
+    installed = [
+        one
+        for one in written.in_target
+        if one[:1] == ("install",) and one[-1].endswith(bootloader.FALLBACK_IMAGE)
+    ]
+    assert installed, written.commands
+    assert bootloader.FALLBACK_IMAGE in operation.describe(), operation.describe()


### PR DESCRIPTION
`InstallZfsBootMenu.describe()` said the image is built under `EFI/zbm` and stopped there. `apply()` then runs `install -D -m0644 <image> <esp>/EFI/BOOT/BOOTX64.EFI` unconditionally.

That copy is deliberate: firmware that drops an `efibootmgr` entry starts the removable-media path instead. On a reused esp the file it replaces belongs to whatever was installed before, and a dry-run showed nothing of it.

The behaviour is unchanged and the description now names the path. The test reads the `install` command out of `apply()` before checking the wording, and the control was run red; six golden files are regenerated in the same commit.