### PR TITLE
vm: check every display manager the operator asked for, not greetd alone

### DIFF
--- a/tests/fixtures/btrfs-luks.toml
+++ b/tests/fixtures/btrfs-luks.toml
@@ -45,6 +45,7 @@ kernel_params = ["console=ttyS0,115200"]
 
 [packages]
 desktop = "plasma"
+display_manager = "sddm"
 applications = ["fcitx5", "rime", "rime-simplified", "noto-cjk", "flclash"]
 
 [disk]

--- a/tests/golden/btrfs-luks.txt
+++ b/tests/golden/btrfs-luks.txt
@@ -54,9 +54,10 @@
   accept sys-kernel/gentoo-cjk-kernel-bin as testing, with cjk off, writing /etc/portage/package.use/cjk-kernel
   unmask virtual/dist-kernel, which the cjk kernel depends on by revision
   ask for app-i18n/fcitx-configtool kcm; sys-libs/minizip-ng compat; kde-plasma/kwin lock; kde-plasma/kwin-x11 lock for the plasma group
+  ask for x11-misc/sddm systemd; sys-auth/pambase systemd for the sddm group
   ask for app-i18n/rime-data extra for the rime-simplified group
   ask for dev-libs/libdbusmenu gtk3 for the flclash group
-  resolve app-admin/sudo net-misc/openssh sys-process/cronie sys-kernel/installkernel sys-apps/systemd sys-kernel/dracut sys-kernel/linux-firmware sys-fs/cryptsetup sys-fs/btrfs-progs sys-fs/dosfstools sys-kernel/gentoo-cjk-kernel-bin sys-boot/grub sys-boot/efibootmgr kde-plasma/plasma-meta x11-base/xorg-server kde-apps/konsole kde-apps/dolphin app-i18n/fcitx app-i18n/fcitx-gtk app-i18n/fcitx-qt app-i18n/fcitx-configtool app-i18n/fcitx-rime app-i18n/rime-data media-fonts/noto-cjk media-fonts/noto media-libs/fontconfig net-proxy/flclash-bin together before installing the requested packages
+  resolve app-admin/sudo net-misc/openssh sys-process/cronie sys-kernel/installkernel sys-apps/systemd sys-kernel/dracut sys-kernel/linux-firmware sys-fs/cryptsetup sys-fs/btrfs-progs sys-fs/dosfstools sys-kernel/gentoo-cjk-kernel-bin sys-boot/grub sys-boot/efibootmgr kde-plasma/plasma-meta x11-base/xorg-server kde-apps/konsole kde-apps/dolphin x11-misc/sddm app-i18n/fcitx app-i18n/fcitx-gtk app-i18n/fcitx-qt app-i18n/fcitx-configtool app-i18n/fcitx-rime app-i18n/rime-data media-fonts/noto-cjk media-fonts/noto media-libs/fontconfig net-proxy/flclash-bin together before installing the requested packages
 
 [system]
   write /etc/locale.gen with locales en_US.UTF-8, zh_TW.UTF-8 and verify them
@@ -99,6 +100,8 @@
 
 [packages]
   install the plasma group: emerge kde-plasma/plasma-meta x11-base/xorg-server kde-apps/konsole kde-apps/dolphin
+  install the sddm group: emerge x11-misc/sddm
+  enable sddm at boot
   install the fcitx5 group: emerge app-i18n/fcitx app-i18n/fcitx-gtk app-i18n/fcitx-qt app-i18n/fcitx-configtool
   install the rime group: emerge app-i18n/fcitx-rime app-i18n/rime-data
   install the rime-simplified group: emerge app-i18n/fcitx-rime app-i18n/rime-data

