### PR TITLE
validate: refuse a group written into the wrong field

### DIFF
--- a/gentoo_install/model/validate.py
+++ b/gentoo_install/model/validate.py
@@ -290,6 +290,7 @@ def validate(
         *_system_value_problems(config, available_timezones),
         *_package_group_problems(config, available_package_groups),
         *_desktop_profile_problems(config, declared_desktop_profiles),
+        *_group_role_problems(config, declared_desktop_profiles),
         *_l10n_problems(config),
         *_repository_name_problems(config),
         *compat.binhost_subarch_problems(config, supports_v3),
@@ -711,6 +712,43 @@ def _profile_problems(config: InstallConfig) -> list[str]:
     return [f"init is {config.system.init.value} and the profile is {profile}; use {wanted}"]
 
 
+
+
+def _group_role_problems(
+    config: InstallConfig,
+    declared: Mapping[str, str] | _ShippedValuesNotRead,
+) -> list[str]:
+    """A group has to fit the field it was written in.
+
+    `_package_group_problems` checks only that the name is a group at all, so
+    `display_manager = "plasma"` and `desktop = "greetd"` both validate and
+    stop in `Stage.PACKAGES` with the disks partitioned and the packages
+    merged. A group that declares a profile is a desktop and nothing else is:
+    `data/profiles/` is where the six of them live and every other group comes
+    from `data/packages/` with no profile to declare.
+    """
+    if isinstance(declared, _ShippedValuesNotRead):
+        return []
+    problems: list[str] = []
+    packages = config.packages
+    if packages.desktop and packages.desktop not in declared:
+        problems.append(
+            f"packages.desktop is {packages.desktop!r}, which declares no profile, "
+            "so it is not a desktop"
+        )
+    elsewhere = (
+        ("applications", packages.applications),
+        ("graphics", packages.graphics),
+        ("display_manager", (packages.display_manager,)),
+    )
+    problems += [
+        f"packages.{field} names {name!r}, which is a desktop; "
+        "put it in packages.desktop"
+        for field, names in elsewhere
+        for name in names
+        if name and name in declared
+    ]
+    return problems
 
 
 def _desktop_profile_problems(

--- a/tests/unit/test_validate.py
+++ b/tests/unit/test_validate.py
@@ -1724,3 +1724,49 @@ def test_a_desktop_paired_with_another_desktops_profile_is_refused() -> None:
     # read at the entry point and a caller that has not read them cannot
     # decide: the TUI validates a graph mid-edit with nothing injected.
     validate(generic)
+
+
+def test_a_group_has_to_fit_the_field_it_was_written_in() -> None:
+    """`_package_group_problems` checks the name is a group, not its role.
+
+    `display_manager = "plasma"` and `desktop = "greetd"` both pass it, and
+    the run then stops in `Stage.PACKAGES` — after the disks are partitioned
+    and the packages merged — with `cannot verify greetd session directories
+    because no desktop package was selected`.
+
+    A group that declares a profile is a desktop and nothing else is: the six
+    live in `data/profiles/` and every other group comes from
+    `data/packages/` with no profile to declare.
+    """
+    from gentoo_install import data
+
+    catalog = data.load_catalog()
+    declared = {name: group.profile for name, group in catalog.items() if group.profile}
+    assert set(declared) == {
+        "console",
+        "gnome",
+        "gnome-full",
+        "plasma",
+        "plasma-full",
+        "xfce",
+    }, sorted(declared)
+
+    base = load(Path("tests/fixtures/vm-desktop.toml"))
+    validate(base, declared_desktop_profiles=declared)
+
+    as_a_login = replace(
+        base, packages=replace(base.packages, display_manager="plasma")
+    )
+    with pytest.raises(ValidationFailed, match="which is a desktop"):
+        validate(as_a_login, declared_desktop_profiles=declared)
+
+    as_a_desktop = replace(
+        base,
+        packages=replace(base.packages, desktop="greetd", display_manager=""),
+    )
+    with pytest.raises(ValidationFailed, match="declares no profile"):
+        validate(as_a_desktop, declared_desktop_profiles=declared)
+
+    # A caller that injected nothing is unaffected, which is what the TUI
+    # needs while a graph is still being edited.
+    validate(as_a_login)


### PR DESCRIPTION
`_package_group_problems` checks that a name is a group in the catalog and nothing more, so `display_manager = "plasma"` and `desktop = "greetd"` both validate. The run then stops in `Stage.PACKAGES` — after the disks are partitioned and the packages merged — with `cannot verify greetd session directories because no desktop package was selected`.

A group that declares a profile is a desktop and nothing else is: the six live in `data/profiles/` and every other group comes from `data/packages/` with none to declare. `declared_desktop_profiles` is already injected for the desktop-profile rule, so this needs no new injection and no new column.

A caller that injects nothing is unaffected, which is what the menu needs while a graph is still being edited. The control was run red.