### PR TITLE
cli: take the affirmative in the language the question was asked in

### DIFF
--- a/gentoo_install/cli.py
+++ b/gentoo_install/cli.py
@@ -771,7 +771,9 @@ def install(
                 record,
                 stopped,
                 _unattended(arguments),
-                _asked,
+                # Bound to the catalog: `offer_paste` asks in the menu's
+                # language and the answer has to be readable in it too.
+                lambda question: _asked(question, translate),
                 show_the_address,
                 translate,
             )
@@ -925,21 +927,36 @@ def _configuration_from(source: str) -> InstallConfig:
     return load_source(source, getpass.getpass("password for this paste: "))
 
 
-def _asked(question: str) -> bool:
+def _asked(question: str, translate: Catalog | None = None) -> bool:
     """Ask, after throwing away what was typed before the question existed.
 
     The menu is curses and the key that left it is still in the terminal's
     input queue when this runs, so `readline` returned it at once: both
     questions after a failed install were answered by keystrokes aimed at the
     screen before them, and the operator watched two offers go past.
+
+    The question is translated and the answer was not, so an operator reading
+    Chinese had to type an English word to say yes.
     """
     _forget_what_was_typed()
     print(f"{question} [y/N] ", end="")
     sys.stdout.flush()
     try:
-        return sys.stdin.readline().strip().lower() in ("y", "yes")
+        return sys.stdin.readline().strip().lower() in _affirmatives(translate)
     except (EOFError, KeyboardInterrupt):
         return False
+
+
+def _affirmatives(translate: Catalog | None) -> frozenset[str]:
+    """What counts as yes here: `y` and `yes`, and whatever the locale adds.
+
+    Both are kept whatever the language, because the hint printed beside the
+    question names them and nothing else.
+    """
+    # The literal at the call, the way every other catalog key is written: the
+    # check that every shipped key is shown reads them out of the source.
+    said = translate("y|yes") if translate is not None else "y|yes"
+    return frozenset({"y", "yes", *(one.strip().lower() for one in said.split("|") if one.strip())})
 
 
 def _forget_what_was_typed() -> None:
@@ -1017,7 +1034,7 @@ def _offer_a_shell(
         if mode is DiskMode.IN_PLACE
         else translate("enter a root shell in {target} before unmounting?")
     ).format(target=target)
-    if not _asked(question):
+    if not _asked(question, translate):
         return
     opened = machine.runner.run(["chroot", str(target), "/bin/bash", "--login"], check=False)
     if opened.returncode in CHROOT_COULD_NOT_START:

--- a/gentoo_install/data/locale/ja.toml
+++ b/gentoo_install/data/locale/ja.toml
@@ -782,3 +782,4 @@
 "the install stopped" = "インストールは停止しました"
 "the install finished" = "インストールが完了しました"
 "{outcome}. send the log to {host}, which is public?" = "{outcome}。ログを {host} に送りますか。公開されます"
+"y|yes" = "y|yes|はい"

--- a/gentoo_install/data/locale/ko.toml
+++ b/gentoo_install/data/locale/ko.toml
@@ -782,3 +782,4 @@
 "the install stopped" = "설치가 중단되었다"
 "the install finished" = "설치가 끝났다"
 "{outcome}. send the log to {host}, which is public?" = "{outcome}. 로그를 {host} 에 보낼까? 공개된다"
+"y|yes" = "y|yes|예"

--- a/gentoo_install/data/locale/zh-CN.toml
+++ b/gentoo_install/data/locale/zh-CN.toml
@@ -783,3 +783,4 @@
 "the install stopped" = "安装已停止"
 "the install finished" = "安装已完成"
 "{outcome}. send the log to {host}, which is public?" = "{outcome}。要把日志发送到 {host} 吗？那是公开的"
+"y|yes" = "y|yes|是|好"

--- a/gentoo_install/data/locale/zh-TW.toml
+++ b/gentoo_install/data/locale/zh-TW.toml
@@ -783,3 +783,4 @@
 "the install stopped" = "安裝已停止"
 "the install finished" = "安裝已完成"
 "{outcome}. send the log to {host}, which is public?" = "{outcome}。要把日誌送到 {host} 嗎？那是公開的"
+"y|yes" = "y|yes|是|好"

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -22,6 +22,7 @@ from gentoo_install.exec.probe import BootMethod, Probe as RealProbe
 from gentoo_install.exec.runner import Result, Runner
 from gentoo_install.cli import EXIT_CONFIG, EXIT_INTEGRITY, EXIT_OK, EXIT_PREFLIGHT, main
 from gentoo_install.errors import CommandFailed, ConfigError, IntegrityError
+from gentoo_install.plan.operations import CommandOutput
 from gentoo_install.model.config import DiskConfig, DiskMode, ImageFormat, MemoryLaunch, MemoryMode
 from gentoo_install.model.hardware import CpuVendor, HardwareFacts
 from gentoo_install.model.device import DeviceGraph, DeviceId, StorageFacts, StorageLayout
