### PR TITLE
netboot: say what the memory environment left on the machine

### DIFF
--- a/gentoo_install/cli.py
+++ b/gentoo_install/cli.py
@@ -149,7 +149,10 @@ def parser() -> argparse.ArgumentParser:
     parsed.add_argument(
         "--dry-run",
         action="store_true",
-        help="print the operations the configuration produces and exit without touching anything",
+        help=(
+            "print the operations the configuration produces and exit without "
+            "applying any of them"
+        ),
     )
     parsed.add_argument("--mirror", default=DEFAULT_MIRROR, help="where to fetch stage3 from")
     parsed.add_argument(

--- a/gentoo_install/plan/netboot.py
+++ b/gentoo_install/plan/netboot.py
@@ -116,6 +116,11 @@ PLACE: Final[str] = "gentoo-install-ram"
 #: from the esp, and those are tens of megabytes.
 STAGING: Final[PurePosixPath] = PurePosixPath("/") / PLACE
 
+#: What the decline answers, in the banner's own words. `nothing was changed`
+#: was wrong for the same reason the banner no longer says the disk is
+#: untouched: the payload and the boot entry are already on the machine.
+DECLINED: Final[str] = "no partition table and no filesystem was changed"
+
 #: What the entry is called wherever the boot method keeps names.
 ENTRY_LABEL: Final[str] = "gentoo-install memory environment"
 
@@ -855,7 +860,7 @@ def _start(mode: MemoryMode) -> str:
         "yes|y|install)\n"
         # `sh`, not `exec sh`: this is sourced, so exec removes the login shell.
         + f"    sh {COMMAND} ;;\n"
-        + f"*) printf '%s\\n' 'nothing was changed; run {COMMAND} when ready' ;;\n"
+        + f"*) printf '%s\\n' '{DECLINED}; run {COMMAND} when ready' ;;\n"
         "esac\n"
     )
 

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -3084,3 +3084,28 @@ def test_a_conversion_that_replaced_usr_is_not_told_nothing_was_written() -> Non
     quiet = cli.RunState()
     quiet.operation_started(_at_stage(Stage.PREFLIGHT))
     assert not quiet.disk_was_written
+
+
+def test_the_dry_run_help_promises_only_what_a_dry_run_keeps() -> None:
+    """It said a dry run exits `without touching anything`, and it can set the RTC.
+
+    A dry run with no configuration opens the menu, which reads versions over
+    HTTPS, so `_needs_network` is true and `_check_the_clock` runs before the
+    read: a machine more than a day out has `hwclock --set` and
+    `hwclock --hctosys` run on it. Both facts are read off the code here, so
+    the day either of them changes this stops holding the promise to the
+    weaker wording.
+    """
+    import inspect
+
+    arguments = cli.parser().parse_args(["--dry-run"])
+    assert arguments.config is None
+    assert cli._needs_network(arguments), "a dry run with no config reads the network"
+    assert "hwclock" in inspect.getsource(cli._check_the_clock)
+
+    said = next(
+        one.help for one in cli.parser()._actions if "--dry-run" in one.option_strings
+    )
+    assert said is not None
+    assert "anything" not in said, said
+    assert "without applying any of them" in said, said

--- a/tests/unit/test_plan_netboot.py
+++ b/tests/unit/test_plan_netboot.py
@@ -1403,16 +1403,25 @@ def test_the_first_screen_asks_and_leaves_the_login_shell_alive(
     assert "LOGIN-SHELL-ALIVE" in said, said
 
 
-def test_any_other_answer_changes_nothing(
+def test_any_other_answer_installs_nothing_and_says_only_that(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
     """Two answers and no timeout, and everything that is not the install is
-    the rescue shell."""
+    the rescue shell.
+
+    It said `nothing was changed`, which is the claim the banner above it
+    stopped making: the kernel, the initramfs and the boot entry are on the
+    machine before this screen is reached. Both now say the same thing, and
+    the banner is read here rather than repeated.
+    """
     where = _payload_at(tmp_path, monkeypatch)
+    banner = " ".join(netboot.BANNER[MemoryMode.RAM])
+    assert netboot.DECLINED.removesuffix(" was changed") in banner, banner
 
     for answer in ("shell", "", "no", "INSTALL"):
         said = _sourced(where, answer)
-        assert "nothing was changed" in said, (answer, said)
+        assert netboot.DECLINED in said, (answer, said)
+        assert "nothing was changed" not in said, (answer, said)
         assert "BOOTSTRAP" not in said, (answer, said)
         assert "LOGIN-SHELL-ALIVE" in said, (answer, said)
 


### PR DESCRIPTION
The banner stopped claiming the disk is untouched because `PlaceMemoryKernel` and `WriteMemoryEntry` run before that screen is reached. The answer beside it still printed `nothing was changed`, so the correction landed on one of the two texts. The test reads the banner rather than repeating it.

`--dry-run` promised an exit `without touching anything`. Without `--config` it opens the menu, so `_needs_network` is true and `_check_the_clock` can run `hwclock --set` first. `REFERENCE.md` was already accurate, so the help is what changes.