### PR TITLE
tui: take back the fonts and framework a desktop proposed

### DIFF
--- a/gentoo_install/tui/context.py
+++ b/gentoo_install/tui/context.py
@@ -54,6 +54,10 @@ class ValueKind(Enum):
     DISPLAY_MANAGER = "display manager"
     OVERLAY = "overlay"
     COMMUNITY_BINHOST = "community binhost"
+    #: A package group a desktop proposed. Recorded so choosing no desktop
+    #: takes back what the desktop asked for: CJK fonts and an input framework
+    #: render nothing without a session.
+    APPLICATION = "application"
 
 
 class ValueSource(Enum):

--- a/gentoo_install/tui/packages.py
+++ b/gentoo_install/tui/packages.py
@@ -338,7 +338,21 @@ def _desktop_proposes(
             system=replace(changed.system, networking=SystemConfig().networking),
         )
     if not desktop:
-        return changed
+        # What the previous desktop proposed goes with it. CJK fonts and an
+        # input framework render nothing without a session, and choosing no
+        # desktop after Plasma left `media-fonts/noto-cjk` and fcitx5 merged
+        # on a machine with nothing to draw them.
+        return replace(
+            changed,
+            packages=replace(
+                changed.packages,
+                applications=tuple(
+                    name
+                    for name in changed.packages.applications
+                    if not _has_derived(context, ValueKind.APPLICATION, name)
+                ),
+            ),
+        )
     login = LOGIN_SCREEN.get(desktop, "")
     if login and not changed.packages.display_manager and login in context.groups:
         changed = replace(
@@ -372,10 +386,15 @@ def _input_framework_a_desktop_needs(
 
     Nothing when the interface is not CJK and nothing when the operator has
     already chosen one: this proposes, it does not overrule.
+
+    A framework the previous desktop proposed is not the operator's, so it
+    does not block this one. Plasma proposes fcitx and GNOME ibus, and
+    without this Plasma's answer stood after the desktop changed to GNOME.
     """
     if context.tag not in CJK_INTERFACES:
         return ""
-    if _selected_input_framework(config, context.groups):
+    chosen = _selected_input_framework(config, context.groups)
+    if chosen and not _has_derived(context, ValueKind.APPLICATION, chosen):
         return ""
     wanted = DESKTOP_INPUT_FRAMEWORK.get(desktop, "")
     return wanted if wanted in set(input_framework_groups(context.groups)) else ""
@@ -522,6 +541,7 @@ def _record_derived(context: Context, after: InstallConfig, effects: Effects) ->
         ValueKind.VIDEO_CARD,
         ValueKind.NETWORKING,
         ValueKind.DISPLAY_MANAGER,
+        ValueKind.APPLICATION,
     }
     context.provenance = {
         one
@@ -552,6 +572,11 @@ def _record_derived(context: Context, after: InstallConfig, effects: Effects) ->
                 ValueSource.DERIVED,
             )
         )
+    context.provenance.update(
+        ValueProvenance(ValueKind.APPLICATION, value, ValueSource.DERIVED)
+        for value in (*effects.fonts, effects.input_framework)
+        if value
+    )
 
 
 def _record_operator(context: Context, kind: ValueKind, values: Sequence[str]) -> None:

--- a/tests/unit/test_automatic.py
+++ b/tests/unit/test_automatic.py
@@ -1719,3 +1719,34 @@ def test_the_gentoo_zh_binary_host_has_a_row_on_the_mirror_screen() -> None:
     assert mirror._ZH_BINHOST in [
         item.value for item in mirror._mirror_fields(with_overlay, context().translate)
     ]
+
+
+def test_a_desktop_takes_back_the_fonts_and_framework_it_proposed() -> None:
+    """Adding without a withdrawal, on the row that decides a whole session.
+
+    A CJK interface with Plasma proposes `noto-cjk` and fcitx5 because a
+    desktop is what renders them. Choosing no desktop afterwards left both in
+    `packages.applications`, so a machine with no session merged the fonts and
+    the input framework anyway — the display manager and the network manager
+    already had this undo and the applications did not.
+    """
+    from gentoo_install.tui import packages as tui_packages
+    from tests.unit.fake_screen import FakeScreen
+    from tests.unit.test_tui_app import context, down
+
+    at = context()
+    at.tag = "zh-TW"
+    chinese = screens.with_language(config(), "zh-TW", at)
+
+    with_plasma = tui_packages.desktop_screen(
+        FakeScreen(keys=[*down(1), "\n", "\n"], lines=40, columns=110), chinese, at
+    ).unwrap()
+    proposed = set(with_plasma.packages.applications)
+    assert proposed, with_plasma.packages.applications
+
+    # Back to no desktop: the first row of that menu.
+    none = tui_packages.desktop_screen(
+        FakeScreen(keys=["KEY_UP", "\n", "\n"], lines=40, columns=110), with_plasma, at
+    ).unwrap()
+    assert none.packages.desktop == "", none.packages.desktop
+    assert not (set(none.packages.applications) & proposed), none.packages.applications


### PR DESCRIPTION
A CJK interface with Plasma proposes `noto-cjk` and fcitx5, and the reason is that a desktop is what renders them. `_desktop_proposes` returned early for the no-desktop choice, so both stayed in `packages.applications` and a machine with no session merged them anyway. The display manager and the network manager already had exactly this undo; the application groups did not, which is the same shape as the console-CJK row that kept its overlay.

The same change lets one desktop replace another`s proposal. `_input_framework_a_desktop_needs` declines when a framework is already selected, and a framework the previous desktop proposed is not the operator`s, so Plasma`s fcitx stood after the desktop changed to GNOME.

`ValueKind.APPLICATION` records what was proposed, the way the other four kinds are recorded, and `_record_derived` owns it so a later choice replaces it rather than accumulating. The control was run red — after a first attempt whose slice duplicated the block instead of removing it and left the test green, which the restore-side `grep` caught.