### PR TITLE
compat: drop a kernel trait no plan reads

### DIFF
--- a/gentoo_install/model/compat.py
+++ b/gentoo_install/model/compat.py
@@ -331,7 +331,6 @@ class KernelPackage:
 
     atom: str
     applies_cjktty: bool
-    cjk_use_defaults_on: bool
 
 
 #: The package that provides each kernel choice. Here rather than in `plan/`
@@ -341,27 +340,22 @@ KERNEL_PACKAGES: Final[dict[KernelSource, KernelPackage]] = {
     KernelSource.DIST_BIN: KernelPackage(
         atom="sys-kernel/gentoo-kernel-bin",
         applies_cjktty=False,
-        cjk_use_defaults_on=False,
     ),
     KernelSource.DIST_SOURCE: KernelPackage(
         atom="sys-kernel/gentoo-kernel",
         applies_cjktty=False,
-        cjk_use_defaults_on=False,
     ),
     KernelSource.CJK_BIN: KernelPackage(
         atom="sys-kernel/gentoo-cjk-kernel-bin",
         applies_cjktty=True,
-        cjk_use_defaults_on=True,
     ),
     KernelSource.CJK: KernelPackage(
         atom="sys-kernel/gentoo-cjk-kernel",
         applies_cjktty=True,
-        cjk_use_defaults_on=True,
     ),
     KernelSource.XANMOD: KernelPackage(
         atom="sys-kernel/xanmod-kernel",
         applies_cjktty=True,
-        cjk_use_defaults_on=False,
     ),
 }
 

--- a/tests/unit/test_compat.py
+++ b/tests/unit/test_compat.py
@@ -1016,7 +1016,6 @@ def test_the_kernel_package_table_is_the_only_one() -> None:
     xanmod = compat.KERNEL_PACKAGES[KernelSource.XANMOD]
     assert xanmod.atom == "sys-kernel/xanmod-kernel"
     assert xanmod.applies_cjktty
-    assert not xanmod.cjk_use_defaults_on
 
     # Derived rather than listed: the cjk set has to move when the table does.
     assert compat._CJK_KERNEL_PACKAGES == {
@@ -1414,3 +1413,33 @@ def test_validate_reads_the_cjktty_rule() -> None:
         with _pytest.raises(ValidationFailed) as refused:
             validate.validate(cjk)
     assert "cjktty" in str(refused.value), str(refused.value)
+
+
+def test_every_kernel_package_trait_has_a_reader() -> None:
+    """A column nothing reads is state implying a behaviour nothing implements.
+
+    `cjk_use_defaults_on` recorded whether an ebuild turns its CJK USE flags
+    on by itself. `RequestCjkKernel` writes `cjk` or `-cjk` explicitly for
+    every patched kernel, so the ebuild's own default decided nothing, and
+    only two tests naming the field kept it alive. The five rows carried a
+    trait whose value could not change an install.
+    """
+    import ast
+    from dataclasses import fields
+    from pathlib import Path
+
+    # The whole package, `compat.py` included: `applies_cjktty` is read by
+    # `cjk_kernels()` beside the table, and `CJK_KERNELS` is what `plan/`
+    # takes. A reader in the module that owns the rule is still a reader.
+    root = Path(__file__).resolve().parents[2] / "gentoo_install"
+    read: set[str] = set()
+    for path in sorted(root.rglob("*.py")):
+        for node in ast.walk(ast.parse(path.read_text())):
+            if isinstance(node, ast.Attribute) and isinstance(node.ctx, ast.Load):
+                read.add(node.attr)
+
+    traits = [one.name for one in fields(compat.KernelPackage)]
+    assert traits, "the table has no column at all"
+    assert [one for one in traits if one not in read] == [], sorted(
+        one for one in traits if one not in read
+    )

--- a/tests/unit/test_plan_boot.py
+++ b/tests/unit/test_plan_boot.py
@@ -720,7 +720,6 @@ def test_the_prebuilt_patched_kernel_is_the_one_a_chinese_interface_takes() -> N
     prebuilt = KERNEL_PACKAGES[KernelSource.CJK_BIN]
     assert prebuilt.atom == "sys-kernel/gentoo-cjk-kernel-bin"
     assert prebuilt.applies_cjktty
-    assert prebuilt.cjk_use_defaults_on
     assert set(CJK_KERNELS) == {
         KernelSource.CJK_BIN,
         KernelSource.CJK,
@@ -745,12 +744,10 @@ def test_a_cjk_kernel_choice_is_read_out_of_the_package_table() -> None:
             KernelSource.DIST_BIN: KernelPackage(
                 atom="sys-kernel/latency-kernel",
                 applies_cjktty=True,
-                cjk_use_defaults_on=False,
             ),
             KernelSource.DIST_SOURCE: KernelPackage(
                 atom="sys-kernel/gentoo-kernel",
                 applies_cjktty=False,
-                cjk_use_defaults_on=False,
             ),
         }
     ) == (KernelSource.DIST_BIN,)


### PR DESCRIPTION
`KernelPackage.cjk_use_defaults_on` recorded whether a kernel ebuild turns its CJK USE flags on without being asked. `RequestCjkKernel` writes `cjk` or `-cjk` explicitly for every patched kernel, so the ebuild`s own default never reached a decision: flipping the column on any of the five rows changed no plan. Two tests that named the field were what kept it alive.

A column nothing reads is state implying a behaviour nothing implements, which is the same failure as a rule that cannot fail. The replacement asserts that every field of `KernelPackage` is read somewhere in `gentoo_install/` — `compat.py` included, because `applies_cjktty` is read by `cjk_kernels()` beside the table and `CJK_KERNELS` is what the plan takes.

The control was run red by putting the field back.