### PR TITLE
docs: name the publishing action and the one probe a dry run makes

### DIFF
--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -277,7 +277,7 @@ The hash above is an example and must be replaced before execution. Only `disk` 
 
 [`tests/fixtures/vm-binpkg.toml`](tests/fixtures/vm-binpkg.toml) is a complete UEFI and ext4 schema reference. Other files under [`tests/fixtures/`](tests/fixtures/) cover BIOS, LUKS2, LVM, mdraid, ZFS, btrfs subvolumes and desktops. They contain virtual-machine disk selectors and test credentials, so they must not be installed unchanged on a real machine.
 
-Parsing and planning do not probe storage hardware. A machine without the target disk can therefore check a configuration with `--dry-run`.
+Parsing and planning probe storage hardware only for a layout that asks for a share of the disk: a share is a share of a capacity, so `--dry-run` reads that one disk's size rather than printing a number the install would not write. A machine without the target disk can therefore check any configuration with `--dry-run` except one using shares.
 
 The following reference names every persisted key. A table path is TOML table notation, and `[[disk.devices]]` carries the graph nodes.
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -25,10 +25,11 @@ by one person: a reply comes when there is one to give.
 - **Passphrases are staged in a file.** A LUKS or ZFS passphrase is written
   under `/run/gentoo-install/keys/` with mode `0600` for the command that
   reads it, and `/run` is a tmpfs, so it does not survive the reboot into the
-  installed system. The installer does not delete it before then. `--paste`
-  replaces `password_hash`, `root_password_hash` and `passphrase_file` and
-  drops the proxy username and password, so a published configuration carries
-  none of them. The key file's path is replaced as well as the hashes: it is
+  installed system. The installer does not delete it before then. Publishing a
+  configuration from the menu replaces `password_hash`, `root_password_hash`
+  and `passphrase_file` and drops the proxy username and password, so a
+  published configuration carries none of them. Publishing is a menu action and the closing
+  offer to send a run's log; it is not a command-line option. The key file's path is replaced as well as the hashes: it is
   not the key, and it still says where key material sits on the machine.
 - **What is verified.** The stage3 is checked against its DIGESTS and its
   OpenPGP signature; the repository snapshot is verified by `emerge-webrsync`;

--- a/tests/unit/test_project_docs.py
+++ b/tests/unit/test_project_docs.py
@@ -28,12 +28,19 @@ def test_a_report_has_somewhere_to_go(name: str) -> None:
 
 
 def test_security_names_what_publishing_actually_removes() -> None:
-    """`SECURITY.md` tells an operator which values `--paste` takes out. The
+    """`SECURITY.md` tells an operator which values publishing takes out. The
     list is `serialise.SECRET` plus the two proxy credentials, and a field
     added to one and not the other leaves the document promising a protection
-    that is not there."""
+    that is not there.
+
+    The paragraph is found by the redaction it describes rather than by a
+    flag name: it was found by `--paste`, which is not an option this
+    installer has, so the document and the test agreed on something the
+    operator cannot type."""
     said = (ROOT / "SECURITY.md").read_text(encoding="utf-8")
-    paragraph = next(part for part in said.split("\n- ") if "--paste" in part)
+    paragraph = next(
+        part for part in said.split("\n- ") if "Publishing a\n  configuration" in part
+    )
 
     # Both tables: `NOT_FOR_A_PASTE` was added without a document guard of its
     # own, which is the same gap the redaction itself was closing.
@@ -69,3 +76,29 @@ def test_the_issue_form_sends_a_vulnerability_somewhere_else() -> None:
     reporter and the issue tracker."""
     config = (ROOT / ".github" / "ISSUE_TEMPLATE" / "config.yml").read_text(encoding="utf-8")
     assert "SECURITY.md" in config, config
+
+
+def test_the_reference_documents_name_only_options_the_parser_has() -> None:
+    """`SECURITY.md` described `--paste`, and no such option exists.
+
+    Publishing a configuration is a menu action and the log offer is the
+    closing question, so an operator reading that line had a flag to type
+    that `--help` does not list. Only these two documents describe this
+    installer's own command line; `CONTRIBUTING.md` and `TESTED.md` name
+    options of `tests/vm/run.py` and of `emerge`.
+    """
+    import re
+
+    from gentoo_install.cli import parser
+
+    offered = {one for action in parser()._actions for one in action.option_strings}
+    offered.add("--help")
+    assert len(offered) > 10, sorted(offered)
+
+    unknown: list[str] = []
+    for name in ("REFERENCE.md", "SECURITY.md"):
+        said = (ROOT / name).read_text(encoding="utf-8")
+        for found in re.finditer(r"--[a-z][a-z0-9-]*", said):
+            if found.group(0) not in offered:
+                unknown.append(f"{name}: {found.group(0)}")
+    assert unknown == [], unknown


### PR DESCRIPTION
`SECURITY.md` said `--paste` removes `password_hash`, `root_password_hash` and `passphrase_file`. There is no such option: publishing a configuration is a menu action reaching `report.publish_config`, and the log offer is the closing question in `report.offer_paste`. The test that pinned the paragraph located it by searching for `--paste`, so the document and its guard agreed on something an operator cannot type.

`REFERENCE.md` said parsing and planning do not probe storage hardware, while its own share section says shares are resolved from the disk`s capacity before the plan is built. `cli.py` is with the share section: `--dry-run` reads that one disk`s size when the layout asks for a share, so the printed number is the one the install writes.

A new rule holds every `--flag` in these two documents to `parser()`. `CONTRIBUTING.md` and `TESTED.md` are out of scope because they name options of `tests/vm/run.py` and of `emerge` — seventeen of them. The first wording of the fix tripped the new rule by containing the flag it was disowning; the control was run red.