--- a/tests/unit/test_harness.py
+++ b/tests/unit/test_harness.py
@@ -632,8 +632,8 @@ def test_every_installed_check_is_line_bounded_or_names_why_it_is_not() -> None:
     assert exceptions == {
         ("mounts", "requires every configured mount line"),
         ("kernel", "joins a running release to a boot path"),
-        ("greetd service", "requires enabled and active state lines"),
-        ("greetd service", "requires default service and process lines"),
+        ("greeter service", "requires enabled and active state lines"),
+        ("greeter service", "requires default service and process lines"),
         ("greetd config", "requires constraints across greetd config lines"),
         ("inputmethod", "requires the binary and every environment line"),
         ("authorized keys root", "requires every fingerprint and both modes"),
@@ -837,7 +837,7 @@ def test_an_openrc_machine_is_asked_about_greetd_the_way_openrc_answers() -> Non
     )
 
     asked = next(
-        one for one in checks(under_openrc) if one.name == "greetd service"
+        one for one in checks(under_openrc) if one.name == "greeter service"
     )
 
     assert "systemctl" not in asked.command, asked.command
@@ -854,11 +854,11 @@ def test_greetd_service_check_reads_systemd_state() -> None:
     from tests.vm.installed import InstalledCheck, checks
 
     installation = load(Path("tests/fixtures/vm-greetd.toml"))
-    actual = [one for one in checks(installation) if one.name == "greetd service"]
+    actual = [one for one in checks(installation) if one.name == "greeter service"]
     assert actual == [
         InstalledCheck(
-            "greetd service",
-            "systemctl is-enabled greetd.service; systemctl is-active greetd.service",
+            "greeter service",
+            "systemctl is-enabled greetd.service; systemctl is-active display-manager.service",
             r"(?m)^enabled$\n^active$",
             "requires enabled and active state lines",
         )
@@ -931,7 +931,10 @@ def test_greetd_checks_are_not_requested_without_greetd() -> None:
     installation = replace(
         selected, packages=replace(selected.packages, display_manager="lightdm")
     )
-    assert [one for one in checks(installation) if one.name.startswith("greetd")] == []
+    named = [one.name for one in checks(installation)]
+    assert "greetd config" not in named, named
+    # The service check is every display manager's, so lightdm keeps it.
+    assert "greeter service" in named, named
 
 
 def test_a_guest_waits_until_the_machine_has_room_for_it() -> None:

--- a/tests/vm/installed.py
+++ b/tests/vm/installed.py
@@ -311,12 +311,18 @@ def checks(installation: InstallConfig) -> tuple[InstalledCheck, ...]:
                 r"(?m)^/dev/zram0$",
             )
         )
-    if installation.packages.display_manager == "greetd":
+    # Every display manager, not `greetd` alone: the KDE guest of 2026-09-01
+    # asked for none, so `sddm` arrived as a dependency of `plasma-meta`, its
+    # unit stayed `disabled` under a default target of `graphical.target`, and
+    # the machine drew a text login with the whole desktop installed.
+    if installation.packages.display_manager:
+        greeter = installation.packages.display_manager
         if installation.system.init is InitSystem.SYSTEMD:
             result.append(
                 InstalledCheck(
-                    "greetd service",
-                    "systemctl is-enabled greetd.service; systemctl is-active greetd.service",
+                    "greeter service",
+                    f"systemctl is-enabled {greeter}.service; "
+                    "systemctl is-active display-manager.service",
                     r"(?m)^enabled$\n^active$",
                     "requires enabled and active state lines",
                 )
@@ -324,12 +330,13 @@ def checks(installation: InstallConfig) -> tuple[InstalledCheck, ...]:
         else:
             result.append(
                 InstalledCheck(
-                    "greetd service",
-                    "rc-update show default; pgrep -x greetd",
+                    "greeter service",
+                    f"rc-update show default; pgrep -x {greeter}",
                     r"(?ms)(?=.*^display-manager\s+\|\s+default$)(?=.*^[1-9][0-9]*$)",
                     "requires default service and process lines",
                 )
             )
+    if installation.packages.display_manager == "greetd":
         result.append(
             InstalledCheck(
                 "greetd config",


### PR DESCRIPTION
The installed-state checks asked whether `greetd` was enabled and active, and asked nothing about the other four. A KDE guest built from a configuration that named no display manager reached `graphical.target` with `sddm` on disk as a dependency of `plasma-meta`, its unit `disabled`, and drew a text login; nothing in this repository could see that.

The check now covers whichever manager the configuration named. A desktop with none stays legal — `test_an_openrc_desktop_gets_dbus_and_elogind_without_a_display_manager` is the case that says so — and whether an unset value should adopt the desktop’s own greeter is a model question left in `defaults-decision.md`.