### PR TITLE
docs: let the memory-mode section claim only what it records

### DIFF
--- a/TESTED.md
+++ b/TESTED.md
@@ -288,13 +288,15 @@ cluster fixture left it with the row above.
 
 ## Mode 3: boot into RAM, then install or write an image
 
-Implemented and wired into `cli.py`, and every path in it has a record:
-machines rebooted into both environments it arms, and an image written and
-read back. `--ram` fetches the Gentoo CJK ISO, `--lowram` the
-Alpine netboot archive; both place a kernel where the machine's own bootloader
-reads one, deliver the configuration and the installer's own tree in a cpio
-appended to the initramfs, and arm a single boot. `--bypass` replaces the
-default entry instead of arming one boot.
+Implemented and wired into `cli.py`. What has a record: machines rebooted
+into both environments it arms, and an image written and read back. What has
+none is named at the end of this section, and `--disarm` is one of them.
+
+`--ram` fetches the Gentoo CJK ISO, `--lowram` the Alpine netboot archive; both
+place a kernel where the machine's own bootloader reads one, deliver the
+configuration and the installer's own tree in a cpio appended to the initramfs,
+and arm a single boot. `--bypass` replaces the default entry instead of arming
+one boot.
 
 `dd` writes a prepared image over a whole disk from inside that environment,
 streamed rather than staged, and is offered only on a live medium or in a
@@ -440,8 +442,9 @@ assumed, and each contradicted a reading of the source that preceded it:
 | Does an appended segment reach the initramfs at all? | Only from a four-byte boundary. Alpine's `initramfs-lts` is 27951899 bytes, 3 mod 4, and a guest booted with the segment appended to it printed no sign of the payload; one zero byte in front of the same segment answered `Loading user settings from /gentoo-install.apkovl.tar.gz: ok.` |
 
 What has no record yet: a machine that goes on to install Gentoo from inside
-the environment it came up in, and a deliberately failed arming proving the
-machine returns to its own system because the entry is one-shot.
+the environment it came up in; a deliberately failed arming proving the
+machine returns to its own system because the entry is one-shot; and
+`--disarm`, which `REFERENCE.md` documents and no run here has exercised.
 
 ## The interface alone, from the menu to a booted system
 

--- a/tests/unit/test_project_docs.py
+++ b/tests/unit/test_project_docs.py
@@ -204,3 +204,29 @@ def test_the_reference_lists_every_kernel_source_and_the_real_exit_codes() -> No
     assert refused.returncode == EXIT_CONFIG, refused.returncode
     assert f"| `{EXIT_CONFIG}` | configuration error" in said, said[:0]
     assert f"| `{EXIT_PREFLIGHT}` | preflight failure |" in said
+
+
+def test_the_memory_mode_section_does_not_claim_more_than_it_records() -> None:
+    """Two sentences in one section contradicted each other.
+
+    It opened with `every path in it has a record` and closed with `What has
+    no record yet:` naming two of them. `--disarm` is a real option and
+    appeared nowhere in the file at all. This is the document `README.md`
+    points at for the verification boundary, so an over-claim here is the
+    expensive kind.
+    """
+    from gentoo_install.cli import parser
+
+    said = (ROOT / "TESTED.md").read_text(encoding="utf-8")
+    section = said[said.index("## Mode 3") : said.index("## The interface alone")]
+
+    assert "every path in it has a record" not in section, section[:200]
+    unrecorded = section[section.index("What has no record yet") :]
+
+    memory = {"--ram", "--lowram", "--bypass", "--disarm"}
+    offered = {one for action in parser()._actions for one in action.option_strings}
+    assert memory <= offered, sorted(memory - offered)
+    for flag in sorted(memory):
+        assert f"`{flag}`" in section, flag
+    # The one no run has exercised is named where the gaps are named.
+    assert "`--disarm`" in unrecorded, unrecorded[:200]


### PR DESCRIPTION
`TESTED.md`s Mode 3 section opened with `every path in it has a record` and closed with `What has no record yet:` naming two of them. `--disarm` is a real option and appeared nowhere in the file.

This is the document `README.md` points at for the verification boundary, so an over-claim here is the expensive kind: a reader decides whether to trust the memory mode on that sentence, and it is contradicted three paragraphs later.

The opening now lists the two things that do have a record and points at the closing paragraph for the rest, where `--disarm` joins them. The test reads the four memory-mode options off `parser()`, requires each in the section, and requires the unrecorded one to appear after `What has no record yet` — not that a word is in the file, but which half of it the word is in. The control was run red.