### PR TITLE
cli: finish the secret question

### DIFF
--- a/gentoo_install/cli.py
+++ b/gentoo_install/cli.py
@@ -536,7 +536,9 @@ def _once(arguments: argparse.Namespace, state: RunState, refused: str) -> int |
             # this hashes, and a password hash carries a fresh salt, so an
             # identity taken afterwards never matched its own resume.
             identity = _run_identity(config)
-            config = _with_a_root_password_if_asked(config, arguments)
+            config = _with_a_root_password_if_asked(
+                config, arguments, _closing_catalog(state, arguments)
+            )
         if not arguments.missing_commands:
             catalog = load_catalog()
             validate(
@@ -757,7 +759,7 @@ def install(
         # after the passphrase was written and before `apply` removes it,
         # and the work directory outlives the run until the next reboot.
         try:
-            config = _with_passphrases_if_asked(config, arguments, work)
+            config = _with_passphrases_if_asked(config, arguments, work, translate)
             if not arguments.skip_preflight:
                 preflight_report = preflight.check(
                     config, probe, str(target), operations=operations
@@ -1019,7 +1021,7 @@ def _passphrase_minimum(node: Node) -> int:
 
 
 def _with_passphrases_if_asked(
-    config: InstallConfig, arguments: argparse.Namespace, work: Path
+    config: InstallConfig, arguments: argparse.Namespace, work: Path, translate: Catalog
 ) -> InstallConfig:
     """Ask for the passphrases a shared configuration cannot carry.
 
@@ -1039,12 +1041,12 @@ def _with_passphrases_if_asked(
         minimum = _passphrase_minimum(node)
         for _ in range(PASSWORD_TRIES):
             _forget_what_was_typed()
-            first = getpass.getpass(f"passphrase for {node.id}: ")
+            first = getpass.getpass(translate("passphrase for {}: ").format(node.id))
             if len(first) < minimum:
-                print(f"at least {minimum} characters", file=sys.stderr)
+                print(translate("at least {} characters").format(minimum), file=sys.stderr)
                 continue
-            if first != getpass.getpass("again: "):
-                print("the two did not match", file=sys.stderr)
+            if first != getpass.getpass(translate("again: ")):
+                print(translate("the two did not match"), file=sys.stderr)
                 continue
             store.stage(node.id, first)
             staged[node.id] = str(store.path(node.id))
@@ -1084,7 +1086,7 @@ def _only_answers_a_question(arguments: argparse.Namespace) -> bool:
 
 
 def _with_a_root_password_if_asked(
-    config: InstallConfig, arguments: argparse.Namespace
+    config: InstallConfig, arguments: argparse.Namespace, translate: Catalog
 ) -> InstallConfig:
     """Ask for a root password when the configuration leaves no way in.
 
@@ -1110,11 +1112,11 @@ def _with_a_root_password_if_asked(
     runner = Runner(log=lambda _: None, echo=False)
     for _ in range(PASSWORD_TRIES):
         _forget_what_was_typed()
-        first = getpass.getpass("root password for this machine: ")
+        first = getpass.getpass(translate("root password for this machine: "))
         if not first:
             continue
-        if first != getpass.getpass("again: "):
-            print("the two did not match", file=sys.stderr)
+        if first != getpass.getpass(translate("again: ")):
+            print(translate("the two did not match"), file=sys.stderr)
             continue
         return replace(
             config,

--- a/gentoo_install/cli.py
+++ b/gentoo_install/cli.py
@@ -520,10 +520,14 @@ def _once(arguments: argparse.Namespace, state: RunState, refused: str) -> int |
                 print("cancelled", file=sys.stderr)
                 return EXIT_ABORTED
             config = chosen
+            identity = _run_identity(config)
         else:
-            config = _with_a_root_password_if_asked(
-                _configuration_from(arguments.config, arguments), arguments
-            )
+            config = _configuration_from(arguments.config, arguments)
+            # Before the questions, and kept: every answer changes the text
+            # this hashes, and a password hash carries a fresh salt, so an
+            # identity taken afterwards never matched its own resume.
+            identity = _run_identity(config)
+            config = _with_a_root_password_if_asked(config, arguments)
         if not arguments.missing_commands:
             catalog = load_catalog()
             validate(
@@ -605,7 +609,14 @@ def _once(arguments: argparse.Namespace, state: RunState, refused: str) -> int |
         # the check that refuses a mounted disk has to see the empty graph a
         # conversion was given, and everything that resolves a `DeviceId` has
         # to see the graph read from the machine.
-        return install(config, operations, arguments, state, running_config(config, layout))
+        return install(
+            config,
+            operations,
+            arguments,
+            state,
+            running_config(config, layout),
+            identity=identity,
+        )
     except errors.DeviceNotFound as error:
         _print_machine_state(state)
         print(f"device: {error}", file=sys.stderr)
@@ -709,8 +720,15 @@ def install(
     arguments: argparse.Namespace,
     state: RunState,
     running: InstallConfig | None = None,
+    identity: Mapping[str, str] | None = None,
 ) -> int:
-    """Check the machine, then perform every operation in order."""
+    """Check the machine, then perform every operation in order.
+
+    `identity` is what a resume compares against, and it is the caller's
+    because the answers this function asks for do not belong in it: a password
+    hash carries a fresh salt every time it is computed, so a run that asked
+    for one recorded an identity its own resume could never match.
+    """
     work: Path = arguments.work
     translate = _closing_catalog(state, arguments)
     # A conversion replaces the running userland, so every operation after the
@@ -747,13 +765,13 @@ def install(
                 work=work,
                 mountpoint=target,
             )
-            identity = _run_identity(config)
+            recorded = dict(identity) if identity is not None else _run_identity(config)
             if arguments.resume:
                 resuming = journal.resume()
-                _refuse_a_different_run(journal, identity, record)
+                _refuse_a_different_run(journal, recorded, record)
                 _refuse_a_resume_with_no_journal(arguments.work, resuming)
             else:
-                journal.started(**identity)
+                journal.started(**recorded)
             finished = completed(journal) if arguments.resume else frozenset()
             if arguments.resume:
                 # Replayed before anything runs. The operation that recorded an

--- a/gentoo_install/cli.py
+++ b/gentoo_install/cli.py
@@ -313,6 +313,15 @@ def _validate_memory_launch(
         raise errors.PreflightFailed(
             f"--{launch.mode.value} cannot arm a one-shot boot entry on this machine"
         )
+    unanswered = [node.id for node in config.disk.graph.nodes.values() if _needs_a_passphrase(node)]
+    if unanswered:
+        # Refused rather than asked here: the answer would have to travel in
+        # the payload, and that puts a passphrase on the esp, which is the one
+        # place `SECURITY.md` promises it never reaches.
+        raise errors.PreflightFailed(
+            f"--{launch.mode.value} reboots into an environment with nobody to ask, and "
+            f"{', '.join(unanswered)} names no passphrase_file"
+        )
     if launch.mode is MemoryMode.RAM and not config.disk.graph.of_type(ZfsPool):
         print(
             "warning: --ram is slower for a layout without ZFS; --lowram uses the smaller Alpine netboot",

--- a/gentoo_install/data/locale/ja.toml
+++ b/gentoo_install/data/locale/ja.toml
@@ -798,3 +798,8 @@
 "the install finished" = "インストールが完了しました"
 "{outcome}. send the log to {host}, which is public?" = "{outcome}。ログを {host} に送りますか。公開されます"
 "y|yes" = "y|yes|はい"
+"root password for this machine: " = "このマシンの root パスワード："
+"again: " = "もう一度入力："
+"the two did not match" = "2 回の入力が一致しません"
+"passphrase for {}: " = "{} のパスフレーズ："
+"at least {} characters" = "{} 文字以上が必要です"

--- a/gentoo_install/data/locale/ko.toml
+++ b/gentoo_install/data/locale/ko.toml
@@ -798,3 +798,8 @@
 "{outcome}. send the log to {host}, which is public?" = "{outcome}. 로그 전송 대상은 공개된 호스트 {host}입니다. 전송하시겠습니까?"
 "y|yes" = "y|yes|예"
 "Encryption is a field of each partition, under Partitions." = "암호화는 \"파티션\" 화면의 각 파티션에 있는 항목입니다."
+"root password for this machine: " = "이 머신의 root 비밀번호: "
+"again: " = "다시 입력: "
+"the two did not match" = "두 입력이 일치하지 않습니다"
+"passphrase for {}: " = "{} 암호 문구: "
+"at least {} characters" = "{}자 이상이어야 합니다"

--- a/gentoo_install/data/locale/zh-CN.toml
+++ b/gentoo_install/data/locale/zh-CN.toml
@@ -799,3 +799,8 @@
 "the install finished" = "安装已完成"
 "{outcome}. send the log to {host}, which is public?" = "{outcome}。要把日志发送到 {host} 吗？那是公开的"
 "y|yes" = "y|yes|是|好"
+"root password for this machine: " = "这台机器的 root 密码："
+"again: " = "再输入一次："
+"the two did not match" = "两次输入不一致"
+"passphrase for {}: " = "{} 的密语："
+"at least {} characters" = "至少 {} 个字符"

--- a/gentoo_install/data/locale/zh-TW.toml
+++ b/gentoo_install/data/locale/zh-TW.toml
@@ -799,3 +799,8 @@
 "the install finished" = "安裝已完成"
 "{outcome}. send the log to {host}, which is public?" = "{outcome}。要把日誌送到 {host} 嗎？那是公開的"
 "y|yes" = "y|yes|是|好"
+"root password for this machine: " = "這台機器的 root 密碼："
+"again: " = "再輸入一次："
+"the two did not match" = "兩次輸入不一致"
+"passphrase for {}: " = "{} 的密語："
+"at least {} characters" = "至少 {} 個字元"

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -3266,6 +3266,10 @@ def _no_way_in() -> Any:
     return replace(started, system=replace(started.system, root_password_hash=""))
 
 
+def _english() -> Catalog:
+    return Catalog("en")
+
+
 def _driven(*, no_shell: bool = False, menu: bool = False) -> argparse.Namespace:
     return argparse.Namespace(
         no_shell=no_shell, menu=menu, dry_run=False, missing_commands=False
@@ -3283,7 +3287,7 @@ def test_a_configuration_with_no_login_is_left_alone_off_a_terminal(
         getpass, "getpass", lambda _: pytest.fail("asked with no terminal")
     )
     locked = _no_way_in()
-    assert cli._with_a_root_password_if_asked(locked, _driven()) is locked
+    assert cli._with_a_root_password_if_asked(locked, _driven(), _english()) is locked
 
 
 def test_a_configuration_with_no_login_is_asked_for_one_on_a_terminal(
@@ -3296,7 +3300,7 @@ def test_a_configuration_with_no_login_is_asked_for_one_on_a_terminal(
     answers = iter(["hunter2hunter2", "hunter2hunter2"])
     monkeypatch.setattr(getpass, "getpass", lambda _: next(answers))
 
-    filled = cli._with_a_root_password_if_asked(_no_way_in(), _driven())
+    filled = cli._with_a_root_password_if_asked(_no_way_in(), _driven(), _english())
     assert filled.system.root_password_hash.startswith("$6$")
 
 
@@ -3306,7 +3310,7 @@ def test_a_mistyped_confirmation_is_asked_again(monkeypatch: pytest.MonkeyPatch)
     answers = iter(["one", "other", "same", "same"])
     monkeypatch.setattr(getpass, "getpass", lambda _: next(answers))
 
-    filled = cli._with_a_root_password_if_asked(_no_way_in(), _driven())
+    filled = cli._with_a_root_password_if_asked(_no_way_in(), _driven(), _english())
     assert filled.system.root_password_hash.startswith("$6$")
 
 
@@ -3318,7 +3322,7 @@ def test_asking_stops_rather_than_repeating_forever(monkeypatch: pytest.MonkeyPa
     monkeypatch.setattr(getpass, "getpass", lambda _: "")
 
     with pytest.raises(errors.ValidationFailed, match="no root password"):
-        cli._with_a_root_password_if_asked(_no_way_in(), _driven())
+        cli._with_a_root_password_if_asked(_no_way_in(), _driven(), _english())
 
 
 def test_an_encrypted_paste_is_not_asked_about_under_no_shell(
@@ -3349,7 +3353,7 @@ def test_no_shell_on_a_terminal_is_still_unattended(
         getpass, "getpass", lambda _: pytest.fail("asked under --no-shell")
     )
     locked = _no_way_in()
-    assert cli._with_a_root_password_if_asked(locked, _driven(no_shell=True)) is locked
+    assert cli._with_a_root_password_if_asked(locked, _driven(no_shell=True), _english()) is locked
 
 
 def test_a_configuration_that_can_already_log_in_is_not_asked(
@@ -3360,7 +3364,7 @@ def test_a_configuration_that_can_already_log_in_is_not_asked(
         getpass, "getpass", lambda _: pytest.fail("asked with a password already set")
     )
     started = load(FIXTURES / "ext4-bios.toml")
-    assert cli._with_a_root_password_if_asked(started, _driven()) is started
+    assert cli._with_a_root_password_if_asked(started, _driven(), _english()) is started
 
 
 def _encrypted_without_a_key_file() -> Any:
@@ -3387,7 +3391,7 @@ def test_an_encrypted_device_with_no_key_file_is_asked_about(
     monkeypatch.setattr(getpass, "getpass", lambda _: next(answers))
 
     filled = cli._with_passphrases_if_asked(
-        _encrypted_without_a_key_file(), _driven(), tmp_path
+        _encrypted_without_a_key_file(), _driven(), tmp_path, _english()
     )
     named = [
         node.passphrase_file
@@ -3410,7 +3414,7 @@ def test_an_encrypted_device_is_not_asked_about_unattended(
     monkeypatch.setattr(sys.stdin, "isatty", lambda: True)
     monkeypatch.setattr(getpass, "getpass", lambda _: pytest.fail("asked unattended"))
     started = _encrypted_without_a_key_file()
-    assert cli._with_passphrases_if_asked(started, _driven(no_shell=True), tmp_path) is started
+    assert cli._with_passphrases_if_asked(started, _driven(no_shell=True), tmp_path, _english()) is started
 
 
 def test_a_named_key_file_is_left_for_preflight_to_read(
@@ -3419,7 +3423,7 @@ def test_a_named_key_file_is_left_for_preflight_to_read(
     monkeypatch.setattr(sys.stdin, "isatty", lambda: True)
     monkeypatch.setattr(getpass, "getpass", lambda _: pytest.fail("asked with a file named"))
     started = load(FIXTURES / "vm-luks.toml")
-    assert cli._with_passphrases_if_asked(started, _driven(), tmp_path) is started
+    assert cli._with_passphrases_if_asked(started, _driven(), tmp_path, _english()) is started
 
 
 def test_a_short_zfs_passphrase_is_refused_at_the_question(
@@ -3442,7 +3446,7 @@ def test_a_short_zfs_passphrase_is_refused_at_the_question(
     ]
     stripped = replace(started, disk=replace(started.disk, graph=DeviceGraph.build(pools)))
 
-    filled = cli._with_passphrases_if_asked(stripped, _driven(), tmp_path)
+    filled = cli._with_passphrases_if_asked(stripped, _driven(), tmp_path, _english())
     named = [
         node.passphrase_file
         for node in filled.disk.graph.nodes.values()
@@ -3582,8 +3586,8 @@ def test_a_password_answered_at_the_prompt_does_not_move_the_run_identity(
     monkeypatch.setattr(getpass, "getpass", lambda _: "hunter2hunter2")
 
     loaded = load(source)
-    first = cli._with_a_root_password_if_asked(loaded, _driven())
-    second = cli._with_a_root_password_if_asked(loaded, _driven())
+    first = cli._with_a_root_password_if_asked(loaded, _driven(), _english())
+    second = cli._with_a_root_password_if_asked(loaded, _driven(), _english())
     # The premise: the two answers are the same and their hashes are not.
     assert first.system.root_password_hash != second.system.root_password_hash
 

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -3616,3 +3616,34 @@ def test_install_records_the_identity_it_was_given(
         one for one in Journal(work / "install.jsonl").replay() if "configuration" in one
     ]
     assert recorded and recorded[-1]["configuration"] == "written-before", recorded
+
+
+def test_a_memory_launch_refuses_a_passphrase_it_cannot_ask_for(tmp_path: Path) -> None:
+    """The root password is answered on the host and travels in the payload.
+    A passphrase cannot: carrying it would put it on the esp, which is where
+    `SECURITY.md` says it never goes. So the run stops before it arms one."""
+    from dataclasses import replace as _replace
+
+    from gentoo_install.exec.probe import BootMethod
+    from gentoo_install.model.config import MemoryLaunch, MemoryMode
+    from gentoo_install.model.device import DeviceGraph, Luks
+
+    started = load(FIXTURES / "vm-luks.toml")
+    rebuilt = [
+        _replace(node, passphrase_file="") if isinstance(node, Luks) else node
+        for node in started.disk.graph.nodes.values()
+    ]
+    unlocked = _replace(
+        started, disk=_replace(started.disk, graph=DeviceGraph.build(rebuilt))
+    )
+
+    class Booting(RealProbe):
+        def boot_method(self) -> BootMethod:
+            return BootMethod.UEFI_GRUB
+
+    with pytest.raises(errors.PreflightFailed, match="names no passphrase_file"):
+        cli._validate_memory_launch(
+            unlocked,
+            MemoryLaunch(mode=MemoryMode.LOWRAM),
+            Booting(runner=Runner(log=lambda line: None), work=tmp_path),
+        )

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -3563,3 +3563,56 @@ def test_a_passphrase_does_not_stay_when_a_refused_resume_ends_the_run(
     staged = work / "keys" / "approved"
     left = sorted(one.name for one in staged.iterdir()) if staged.is_dir() else []
     assert left == [], left
+
+
+def test_a_password_answered_at_the_prompt_does_not_move_the_run_identity(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """`openssl passwd -6` salts every hash it computes, so an identity taken
+    after the question differed on every run and the next `--resume` refused
+    the journal its own predecessor had written."""
+    source = tmp_path / "no-password.toml"
+    given = (FIXTURES / "ext4-bios.toml").read_text(encoding="utf-8")
+    source.write_text(
+        re.sub(r'(?m)^root_password_hash = .*$', 'root_password_hash = ""', given),
+        encoding="utf-8",
+    )
+    monkeypatch.setattr(sys.stdin, "isatty", lambda: True)
+    monkeypatch.setattr(cli, "_forget_what_was_typed", lambda: None)
+    monkeypatch.setattr(getpass, "getpass", lambda _: "hunter2hunter2")
+
+    loaded = load(source)
+    first = cli._with_a_root_password_if_asked(loaded, _driven())
+    second = cli._with_a_root_password_if_asked(loaded, _driven())
+    # The premise: the two answers are the same and their hashes are not.
+    assert first.system.root_password_hash != second.system.root_password_hash
+
+    assert cli._run_identity(loaded) == cli._run_identity(loaded)
+    assert cli._run_identity(first) != cli._run_identity(second)
+
+
+def test_install_records_the_identity_it_was_given(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """The caller takes it before the questions, so the answers cannot move it."""
+    from gentoo_install.log import Journal
+
+    work = tmp_path / "work"
+    arguments = argparse.Namespace(
+        work=work,
+        target=tmp_path / "target",
+        resume=False,
+        skip_preflight=True,
+        no_shell=True,
+        menu=False,
+        dry_run=False,
+        missing_commands=False,
+        lang="en",
+    )
+    wanted = {"configuration": "written-before", "session": "s", "installer": "i"}
+    assert cli.install(load(FIXTURES / "ext4-bios.toml"), (), arguments, cli.RunState(), identity=wanted) == EXIT_OK
+
+    recorded = [
+        one for one in Journal(work / "install.jsonl").replay() if "configuration" in one
+    ]
+    assert recorded and recorded[-1]["configuration"] == "written-before", recorded


### PR DESCRIPTION
Three defects the adversarial review left, all in the question that asks for a secret a shared configuration omits.

`openssl passwd -6` salts every hash it computes, and the run identity was taken from the configuration after the question, so the same operator typing the same password produced a different identity on every run and the next `--resume` refused the journal its own predecessor had written. The caller takes the identity before any question now and passes it down.

A memory launch is armed on the host and the install runs after the reboot, where nobody can be asked. The root password travels in the payload; a passphrase cannot, because carrying it would put one on the esp, which is the one place `SECURITY.md` says a passphrase never reaches. The run stops before arming instead, naming the device.

The five prompts were English literals outside the catalog.