### PR TITLE
tests: read an import out of the syntax, not out of the text

### DIFF
--- a/gentoo_install/plan/kernel.py
+++ b/gentoo_install/plan/kernel.py
@@ -21,7 +21,6 @@ from ..errors import (
     NothingToBoot,
     ValidationFailed,
 )
-from ..model import compat
 from ..model.compat import CJK_KERNELS, KERNEL_PACKAGES
 from ..model.hardware import HardwareFacts
 from ..model.validate import zfs_kernel_version_problem

--- a/gentoo_install/tui/packages.py
+++ b/gentoo_install/tui/packages.py
@@ -37,12 +37,10 @@ from .context import (
     ValueSource,
     current_menu,
     footer,
-    pick,
     say,
 )
 from .widgets import (
     Answer,
-    Confirm,
     Item,
     Menu,
     MultipleChoiceMenu,

--- a/gentoo_install/tui/partitions.py
+++ b/gentoo_install/tui/partitions.py
@@ -21,13 +21,10 @@ from ..model import manual
 from ..model.config import (
     Bootloader,
     DiskConfig,
-    Firmware,
     InstallConfig,
 )
 from ..model.device import (
-    Filesystem,
     FilesystemType,
-    Partition,
     PartitionRole,
     RaidLevel,
     RaidMetadata,

--- a/gentoo_install/tui/screens.py
+++ b/gentoo_install/tui/screens.py
@@ -46,8 +46,6 @@ from ..model.config import (
 from ..model.device import (
     DeviceGraph,
     DeviceId,
-    Partition,
-    Swap,
     FilesystemType,
     PartitionRole,
     TableType,

--- a/gentoo_install/tui/settings.py
+++ b/gentoo_install/tui/settings.py
@@ -18,7 +18,6 @@ from typing import Callable, Final
 from ..model.architecture import DEFAULT_ARCHITECTURE
 from ..model.config import (
     BASE_PROFILE,
-    Bootloader,
     DiskMode,
     Firewall,
     InitSystem,
@@ -58,7 +57,6 @@ from .packages import (
 )
 from .partitions import partitions_screen
 from .context import Context, Step, ValueKind, ValueSource, footer
-from ..i18n import width
 from .widgets import Answer, Item, Menu, Outcome, Screen, Style, fit
 
 #: Shown for a row the operator has not visited and that has no usable default.

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -2,7 +2,6 @@
 from __future__ import annotations
 
 import argparse
-import dataclasses
 import io
 import os
 import shutil

--- a/tests/unit/test_compat.py
+++ b/tests/unit/test_compat.py
@@ -884,7 +884,6 @@ def test_a_mirror_with_no_ipv6_is_refused_on_an_ipv6_only_machine() -> None:
     """Four of the mirrors publish no AAAA record and one publishes an AAAA it
     does not answer on. An IPv6-only machine reaches none of them, and finding
     that out when the stage3 does not arrive is an hour lost."""
-    from dataclasses import replace as _replace
 
     from gentoo_install.data import load_catalog
     from gentoo_install.i18n import Catalog

--- a/tests/unit/test_every_row.py
+++ b/tests/unit/test_every_row.py
@@ -18,7 +18,7 @@ from dataclasses import replace
 import pytest
 
 from gentoo_install.model.config import InstallConfig
-from gentoo_install.tui import app, settings
+from gentoo_install.tui import settings
 from gentoo_install.tui.context import Context
 from gentoo_install.tui.settings import UNSET, Setting
 from gentoo_install.tui.widgets import Answer, Outcome

--- a/tests/unit/test_exec.py
+++ b/tests/unit/test_exec.py
@@ -3152,7 +3152,6 @@ def test_a_findmnt_that_could_not_run_is_not_read_as_unmounted(tmp_path: Path) -
     """`plan/disk.py` already refuses to read a failed probe as unmounted. This
     is the third reader of the same rule, and reading 2 as `not mounted` mounted
     a second filesystem over one that was already there."""
-    from gentoo_install.plan.disk import Mount
 
     class Broken(Runner):
         def __init__(self) -> None:

--- a/tests/unit/test_layers.py
+++ b/tests/unit/test_layers.py
@@ -11,6 +11,7 @@ from __future__ import annotations
 import ast
 import subprocess
 import re
+import warnings
 from collections.abc import Iterator, Mapping
 from pathlib import Path
 from typing import Final
@@ -819,36 +820,87 @@ def test_no_module_imports_a_name_it_never_uses() -> None:
     """Twenty dead imports were in the tree at once, twelve of them left in
     `tui/screens.py` by two moves that took their users away. `mypy` does not
     see them and no lint gate is configured, so an import that survives its
-    last caller reads as a dependency the module still has."""
+    last caller reads as a dependency the module still has.
+
+    Read out of the syntax, not out of the text: searching the rest of the
+    file for the spelling counted a name in a comment or a docstring as a
+    use, and twenty-eight dead imports were in the tree while this passed.
+    `Iterable` in `tests/unit/test_i18n.py` is the case that keeps string
+    expressions in: `cast("Iterable[...]", ...)` is a real use inside a
+    literal, and a rule blind to it deletes an import mypy still needs.
+    """
+    root = Path(__file__).resolve().parents[2]
+    paths = [
+        path
+        for where in ("gentoo_install", "tests")
+        for path in sorted((root / where).rglob("*.py"))
+    ]
+    trees = {path: ast.parse(path.read_text()) for path in paths}
+
+    # A name imported here so another module can import it from here.
+    reexported: dict[str, set[str]] = {}
+    for tree in trees.values():
+        for node in ast.walk(tree):
+            if isinstance(node, ast.ImportFrom) and node.module:
+                reexported.setdefault(node.module.split(".")[-1], set()).update(
+                    one.name for one in node.names
+                )
+
     dead: list[str] = []
-    # The harness as well as the package: `tests/vm/` carried seven of its own.
-    for path in [*sorted(PACKAGE.rglob("*.py")), *sorted(HARNESS.rglob("*.py"))]:
-        source = path.read_text()
-        tree = ast.parse(source)
-        lines = source.splitlines()
+    counted = 0
+    for path in paths:
+        tree = trees[path]
         imported: dict[str, int] = {}
-        # Every line of the statement, not the line it starts on: a name
-        # inside `from x import (\n    Name,\n)` sits on its own line, and
-        # excluding only the first left it there to be found as its own use.
-        spanned: set[int] = set()
         for node in ast.walk(tree):
             if isinstance(node, (ast.Import, ast.ImportFrom)):
                 # `from __future__ import annotations` has no user by design.
                 if isinstance(node, ast.ImportFrom) and node.module == "__future__":
                     continue
-                spanned.update(range(node.lineno, (node.end_lineno or node.lineno) + 1))
                 for alias in node.names:
+                    if alias.name == "*":
+                        continue
                     imported[alias.asname or alias.name.split(".")[0]] = node.lineno
-        # The import statements themselves are not uses of what they bind.
-        elsewhere = "\n".join(
-            line for number, line in enumerate(lines, 1) if number not in spanned
-        )
-        dead += [
-            f"{path.relative_to(PACKAGE.parent)}:{line} {name}"
-            for name, line in sorted(imported.items())
-            if not re.search(rf"\b{re.escape(name)}\b", elsewhere)
-        ]
+        used = {
+            one.id
+            for one in ast.walk(tree)
+            if isinstance(one, ast.Name) and isinstance(one.ctx, ast.Load)
+        }
+        used |= {one.attr for one in ast.walk(tree) if isinstance(one, ast.Attribute)}
+        used |= _names_inside_string_expressions(tree)
+        for name, line in sorted(imported.items()):
+            counted += 1
+            if name in used or name in reexported.get(path.stem, set()):
+                continue
+            dead.append(f"{path.relative_to(root)}:{line} {name}")
+    # The count guards the walk: a matcher that stopped matching imports would
+    # leave this passing over an empty set.
+    assert counted > 1000, counted
     assert not dead, dead
+
+
+def _names_inside_string_expressions(tree: ast.Module) -> set[str]:
+    """Every name in a string that parses as an expression.
+
+    Forward references and `cast("Iterable[X]", ...)` both put a real use
+    inside a literal.
+    """
+    found: set[str] = set()
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.Constant) or not isinstance(node.value, str):
+            continue
+        try:
+            with warnings.catch_warnings():
+                # Prose parses as an expression often enough to fill the run
+                # with `invalid escape sequence` from strings nobody meant as
+                # code.
+                warnings.simplefilter("ignore", SyntaxWarning)
+                parsed = ast.parse(node.value, mode="eval")
+        except SyntaxError:
+            continue
+        for inner in ast.walk(parsed):
+            if isinstance(inner, ast.Name):
+                found.add(inner.id)
+    return found
 
 
 def test_the_passphrase_minimum_is_one_number() -> None:

--- a/tests/unit/test_plan.py
+++ b/tests/unit/test_plan.py
@@ -23,7 +23,6 @@ from gentoo_install.model.config import (
     PackagesConfig,
     User,
     PortageConfig,
-    SystemConfig,
 )
 from gentoo_install.model.device import Node, Partition, PartitionRole
 from gentoo_install.exec.config import load

--- a/tests/unit/test_plan_boot.py
+++ b/tests/unit/test_plan_boot.py
@@ -30,14 +30,10 @@ from gentoo_install.model.device import (
     FilesystemType,
     Luks,
     MdRaid,
-    Mountpoint,
     Node,
-    Partition,
-    PartitionRole,
     RaidLevel,
     ZfsPool,
 )
-from gentoo_install.model.size import Size
 from gentoo_install.exec.config import load
 from gentoo_install.model.validate import validate
 from gentoo_install.plan import bootloader, kernel

--- a/tests/unit/test_plan_convert.py
+++ b/tests/unit/test_plan_convert.py
@@ -11,7 +11,6 @@ import pytest
 
 from gentoo_install.model.config import InstallConfig
 from gentoo_install.plan import disk as plan_disk
-from gentoo_install.plan import portage as plan_portage
 from gentoo_install.plan.bootloader import InstallGrub
 from gentoo_install.plan.build import build
 from gentoo_install.plan.convert import SwapDirectories

--- a/tests/unit/test_plan_portage.py
+++ b/tests/unit/test_plan_portage.py
@@ -12,7 +12,6 @@ from typing import Any, Final, Sequence
 from gentoo_install.model.config import (
     Binhost,
     BinhostChannel,
-    Firmware,
     InitSystem,
     InstallConfig,
     Keywords,

--- a/tests/unit/test_proxmox.py
+++ b/tests/unit/test_proxmox.py
@@ -566,7 +566,6 @@ def test_the_handshake_accept_must_match_the_key_that_was_sent(
     import ssl
     from typing import cast
 
-    from tests.vm import websocket
 
     key_bytes = b"0123456789abcdef"
     key = base64.b64encode(key_bytes)
@@ -1630,7 +1629,6 @@ def test_each_encrypted_boot_path_answers_its_own_number_of_prompts(
     One scripted console per encrypted layout, and a BIOS one whose prompt is
     on the VGA console and never reaches the serial port at all.
     """
-    from dataclasses import replace
 
     from gentoo_install.exec.config import load
     from gentoo_install.model.config import Firmware as BootFirmware

--- a/tests/unit/test_sshkey.py
+++ b/tests/unit/test_sshkey.py
@@ -264,7 +264,6 @@ def test_a_configuration_url_that_needs_a_password_says_so_not_parses_html() -> 
     the status hands an HTML page to `tomllib` and reports a syntax error at
     line 1 of a configuration the operator never wrote."""
     import urllib.request
-    from io import BytesIO
 
     import pytest
 

--- a/tests/unit/test_tui_session.py
+++ b/tests/unit/test_tui_session.py
@@ -14,7 +14,6 @@ from pathlib import Path
 import pytest
 
 from tests.tui import session as tui_session
-from tests.tui.screen import Screen
 
 
 class DeadConsole:

--- a/tests/vm/cluster.py
+++ b/tests/vm/cluster.py
@@ -27,7 +27,6 @@ import queue
 import shutil
 import signal
 import re
-import socket
 import subprocess
 import sys
 import threading

--- a/tests/vm/proxmox.py
+++ b/tests/vm/proxmox.py
@@ -32,7 +32,7 @@ from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any, Final, Protocol
 
-from .console import ConsoleClosed, ConsoleTimeout, SerialConsole
+from .console import ConsoleClosed, ConsoleTimeout
 from .monitor import keys_for
 from .websocket import Framed, WebSocket, WebSocketError
 


### PR DESCRIPTION
`test_no_module_imports_a_name_it_never_uses` searched the rest of each file for `\b<name>\b`, so a name appearing in a comment or a docstring counted as a use. Twenty-eight dead imports were in the tree while it passed, among them `compat` in `plan/kernel.py`, which reads as a module that consults the compatibility table and does not.

It now reads loads, attribute names and the names inside strings that parse as expressions. That last part is what keeps `Iterable` in `tests/unit/test_i18n.py`: `cast("Iterable[...]", ...)` is a real use hidden in a literal, and a first version without it would have removed an import mypy still needs. A name re-exported for another module to import counts as used, and the scope now covers all of `tests/` rather than `tests/vm/` alone.

The twenty-eight imports go with it. Only the lines naming them are removed — a first attempt rewrote each parenthesised block onto one line, which is a reformat this repository does not take, and it turned a 27-line deletion into 117. The rule carries a count assertion, and the control was run red.