### PR TITLE
tui: draw the row that sets the gentoo-zh binary host

### DIFF
--- a/gentoo_install/tui/mirror.py
+++ b/gentoo_install/tui/mirror.py
@@ -170,6 +170,15 @@ def _mirror_fields(config: InstallConfig, translate: Catalog) -> list[Item[str]]
         ),
         next(field.row(config, translate) for field in _ALL_MIRROR_FIELDS if field.key == _BINHOST),
         next(field.row(config, translate) for field in _ALL_MIRROR_FIELDS if field.key == _ZH_SITE),
+        # Beside the overlay it serves, and drawn whatever the channel is:
+        # adding gentoo-zh turns this host on, the installed system configures
+        # and trusts it, and the row that sets it was in `_ALL_MIRROR_FIELDS`
+        # for `_edit_field` to find and in no list the menu drew.
+        next(
+            field.row(config, translate)
+            for field in _ALL_MIRROR_FIELDS
+            if field.key == _ZH_BINHOST
+        ),
     ]
     if "gentoo-zh" in used:
         rows += [field.row(config, translate) for field in _ZH_MIRROR_FIELDS]

--- a/tests/unit/test_automatic.py
+++ b/tests/unit/test_automatic.py
@@ -1671,3 +1671,38 @@ def test_the_overview_says_no_disk_has_been_written_yet() -> None:
     drawn = FakeScreen(keys=["q"], lines=120, columns=130)
     overview_screen(drawn, config(ext4_on_gpt()), context())
     assert "nothing has been written to the disks yet" in drawn.last
+
+
+def test_the_gentoo_zh_binary_host_has_a_row_on_the_mirror_screen() -> None:
+    """Adding the overlay turns that host on and the row was never drawn.
+
+    `with_gentoo_zh` moves `binhost.community` from `OFF` to `STABLE`, and the
+    installed system configures and trusts it. `_ZH_BINHOST` was in
+    `_ALL_MIRROR_FIELDS`, which is what `_edit_field` looks in, and in no list
+    `_mirror_fields` drew, so nothing could set it to `off` or `unstable`.
+    """
+    from dataclasses import replace as _replace
+
+    from gentoo_install.model.config import BinhostChannel
+    from gentoo_install.tui.context import with_gentoo_zh
+    from tests.unit.fake_screen import FakeScreen
+    from tests.unit.test_tui_app import context
+
+    started = config(ext4_on_gpt())
+    with_overlay = _replace(started, portage=with_gentoo_zh(started))
+    assert with_overlay.portage.binhost.community is BinhostChannel.STABLE
+
+    drawn = FakeScreen(keys=["q"], lines=40, columns=110)
+    mirror.mirror_screen(drawn, with_overlay, context())
+    row = next(
+        (one for one in drawn.last.splitlines() if "gentoo-zh binary packages" in one),
+        "",
+    )
+    assert row, drawn.last
+
+    # The row the menu draws is the one `_edit_field` dispatches on, or it
+    # would be drawn and unreachable rather than reachable and undrawn.
+    assert any(field.key == mirror._ZH_BINHOST for field in mirror._ALL_MIRROR_FIELDS)
+    assert mirror._ZH_BINHOST in [
+        item.value for item in mirror._mirror_fields(with_overlay, context().translate)
+    ]


### PR DESCRIPTION
`with_gentoo_zh` moves `binhost.community` from `OFF` to `STABLE`, and the installed system then configures that host and imports and signs its key. `_ZH_BINHOST` was in `_ALL_MIRROR_FIELDS`, which is the table `_edit_field` dispatches on, and in none of the lists `_mirror_fields` drew: reachable and never drawn, so nothing could set it to `off` or `unstable`.

The row is drawn beside the overlay it serves, whatever the channel is, because turning it off has to be visible too.

The test asserts both halves — that the line appears on the drawn screen, and that its value is the key `_edit_field` dispatches on — since fixing only the first half would produce a row that is drawn and does nothing. The control was run red.