### PR TITLE
tests: hold what two dry-run assertions claimed to hold

### DIFF
--- a/tests/unit/test_layers.py
+++ b/tests/unit/test_layers.py
@@ -1426,3 +1426,60 @@ def test_every_desktop_fixture_names_the_profile_its_desktop_declares() -> None:
         if profile != wanted:
             wrong.append(f"{path.name}: {desktop} has {profile}, not {wanted}")
     assert wrong == [], wrong
+
+
+def test_no_description_reads_the_machine_it_describes() -> None:
+    """`render()` prints every `describe()` and applies nothing.
+
+    A description that runs a command turns `--dry-run` into a run, and the
+    claim was asserted in `tests/unit/test_plan_netboot.py` against a
+    `Recorder` that was never passed to an operation: `describe()` could have
+    read the machine and the empty recorder would still have been empty.
+
+    Read out of the syntax rather than by calling: an operation whose
+    description happens to take a branch that touches nothing under a test's
+    inputs is still one that can.
+    """
+    root = Path(__file__).resolve().parents[2]
+    # The names that reach a machine from inside a plan module: the execution
+    # seam is `Context`, and the three modules a description must not import
+    # its own way around.
+    forbidden = {
+        "context",
+        "subprocess",
+        "open",
+        "run",
+        "run_in_target",
+        "read",
+        "read_text",
+        "write",
+        "write_text",
+        "Path",
+        "os",
+    }
+    offenders: list[str] = []
+    described = 0
+    for path in sorted((root / "gentoo_install" / "plan").rglob("*.py")):
+        tree = ast.parse(path.read_text())
+        for node in ast.walk(tree):
+            if not isinstance(node, ast.ClassDef):
+                continue
+            for item in node.body:
+                if not isinstance(item, ast.FunctionDef):
+                    continue
+                if item.name not in ("describe", "describe_parts"):
+                    continue
+                described += 1
+                names = {one.id for one in ast.walk(item) if isinstance(one, ast.Name)}
+                attributes = {
+                    one.attr for one in ast.walk(item) if isinstance(one, ast.Attribute)
+                }
+                touched = sorted((names | attributes) & forbidden)
+                if touched:
+                    offenders.append(
+                        f"{path.name}:{node.name}.{item.name} uses {', '.join(touched)}"
+                    )
+    # The count guards the walk itself: a rename that stops matching any
+    # method would leave this passing over nothing at all.
+    assert described > 100, described
+    assert not offenders, offenders

--- a/tests/unit/test_plan_boot.py
+++ b/tests/unit/test_plan_boot.py
@@ -913,16 +913,38 @@ def test_the_cjk_kernel_lifts_the_mask_its_dependency_carries() -> None:
         assert written.strip() == "virtual/dist-kernel"
 
 
-def test_the_stray_kernel_is_deleted_before_the_package_reinstalls_one() -> None:
-    """Deleting last left `/boot` empty: the misnamed image `sys-fs/zfs`
-    leaves is often the only one there, and generate-zbm then answers
-    `Unable to find latest kernel`. `emerge --config` puts the image back
-    under the name the package carries, so the removal has to come first."""
-    from gentoo_install.plan.kernel import RebuildInitramfs
+def test_the_initramfs_is_rebuilt_after_its_modules_and_checked_after_that() -> None:
+    """`assert rebuild >= 0` held nothing: `enumerate` never yields less.
+
+    `RemoveUnbootableKernels`, which the old name referred to, was replaced by
+    `RequireKernelImage` in `#261` and removed in `clean: remove twelve
+    definitions nothing reaches`, so the delete-before-rebuild pair the
+    assertion was written for no longer exists. What does is the order the
+    three surviving operations have to keep: dracut reads the module list
+    from the file `WriteDracutModules` writes, `emerge --config` builds the
+    image from it, and only then is there an image to check for.
+    """
+    from gentoo_install.plan.kernel import (
+        RebuildInitramfs,
+        RequireKernelImage,
+        WriteDracutModules,
+    )
 
     built = kernel.build(config(zfs_root()))
-    rebuild = next(n for n, one in enumerate(built) if isinstance(one, RebuildInitramfs))
-    assert rebuild >= 0
+
+    def at(kind: type) -> int:
+        return next(n for n, one in enumerate(built) if isinstance(one, kind))
+
+    assert at(WriteDracutModules) < at(RebuildInitramfs) < at(RequireKernelImage)
+
+    # And the rebuild names a versioned atom: `emerge --config` over a bare
+    # package with two slots installed answers `Please use a specific atom`.
+    rebuild = built[at(RebuildInitramfs)]
+    assert isinstance(rebuild, RebuildInitramfs)
+    assert rebuild.package, rebuild
+    recorder = Recorder()
+    rebuild.apply(recorder)
+    assert ("emerge", "--config", rebuild.package) in recorder.in_target, recorder.in_target
 
 
 def test_a_zfs_root_keeps_its_kernel_in_the_pool() -> None:

--- a/tests/unit/test_plan_netboot.py
+++ b/tests/unit/test_plan_netboot.py
@@ -146,15 +146,19 @@ def _run(recorder: Recorder, first: str) -> list[tuple[str, ...]]:
     return [one for one in recorder.commands if one and one[0] == first]
 
 
-def test_every_operation_describes_itself_without_touching_anything() -> None:
-    """`render()` prints `describe()` and applies nothing, so a description
-    that reads the machine is a dry run that is not one."""
+def test_every_operation_describes_itself() -> None:
+    """`render()` prints `describe()` and applies nothing.
+
+    This holds that each operation has a description at all. That none of
+    them reads the machine is
+    `test_no_description_reads_the_machine_it_describes` in
+    `tests/unit/test_layers.py`: it was asserted here against a `Recorder`
+    that was never passed to an operation, so `describe()` could have run any
+    command it liked and the empty recorder would still have been empty.
+    """
     plan = netboot.build(launch=_launch(), target=_target())
-    empty = Recorder()
     for operation in plan:
         assert operation.describe()
-    assert empty.commands == []
-    assert empty.files == {}
 
 
 def test_the_plan_refuses_and_checks_before_it_fetches() -> None:


### PR DESCRIPTION
`test_plan_netboot.py` built a `Recorder()`, never passed it to an operation, and asserted it was empty. `describe()` takes no `Context`, so that assertion held by construction: a description could have read the machine and the recorder would still have been empty. The dry-run purity claim moves to `test_layers.py` as an AST rule over every `describe`/`describe_parts` in `gentoo_install/plan/`, with a count assertion so a rename cannot leave it walking an empty set.

`test_plan_boot.py` found `RebuildInitramfs` with `enumerate()` and asserted the index is at least zero. `RemoveUnbootableKernels`, the operation its name and docstring referred to, was replaced by `RequireKernelImage` in `#261` and removed from the tree afterwards, so the delete-before-rebuild pair it was written for no longer exists. It now holds the order that does matter — modules written, image rebuilt, image checked — and that `emerge --config` is given a versioned atom, which is what a machine with two slots installed requires.

Both controls were run red.