### PR TITLE
cli: ask for a root password a shared configuration omits

### DIFF
--- a/gentoo_install/cli.py
+++ b/gentoo_install/cli.py
@@ -17,7 +17,7 @@ import getpass
 import sys
 import termios
 import time
-from dataclasses import dataclass
+from dataclasses import dataclass, replace
 from datetime import datetime, timezone
 from pathlib import Path
 from typing import Callable, Final, Mapping, Sequence
@@ -54,7 +54,7 @@ from .tui import context as tui_context
 from .tui.curses_screen import CursesScreen, too_small
 from .i18n import Catalog, tag_for
 from .exec.console import kernel_messages_held
-from .model import mirrors, qr, refusals, templates
+from .model import compat, mirrors, qr, refusals, templates
 from .model.architecture import official_subarch
 from .model.config import (
     BootloaderConfig,
@@ -519,7 +519,9 @@ def _once(arguments: argparse.Namespace, state: RunState, refused: str) -> int |
                 return EXIT_ABORTED
             config = chosen
         else:
-            config = _configuration_from(arguments.config)
+            config = _with_a_root_password_if_asked(
+                _configuration_from(arguments.config, arguments), arguments
+            )
         if not arguments.missing_commands:
             catalog = load_catalog()
             validate(
@@ -911,17 +913,19 @@ def _closing_catalog(state: RunState, arguments: argparse.Namespace) -> Catalog:
     return Catalog(state.language or tag_for(override=arguments.lang))
 
 
-def _configuration_from(source: str) -> InstallConfig:
+def _configuration_from(source: str, arguments: argparse.Namespace) -> InstallConfig:
     """The configuration, asking for a password when the paste needs one.
 
     Asked rather than taken from the command line: a password there reaches
-    the shell's history and every `ps` on the machine. An unattended run has
-    no terminal to ask, so the refusal stands and names what is missing.
+    the shell's history and every `ps` on the machine. `_unattended` and not
+    `isatty` alone, for the reason `_with_a_root_password_if_asked` carries:
+    `--no-shell` is a real terminal with nobody at it. With nobody to ask, the
+    refusal stands and names what is missing.
     """
     try:
         return load_source(source)
     except errors.ConfigError as refused:
-        if "encrypted paste" not in str(refused) or not sys.stdin.isatty():
+        if "encrypted paste" not in str(refused) or _unattended(arguments):
             raise
     _forget_what_was_typed()
     return load_source(source, getpass.getpass("password for this paste: "))
@@ -957,6 +961,47 @@ def _affirmatives(translate: Catalog | None) -> frozenset[str]:
     # check that every shipped key is shown reads them out of the source.
     said = translate("y|yes") if translate is not None else "y|yes"
     return frozenset({"y", "yes", *(one.strip().lower() for one in said.split("|") if one.strip())})
+
+
+#: How many times a mistyped confirmation is worth asking again. A person
+#: mistypes; a script that answers wrongly forever is what the ceiling stops.
+PASSWORD_TRIES: Final[int] = 3
+
+
+def _with_a_root_password_if_asked(
+    config: InstallConfig, arguments: argparse.Namespace
+) -> InstallConfig:
+    """Ask for a root password when the configuration leaves no way in.
+
+    Batch installation is one configuration and many machines, and `--config`
+    already takes a URL, so the only thing that has to differ per machine is
+    the secret. `_unattended` and not `isatty` alone: the driver CD passes
+    `--no-shell` on a real terminal, so a question guarded on the terminal
+    would have sat there. With nobody to ask, `validate` refuses exactly as it
+    did before.
+    """
+    locked = [
+        one
+        for one in compat.violations_without_a_graph(config)
+        if one.when is compat.Trait.ROOT_LOCKED and one.excludes is compat.Trait.NO_OTHER_LOGIN
+    ]
+    if not locked or _unattended(arguments):
+        return config
+    print(locked[0].reason, file=sys.stderr)
+    runner = Runner(log=lambda _: None, echo=False)
+    for _ in range(PASSWORD_TRIES):
+        _forget_what_was_typed()
+        first = getpass.getpass("root password for this machine: ")
+        if not first:
+            continue
+        if first != getpass.getpass("again: "):
+            print("the two did not match", file=sys.stderr)
+            continue
+        return replace(
+            config,
+            system=replace(config.system, root_password_hash=fetch.password_hash(first, runner)),
+        )
+    raise errors.ValidationFailed("no root password was given")
 
 
 def _forget_what_was_typed() -> None:

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -2,6 +2,7 @@
 from __future__ import annotations
 
 import argparse
+import getpass
 import io
 import os
 import shutil
@@ -3250,3 +3251,104 @@ def test_the_closing_questions_take_the_answer_they_asked_for(
         catalog,
     )
     assert not any("by hand" in one for one in said), said
+
+
+def _no_way_in() -> Any:
+    """A configuration whose only login is a root hash, with that hash gone."""
+    started = load(FIXTURES / "ext4-bios.toml")
+    return replace(started, system=replace(started.system, root_password_hash=""))
+
+
+def _driven(*, no_shell: bool = False, menu: bool = False) -> argparse.Namespace:
+    return argparse.Namespace(no_shell=no_shell, menu=menu)
+
+
+def test_a_configuration_with_no_login_is_left_alone_off_a_terminal(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A question added to an unattended run is a way for it to hang, so the
+    prompt exists only where somebody can answer it; `validate` still refuses.
+    """
+    monkeypatch.setattr(sys.stdin, "isatty", lambda: False)
+    monkeypatch.setattr(
+        getpass, "getpass", lambda _: pytest.fail("asked with no terminal")
+    )
+    locked = _no_way_in()
+    assert cli._with_a_root_password_if_asked(locked, _driven()) is locked
+
+
+def test_a_configuration_with_no_login_is_asked_for_one_on_a_terminal(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """One configuration, many machines: `--config` already takes a URL, so the
+    password is the only thing that has to differ per machine."""
+    monkeypatch.setattr(sys.stdin, "isatty", lambda: True)
+    monkeypatch.setattr(cli, "_forget_what_was_typed", lambda: None)
+    answers = iter(["hunter2hunter2", "hunter2hunter2"])
+    monkeypatch.setattr(getpass, "getpass", lambda _: next(answers))
+
+    filled = cli._with_a_root_password_if_asked(_no_way_in(), _driven())
+    assert filled.system.root_password_hash.startswith("$6$")
+
+
+def test_a_mistyped_confirmation_is_asked_again(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(sys.stdin, "isatty", lambda: True)
+    monkeypatch.setattr(cli, "_forget_what_was_typed", lambda: None)
+    answers = iter(["one", "other", "same", "same"])
+    monkeypatch.setattr(getpass, "getpass", lambda _: next(answers))
+
+    filled = cli._with_a_root_password_if_asked(_no_way_in(), _driven())
+    assert filled.system.root_password_hash.startswith("$6$")
+
+
+def test_asking_stops_rather_than_repeating_forever(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A person mistypes; something answering wrongly forever is what the
+    ceiling stops."""
+    monkeypatch.setattr(sys.stdin, "isatty", lambda: True)
+    monkeypatch.setattr(cli, "_forget_what_was_typed", lambda: None)
+    monkeypatch.setattr(getpass, "getpass", lambda _: "")
+
+    with pytest.raises(errors.ValidationFailed, match="no root password"):
+        cli._with_a_root_password_if_asked(_no_way_in(), _driven())
+
+
+def test_an_encrypted_paste_is_not_asked_about_under_no_shell(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The same guard as the root password: `--no-shell` is a real terminal
+    with nobody at it, so the refusal has to stand instead of a prompt."""
+    monkeypatch.setattr(sys.stdin, "isatty", lambda: True)
+    monkeypatch.setattr(
+        getpass, "getpass", lambda _: pytest.fail("asked under --no-shell")
+    )
+
+    def refuse(source: str, password: str | None = None) -> None:
+        raise ConfigError("this is an encrypted paste")
+
+    monkeypatch.setattr(cli, "load_source", refuse)
+    with pytest.raises(ConfigError, match="encrypted paste"):
+        cli._configuration_from("https://paste.example/x", _driven(no_shell=True))
+
+
+def test_no_shell_on_a_terminal_is_still_unattended(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The driver CD passes `--no-shell` on a real terminal, so a question
+    guarded on `isatty` alone would have sat there for the whole run."""
+    monkeypatch.setattr(sys.stdin, "isatty", lambda: True)
+    monkeypatch.setattr(
+        getpass, "getpass", lambda _: pytest.fail("asked under --no-shell")
+    )
+    locked = _no_way_in()
+    assert cli._with_a_root_password_if_asked(locked, _driven(no_shell=True)) is locked
+
+
+def test_a_configuration_that_can_already_log_in_is_not_asked(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(sys.stdin, "isatty", lambda: True)
+    monkeypatch.setattr(
+        getpass, "getpass", lambda _: pytest.fail("asked with a password already set")
+    )
+    started = load(FIXTURES / "ext4-bios.toml")
+    assert cli._with_a_root_password_if_asked(started, _driven()) is started


### PR DESCRIPTION
Batch installation is one configuration and many machines. `--config` already accepts an `http://` or `https://` source, so the only thing that has to differ per machine is the secret, and today every secret has to be in the file before the run starts: `root_password_hash` is a field, and a LUKS or ZFS passphrase has to be a file `_passphrase_problems` can read before the first disk is touched. Nothing anywhere asks.

A configuration that leaves no way into the installed system now gets one question, twice for confirmation, hashed with `openssl passwd -6`. Whether there is anyone to ask is `_unattended`, not `isatty`: `--no-shell` is a real terminal with nobody at it, which is what the driver CD passes on every run, so a prompt guarded on the terminal alone would have sat there. The encrypted-paste prompt had that defect already and takes the same guard.

Which configurations have no way in is read from the `ROOT_LOCKED` / `NO_OTHER_LOGIN` rule itself rather than a second copy of the judgement. Passphrases are not covered: those name a device-graph field.