### PR TITLE
tui: propose the sound server a graphical desktop needs

### DIFF
--- a/gentoo_install/data/locale/ja.toml
+++ b/gentoo_install/data/locale/ja.toml
@@ -568,6 +568,7 @@
 "the rest" = "残り全体"
 "written by the template" = "テンプレートが書く"
 "Other locales" = "その他のロケール"
+"Audio" = "オーディオ"
 "Input method" = "入力メソッド"
 "The installed system starts in this locale." = "インストールしたシステムはこのロケールで起動します。"
 "The system language is always generated." = "システム言語のロケールは必ず生成されるため、ここで選ぶ必要はありません。"

--- a/gentoo_install/data/locale/ko.toml
+++ b/gentoo_install/data/locale/ko.toml
@@ -568,6 +568,7 @@
 "the rest" = "나머지 전체"
 "written by the template" = "템플릿이 작성"
 "Other locales" = "다른 로캘"
+"Audio" = "오디오"
 "Input method" = "입력기"
 "The installed system starts in this locale." = "설치한 시스템은 이 로캘로 시작합니다."
 "The system language is always generated." = "시스템 언어의 로캘은 항상 생성되므로 여기서 다시 선택할 필요가 없습니다."

--- a/gentoo_install/data/locale/zh-CN.toml
+++ b/gentoo_install/data/locale/zh-CN.toml
@@ -569,6 +569,7 @@
 "the rest" = "剩余空间"
 "written by the template" = "由模板写出"
 "Other locales" = "其他语系"
+"Audio" = "音效"
 "Input method" = "输入法"
 "The installed system starts in this locale." = "安装完成的系统以这个语系启动。"
 "The system language is always generated." = "系统语言的语系一定会生成，这里不必重复选。"

--- a/gentoo_install/data/locale/zh-TW.toml
+++ b/gentoo_install/data/locale/zh-TW.toml
@@ -569,6 +569,7 @@
 "the rest" = "剩餘空間"
 "written by the template" = "由樣板寫出"
 "Other locales" = "其他語系"
+"Audio" = "音效"
 "Input method" = "輸入法"
 "The installed system starts in this locale." = "安裝完成的系統以這個語系啟動。"
 "The system language is always generated." = "系統語言的語系一定會產生，不必重複選擇。"

--- a/gentoo_install/tui/packages.py
+++ b/gentoo_install/tui/packages.py
@@ -193,12 +193,18 @@ class Effects:
     #: The input framework a desktop proposes. Listed like the fonts, because
     #: it installs packages the operator did not ask for by name.
     input_framework: str = ""
