### PR TITLE
docs: describe the disk keys the parser accepts

### DIFF
--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -420,8 +420,8 @@ The following reference names every persisted key. A table path is TOML table no
 
 | `disk` key | Meaning and default or choices |
 | --- | --- |
-| `graph` | Device graph represented by `[[disk.devices]]`; required. |
-| `root` | Root graph-node identifier; required outside conversion; `""` uses the running layout in conversion. |
+| `devices` | The device graph, written as `[[disk.devices]]` tables. Either these or `[disk.simple]`, never both. |
+| `root` | Root graph-node identifier. Required with `[[disk.devices]]`; `[disk.simple]` derives it, and conversion without it uses the running layout. |
 | `mode` | `partition`, `in-place`, `image`, or `dd`; `partition`. |
 | `image` | Sparse image path in image mode; `""`. |
 | `size` | Sparse image size in image mode; unset. |
@@ -433,7 +433,7 @@ The following reference names every persisted key. A table path is TOML table no
 | Template input | Meaning and default or choices |
 | --- | --- |
 | `disk` | Whole-disk selector; required. |
-| `layout` | `whole-disk`, `whole-disk-btrfs`, `whole-disk-zfs`, or `reuse`; `whole-disk`. |
+| `layout` | `whole-disk`, `whole-disk-btrfs`, or `whole-disk-zfs`; `whole-disk`. The menu's `reuse` has no template form: it names partitions that already exist, so a file writes those as `[[disk.devices]]`. |
 | `firmware` | Template firmware; `uefi`. |
 | `table` | Partition-table override; unset derives GPT for UEFI and MBR for BIOS. |
 | `filesystem` | Root filesystem for non-Btrfs and non-ZFS whole-disk layouts; `xfs`. |

--- a/tests/unit/test_readme.py
+++ b/tests/unit/test_readme.py
@@ -5,6 +5,8 @@ from __future__ import annotations
 
 import re
 import tomllib
+
+import pytest
 from pathlib import Path
 from typing import Final
 
@@ -394,3 +396,43 @@ def test_the_reference_names_every_persisted_key() -> None:
     assert len(every) > 60, len(every)
     missing = [path for path, leaf in every if f"`{leaf}`" not in said]
     assert missing == [], missing
+
+def test_the_disk_tables_describe_what_the_parser_accepts() -> None:
+    """Three claims in the disk tables were refused by the parser.
+
+    `graph` was named as a `disk` key and `disk has unknown keys: graph` is
+    what a file using it gets; `root` was called required outside conversion
+    and a complete `[disk.simple]` without it parses; `reuse` was listed as a
+    template layout and the parser refuses it by name, telling the operator
+    to write the partitions as devices instead.
+
+    Run rather than read: each row is checked by parsing a file that uses it.
+    """
+    import tomllib
+
+    from gentoo_install.errors import GentooInstallError
+    from gentoo_install.model.parse import parse
+
+    said = (ROOT / REFERENCE).read_text(encoding="utf-8")
+    assert "| `graph` |" not in said, "the disk table names a key the parser refuses"
+    assert "| `devices` |" in said, said[:0]
+
+    header = (
+        'config_version = 1\n[system]\nroot_password_hash = "'
+        "$6$gentooinst$IR3GrdJ862XljQYDqocr4tKniIRDIT.jQNFzIrHE3U75H6B6YSWZoSYoVd5"
+        'edSHpqaYBdiNfXHCoIPRVgb9lT/"\n'
+    )
+    simple = f'{header}[disk.simple]\ndisk = "/dev/disk/by-id/one"\n'
+
+    # No `root`, and it parses: the table must not call it required here.
+    parse(tomllib.loads(simple))
+    root_row = next(line for line in said.splitlines() if line.startswith("| `root` |"))
+    assert "Required with `[[disk.devices]]`" in root_row, root_row
+
+    # `reuse` is refused, so it is not a template layout.
+    with pytest.raises(GentooInstallError, match="reuse"):
+        parse(tomllib.loads(f'{simple}layout = "reuse"\n'))
+    layout_row = next(
+        line for line in said.splitlines() if line.startswith("| `layout` |")
+    )
+    assert "`reuse`" in layout_row and "no template form" in layout_row, layout_row


### PR DESCRIPTION
Three rows in the disk tables describe something the parser refuses, and each was checked by parsing a file that uses it.

`graph` was listed as a `disk` key; a file with it gets `disk has unknown keys: graph`, and the key is `[[disk.devices]]`. `root` was called required outside conversion; a complete `[disk.simple]` without it parses and validates. `reuse` was listed as a template layout; `parse.py` refuses it by name and tells the operator to write those partitions as devices, because it means partitions that already exist.

The test parses a real file for each row rather than matching strings: the `reuse` row requires the parser to raise, the `root` row requires it not to. The control was run red.