### PR TITLE
validate: refuse a desktop paired with another profile

### DIFF
--- a/gentoo_install/cli.py
+++ b/gentoo_install/cli.py
@@ -506,6 +506,9 @@ def _once(arguments: argparse.Namespace, state: RunState, refused: str) -> int |
                 config,
                 available_timezones=load_timezones(),
                 available_package_groups=catalog,
+                declared_desktop_profiles={
+                    name: group.profile for name, group in catalog.items() if group.profile
+                },
             )
         if launch is not None:
             if arguments.config is not None and _needs_network(arguments):

--- a/gentoo_install/model/validate.py
+++ b/gentoo_install/model/validate.py
@@ -226,6 +226,8 @@ def validate(
     available_timezones: Collection[str] | _ShippedValuesNotRead = _SHIPPED_VALUES_NOT_READ,
     available_package_groups: Collection[str]
     | _ShippedValuesNotRead = _SHIPPED_VALUES_NOT_READ,
+    declared_desktop_profiles: Mapping[str, str]
+    | _ShippedValuesNotRead = _SHIPPED_VALUES_NOT_READ,
     zfs_kernel_max: str | None | _ZfsKernelCeilingNotChecked = (
         _ZFS_KERNEL_CEILING_NOT_CHECKED
     ),
@@ -287,6 +289,7 @@ def validate(
         *_locale_problems(config),
         *_system_value_problems(config, available_timezones),
         *_package_group_problems(config, available_package_groups),
+        *_desktop_profile_problems(config, declared_desktop_profiles),
         *_l10n_problems(config),
         *_repository_name_problems(config),
         *compat.binhost_subarch_problems(config, supports_v3),
@@ -708,6 +711,35 @@ def _profile_problems(config: InstallConfig) -> list[str]:
     return [f"init is {config.system.init.value} and the profile is {profile}; use {wanted}"]
 
 
+
+
+def _desktop_profile_problems(
+    config: InstallConfig,
+    declared: Mapping[str, str] | _ShippedValuesNotRead,
+) -> list[str]:
+    """The desktop group names the profile its packages are built against.
+
+    `tests/fixtures/btrfs-luks.toml` paired `desktop = "plasma"` with the
+    generic `.../desktop/systemd`, and three cluster rounds stalled at
+    `install the plasma group`. Nothing refused it: the profile is valid, it
+    matches the init, and the repository has it.
+
+    The init suffix stays the caller's: `data/profiles/base/plasma.toml`
+    declares `.../desktop/plasma`, and a systemd system wants that path with
+    `/systemd` on the end.
+    """
+    if isinstance(declared, _ShippedValuesNotRead):
+        return []
+    wanted = declared.get(config.packages.desktop, "")
+    if not wanted:
+        return []
+    chosen = config.portage.profile
+    if chosen in (wanted, f"{wanted}/systemd"):
+        return []
+    return [
+        f"desktop is {config.packages.desktop} and the profile is {chosen}; "
+        f"that desktop is built against {wanted}"
+    ]
 
 
 def _repository_profile_problems(

--- a/tests/unit/test_validate.py
+++ b/tests/unit/test_validate.py
@@ -1691,3 +1691,38 @@ def test_a_vfat_label_is_refused_unless_mkfs_can_write_it(
         return
     with pytest.raises(ValidationFailed, match="which mkfs cannot write into one"):
         validate(config(nodes))
+
+
+def test_a_desktop_paired_with_another_desktops_profile_is_refused() -> None:
+    """Nothing refused `desktop = "plasma"` on `.../desktop/systemd`.
+
+    That pairing is in `tests/fixtures/btrfs-luks.toml` and it stalled three
+    cluster rounds at `install the plasma group`: the profile is valid, it
+    matches the init and the repository has it, so every existing rule passed
+    it. `data/profiles/base/plasma.toml` declares the profile its packages are
+    built against, and that is what the config has to name.
+    """
+    from gentoo_install import data
+
+    catalog = data.load_catalog()
+    declared = {name: group.profile for name, group in catalog.items() if group.profile}
+    assert declared, "no shipped group declares a profile"
+
+    base = load(Path("tests/fixtures/vm-desktop.toml"))
+    assert base.packages.desktop in declared, base.packages.desktop
+
+    # The one the fixture was written with, which is the desktop's own.
+    validate(base, declared_desktop_profiles=declared)
+
+    generic = replace(
+        base,
+        portage=replace(base.portage, profile="default/linux/amd64/23.0/desktop/systemd"),
+    )
+    with pytest.raises(ValidationFailed) as refused:
+        validate(generic, declared_desktop_profiles=declared)
+    assert "is built against" in str(refused.value), str(refused.value)
+
+    # Without the mapping the rule is silent, because the shipped names are
+    # read at the entry point and a caller that has not read them cannot
+    # decide: the TUI validates a graph mid-edit with nothing injected.
+    validate(generic)


### PR DESCRIPTION
`tests/fixtures/btrfs-luks.toml` paired `desktop = "plasma"` with the generic `default/linux/amd64/23.0/desktop/systemd` and stalled three cluster rounds at `[78/90] install the plasma group`. Nothing refused it: that profile is valid, it matches the init, and the repository has it.

`data/profiles/*.toml` already declares the profile each desktop is built against, so `cli.py` collects those into a name-to-profile map and injects it, the way `docs/design.md` says closed names reach the validator. The init suffix stays the caller`s: `plasma.toml` declares `.../desktop/plasma` and a systemd system wants that path with `/systemd` on the end.

A caller that injects nothing is unaffected, which is what the TUI needs while a graph is still being edited. The control was run red.