### PR TITLE
docs: list every kernel source and the exit code the parser gives

### DIFF
--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -381,7 +381,7 @@ The following reference names every persisted key. A table path is TOML table no
 
 | `kernel` key | Meaning and default or choices |
 | --- | --- |
-| `source` | Kernel choice: `dist-bin`, `dist-source`, `cjk-bin`, or `cjk`; `dist-bin`. |
+| `source` | Kernel choice: `dist-bin`, `dist-source`, `cjk-bin`, `cjk`, or `xanmod`; `dist-bin`. |
 | `package` | Overrides the package implied by `source`; `""`. |
 | `version` | Version pin; `""` lets Portage choose the newest keyword-allowed version. |
 | `dracut_modules` | Adds dracut modules required by the disk layout; `[]`. |
@@ -393,6 +393,7 @@ The following reference names every persisted key. A table path is TOML table no
 | `dist-source` | `sys-kernel/gentoo-kernel`; not a CJK kernel. |
 | `cjk-bin` | `sys-kernel/gentoo-cjk-kernel-bin`; CJK kernel. |
 | `cjk` | `sys-kernel/gentoo-cjk-kernel`; CJK kernel. |
+| `xanmod` | `sys-kernel/xanmod-kernel`; CJK kernel, built from source. |
 
 | `kernel.remote_unlock` key | Meaning and default |
 | --- | --- |
@@ -516,8 +517,8 @@ A verified binhost runs `getuto`, imports its signing key, locally signs that ke
 | Code | `gentoo-install` |
 | --- | --- |
 | `0` | successful completion |
-| `1` | configuration error |
-| `2` | `argparse` usage error or preflight failure |
+| `1` | configuration error, including an `argparse` usage error |
+| `2` | preflight failure |
 | `3` | integrity failure |
 | `4` | download, external-command, OS or uncategorized installer failure |
 | `5` | operator abort |

--- a/tests/unit/test_project_docs.py
+++ b/tests/unit/test_project_docs.py
@@ -169,3 +169,38 @@ def test_security_says_when_the_staged_passphrase_goes() -> None:
         if isinstance(node, ast.Attribute) and node.attr == "cleanup_secrets"
     ]
     assert cleaned, ast.dump(tree)[:200]
+
+def test_the_reference_lists_every_kernel_source_and_the_real_exit_codes() -> None:
+    """Two tables in `REFERENCE.md` were written once and not kept.
+
+    The kernel table names four of the five `KernelSource` members: `xanmod`
+    is offered on the Kernel screen and merges `sys-kernel/xanmod-kernel`, so
+    the reference described a choice the installer has as one it does not.
+
+    The exit-code table gave `2` to an argparse usage error. `cli.py`
+    translates the parser's `SystemExit(2)` to `EXIT_CONFIG`, so the process
+    exits `1` and `2` is preflight alone. Both are read off the code here
+    rather than repeated.
+    """
+    import subprocess
+    import sys
+
+    from gentoo_install.cli import EXIT_CONFIG, EXIT_PREFLIGHT
+    from gentoo_install.model.compat import KERNEL_PACKAGES
+
+    said = (ROOT / "REFERENCE.md").read_text(encoding="utf-8")
+
+    assert len(KERNEL_PACKAGES) >= 5, sorted(one.value for one in KERNEL_PACKAGES)
+    for source, package in KERNEL_PACKAGES.items():
+        assert f"`{source.value}`" in said, source.value
+        assert f"`{package.atom}`" in said, package.atom
+
+    # What the parser actually does, not what the table remembers.
+    refused = subprocess.run(
+        [sys.executable, "-m", "gentoo_install", "--an-option-that-does-not-exist"],
+        capture_output=True,
+        cwd=ROOT,
+    )
+    assert refused.returncode == EXIT_CONFIG, refused.returncode
+    assert f"| `{EXIT_CONFIG}` | configuration error" in said, said[:0]
+    assert f"| `{EXIT_PREFLIGHT}` | preflight failure |" in said


### PR DESCRIPTION
`REFERENCE.md` names four of the five `KernelSource` members. `xanmod` is offered on the Kernel screen, merges `sys-kernel/xanmod-kernel` and carries the cjktty patch, so the reference described a choice the installer has as one it does not.

The exit-code table gave `2` to an argparse usage error. `cli.py` translates the parser`s `SystemExit(2)` into `EXIT_CONFIG`, so the process exits `1` and `2` belongs to preflight alone.

Both tables describe something the code already holds, so the test reads it there: it walks `KERNEL_PACKAGES` and requires each value and atom in the document, and it runs `python3 -m gentoo_install` with an unknown option and compares the real exit status against `EXIT_CONFIG`. A sixth kernel source will fail it. The control was run red.