### PR TITLE
tui: stop letting the interface language choose the kernel

### DIFF
--- a/gentoo_install/cli.py
+++ b/gentoo_install/cli.py
@@ -1400,15 +1400,15 @@ def _from_menu(
             context.tag = "en"
             if state is not None:
                 state.language = "en"
-            return app.run(display, screens.with_language(start, "en", context), context)
+            return app.run(display, screens.with_language(start, "en"), context)
         # Asked before the menu: the environment says which language the
         # operator reads, not whether this terminal can draw it.
         if not arguments.lang:
             context.translate = Catalog(screens.language_screen(display, context))
             context.tag = context.translate.tag
-            chosen = screens.with_language(start, context.tag, context)
+            chosen = screens.with_language(start, context.tag)
         else:
-            chosen = screens.with_language(start, context.translate.tag, context)
+            chosen = screens.with_language(start, context.translate.tag)
         if state is not None:
             state.language = context.translate.tag
         if refused:

--- a/gentoo_install/data/locale/ja.toml
+++ b/gentoo_install/data/locale/ja.toml
@@ -362,6 +362,7 @@
 "a partition" = "パーティション"
 "not set" = "未設定"
 "Console CJK is off, so the kernel goes back to {}." = "コンソールの CJK 表示を無効にしたため、カーネルを {} に戻します。"
+"Console CJK needs cjktty, so the kernel becomes {}." = "コンソールの CJK 表示には cjktty が必要なため、カーネルを {} に変更します。"
 "This kernel has no cjktty: console CJK is off." = "このカーネルには cjktty がないため、コンソールの CJK 表示は無効です。"
 "System logger" = "システムロガー"
 "Cron" = "cron"

--- a/gentoo_install/data/locale/ko.toml
+++ b/gentoo_install/data/locale/ko.toml
@@ -362,6 +362,7 @@
 "a partition" = "파티션"
 "not set" = "설정 안 됨"
 "Console CJK is off, so the kernel goes back to {}." = "콘솔 CJK 표시를 껐으므로 커널을 다음으로 되돌립니다: {}."
+"Console CJK needs cjktty, so the kernel becomes {}." = "콘솔 CJK 표시에는 cjktty가 필요하므로 커널을 다음으로 변경합니다: {}."
 "This kernel has no cjktty: console CJK is off." = "cjktty가 없어 콘솔 CJK 표시를 껐습니다."
 "System logger" = "시스템 로거"
 "Cron" = "cron"

--- a/gentoo_install/data/locale/zh-CN.toml
+++ b/gentoo_install/data/locale/zh-CN.toml
@@ -362,6 +362,7 @@
 "a partition" = "一个分区"
 "not set" = "未设置"
 "Console CJK is off, so the kernel goes back to {}." = "控制台 CJK 显示已关闭，内核改回 {}。"
+"Console CJK needs cjktty, so the kernel becomes {}." = "控制台 CJK 显示需要 cjktty，内核改为 {}。"
 "This kernel has no cjktty: console CJK is off." = "这个内核未含 cjktty，控制台 CJK 显示已关闭。"
 "System logger" = "系统日志服务"
 "Cron" = "计划任务"

--- a/gentoo_install/data/locale/zh-TW.toml
+++ b/gentoo_install/data/locale/zh-TW.toml
@@ -362,6 +362,7 @@
 "a partition" = "一個分割區"
 "not set" = "未設定"
 "Console CJK is off, so the kernel goes back to {}." = "主控台 CJK 顯示已關閉，核心改回 {}。"
+"Console CJK needs cjktty, so the kernel becomes {}." = "主控台 CJK 顯示需要 cjktty，核心改為 {}。"
 "This kernel has no cjktty: console CJK is off." = "這個核心未含 cjktty，主控台 CJK 顯示已關閉。"
 "System logger" = "系統日誌服務"
 "Cron" = "排程"

--- a/gentoo_install/tui/screens.py
+++ b/gentoo_install/tui/screens.py
@@ -1962,7 +1962,25 @@ def console_cjk_screen(
     """
     wanted = not config.system.console_cjk
     changed = replace(config, system=replace(config.system, console_cjk=wanted))
-    if wanted or config.kernel.source not in compat.CJK_KERNELS:
+    if wanted:
+        if config.kernel.source in compat.CJK_KERNELS:
+            return Answer(Outcome.CHOSE, changed)
+        # The mirror of the branch below, and of the kernel row: `compat.py`
+        # refuses this flag beside a kernel without the patch, and the
+        # interface language stopped choosing one, so this row is where the
+        # kernel and its overlay arrive.
+        say(
+            screen,
+            context,
+            context.translate("Console CJK needs cjktty, so the kernel becomes {}.").format(
+                KERNEL_PACKAGES[KernelSource.CJK_BIN].atom
+            ),
+        )
+        changed = replace(changed, kernel=replace(changed.kernel, source=KernelSource.CJK_BIN))
+        if not any(one.name == GENTOO_ZH for one in config.portage.overlays):
+            mark_derived(context, ValueKind.OVERLAY, GENTOO_ZH)
+        return Answer(Outcome.CHOSE, replace(changed, portage=with_gentoo_zh(changed)))
+    if config.kernel.source not in compat.CJK_KERNELS:
         return Answer(Outcome.CHOSE, changed)
     # The dataclass default, not a second literal: the kernel this row falls
     # back to is the one a configuration that never chose has.
@@ -2297,29 +2315,19 @@ class LanguageDefaults:
     #: True for the languages the cjktty patch is the point of. It pulls in
     #: gentoo-zh, so it is not a default for a language that would not use the
     #: rest of that overlay.
-    cjk_console: bool = False
 
 
 #: One row per interface language. Keyed by the same tags as the catalogs.
 LANGUAGE_DEFAULTS: Final[dict[str, LanguageDefaults]] = {
     "en": LanguageDefaults("en_US.UTF-8", "UTC", MirrorRegion.GLOBAL),
-    "zh-CN": LanguageDefaults(
-        "zh_CN.UTF-8",
-        "Asia/Shanghai",
-        MirrorRegion.CN,
-        cjk_console=True,
-    ),
-    "zh-TW": LanguageDefaults(
-        "zh_TW.UTF-8",
-        "Asia/Taipei",
-        MirrorRegion.GLOBAL,
-        cjk_console=True,
-    ),
-    # cjktty is what puts Chinese, Japanese and Korean on the console, so all
-    # four of those catalogs take the patched kernel and not only the two
-    # Chinese ones.
-    "ja": LanguageDefaults("ja_JP.UTF-8", "Asia/Tokyo", MirrorRegion.GLOBAL, True),
-    "ko": LanguageDefaults("ko_KR.UTF-8", "Asia/Seoul", MirrorRegion.GLOBAL, True),
+    # No CJK console and no kernel of its own. The interface language says
+    # which language the operator reads; the official prebuilt kernel is what
+    # a machine gets until someone asks for cjktty on the console screen or
+    # picks that kernel outright.
+    "zh-CN": LanguageDefaults("zh_CN.UTF-8", "Asia/Shanghai", MirrorRegion.CN),
+    "zh-TW": LanguageDefaults("zh_TW.UTF-8", "Asia/Taipei", MirrorRegion.GLOBAL),
+    "ja": LanguageDefaults("ja_JP.UTF-8", "Asia/Tokyo", MirrorRegion.GLOBAL),
+    "ko": LanguageDefaults("ko_KR.UTF-8", "Asia/Seoul", MirrorRegion.GLOBAL),
 }
 
 
@@ -2334,14 +2342,13 @@ def _site_kept_in(site: str, region: MirrorRegion) -> str:
     return ""
 
 
-def with_language(
-    config: InstallConfig, tag: str, context: Context | None = None
-) -> InstallConfig:
+def with_language(config: InstallConfig, tag: str) -> InstallConfig:
     """The configuration as the chosen interface language leaves it.
 
-    `context` records that the overlay came from this choice, so the console
-    CJK row can take it back. Without it the addition has no matching
-    withdrawal and the CJK family stays merged with its feature off.
+    Locale, timezone and mirror region, and nothing else. It chose the kernel
+    until 2026-09-01: a CJK catalog took `gentoo-cjk-kernel-bin` and the
+    overlay that carries it, so reading Chinese decided what the machine ran.
+    The console screen and the kernel screen are where cjktty is asked for.
     """
     chosen = LANGUAGE_DEFAULTS.get(tag)
     if chosen is None:
@@ -2374,7 +2381,6 @@ def with_language(
             locale=chosen.locale,
             timezone=chosen.timezone,
             locales=locales,
-            console_cjk=chosen.cjk_console,
         ),
         packages=replace(config.packages, applications=applications),
         portage=replace(
@@ -2389,19 +2395,7 @@ def with_language(
             ),
         ),
     )
-    if not chosen.cjk_console:
-        return seeded
-    # The patched kernel is what puts CJK on the console, and it is in gentoo-zh
-    # and nowhere else, so the overlay comes with it or the row is unusable.
-    if context is not None and not any(
-        one.name == GENTOO_ZH for one in config.portage.overlays
-    ):
-        mark_derived(context, ValueKind.OVERLAY, GENTOO_ZH)
-    return replace(
-        seeded,
-        kernel=replace(seeded.kernel, source=KernelSource.CJK_BIN),
-        portage=with_gentoo_zh(seeded),
-    )
+    return seeded
 
 
 def language_screen(screen: Screen, context: Context) -> str:

--- a/gentoo_install/tui/settings.py
+++ b/gentoo_install/tui/settings.py
@@ -755,13 +755,6 @@ def _erase(config: InstallConfig, context: Context) -> str:
 
 
 
-def _console_cjk_kernel_only(config: InstallConfig, context: Context) -> str:
-    """The cjktty switch cannot turn on without a kernel carrying the patch."""
-    if config.kernel.source not in CJK_KERNELS:
-        return context.translate("only the cjk kernel draws CJK on the console")
-    return ""
-
-
 def _cjk_kernel_only(config: InstallConfig, context: Context) -> str:
     """A font with CJK glyphs draws nothing without the patch that lets the
     console show them, so the size is a choice only under that kernel."""
@@ -860,7 +853,6 @@ KERNEL: Final[tuple[Setting, ...]] = (
         "Console CJK",
         lambda c, x: x.translate("in use" if c.system.console_cjk else "not used"),
         screens.console_cjk_screen,
-        unavailable=_console_cjk_kernel_only,
     ),
     Setting(
         "console_font",

--- a/tests/unit/test_automatic.py
+++ b/tests/unit/test_automatic.py
@@ -948,10 +948,11 @@ def test_choosing_a_chinese_interface_installs_no_package_group() -> None:
             seeded.packages.applications,
         )
         assert seeded.packages.desktop == "", (tag, seeded.packages.desktop)
-        # The language itself still arrives, and the CJK console with it:
-        # that comes from the cjktty kernel, not from a font package.
+        # The language itself still arrives. The CJK console does not: it
+        # needs the cjktty kernel, and since 2026-09-01 that is asked for on
+        # the console row rather than decided by which language is read.
         assert seeded.system.locale.startswith("zh_"), seeded.system.locale
-        assert seeded.system.console_cjk
+        assert not seeded.system.console_cjk
         assert seeded.system.timezone.startswith("Asia/"), seeded.system.timezone
 
 
@@ -1738,7 +1739,7 @@ def test_a_desktop_takes_back_the_fonts_and_framework_it_proposed() -> None:
 
     at = context()
     at.tag = "zh-TW"
-    chinese = screens.with_language(config(), "zh-TW", at)
+    chinese = screens.with_language(config(), "zh-TW")
 
     # `_desktop_proposes` rather than the menu: a row index picked `console`,
     # which is a profile-bearing group and not a session, so the test was

--- a/tests/unit/test_every_row.py
+++ b/tests/unit/test_every_row.py
@@ -161,8 +161,10 @@ def test_leaving_a_row_alone_changes_nothing() -> None:
     before = config(ext4_on_gpt())
     for row in openable():
         screen, answer = leave(row, before, at)
-        if not screen.frames:
-            continue  # A toggle: flipping is what it is for.
+        # A toggle: flipping is what it is for. `console_cjk` is one and still
+        # draws, because both directions name the kernel they move to.
+        if not screen.frames or row.key == "console_cjk":
+            continue
         if answer.outcome is not Outcome.CHOSE:
             continue
         if row.key == "mirror":

--- a/tests/unit/test_tui_app.py
+++ b/tests/unit/test_tui_app.py
@@ -1181,16 +1181,21 @@ def test_console_cjk_has_an_independent_switch_beside_its_font() -> None:
     cjk, font = settings.KERNEL[1:3]
     assert (cjk.key, font.key) == ("console_cjk", "console_font")
 
-    at = context()
-    assert cjk.unavailable(config(), at)
-    chinese = screens.with_language(config(), "zh-TW")
-    assert cjk.unavailable(chinese, at) == ""
+    from gentoo_install.model.config import KernelSource
 
-    # A key, because turning the row off says which kernel it falls back to:
-    # the language chose the patched one and `RequestCjkKernel` reads this
-    # flag, so leaving that kernel here writes `-cjk`.
-    disabled = screens.console_cjk_screen(FakeScreen(keys=["\n"]), chinese, at).unwrap()
+    at = context()
+    # The row is never greyed out: it is the one place that can turn cjktty on
+    # by itself, and the interface language stopped doing it.
+    assert cjk.unavailable(config(), at) == ""
+
+    # A key each way, because both directions say which kernel they move to.
+    enabled = screens.console_cjk_screen(FakeScreen(keys=["\n"]), config(), at).unwrap()
+    assert enabled.system.console_cjk
+    assert enabled.kernel.source is KernelSource.CJK_BIN
+
+    disabled = screens.console_cjk_screen(FakeScreen(keys=["\n"]), enabled, at).unwrap()
     assert not disabled.system.console_cjk
+    assert disabled.kernel.source is not KernelSource.CJK_BIN
 
 
 def test_a_chinese_system_locale_selects_no_input_method_or_font_group() -> None:
@@ -1294,7 +1299,8 @@ def test_a_chinese_interface_selects_no_package_group_at_all() -> None:
     of a 1:43:48 install, pulling `fcitx-gtk` and `fcitx-qt` onto a machine
     with no X and no Wayland. The language decides the locale, the timezone,
     the console and the mirror region; the CJK console comes from the cjktty
-    kernel and not from a font package.
+    kernel and not from a font package, and since 2026-09-01 the language does
+    not choose that kernel either.
     """
     at = context()
     started = config()
@@ -1302,7 +1308,7 @@ def test_a_chinese_interface_selects_no_package_group_at_all() -> None:
 
     assert chinese.packages.desktop == ""
     assert chinese.packages.applications == started.packages.applications
-    assert chinese.system.console_cjk
+    assert not chinese.system.console_cjk
 
     # And each group is still selectable on its own row.
     with_fonts = tui_packages.select_cjk_fonts(chinese, at.groups, ("noto-cjk",), ())
@@ -1517,33 +1523,30 @@ def test_the_nvidia_group_writes_no_file_of_its_own() -> None:
     assert nvidia.package_use == ("x11-drivers/nvidia-drivers dist-kernel",)
 
 
-def test_a_chinese_interface_defaults_to_the_patched_kernel() -> None:
-    """cjktty is what puts CJK on the console, and it is in gentoo-zh and
-    nowhere else, so the overlay is ticked with it rather than after it."""
+def test_a_chinese_interface_keeps_the_official_kernel() -> None:
+    """Decided on 2026-09-01: the cjktty kernel is never a default. Reading
+    Chinese chose `gentoo-cjk-kernel-bin` and the overlay that carries it, so
+    an interface language decided which kernel the machine ran."""
     from gentoo_install.model.config import KernelSource
 
     for tag in ("zh-CN", "zh-TW"):
         seeded = screens.with_language(config(), tag)
-        assert seeded.kernel.source is KernelSource.CJK_BIN, tag
-        assert seeded.system.console_cjk, tag
-        assert [one.name for one in seeded.portage.overlays] == ["gentoo-zh"], tag
+        assert seeded.kernel.source is config().kernel.source, tag
+        assert seeded.kernel.source is not KernelSource.CJK_BIN, tag
+        assert not seeded.system.console_cjk, tag
+        assert seeded.portage.overlays == (), tag
         validate(seeded)
 
 
-def test_every_cjk_catalog_takes_the_patched_kernel_and_english_does_not() -> None:
-    """cjktty is what draws Chinese, Japanese and Korean on the console, so all
-    four of those catalogs need it; English has nothing to gain from the
-    overlay and is not defaulted into one."""
+def test_no_catalog_takes_the_patched_kernel_or_an_overlay() -> None:
+    """The four CJK catalogs took both and English took neither. All five now
+    take neither: cjktty comes from the console row or the kernel row."""
     from gentoo_install.model.config import KernelSource
 
-    for tag in ("zh-TW", "zh-CN", "ja", "ko"):
+    for tag in ("zh-TW", "zh-CN", "ja", "ko", "en"):
         seeded = screens.with_language(config(), tag)
-        assert seeded.kernel.source is KernelSource.CJK_BIN, tag
-        assert [one.name for one in seeded.portage.overlays] == ["gentoo-zh"], tag
-
-    english = screens.with_language(config(), "en")
-    assert english.kernel.source is not KernelSource.CJK_BIN
-    assert english.portage.overlays == ()
+        assert seeded.kernel.source is not KernelSource.CJK_BIN, tag
+        assert seeded.portage.overlays == (), tag
 
 
 def test_the_tree_row_names_the_address_the_chosen_method_uses() -> None:
@@ -2091,14 +2094,15 @@ def test_a_profile_the_operator_picked_survives_choosing_a_desktop() -> None:
 
 def test_choosing_a_kernel_without_cjktty_turns_console_cjk_off_and_says_so() -> None:
     """The rule refused the install with a message about the kernel, and the
-    only row that set console_cjk was the language screen before the menu."""
+    row that turns console_cjk on is the console row: the interface language
+    stopped setting it on 2026-09-01."""
     from gentoo_install.model.config import KernelSource
 
     at = context()
-    chinese = screens.with_language(config(), "zh-TW")
+    chinese = screens.console_cjk_screen(FakeScreen(keys=["\n"]), config(), at).unwrap()
     assert chinese.system.console_cjk
 
-    # A Chinese interface holds `cjk-bin`, so the menu opens there and reaching
+    # Turning the row on holds `cjk-bin`, so the menu opens there and reaching
     # a kernel without the patch takes two steps up.
     screen = FakeScreen(keys=["KEY_UP", "KEY_UP", "\n", "\n"], lines=30, columns=100)
     plain = screens.kernel_screen(screen, chinese, at).unwrap()
@@ -4851,17 +4855,17 @@ def test_changing_the_install_mode_takes_back_the_erase_confirmation() -> None:
 def test_turning_console_cjk_off_takes_back_what_turning_it_on_added() -> None:
     """Adding without a withdrawal is the shape `#1125` already fixed once.
 
-    Choosing a CJK interface language sets `KernelSource.CJK_BIN`, adds
-    `gentoo-zh` and turns the community binary host on. The console CJK row
-    flipped one flag, so the machine kept the whole CJK package family, the
-    overlay and a trusted binary host with the feature off: `RequestCjkKernel`
-    reads that flag and writes `-cjk`.
+    Turning the console CJK row on sets `KernelSource.CJK_BIN`, adds
+    `gentoo-zh` and turns the community binary host on. The row flipped one
+    flag, so the machine kept the whole CJK package family, the overlay and a
+    trusted binary host with the feature off: `RequestCjkKernel` reads that
+    flag and writes `-cjk`.
     """
     from gentoo_install.model.config import BinhostChannel, KernelSource
     from gentoo_install.tui.context import GENTOO_ZH
 
     at = context()
-    chinese = screens.with_language(config(), "zh-TW", at)
+    chinese = screens.console_cjk_screen(FakeScreen(keys=["\n"]), config(), at).unwrap()
     assert chinese.kernel.source is KernelSource.CJK_BIN
     assert any(one.name == GENTOO_ZH for one in chinese.portage.overlays)
     assert chinese.portage.binhost.community is BinhostChannel.STABLE


### PR DESCRIPTION
The owner decided on 2026-09-01 that the cjktty kernel is never a default and that a machine takes the official prebuilt kernel unless someone asks otherwise.

Four rows of `LANGUAGE_DEFAULTS` carried `cjk_console`, and `with_language` read it to set `KernelSource.CJK_BIN` and add `gentoo-zh`, so reading Chinese, Japanese or Korean decided which kernel the machine ran. That branch is gone and the function now sets the locale, the timezone and the mirror region alone.

`compat.py` already refuses console CJK beside a kernel without the patch, and that state was unreachable while the language set both. It is reachable now, so the console row loses the guard that required a cjktty kernel before it could be opened and gains the kernel and the overlay in the direction that turns it on, matching the withdrawal it already had.