### PR TITLE
netboot: take back everything an arming put on the machine

### DIFF
--- a/gentoo_install/data/locale/ja.toml
+++ b/gentoo_install/data/locale/ja.toml
@@ -669,7 +669,7 @@
 "write a {} entry for the {} environment" = "{} 用のエントリーを書き込む（{} 環境）"
 "write {}, a {} entry for the {} environment" = "{} を書き込む：{} 用のエントリー、{} 環境"
 "arm one boot into the memory environment with {}" = "{} でメモリー環境への一度きりの起動を設定"
-"replace the default boot entry with the memory environment ({})" = "既定の起動エントリーをメモリー環境に置き換える（{}）"
+"replace the default boot entry with the memory environment ({}) and write {}, which is what lets a disarm take the replacement back" = "既定の起動エントリーをメモリー環境に置き換え（{}）、解除時に置き換えを戻す根拠となる {} を書き込む"
 "take back the armed boot and delete what it placed" = "設定した起動を取り消し、配置したものを削除"
 "download the newest {} stage3 from {} via {}, verify it against {}, unpack it into the target and write {}" = "最新の {} stage3 を {} から {} 経由でダウンロードし、{} で検証してインストール先へ展開し、{} を書き込む"
 "download the newest {} stage3 from {} directly, verify it against {}, unpack it into the target and write {}" = "最新の {} stage3 を {} から直接ダウンロードし、{} で検証してインストール先へ展開し、{} を書き込む"

--- a/gentoo_install/data/locale/ko.toml
+++ b/gentoo_install/data/locale/ko.toml
@@ -669,7 +669,7 @@
 "write a {} entry for the {} environment" = "{} 항목 작성 ({} 환경)"
 "write {}, a {} entry for the {} environment" = "{} 작성: {} 항목, {} 환경"
 "arm one boot into the memory environment with {}" = "{}로 메모리 환경 일회성 부팅 설정"
-"replace the default boot entry with the memory environment ({})" = "기본 부팅 항목을 메모리 환경으로 교체 ({})"
+"replace the default boot entry with the memory environment ({}) and write {}, which is what lets a disarm take the replacement back" = "기본 부팅 항목을 메모리 환경으로 교체하고 ({}) 해제할 때 되돌릴 근거를 {} 경로에 기록"
 "take back the armed boot and delete what it placed" = "설정한 부팅을 되돌리고 배치한 파일 삭제"
 "download the newest {} stage3 from {} via {}, verify it against {}, unpack it into the target and write {}" = "최신 {} stage3를 {}에서 {}를 통해 내려받고 {}로 검증한 뒤 설치 대상에 풀고 {} 작성"
 "download the newest {} stage3 from {} directly, verify it against {}, unpack it into the target and write {}" = "최신 {} stage3를 {}에서 직접 내려받고 {}로 검증한 뒤 설치 대상에 풀고 {} 작성"

--- a/gentoo_install/data/locale/zh-CN.toml
+++ b/gentoo_install/data/locale/zh-CN.toml
@@ -670,7 +670,7 @@
 "write a {} entry for the {} environment" = "写入 {} 的启动项，用于 {} 环境"
 "write {}, a {} entry for the {} environment" = "写入 {}：{} 的启动项，用于 {} 环境"
 "arm one boot into the memory environment with {}" = "以 {} 预约一次进入内存环境的启动"
-"replace the default boot entry with the memory environment ({})" = "将默认启动项换成内存环境（{}）"
+"replace the default boot entry with the memory environment ({}) and write {}, which is what lets a disarm take the replacement back" = "将默认启动项换成内存环境（{}），并写入 {}，解除武装靠它还原这次替换"
 "take back the armed boot and delete what it placed" = "取消启动预约并删除它放置的文件"
 "download the newest {} stage3 from {} via {}, verify it against {}, unpack it into the target and write {}" = "下载最新的 {} stage3，来源 {}，通过 {}，使用 {} 验证后解包到目标系统，并写入 {}"
 "download the newest {} stage3 from {} directly, verify it against {}, unpack it into the target and write {}" = "下载最新的 {} stage3，直接取自 {}，使用 {} 验证后解包到目标系统，并写入 {}"

--- a/gentoo_install/data/locale/zh-TW.toml
+++ b/gentoo_install/data/locale/zh-TW.toml
@@ -670,7 +670,7 @@
 "write a {} entry for the {} environment" = "寫入 {} 的開機項目，用於 {} 環境"
 "write {}, a {} entry for the {} environment" = "寫入 {}：{} 的開機項目，用於 {} 環境"
 "arm one boot into the memory environment with {}" = "以 {} 預約一次進入記憶體環境的開機"
