### PR TITLE
docs: say when the staged passphrase is removed

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -23,9 +23,12 @@ by one person: a reply comes when there is one to give.
   overlays and packages. Treat one you did not write as you would a shell
   script from the same source.
 - **Passphrases are staged in a file.** A LUKS or ZFS passphrase is written
-  under `/run/gentoo-install/keys/` with mode `0600` for the command that
-  reads it, and `/run` is a tmpfs, so it does not survive the reboot into the
-  installed system. The installer does not delete it before then. Publishing a
+  under `/run/gentoo-install/keys/approved/` with mode `0600` for the command
+  that reads it. `/run` is a tmpfs, so nothing there survives the reboot into
+  the installed system, and the run removes the staged keys before that: the
+  clean-up is in a `finally`, so it happens whether the install finished or
+  stopped, and before the root shell the installer offers. A key that could
+  not be removed is named in the log rather than passed over. Publishing a
   configuration from the menu replaces `password_hash`, `root_password_hash`
   and `passphrase_file` and drops the proxy username and password, so a
   published configuration carries none of them. Publishing is a menu action and the closing

--- a/tests/unit/test_project_docs.py
+++ b/tests/unit/test_project_docs.py
@@ -132,3 +132,40 @@ def test_every_fixture_the_record_names_still_exists() -> None:
                 named.add(word)
     assert len(named) > 20, sorted(named)
     assert sorted(named - have) == [], sorted(named - have)
+
+
+def test_security_says_when_the_staged_passphrase_goes() -> None:
+    """The document said the installer does not delete it before the reboot.
+
+    `apply` clears the staged keys in a `finally`, so they are gone when the
+    run ends whether it finished or stopped, and before the root shell it
+    offers. A security document that understates its own protection is still
+    wrong, and the sentence would have stayed wrong if the clean-up were
+    removed.
+    """
+    import ast
+    import inspect
+
+    from gentoo_install.exec import apply as exec_apply
+    from gentoo_install.exec.preflight import SecretStore
+    from gentoo_install.model.device import DeviceId
+
+    said = (ROOT / "SECURITY.md").read_text(encoding="utf-8")
+    paragraph = next(part for part in said.split("\n- ") if "staged in a file" in part)
+    assert "finally" in paragraph, paragraph
+    assert "0600" in paragraph, paragraph
+
+    # The path the document names is the one the store writes.
+    where = SecretStore(Path("/run/gentoo-install")).path(DeviceId("one"))
+    assert str(where.parent) in paragraph, (where, paragraph)
+
+    # The clean-up is in a `finally`, which is what makes the sentence true.
+    tree = ast.parse(inspect.getsource(exec_apply.apply))
+    cleaned = [
+        node
+        for outer in ast.walk(tree)
+        if isinstance(outer, ast.Try)
+        for node in ast.walk(ast.Module(body=outer.finalbody, type_ignores=[]))
+        if isinstance(node, ast.Attribute) and node.attr == "cleanup_secrets"
+    ]
+    assert cleaned, ast.dump(tree)[:200]


### PR DESCRIPTION
`SECURITY.md` said a staged LUKS or ZFS passphrase survives until the reboot, and that the installer does not delete it before then. `apply` clears the staged keys in a `finally`, so they are gone when the run ends whether it finished or stopped, and before the root shell the installer offers. A key that could not be removed is named in the log rather than passed over.

A security document that understates its own protection is still wrong, and this one would have stayed wrong if the clean-up were removed, so it was not a claim that could fail. The path it names is corrected to the one `SecretStore` writes.

The test reads the path off `SecretStore.path` rather than repeating it, and checks by AST that the clean-up is in the `finally`. The first control deleted `finally:` outright, left a `try:` with no handler, and went red on a `SyntaxError` rather than on the assertion; the one that counts moves the call out of the `finally` and keeps the structure.