### PR TITLE
packages: read a graphical session off the profile, not the name

### DIFF
--- a/gentoo_install/plan/packages.py
+++ b/gentoo_install/plan/packages.py
@@ -1065,7 +1065,7 @@ def _operations(
             )
     # After the groups: `rc-update` refuses a service whose package is absent,
     # and both of these arrive as dependencies of the desktop above.
-    operations += _session_services(config)
+    operations += _session_services(config, catalog)
     operations += _input_method(config, chosen)
     if config.packages.extra:
         operations.append(
@@ -1193,6 +1193,26 @@ def _required_video_cards(config: InstallConfig, chosen: Sequence[Group]) -> tup
     return tuple(wanted)
 
 
+#: What a desktop group's profile carries and a text one does not. Every
+#: graphical profile selects `default/linux/amd64/23.0/desktop...` and
+#: `console` selects the plain `23.0`, so the table already says which is
+#: which; a `graphical = true` column would be a second place to keep right.
+GRAPHICAL_PROFILE: Final[str] = "/desktop"
+
+
+def draws_a_session(catalog: Catalog, desktop: str) -> bool:
+    """Whether that desktop choice produces a graphical session.
+
+    `console` is a profile-bearing group, so it appears in the Desktop menu
+    and `packages.desktop` is not empty for it. Every reader that tested the
+    name for truth therefore treated a text console as a desktop: `dbus` and
+    `elogind` were merged and enabled for it, and the menu proposed a network
+    manager, CJK fonts and an input framework for a machine with no session.
+    """
+    group = catalog.get(desktop)
+    return group is not None and GRAPHICAL_PROFILE in group.profile
+
+
 #: openrc runs every display manager through one init script, which reads the
 #: name from its conf.d file. `gui-libs/display-manager-init` is what ships
 #: both, and nothing else pulls it in.
@@ -1210,7 +1230,7 @@ SESSION_PACKAGES: Final[tuple[tuple[str, str, str], ...]] = (
 )
 
 
-def _session_services(config: InstallConfig) -> list[Operation]:
+def _session_services(config: InstallConfig, catalog: Catalog) -> list[Operation]:
     """What a graphical session needs running before anything can start one.
 
     Neither package is in a stage3 and neither is in `@system`: they arrive as
@@ -1219,7 +1239,10 @@ def _session_services(config: InstallConfig) -> list[Operation]:
     """
     if config.system.init is InitSystem.SYSTEMD:
         return []
-    if not (config.packages.desktop or config.packages.display_manager):
+    if not (
+        draws_a_session(catalog, config.packages.desktop)
+        or config.packages.display_manager
+    ):
         return []
     return [
         Emerge(

--- a/gentoo_install/tui/packages.py
+++ b/gentoo_install/tui/packages.py
@@ -29,7 +29,7 @@ from ..plan.packages import Catalog as Groups
 from ..plan.packages import FRAMEWORK_GROUPS
 from ..plan.packages import FONT_CONFIGURATION_DISABLED, FONT_CONFIGURATION_ENABLED
 from ..plan.packages import INPUT_CONFIGURATION_DISABLED, INPUT_CONFIGURATION_ENABLED
-from ..plan.packages import driver_conflict, framework_conflict
+from ..plan.packages import draws_a_session, driver_conflict, framework_conflict
 from .context import (
     Context,
     ValueKind,
@@ -349,7 +349,10 @@ def _desktop_proposes(
             changed,
             system=replace(changed.system, networking=SystemConfig().networking),
         )
-    if not desktop:
+    if not draws_a_session(context.groups, desktop):
+        # `console` as well as no desktop: it is a profile-bearing group, so
+        # it reaches this row with a name, and a text machine was proposed a
+        # network manager, CJK fonts and an input framework it cannot draw.
         # What the previous desktop proposed goes with it. CJK fonts and an
         # input framework render nothing without a session, and choosing no
         # desktop after Plasma left `media-fonts/noto-cjk` and fcitx5 merged
@@ -430,13 +433,10 @@ AUDIO_GROUP: Final[str] = "pipewire"
 def _audio_a_desktop_needs(config: InstallConfig, context: Context, desktop: str) -> str:
     """The sound server a graphical desktop proposes, or empty.
 
-    Graphical is read from the profile the desktop group declares: every one
-    of them selects a `.../desktop` profile and `console` selects the plain
-    one. A second column saying `graphical = true` would be a second place to
-    keep the same fact right.
+    Graphical is `draws_a_session`, which reads the profile the group
+    declares rather than whether its name is empty.
     """
-    group = context.groups.get(desktop)
-    if group is None or "/desktop" not in group.profile:
+    if not draws_a_session(context.groups, desktop):
         return ""
     if AUDIO_GROUP not in context.groups:
         return ""

--- a/tests/unit/test_automatic.py
+++ b/tests/unit/test_automatic.py
@@ -1734,21 +1734,29 @@ def test_a_desktop_takes_back_the_fonts_and_framework_it_proposed() -> None:
     from tests.unit.fake_screen import FakeScreen
     from tests.unit.test_tui_app import context, down
 
+    from dataclasses import replace as _replace
+
     at = context()
     at.tag = "zh-TW"
     chinese = screens.with_language(config(), "zh-TW", at)
 
-    with_plasma = tui_packages.desktop_screen(
-        FakeScreen(keys=[*down(1), "\n", "\n"], lines=40, columns=110), chinese, at
-    ).unwrap()
+    # `_desktop_proposes` rather than the menu: a row index picked `console`,
+    # which is a profile-bearing group and not a session, so the test was
+    # passing on the very defect the graphical predicate exists to fix.
+    picked = _replace(chinese, packages=_replace(chinese.packages, desktop="plasma"))
+    with_plasma = tui_packages._desktop_proposes(picked, chinese, at, "plasma")
     proposed = set(with_plasma.packages.applications)
     assert proposed, with_plasma.packages.applications
+    tui_packages._record_derived(
+        at, with_plasma, tui_packages.derive_effects(chinese, with_plasma, at)
+    )
 
-    # Back to no desktop: the first row of that menu.
-    none = tui_packages.desktop_screen(
-        FakeScreen(keys=["KEY_UP", "\n", "\n"], lines=40, columns=110), with_plasma, at
-    ).unwrap()
-    assert none.packages.desktop == "", none.packages.desktop
+    none = tui_packages._desktop_proposes(
+        _replace(with_plasma, packages=_replace(with_plasma.packages, desktop="")),
+        with_plasma,
+        at,
+        "",
+    )
     assert not (set(none.packages.applications) & proposed), none.packages.applications
 
 

--- a/tests/unit/test_packages.py
+++ b/tests/unit/test_packages.py
@@ -729,3 +729,67 @@ def test_the_session_check_names_the_directories_it_will_look_in() -> None:
         said = check.describe()
         for path in check.paths:
             assert str(path) in said, (path, said)
+
+
+def test_the_text_console_is_not_treated_as_a_graphical_session() -> None:
+    """`console` is a profile-bearing group, so `packages.desktop` is not
+    empty for it and every reader that tested the name for truth called it a
+    desktop: `sys-apps/dbus` and `sys-auth/elogind` were merged and enabled
+    for a machine whose own profile comment says `No desktop: a text console`.
+
+    The profile the group declares is what separates them — `console` selects
+    the plain `23.0` and every graphical one a `.../desktop` — so one
+    predicate reads it and the menu and the plan share it.
+    """
+    from gentoo_install.model.config import InitSystem
+    from gentoo_install.plan.packages import SESSION_PACKAGES, draws_a_session
+
+    catalog = load_catalog()
+    assert not draws_a_session(catalog, "console"), catalog["console"].profile
+    assert not draws_a_session(catalog, ""), "no desktop is not a session"
+    for name in ("plasma", "gnome", "xfce"):
+        assert draws_a_session(catalog, name), catalog[name].profile
+
+    session = {atom for atom, _, _ in SESSION_PACKAGES}
+    installation = config()
+    openrc = replace(
+        installation,
+        system=replace(installation.system, init=InitSystem.OPENRC),
+        packages=replace(installation.packages, desktop="console", display_manager=""),
+    )
+    merged = {
+        atom
+        for one in plan_packages.build(openrc, catalog)
+        for atom in getattr(one, "packages", ())
+    }
+    assert not (merged & session), sorted(merged & session)
+
+    graphical = replace(
+        openrc, packages=replace(openrc.packages, desktop="xfce")
+    )
+    with_session = {
+        atom
+        for one in plan_packages.build(graphical, catalog)
+        for atom in getattr(one, "packages", ())
+    }
+    assert session <= with_session, sorted(session - with_session)
+
+
+def test_the_text_console_is_offered_no_desktop_proposals() -> None:
+    """The menu proposed a network manager, CJK fonts and an input framework
+    for `console`, because the row tested whether the name was empty and that
+    name is not. A text machine draws none of them."""
+    from gentoo_install.tui import packages as tui_packages
+    from tests.unit.test_tui_app import context
+
+    at = context()
+    at.tag = "zh-TW"
+    before = config()
+    picked = replace(before, packages=replace(before.packages, desktop="console"))
+    after = tui_packages._desktop_proposes(picked, before, at, "console")
+
+    assert after.packages.applications == before.packages.applications, (
+        after.packages.applications
+    )
+    assert after.system.networking is before.system.networking, after.system.networking
+    assert after.packages.display_manager == "", after.packages.display_manager


### PR DESCRIPTION
`console` is a profile-bearing group, so it appears in the Desktop menu and `packages.desktop` is not empty for it. Every reader that tested that name for truth therefore called a text machine a desktop: on OpenRC `sys-apps/dbus` and `sys-auth/elogind` were merged and enabled, and the menu proposed a network manager, CJK fonts and an input framework. The profile`s own first line reads `No desktop: a text console`.

`draws_a_session` reads the profile the group declares — `console` selects the plain `23.0` and every graphical one a `.../desktop` — and the plan and the menu share it. The sound-server proposal already used that test, so the tree briefly held one correct reader and three that were not.

The change made `test_a_desktop_takes_back_the_fonts_and_framework_it_proposed` fail, which is worth recording: it selected a desktop with `down(1)`, that row is `console`, and it passed only because `console` took the graphical path and so had something to withdraw. It now drives `_desktop_proposes` with `plasma` by name rather than by row order. Both halves of the change have their own control, run red.