-"replace the default boot entry with the memory environment ({})" = "將預設開機項目換成記憶體環境（{}）"
+"replace the default boot entry with the memory environment ({}) and write {}, which is what lets a disarm take the replacement back" = "將預設開機項目換成記憶體環境（{}），並寫入 {}，解除武裝靠它還原這次替換"
 "take back the armed boot and delete what it placed" = "取消開機預約並刪除它放置的檔案"
 "download the newest {} stage3 from {} via {}, verify it against {}, unpack it into the target and write {}" = "下載最新的 {} stage3，來源 {}，經由 {}，以 {} 驗證後解開至目標系統，並寫入 {}"
 "download the newest {} stage3 from {} directly, verify it against {}, unpack it into the target and write {}" = "下載最新的 {} stage3，直接取自 {}，以 {} 驗證後解開至目標系統，並寫入 {}"

--- a/gentoo_install/plan/netboot.py
+++ b/gentoo_install/plan/netboot.py
@@ -327,8 +327,29 @@ def _take_back(context: Context, target: BootTarget) -> None:
     arming writes, the other when the operator changed their mind.
     """
     _disarm(context, target)
+    _remove_the_entry(context, target)
     for gone in (target.place, STAGING):
         context.run(["rm", "--recursive", "--force", str(gone)], check=False)
+
+
+def _remove_the_entry(context: Context, target: BootTarget) -> None:
+    """Delete what `WriteMemoryEntry` wrote, which is outside `target.place`.
+
+    Deleting the kernel and leaving the entry gives a menu whose first choice
+    stops at `error: file not found` for ever, and on `--bypass` that entry is
+    also the default.
+    """
+    if target.method is BootMethod.SYSTEMD_BOOT:
+        entry = PurePosixPath(str(target.esp_mountpoint)) / "loader" / "entries" / f"{PLACE}.conf"
+        context.run(["rm", "--force", str(entry)], check=False)
+        return
+    if target.grub_directory is None:
+        return
+    custom = PurePosixPath(target.grub_directory) / "custom.cfg"
+    written = context.read(custom)
+    kept = _without_previous(written)
+    if kept != written:
+        context.write(custom, kept)
 
 
 def _disarm(context: Context, target: BootTarget) -> None:

--- a/gentoo_install/plan/netboot.py
+++ b/gentoo_install/plan/netboot.py
@@ -121,6 +121,10 @@ STAGING: Final[PurePosixPath] = PurePosixPath("/") / PLACE
 #: untouched: the payload and the boot entry are already on the machine.
 DECLINED: Final[str] = "no partition table and no filesystem was changed"
 
+#: Written inside the placed directory by `--bypass` alone, so a disarm can
+#: tell a default this installer replaced from one the operator chose.
+BYPASS_RECORD: Final[str] = "replaced-default"
+
 #: What the entry is called wherever the boot method keeps names.
 ENTRY_LABEL: Final[str] = "gentoo-install memory environment"
 
@@ -362,6 +366,11 @@ def _disarm(context: Context, target: BootTarget) -> None:
     """
     if target.method is BootMethod.SYSTEMD_BOOT:
         context.run(["bootctl", "set-oneshot", ""], check=False)
+        if context.read(target.place / BYPASS_RECORD):
+            # An empty ID unsets the variable, `bootctl(1)`. Only on the record
+            # `--bypass` left: the machine falls back to `loader.conf`, and one
+            # that was never bypassed keeps the default the operator set.
+            context.run(["bootctl", "set-default", ""], check=False)
         return
     if target.grub_directory is not None:
         environment = f"{target.grub_directory}/grubenv"
@@ -1089,12 +1098,19 @@ class ReplaceDefaultBoot(Operation):
     stage: Stage = Stage.BOOTLOADER
     target: BootTarget
 
+    def destinations(self) -> tuple[PurePosixPath, ...]:
+        return (self.target.place / BYPASS_RECORD,)
+
     def describe_parts(self) -> tuple[str, tuple[str, ...]]:
