### PR TITLE
tui: drop a kernel pin when the source it came from changes

### DIFF
--- a/gentoo_install/tui/screens.py
+++ b/gentoo_install/tui/screens.py
@@ -1109,7 +1109,14 @@ def kernel_screen(screen: Screen, config: InstallConfig, context: Context) -> An
     if not answer.chosen:
         return Answer(answer.outcome)
     chosen = answer.unwrap()
-    changed = replace(config, kernel=replace(config.kernel, source=chosen))
+    # The pin goes with the source it was read from: the version list is
+    # `kernel_versions(package)` for that one package, so keeping `7.1.12`
+    # across a change of source composes `=<new atom>-7.1.12`, which the
+    # keyword check accepts as syntax and the merge refuses as a version.
+    version = config.kernel.version if chosen is config.kernel.source else ""
+    changed = replace(
+        config, kernel=replace(config.kernel, source=chosen, version=version)
+    )
     if chosen in compat.CJK_KERNELS:
         # cjk on with it, the mirror of the branch below: `RequestCjkKernel`
         # reads this flag, so choosing the patched kernel and leaving the flag

--- a/tests/unit/test_tui_app.py
+++ b/tests/unit/test_tui_app.py
@@ -4818,3 +4818,35 @@ def test_an_overlay_the_operator_chose_survives_the_console_cjk_row() -> None:
     off = screens.console_cjk_screen(FakeScreen(keys=["\n"]), theirs, at).unwrap()
     assert not off.system.console_cjk
     assert [one for one in off.portage.overlays if one.name == GENTOO_ZH]
+
+
+def test_changing_the_kernel_source_drops_the_version_pinned_to_the_old_one() -> None:
+    """A pin is read from one package's version list and composed onto another.
+
+    `kernel_version_screen` offers `context.kernel_versions(package)`, so
+    `7.1.12` is a version of the package that was selected then. Keeping it
+    across a change of source composes `=<new atom>-7.1.12`, and `compat.py`
+    checks that atom for syntax alone, so the run reaches `Stage.KERNEL` after
+    partitioning, formatting, mounting and unpacking stage3.
+    """
+    from gentoo_install.model.config import KernelSource
+
+    at = context()
+    pinned = replace(
+        config(),
+        kernel=replace(config().kernel, source=KernelSource.DIST_BIN, version="7.1.12"),
+    )
+
+    # One step down from `dist-bin` is another source, so the pin has to go.
+    moved = screens.kernel_screen(
+        FakeScreen(keys=["KEY_DOWN", "\n", "\n"], lines=30, columns=100), pinned, at
+    ).unwrap()
+    assert moved.kernel.source is not pinned.kernel.source
+    assert moved.kernel.version == "", moved.kernel.version
+
+    # Choosing the source it already has changes nothing, so the pin stays.
+    kept = screens.kernel_screen(
+        FakeScreen(keys=["\n", "\n"], lines=30, columns=100), pinned, at
+    ).unwrap()
+    assert kept.kernel.source is pinned.kernel.source
+    assert kept.kernel.version == "7.1.12"


### PR DESCRIPTION
The version screen offers `context.kernel_versions(package)`, so a pinned `7.1.12` is a version of whichever package was selected at the time. Changing the source kept the whole `KernelConfig` and replaced only `source`, composing `=<new atom>-7.1.12`. `compat.py` checks that atom for syntax and accepts it, so the run reaches `Stage.KERNEL` — after partitioning, formatting, mounting and unpacking stage3 — before anything refuses.

Choosing the source already in hand leaves the pin alone, which is what an operator opening the row and pressing enter expects.

The control was run red.