### PR TITLE
portage: say what an emptied INPUT_DEVICES leaves behind

### DIFF
--- a/gentoo_install/model/config.py
+++ b/gentoo_install/model/config.py
@@ -439,9 +439,9 @@ class PortageConfig:
     video_cards: tuple[str, ...] = ()
     #: Empty derives L10N from the generated locales.
     l10n: tuple[str, ...] = ()
-    #: `INPUT_DEVICES`. libinput is what every current desktop reads; the
-    #: profile's own value is replaced outright by make.conf, so an empty
-    #: tuple here would leave a machine with no pointer driver.
+    #: `INPUT_DEVICES`. Empty writes no assignment, so `profiles/base/
+    #: make.defaults` line 53, `INPUT_DEVICES="libinput"`, stands: emptying
+    #: this leaves the driver, not a machine without one.
     input_devices: tuple[str, ...] = ("libinput",)
     accept_license: tuple[str, ...] = ("@FREE",)
     #: Detected from /proc/cpuinfo when the interface fills it in. Empty means

--- a/gentoo_install/tui/screens.py
+++ b/gentoo_install/tui/screens.py
@@ -2194,8 +2194,10 @@ def input_devices_screen(
 ) -> Answer[InstallConfig]:
     """`INPUT_DEVICES`, which make.conf replaces outright rather than adds to.
 
-    Emptying it leaves a machine with no pointer driver, so `libinput` is the
-    default rather than something the operator has to know to type.
+    Emptying it writes no assignment at all, so the profile's own value
+    stands. `libinput` is the default here because it is also what
+    `profiles/base/make.defaults` sets, and a row that shows nothing where
+    every machine has one reads as a value that was lost.
     """
     answer = _typed_beside_automatic(
         screen,

--- a/tests/unit/test_automatic.py
+++ b/tests/unit/test_automatic.py
@@ -313,13 +313,26 @@ def test_a_hybrid_machine_can_name_more_than_one_card() -> None:
     assert required_video_cards(installation, catalog) == ("nvidia", "amdgpu", "radeonsi")
 
 
-def test_input_devices_is_never_left_empty_by_default() -> None:
-    """make.conf replaces the profile's INPUT_DEVICES rather than adding to it,
-    so a machine installed with the row untouched would have no pointer."""
+def test_an_emptied_input_devices_leaves_the_profile_to_answer() -> None:
+    """An assignment in make.conf replaces the profile's value outright.
+
+    The row's own comment said emptying it leaves a machine with no pointer
+    driver. `make_conf` writes the key only when the tuple is not empty, and
+    `profiles/base/make.defaults` line 53 reads `INPUT_DEVICES="libinput"`
+    for every profile, so emptying the row leaves the driver.
+    """
     from gentoo_install.plan.portage import make_conf
 
-    written = dict(make_conf(config(ext4_on_gpt()), (), ()))
+    installation = config(ext4_on_gpt())
+    written = dict(make_conf(installation, (), ()))
     assert written["INPUT_DEVICES"] == "libinput"
+
+    # Emptied: no assignment at all, which is what leaves the profile in force.
+    # An assignment of the empty string would be the loss the comment feared.
+    emptied = replace(
+        installation, portage=replace(installation.portage, input_devices=())
+    )
+    assert "INPUT_DEVICES" not in dict(make_conf(emptied, (), ()))
 
 
 def test_the_confirmation_can_open_the_row_the_values_landed_on() -> None:


### PR DESCRIPTION
Three comments and a test docstring said emptying the `INPUT_DEVICES` row leaves a machine with no pointer driver, one of them beside the model field itself. `profiles/base/make.defaults` line 53 reads `INPUT_DEVICES="libinput"` and every profile inherits it, and `make_conf` writes the key only when the tuple is not empty. Emptying the row therefore writes no assignment and leaves the profile's value in force.

The wording now states the mechanism instead. `libinput` stays the default here because a row showing nothing where every machine has a value reads as one that was lost.

The test is the part that was missing: it asserts that an emptied tuple produces no `INPUT_DEVICES` key at all, which is what leaves the profile to answer. An assignment of the empty string would be the loss the comments feared, and nothing could tell the two apart before. The control was run red.