-        return "replace the default boot entry with the memory environment ({})", (
-            self.target.method.value,
+        (record,) = self.destinations()
+        return (
+            "replace the default boot entry with the memory environment ({}) and "
+            "write {}, which is what lets a disarm take the replacement back",
+            (self.target.method.value, str(record)),
         )
 
     def apply(self, context: Context) -> None:
+        context.write(self.target.place / BYPASS_RECORD, f"{self.target.method.value}\n")
         if self.target.method is BootMethod.SYSTEMD_BOOT:
             context.run(["bootctl", "set-default", f"{PLACE}.conf"])
             return

--- a/gentoo_install/plan/netboot.py
+++ b/gentoo_install/plan/netboot.py
@@ -364,10 +364,16 @@ def _disarm(context: Context, target: BootTarget) -> None:
         context.run(["bootctl", "set-oneshot", ""], check=False)
         return
     if target.grub_directory is not None:
-        context.run(
-            ["grub-editenv", f"{target.grub_directory}/grubenv", "unset", "next_entry"],
-            check=False,
-        )
+        environment = f"{target.grub_directory}/grubenv"
+        context.run(["grub-editenv", environment, "unset", "next_entry"], check=False)
+        # Only when it names this installer's entry: `--bypass` wrote it with
+        # `grub-set-default`, and unsetting it unconditionally would throw away
+        # a default the operator chose on a machine that was never bypassed.
+        # The whole line, so a failure's message on stdout cannot match it and
+        # the exit code does not have to be read here.
+        listed = context.run(["grub-editenv", environment, "list"], check=False)
+        if f"saved_entry={ENTRY_LABEL}" in str(listed).splitlines():
+            context.run(["grub-editenv", environment, "unset", "saved_entry"], check=False)
 
 
 @dataclass(frozen=True, kw_only=True)

--- a/tests/golden/memory-bypass.txt
+++ b/tests/golden/memory-bypass.txt
@@ -9,4 +9,4 @@
 [bootloader]
   unpack the ram kernel and initramfs into /boot/efi/gentoo-install-ram
   write /boot/efi/loader/entries/gentoo-install-ram.conf, a systemd-boot entry for the ram environment
-  replace the default boot entry with the memory environment (systemd-boot)
+  replace the default boot entry with the memory environment (systemd-boot) and write /boot/efi/gentoo-install-ram/replaced-default, which is what lets a disarm take the replacement back

--- a/tests/unit/test_i18n.py
+++ b/tests/unit/test_i18n.py
@@ -569,6 +569,8 @@ REVIEWED_TEMPLATES: frozenset[str] = frozenset(
         "write {} for the wired interfaces with DHCP and DNS {}",
         "write {} for {} with DHCP",
         "configure {} of compressed swap in {}",
+        "replace the default boot entry with the memory environment ({}) and write {},"
+        " which is what lets a disarm take the replacement back",
         "create user {} in {} with a password",
         "create user {} in {} with no password",
         "download the newest {} stage3 from {} directly, verify it against {},"

--- a/tests/unit/test_layers.py
+++ b/tests/unit/test_layers.py
@@ -751,6 +751,7 @@ def test_the_dry_run_names_every_file_only_its_owner_may_read() -> None:
         "ConfigureZram",
         "GenerateLocales",
         "GrantSudo",
+        "ReplaceDefaultBoot",
         "SelectLocale",
         "SettleBinhostFeature",
         "SetHardwareClock",

--- a/tests/unit/test_plan_netboot.py
+++ b/tests/unit/test_plan_netboot.py
@@ -1150,6 +1150,50 @@ def test_the_placed_directory_goes_with_the_arming() -> None:
     ), recorder.commands
 
 
+def test_taking_an_arming_back_removes_the_entry_it_wrote() -> None:
+    """The kernel went and the entry stayed, on every path and not only
+
+    `--bypass`. `WriteMemoryEntry` writes outside `target.place`, which is all
+    `_take_back` deleted, so the menu kept a first choice that stops at
+    `error: file not found` and on `--bypass` that choice was the default.
+    """
+    target = _target()
+    written = netboot.WriteMemoryEntry(
+        mode=MemoryMode.RAM, target=target, launch=_launch()
+    ).destinations()
+    assert written, "systemd-boot writes an entry file and this reads its name"
+
+    recorder = _answering()
+    netboot.ClearPreviousArming(target=target).apply(recorder)
+
+    assert any(
+        one[0] == "rm" and str(written[0]) in one for one in recorder.commands
+    ), recorder.commands
+
+
+def test_taking_an_arming_back_leaves_a_grub_machine_its_own_entries() -> None:
+    """The marker block goes and everything the operator wrote stays.
+
+    Armed and then taken back through the same recorder, because whether the
+    rewritten file still holds somebody else's `menuentry` is not visible in
+    either function on its own.
+    """
+    target = _target(BootMethod.BIOS_GRUB)
+    custom = PurePosixPath(str(target.grub_directory)) / "custom.cfg"
+    theirs = "menuentry 'memtest86+' {\n    linux16 /boot/memtest\n}\n"
+
+    recorder = _answering()
+    recorder.files[custom] = theirs
+    netboot.WriteMemoryEntry(mode=MemoryMode.RAM, target=target, launch=_launch()).apply(recorder)
+    assert netboot.CUSTOM_BEGIN in recorder.files[custom]
+
+    netboot.ClearPreviousArming(target=target).apply(recorder)
+
+    assert netboot.CUSTOM_BEGIN not in recorder.files[custom], recorder.files[custom]
+    assert netboot.ENTRY_LABEL not in recorder.files[custom], recorder.files[custom]
+    assert "memtest86+" in recorder.files[custom], recorder.files[custom]
+
+
 def test_disarming_and_clearing_ask_for_the_same_thing() -> None:
     """One way of taking an arming back, or the two drift and the operator
     who answers no is left with a machine armed differently from one whose

--- a/tests/unit/test_plan_netboot.py
+++ b/tests/unit/test_plan_netboot.py
@@ -1223,6 +1223,28 @@ def test_a_bypassed_grub_machine_gets_its_own_saved_entry_back() -> None:
     ) not in theirs.commands, theirs.commands
 
 
+def test_only_a_bypassed_machine_has_its_systemd_boot_default_cleared() -> None:
+    """`--bypass` persisted a default and the disarm cleared the one-shot alone.
+
+    The entry that default names is deleted in the same operation, so the
+    machine chose a kernel that is not there. Armed and taken back through one
+    recorder, because whether the record is there when `_disarm` reads it
+    depends on the order the two operations run in.
+    """
+    target = _target()
+    recorder = _answering()
+    netboot.ReplaceDefaultBoot(target=target).apply(recorder)
+    assert recorder.files[target.place / netboot.BYPASS_RECORD]
+
+    netboot.ClearPreviousArming(target=target).apply(recorder)
+    assert ("bootctl", "set-default", "") in recorder.commands, recorder.commands
+
+    # A machine that was never bypassed keeps the default the operator set.
+    ordinary = _answering()
+    netboot.ClearPreviousArming(target=target).apply(ordinary)
+    assert ("bootctl", "set-default", "") not in ordinary.commands, ordinary.commands
+
+
 def test_disarming_and_clearing_ask_for_the_same_thing() -> None:
     """One way of taking an arming back, or the two drift and the operator
     who answers no is left with a machine armed differently from one whose

--- a/tests/unit/test_plan_netboot.py
+++ b/tests/unit/test_plan_netboot.py
@@ -1194,6 +1194,35 @@ def test_taking_an_arming_back_leaves_a_grub_machine_its_own_entries() -> None:
     assert "memtest86+" in recorder.files[custom], recorder.files[custom]
 
 
+def test_a_bypassed_grub_machine_gets_its_own_saved_entry_back() -> None:
+    """`--bypass` runs `grub-set-default`, and taking it back left it.
+
+    The entry it names is deleted in the same operation, so GRUB then chose a
+    kernel that is not there. Guarded by the whole line rather than unset
+    outright: on a machine that was never bypassed, `saved_entry` is the
+    operator's own default.
+    """
+    target = _target(BootMethod.BIOS_GRUB)
+    environment = f"{target.grub_directory}/grubenv"
+
+    ours = _answering()
+    ours.answering = lambda argv: (
+        f"saved_entry={netboot.ENTRY_LABEL}\n" if argv[-1] == "list" else None
+    )
+    netboot.ClearPreviousArming(target=target).apply(ours)
+    assert ("grub-editenv", environment, "unset", "saved_entry") in ours.commands, ours.commands
+
+    theirs = _answering()
+    theirs.answering = lambda argv: "saved_entry=Debian GNU/Linux\n" if argv[-1] == "list" else None
+    netboot.ClearPreviousArming(target=target).apply(theirs)
+    assert (
+        "grub-editenv",
+        environment,
+        "unset",
+        "saved_entry",
+    ) not in theirs.commands, theirs.commands
+
+
 def test_disarming_and_clearing_ask_for_the_same_thing() -> None:
     """One way of taking an arming back, or the two drift and the operator
     who answers no is left with a machine armed differently from one whose


### PR DESCRIPTION
Three defects behind one audit line about `--bypass`. `WriteMemoryEntry` writes outside `target.place`, which is all `_take_back` removed, so every disarm — not only a bypassed one — left a menu entry pointing at the kernel it had just deleted.

`grub-set-default` and `bootctl set-default` persist a default naming that entry. GRUB is cleared only when `grub-editenv list` shows the whole line is ours; systemd-boot is cleared on a record `--bypass` writes inside the placed directory, because a machine that was never bypassed keeps the default its operator set. `bootctl(1)` is the source for the empty ID unsetting the variable.

Unverified: no fixture arms `--bypass`, so none of this has a guest behind it.