### PR TITLE
cli: ask for the secrets a shared configuration cannot carry

### DIFF
--- a/gentoo_install/cli.py
+++ b/gentoo_install/cli.py
@@ -42,6 +42,8 @@ from .log import Journal
 from .model.device import (
     DeviceGraph,
     DeviceId,
+    Luks,
+    Node,
     StorageFacts,
     StorageLayout,
     ZfsPool,
@@ -723,6 +725,7 @@ def install(
         runner = Runner(log=record, journal=journal)
         probe = Probe(runner=runner, work=work)
         probe.load()
+        config = _with_passphrases_if_asked(config, arguments, work)
         if not arguments.skip_preflight:
             preflight_report = preflight.check(
                 config, probe, str(target), operations=operations
@@ -966,6 +969,67 @@ def _affirmatives(translate: Catalog | None) -> frozenset[str]:
 #: How many times a mistyped confirmation is worth asking again. A person
 #: mistypes; a script that answers wrongly forever is what the ceiling stops.
 PASSWORD_TRIES: Final[int] = 3
+
+
+def _needs_a_passphrase(node: Node) -> bool:
+    """Whether this node is encrypted and names no file to read a key from."""
+    if isinstance(node, Luks):
+        return not node.passphrase_file
+    return isinstance(node, ZfsPool) and node.encrypted and not node.passphrase_file
+
+
+def _passphrase_minimum(node: Node) -> int:
+    """`zpool create` refuses a short one only once the vdevs are partitioned,
+    which leaves the disk wiped, so the length is checked at the question."""
+    return preflight.ZFS_PASSPHRASE_MINIMUM if isinstance(node, ZfsPool) else 1
+
+
+def _with_passphrases_if_asked(
+    config: InstallConfig, arguments: argparse.Namespace, work: Path
+) -> InstallConfig:
+    """Ask for the passphrases a shared configuration cannot carry.
+
+    Here rather than where the configuration is loaded, because the answer is
+    written to a file: `SecretStore` is emptied by `raise_if_fatal` and by
+    `cleanup_secrets`, and neither is reached from the load, so a `validate`
+    refusal or a dry run would have left a passphrase in `/run`. A dry run
+    never arrives here, which is right — it has no disk to unlock.
+    """
+    wanted = [node for node in config.disk.graph.nodes.values() if _needs_a_passphrase(node)]
+    if not wanted or _unattended(arguments):
+        return config
+    store = preflight.SecretStore(work)
+    staged: dict[DeviceId, str] = {}
+    for node in wanted:
+        minimum = _passphrase_minimum(node)
+        for _ in range(PASSWORD_TRIES):
+            _forget_what_was_typed()
+            first = getpass.getpass(f"passphrase for {node.id}: ")
+            if len(first) < minimum:
+                print(f"at least {minimum} characters", file=sys.stderr)
+                continue
+            if first != getpass.getpass("again: "):
+                print("the two did not match", file=sys.stderr)
+                continue
+            store.stage(node.id, first)
+            staged[node.id] = str(store.path(node.id))
+            break
+        else:
+            raise errors.ValidationFailed(f"no passphrase was given for {node.id}")
+    rebuilt: list[Node] = []
+    for node in config.disk.graph.nodes.values():
+        where = staged.get(node.id)
+        if where is None:
+            rebuilt.append(node)
+        elif isinstance(node, Luks):
+            rebuilt.append(replace(node, passphrase_file=where))
+        elif isinstance(node, ZfsPool):
+            rebuilt.append(replace(node, passphrase_file=where))
+        else:
+            rebuilt.append(node)
+    return replace(
+        config, disk=replace(config.disk, graph=DeviceGraph.build(rebuilt))
+    )
 
 
 def _with_a_root_password_if_asked(

--- a/gentoo_install/exec/preflight.py
+++ b/gentoo_install/exec/preflight.py
@@ -174,6 +174,10 @@ def assess_commands(
 #: has already been partitioned.
 ZFS_PASSPHRASE_MINIMUM: Final[int] = 8
 
+#: The first uid `useradd` hands out on Gentoo, and what separates a
+#: person's home directory from a system account that happens to own one.
+UID_MIN: Final[int] = 1000
+
 #: Below this, compiling in a tmpfs is what runs the machine out of memory.
 TMPFS_MINIMUM: Final[int] = 8 * 1024**3
 
@@ -307,6 +311,32 @@ def _disks_at_risk(graph: DeviceGraph) -> list[Existing]:
     device the operator kept.
     """
     return list(compat.destroyed(graph))
+
+
+def _orphaned_home_directories(config: InstallConfig, probe: Probe) -> list[str]:
+    """Home directories whose owner the converted machine will not have.
+
+    `/home` is not among the directories a conversion replaces and `/etc` is,
+    so the files stay and the accounts that own them do not. A name the
+    configuration recreates still gets whatever uid `useradd` picks, which is
+    why the old one is named here rather than only the account.
+    """
+    wanted = {user.name for user in config.system.users}
+    problems: list[str] = []
+    for path, uid, name in probe.home_accounts():
+        if name and name in wanted:
+            problems.append(
+                f"{path} belongs to uid {uid} ({name}), and the conversion recreates that "
+                "account: give it the same uid or its files stay unreadable to it"
+            )
+        elif uid >= UID_MIN:
+            problems.append(
+                f"{path} belongs to uid {uid}"
+                + (f" ({name})" if name else "")
+                + ", which this configuration does not create: the conversion replaces "
+                "/etc, so those files will have no account behind them"
+            )
+    return problems
 
 
 def _passphrase_problems(
@@ -598,6 +628,7 @@ def inspect(
                 "in-place conversion replaces the running userland, and this is a live "
                 f"medium ({medium}): install onto a disk instead"
             )
+        warnings += _orphaned_home_directories(config, probe)
 
     if config.disk.mode is not DiskMode.IMAGE:
         if _disks_at_risk(config.disk.graph) and not probe.live_medium():

--- a/gentoo_install/exec/probe.py
+++ b/gentoo_install/exec/probe.py
@@ -1316,6 +1316,36 @@ class Probe:
             return BootMethod.BIOS_GRUB
         return BootMethod.NONE
 
+    def home_accounts(self) -> tuple[tuple[str, int, str], ...]:
+        """Each directory under `/home`, its owning uid, and that uid's name.
+
+        A conversion keeps `/home` and replaces `/etc`, so the files stay and
+        the accounts that own them do not. Read from the running system's own
+        `passwd`, because that is the only place the name still exists once
+        the swap has happened.
+        """
+        home = Path("/home")
+        try:
+            entries = sorted(one for one in home.iterdir() if one.is_dir())
+        except OSError:
+            return ()
+        names: dict[int, str] = {}
+        try:
+            for line in Path("/etc/passwd").read_text(encoding="utf-8").splitlines():
+                fields = line.split(":")
+                if len(fields) > 2 and fields[2].isdigit():
+                    names.setdefault(int(fields[2]), fields[0])
+        except OSError:
+            pass
+        found: list[tuple[str, int, str]] = []
+        for one in entries:
+            try:
+                uid = one.stat().st_uid
+            except OSError:
+                continue
+            found.append((str(one), uid, names.get(uid, "")))
+        return tuple(found)
+
     def root_source(self) -> str:
         """What `/` is mounted from, for the warning that names it."""
         said = self.runner.run(

--- a/gentoo_install/plan/system.py
+++ b/gentoo_install/plan/system.py
@@ -1382,7 +1382,10 @@ def _zfs_services(config: InstallConfig) -> list[Operation]:
         EnableService(stage=STORAGE_SERVICE_STAGE, service=service, init=init, runlevel=runlevel)
         for service, runlevel in ZFS_SERVICES[init]
     ]
-    if init is InitSystem.OPENRC and any(pool.passphrase_file for pool in pools):
+    # `encrypted`, not `passphrase_file`: the two answer the same today only
+    # because preflight refuses an encrypted pool that names no file, and
+    # the key service is needed for the encryption rather than for the path.
+    if init is InitSystem.OPENRC and any(pool.encrypted for pool in pools):
         operations.insert(
             1,
             EnableService(

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -26,7 +26,14 @@ from gentoo_install.errors import CommandFailed, ConfigError, IntegrityError
 from gentoo_install.plan.operations import CommandOutput
 from gentoo_install.model.config import DiskConfig, DiskMode, ImageFormat, MemoryLaunch, MemoryMode
 from gentoo_install.model.hardware import CpuVendor, HardwareFacts
-from gentoo_install.model.device import DeviceGraph, DeviceId, StorageFacts, StorageLayout
+from gentoo_install.model.device import (
+    DeviceGraph,
+    DeviceId,
+    Luks,
+    StorageFacts,
+    StorageLayout,
+    ZfsPool,
+)
 from gentoo_install.plan.build import DEFAULT_MIRROR
 from gentoo_install.exec.config import load
 
@@ -3352,3 +3359,92 @@ def test_a_configuration_that_can_already_log_in_is_not_asked(
     )
     started = load(FIXTURES / "ext4-bios.toml")
     assert cli._with_a_root_password_if_asked(started, _driven()) is started
+
+
+def _encrypted_without_a_key_file() -> Any:
+    """A LUKS root whose configuration names no passphrase file."""
+    started = load(FIXTURES / "vm-luks.toml")
+    graph = started.disk.graph
+    rebuilt = [
+        replace(node, passphrase_file="") if isinstance(node, Luks) else node
+        for node in graph.nodes.values()
+    ]
+    return replace(
+        started, disk=replace(started.disk, graph=DeviceGraph.build(rebuilt))
+    )
+
+
+def test_an_encrypted_device_with_no_key_file_is_asked_about(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """A shared configuration carries no secret, so the passphrase is the one
+    thing that has to arrive per machine."""
+    monkeypatch.setattr(sys.stdin, "isatty", lambda: True)
+    monkeypatch.setattr(cli, "_forget_what_was_typed", lambda: None)
+    answers = iter(["opensesame", "opensesame"])
+    monkeypatch.setattr(getpass, "getpass", lambda _: next(answers))
+
+    filled = cli._with_passphrases_if_asked(
+        _encrypted_without_a_key_file(), _driven(), tmp_path
+    )
+    named = [
+        node.passphrase_file
+        for node in filled.disk.graph.nodes.values()
+        if isinstance(node, Luks)
+    ]
+    # Under the run's own work directory, asserted before the file is read: a
+    # configuration left untouched still names a path, and reading that one
+    # fails with an errno rather than with this test's own claim.
+    assert named and all(one.startswith(str(tmp_path)) for one in named), named
+    written = Path(named[0])
+    assert written.read_text() == "opensesame"
+    assert written.stat().st_mode & 0o777 == 0o600
+
+
+def test_an_encrypted_device_is_not_asked_about_unattended(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """Preflight refuses it by name instead; a question here would hang the run."""
+    monkeypatch.setattr(sys.stdin, "isatty", lambda: True)
+    monkeypatch.setattr(getpass, "getpass", lambda _: pytest.fail("asked unattended"))
+    started = _encrypted_without_a_key_file()
+    assert cli._with_passphrases_if_asked(started, _driven(no_shell=True), tmp_path) is started
+
+
+def test_a_named_key_file_is_left_for_preflight_to_read(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    monkeypatch.setattr(sys.stdin, "isatty", lambda: True)
+    monkeypatch.setattr(getpass, "getpass", lambda _: pytest.fail("asked with a file named"))
+    started = load(FIXTURES / "vm-luks.toml")
+    assert cli._with_passphrases_if_asked(started, _driven(), tmp_path) is started
+
+
+def test_a_short_zfs_passphrase_is_refused_at_the_question(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """`zpool create` refuses one only once the vdevs are partitioned, which
+    leaves the disk wiped and the install stopped."""
+    from gentoo_install.exec.preflight import ZFS_PASSPHRASE_MINIMUM
+
+    monkeypatch.setattr(sys.stdin, "isatty", lambda: True)
+    monkeypatch.setattr(cli, "_forget_what_was_typed", lambda: None)
+    short = "a" * (ZFS_PASSPHRASE_MINIMUM - 1)
+    answers = iter([short, "longenoughnow", "longenoughnow"])
+    monkeypatch.setattr(getpass, "getpass", lambda _: next(answers))
+
+    started = load(FIXTURES / "vm-zfs-encrypted.toml")
+    pools = [
+        replace(node, passphrase_file="") if isinstance(node, ZfsPool) else node
+        for node in started.disk.graph.nodes.values()
+    ]
+    stripped = replace(started, disk=replace(started.disk, graph=DeviceGraph.build(pools)))
+
+    filled = cli._with_passphrases_if_asked(stripped, _driven(), tmp_path)
+    named = [
+        node.passphrase_file
+        for node in filled.disk.graph.nodes.values()
+        if isinstance(node, ZfsPool)
+    ]
+    assert named and all(one.startswith(str(tmp_path)) for one in named), named
+    assert Path(named[0]).read_text() == "longenoughnow"

--- a/tests/unit/test_plan_system.py
+++ b/tests/unit/test_plan_system.py
@@ -1125,6 +1125,33 @@ def test_an_encrypted_pool_loads_its_key_between_import_and_mount() -> None:
     assert order.index("zfs-import") < order.index("zfs-load-key") < order.index("zfs-mount")
 
 
+def test_an_encrypted_pool_gets_the_key_service_before_its_file_is_named() -> None:
+    """The operation list is built before the passphrase is asked for, so a
+    configuration that names no file would have been built without the service
+    and the machine would boot with nothing to load its key."""
+    from dataclasses import replace as _replace
+
+    from gentoo_install.model.device import ZfsPool
+
+    from .layouts import zfs_root
+
+    nodes = [
+        _replace(node, encrypted=True, passphrase_file="")
+        if isinstance(node, ZfsPool)
+        else node
+        for node in zfs_root()
+    ]
+    encrypted = replace(
+        config(nodes),
+        system=SystemConfig(init=InitSystem.OPENRC),
+        portage=replace(config().portage, profile="default/linux/amd64/23.0"),
+    )
+    services = [
+        one.service for one in system.build(encrypted) if isinstance(one, system.EnableService)
+    ]
+    assert "zfs-load-key" in services, services
+
+
 def test_every_logger_has_a_package_a_service_and_a_row() -> None:
     """It was two tables of the same name: `plan/system.py` held the package
     and the service, `tui/screens.py` held the menu row. A logger added to one

--- a/tests/unit/test_preflight.py
+++ b/tests/unit/test_preflight.py
@@ -349,3 +349,51 @@ def test_a_bios_machine_is_told_why_a_uefi_configuration_refuses(tmp_path: Path)
 
     assert any("booted by BIOS" in one for one in report.fatal), report.fatal
     assert not any("efivarfs" in one for one in report.fatal), report.fatal
+
+
+def test_a_conversion_names_the_home_directories_it_will_orphan(tmp_path: Path) -> None:
+    """`/home` is kept and `/etc` is replaced, so the files stay and the
+    accounts that own them do not: the machine boots and is wrong in a way
+    nothing in the run reports."""
+    from gentoo_install.exec import preflight as checking
+
+    class WithHomes(Probe):
+        def home_accounts(self) -> tuple[tuple[str, int, str], ...]:
+            return (("/home/zakk", 1000, "zakk"), ("/home/olduser", 1001, "olduser"))
+
+        def live_medium(self) -> str:
+            return ""
+
+    from gentoo_install.model.config import User
+
+    started = config()
+    recreated = replace(
+        started,
+        system=replace(started.system, users=(User(name="zakk", password_hash="x"),)),
+    )
+    said = checking._orphaned_home_directories(
+        recreated, WithHomes(runner=Runner(log=lambda line: None), work=tmp_path)
+    )
+    assert len(said) == 2, said
+    # Both branches, because a recreated account is the case that reads as
+    # fine and is not: `useradd` picks its own uid.
+    assert any("/home/zakk" in one and "same uid" in one for one in said), said
+    assert any("/home/olduser" in one and "does not create" in one for one in said), said
+
+
+def test_a_system_account_owning_a_home_directory_is_not_reported(tmp_path: Path) -> None:
+    """A uid below the first one `useradd` hands out is a service account, and
+    naming it would bury the two lines that matter."""
+    from gentoo_install.exec import preflight as checking
+
+    class WithService(Probe):
+        def home_accounts(self) -> tuple[tuple[str, int, str], ...]:
+            return (("/home/postgres", 70, "postgres"),)
+
+    started = config()
+    assert (
+        checking._orphaned_home_directories(
+            started, WithService(runner=Runner(log=lambda line: None), work=tmp_path)
+        )
+        == []
+    )


### PR DESCRIPTION
Batch installation is one configuration and many machines, and every secret has to be in the file before the run starts. `--config` already accepts a URL, so the secret is the only thing that has to differ, and nothing anywhere asks for one.

A LUKS or ZFS device naming no `passphrase_file` is now asked about, twice for confirmation, with the ZFS minimum enforced at the question rather than by `zpool create` once the vdevs are partitioned. The question sits after `probe.load()` and before `preflight.check()`, because the answer becomes a file and `SecretStore` is emptied only by `raise_if_fatal` and `cleanup_secrets`: asking where the configuration is loaded would leave a passphrase in `/run` after a validate refusal or a dry run.

Two things came out of that. The openrc ZFS key service keyed on `passphrase_file` having a value, and the operation list is built before anything can be asked, so a configuration naming no file was built without the service; it keys on `encrypted` now. And a conversion keeps `/home` while replacing `/etc`, so the files stay and the accounts owning them do not — preflight names each directory and its uid, including the case that reads as fine, where the account is recreated and `useradd` picks a different uid.