### PR TITLE
vm: give the detached install a pty so its output leaves the process

### DIFF
--- a/tests/unit/test_cluster.py
+++ b/tests/unit/test_cluster.py
@@ -9,6 +9,7 @@ import os
 import re
 import signal
 import subprocess
+import sys
 import time
 import urllib.request
 from collections.abc import Callable
@@ -4809,3 +4810,54 @@ def test_the_follower_says_the_install_grew_and_stays_silent_when_it_did_not(
     )
     ender.wait(timeout=10)
     assert cluster.INSTALL_BYTES not in stopped.stdout, stopped.stdout
+
+
+def test_the_detached_install_writes_through_a_pty(tmp_path: Path) -> None:
+    """A redirect into a file leaves the install block-buffering.
+
+    Rounds 31 and 32 ended `btrfs-luks` and `vm-desktop` inside `emerge
+    kde-plasma/plasma-meta`, which both had passed under the `tee` this
+    replaced — and `tee` was reading a pty. `vm-cjk-kernel` and `vm-lvm`
+    passed either way, because their work prints constantly; a long C++ link
+    does not, and nothing reached `install.txt` for longer than
+    `INSTALL_IDLE`.
+
+    Measured rather than argued: the same program under a plain redirect has
+    written nothing while it is running, and under `script` its lines are
+    already there. `script -e` carries the child's exit status out, which is
+    what `install.rc` records.
+    """
+    printer = tmp_path / "slow.py"
+    printer.write_text(
+        "import sys, time\n"
+        "for i in range(6):\n"
+        "    sys.stdout.write(f'line {i}\\n')\n"
+        "    time.sleep(1)\n"
+        "sys.exit(7)\n"
+    )
+
+    def written_after(command: str, name: str) -> int:
+        out = tmp_path / name
+        running = subprocess.Popen(["sh", "-c", f"{command} > {out} 2>&1"])
+        time.sleep(3)
+        early = out.stat().st_size if out.exists() else 0
+        running.wait(timeout=30)
+        return early
+
+    plain = written_after(f"{sys.executable} {printer}", "plain.txt")
+    through = written_after(
+        f"script -q -e -c '{sys.executable} {printer}' /dev/null", "pty.txt"
+    )
+    assert plain == 0, plain
+    assert through > 0, through
+
+    # The exit status still reaches `install.rc`.
+    kept = subprocess.run(
+        ["sh", "-c", f"script -q -e -c '{sys.executable} {printer}' /dev/null"],
+        capture_output=True,
+        timeout=60,
+    )
+    assert kept.returncode == 7, kept.returncode
+
+    # And the launcher puts the install inside it.
+    assert "script -q -e -c" in cluster.detached_install("x.toml")

--- a/tests/vm/cluster.py
+++ b/tests/vm/cluster.py
@@ -3205,12 +3205,24 @@ def detached_install(
     a second `starting serial terminal on interface serial0` and a fresh
     `root@livecd ~ #` under it.
 
+    Under `script`, which gives it a pty. A redirect into a file leaves
+    portage block-buffering, so `install.txt` grows in chunks of tens of
+    kilobytes and a long C++ link inside `emerge kde-plasma/plasma-meta`
+    writes nothing for longer than `INSTALL_IDLE`: rounds 31 and 32 ended
+    `btrfs-luks` and `vm-desktop` there, both of which had passed the same
+    merge under the `tee` this replaced, and `tee` was reading a pty. Guests
+    whose work prints constantly, `vm-cjk-kernel` and `vm-lvm`, passed either
+    way, which is what separates the two.
+
     Braced: the console wrapper appends `; printf MARK`, and a bare `&`
     followed by `;` is a syntax error. Guarded on `install.txt`, so a resend
     after a reconnect starts nothing a second time.
     """
+    inside = f"sh {entry} --config fixtures/{fixture_name}"
     body = (
-        f"{{ sh {entry} --config fixtures/{fixture_name}; "
+        # Double quotes: the whole command is already inside the single-quoted
+        # `sh -c` the launcher wraps it in.
+        f'{{ script -q -e -c "{inside}" /dev/null; '
         f"echo $? > {results}/install.rc; }} > {results}/install.txt 2>&1"
     )
     return (


### PR DESCRIPTION
Rounds 31 and 32 ended `btrfs-luks` and `vm-desktop` inside `emerge kde-plasma/plasma-meta`. Both had passed that merge at 126.6 and 104.1 minutes under the `tee` the detached install replaced, and `tee` was reading a pty. In the same round `vm-cjk-kernel` and `vm-lvm` passed with 43 and 49 heartbeats, because their work prints constantly.

That is the difference. The heartbeat added for the previous layer reads `stat -c%s install.txt`, and the file itself does not grow: a redirect into a file leaves the process block-buffering, so a long C++ link writes nothing for longer than `INSTALL_IDLE`.

Measured rather than argued: the same program, three lines in, has written 0 bytes under a plain redirect and 24 under `script -q -e -c`. The install goes back inside a pty, and `-e` carries the child`s exit status out to `install.rc`.

This is the third layer of one change — the hangup killed the foreground install, `tail -n 0` then let the console fall silent, and the output was not leaving the process at all. Each layer showed up only on the heaviest fixture, which is why `vm-cjk-kernel` passing three rounds running never tested it. The control was run red.