### PR TITLE
preflight: refuse a firmware mismatch once

### DIFF
--- a/gentoo_install/exec/preflight.py
+++ b/gentoo_install/exec/preflight.py
@@ -529,8 +529,6 @@ def inspect(
         )
     targets_machine_firmware = config.disk.mode in (DiskMode.PARTITION, DiskMode.IN_PLACE)
     wants_uefi = config.bootloader.firmware is Firmware.UEFI
-    if targets_machine_firmware and wants_uefi and not machine.uefi:
-        fatal.append(f"the configuration boots by UEFI and this machine booted by BIOS")
     if targets_machine_firmware and not wants_uefi and not installs.bios_target:
         # Fatal, not the warning below: this is not a machine that could boot
         # either way. GRUB builds no BIOS platform for this architecture, so

--- a/tests/unit/test_exec.py
+++ b/tests/unit/test_exec.py
@@ -554,8 +554,14 @@ def test_preflight_collects_every_reason_rather_than_the_first(tmp_path: Path) -
 
 
 def test_a_uefi_configuration_on_a_bios_boot_is_fatal(tmp_path: Path) -> None:
+    """One refusal, not two: the same condition was tested twice and appended
+    a bare restatement beside the message that names the key to set. An
+    operator reading two fatal lines for one mismatch looks for two problems.
+    """
     report = preflight.inspect(config(), described(uefi=False), probe_of(tmp_path))
-    assert any("booted by BIOS" in reason for reason in report.fatal)
+    said = [reason for reason in report.fatal if "booted by BIOS" in reason]
+    assert len(said) == 1, said
+    assert 'firmware = "bios"' in said[0], said[0]
 
 
 def test_a_uefi_boot_without_efivarfs_is_fatal(tmp_path: Path) -> None:


### PR DESCRIPTION
A configuration that installs for UEFI on a machine that booted by BIOS produced two fatal lines. `preflight.py` tested `targets_machine_firmware and wants_uefi and not machine.uefi` twice: once appending `the configuration boots by UEFI and this machine booted by BIOS`, once appending the message that says to set `firmware = "bios"` under `[bootloader]`.

The second was added when the first wording was corrected — it used to send a BIOS operator looking for efivarfs — and the old line stayed. An operator reading two fatal lines for one mismatch looks for two problems.

The restatement goes; it also carried an `f` prefix with nothing to interpolate. The test now asserts exactly one line mentions the mismatch and that the line names the key to change. The control was run red.