+    #: The sound server a graphical desktop proposes. Plasma reaches PipeWire
+    #: through `kpipewire` whatever this says, and a transitive merge enables
+    #: no unit and adds nobody to the `pipewire` group, so the desktop came up
+    #: silent. Proposed rather than hidden: it is listed here to be confirmed.
+    audio: str = ""
 
     @property
     def has_changes(self) -> bool:
         """Whether the choice has a value to confirm."""
         return bool(
             self.input_framework
+            or self.audio
             or self.fonts
             or self.use_flags
             or self.video_cards
@@ -253,6 +259,12 @@ def derive_effects(
             for name in after.packages.applications
             if name not in before.packages.applications
             and name in cjk_font_groups(context.groups)
+        ),
+        audio=(
+            AUDIO_GROUP
+            if AUDIO_GROUP in after.packages.applications
+            and AUDIO_GROUP not in before.packages.applications
+            else ""
         ),
         withdrawn_use=tuple(
             one.value
@@ -376,6 +388,14 @@ def _desktop_proposes(
     framework = _input_framework_a_desktop_needs(changed, context, desktop)
     if framework:
         changed = select_input_framework(changed, context.groups, framework)
+    audio = _audio_a_desktop_needs(changed, context, desktop)
+    if audio:
+        changed = replace(
+            changed,
+            packages=replace(
+                changed.packages, applications=(*changed.packages.applications, audio)
+            ),
+        )
     return changed
 
 
@@ -398,6 +418,31 @@ def _input_framework_a_desktop_needs(
         return ""
     wanted = DESKTOP_INPUT_FRAMEWORK.get(desktop, "")
     return wanted if wanted in set(input_framework_groups(context.groups)) else ""
+
+
+#: The group that makes a merged PipeWire work: it carries the `pipewire` user
+#: group, the three user units systemd needs started, and `sound-server`, which
+#: is off outside a desktop profile. The packages arrive with Plasma either
+#: way; without this group nothing enables them.
+AUDIO_GROUP: Final[str] = "pipewire"
+
+
+def _audio_a_desktop_needs(config: InstallConfig, context: Context, desktop: str) -> str:
+    """The sound server a graphical desktop proposes, or empty.
+
+    Graphical is read from the profile the desktop group declares: every one
+    of them selects a `.../desktop` profile and `console` selects the plain
+    one. A second column saying `graphical = true` would be a second place to
+    keep the same fact right.
+    """
+    group = context.groups.get(desktop)
+    if group is None or "/desktop" not in group.profile:
+        return ""
+    if AUDIO_GROUP not in context.groups:
+        return ""
+    if AUDIO_GROUP in config.packages.applications:
+        return ""
+    return AUDIO_GROUP
 
 
 def _cjk_fonts_a_desktop_needs(config: InstallConfig, context: Context) -> tuple[str, ...]:
@@ -449,6 +494,8 @@ def settle(
         lines.append(f"{translate('Fonts')}: {' '.join(effects.fonts)}")
     if effects.input_framework:
         lines.append(f"{translate('Input method')}: {effects.input_framework}")
+    if effects.audio:
+        lines.append(f"{translate('Audio')}: {effects.audio}")
     if effects.use_flags:
         lines.append(f"USE: {' '.join(effects.use_flags)}")
     if effects.display_manager_changed:
@@ -574,7 +621,7 @@ def _record_derived(context: Context, after: InstallConfig, effects: Effects) ->
         )
     context.provenance.update(
         ValueProvenance(ValueKind.APPLICATION, value, ValueSource.DERIVED)
-        for value in (*effects.fonts, effects.input_framework)
+        for value in (*effects.fonts, effects.input_framework, effects.audio)
         if value
     )
 

--- a/tests/unit/test_automatic.py
+++ b/tests/unit/test_automatic.py
@@ -1750,3 +1750,61 @@ def test_a_desktop_takes_back_the_fonts_and_framework_it_proposed() -> None:
     ).unwrap()
     assert none.packages.desktop == "", none.packages.desktop
     assert not (set(none.packages.applications) & proposed), none.packages.applications
+
+
+def test_a_graphical_desktop_proposes_the_sound_server_it_needs() -> None:
+    """Plasma reaches PipeWire through `kpipewire` whatever the plan says.
+
+    A transitive merge enables no unit and adds nobody to the `pipewire`
+    group, and the ebuild's own postinst says systemd needs both by hand, so
+    the desktop came up silent. `data/packages/pipewire.toml` already carries
+    the group, the three user units and `sound-server`; nothing selected it.
+
+    Every desktop fixture selects `pipewire` explicitly, which is why no
+    cluster round ever saw this: the tested path is the one that opts in.
+
+    Graphical is read from the profile the group declares — `console` selects
+    the plain `23.0` profile and every other one a `.../desktop` profile —
+    rather than from a second column saying so.
+    """
+    from dataclasses import replace as _replace
+
+    from gentoo_install.data import load_catalog
+    from gentoo_install.tui import packages as tui_packages
+    from tests.unit.test_tui_app import context
+
+    catalog = load_catalog()
+    assert tui_packages.AUDIO_GROUP in catalog, sorted(catalog)
+    audio = catalog[tui_packages.AUDIO_GROUP]
+    assert audio.user_groups and audio.user_services, audio
+
+    at = context()
+    desktops = [
+        name
+        for name, group in catalog.items()
+        if name in {"plasma", "plasma-full", "gnome", "gnome-full", "xfce", "console"}
+    ]
+    assert len(desktops) == 6, sorted(desktops)
+
+    for name in desktops:
+        graphical = "/desktop" in catalog[name].profile
+        before = config()
+        chosen = _replace(
+            before, packages=_replace(before.packages, desktop=name)
+        )
+        after = tui_packages._desktop_proposes(chosen, before, at, name)
+        selected = tui_packages.AUDIO_GROUP in after.packages.applications
+        assert selected is graphical, (name, catalog[name].profile)
+
+    # An operator who selected it keeps one entry, not two.
+    with_audio = config()
+    with_audio = _replace(
+        with_audio,
+        packages=_replace(
+            with_audio.packages,
+            desktop="plasma",
+            applications=(tui_packages.AUDIO_GROUP,),
+        ),
+    )
+    again = tui_packages._desktop_proposes(with_audio, config(), at, "plasma")
+    assert again.packages.applications.count(tui_packages.AUDIO_GROUP) == 1


### PR DESCRIPTION
Plasma reaches PipeWire through `kpipewire` whatever the plan says. A package that arrives as a dependency enables no unit and adds nobody to the `pipewire` group, and the ebuild`s own postinst says systemd needs both done by hand, so a Plasma or GNOME install came up with no sound.

`data/packages/pipewire.toml` already carries all of it — the user group, the three user units, and `sound-server`, which is off outside a desktop profile — with the ebuild quoted in its comments. Nothing selected it.

No cluster round could see this: `vm-desktop`, `vm-gnome`, `vm-greetd` and `vm-openrc-desktop` all name `pipewire` in `applications`, so the tested path is the one that opts in and the menu default is the one that does not.

A graphical desktop now proposes the group the way it already proposes CJK fonts and an input framework: listed in `settle` for the operator to confirm, recorded as derived, and withdrawn when the desktop changes. Graphical is read from the profile the group declares — `console` selects the plain `23.0` profile and every other one a `.../desktop` profile — rather than from a second column that would have to be kept right. The control was run red.