### PR TITLE
packages: name the session directories the check looks in

### DIFF
--- a/gentoo_install/plan/packages.py
+++ b/gentoo_install/plan/packages.py
@@ -215,7 +215,13 @@ class VerifySessionDirectories(Operation):
     paths: tuple[PurePosixPath, ...]
 
     def describe(self) -> str:
-        return f"verify session directories for {self.package}"
+        # The paths, because they are what the failure names: an install that
+        # stops here has already merged every package, and the operator's next
+        # step is to look in these directories on the machine.
+        return (
+            f"verify {self.package} provides a session in "
+            f"{', '.join(str(one) for one in self.paths)}"
+        )
 
     def apply(self, context: Context) -> None:
         if not self.package:

--- a/tests/golden/vm-greetd.txt
+++ b/tests/golden/vm-greetd.txt
@@ -79,7 +79,7 @@
   install the greetd group: emerge gui-libs/greetd gui-apps/tuigreet
   verify gui-libs/greetd installed /etc/greetd/config.toml
   verify gui-apps/tuigreet installed /usr/bin/tuigreet with --time, --remember, --remember-session, --sessions, --xsessions
-  verify session directories for xfce-base/xfce4-meta
+  verify xfce-base/xfce4-meta provides a session in /usr/share/wayland-sessions, /usr/share/xsessions
   set the greetd default session command in /etc/greetd/config.toml
   enable greetd at boot
   install the ibus-pinyin group: emerge app-i18n/ibus-libpinyin

--- a/tests/unit/test_packages.py
+++ b/tests/unit/test_packages.py
@@ -698,3 +698,34 @@ def test_the_target_probes_answer_absence_without_hiding_an_escape(
     for probe in (target_is_file, target_is_directory):
         with pytest.raises(CommandFailed, match="cannot inspect"):
             probe(target, PurePosixPath("/usr/escape/anything"))
+
+
+def test_the_session_check_names_the_directories_it_will_look_in() -> None:
+    """An install that stops here has already merged every package.
+
+    `apply()` fails with `<package> was expected to provide a session in
+    <paths>`, and the description named only the package, so the dry-run gave
+    no path to look at on the machine before running it. The paths come from
+    `data/packages/greetd.toml`, and reading them off the built operation is
+    what keeps the description and the catalog from drifting apart.
+    """
+    installation = config()
+    selected = replace(
+        installation,
+        packages=replace(
+            installation.packages, desktop="xfce", display_manager="greetd"
+        ),
+    )
+
+    checks = [
+        one
+        for one in plan_packages.build(selected, load_catalog())
+        if isinstance(one, plan_packages.VerifySessionDirectories)
+    ]
+    assert checks, "no session check was planned for greetd"
+
+    for check in checks:
+        assert check.paths, check
+        said = check.describe()
+        for path in check.paths:
+            assert str(path) in said, (path, said)


### PR DESCRIPTION
`VerifySessionDirectories.apply` fails with `<package> was expected to provide a session in <paths>`. `describe()` said `verify session directories for <package>`, so the dry-run named neither directory.

That matters more here than in most operations: this check runs in `Stage.PACKAGES`, so an install that stops on it has already merged everything, and the operator`s next step is to look in those directories on the machine. The paths come from `data/packages/greetd.toml`.

The test reads the paths off the built operation rather than repeating them, so changing the catalog moves the description with it. The control was run red; the golden files are regenerated in the same commit.