### PR TITLE
preflight: name the network a conversion is about to replace

### DIFF
--- a/gentoo_install/exec/preflight.py
+++ b/gentoo_install/exec/preflight.py
@@ -10,7 +10,7 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 from pathlib import Path
-from typing import AbstractSet, Final, Iterable, Mapping
+from typing import AbstractSet, Final, Iterable, Mapping, Sequence
 
 from ..errors import DeviceNotFound, PreflightFailed
 from ..model import compat
@@ -311,6 +311,52 @@ def _disks_at_risk(graph: DeviceGraph) -> list[Existing]:
     device the operator kept.
     """
     return list(compat.destroyed(graph))
+
+
+def _routing_interfaces(routes: Sequence[str]) -> tuple[str, ...]:
+    """The interfaces the default routes leave by, from `dev <name>`."""
+    found: list[str] = []
+    for route in routes:
+        fields = route.split()
+        if "dev" in fields:
+            name = fields[fields.index("dev") + 1]
+            if name not in found:
+                found.append(name)
+    return tuple(found)
+
+
+def _replaced_network(config: InstallConfig, probe: Probe) -> list[str]:
+    """What the machine reaches the network with now, beside what replaces it.
+
+    A conversion replaces `/etc`, and the interface configuration of the
+    distribution being replaced is in it. Nothing here decides whether an
+    address was configured statically: `dynamic` is reported because the
+    kernel sets it, and an operator reading their own machine's address
+    beside what the configuration will write is better placed to answer than
+    a rule that can be wrong in the direction of false reassurance.
+    """
+    routes = probe.default_routes()
+    if not routes:
+        return []
+    leaving = _routing_interfaces(routes)
+    holding = [one for one in probe.current_addresses() if one[0] in leaving]
+    if not holding:
+        return []
+    now = ", ".join(
+        f"{address} on {interface}" + (" (dynamic)" if dynamic else "")
+        for interface, address, dynamic in holding
+    )
+    if config.system.addresses:
+        after = "the configuration writes " + ", ".join(config.system.addresses)
+        kept = {one.split("/")[0] for one in config.system.addresses}
+        if not kept & {address.split("/")[0] for _, address, _ in holding}:
+            after += ", none of which this machine holds now"
+    else:
+        after = "the configuration names no address, so the converted system asks a DHCP server"
+    return [
+        f"this machine reaches the network as {now} via {'; '.join(routes)}; "
+        f"the conversion replaces /etc, and {after}"
+    ]
 
 
 def _orphaned_home_directories(config: InstallConfig, probe: Probe) -> list[str]:
@@ -629,6 +675,7 @@ def inspect(
                 f"medium ({medium}): install onto a disk instead"
             )
         warnings += _orphaned_home_directories(config, probe)
+        warnings += _replaced_network(config, probe)
 
     if config.disk.mode is not DiskMode.IMAGE:
         if _disks_at_risk(config.disk.graph) and not probe.live_medium():

--- a/gentoo_install/exec/probe.py
+++ b/gentoo_install/exec/probe.py
@@ -877,6 +877,42 @@ class Probe:
         has6 = any(address is not None and address not in _ULA_V6 for address in addresses6)
         return has4, has6
 
+    def current_addresses(self) -> tuple[tuple[str, str, bool], ...]:
+        """Every routable address this machine holds now, and how it got it.
+
+        The interface, the address in CIDR, and whether the kernel marked it
+        `dynamic`, which is what an address from DHCP or a router
+        advertisement carries. Reported rather than judged: a static address
+        configured by a cloud image looks like any other, and concluding
+        wrongly here would tell an operator their machine is safe to convert.
+        """
+        listed = self.runner.run(
+            ["ip", "-oneline", "address", "show", "scope", "global"], check=False
+        )
+        if listed.returncode != 0:
+            return ()
+        found: list[tuple[str, str, bool]] = []
+        for line in listed.stdout.splitlines():
+            fields = line.split()
+            if len(fields) < 4 or fields[2] not in ("inet", "inet6"):
+                continue
+            found.append((fields[1], fields[3], "dynamic" in fields))
+        return tuple(found)
+
+    def default_routes(self) -> tuple[str, ...]:
+        """Each default route, as `ip` prints it.
+
+        Whole lines: `proto dhcp` and the source address are the parts an
+        operator reads to recognise their own machine, and rewriting them
+        into fields loses exactly that.
+        """
+        listed = self.runner.run(
+            ["ip", "-oneline", "route", "show", "default"], check=False
+        )
+        if listed.returncode != 0:
+            return ()
+        return tuple(line.strip() for line in listed.stdout.splitlines() if line.strip())
+
     def mdraid_metadata(self, selector: str) -> MdraidMetadataFact:
         """The metadata version an array already on the machine carries.
 

