### PR TITLE
vm: let a stalled schedule say where its threads are

### DIFF
--- a/tests/unit/test_harness.py
+++ b/tests/unit/test_harness.py
@@ -6594,3 +6594,33 @@ def test_the_console_connection_is_the_one_that_gets_keepalive() -> None:
         if isinstance(node, ast.Call)
     }
     assert "keep_asking" in called, sorted(called)
+
+
+def test_a_stalled_schedule_can_be_asked_where_its_threads_are() -> None:
+    """A campaign that stalls says what it failed at and nothing about why.
+
+    On 2026-09-01 it answered `GET /nodes did not answer` for twenty minutes
+    while a fresh process made the same call in three seconds and `free_slots`
+    reported two free slots. `kill -USR1` now writes every thread's stack and
+    the schedule carries on, so the next stall is evidence rather than a
+    guess. Run rather than read: whether a handler survives the other three
+    this function installs is not visible in the source.
+    """
+    import subprocess
+    import sys
+
+    program = (
+        "import os, signal, sys, threading, time;"
+        "sys.path.insert(0, '.');"
+        "from tests.vm.cluster import _leave_on_a_signal;"
+        "_leave_on_a_signal();"
+        "threading.Thread(target=time.sleep, args=(30,), daemon=True).start();"
+        "os.kill(os.getpid(), signal.SIGUSR1);"
+        "time.sleep(0.5);"
+        "print('STILL-RUNNING')"
+    )
+    said = subprocess.run(
+        [sys.executable, "-c", program], capture_output=True, text=True, timeout=60
+    )
+    assert "STILL-RUNNING" in said.stdout, said.stdout
+    assert "Thread 0x" in said.stderr or "Current thread" in said.stderr, said.stderr

--- a/tests/vm/cluster.py
+++ b/tests/vm/cluster.py
@@ -20,6 +20,7 @@ what separates a slow mirror from a dead guest.
 from __future__ import annotations
 
 import argparse
+import faulthandler
 import fcntl
 import hashlib
 import ipaddress
@@ -4975,6 +4976,13 @@ def _leave_on_a_signal() -> None:
     signal.signal(signal.SIGTERM, raised)
     signal.signal(signal.SIGHUP, raised)
     signal.signal(signal.SIGINT, raised)
+    # `kill -USR1 <schedule>` writes every thread's stack to stderr and the
+    # schedule carries on. A campaign that stalls for an hour otherwise says
+    # only what it failed at: on 2026-09-01 it answered `GET /nodes did not
+    # answer` for twenty minutes while a fresh process made the same call in
+    # three seconds and `free_slots` reported two free slots, and there was no
+    # way to ask the running one where its threads were.
+    faulthandler.register(signal.SIGUSR1, all_threads=True, chain=False)
 
 
 def main(argv: list[str] | None = None) -> int:


### PR DESCRIPTION
A campaign answered `GET /nodes did not answer: <urlopen error timed out>` for twenty minutes. At the same moments a fresh process made that call through the same client in three seconds, `free_slots` reported two free slots, `curl` returned 200 twelve times out of twelve and fourteen concurrent calls all returned 200, and the stalled process held four threads and nine file descriptors. The fault is inside the long-running process and nothing reproduces it from outside.

`kill -USR1` now writes every thread stack to stderr and the schedule carries on, so the next stall is evidence instead of a guess.