### PR TITLE
tui: treat a loaded configuration as the operator answers

### DIFF
--- a/gentoo_install/tui/context.py
+++ b/gentoo_install/tui/context.py
@@ -23,7 +23,9 @@ from ..model.config import (
     Firmware,
     InstallConfig,
     Overlay,
+    PackagesConfig,
     PortageConfig,
+    SystemConfig,
 )
 from ..model.device import (
     Existing,
@@ -287,6 +289,45 @@ class Context:
         self.layout_was_loaded = True
         self.confirmed.clear()
         self.inspect_disk(disk)
+
+    def hydrate_provenance(self, config: InstallConfig) -> None:
+        """Mark what a loaded file says as the operator's own answers.
+
+        Provenance starts empty, so every value in a loaded configuration read
+        as an unchosen default and the next desktop proposal wrote over it: a
+        file saying `networking = "networkmanager-iwd"` came back from the
+        desktop row as `networkmanager-wpa`.
+
+        A value equal to the dataclass default is left unmarked. The parser
+        fills an omitted key with that default, so the file and the default
+        are the same text by then and nothing here can tell them apart; the
+        proposals may still move those, which is what they are for.
+        """
+        # The section defaults, not a whole `InstallConfig`: that one needs a
+        # disk, and the disk is not what this reads.
+        answered: list[tuple[ValueKind, tuple[str, ...]]] = [
+            (
+                ValueKind.NETWORKING,
+                (config.system.networking.value,)
+                if config.system.networking is not SystemConfig().networking
+                else (),
+            ),
+            (
+                ValueKind.DISPLAY_MANAGER,
+                (config.packages.display_manager,)
+                if config.packages.display_manager != PackagesConfig().display_manager
+                else (),
+            ),
+            (ValueKind.USE_FLAG, config.portage.use),
+            (ValueKind.VIDEO_CARD, config.portage.video_cards),
+            (ValueKind.APPLICATION, config.packages.applications),
+        ]
+        for kind, values in answered:
+            self.provenance.update(
+                ValueProvenance(kind, value, ValueSource.OPERATOR)
+                for value in values
+                if value
+            )
 
     def shown_as(self, selector: str) -> str:
         """What to call a device on screen.

--- a/gentoo_install/tui/screens.py
+++ b/gentoo_install/tui/screens.py
@@ -1796,6 +1796,7 @@ def saved_config_screen(
         try:
             loaded = context.load_config(answer.unwrap())
             context.hydrate_disk(loaded)
+            context.hydrate_provenance(loaded)
             fetch.configure_proxy(loaded.proxy)
             return Answer(Outcome.CHOSE, loaded)
         except GentooInstallError as error:

--- a/tests/unit/test_automatic.py
+++ b/tests/unit/test_automatic.py
@@ -1816,3 +1816,64 @@ def test_a_graphical_desktop_proposes_the_sound_server_it_needs() -> None:
     )
     again = tui_packages._desktop_proposes(with_audio, config(), at, "plasma")
     assert again.packages.applications.count(tui_packages.AUDIO_GROUP) == 1
+
+
+def test_a_loaded_configuration_answer_survives_a_desktop_choice() -> None:
+    """Provenance starts empty, so a loaded file read as unchosen defaults.
+
+    A configuration saying `networking = "networkmanager-iwd"` came back from
+    the desktop row as `networkmanager-wpa`: `_desktop_proposes` keeps only
+    what `ValueSource.OPERATOR` marks, and loading marked nothing. The saved
+    file is the operator's answer as much as a row they walked.
+
+    A value equal to its section default stays unmarked: the parser fills an
+    omitted key with that default, so by then the file and the default are
+    the same text and nothing can tell them apart.
+    """
+    from dataclasses import replace as _replace
+
+    from gentoo_install.model.config import Networking, SystemConfig
+    from gentoo_install.tui import packages as tui_packages
+    from gentoo_install.tui.context import ValueKind, ValueSource
+    from tests.unit.test_tui_app import context
+
+    at = context()
+    loaded = _replace(
+        config(),
+        system=_replace(config().system, networking=Networking.NETWORKMANAGER_IWD),
+    )
+    at.hydrate_provenance(loaded)
+
+    picked = _replace(loaded, packages=_replace(loaded.packages, desktop="plasma"))
+    after = tui_packages._desktop_proposes(picked, loaded, at, "plasma")
+    assert after.system.networking is Networking.NETWORKMANAGER_IWD, (
+        after.system.networking
+    )
+
+    # And the load screen is what records it: a test that calls
+    # `hydrate_provenance` itself stays green when the call site goes.
+    from tests.unit.fake_screen import FakeScreen
+
+    walked = context()
+    walked.configs_here = ("my-install.toml",)
+    walked.load_config = lambda name: loaded
+    screens.saved_config_screen(
+        FakeScreen(keys=["KEY_DOWN", "\n"], lines=24, columns=100), config(), walked
+    )
+    assert any(
+        one.kind is ValueKind.NETWORKING and one.source is ValueSource.OPERATOR
+        for one in walked.provenance
+    ), walked.provenance
+
+    # The default is not an answer: a desktop still proposes over it.
+    plain = context()
+    default = config()
+    assert default.system.networking is SystemConfig().networking
+    plain.hydrate_provenance(default)
+    proposed = tui_packages._desktop_proposes(
+        _replace(default, packages=_replace(default.packages, desktop="plasma")),
+        default,
+        plain,
+        "plasma",
+    )
+    assert proposed.system.networking is Networking.NETWORKMANAGER_WPA


### PR DESCRIPTION
`Context.provenance` starts empty and loading a configuration recorded none of it, so every value in a saved file read as an unchosen default. A file saying `networking = "networkmanager-iwd"` came back from the desktop row as `networkmanager-wpa`, because `_desktop_proposes` keeps only what `ValueSource.OPERATOR` marks. A saved file is the operator`s answer as much as a row they walked, and the workflow the README documents — save, dry-run, inspect, install — runs straight through it.

`hydrate_provenance` marks the values that differ from their section default, across the five kinds the proposals read. A value equal to the default stays unmarked: the parser fills an omitted key with that default, so by then the file and the default are the same text and nothing here can tell them apart.

The first test called `hydrate_provenance` itself and stayed green when the call site was removed, so it now drives `saved_config_screen`. The control was run red against the call site.