### PR TITLE
portage: append the overlay distfiles only with the overlay

### DIFF
--- a/gentoo_install/model/compat.py
+++ b/gentoo_install/model/compat.py
@@ -892,7 +892,9 @@ def traits_of(
         found.add(Trait.CONSOLE_CJK)
     if config.portage.binhost.community is not BinhostChannel.OFF:
         found.add(Trait.COMMUNITY_BINHOST)
-    if not any(overlay.name == "gentoo-zh" for overlay in config.portage.overlays):
+    if not any(
+        overlay.name == mirrors.GENTOO_ZH_OVERLAY for overlay in config.portage.overlays
+    ):
         found.add(Trait.NO_GENTOOZH_OVERLAY)
     # Not under remote unlock: dracut-crypt-ssh reads /root/.ssh/authorized_keys
     # and nothing else, so a key that only the initramfs uses is what was asked

--- a/gentoo_install/model/mirrors.py
+++ b/gentoo_install/model/mirrors.py
@@ -303,13 +303,20 @@ def gentoozh_binhost(
     return f"{gentoozh(chosen).distfiles}/{where}/{subarch}"
 
 
+#: The overlay's name, spelled once. It is the key `overlay_sync_uris` reads,
+#: the one `compat` looks for among the selected overlays, the one the TUI
+#: adds and removes, and the one that decides whether its distfiles belong in
+#: `GENTOO_MIRRORS`. Four modules kept the same literal.
+GENTOO_ZH_OVERLAY: Final[str] = "gentoo-zh"
+
+
 def overlay_sync_uris(name: str, chosen: GentooZhMirror) -> tuple[str, ...]:
     """Every site carrying that overlay, the chosen one first.
 
     Only gentoo-zh has a mirror set. `gig` is published from one host, so an
     install that cannot reach it has nowhere else to look and stops there.
     """
-    if name != "gentoo-zh":
+    if name != GENTOO_ZH_OVERLAY:
         return ()
     ordered = sorted(GENTOOZH_SITES, key=lambda site: site.key != chosen.value)
     return tuple(site.git for site in ordered if site.git)

--- a/gentoo_install/plan/portage.py
+++ b/gentoo_install/plan/portage.py
@@ -2089,8 +2089,18 @@ def _distfiles(portage: PortageConfig) -> tuple[str, ...]:
 
 def _appended_distfiles(portage: PortageConfig) -> tuple[str, ...]:
     """gentoo-zh's own distfiles, when they were asked for. They hold the
-    sources of that overlay's packages and no main mirror carries them."""
+    sources of that overlay's packages and no main mirror carries them.
+
+    The overlay decides as well as the flag: without it nothing on the machine
+    can want those sources, and the flag's default is on, so a minimal
+    configuration wrote five hosts into the installed `make.conf` that its
+    operator never chose and nothing would ever fetch from.
+    """
     if not portage.mirrors.gentoo_zh_distfiles:
+        return ()
+    if not any(
+        overlay.name == mirrors.GENTOO_ZH_OVERLAY for overlay in portage.overlays
+    ):
         return ()
     return mirrors.gentoozh_distfiles(portage.mirrors.gentoo_zh)
 

--- a/gentoo_install/tui/context.py
+++ b/gentoo_install/tui/context.py
@@ -453,7 +453,7 @@ DROP: Final[str] = "drop"
 #: Named once: this module composes its address, the bootloader screen adds it
 #: and the mirror screen removes it, and a literal in each is a fourth place to
 #: keep the same string right.
-GENTOO_ZH: Final[str] = "gentoo-zh"
+GENTOO_ZH: Final[str] = mirrors.GENTOO_ZH_OVERLAY
 
 
 def with_gentoo_zh(config: InstallConfig) -> PortageConfig:

--- a/tests/golden/ext2.txt
+++ b/tests/golden/ext2.txt
@@ -21,7 +21,7 @@
   seed the target's resolv.conf from the install medium
 
 [portage]
-  write /etc/portage/make.conf with MAKEOPTS, INPUT_DEVICES, ACCEPT_LICENSE, L10N; 3 mirrors in the configured order, 5 appended
+  write /etc/portage/make.conf with MAKEOPTS, INPUT_DEVICES, ACCEPT_LICENSE, L10N; 3 mirrors in the configured order
   write no proxy configuration, so every client connects directly
   create /etc/portage/package.use/zz-autounmask, /etc/portage/package.accept_keywords/zz-autounmask, /etc/portage/package.license/zz-autounmask, which emerge writes its decisions into
   disable inherited binary package host gentoo

--- a/tests/golden/ext3.txt
+++ b/tests/golden/ext3.txt
@@ -21,7 +21,7 @@
   seed the target's resolv.conf from the install medium
 
 [portage]
-  write /etc/portage/make.conf with MAKEOPTS, INPUT_DEVICES, ACCEPT_LICENSE, L10N; 3 mirrors in the configured order, 5 appended
+  write /etc/portage/make.conf with MAKEOPTS, INPUT_DEVICES, ACCEPT_LICENSE, L10N; 3 mirrors in the configured order
   write no proxy configuration, so every client connects directly
   create /etc/portage/package.use/zz-autounmask, /etc/portage/package.accept_keywords/zz-autounmask, /etc/portage/package.license/zz-autounmask, which emerge writes its decisions into
   disable inherited binary package host gentoo

--- a/tests/golden/ext4-bios.txt
+++ b/tests/golden/ext4-bios.txt
@@ -21,7 +21,7 @@
   seed the target's resolv.conf from the install medium
 
 [portage]
-  write /etc/portage/make.conf with MAKEOPTS, INPUT_DEVICES, ACCEPT_LICENSE, L10N; 3 mirrors in the configured order, 5 appended
+  write /etc/portage/make.conf with MAKEOPTS, INPUT_DEVICES, ACCEPT_LICENSE, L10N; 3 mirrors in the configured order
   write no proxy configuration, so every client connects directly
   create /etc/portage/package.use/zz-autounmask, /etc/portage/package.accept_keywords/zz-autounmask, /etc/portage/package.license/zz-autounmask, which emerge writes its decisions into
   disable inherited binary package host gentoo

--- a/tests/golden/mbr-edit.txt
+++ b/tests/golden/mbr-edit.txt
@@ -18,7 +18,7 @@
   seed the target's resolv.conf from the install medium
 
 [portage]
-  write /etc/portage/make.conf with MAKEOPTS, INPUT_DEVICES, ACCEPT_LICENSE, L10N, FEATURES; 3 mirrors in the configured order, 5 appended
+  write /etc/portage/make.conf with MAKEOPTS, INPUT_DEVICES, ACCEPT_LICENSE, L10N, FEATURES; 3 mirrors in the configured order
   write no proxy configuration, so every client connects directly
   create /etc/portage/package.use/zz-autounmask, /etc/portage/package.accept_keywords/zz-autounmask, /etc/portage/package.license/zz-autounmask, which emerge writes its decisions into
   disable inherited binary package host gentoo

--- a/tests/golden/openrc-sdboot.txt
+++ b/tests/golden/openrc-sdboot.txt
@@ -22,7 +22,7 @@
   seed the target's resolv.conf from the install medium
 
 [portage]
-  write /etc/portage/make.conf with MAKEOPTS, INPUT_DEVICES, ACCEPT_LICENSE, L10N, FEATURES; 3 mirrors in the configured order, 5 appended
+  write /etc/portage/make.conf with MAKEOPTS, INPUT_DEVICES, ACCEPT_LICENSE, L10N, FEATURES; 3 mirrors in the configured order
   write no proxy configuration, so every client connects directly
   create /etc/portage/package.use/zz-autounmask, /etc/portage/package.accept_keywords/zz-autounmask, /etc/portage/package.license/zz-autounmask, which emerge writes its decisions into
   disable inherited binary package host gentoo

--- a/tests/golden/static-ip.txt
+++ b/tests/golden/static-ip.txt
@@ -22,7 +22,7 @@
   seed the target's resolv.conf from the install medium
 
 [portage]
-  write /etc/portage/make.conf with MAKEOPTS, INPUT_DEVICES, ACCEPT_LICENSE, L10N, FEATURES; 3 mirrors in the configured order, 5 appended
+  write /etc/portage/make.conf with MAKEOPTS, INPUT_DEVICES, ACCEPT_LICENSE, L10N, FEATURES; 3 mirrors in the configured order
   write no proxy configuration, so every client connects directly
   create /etc/portage/package.use/zz-autounmask, /etc/portage/package.accept_keywords/zz-autounmask, /etc/portage/package.license/zz-autounmask, which emerge writes its decisions into
   disable inherited binary package host gentoo

--- a/tests/golden/vm-binhost-fallback.txt
+++ b/tests/golden/vm-binhost-fallback.txt
@@ -22,7 +22,7 @@
   seed the target's resolv.conf from the install medium
 
 [portage]
-  write /etc/portage/make.conf with MAKEOPTS, INPUT_DEVICES, ACCEPT_LICENSE, L10N, FEATURES; 23 mirrors in the configured order, 5 appended
+  write /etc/portage/make.conf with MAKEOPTS, INPUT_DEVICES, ACCEPT_LICENSE, L10N, FEATURES; 23 mirrors in the configured order
   write no proxy configuration, so every client connects directly
   create /etc/portage/package.use/zz-autounmask, /etc/portage/package.accept_keywords/zz-autounmask, /etc/portage/package.license/zz-autounmask, which emerge writes its decisions into
   disable inherited binary package host gentoo

--- a/tests/golden/vm-binpkg.txt
+++ b/tests/golden/vm-binpkg.txt
@@ -22,7 +22,7 @@
   seed the target's resolv.conf from the install medium
 
 [portage]
-  write /etc/portage/make.conf with MAKEOPTS, INPUT_DEVICES, ACCEPT_LICENSE, L10N, FEATURES; 3 mirrors in the configured order, 5 appended
+  write /etc/portage/make.conf with MAKEOPTS, INPUT_DEVICES, ACCEPT_LICENSE, L10N, FEATURES; 3 mirrors in the configured order
   write no proxy configuration, so every client connects directly
   create /etc/portage/package.use/zz-autounmask, /etc/portage/package.accept_keywords/zz-autounmask, /etc/portage/package.license/zz-autounmask, which emerge writes its decisions into
   disable inherited binary package host gentoo

--- a/tests/golden/vm-bios-luks.txt
+++ b/tests/golden/vm-bios-luks.txt
@@ -25,7 +25,7 @@
   seed the target's resolv.conf from the install medium
 
 [portage]
-  write /etc/portage/make.conf with MAKEOPTS, INPUT_DEVICES, ACCEPT_LICENSE, L10N, FEATURES; 3 mirrors in the configured order, 5 appended
+  write /etc/portage/make.conf with MAKEOPTS, INPUT_DEVICES, ACCEPT_LICENSE, L10N, FEATURES; 3 mirrors in the configured order
   write no proxy configuration, so every client connects directly
   create /etc/portage/package.use/zz-autounmask, /etc/portage/package.accept_keywords/zz-autounmask, /etc/portage/package.license/zz-autounmask, which emerge writes its decisions into
   disable inherited binary package host gentoo

--- a/tests/golden/vm-bios.txt
+++ b/tests/golden/vm-bios.txt
@@ -21,7 +21,7 @@
   seed the target's resolv.conf from the install medium
 
 [portage]
-  write /etc/portage/make.conf with MAKEOPTS, INPUT_DEVICES, ACCEPT_LICENSE, L10N, FEATURES; 3 mirrors in the configured order, 5 appended
+  write /etc/portage/make.conf with MAKEOPTS, INPUT_DEVICES, ACCEPT_LICENSE, L10N, FEATURES; 3 mirrors in the configured order
   write no proxy configuration, so every client connects directly
   create /etc/portage/package.use/zz-autounmask, /etc/portage/package.accept_keywords/zz-autounmask, /etc/portage/package.license/zz-autounmask, which emerge writes its decisions into
   disable inherited binary package host gentoo

--- a/tests/golden/vm-btrfs.txt
+++ b/tests/golden/vm-btrfs.txt
@@ -25,7 +25,7 @@
   seed the target's resolv.conf from the install medium
 
 [portage]
-  write /etc/portage/make.conf with MAKEOPTS, INPUT_DEVICES, ACCEPT_LICENSE, L10N, FEATURES; 3 mirrors in the configured order, 5 appended
+  write /etc/portage/make.conf with MAKEOPTS, INPUT_DEVICES, ACCEPT_LICENSE, L10N, FEATURES; 3 mirrors in the configured order
   write no proxy configuration, so every client connects directly
   create /etc/portage/package.use/zz-autounmask, /etc/portage/package.accept_keywords/zz-autounmask, /etc/portage/package.license/zz-autounmask, which emerge writes its decisions into
   disable inherited binary package host gentoo

--- a/tests/golden/vm-convert.txt
+++ b/tests/golden/vm-convert.txt
@@ -7,7 +7,7 @@
   seed the target's resolv.conf from the install medium, in /gentoo-install.new
 
 [portage]
-  write /etc/portage/make.conf with MAKEOPTS, INPUT_DEVICES, ACCEPT_LICENSE, L10N, FEATURES; 3 mirrors in the configured order, 5 appended, in /gentoo-install.new
+  write /etc/portage/make.conf with MAKEOPTS, INPUT_DEVICES, ACCEPT_LICENSE, L10N, FEATURES; 3 mirrors in the configured order, in /gentoo-install.new
   write no proxy configuration, so every client connects directly, in /gentoo-install.new
   create /etc/portage/package.use/zz-autounmask, /etc/portage/package.accept_keywords/zz-autounmask, /etc/portage/package.license/zz-autounmask, which emerge writes its decisions into, in /gentoo-install.new
   disable inherited binary package host gentoo, in /gentoo-install.new

--- a/tests/golden/vm-desktop.txt
+++ b/tests/golden/vm-desktop.txt
@@ -22,7 +22,7 @@
   seed the target's resolv.conf from the install medium
 
 [portage]
-  write /etc/portage/make.conf with MAKEOPTS, USE, INPUT_DEVICES, ACCEPT_LICENSE, L10N, FEATURES; 3 mirrors in the configured order, 5 appended
+  write /etc/portage/make.conf with MAKEOPTS, USE, INPUT_DEVICES, ACCEPT_LICENSE, L10N, FEATURES; 3 mirrors in the configured order
   write no proxy configuration, so every client connects directly
   create /etc/portage/package.use/zz-autounmask, /etc/portage/package.accept_keywords/zz-autounmask, /etc/portage/package.license/zz-autounmask, which emerge writes its decisions into
   disable inherited binary package host gentoo

--- a/tests/golden/vm-f2fs.txt
+++ b/tests/golden/vm-f2fs.txt
@@ -22,7 +22,7 @@
   seed the target's resolv.conf from the install medium
 
 [portage]
-  write /etc/portage/make.conf with MAKEOPTS, INPUT_DEVICES, ACCEPT_LICENSE, L10N, FEATURES; 3 mirrors in the configured order, 5 appended
+  write /etc/portage/make.conf with MAKEOPTS, INPUT_DEVICES, ACCEPT_LICENSE, L10N, FEATURES; 3 mirrors in the configured order
   write no proxy configuration, so every client connects directly
   create /etc/portage/package.use/zz-autounmask, /etc/portage/package.accept_keywords/zz-autounmask, /etc/portage/package.license/zz-autounmask, which emerge writes its decisions into
   disable inherited binary package host gentoo

--- a/tests/golden/vm-gnome.txt
+++ b/tests/golden/vm-gnome.txt
@@ -22,7 +22,7 @@
   seed the target's resolv.conf from the install medium
 
 [portage]
-  write /etc/portage/make.conf with MAKEOPTS, USE, INPUT_DEVICES, ACCEPT_LICENSE, L10N, FEATURES; 3 mirrors in the configured order, 5 appended
+  write /etc/portage/make.conf with MAKEOPTS, USE, INPUT_DEVICES, ACCEPT_LICENSE, L10N, FEATURES; 3 mirrors in the configured order
   write no proxy configuration, so every client connects directly
   create /etc/portage/package.use/zz-autounmask, /etc/portage/package.accept_keywords/zz-autounmask, /etc/portage/package.license/zz-autounmask, which emerge writes its decisions into
   disable inherited binary package host gentoo

--- a/tests/golden/vm-greetd.txt
+++ b/tests/golden/vm-greetd.txt
@@ -22,7 +22,7 @@
   seed the target's resolv.conf from the install medium
 
 [portage]
-  write /etc/portage/make.conf with MAKEOPTS, USE, INPUT_DEVICES, ACCEPT_LICENSE, L10N, FEATURES; 3 mirrors in the configured order, 5 appended
+  write /etc/portage/make.conf with MAKEOPTS, USE, INPUT_DEVICES, ACCEPT_LICENSE, L10N, FEATURES; 3 mirrors in the configured order
   write no proxy configuration, so every client connects directly
   create /etc/portage/package.use/zz-autounmask, /etc/portage/package.accept_keywords/zz-autounmask, /etc/portage/package.license/zz-autounmask, which emerge writes its decisions into
   disable inherited binary package host gentoo

--- a/tests/golden/vm-home-key.txt
+++ b/tests/golden/vm-home-key.txt
@@ -25,7 +25,7 @@
   seed the target's resolv.conf from the install medium
 
 [portage]
-  write /etc/portage/make.conf with MAKEOPTS, INPUT_DEVICES, ACCEPT_LICENSE, L10N, FEATURES; 3 mirrors in the configured order, 5 appended
+  write /etc/portage/make.conf with MAKEOPTS, INPUT_DEVICES, ACCEPT_LICENSE, L10N, FEATURES; 3 mirrors in the configured order
   write no proxy configuration, so every client connects directly
   create /etc/portage/package.use/zz-autounmask, /etc/portage/package.accept_keywords/zz-autounmask, /etc/portage/package.license/zz-autounmask, which emerge writes its decisions into
   disable inherited binary package host gentoo

--- a/tests/golden/vm-image.txt
+++ b/tests/golden/vm-image.txt
@@ -23,7 +23,7 @@
   seed the target's resolv.conf from the install medium
 
 [portage]
-  write /etc/portage/make.conf with MAKEOPTS, INPUT_DEVICES, ACCEPT_LICENSE, L10N, FEATURES; 3 mirrors in the configured order, 5 appended
+  write /etc/portage/make.conf with MAKEOPTS, INPUT_DEVICES, ACCEPT_LICENSE, L10N, FEATURES; 3 mirrors in the configured order
   write no proxy configuration, so every client connects directly
   create /etc/portage/package.use/zz-autounmask, /etc/portage/package.accept_keywords/zz-autounmask, /etc/portage/package.license/zz-autounmask, which emerge writes its decisions into
   disable inherited binary package host gentoo

--- a/tests/golden/vm-luks.txt
+++ b/tests/golden/vm-luks.txt
@@ -29,7 +29,7 @@
   seed the target's resolv.conf from the install medium
 
 [portage]
-  write /etc/portage/make.conf with MAKEOPTS, INPUT_DEVICES, ACCEPT_LICENSE, L10N, FEATURES; 3 mirrors in the configured order, 5 appended
+  write /etc/portage/make.conf with MAKEOPTS, INPUT_DEVICES, ACCEPT_LICENSE, L10N, FEATURES; 3 mirrors in the configured order
   write no proxy configuration, so every client connects directly
   create /etc/portage/package.use/zz-autounmask, /etc/portage/package.accept_keywords/zz-autounmask, /etc/portage/package.license/zz-autounmask, which emerge writes its decisions into
   disable inherited binary package host gentoo

--- a/tests/golden/vm-lvm.txt
+++ b/tests/golden/vm-lvm.txt
@@ -30,7 +30,7 @@
   seed the target's resolv.conf from the install medium
 
 [portage]
-  write /etc/portage/make.conf with MAKEOPTS, INPUT_DEVICES, ACCEPT_LICENSE, L10N, FEATURES; 3 mirrors in the configured order, 5 appended
+  write /etc/portage/make.conf with MAKEOPTS, INPUT_DEVICES, ACCEPT_LICENSE, L10N, FEATURES; 3 mirrors in the configured order
   write no proxy configuration, so every client connects directly
   create /etc/portage/package.use/zz-autounmask, /etc/portage/package.accept_keywords/zz-autounmask, /etc/portage/package.license/zz-autounmask, which emerge writes its decisions into
   disable inherited binary package host gentoo

--- a/tests/golden/vm-mdraid.txt
+++ b/tests/golden/vm-mdraid.txt
@@ -30,7 +30,7 @@
   seed the target's resolv.conf from the install medium
 
 [portage]
-  write /etc/portage/make.conf with MAKEOPTS, INPUT_DEVICES, ACCEPT_LICENSE, L10N, FEATURES; 3 mirrors in the configured order, 5 appended
+  write /etc/portage/make.conf with MAKEOPTS, INPUT_DEVICES, ACCEPT_LICENSE, L10N, FEATURES; 3 mirrors in the configured order
   write no proxy configuration, so every client connects directly
   create /etc/portage/package.use/zz-autounmask, /etc/portage/package.accept_keywords/zz-autounmask, /etc/portage/package.license/zz-autounmask, which emerge writes its decisions into
   disable inherited binary package host gentoo

--- a/tests/golden/vm-openrc-desktop.txt
+++ b/tests/golden/vm-openrc-desktop.txt
@@ -22,7 +22,7 @@
   seed the target's resolv.conf from the install medium
 
 [portage]
-  write /etc/portage/make.conf with MAKEOPTS, USE, INPUT_DEVICES, ACCEPT_LICENSE, L10N, FEATURES; 3 mirrors in the configured order, 5 appended
+  write /etc/portage/make.conf with MAKEOPTS, USE, INPUT_DEVICES, ACCEPT_LICENSE, L10N, FEATURES; 3 mirrors in the configured order
   write no proxy configuration, so every client connects directly
   create /etc/portage/package.use/zz-autounmask, /etc/portage/package.accept_keywords/zz-autounmask, /etc/portage/package.license/zz-autounmask, which emerge writes its decisions into
   disable inherited binary package host gentoo

--- a/tests/golden/vm-proxy-dead.txt
+++ b/tests/golden/vm-proxy-dead.txt
@@ -25,7 +25,7 @@
   seed the target's resolv.conf from the install medium
 
 [portage]
-  write /etc/portage/make.conf with MAKEOPTS, INPUT_DEVICES, ACCEPT_LICENSE, L10N, http_proxy, https_proxy, ftp_proxy, all_proxy, no_proxy, FETCHCOMMAND, RESUMECOMMAND, RSYNC_PROXY, FEATURES; 3 mirrors in the configured order, 5 appended
+  write /etc/portage/make.conf with MAKEOPTS, INPUT_DEVICES, ACCEPT_LICENSE, L10N, http_proxy, https_proxy, ftp_proxy, all_proxy, no_proxy, FETCHCOMMAND, RESUMECOMMAND, RSYNC_PROXY, FEATURES; 3 mirrors in the configured order
   configure wget, curl and git for http://127.0.0.1:1 in /etc/wgetrc, /etc/gitconfig, curl-proxy.conf and proxy.toml
   create /etc/portage/package.use/zz-autounmask, /etc/portage/package.accept_keywords/zz-autounmask, /etc/portage/package.license/zz-autounmask, which emerge writes its decisions into
   disable inherited binary package host gentoo

--- a/tests/golden/vm-proxy-http.txt
+++ b/tests/golden/vm-proxy-http.txt
@@ -25,7 +25,7 @@
   seed the target's resolv.conf from the install medium
 
 [portage]
-  write /etc/portage/make.conf with MAKEOPTS, INPUT_DEVICES, ACCEPT_LICENSE, L10N, http_proxy, https_proxy, ftp_proxy, all_proxy, no_proxy, FETCHCOMMAND, RESUMECOMMAND, RSYNC_PROXY, FEATURES; 3 mirrors in the configured order, 5 appended
+  write /etc/portage/make.conf with MAKEOPTS, INPUT_DEVICES, ACCEPT_LICENSE, L10N, http_proxy, https_proxy, ftp_proxy, all_proxy, no_proxy, FETCHCOMMAND, RESUMECOMMAND, RSYNC_PROXY, FEATURES; 3 mirrors in the configured order
   configure wget, curl and git for http://10.0.2.2:3129 in /etc/wgetrc, /etc/gitconfig, curl-proxy.conf and proxy.toml
   create /etc/portage/package.use/zz-autounmask, /etc/portage/package.accept_keywords/zz-autounmask, /etc/portage/package.license/zz-autounmask, which emerge writes its decisions into
   disable inherited binary package host gentoo

--- a/tests/golden/vm-proxy.txt
+++ b/tests/golden/vm-proxy.txt
@@ -25,7 +25,7 @@
   seed the target's resolv.conf from the install medium
 
 [portage]
-  write /etc/portage/make.conf with MAKEOPTS, INPUT_DEVICES, ACCEPT_LICENSE, L10N, all_proxy, no_proxy, FETCHCOMMAND, RESUMECOMMAND, FEATURES; 3 mirrors in the configured order, 5 appended
+  write /etc/portage/make.conf with MAKEOPTS, INPUT_DEVICES, ACCEPT_LICENSE, L10N, all_proxy, no_proxy, FETCHCOMMAND, RESUMECOMMAND, FEATURES; 3 mirrors in the configured order
   configure wget, curl and git for socks5h://10.0.2.2:1080 in /etc/wgetrc, /etc/gitconfig, curl-proxy.conf and proxy.toml
   create /etc/portage/package.use/zz-autounmask, /etc/portage/package.accept_keywords/zz-autounmask, /etc/portage/package.license/zz-autounmask, which emerge writes its decisions into
   disable inherited binary package host gentoo

--- a/tests/golden/vm-ram.txt
+++ b/tests/golden/vm-ram.txt
@@ -22,7 +22,7 @@
   seed the target's resolv.conf from the install medium
 
 [portage]
-  write /etc/portage/make.conf with MAKEOPTS, INPUT_DEVICES, ACCEPT_LICENSE, L10N, FEATURES; 3 mirrors in the configured order, 5 appended
+  write /etc/portage/make.conf with MAKEOPTS, INPUT_DEVICES, ACCEPT_LICENSE, L10N, FEATURES; 3 mirrors in the configured order
   write no proxy configuration, so every client connects directly
   create /etc/portage/package.use/zz-autounmask, /etc/portage/package.accept_keywords/zz-autounmask, /etc/portage/package.license/zz-autounmask, which emerge writes its decisions into
   disable inherited binary package host gentoo

--- a/tests/golden/vm-sdboot.txt
+++ b/tests/golden/vm-sdboot.txt
@@ -22,7 +22,7 @@
   seed the target's resolv.conf from the install medium
 
 [portage]
-  write /etc/portage/make.conf with MAKEOPTS, INPUT_DEVICES, ACCEPT_LICENSE, L10N, FEATURES; 3 mirrors in the configured order, 5 appended
+  write /etc/portage/make.conf with MAKEOPTS, INPUT_DEVICES, ACCEPT_LICENSE, L10N, FEATURES; 3 mirrors in the configured order
   write no proxy configuration, so every client connects directly
   create /etc/portage/package.use/zz-autounmask, /etc/portage/package.accept_keywords/zz-autounmask, /etc/portage/package.license/zz-autounmask, which emerge writes its decisions into
   disable inherited binary package host gentoo

--- a/tests/golden/vm-shares.txt
+++ b/tests/golden/vm-shares.txt
@@ -25,7 +25,7 @@
   seed the target's resolv.conf from the install medium
 
 [portage]
-  write /etc/portage/make.conf with MAKEOPTS, INPUT_DEVICES, ACCEPT_LICENSE, L10N, FEATURES; 3 mirrors in the configured order, 5 appended
+  write /etc/portage/make.conf with MAKEOPTS, INPUT_DEVICES, ACCEPT_LICENSE, L10N, FEATURES; 3 mirrors in the configured order
   write no proxy configuration, so every client connects directly
   create /etc/portage/package.use/zz-autounmask, /etc/portage/package.accept_keywords/zz-autounmask, /etc/portage/package.license/zz-autounmask, which emerge writes its decisions into
   disable inherited binary package host gentoo

--- a/tests/golden/vm-source-kernel.txt
+++ b/tests/golden/vm-source-kernel.txt
@@ -22,7 +22,7 @@
   seed the target's resolv.conf from the install medium
 
 [portage]
-  write /etc/portage/make.conf with MAKEOPTS, INPUT_DEVICES, ACCEPT_LICENSE, L10N, FEATURES; 3 mirrors in the configured order, 5 appended
+  write /etc/portage/make.conf with MAKEOPTS, INPUT_DEVICES, ACCEPT_LICENSE, L10N, FEATURES; 3 mirrors in the configured order
   write no proxy configuration, so every client connects directly
   create /etc/portage/package.use/zz-autounmask, /etc/portage/package.accept_keywords/zz-autounmask, /etc/portage/package.license/zz-autounmask, which emerge writes its decisions into
   disable inherited binary package host gentoo

--- a/tests/golden/vm-unlock.txt
+++ b/tests/golden/vm-unlock.txt
@@ -32,7 +32,7 @@
   seed the target's resolv.conf from the install medium
 
 [portage]
-  write /etc/portage/make.conf with MAKEOPTS, INPUT_DEVICES, ACCEPT_LICENSE, L10N, FEATURES; 3 mirrors in the configured order, 5 appended
+  write /etc/portage/make.conf with MAKEOPTS, INPUT_DEVICES, ACCEPT_LICENSE, L10N, FEATURES; 3 mirrors in the configured order
   write no proxy configuration, so every client connects directly
   create /etc/portage/package.use/zz-autounmask, /etc/portage/package.accept_keywords/zz-autounmask, /etc/portage/package.license/zz-autounmask, which emerge writes its decisions into
   disable inherited binary package host gentoo

--- a/tests/golden/vm-user-key.txt
+++ b/tests/golden/vm-user-key.txt
@@ -22,7 +22,7 @@
   seed the target's resolv.conf from the install medium
 
 [portage]
-  write /etc/portage/make.conf with MAKEOPTS, INPUT_DEVICES, ACCEPT_LICENSE, L10N, FEATURES; 3 mirrors in the configured order, 5 appended
+  write /etc/portage/make.conf with MAKEOPTS, INPUT_DEVICES, ACCEPT_LICENSE, L10N, FEATURES; 3 mirrors in the configured order
   write no proxy configuration, so every client connects directly
   create /etc/portage/package.use/zz-autounmask, /etc/portage/package.accept_keywords/zz-autounmask, /etc/portage/package.license/zz-autounmask, which emerge writes its decisions into
   disable inherited binary package host gentoo

--- a/tests/golden/vm-xfs.txt
+++ b/tests/golden/vm-xfs.txt
@@ -22,7 +22,7 @@
   seed the target's resolv.conf from the install medium
 
 [portage]
-  write /etc/portage/make.conf with MAKEOPTS, INPUT_DEVICES, ACCEPT_LICENSE, L10N, FEATURES; 3 mirrors in the configured order, 5 appended
+  write /etc/portage/make.conf with MAKEOPTS, INPUT_DEVICES, ACCEPT_LICENSE, L10N, FEATURES; 3 mirrors in the configured order
   write no proxy configuration, so every client connects directly
   create /etc/portage/package.use/zz-autounmask, /etc/portage/package.accept_keywords/zz-autounmask, /etc/portage/package.license/zz-autounmask, which emerge writes its decisions into
   disable inherited binary package host gentoo

--- a/tests/golden/vm-zram.txt
+++ b/tests/golden/vm-zram.txt
@@ -22,7 +22,7 @@
   seed the target's resolv.conf from the install medium
 
 [portage]
-  write /etc/portage/make.conf with MAKEOPTS, INPUT_DEVICES, ACCEPT_LICENSE, L10N, FEATURES; 3 mirrors in the configured order, 5 appended
+  write /etc/portage/make.conf with MAKEOPTS, INPUT_DEVICES, ACCEPT_LICENSE, L10N, FEATURES; 3 mirrors in the configured order
   write no proxy configuration, so every client connects directly
   create /etc/portage/package.use/zz-autounmask, /etc/portage/package.accept_keywords/zz-autounmask, /etc/portage/package.license/zz-autounmask, which emerge writes its decisions into
   disable inherited binary package host gentoo

--- a/tests/unit/test_plan_portage.py
+++ b/tests/unit/test_plan_portage.py
@@ -3353,3 +3353,45 @@ def test_a_description_names_only_the_files_that_run_writes() -> None:
         proxy=ProxyConfig(kind=ProxyKind.HTTP, host="127.0.0.1", port=3128)
     )
     assert "dirmngr.conf" in over_http.describe_parts()[0]
+
+
+def test_the_overlay_distfiles_need_the_overlay() -> None:
+    """`gentoo_zh_distfiles` defaults on and nothing checked for the overlay.
+
+    A minimal configuration selects no overlay, so nothing on the machine can
+    want those sources, and `WriteMakeConf` still appended five gentoo-zh
+    hosts to `GENTOO_MIRRORS` in the installed system: an operator's own
+    `make.conf` naming hosts they never chose and nothing would fetch from.
+    """
+    from dataclasses import replace as _replace
+
+    from gentoo_install.model import mirrors
+    from gentoo_install.model.config import Overlay
+
+    plain = config()
+    assert plain.portage.mirrors.gentoo_zh_distfiles, "the flag's default moved"
+    assert not plain.portage.overlays, plain.portage.overlays
+    assert portage._appended_distfiles(plain.portage) == ()
+
+    with_overlay = _replace(
+        plain.portage,
+        overlays=(
+            Overlay(
+                name=mirrors.GENTOO_ZH_OVERLAY, sync_uri="https://example.invalid/zh.git"
+            ),
+        ),
+    )
+    appended = portage._appended_distfiles(with_overlay)
+    assert appended == mirrors.gentoozh_distfiles(with_overlay.mirrors.gentoo_zh)
+    assert appended, appended
+
+    # And the flag still turns them off with the overlay present.
+    assert (
+        portage._appended_distfiles(
+            _replace(
+                with_overlay,
+                mirrors=_replace(with_overlay.mirrors, gentoo_zh_distfiles=False),
+            )
+        )
+        == ()
+    )

--- a/tests/unit/test_tui_app.py
+++ b/tests/unit/test_tui_app.py
@@ -978,13 +978,26 @@ def test_choosing_a_gentoozh_mirror_is_what_adds_the_overlay() -> None:
 def test_the_gentoozh_distfiles_are_appended_and_never_ranked() -> None:
     """They hold the overlay's own sources, so ranking them with the main
     mirrors would order one repository by how fast the other answers."""
-    from gentoo_install.model.config import GentooZhMirror
+    from gentoo_install.model import mirrors as model_mirrors
+    from gentoo_install.model.config import GentooZhMirror, Overlay
     from gentoo_install.plan.portage import _appended_distfiles
 
-    off = replace(config().portage, mirrors=MirrorConfig(gentoo_zh_distfiles=False))
+    # With the overlay: without it nothing wants those sources and the
+    # appending is skipped, which is what this fixture is about ordering.
+    selected = (
+        Overlay(
+            name=model_mirrors.GENTOO_ZH_OVERLAY, sync_uri="https://example.invalid/zh.git"
+        ),
+    )
+    off = replace(
+        config().portage,
+        overlays=selected,
+        mirrors=MirrorConfig(gentoo_zh_distfiles=False),
+    )
     assert _appended_distfiles(off) == ()
     on = replace(
         config().portage,
+        overlays=selected,
         mirrors=MirrorConfig(gentoo_zh=GentooZhMirror.NJU, gentoo_zh_distfiles=True),
     )
     appended = _appended_distfiles(on)


### PR DESCRIPTION
`_appended_distfiles` read `gentoo_zh_distfiles` alone, and that flag defaults on. A configuration selecting no overlay therefore wrote five gentoo-zh hosts into the installed `make.conf`: addresses its operator never chose, for sources nothing on that machine can want. The flag`s own docstring says these are appended `when they were asked for`, and an absent overlay is not asking.

Thirty-three golden files lose `5 appended` and the ones that select `gentoo-zh` keep it, which is the check the dry-run was already printing without anyone reading it that way.

The same commit spells `gentoo-zh` once as `mirrors.GENTOO_ZH_OVERLAY`. `mirrors.overlay_sync_uris`, `compat`, `tui/context` and this new reader each carried the literal, and the note above the one in `tui/context` already warned that a fourth copy was the risk. The control was run red.