### PR TITLE
tui: keep the mirror region the egress decided

### DIFF
--- a/gentoo_install/tui/screens.py
+++ b/gentoo_install/tui/screens.py
@@ -2349,6 +2349,16 @@ def with_language(
     # from 0:33:01 to 1:39:38 of a 1:43:48 install. The CJK console comes from
     # `console_cjk` and the cjktty kernel, not from those fonts.
     applications = config.packages.applications
+    # `cli.py`'s `_region` reads where the packets come out and writes down
+    # why: a machine in China reading English is behind the Great Firewall and
+    # one in Taiwan reading Chinese is not. The interface language is a weaker
+    # signal than that measurement, so it may narrow to `CN` and never widen
+    # away from it. An operator who disagrees says so on the Mirrors screen.
+    region = (
+        MirrorRegion.CN
+        if config.portage.mirrors.region is MirrorRegion.CN
+        else chosen.mirror_region
+    )
     seeded = replace(
         config,
         system=replace(
@@ -2366,8 +2376,8 @@ def with_language(
             # `global` resolves to `distfiles.gentoo.org` and nothing says so.
             mirrors=replace(
                 config.portage.mirrors,
-                region=chosen.mirror_region,
-                site=_site_kept_in(config.portage.mirrors.site, chosen.mirror_region),
+                region=region,
+                site=_site_kept_in(config.portage.mirrors.site, region),
             ),
         ),
     )

--- a/tests/unit/test_tui_app.py
+++ b/tests/unit/test_tui_app.py
@@ -4850,3 +4850,41 @@ def test_changing_the_kernel_source_drops_the_version_pinned_to_the_old_one() ->
     ).unwrap()
     assert kept.kernel.source is pinned.kernel.source
     assert kept.kernel.version == "7.1.12"
+
+def test_the_interface_language_does_not_widen_a_measured_cn_region() -> None:
+    """Two readers wrote down opposite policies and the reasoned one lost.
+
+    `cli._region` reads where the packets come out and says why in the source:
+    a machine in China reading English is behind the Great Firewall, and one
+    in Taiwan reading Chinese is not. `with_language` then wrote the interface
+    tag's own region over it, so answering English on a Chinese machine sent
+    every stage3 fetch through a mirror set that machine cannot reach.
+    """
+    from gentoo_install import cli
+    from gentoo_install.model.config import MirrorRegion
+
+    measured = replace(
+        config(),
+        portage=replace(
+            config().portage,
+            mirrors=replace(config().portage.mirrors, region=cli._region("CN")),
+        ),
+    )
+    assert measured.portage.mirrors.region is MirrorRegion.CN
+
+    for tag in ("en", "zh-TW", "ja", "ko"):
+        kept = screens.with_language(measured, tag)
+        assert kept.portage.mirrors.region is MirrorRegion.CN, tag
+
+    # Narrowing still works: an unread country takes the global list, and the
+    # language is then the only thing that knows anything.
+    unread = replace(
+        config(),
+        portage=replace(
+            config().portage,
+            mirrors=replace(config().portage.mirrors, region=cli._region("")),
+        ),
+    )
+    assert unread.portage.mirrors.region is MirrorRegion.GLOBAL
+    assert screens.with_language(unread, "zh-CN").portage.mirrors.region is MirrorRegion.CN
+    assert screens.with_language(unread, "zh-TW").portage.mirrors.region is MirrorRegion.GLOBAL


### PR DESCRIPTION
`cli._region` reads the country the packets come out of and writes the reason down: a machine in Taiwan reading Chinese is not behind the Great Firewall, and one in China reading English is. `with_language` then wrote the interface tag`s own region over that value, so answering English on a Chinese machine widened a measured `CN` back to `GLOBAL` and sent every stage3 fetch through hosts that machine cannot reach.

The interface language may now narrow to `CN` and never widen away from it: the egress is measured and the tag is a guess, so the weaker signal does not overwrite the stronger one. An operator who disagrees says so on the Mirrors screen, which is an explicit choice rather than a side effect of picking a language.

No provenance record is introduced for it; the two regions are enough to state the rule. The control was run red.