--- a/tests/unit/test_preflight.py
+++ b/tests/unit/test_preflight.py
@@ -397,3 +397,71 @@ def test_a_system_account_owning_a_home_directory_is_not_reported(tmp_path: Path
         )
         == []
     )
+
+
+class _WithNetwork(Probe):
+    """A machine holding one address on the interface its default route uses."""
+
+    routes: ClassVar[tuple[str, ...]] = (
+        "default via 192.0.2.1 dev eth0 proto static src 192.0.2.10",
+    )
+    addresses: ClassVar[tuple[tuple[str, str, bool], ...]] = (
+        ("eth0", "192.0.2.10/24", False),
+        ("virbr0", "192.168.122.1/24", False),
+    )
+
+    def default_routes(self) -> tuple[str, ...]:
+        return self.routes
+
+    def current_addresses(self) -> tuple[tuple[str, str, bool], ...]:
+        return self.addresses
+
+
+def test_a_conversion_says_what_the_machine_reaches_the_network_with(
+    tmp_path: Path,
+) -> None:
+    """`/etc` holds the interface configuration of the distribution being
+    replaced, so a machine whose address was configured there does not come
+    back. Nothing in the run said so."""
+    from gentoo_install.exec import preflight as checking
+
+    said = checking._replaced_network(
+        config(), _WithNetwork(runner=Runner(log=lambda line: None), work=tmp_path)
+    )
+    assert len(said) == 1, said
+    assert "192.0.2.10/24 on eth0" in said[0], said
+    assert "asks a DHCP server" in said[0], said
+    # Only the interface the default route leaves by: a bridge or a tunnel
+    # address is not what the operator is connected through.
+    assert "192.168.122.1" not in said[0], said
+
+
+def test_a_conversion_says_when_the_configured_address_is_a_different_one(
+    tmp_path: Path,
+) -> None:
+    from gentoo_install.exec import preflight as checking
+
+    started = config()
+    elsewhere = replace(
+        started, system=replace(started.system, addresses=("198.51.100.5/24",))
+    )
+    said = checking._replaced_network(
+        elsewhere, _WithNetwork(runner=Runner(log=lambda line: None), work=tmp_path)
+    )
+    assert "none of which this machine holds now" in said[0], said
+
+
+def test_a_machine_with_no_default_route_is_not_reported(tmp_path: Path) -> None:
+    """Nothing to compare against, and a line naming no route reads as though
+    the machine had lost one."""
+    from gentoo_install.exec import preflight as checking
+
+    class NoRoute(_WithNetwork):
+        routes: ClassVar[tuple[str, ...]] = ()
+
+    assert (
+        checking._replaced_network(
+            config(), NoRoute(runner=Runner(log=lambda line: None), work=tmp_path)
+        )
+        == []
+    )


### PR DESCRIPTION
A conversion replaces `/etc`, and the interface configuration of the distribution being replaced is in it. What the converted system comes up with is `system.networking` and `system.addresses` instead, where no address means DHCP. A machine addressed statically by its provider, converted with a configuration that names no address, completes and never answers again — the worst outcome this mode has, and nothing in the run mentioned it.

The addresses on the interface each default route leaves by are printed beside what the configuration will write. Only that interface: a bridge or a tunnel address is not what the operator is connected through.

Nothing decides whether an address was configured statically. `dynamic` is reported because the kernel sets it, but an address a cloud image wrote into a file looks like any other, and a wrong answer here reassures an operator whose machine is about to disappear.