### PR TITLE
vm: drop three pieces of state nothing reads

### DIFF
--- a/tests/unit/test_convert.py
+++ b/tests/unit/test_convert.py
@@ -629,3 +629,33 @@ def test_the_mount_state_is_read_once_for_each_destination(
     )
 
     assert len(reads) == 1, reads
+
+
+def test_every_field_of_a_cloud_image_row_is_read_somewhere() -> None:
+    """`installer` named each image's package manager and nothing read it.
+
+    Its comment said it was for the line `bootstrap.sh --missing-commands`
+    prints; that reading was replaced because it did not work — the note above
+    `install_tools` records that looking for the installer's own name found
+    nothing and installed nothing — and the column outlived it. A row of a
+    table is state that implies a behaviour, so each of its fields has to have
+    a reader.
+    """
+    import ast
+    from dataclasses import fields
+    from pathlib import Path
+
+    from tests.vm.convert import CloudImage
+
+    root = Path(__file__).resolve().parents[2] / "tests" / "vm"
+    read: set[str] = set()
+    for path in sorted(root.rglob("*.py")):
+        for node in ast.walk(ast.parse(path.read_text())):
+            if isinstance(node, ast.Attribute) and isinstance(node.ctx, ast.Load):
+                read.add(node.attr)
+
+    columns = [one.name for one in fields(CloudImage)]
+    assert columns, "the table has no column at all"
+    assert [one for one in columns if one not in read] == [], sorted(
+        one for one in columns if one not in read
+    )

--- a/tests/vm/cluster.py
+++ b/tests/vm/cluster.py
@@ -544,8 +544,6 @@ class Watchdog:
     strikes: int = 0
     _seen: int = field(default=0, init=False)
     _moved: int = field(default=0, init=False)
-    _counter_before: int = field(default=0, init=False)
-    _counter_after: int = field(default=0, init=False)
     _network: tuple[int, int] = field(default=(0, 0), init=False)
     _disk: tuple[int, int] = field(default=(0, 0), init=False)
     _cpu: float = field(default=0.0, init=False)
@@ -588,8 +586,6 @@ class Watchdog:
             return self._blind < BLIND_SAMPLES
         self._blind = 0
         moved, self._cpu = traffic.moved, traffic.cpu
-        self._counter_before = self._moved
-        self._counter_after = moved
         # Both directions, so a verdict can say which of them stopped. The
         # first sample has no earlier reading to compare against, so it is its
         # own predecessor rather than a jump from zero.

--- a/tests/vm/convert.py
+++ b/tests/vm/convert.py
@@ -199,10 +199,6 @@ class CloudImage:
 
     name: str
     filename: str
-    #: What the image's own package manager is called, for the line
-    #: `bootstrap.sh --missing-commands` prints. Read from the image rather
-    #: than guessed: the launcher already knows every one of these.
-    installer: str
     #: What `--missing-commands` asks for is turned into this command.
     install: str
     #: The firmware the image can boot. `genericcloud` and Fedora Cloud Base
@@ -228,7 +224,6 @@ IMAGES: Final[dict[str, CloudImage]] = {
         CloudImage(
             "fedora",
             "Fedora-Cloud-Base-Generic-41-1.4.x86_64.qcow2",
-            "dnf",
             "dnf install -y --setopt=install_weak_deps=False",
             Firmware.UEFI,
             {"mkfs.vfat": "dosfstools", "sgdisk": "gdisk", "mkfs.btrfs": "btrfs-progs",
@@ -237,7 +232,6 @@ IMAGES: Final[dict[str, CloudImage]] = {
         CloudImage(
             "debian",
             "debian-12-genericcloud-amd64.qcow2",
-            "apt-get",
             "apt-get update && apt-get install -y --no-install-recommends",
             Firmware.UEFI,
             {"mkfs.vfat": "dosfstools", "sgdisk": "gdisk", "mkfs.btrfs": "btrfs-progs",
@@ -247,7 +241,6 @@ IMAGES: Final[dict[str, CloudImage]] = {
         CloudImage(
             "arch",
             "Arch-Linux-x86_64-cloudimg.qcow2",
-            "pacman",
             "pacman -Sy --noconfirm",
             Firmware.UEFI,
             {"mkfs.vfat": "dosfstools", "sgdisk": "gptfdisk", "mkfs.btrfs": "btrfs-progs",

--- a/tests/vm/installed.py
+++ b/tests/vm/installed.py
@@ -112,7 +112,7 @@ def checks(installation: InstallConfig) -> tuple[InstalledCheck, ...]:
             "kernel",
             "uname -r; find /boot -maxdepth 4 -type f "
             r"\( -name 'vmlinuz*' -o -name 'kernel-*' -o -name linux -o -name '*.conf' \) | sort",
-            _kernel_pattern(installation),
+            KERNEL_MATCHES_ITS_RELEASE,
             "joins a running release to a boot path",
         ),
         InstalledCheck(
@@ -494,11 +494,6 @@ def _hostname_pattern(installation: InstallConfig) -> str:
 #: (dist-bin), `vmlinuz-<release>` (BIOS), and systemd-boot's
 #: `<machine-id>/<release>/linux` all carry it.
 KERNEL_MATCHES_ITS_RELEASE: Final[str] = r"(?ms)\A\s*(?P<release>[0-9]\S*)$.*^/boot/\S*(?P=release)"
-
-
-def _kernel_pattern(installation: InstallConfig) -> str:
-    """Match a `/boot` file against the release the machine is running."""
-    return KERNEL_MATCHES_ITS_RELEASE
 
 
 def stage_passphrase_commands(installation: InstallConfig) -> tuple[str, ...]:


### PR DESCRIPTION
`Watchdog._counter_before` and `_counter_after` were assigned on every sample and never read; a verdict prints `_network`, `_disk` and `_cpu`.

`installed._kernel_pattern(installation)` took the configuration and returned a constant. The constant`s own note records that it was measured against fourteen guests and that `kernel-<release>`, `vmlinuz-<release>` and systemd-boot`s `<machine-id>/<release>/linux` all satisfy one expression, so there was nothing for the parameter to decide.

`CloudImage.installer` named each image`s package manager. Its comment said it was for the line `bootstrap.sh --missing-commands` prints; that reading was replaced because it matched nothing and installed nothing, as the note above `install_tools` records, and the column outlived it.

`CloudImage` is a table row, so its fields now carry the same rule `KernelPackage` does: each one must have a reader in `tests/vm/`. The control was run red — after a first attempt that failed on a dataclass field-order `TypeError` instead of the assertion, which is not a control.