### PR TITLE
vm: let the follower say the install is still writing

### DIFF
--- a/tests/unit/test_cluster.py
+++ b/tests/unit/test_cluster.py
@@ -4760,3 +4760,52 @@ def test_a_repeatable_wait_is_sent_again_after_a_reconnect() -> None:
     # Not the prompt fallback: a repeatable wait never accepts one, because a
     # prompt is exactly what a hangup leaves behind.
     assert not any("root@" in one for one in console.patterns), console.patterns
+
+
+def test_the_follower_says_the_install_grew_and_stays_silent_when_it_did_not(
+    tmp_path: Path,
+) -> None:
+    """A compiling install and a stopped one looked the same on the console.
+
+    `tail -n 0 -F` starts at the end of the file, and the detached install
+    redirects into a file where `tee` into a pty used to line-buffer, so a
+    reconnect during a long compile produced nothing for the watchdog to
+    read: `btrfs-luks` was ended at 55.8 minutes inside
+    `emerge kde-plasma/plasma-meta`, having passed the same fixture at 126.6
+    minutes the round before.
+
+    The size is printed only when it grew, so silence still means a stopped
+    install. Run rather than read: a heartbeat sent regardless would keep the
+    watchdog quiet for an install that had stopped.
+    """
+    results = tmp_path / "results"
+    results.mkdir()
+    follow = cluster.follow_install(results=str(results)).replace("sleep 30", "sleep 1")
+
+    # Growing without newlines, which is what a block-buffered compile does.
+    (results / "install.txt").write_bytes(b"")
+    grower = subprocess.Popen(
+        [
+            "sh",
+            "-c",
+            f"for i in 1 2 3; do printf 'xxxxxxxx' >> {results}/install.txt; sleep 1;"
+            f" done; echo 0 > {results}/install.rc",
+        ]
+    )
+    growing = subprocess.run(
+        ["sh", "-c", follow], capture_output=True, text=True, timeout=60
+    )
+    grower.wait(timeout=10)
+    assert growing.stdout.count(f"{cluster.INSTALL_BYTES}=") >= 2, growing.stdout
+
+    # Stopped: the file never grows and nothing is printed for it.
+    quiet = tmp_path / "quiet"
+    quiet.mkdir()
+    (quiet / "install.txt").write_bytes(b"")
+    silent = cluster.follow_install(results=str(quiet)).replace("sleep 30", "sleep 1")
+    ender = subprocess.Popen(["sh", "-c", f"sleep 4; echo 0 > {quiet}/install.rc"])
+    stopped = subprocess.run(
+        ["sh", "-c", silent], capture_output=True, text=True, timeout=60
+    )
+    ender.wait(timeout=10)
+    assert cluster.INSTALL_BYTES not in stopped.stdout, stopped.stdout

--- a/tests/vm/cluster.py
+++ b/tests/vm/cluster.py
@@ -3219,6 +3219,12 @@ def detached_install(
     )
 
 
+#: What the follower prints when `install.txt` has grown since it last
+#: looked. A number the guest computed: the command's own echo carries `%s`
+#: where the answer goes, so it cannot satisfy the pattern by itself.
+INSTALL_BYTES: Final[str] = "INSTALL_BYTES"
+
+
 def follow_install(*, results: str = RESULT_DIR) -> str:
     """The command that puts a detached install back on the console.
 
@@ -3226,10 +3232,24 @@ def follow_install(*, results: str = RESULT_DIR) -> str:
     arrived since rather than replaying the 294910 lines `install.txt` holds.
     The whole file is collected from the guest either way; the console carries
     it for the watchdog and for a reader.
+
+    That start-at-the-end, and a redirect into a file where `tee` into a pty
+    used to line-buffer, made a compiling install and a stopped one look the
+    same on the console: `btrfs-luks` was ended at 55.8 minutes inside
+    `emerge kde-plasma/plasma-meta` having passed the same fixture at 126.6
+    minutes the round before.
+
+    The size is printed only when it has grown. A heartbeat sent regardless
+    would keep the watchdog quiet for an install that had stopped, which is
+    the shape of a check that cannot fail; `%s` carries a number the guest
+    computed, so the line cannot be produced by the command's own echo.
     """
     return (
-        f"tail -n 0 -F {results}/install.txt & follower=$!; "
-        f"while [ ! -e {results}/install.rc ]; do sleep 5; done; "
+        f"tail -n 0 -F {results}/install.txt & follower=$!; seen=0; "
+        f"while [ ! -e {results}/install.rc ]; do sleep 30; "
+        f"grew=$(stat -c%s {results}/install.txt 2>/dev/null || echo 0); "
+        f'if [ "$grew" != "$seen" ]; then '
+        f'printf \'{INSTALL_BYTES}=%s\\n\' "$grew"; seen=$grew; fi; done; '
         f"sleep 3; kill $follower 2>/dev/null"
     )
 


### PR DESCRIPTION
Round 31 ended `btrfs-luks` at 55.8 minutes inside `emerge kde-plasma/plasma-meta`; the same fixture passed at 126.6 minutes the round before. Its console shows the follower being resent after each reconnect and nothing arriving, which is not a stalled install: the install is detached and was still running.

Two things stack. `tail -n 0` starts at the end of the file, which is what keeps a reconnect from replaying 294910 lines. And the detached install redirects into a file where `tee` into a pty used to line-buffer, so output now arrives in large blocks. Between blocks, a compiling install and a stopped one are the same silence, and the watchdog reads only the console.

The follower now reads `install.txt` every thirty seconds and prints its size **only when it grew**. A compile keeps the console alive; an install that stopped prints nothing and is still ended. A heartbeat sent regardless would be a check that cannot fail, and `%s` carries a number the guest computed, so the line cannot come from the command`s own echo.

Run rather than read: the test drives both a growing file and a stopped one. The control replaced the condition with `if true` and went red.