### PR TITLE
packages: read a GNOME session off the profile, not the name

### DIFF
--- a/gentoo_install/plan/packages.py
+++ b/gentoo_install/plan/packages.py
@@ -612,7 +612,17 @@ INPUT_ENVIRONMENT: Final[dict[tuple[str, Session], tuple[str, ...]]] = {
     ),
 }
 
-GNOME_DESKTOP_GROUP: Final[str] = "gnome"
+#: The profile a GNOME desktop group declares. `gnome` and `gnome-full` both
+#: select it and nothing else does, so the table already says which desktops
+#: are GNOME; comparing the group's name matched one of the two and left the
+#: other without the dconf input sources that session reads.
+GNOME_PROFILE: Final[str] = "/desktop/gnome"
+
+
+def is_gnome(catalog: Catalog, desktop: str) -> bool:
+    """Whether that desktop choice is a GNOME session."""
+    group = catalog.get(desktop)
+    return group is not None and group.profile.endswith(GNOME_PROFILE)
 DCONF_PROFILE: Final[PurePosixPath] = PurePosixPath("/etc/dconf/profile/user")
 GNOME_INPUT_SOURCES: Final[PurePosixPath] = PurePosixPath(
     "/etc/dconf/db/local.d/00-gentoo-install-input-sources"
@@ -1066,7 +1076,7 @@ def _operations(
     # After the groups: `rc-update` refuses a service whose package is absent,
     # and both of these arrive as dependencies of the desktop above.
     operations += _session_services(config, catalog)
-    operations += _input_method(config, chosen)
+    operations += _input_method(config, chosen, catalog)
     if config.packages.extra:
         operations.append(
             Emerge(
@@ -1353,7 +1363,9 @@ def _framework_package(chosen: Sequence[Group], framework: str) -> str:
     return ""
 
 
-def _input_method(config: InstallConfig, chosen: tuple[Group, ...]) -> list[Operation]:
+def _input_method(
+    config: InstallConfig, chosen: tuple[Group, ...], catalog: Catalog
+) -> list[Operation]:
     """Configure one selected framework and every engine belonging to it."""
     engines: list[str] = []
     for group in chosen:
@@ -1417,7 +1429,7 @@ def _input_method(config: InstallConfig, chosen: tuple[Group, ...]) -> list[Oper
                     package=RIME_DATA_PACKAGE, schemas=tuple(schemas)
                 )
             )
-    if framework == "ibus" and config.packages.desktop == GNOME_DESKTOP_GROUP:
+    if framework == "ibus" and is_gnome(catalog, config.packages.desktop):
         sources = tuple(group.input_source for group in chosen if group.input_source)
         if sources:
             operations.append(
@@ -1448,7 +1460,7 @@ def input_environment(config: InstallConfig, catalog: Catalog) -> tuple[str, ...
     Derived here rather than restated there: `plan/automatic.py` exists so the
     operator sees what the installer adds, and a second list would drift.
     """
-    for one in _input_method(config, groups(config, catalog)):
+    for one in _input_method(config, groups(config, catalog), catalog):
         if isinstance(one, WriteInputMethodEnvironment):
             return INPUT_ENVIRONMENT[(one.framework, one.session)]
     return ()

--- a/tests/unit/test_packages.py
+++ b/tests/unit/test_packages.py
@@ -793,3 +793,42 @@ def test_the_text_console_is_offered_no_desktop_proposals() -> None:
     )
     assert after.system.networking is before.system.networking, after.system.networking
     assert after.packages.display_manager == "", after.packages.display_manager
+
+
+def test_both_gnome_variants_get_their_input_sources_configured() -> None:
+    """`gnome-full` is GNOME and was compared out of it by name.
+
+    `ConfigureGnomeInputSources` writes `/etc/dconf/profile/user` and the
+    input-source keys IBus needs a GNOME session to read, and the test was
+    `config.packages.desktop == "gnome"`. The full variant declares the same
+    `.../desktop/gnome` profile, proposes the same IBus, and installed a
+    session with no configured input source.
+
+    Read off the profile, like the graphical test beside it: the table
+    already separates GNOME from Plasma from Xfce.
+    """
+    from gentoo_install.plan.packages import ConfigureGnomeInputSources, is_gnome
+
+    catalog = load_catalog()
+    for name in ("gnome", "gnome-full"):
+        assert is_gnome(catalog, name), catalog[name].profile
+    for name in ("plasma", "plasma-full", "xfce", "console"):
+        assert not is_gnome(catalog, name), catalog[name].profile
+
+    installation = config()
+    for name in ("gnome", "gnome-full"):
+        selected = replace(
+            installation,
+            packages=replace(
+                installation.packages,
+                desktop=name,
+                applications=("ibus", "ibus-pinyin"),
+            ),
+        )
+        configured = [
+            one
+            for one in plan_packages.build(selected, catalog)
+            if isinstance(one, ConfigureGnomeInputSources)
+        ]
+        assert configured, name
+        assert configured[0].engines, (name, configured[0])


### PR DESCRIPTION
`ConfigureGnomeInputSources` writes `/etc/dconf/profile/user` and the input-source keys IBus needs a GNOME session to read. It was gated on `config.packages.desktop == "gnome"`, which matches one of the two GNOME groups. `gnome-full` declares the same `.../desktop/gnome` profile and is proposed the same IBus, so it installed a session with no configured input source.

`is_gnome` reads the profile the group declares, the same test as `draws_a_session` beside it. The table already separates the two GNOME variants from the two Plasma ones, from Xfce, and from `console`.

This is the third defect of one shape in a day: a name compared where a property was meant. The other two were `packages.desktop` read for truth, which made `console` a graphical desktop, and no test at all, which left PipeWire`s units unenabled. The control was run red.