### PR TITLE
docs: describe the device graph nodes and their keys

### DIFF
--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -507,6 +507,36 @@ source = "rootfs"
 path = "/"
 ```
 
+## Device graph nodes
+
+Every `[[disk.devices]]` table carries `kind` and `id`. `id` names the node for
+the keys that reference it; `disk.root` and every reference below name an `id`.
+A key this table does not list is refused by name, so a typo stops the run
+before a disk is touched.
+
+| `kind` | Its own keys | Refers to |
+| --- | --- | --- |
+| `existing` | `selector` (required), `wipe` | — |
+| `table` | `table` (`gpt`, `mbr`; `gpt`), `create` (`true`), `remove` (entry numbers, from 1) | `disk` |
+| `partition` | `index` (required), `role` (`esp`, `boot`, `bios-boot`, `swap`, `data`; `data`), `size`, `label`, `min`, `max` | `table` |
+| `luks` | `name` (required), `passphrase_file` | `backing` |
+| `raid` | `level` (required), `name` (required), `metadata` | `members` |
+| `volume-group` | `name` (required) | `members` |
+| `logical-volume` | `name` (required), `size` | `group` |
+| `zpool` | `name` (required), `topology` (`stripe`, `mirror`, `raidz`, `raidz2`, `raidz3`; `stripe`), `encrypted`, `passphrase_file` | `vdevs` |
+| `dataset` | `name` (required) | `pool` |
+| `filesystem` | `type` (required), `label`, `create` (`true`) | `device` |
+| `subvolume` | `name` (required), `create` (`true`) | `filesystem` |
+| `swap` | — | `device` |
+| `mountpoint` | `path` (required), `options` | `source` |
+
+`selector` is a device path, and `/dev/disk/by-id/` is the form that survives a
+reboot. `size` accepts a byte count with a suffix such as `512MiB`; `min` and
+`max` bound a partition that takes its share of what is left, and a partition
+with none of the three takes the rest of the disk. `passphrase_file` names a
+file the operator writes before an unattended run; the installer reads it and
+never writes the passphrase anywhere else.
+
 ## Binary packages
 
 Binary packages are optional. Disabling them keeps source builds available. The official binhost and the gentoo-zh binhost are separate options with separate trust configuration. One degradation path has end-to-end evidence: `TESTED.md` records `vm-binhost-fallback` on `e16f57a39199d` installing from source after its host served no package index, with the reason in the journal. That fixture no longer reproduces it — the same host answered on 2026-08-24 — so the path is recorded rather than currently exercised. A missing signature and an untrusted key have no end-to-end evidence and remain unverified.

--- a/tests/unit/test_project_docs.py
+++ b/tests/unit/test_project_docs.py
@@ -344,3 +344,52 @@ def test_the_operator_brief_counts_the_commands_it_lists() -> None:
 
     counted = {1: "one", 2: "two", 3: "three", 4: "four"}[len(listed)]
     assert f"other than the {counted} above" in said, sorted(listed)
+
+
+def test_the_reference_documents_every_device_node_and_its_keys() -> None:
+    """`[[disk.devices]]` was named as the graph's shape and never described.
+
+    An operator writing one by hand had the thirteen node kinds and their
+    fields in `parse.py` and nowhere else. Both are read out of the parser
+    here: the next kind, and the next key on an existing kind, fails until
+    the table names it.
+    """
+    import ast
+
+    source = (ROOT / "gentoo_install" / "model" / "parse.py").read_text(encoding="utf-8")
+    tree = ast.parse(source)
+    builders: dict[str, str] = {}
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.Dict):
+            continue
+        pairs = {
+            key.value: value.id
+            for key, value in zip(node.keys, node.values)
+            if isinstance(key, ast.Constant)
+            and isinstance(key.value, str)
+            and isinstance(value, ast.Name)
+        }
+        if "mountpoint" in pairs and "partition" in pairs:
+            builders = pairs
+    assert len(builders) >= 13, sorted(builders)
+
+    accepted: dict[str, set[str]] = {}
+    for function in (one for one in ast.walk(tree) if isinstance(one, ast.FunctionDef)):
+        for call in ast.walk(function):
+            if not isinstance(call, ast.Call) or getattr(call.func, "id", "") != "_reject_unknown":
+                continue
+            names = call.args[-1]
+            if isinstance(names, ast.Set):
+                accepted[function.name] = {
+                    one.value
+                    for one in names.elts
+                    if isinstance(one, ast.Constant) and isinstance(one.value, str)
+                }
+
+    said = (ROOT / "REFERENCE.md").read_text(encoding="utf-8")
+    section = said[said.index("## Device graph nodes") : said.index("## Binary packages")]
+    for kind, builder in sorted(builders.items()):
+        assert f"| `{kind}` |" in section, kind
+        row = next(line for line in section.splitlines() if line.startswith(f"| `{kind}` |"))
+        for key in sorted(accepted.get(builder, set()) - {"kind", "id"}):
+            assert f"`{key}`" in row, (kind, key, row)

--- a/tests/unit/test_readme.py
+++ b/tests/unit/test_readme.py
@@ -122,6 +122,7 @@ REFERENCE_SECTIONS = (
     "Capabilities",
     "Validation",
     "Configuration files",
+    "Device graph nodes",
     "Binary packages",
     "Exit codes",
 )


### PR DESCRIPTION
The reference said `[[disk.devices]]` carries the graph nodes and stopped there. Somebody writing one by hand had the thirteen kinds and every field they accept in `parse.py` and nowhere else.

The new table names each kind, its own keys with their defaults, and the key that refers to another node. The check reads both out of the parser — the `_NODES` table and each builder’s accepted set — so the next kind, and the next key on an existing kind, fails until the table names it.