### PR TITLE
tui: say that opening the editor replaces a loaded layout

### DIFF
--- a/gentoo_install/data/locale/ja.toml
+++ b/gentoo_install/data/locale/ja.toml
@@ -24,6 +24,7 @@
 "These flags select the instruction set used to compile packages." = "これらのフラグでパッケージのコンパイルに使う命令セットを選びます。"
 "This selects the service that brings interfaces up." = "インターフェースを起動するサービスを選びます。"
 "This installs a packet filter but does not write its policy." = "パケットフィルターをインストールしますが、ポリシーは書きません。"
+"The loaded layout cannot be edited here. Opening this editor replaces it with what the disk holds now." = "読み込んだレイアウトはここでは編集できません。このエディタを開くと、ディスクの現在の内容で置き換わります。"
 "This editor controls which partitions are kept, formatted, mounted, or erased." = "このエディターでパーティションを保持、フォーマット、マウント、消去するか決めます。"
 "Disks" = "ディスク"
 "Proxy" = "プロキシ"

--- a/gentoo_install/data/locale/ko.toml
+++ b/gentoo_install/data/locale/ko.toml
@@ -24,6 +24,7 @@
 "These flags select the instruction set used to compile packages." = "이 플래그가 패키지 컴파일에 사용할 명령어 집합을 선택합니다."
 "This selects the service that brings interfaces up." = "네트워크 인터페이스를 활성화할 서비스를 선택합니다."
 "This installs a packet filter but does not write its policy." = "패킷 필터를 설치하지만 정책은 작성하지 않습니다."
+"The loaded layout cannot be edited here. Opening this editor replaces it with what the disk holds now." = "불러온 레이아웃은 여기서 편집할 수 없습니다. 이 편집기를 열면 디스크의 현재 내용으로 바뀝니다."
 "This editor controls which partitions are kept, formatted, mounted, or erased." = "이 편집기에서 파티션을 유지, 포맷, 마운트 또는 삭제할지 정합니다."
 "Disks" = "디스크"
 "Proxy" = "프록시"

--- a/gentoo_install/data/locale/zh-CN.toml
+++ b/gentoo_install/data/locale/zh-CN.toml
@@ -24,6 +24,7 @@
 "These flags select the instruction set used to compile packages." = "这些标志选择构建软件包时使用的指令集。"
 "This selects the service that brings interfaces up." = "此选择决定启用网络接口的服务。"
 "This installs a packet filter but does not write its policy." = "此选择会安装数据包过滤软件包，但不会写入策略。"
+"The loaded layout cannot be edited here. Opening this editor replaces it with what the disk holds now." = "载入的分区版面无法在这里编辑。打开这个编辑器会用磁盘当前的内容取代它。"
 "This editor controls which partitions are kept, formatted, mounted, or erased." = "此编辑器控制哪些分区要保留、格式化、挂载或清除。"
 "Disks" = "磁盘"
 "Proxy" = "代理"

--- a/gentoo_install/data/locale/zh-TW.toml
+++ b/gentoo_install/data/locale/zh-TW.toml
@@ -24,6 +24,7 @@
 "These flags select the instruction set used to compile packages." = "這些旗標選擇編譯套件時使用的指令集。"
 "This selects the service that brings interfaces up." = "此選擇決定啟用網路介面的服務。"
 "This installs a packet filter but does not write its policy." = "此選擇會安裝封包過濾套件，但不會寫入政策。"
+"The loaded layout cannot be edited here. Opening this editor replaces it with what the disk holds now." = "載入的分割版面無法在這裡編輯。開啟這個編輯器會用磁碟目前的內容取代它。"
 "This editor controls which partitions are kept, formatted, mounted, or erased." = "此編輯器控制哪些分割區要保留、格式化、掛載或清除。"
 "Disks" = "磁碟"
 "Proxy" = "Proxy"

--- a/gentoo_install/tui/context.py
+++ b/gentoo_install/tui/context.py
@@ -208,6 +208,11 @@ class Context:
         self.layout = manual.Layout()
         #: Whether the disk comes from that table rather than a template.
         self.manual = False
