### PR TITLE
tui: take back what console CJK brought in

### DIFF
--- a/gentoo_install/cli.py
+++ b/gentoo_install/cli.py
@@ -1352,15 +1352,15 @@ def _from_menu(
             context.tag = "en"
             if state is not None:
                 state.language = "en"
-            return app.run(display, screens.with_language(start, "en"), context)
+            return app.run(display, screens.with_language(start, "en", context), context)
         # Asked before the menu: the environment says which language the
         # operator reads, not whether this terminal can draw it.
         if not arguments.lang:
             context.translate = Catalog(screens.language_screen(display, context))
             context.tag = context.translate.tag
-            chosen = screens.with_language(start, context.tag)
+            chosen = screens.with_language(start, context.tag, context)
         else:
-            chosen = screens.with_language(start, context.translate.tag)
+            chosen = screens.with_language(start, context.translate.tag, context)
         if state is not None:
             state.language = context.translate.tag
         if refused:

--- a/gentoo_install/data/locale/ja.toml
+++ b/gentoo_install/data/locale/ja.toml
@@ -353,6 +353,7 @@
 "manual" = "手動"
 "a partition" = "パーティション"
 "not set" = "未設定"
+"Console CJK is off, so the kernel goes back to {}." = "コンソールの CJK 表示を無効にしたため、カーネルを {} に戻します。"
 "This kernel has no cjktty: console CJK is off." = "cjktty がないため、コンソールの CJK 表示は無効"
 "System logger" = "システムログ"
 "Cron" = "cron"

--- a/gentoo_install/data/locale/ko.toml
+++ b/gentoo_install/data/locale/ko.toml
@@ -353,6 +353,7 @@
 "manual" = "수동"
 "a partition" = "파티션"
 "not set" = "설정 안 됨"
+"Console CJK is off, so the kernel goes back to {}." = "콘솔 CJK 표시를 껐으므로 커널을 {}(으)로 되돌립니다."
 "This kernel has no cjktty: console CJK is off." = "cjktty가 없어 콘솔 CJK 표시를 껐습니다."
 "System logger" = "시스템 로그"
 "Cron" = "cron"

--- a/gentoo_install/data/locale/zh-CN.toml
+++ b/gentoo_install/data/locale/zh-CN.toml
@@ -353,6 +353,7 @@
 "manual" = "手动"
 "a partition" = "一个分区"
 "not set" = "未设置"
+"Console CJK is off, so the kernel goes back to {}." = "控制台 CJK 显示已关闭，内核改回 {}。"
 "This kernel has no cjktty: console CJK is off." = "这个内核未含 cjktty，控制台 CJK 显示已关闭。"
 "System logger" = "系统日志服务"
 "Cron" = "计划任务"

--- a/gentoo_install/data/locale/zh-TW.toml
+++ b/gentoo_install/data/locale/zh-TW.toml
@@ -353,6 +353,7 @@
 "manual" = "手動"
 "a partition" = "一個分割區"
 "not set" = "未設定"
+"Console CJK is off, so the kernel goes back to {}." = "主控台 CJK 顯示已關閉，核心改回 {}。"
 "This kernel has no cjktty: console CJK is off." = "這個核心未含 cjktty，主控台 CJK 顯示已關閉。"
 "System logger" = "系統日誌服務"
 "Cron" = "排程"

--- a/gentoo_install/tui/screens.py
+++ b/gentoo_install/tui/screens.py
@@ -80,13 +80,18 @@ from .partitions import (
     partitions_screen,
 )
 from .context import (
+    GENTOO_ZH,
     Context,
     ValueKind,
     answers,
     current_menu,
     footer,
+    forget_derived,
+    mark_derived,
     say,
+    was_derived,
     with_gentoo_zh,
+    without_gentoo_zh,
 )
 from .widgets import (
     Accepts,
@@ -1113,6 +1118,8 @@ def kernel_screen(screen: Screen, config: InstallConfig, context: Context) -> An
         changed = replace(changed, system=replace(changed.system, console_cjk=True))
         # The package is in gentoo-zh and in no other repository, so choosing
         # it is consenting to that overlay rather than having it added quietly.
+        if not any(one.name == GENTOO_ZH for one in config.portage.overlays):
+            mark_derived(context, ValueKind.OVERLAY, GENTOO_ZH)
         return Answer(Outcome.CHOSE, replace(changed, portage=with_gentoo_zh(changed)))
     if config.system.console_cjk:
         # Turned off with the kernel that carried it, and said out loud: the
@@ -1120,7 +1127,7 @@ def kernel_screen(screen: Screen, config: InstallConfig, context: Context) -> An
         # kernel, from a row that has no way to clear this.
         say(screen, context, translate("This kernel has no cjktty: console CJK is off."))
         changed = replace(changed, system=replace(changed.system, console_cjk=False))
-    return Answer(Outcome.CHOSE, changed)
+    return Answer(Outcome.CHOSE, _withdrawing_a_derived_overlay(changed, context))
 
 
 
@@ -1918,14 +1925,47 @@ def _pick_keymap(
     )
 
 
+def _withdrawing_a_derived_overlay(config: InstallConfig, context: Context) -> InstallConfig:
+    """Take back gentoo-zh when a choice, not the operator, put it there.
+
+    An overlay selected on the Mirrors screen is the operator's and this does
+    not reach across and take it, which is why the record decides rather than
+    the overlay's presence. Without it the CJK package family stays merged on
+    a machine whose console CJK is off, and the community binary host stays
+    configured and trusted from a row nobody is looking at.
+    """
+    if not was_derived(context, ValueKind.OVERLAY, GENTOO_ZH):
+        return config
+    forget_derived(context, ValueKind.OVERLAY)
+    return replace(config, portage=without_gentoo_zh(config))
+
+
 def console_cjk_screen(
     screen: Screen, config: InstallConfig, context: Context
 ) -> Answer[InstallConfig]:
-    """Flipped where it stands: the row reads `in use` or `not used` already."""
-    return Answer(
-        Outcome.CHOSE,
-        replace(config, system=replace(config.system, console_cjk=not config.system.console_cjk)),
+    """Flipped where it stands: the row reads `in use` or `not used` already.
+
+    Turning it off takes the cjktty kernel with it. `RequestCjkKernel` reads
+    this flag and writes `-cjk`, so leaving that kernel selected merges the
+    whole CJK family with the patch compiled out of the package that exists
+    to carry it.
+    """
+    wanted = not config.system.console_cjk
+    changed = replace(config, system=replace(config.system, console_cjk=wanted))
+    if wanted or config.kernel.source not in compat.CJK_KERNELS:
+        return Answer(Outcome.CHOSE, changed)
+    # The dataclass default, not a second literal: the kernel this row falls
+    # back to is the one a configuration that never chose has.
+    fallback = KernelConfig().source
+    say(
+        screen,
+        context,
+        context.translate("Console CJK is off, so the kernel goes back to {}.").format(
+            KERNEL_PACKAGES[fallback].atom
+        ),
     )
+    changed = replace(changed, kernel=replace(changed.kernel, source=fallback))
+    return Answer(Outcome.CHOSE, _withdrawing_a_derived_overlay(changed, context))
 
 
 def console_font_screen(
@@ -2277,8 +2317,15 @@ def _site_kept_in(site: str, region: MirrorRegion) -> str:
     return ""
 
 
-def with_language(config: InstallConfig, tag: str) -> InstallConfig:
-    """The configuration as the chosen interface language leaves it."""
+def with_language(
+    config: InstallConfig, tag: str, context: Context | None = None
+) -> InstallConfig:
+    """The configuration as the chosen interface language leaves it.
+
+    `context` records that the overlay came from this choice, so the console
+    CJK row can take it back. Without it the addition has no matching
+    withdrawal and the CJK family stays merged with its feature off.
+    """
     chosen = LANGUAGE_DEFAULTS.get(tag)
     if chosen is None:
         return config
@@ -2319,6 +2366,10 @@ def with_language(config: InstallConfig, tag: str) -> InstallConfig:
         return seeded
     # The patched kernel is what puts CJK on the console, and it is in gentoo-zh
     # and nowhere else, so the overlay comes with it or the row is unusable.
+    if context is not None and not any(
+        one.name == GENTOO_ZH for one in config.portage.overlays
+    ):
+        mark_derived(context, ValueKind.OVERLAY, GENTOO_ZH)
     return replace(
         seeded,
         kernel=replace(seeded.kernel, source=KernelSource.CJK_BIN),

--- a/tests/unit/test_tui_app.py
+++ b/tests/unit/test_tui_app.py
@@ -1128,7 +1128,10 @@ def test_console_cjk_has_an_independent_switch_beside_its_font() -> None:
     chinese = screens.with_language(config(), "zh-TW")
     assert cjk.unavailable(chinese, at) == ""
 
-    disabled = screens.console_cjk_screen(FakeScreen(keys=[]), chinese, at).unwrap()
+    # A key, because turning the row off says which kernel it falls back to:
+    # the language chose the patched one and `RequestCjkKernel` reads this
+    # flag, so leaving that kernel here writes `-cjk`.
+    disabled = screens.console_cjk_screen(FakeScreen(keys=["\n"]), chinese, at).unwrap()
     assert not disabled.system.console_cjk
 
 
@@ -4757,3 +4760,61 @@ def test_changing_the_install_mode_takes_back_the_erase_confirmation() -> None:
     assert at.confirmed == set(), at.confirmed
     assert not at.manual
     assert not at.layout.disks
+
+
+def test_turning_console_cjk_off_takes_back_what_turning_it_on_added() -> None:
+    """Adding without a withdrawal is the shape `#1125` already fixed once.
+
+    Choosing a CJK interface language sets `KernelSource.CJK_BIN`, adds
+    `gentoo-zh` and turns the community binary host on. The console CJK row
+    flipped one flag, so the machine kept the whole CJK package family, the
+    overlay and a trusted binary host with the feature off: `RequestCjkKernel`
+    reads that flag and writes `-cjk`.
+    """
+    from gentoo_install.model.config import BinhostChannel, KernelSource
+    from gentoo_install.tui.context import GENTOO_ZH
+
+    at = context()
+    chinese = screens.with_language(config(), "zh-TW", at)
+    assert chinese.kernel.source is KernelSource.CJK_BIN
+    assert any(one.name == GENTOO_ZH for one in chinese.portage.overlays)
+    assert chinese.portage.binhost.community is BinhostChannel.STABLE
+
+    off = screens.console_cjk_screen(FakeScreen(keys=["\n"]), chinese, at).unwrap()
+    assert not off.system.console_cjk
+    assert off.kernel.source is KernelSource.DIST_BIN
+    assert not [one for one in off.portage.overlays if one.name == GENTOO_ZH]
+    assert off.portage.binhost.community is BinhostChannel.OFF
+    validate(off)
+
+    # Back on, and off again, leaves the same machine: the record is what
+    # decides, so a second withdrawal is not a second removal of something
+    # that is no longer there.
+    again = screens.console_cjk_screen(FakeScreen(keys=["\n"]), off, at).unwrap()
+    assert again.system.console_cjk
+
+
+def test_an_overlay_the_operator_chose_survives_the_console_cjk_row() -> None:
+    """An overlay selected on the Mirrors screen is theirs.
+
+    `was_derived` is what separates the two, and the bootloader row already
+    reads it the same way; a withdrawal keyed on the overlay being present
+    would reach across and take it.
+    """
+    from gentoo_install.model.config import KernelSource, Overlay
+    from gentoo_install.tui.context import GENTOO_ZH
+
+    at = context()
+    theirs = replace(
+        config(),
+        system=replace(config().system, console_cjk=True),
+        kernel=replace(config().kernel, source=KernelSource.CJK_BIN),
+        portage=replace(
+            config().portage,
+            overlays=(Overlay(name=GENTOO_ZH, sync_uri="https://example.invalid/zh.git"),),
+        ),
+    )
+
+    off = screens.console_cjk_screen(FakeScreen(keys=["\n"]), theirs, at).unwrap()
+    assert not off.system.console_cjk
+    assert [one for one in off.portage.overlays if one.name == GENTOO_ZH]


### PR DESCRIPTION
Choosing a CJK interface language sets `KernelSource.CJK_BIN`, adds `gentoo-zh` and turns the community binary host on. `console_cjk_screen` flipped one boolean, so turning the row off left all three in place — and `RequestCjkKernel` reads that flag, so the patched kernel was then built with `-cjk`.

`without_gentoo_zh` already existed and neither path called it. The withdrawal uses the record the bootloader row already reads: `mark_derived` where the overlay is added, `was_derived` before taking it back, so an overlay selected on the Mirrors screen is left alone. `with_language` takes an optional context for the same reason — the record belongs beside the addition.

The kernel falls back to `KernelConfig().source` rather than a second literal, and the row says which package that is. Both controls were run red.