@@ -743,7 +744,7 @@ def test_the_closing_questions_are_asked_in_the_menu_language(
 
     asked: list[str] = []
 
-    def say_no(question: str) -> bool:
+    def say_no(question: str, translate: object = None) -> bool:
         asked.append(question)
         return False
 
@@ -809,7 +810,7 @@ def test_a_conversion_is_offered_a_shell_in_the_root_it_converted(
     # The two unattended guards have their own test above; this one is about
     # what the question and the chroot name once it is asked.
     monkeypatch.setattr(cli, "_unattended", lambda arguments: False)
-    def say_yes(question: str) -> bool:
+    def say_yes(question: str, translate: object = None) -> bool:
         asked.append(question)
         return True
 
@@ -2994,7 +2995,7 @@ def test_a_shell_that_never_started_is_not_recorded_as_one_that_opened(
     from gentoo_install.exec.runner import Result
 
     interactive_stdin(monkeypatch)
-    monkeypatch.setattr(cli, "_asked", lambda question: True)
+    monkeypatch.setattr(cli, "_asked", lambda question, translate=None: True)
 
     def run_a_shell(code: int) -> list[str]:
         said: list[str] = []
@@ -3154,3 +3155,98 @@ def test_the_dry_run_help_promises_only_what_a_dry_run_keeps() -> None:
     assert said is not None
     assert "anything" not in said, said
     assert "without applying any of them" in said, said
+
+
+def test_a_translated_question_takes_the_answer_its_reader_would_type() -> None:
+    """The question was translated and `y`/`yes` was all it accepted.
+
+    An operator reading the Chinese offer of a root shell had to answer in
+    English or lose the mounted target. Each catalog's own affirmative is read
+    here rather than written twice, and `y` and `yes` stay accepted in every
+    language because the hint printed beside the question names them.
+    """
+    from gentoo_install.i18n import Catalog
+
+    # The catalog key, as `cli` writes it at the call.
+    AFFIRMATIVE = "y|yes"
+    assert cli._affirmatives(None) == frozenset({"y", "yes"})
+
+    for tag in ("zh-TW", "zh-CN", "ja", "ko"):
+        catalog = Catalog(tag)
+        said = catalog(AFFIRMATIVE)
+        assert said != AFFIRMATIVE, f"{tag} has no affirmative of its own"
+        taken = cli._affirmatives(catalog)
+        assert {"y", "yes"} <= taken, (tag, sorted(taken))
+        for word in said.split("|"):
+            assert word.strip().lower() in taken, (tag, word)
+
+
+def _recorded(seen: list[list[str]], argv: object) -> CommandOutput:
+    """Record the command and answer the way the real runner does."""
+    seen.append([str(one) for one in cast(Sequence[str], argv)])
+    return CommandOutput("", 0)
+
+
+def test_the_closing_questions_take_the_answer_they_asked_for(
+    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str], tmp_path: Path
+) -> None:
+    """Both closing questions reach `_asked`, and only one of them was bound.
+
+    `_offer_a_shell` calls it directly and `offer_paste` is handed it as a
+    callback, so a catalog passed to the first alone leaves the second asking
+    in Chinese and taking English. Driven through both callers rather than
+    through `_asked`, because what is being checked is who passes what.
+    """
+    import argparse
+    import io
+    from types import SimpleNamespace
+
+    from gentoo_install.exec import report
+    from gentoo_install.exec.apply import Machine
+    from gentoo_install.i18n import Catalog
+    from gentoo_install.exec import fetch
+    from gentoo_install.exec.report import RunFile
+
+    catalog = Catalog("zh-TW")
+    yes = catalog("y|yes").split("|")[-1]
+    assert not yes.isascii(), yes
+
+    monkeypatch.setattr(cli, "_unattended", lambda arguments: False)
+    monkeypatch.setattr(cli, "_forget_what_was_typed", lambda: None)
+    monkeypatch.setattr(sys, "stdin", io.StringIO(f"{yes}\n"))
+
+    ran: list[list[str]] = []
+    machine = cast(
+        Machine,
+        SimpleNamespace(
+            runner=SimpleNamespace(
+                run=lambda argv, **k: _recorded(ran, argv)
+            )
+        ),
+    )
+    cli._offer_a_shell(
+        argparse.Namespace(no_shell=False, menu=True, target=tmp_path, lang=""),
+        machine,
+        lambda one: None,
+        False,
+        tmp_path,
+        DiskMode.PARTITION,
+        catalog,
+    )
+    assert ran and ran[0][0] == "chroot", ran
+
+    # The callback half: the log is published rather than left behind.
+    monkeypatch.setattr(sys, "stdin", io.StringIO(f"{yes}\n"))
+    said: list[str] = []
+    (tmp_path / RunFile.LOG.value).write_text("a log\n", encoding="utf-8")
+    monkeypatch.setattr(fetch, "upload", lambda *a, **k: "https://example/1")
+    report.offer_paste(
+        tmp_path,
+        said.append,
+        False,
+        False,
+        lambda question: cli._asked(question, catalog),
+        lambda one: None,
+        catalog,
+    )
+    assert not any("by hand" in one for one in said), said


### PR DESCRIPTION
Both closing questions are drawn from the catalog and `_asked` accepted `y` and `yes` alone, so an operator reading Chinese had to answer in English or watch the mounted target be unmounted.

Each locale supplies its own words through a catalog key; `y` and `yes` stay accepted everywhere because the hint printed beside the question names them and nothing else. `_offer_a_shell` calls `_asked` directly while `offer_paste` is handed it as a callback, so both are bound and both are driven by the test — binding one alone leaves the other asking in Chinese and taking English.