+        #: Whether the graph in hand was read from a file. `hydrate_disk`
+        #: reduces one to a rough `Choice` and cannot rebuild the editor's
+        #: table from it, so the editor says what opening it costs rather
+        #: than reseeding from the probed disk over a layout nobody saw go.
+        self.layout_was_loaded = False
         #: What the chosen disk holds now, and how big it is. Both come from
         #: `exec/probe.py` and are shown before anything is erased.
         self.existing: tuple[tuple[str, str, str], ...] = ()
@@ -275,6 +280,7 @@ class Context:
         )
         self.manual = False
         self.layout = manual.Layout()
+        self.layout_was_loaded = True
         self.confirmed.clear()
         self.inspect_disk(disk)
 

--- a/gentoo_install/tui/partitions.py
+++ b/gentoo_install/tui/partitions.py
@@ -222,6 +222,21 @@ def partitions_screen(
     """
     translate = context.translate
     if not context.layout.holds(context.choice.disk) or not context.layout.slices:
+        if context.layout_was_loaded:
+            # The loaded graph reduces to a `Choice`, and nothing rebuilds this
+            # table from it, so the seed below is the probed disk and pressing
+            # Done writes it over what the file held. Said before that happens.
+            told = say(
+                screen,
+                context,
+                translate(
+                    "The loaded layout cannot be edited here. "
+                    "Opening this editor replaces it with what the disk holds now."
+                ),
+            )
+            if not told.chosen:
+                return Answer(Outcome.BACK)
+            context.layout_was_loaded = False
         # Seeded from what is on the disk when there is anything, and from the
         # template that was chosen when there is not: opening this row after
         # picking zfs used to show an ext4 root and discard the choice.

--- a/tests/unit/test_tui_partitions.py
+++ b/tests/unit/test_tui_partitions.py
@@ -1862,3 +1862,37 @@ def test_a_mountpoint_that_cannot_be_a_dataset_name_is_refused() -> None:
     graph, root = manual.build(fine)
     assert root
     assert {one.name for one in graph.of_type(ZfsDataset)} == {"ROOT/gentoo", "srv"}
+
+
+def test_a_loaded_layout_is_not_replaced_without_saying_so() -> None:
+    """`hydrate_disk` cannot rebuild this table from a loaded graph.
+
+    It reduces one to a rough automatic `Choice`, sets `manual = False` and
+    empties `layout`, so the editor reseeds from the probed disk and Done
+    writes that over the graph the file held. Nothing said it was going.
+    """
+    from tests.unit.fake_screen import FakeScreen
+    from tests.unit.test_tui_app import context
+
+    at = context()
+    at.hydrate_disk(config())
+    assert at.layout_was_loaded
+    assert not at.layout.slices
+
+    # Backing out of the message leaves the loaded graph in hand: the editor
+    # answers BACK and the configuration it was given comes back unchanged.
+    backed = FakeScreen(keys=["q"], lines=30, columns=110)
+    answer = partitions.partitions_screen(backed, config(), at)
+    assert answer.outcome is Outcome.BACK
+    assert at.layout_was_loaded
+    assert not at.layout.slices
+    drawn = "\n".join("\n".join(frame) for frame in backed.frames)
+    assert "cannot be edited here" in drawn, drawn
+
+    # Answering it opens the editor on the probed disk, and the message is not
+    # shown again: it is a warning about one replacement, not a nag.
+    at.layout_was_loaded = True
+    opening = FakeScreen(keys=["\n", "q"], lines=30, columns=110)
+    partitions.partitions_screen(opening, config(), at)
+    assert not at.layout_was_loaded
+    assert at.layout.slices


### PR DESCRIPTION
`hydrate_disk` reduces a loaded configuration graph to a rough automatic `Choice`, sets `manual = False` and empties `context.layout`. `partitions_screen` reseeds an empty layout from the probed disk, so pressing Done wrote that over the graph the file held, and nothing said it was going.

`model/manual.py` has `build(layout) -> graph` and no inverse. Writing one is a separate change whose mistakes land on a real disk, so this states the loss instead of guessing at a reconstruction: the editor says that opening it replaces the loaded layout, and backing out returns the configuration untouched. The message is shown once per replacement, not on every visit.

Reconstructing the table from a graph stays open; `docs/tasks.md` row 474 records what it needs first. The control was run red.