### PR TITLE
fix five defects an adversarial sweep found in unreviewed code

### DIFF
--- a/gentoo_install/cli.py
+++ b/gentoo_install/cli.py
@@ -44,10 +44,11 @@ from .model.device import (
     DeviceId,
     Luks,
     Node,
+    Partition,
+    PartitionTable,
     StorageFacts,
     StorageLayout,
     ZfsPool,
-    asks_for_a_share,
 )
 from .model.hardware import HardwareFacts
 from .model.size import Size
@@ -491,6 +492,22 @@ def main(argv: Sequence[str] | None = None) -> int:
         refused = outcome
 
 
+def _dry_run_storage_facts(config: InstallConfig, probe: Probe) -> StorageFacts | None:
+    """Evidence a dry run needs to resolve percentage shares."""
+    has_share = False
+    for partition in config.disk.graph.of_type(Partition):
+        share = partition.share
+        if share is None or share.percent is None:
+            continue
+        has_share = True
+        table = config.disk.graph[partition.table]
+        if isinstance(table, PartitionTable) and not table.create:
+            return probe_storage_facts(config, probe)
+    if not has_share:
+        return None
+    return StorageFacts(capacities=probe_capacities(config.disk.graph, probe))
+
+
 def _once(arguments: argparse.Namespace, state: RunState, refused: str) -> int | str:
     """One attempt. A string is why the menu should be walked again."""
     try:
@@ -587,19 +604,15 @@ def _once(arguments: argparse.Namespace, state: RunState, refused: str) -> int |
             layout = Probe(
                 runner=Runner(log=lambda line: None), work=arguments.work
             ).storage_layout()
-        if arguments.dry_run and asks_for_a_share(config.disk.graph):
-            # A capacity even for a dry run, and only when a share needs one:
-            # a share is a share of the disk, so without it the printed plan
-            # cannot say what `40%` is, and a plan that prints a different
-            # number from the one the install writes is the defect this whole
-            # feature exists to avoid. Gated on the share rather than on the
-            # mode, so a configuration that asks for nothing reads nothing.
-            storage_facts = StorageFacts(
-                capacities=probe_capacities(config.disk.graph, reading)
-            )
+        if arguments.dry_run and config.disk.mode is not DiskMode.DD:
+            # A preview has to use the install's share basis, or it can advertise
+            # a different size from the partition the install creates.
+            dry_run_facts = _dry_run_storage_facts(config, reading)
+            if dry_run_facts is not None:
+                storage_facts = dry_run_facts
         if not arguments.dry_run and config.disk.mode is not DiskMode.DD:
-            # The heavier evidence — mdraid metadata, free extents — is only
-            # required before a real install.
+            # Metadata is only needed before a real install; preview shares read
+            # free extents above when an edited table needs them.
             storage_facts = probe_storage_facts(config, reading)
             # `ld.so --help`, the loader's own answer about this machine.
             loader_v3 = reading.supports_v3()

--- a/gentoo_install/exec/fetch.py
+++ b/gentoo_install/exec/fetch.py
@@ -13,11 +13,13 @@ import errno
 import hashlib
 import http.client
 import json
+import os
 import re
 import socket
 import ssl
 import time
 import tomllib
+from dataclasses import dataclass
 from concurrent.futures import ThreadPoolExecutor
 from email.utils import parsedate_to_datetime
 from itertools import takewhile
@@ -146,9 +148,9 @@ def _stage3_from(
     digests = work / f"{name}.DIGESTS"
     _download(f"{builds}/{where}.DIGESTS", digests, runner.log, proxy=selected)
     _import_release_key(runner, work, selected)
-    _verify_signature(digests, fingerprint, runner)
+    verified = _verified_digests(digests, fingerprint, runner)
     try:
-        digest = _verify_digest(archive, digests)
+        digest = _verify_digest(archive, verified)
     except ArchiveDigestMismatch:
         # Removed before the next mirror is asked: the download below skips a
         # file that is already there, so leaving the bad one would make every
@@ -1136,6 +1138,12 @@ def _download_once(
         raise DownloadFailed(scrub(f"{url} could not be fetched: {error}")) from error
 
 
+@dataclass(frozen=True)
+class _VerifiedDigests:
+    name: str
+    text: str
+
+
 def _verify_signature(digests: Path, fingerprint: str, runner: Runner) -> None:
     """Compare the fingerprint gpg reports, not the text it printed.
 
@@ -1172,7 +1180,33 @@ def _signing_key(status: str) -> str | None:
     return None
 
 
-def _verify_digest(archive: Path, digests: Path) -> str:
+def _verified_digests(
+    digests: Path, fingerprint: str, runner: Runner
+) -> _VerifiedDigests:
+    """The cleartext gpg accepted after the pinned key verified it."""
+    # Cleartext can imitate a status record, so fingerprint checking remains a
+    # separate command from the plaintext read.
+    _verify_signature(digests, fingerprint, runner)
+    result = runner.run(
+        [
+            "gpg",
+            "--batch",
+            "--quiet",
+            "--logger-file",
+            os.devnull,
+            "--output",
+            "-",
+            "--decrypt",
+            str(digests),
+        ],
+        check=False,
+    )
+    if result.returncode != 0:
+        raise IntegrityError(f"the signature on {digests.name} does not verify")
+    return _VerifiedDigests(name=digests.name, text=result.stdout)
+
+
+def _verify_digest(archive: Path, digests: _VerifiedDigests) -> str:
     """The archive's SHA-512, once it matches what `DIGESTS` says it is.
 
     Answered rather than discarded: the marker beside the archive holds the
@@ -1188,8 +1222,13 @@ def _verify_digest(archive: Path, digests: Path) -> str:
     return got
 
 
-def _expected_sha512(digests: Path, name: str) -> str:
-    lines = digests.read_text().splitlines()
+def _expected_sha512(digests: _VerifiedDigests, name: str) -> str:
+    """The SHA-512 line in GnuPG's cleartext, never the armored source.
+
+    The armored file carries text outside the signature, and a digest read
+    from there is one the pinned key never signed.
+    """
+    lines = digests.text.splitlines()
     for index, line in enumerate(lines):
         if line.strip().upper().startswith("# SHA512"):
             for candidate in lines[index + 1 :]:

--- a/gentoo_install/plan/bootloader.py
+++ b/gentoo_install/plan/bootloader.py
@@ -91,9 +91,12 @@ MENU_SECONDS: Final[int] = 5
 #: Writing an NVRAM entry needs this, and only UEFI has NVRAM to write to.
 EFI_PACKAGE: Final[str] = "sys-boot/efibootmgr"
 
-#: Where generate-zbm writes, and the path firmware boots with no NVRAM entry.
-#: It names the image after the kernel, so the name is looked up, not assumed.
+#: Where generate-zbm writes; a copy goes to `FALLBACK_IMAGE` for firmware
+#: with no NVRAM entry.
 ZBM_DIRECTORY: Final[str] = "EFI/zbm"
+#: generate-zbm names images after kernels and reports the current path, so
+#: output identifies this build instead of scanning a reused ESP.
+ZBM_IMAGE_REPORT_PREFIX: Final[str] = "Created new UEFI image "
 FALLBACK_IMAGE: Final[str] = f"EFI/BOOT/BOOT{DEFAULT_ARCHITECTURE.efi_name.upper()}.EFI"
 
 
@@ -359,10 +362,11 @@ class InstallSystemdBoot(Operation):
 
     def apply(self, context: Context) -> None:
         command = ["bootctl", f"--esp-path={self.esp}"]
+        # The fallback loader must exist before an optional firmware entry may
+        # be degraded.
+        context.run_in_target([*command, "--no-variables", "install"])
         if self.write_nvram:
             _try_the_nvram_entry(context, [*command, "install"])
-        else:
-            context.run_in_target([*command, "--no-variables", "install"])
 
 
 @dataclass(frozen=True, kw_only=True)
@@ -572,8 +576,7 @@ class InstallZfsBootMenu(Operation):
             ]
         )
         context.write(ZBM_CONFIG, self._config())
-        context.run_in_target(["generate-zbm"])
-        image = self._image(context)
+        image = self._image(context.run_in_target(["generate-zbm"]))
         if self.unlocks_remotely:
             self._say_if_the_image_cannot_unlock(context, image)
         context.run_in_target(["install", "-D", "-m0644", image, f"{self.esp}/{FALLBACK_IMAGE}"])
@@ -590,25 +593,20 @@ class InstallZfsBootMenu(Operation):
                 ],
             )
 
-    def _image(self, context: Context) -> str:
-        """Whatever generate-zbm wrote. It names the image after the kernel
-        it built from, so `vmlinuz.EFI` is only one of the names it can have."""
-        # findutils 4.11.0 exits 1 for an entry it could not read while still
-        # printing the matches it reached, so the listing decides, not the code.
-        listing = str(
-            context.run_in_target(
-                ["find", f"{self.esp}/{ZBM_DIRECTORY}", "-name", "*.EFI"], check=False
-            )
-        ).strip()
-        found = sorted(
-            line.strip() for line in listing.splitlines() if line.strip().endswith(".EFI")
+    def _image(self, generated: str) -> str:
+        """The path `generate-zbm` reports for its current successful build."""
+        reported = [
+            line.removeprefix(ZBM_IMAGE_REPORT_PREFIX)
+            for line in generated.splitlines()
+            if line.startswith(ZBM_IMAGE_REPORT_PREFIX) and line.endswith(".EFI")
+        ]
+        directory = self.esp / ZBM_DIRECTORY
+        if len(reported) == 1 and PurePosixPath(reported[0]).parent == directory:
+            return reported[0]
+        said = f": {generated.strip()[:200]}" if generated.strip() else ""
+        raise NothingToBoot(
+            f"generate-zbm did not report an EFI image under {directory}{said}"
         )
-        if not found:
-            said = f": {listing[:200]}" if listing else ""
-            raise NothingToBoot(
-                f"generate-zbm wrote no EFI image under {self.esp}/{ZBM_DIRECTORY}{said}"
-            )
-        return found[0]
 
 
 def build(config: InstallConfig) -> list[Operation]:

--- a/gentoo_install/plan/disk.py
+++ b/gentoo_install/plan/disk.py
@@ -19,6 +19,7 @@ from ..model.device import (
     dataset_name,
     md_path,
     mapper_path,
+    takes_the_rest,
     DeviceGraph,
     DeviceId,
     Existing,
@@ -1276,12 +1277,16 @@ def _order_key(node: Node) -> tuple[int, int, str]:
     """Partition index first, then whether the node takes the remaining space.
 
     `sgdisk --new=N:0:+size` and `lvcreate -l 100%FREE` both take what is free
-    when they run, so a node with no size has to be created after every sized
-    one that shares its container.
+    when they run, so a partition taking the rest or a logical volume with no
+    size has to be created after every sized one that shares its container.
     """
     index = node.index if isinstance(node, Partition) else 0
-    takes_the_rest = isinstance(node, (Partition, LogicalVolume)) and node.size is None
-    return (index, 1 if takes_the_rest else 0, node.id)
+    is_rest = (
+        takes_the_rest(node)
+        if isinstance(node, Partition)
+        else isinstance(node, LogicalVolume) and node.size is None
+    )
+    return (index, 1 if is_rest else 0, node.id)
 
 
 #: What closes each kind of device, by the node that describes it.
@@ -1454,10 +1459,11 @@ def resolve_share(
     number the run will use: a `--dry-run` that says `40%` and an install that
     writes 96 GiB are two different answers to one question.
 
-    The usable space comes from `Size.usable_for_partitions`, the same
-    function `exec/preflight.py` checks fixed sizes against. Its own docstring
-    says why: answered separately, an operator was told their sizes fitted and
-    the install refused them an hour later.
+    A fresh table's usable space comes from `Size.usable_for_partitions`, the
+    same function `exec/preflight.py` checks fixed sizes against. An edited
+    table uses measured free extents, which exclude retained partitions. That
+    function's docstring says why: answered separately, an operator was told
+    their sizes fitted and the install refused them an hour later.
     """
     if partition.share is None:
         return partition.size
@@ -1466,9 +1472,15 @@ def resolve_share(
     table = _expect(graph, partition.table, PartitionTable)
     base = share_base(graph, table, facts)
     if base is None:
+        if not table.create:
+            raise InvalidLayout(
+                f"{partition.id} asks for {partition.share.percent}% of free space on "
+                f"{table.id}, but no measured free extents were provided; probe the "
+                "table before planning"
+            )
         raise InvalidLayout(
-            f"{partition.id} asks for {partition.share.percent}% of "
-            f"{table.disk}, and this machine did not report that disk's size"
+            f"{partition.id} asks for {partition.share.percent}% of {table.disk}, "
+            f"and this machine did not report that disk's size"
         )
     wanted = Size(int(base.bytes * partition.share.percent / 100)).align_down()
     return _bounded(wanted, partition)
@@ -1481,18 +1493,24 @@ def share_base(
 
     Every absolute size comes off first. A share is then what is left, which
     is how an operator describes it: the esp and the swap take their fixed
-    sizes and the rest is split.
+    sizes and the rest is split. On an edited table, measured free extents
+    already exclude partitions the operator keeps.
     """
+    fixed = sum(
+        one.size.bytes
+        for one in graph.of_type(Partition)
+        if one.table == table.id and one.size is not None
+    )
+    if not table.create:
+        extents = facts.free_extents.get(table.id)
+        if extents is None:
+            return None
+        return Size(max(0, sum(extent.size for extent in extents) - fixed))
     capacity = facts.capacities.get(table.disk)
     if capacity is None:
         return None
     usable = capacity.usable_for_partitions(
         table.table is TableType.GPT, SectorSize(512)
-    )
-    fixed = sum(
-        one.size.bytes
-        for one in graph.of_type(Partition)
-        if one.table == table.id and one.size is not None
     )
     return Size(max(0, usable.bytes - fixed))
 
@@ -1523,8 +1541,8 @@ def _start_of(
     """Where an MBR partition begins.
 
     On a table written from scratch, after every partition with a lower index.
-    A partition with no size takes the rest of the disk, so anything after it
-    has no start to compute; `validate.py` rejects that layout.
+    A partition taking the rest has no later start to compute; `validate.py`
+    rejects that layout.
 
     On a table the operator edits, after the partitions the disk already has:
     those are not model nodes and summing the model's own gave 1MiB, which
@@ -1534,15 +1552,18 @@ def _start_of(
     table = graph[partition.table]
     if isinstance(table, PartitionTable) and table.id in storage_facts.free_extents:
         return _into_free_space(
-            graph, table, partition, storage_facts.free_extents[table.id]
+            graph, table, partition, storage_facts.free_extents[table.id], storage_facts
         )
     start = FIRST_OFFSET
     for sibling in sorted(graph.of_type(Partition), key=lambda node: node.index):
         if sibling.table != partition.table or sibling.index >= partition.index:
             continue
-        if sibling.size is None:
+        if takes_the_rest(sibling):
             return start
-        start = (start + sibling.size).align_up()
+        sibling_size = resolve_share(graph, sibling, storage_facts)
+        if sibling_size is None:
+            raise InvalidLayout(f"{sibling.id} does not resolve to a size")
+        start = (start + sibling_size).align_up()
     return start
 
 
@@ -1554,10 +1575,10 @@ def _extent_end_of(
     """Where the gap this partition was placed in ends, or None for a fresh
     table where the rest of the disk is the answer.
 
-    An unsized partition in an edited table would otherwise be written as
-    `100%`, which reaches past every partition the operator asked to keep.
+    A partition taking the rest in an edited table would otherwise be written
+    as `100%`, which reaches past every partition the operator asked to keep.
     """
-    if partition.size is not None or storage_facts is None:
+    if not takes_the_rest(partition) or storage_facts is None:
         return None
     table = _expect(graph, partition.table, PartitionTable)
     if table.create:
@@ -1575,6 +1596,7 @@ def _into_free_space(
     table: PartitionTable,
     partition: Partition,
     free_extents: tuple[Extent, ...],
+    storage_facts: StorageFacts,
 ) -> Size:
     """The first free extent with room for this partition and the ones before it.
 
@@ -1590,12 +1612,18 @@ def _into_free_space(
     for one in added:
         for extent in free_extents:
             at = cursor[extent.start]
-            wanted = one.size.bytes if one.size is not None else 0
-            if at.bytes + wanted > extent.end + 1:
+            if takes_the_rest(one):
+                wanted = None
+            else:
+                wanted = resolve_share(graph, one, storage_facts)
+                if wanted is None:
+                    raise InvalidLayout(f"{one.id} does not resolve to a size")
+            needed = wanted.bytes if wanted is not None else 0
+            if at.bytes + needed > extent.end + 1:
                 continue
             if one.id == partition.id:
                 return at
-            cursor[extent.start] = (at + one.size).align_up() if one.size else at
+            cursor[extent.start] = (at + wanted).align_up() if wanted is not None else at
             break
         else:
             if one.id == partition.id:

--- a/gentoo_install/plan/kernel.py
+++ b/gentoo_install/plan/kernel.py
@@ -350,13 +350,20 @@ class WriteDracutModules(Operation):
     drivers: tuple[str, ...] = field(default_factory=cloud_drivers)
 
     def describe(self) -> str:
-        carried = f"write {DRACUT_MODULES_CONFIG} so dracut carries {', '.join(self.modules)}"
-        if not self.drivers:
+        wrote = f"write {DRACUT_MODULES_CONFIG}"
+        if self.modules:
+            carried = f"{wrote} so dracut carries {', '.join(self.modules)}"
+            if self.drivers:
+                return f"{carried}, and {len(self.drivers)} cloud bus drivers whatever it detects"
             return carried
-        return f"{carried}, and {len(self.drivers)} cloud bus drivers whatever it detects"
+        if self.drivers:
+            return f"{wrote} so dracut carries {len(self.drivers)} cloud bus drivers whatever it detects"
+        return f"{wrote} with no dracut modules or drivers"
 
     def apply(self, context: Context) -> None:
-        lines = [f'add_dracutmodules+=" {" ".join(self.modules)} "']
+        lines: list[str] = []
+        if self.modules:
+            lines.append(f'add_dracutmodules+=" {" ".join(self.modules)} "')
         if self.drivers:
             lines.append(f'add_drivers+=" {" ".join(self.drivers)} "')
         context.write(
@@ -843,8 +850,7 @@ def build(config: InstallConfig, hardware: HardwareFacts = HardwareFacts()) -> l
                 ),
             )
         )
-    if modules:
-        operations.append(WriteDracutModules(modules=modules))
+    operations.append(WriteDracutModules(modules=modules))
     # Delete first, then rebuild. The misnamed image `sys-fs/zfs` leaves is
     # often the only one in /boot, so deleting it last left generate-zbm with
     # `Unable to find latest kernel`. `emerge --config` reinstalls the image

--- a/gentoo_install/tui/packages.py
+++ b/gentoo_install/tui/packages.py
@@ -145,17 +145,14 @@ def desktop_screen(screen: Screen, config: InstallConfig, context: Context) -> A
     )
     changed = _desktop_proposes(changed, config, context, desktop)
     login = LOGIN_SCREEN.get(desktop, "")
-    effects = derive_effects(config, changed, context, kept_manager)
-    answered = settle(
+    return settle(
         screen,
         context,
         config,
         changed,
         kept_display_manager=kept_manager,
+        record_desktop_proposals=True,
     )
-    if answered.chosen:
-        _record_derived(context, answered.unwrap(), effects)
-    return answered
 #: What each desktop's own login screen is. Proposed rather than fixed: the
 #: row stays editable, and pulling the login screen out of the desktop profile
 #: was right — leaving it empty was not, because the row is then required and
@@ -266,19 +263,11 @@ def derive_effects(
             and AUDIO_GROUP not in before.packages.applications
             else ""
         ),
-        withdrawn_use=tuple(
-            one.value
-            for one in context.provenance
-            if one.kind is ValueKind.USE_FLAG
-            and one.source is ValueSource.DERIVED
-            and not _has_operator(context, ValueKind.USE_FLAG, one.value)
+        withdrawn_use=_withdrawn_derived(
+            automatic_values.use_flags, after, context, ValueKind.USE_FLAG
         ),
-        withdrawn_video_cards=tuple(
-            one.value
-            for one in context.provenance
-            if one.kind is ValueKind.VIDEO_CARD
-            and one.source is ValueSource.DERIVED
-            and not _has_operator(context, ValueKind.VIDEO_CARD, one.value)
+        withdrawn_video_cards=_withdrawn_derived(
+            automatic_values.video_cards, after, context, ValueKind.VIDEO_CARD
         ),
     )
 
@@ -297,6 +286,46 @@ def apply_effects(after: InstallConfig, effects: Effects) -> InstallConfig:
             video_cards=(*kept_cards, *effects.video_cards),
         ),
     )
+
+
+def _withdrawn_derived(
+    derive: Callable[[InstallConfig, Groups], tuple[automatic_values.Added, ...]],
+    after: InstallConfig,
+    context: Context,
+    kind: ValueKind,
+) -> tuple[str, ...]:
+    """Derived pins no active group still requests."""
+    derived = {
+        one.value
+        for one in context.provenance
+        if one.kind is kind
+        and one.source is ValueSource.DERIVED
+        and not _has_operator(context, kind, one.value)
+    }
+    if not derived:
+        return ()
+    if kind is ValueKind.USE_FLAG:
+        unpinned = replace(
+            after,
+            portage=replace(
+                after.portage,
+                use=tuple(value for value in after.portage.use if value not in derived),
+            ),
+        )
+    elif kind is ValueKind.VIDEO_CARD:
+        unpinned = replace(
+            after,
+            portage=replace(
+                after.portage,
+                video_cards=tuple(
+                    value for value in after.portage.video_cards if value not in derived
+                ),
+            ),
+        )
+    else:
+        raise AssertionError(f"{kind} has no automatic values")
+    automatic = {one.value for one in derive(unpinned, context.groups)}
+    return tuple(sorted(derived - automatic))
 
 
 #: Interface languages whose desktop wants CJK glyphs. `ko` and `ja` are here
@@ -469,6 +498,7 @@ def settle(
     before: InstallConfig,
     after: InstallConfig,
     kept_display_manager: str = "",
+    record_desktop_proposals: bool = False,
 ) -> Answer[InstallConfig]:
     """Confirm what a choice changes outside its own row, then write it down.
 
@@ -485,7 +515,18 @@ def settle(
     """
     effects = derive_effects(before, after, context, kept_display_manager)
     if not effects.has_changes:
-        return Answer(Outcome.CHOSE, after)
+        pinned = (
+            apply_effects(after, effects)
+            if effects.withdrawn_use or effects.withdrawn_video_cards
+            else after
+        )
+        _record_derived(
+            context,
+            pinned,
+            effects,
+            desktop_proposals=record_desktop_proposals,
+        )
+        return Answer(Outcome.CHOSE, pinned)
     translate = context.translate
     lines = []
     if effects.video_cards:
@@ -559,12 +600,25 @@ def settle(
     if answered.unwrap() == "open" and where is not None:
         opened = where(screen, pinned, context)
         if opened.chosen:
-            return Answer(Outcome.CHOSE, opened.unwrap())
+            settled = opened.unwrap()
+            _record_derived(
+                context,
+                settled,
+                effects,
+                desktop_proposals=record_desktop_proposals,
+            )
+            return Answer(Outcome.CHOSE, settled)
         if opened.outcome is Outcome.CANCELLED:
             # Cancelling reaches the application's leave confirmation. Reading
             # it as `keep what was pinned` committed a desktop and a profile
             # the operator had refused.
             return Answer(Outcome.CANCELLED)
+    _record_derived(
+        context,
+        pinned,
+        effects,
+        desktop_proposals=record_desktop_proposals,
+    )
     return Answer(Outcome.CHOSE, pinned)
 
 
@@ -578,8 +632,14 @@ def _has_operator(context: Context, kind: ValueKind, value: str) -> bool:
     return ValueProvenance(kind, value, ValueSource.OPERATOR) in context.provenance
 
 
-def _record_derived(context: Context, after: InstallConfig, effects: Effects) -> None:
-    """Replace the previous choice's derived values with the new choice's."""
+def _record_derived(
+    context: Context,
+    after: InstallConfig,
+    effects: Effects,
+    *,
+    desktop_proposals: bool = True,
+) -> None:
+    """Keep still-selected derived values and replace withdrawn ones."""
     # Only the kinds this proposal owns: it used to drop every derived record,
     # so choosing a desktop after ZFSBootMenu erased the overlay's and taking
     # the bootloader back left an overlay nobody had selected.
@@ -590,10 +650,25 @@ def _record_derived(context: Context, after: InstallConfig, effects: Effects) ->
         ValueKind.DISPLAY_MANAGER,
         ValueKind.APPLICATION,
     }
+    retained = {
+        ValueProvenance(kind, value, ValueSource.DERIVED)
+        for kind, values in (
+            (ValueKind.USE_FLAG, after.portage.use),
+            (ValueKind.VIDEO_CARD, after.portage.video_cards),
+            (ValueKind.NETWORKING, (after.system.networking.value,)),
+            (ValueKind.DISPLAY_MANAGER, (after.packages.display_manager,)),
+            (ValueKind.APPLICATION, after.packages.applications),
+        )
+        for value in values
+    }
     context.provenance = {
         one
         for one in context.provenance
-        if not (one.kind in owned and one.source is ValueSource.DERIVED)
+        if not (
+            one.kind in owned
+            and one.source is ValueSource.DERIVED
+            and one not in retained
+        )
     }
     context.provenance.update(
         ValueProvenance(ValueKind.USE_FLAG, value, ValueSource.DERIVED)
@@ -603,27 +678,28 @@ def _record_derived(context: Context, after: InstallConfig, effects: Effects) ->
         ValueProvenance(ValueKind.VIDEO_CARD, value, ValueSource.DERIVED)
         for value in effects.video_cards
     )
-    if effects.networking_changed:
-        context.provenance.add(
-            ValueProvenance(
-                ValueKind.NETWORKING,
-                after.system.networking.value,
-                ValueSource.DERIVED,
+    if desktop_proposals:
+        if effects.networking_changed:
+            context.provenance.add(
+                ValueProvenance(
+                    ValueKind.NETWORKING,
+                    after.system.networking.value,
+                    ValueSource.DERIVED,
+                )
             )
-        )
-    if effects.display_manager_changed:
-        context.provenance.add(
-            ValueProvenance(
-                ValueKind.DISPLAY_MANAGER,
-                after.packages.display_manager,
-                ValueSource.DERIVED,
+        if effects.display_manager_changed:
+            context.provenance.add(
+                ValueProvenance(
+                    ValueKind.DISPLAY_MANAGER,
+                    after.packages.display_manager,
+                    ValueSource.DERIVED,
+                )
             )
+        context.provenance.update(
+            ValueProvenance(ValueKind.APPLICATION, value, ValueSource.DERIVED)
+            for value in (*effects.fonts, effects.input_framework, effects.audio)
+            if value
         )
-    context.provenance.update(
-        ValueProvenance(ValueKind.APPLICATION, value, ValueSource.DERIVED)
-        for value in (*effects.fonts, effects.input_framework, effects.audio)
-        if value
-    )
 
 
 def _record_operator(context: Context, kind: ValueKind, values: Sequence[str]) -> None:

--- a/tests/golden/ext2.txt
+++ b/tests/golden/ext2.txt
@@ -58,6 +58,7 @@
   install the initramfs builder and firmware: emerge sys-kernel/dracut sys-kernel/linux-firmware, with no binhost
   install the storage tools: emerge sys-fs/e2fsprogs, with no binhost
   install the kernel: emerge sys-kernel/gentoo-kernel-bin, with no binhost
+  write /etc/dracut.conf.d/10-gentoo-install.conf so dracut carries 13 cloud bus drivers whatever it detects
   rebuild the initramfs from sys-kernel/gentoo-kernel-bin with the modules written above
   check the installkernel payload names existing kernel files
 

--- a/tests/golden/ext3.txt
+++ b/tests/golden/ext3.txt
@@ -58,6 +58,7 @@
   install the initramfs builder and firmware: emerge sys-kernel/dracut sys-kernel/linux-firmware, with no binhost
   install the storage tools: emerge sys-fs/e2fsprogs, with no binhost
   install the kernel: emerge sys-kernel/gentoo-kernel-bin, with no binhost
+  write /etc/dracut.conf.d/10-gentoo-install.conf so dracut carries 13 cloud bus drivers whatever it detects
   rebuild the initramfs from sys-kernel/gentoo-kernel-bin with the modules written above
   check the installkernel payload names existing kernel files
 

--- a/tests/golden/ext4-bios.txt
+++ b/tests/golden/ext4-bios.txt
@@ -58,6 +58,7 @@
   install the initramfs builder and firmware: emerge sys-kernel/dracut sys-kernel/linux-firmware, with no binhost
   install the storage tools: emerge sys-fs/e2fsprogs, with no binhost
   install the kernel: emerge sys-kernel/gentoo-kernel-bin, with no binhost
+  write /etc/dracut.conf.d/10-gentoo-install.conf so dracut carries 13 cloud bus drivers whatever it detects
   rebuild the initramfs from sys-kernel/gentoo-kernel-bin with the modules written above
   check the installkernel payload names existing kernel files
 

--- a/tests/golden/mbr-edit.txt
+++ b/tests/golden/mbr-edit.txt
@@ -59,6 +59,7 @@
   install the initramfs builder and firmware: emerge sys-kernel/dracut sys-kernel/linux-firmware
   install the storage tools: emerge sys-fs/e2fsprogs
   install the kernel: emerge sys-kernel/gentoo-kernel-bin
+  write /etc/dracut.conf.d/10-gentoo-install.conf so dracut carries 13 cloud bus drivers whatever it detects
   rebuild the initramfs from sys-kernel/gentoo-kernel-bin with the modules written above
   check the installkernel payload names existing kernel files
 

--- a/tests/golden/openrc-sdboot.txt
+++ b/tests/golden/openrc-sdboot.txt
@@ -65,6 +65,7 @@
   install the initramfs builder and firmware: emerge sys-kernel/dracut sys-kernel/linux-firmware
   install the storage tools: emerge sys-fs/dosfstools sys-fs/e2fsprogs
   install the kernel: emerge sys-kernel/gentoo-kernel-bin
+  write /etc/dracut.conf.d/10-gentoo-install.conf so dracut carries 13 cloud bus drivers whatever it detects
   rebuild the initramfs from sys-kernel/gentoo-kernel-bin with the modules written above
   check the installkernel payload names existing kernel files
 

--- a/tests/golden/static-ip.txt
+++ b/tests/golden/static-ip.txt
@@ -60,6 +60,7 @@
   install the initramfs builder and firmware: emerge sys-kernel/dracut sys-kernel/linux-firmware
   install the storage tools: emerge sys-fs/dosfstools sys-fs/e2fsprogs
   install the kernel: emerge sys-kernel/gentoo-kernel-bin
+  write /etc/dracut.conf.d/10-gentoo-install.conf so dracut carries 13 cloud bus drivers whatever it detects
   rebuild the initramfs from sys-kernel/gentoo-kernel-bin with the modules written above
   check the installkernel payload names existing kernel files
 

--- a/tests/golden/vm-binhost-fallback.txt
+++ b/tests/golden/vm-binhost-fallback.txt
@@ -62,6 +62,7 @@
   install the initramfs builder and firmware: emerge sys-kernel/dracut sys-kernel/linux-firmware
   install the storage tools: emerge sys-fs/dosfstools sys-fs/e2fsprogs
   install the kernel: emerge sys-kernel/gentoo-kernel-bin
+  write /etc/dracut.conf.d/10-gentoo-install.conf so dracut carries 13 cloud bus drivers whatever it detects
   rebuild the initramfs from sys-kernel/gentoo-kernel-bin with the modules written above
   check the installkernel payload names existing kernel files
 

--- a/tests/golden/vm-binpkg.txt
+++ b/tests/golden/vm-binpkg.txt
@@ -64,6 +64,7 @@
   install the initramfs builder and firmware: emerge sys-kernel/dracut sys-kernel/linux-firmware
   install the storage tools: emerge sys-fs/dosfstools sys-fs/e2fsprogs
   install the kernel: emerge sys-kernel/gentoo-kernel-bin
+  write /etc/dracut.conf.d/10-gentoo-install.conf so dracut carries 13 cloud bus drivers whatever it detects
   rebuild the initramfs from sys-kernel/gentoo-kernel-bin with the modules written above
   check the installkernel payload names existing kernel files
 

--- a/tests/golden/vm-bios.txt
+++ b/tests/golden/vm-bios.txt
@@ -62,6 +62,7 @@
   install the initramfs builder and firmware: emerge sys-kernel/dracut sys-kernel/linux-firmware
   install the storage tools: emerge sys-fs/e2fsprogs
   install the kernel: emerge sys-kernel/gentoo-kernel-bin
+  write /etc/dracut.conf.d/10-gentoo-install.conf so dracut carries 13 cloud bus drivers whatever it detects
   rebuild the initramfs from sys-kernel/gentoo-kernel-bin with the modules written above
   check the installkernel payload names existing kernel files
 

--- a/tests/golden/vm-cjk-kernel.txt
+++ b/tests/golden/vm-cjk-kernel.txt
@@ -65,6 +65,7 @@
   install the initramfs builder and firmware: emerge sys-kernel/dracut sys-kernel/linux-firmware
   install the storage tools: emerge sys-fs/dosfstools sys-fs/e2fsprogs
   install the kernel: emerge sys-kernel/gentoo-cjk-kernel-bin, from source
+  write /etc/dracut.conf.d/10-gentoo-install.conf so dracut carries 13 cloud bus drivers whatever it detects
   rebuild the initramfs from sys-kernel/gentoo-cjk-kernel-bin with the modules written above
   check the installkernel payload names existing kernel files
 

--- a/tests/golden/vm-convert.txt
+++ b/tests/golden/vm-convert.txt
@@ -50,6 +50,7 @@
   install the initramfs builder and firmware: emerge sys-kernel/dracut sys-kernel/linux-firmware, in /gentoo-install.new
   install the storage tools: emerge sys-fs/dosfstools sys-fs/e2fsprogs, in /gentoo-install.new
   install the kernel: emerge sys-kernel/gentoo-kernel-bin, in /gentoo-install.new
+  write /etc/dracut.conf.d/10-gentoo-install.conf so dracut carries 13 cloud bus drivers whatever it detects, in /gentoo-install.new
   rebuild the initramfs from sys-kernel/gentoo-kernel-bin with the modules written above, in /gentoo-install.new
   check the installkernel payload names existing kernel files, in /gentoo-install.new
 

--- a/tests/golden/vm-desktop.txt
+++ b/tests/golden/vm-desktop.txt
@@ -67,6 +67,7 @@
   install the initramfs builder and firmware: emerge sys-kernel/dracut sys-kernel/linux-firmware
   install the storage tools: emerge sys-fs/dosfstools sys-fs/e2fsprogs
   install the kernel: emerge sys-kernel/gentoo-kernel-bin
+  write /etc/dracut.conf.d/10-gentoo-install.conf so dracut carries 13 cloud bus drivers whatever it detects
   rebuild the initramfs from sys-kernel/gentoo-kernel-bin with the modules written above
   check the installkernel payload names existing kernel files
 

--- a/tests/golden/vm-f2fs.txt
+++ b/tests/golden/vm-f2fs.txt
@@ -64,6 +64,7 @@
   install the initramfs builder and firmware: emerge sys-kernel/dracut sys-kernel/linux-firmware
   install the storage tools: emerge sys-fs/dosfstools sys-fs/f2fs-tools
   install the kernel: emerge sys-kernel/gentoo-kernel-bin
+  write /etc/dracut.conf.d/10-gentoo-install.conf so dracut carries 13 cloud bus drivers whatever it detects
   rebuild the initramfs from sys-kernel/gentoo-kernel-bin with the modules written above
   check the installkernel payload names existing kernel files
 

--- a/tests/golden/vm-gnome.txt
+++ b/tests/golden/vm-gnome.txt
@@ -66,6 +66,7 @@
   install the initramfs builder and firmware: emerge sys-kernel/dracut sys-kernel/linux-firmware
   install the storage tools: emerge sys-fs/dosfstools sys-fs/e2fsprogs
   install the kernel: emerge sys-kernel/gentoo-kernel-bin
+  write /etc/dracut.conf.d/10-gentoo-install.conf so dracut carries 13 cloud bus drivers whatever it detects
   rebuild the initramfs from sys-kernel/gentoo-kernel-bin with the modules written above
   check the installkernel payload names existing kernel files
 

--- a/tests/golden/vm-greetd.txt
+++ b/tests/golden/vm-greetd.txt
@@ -66,6 +66,7 @@
   install the initramfs builder and firmware: emerge sys-kernel/dracut sys-kernel/linux-firmware
   install the storage tools: emerge sys-fs/dosfstools sys-fs/e2fsprogs
   install the kernel: emerge sys-kernel/gentoo-kernel-bin
+  write /etc/dracut.conf.d/10-gentoo-install.conf so dracut carries 13 cloud bus drivers whatever it detects
   rebuild the initramfs from sys-kernel/gentoo-kernel-bin with the modules written above
   check the installkernel payload names existing kernel files
 

--- a/tests/golden/vm-image.txt
+++ b/tests/golden/vm-image.txt
@@ -61,6 +61,7 @@
   install the initramfs builder and firmware: emerge sys-kernel/dracut sys-kernel/linux-firmware
   install the storage tools: emerge sys-fs/dosfstools sys-fs/e2fsprogs
   install the kernel: emerge sys-kernel/gentoo-kernel-bin
+  write /etc/dracut.conf.d/10-gentoo-install.conf so dracut carries 13 cloud bus drivers whatever it detects
   rebuild the initramfs from sys-kernel/gentoo-kernel-bin with the modules written above
   check the installkernel payload names existing kernel files
 

--- a/tests/golden/vm-openrc-desktop.txt
+++ b/tests/golden/vm-openrc-desktop.txt
@@ -70,6 +70,7 @@
   install the initramfs builder and firmware: emerge sys-kernel/dracut sys-kernel/linux-firmware
   install the storage tools: emerge sys-fs/dosfstools sys-fs/e2fsprogs
   install the kernel: emerge sys-kernel/gentoo-kernel-bin
+  write /etc/dracut.conf.d/10-gentoo-install.conf so dracut carries 13 cloud bus drivers whatever it detects
   rebuild the initramfs from sys-kernel/gentoo-kernel-bin with the modules written above
   check the installkernel payload names existing kernel files
 

--- a/tests/golden/vm-ram.txt
+++ b/tests/golden/vm-ram.txt
@@ -64,6 +64,7 @@
   install the initramfs builder and firmware: emerge sys-kernel/dracut sys-kernel/linux-firmware
   install the storage tools: emerge sys-fs/dosfstools sys-fs/e2fsprogs
   install the kernel: emerge sys-kernel/gentoo-kernel-bin
+  write /etc/dracut.conf.d/10-gentoo-install.conf so dracut carries 13 cloud bus drivers whatever it detects
   rebuild the initramfs from sys-kernel/gentoo-kernel-bin with the modules written above
   check the installkernel payload names existing kernel files
 

--- a/tests/golden/vm-sdboot.txt
+++ b/tests/golden/vm-sdboot.txt
@@ -62,6 +62,7 @@
   install the initramfs builder and firmware: emerge sys-kernel/dracut sys-kernel/linux-firmware
   install the storage tools: emerge sys-fs/dosfstools sys-fs/e2fsprogs
   install the kernel: emerge sys-kernel/gentoo-kernel-bin
+  write /etc/dracut.conf.d/10-gentoo-install.conf so dracut carries 13 cloud bus drivers whatever it detects
   rebuild the initramfs from sys-kernel/gentoo-kernel-bin with the modules written above
   check the installkernel payload names existing kernel files
 

--- a/tests/golden/vm-shares.txt
+++ b/tests/golden/vm-shares.txt
@@ -67,6 +67,7 @@
   install the initramfs builder and firmware: emerge sys-kernel/dracut sys-kernel/linux-firmware
   install the storage tools: emerge sys-fs/dosfstools sys-fs/e2fsprogs
   install the kernel: emerge sys-kernel/gentoo-kernel-bin
+  write /etc/dracut.conf.d/10-gentoo-install.conf so dracut carries 13 cloud bus drivers whatever it detects
   rebuild the initramfs from sys-kernel/gentoo-kernel-bin with the modules written above
   check the installkernel payload names existing kernel files
 

--- a/tests/golden/vm-source-kernel.txt
+++ b/tests/golden/vm-source-kernel.txt
@@ -64,6 +64,7 @@
   install the initramfs builder and firmware: emerge sys-kernel/dracut sys-kernel/linux-firmware
   install the storage tools: emerge sys-fs/dosfstools sys-fs/e2fsprogs
   install the kernel: emerge sys-kernel/gentoo-kernel, from source
+  write /etc/dracut.conf.d/10-gentoo-install.conf so dracut carries 13 cloud bus drivers whatever it detects
   rebuild the initramfs from sys-kernel/gentoo-kernel with the modules written above
   check the installkernel payload names existing kernel files
 

--- a/tests/golden/vm-user-key.txt
+++ b/tests/golden/vm-user-key.txt
@@ -68,6 +68,7 @@
   install the initramfs builder and firmware: emerge sys-kernel/dracut sys-kernel/linux-firmware
   install the storage tools: emerge sys-fs/dosfstools sys-fs/xfsprogs
   install the kernel: emerge sys-kernel/gentoo-kernel-bin
+  write /etc/dracut.conf.d/10-gentoo-install.conf so dracut carries 13 cloud bus drivers whatever it detects
   rebuild the initramfs from sys-kernel/gentoo-kernel-bin with the modules written above
   check the installkernel payload names existing kernel files
 

--- a/tests/golden/vm-xfs.txt
+++ b/tests/golden/vm-xfs.txt
@@ -64,6 +64,7 @@
   install the initramfs builder and firmware: emerge sys-kernel/dracut sys-kernel/linux-firmware
   install the storage tools: emerge sys-fs/dosfstools sys-fs/xfsprogs
   install the kernel: emerge sys-kernel/gentoo-kernel-bin
+  write /etc/dracut.conf.d/10-gentoo-install.conf so dracut carries 13 cloud bus drivers whatever it detects
   rebuild the initramfs from sys-kernel/gentoo-kernel-bin with the modules written above
   check the installkernel payload names existing kernel files
 

--- a/tests/golden/vm-zram.txt
+++ b/tests/golden/vm-zram.txt
@@ -66,6 +66,7 @@
   install the initramfs builder and firmware: emerge sys-kernel/dracut sys-kernel/linux-firmware
   install the storage tools: emerge sys-fs/dosfstools sys-fs/xfsprogs
   install the kernel: emerge sys-kernel/gentoo-kernel-bin
+  write /etc/dracut.conf.d/10-gentoo-install.conf so dracut carries 13 cloud bus drivers whatever it detects
   rebuild the initramfs from sys-kernel/gentoo-kernel-bin with the modules written above
   check the installkernel payload names existing kernel files
 

--- a/tests/unit/test_automatic.py
+++ b/tests/unit/test_automatic.py
@@ -1761,6 +1761,96 @@ def test_a_desktop_takes_back_the_fonts_and_framework_it_proposed() -> None:
     assert not (set(none.packages.applications) & proposed), none.packages.applications
 
 
+def test_a_desktop_withdraws_proposals_kept_by_a_second_desktop() -> None:
+    from tests.unit.fake_screen import FakeScreen
+    from tests.unit.test_tui_app import context
+
+    at = context()
+    at.tag = "zh-TW"
+    chinese = screens.with_language(config(), "zh-TW")
+    picked = replace(
+        chinese, packages=replace(chinese.packages, desktop="plasma")
+    )
+    plasma = tui_packages._desktop_proposes(picked, chinese, at, "plasma")
+    proposed = {
+        *tui_packages.CJK_DESKTOP_FONTS,
+        tui_packages.DESKTOP_INPUT_FRAMEWORK["plasma"],
+        tui_packages.AUDIO_GROUP,
+    }
+    assert proposed <= set(plasma.packages.applications), plasma.packages.applications
+    tui_packages._record_derived(
+        at, plasma, tui_packages.derive_effects(chinese, plasma, at)
+    )
+
+    with_graphics = tui_packages.graphics_screen(
+        FakeScreen(keys=[" ", "\n", "\n"], lines=30), plasma, at
+    ).unwrap()
+    assert with_graphics.packages.graphics == ("intel",)
+
+    selected_full = replace(
+        with_graphics,
+        packages=replace(with_graphics.packages, desktop="plasma-full"),
+    )
+    plasma_full = tui_packages._desktop_proposes(
+        selected_full, with_graphics, at, "plasma-full"
+    )
+    tui_packages._record_derived(
+        at,
+        plasma_full,
+        tui_packages.derive_effects(with_graphics, plasma_full, at),
+    )
+
+    selected_none = replace(
+        plasma_full, packages=replace(plasma_full.packages, desktop="")
+    )
+    without_desktop = tui_packages._desktop_proposes(
+        selected_none, plasma_full, at, ""
+    )
+
+    assert not (proposed & set(without_desktop.packages.applications)), (
+        without_desktop.packages.applications
+    )
+    assert without_desktop.packages.display_manager == ""
+    assert without_desktop.system.networking is SystemConfig().networking
+
+
+def test_a_driver_proposal_survives_an_unrelated_choice_until_unticked() -> None:
+    from gentoo_install.tui.context import (
+        ValueKind,
+        ValueProvenance,
+        ValueSource,
+    )
+    from tests.unit.fake_screen import FakeScreen
+    from tests.unit.test_tui_app import context
+
+    at = context()
+    proposed = tui_packages.graphics_screen(
+        FakeScreen(keys=[" ", "\n", "\n"], lines=30), config(), at
+    ).unwrap()
+    driver = ValueProvenance(
+        ValueKind.VIDEO_CARD, "intel", ValueSource.DERIVED
+    )
+    assert proposed.portage.video_cards == ("intel",)
+    assert driver in at.provenance, at.provenance
+
+    pipewire = tui_packages.AUDIO_GROUP
+    unrelated = tui_packages.packages_screen(
+        FakeScreen(keys=["/", *pipewire, "\x1b", " ", "\n", "\n"], lines=30),
+        proposed,
+        at,
+    ).unwrap()
+    assert pipewire in unrelated.packages.applications
+    assert unrelated.portage.video_cards == ("intel",)
+    assert driver in at.provenance, at.provenance
+
+    withdrawn = tui_packages.graphics_screen(
+        FakeScreen(keys=[" ", "\n"], lines=30), unrelated, at
+    ).unwrap()
+    assert withdrawn.packages.graphics == ()
+    assert withdrawn.portage.video_cards == ()
+    assert driver not in at.provenance, at.provenance
+
+
 def test_a_graphical_desktop_proposes_the_sound_server_it_needs() -> None:
     """Plasma reaches PipeWire through `kpipewire` whatever the plan says.
 

--- a/tests/unit/test_exec.py
+++ b/tests/unit/test_exec.py
@@ -670,20 +670,22 @@ def test_little_memory_warns_only_when_the_build_wants_it(tmp_path: Path) -> Non
     assert any("tmpfs" in warning for warning in asked.warnings), asked.warnings
 
 
-def test_a_digests_file_without_the_archive_is_an_integrity_error(tmp_path: Path) -> None:
-    digests = tmp_path / "stage3.tar.xz.DIGESTS"
-    digests.write_text("# SHA512 HASH\nabc  stage3-other.tar.xz\n")
+def test_a_digests_file_without_the_archive_is_an_integrity_error() -> None:
+    signed = fetch._VerifiedDigests(
+        name="stage3.tar.xz.DIGESTS", text="# SHA512 HASH\nabc  stage3-other.tar.xz\n"
+    )
     with pytest.raises(IntegrityError, match="no SHA512 line"):
-        fetch._expected_sha512(digests, "stage3-amd64-systemd-1.tar.xz")
+        fetch._expected_sha512(signed, "stage3-amd64-systemd-1.tar.xz")
 
 
 def test_a_digest_that_does_not_match_stops_the_install(tmp_path: Path) -> None:
     archive = tmp_path / "stage3-amd64-systemd-1.tar.xz"
     archive.write_bytes(b"not really a stage3")
-    digests = tmp_path / "stage3-amd64-systemd-1.tar.xz.DIGESTS"
-    digests.write_text(f"# SHA512 HASH\n{'0' * 128}  {archive.name}\n")
+    signed = fetch._VerifiedDigests(
+        name=f"{archive.name}.DIGESTS", text=f"# SHA512 HASH\n{'0' * 128}  {archive.name}\n"
+    )
     with pytest.raises(IntegrityError, match="SHA512"):
-        fetch._verify_digest(archive, digests)
+        fetch._verify_digest(archive, signed)
 
 
 def test_a_device_that_is_not_a_block_device_is_not_reported_as_mounted(tmp_path: Path) -> None:

--- a/tests/unit/test_fetch.py
+++ b/tests/unit/test_fetch.py
@@ -3,13 +3,40 @@
 
 from __future__ import annotations
 
+from collections.abc import Sequence
 from pathlib import Path
 
 import pytest
 
-from gentoo_install.errors import ArchiveDigestMismatch, DownloadFailed
+from gentoo_install.errors import ArchiveDigestMismatch, DownloadFailed, IntegrityError
 from gentoo_install.exec import fetch
-from gentoo_install.exec.runner import Runner
+from gentoo_install.exec.runner import Result, Runner
+
+def _cleartext_runner(
+    fingerprint: str, cleartext: str, asked: list[tuple[str, ...]]
+) -> Runner:
+    class Cleartext(Runner):
+        def run(
+            self,
+            argv: Sequence[str],
+            *,
+            check: bool = True,
+            input_text: str | None = None,
+            timeout: float | None = None,
+        ) -> Result:
+            asked.append(tuple(argv))
+            if "--verify" in argv:
+                stdout = (
+                    "[GNUPG:] VALIDSIG SUBKEY 2026-09-03 1 4 0 1 8 00 "
+                    f"{fingerprint}\n"
+                )
+            else:
+                assert "--output" in argv and "--decrypt" in argv
+                stdout = cleartext
+            return Result(tuple(argv), 0, stdout, "", 0.0)
+
+    return Cleartext(log=lambda line: None)
+
 
 
 def test_a_mirror_that_cannot_be_reached_is_not_the_end_of_the_install(
@@ -279,8 +306,111 @@ def test_a_corrupt_archive_is_removed_so_the_next_mirror_downloads_again(
     digests.write_text("# SHA512 HASH\n" + "0" * 128 + " stage3.tar.xz\n")
 
     with pytest.raises(ArchiveDigestMismatch):
-        fetch._verify_digest(archive, digests)
+        fetch._verify_digest(
+            archive, fetch._VerifiedDigests(name=digests.name, text=digests.read_text())
+        )
     assert archive.exists(), "the check itself does not remove anything"
+
+
+def test_stage3_rejects_a_digest_before_the_signed_block(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """The digest gpg emits wins; prepended metadata remains unsigned."""
+    name = "stage3-amd64-openrc.tar.xz"
+    fingerprint = "13EBBDBEDE7A12775DFDB1BABB572E0E2D182910"
+    archive = tmp_path / name
+    archive_bytes = b"unsigned archive"
+    archive.write_bytes(archive_bytes)
+    attacker = fetch._sha512(archive)
+    signed = "0" * 128
+    cleartext = f"# SHA512 HASH\n{signed}  {name}\n"
+    supplied = (
+        f"# SHA512 HASH\n{attacker}  {name}\n"
+        "-----BEGIN PGP SIGNED MESSAGE-----\n"
+        "Hash: SHA512\n\n"
+        f"{cleartext}"
+        "-----BEGIN PGP SIGNATURE-----\n"
+        "signature\n"
+        "-----END PGP SIGNATURE-----\n"
+    )
+    digests = tmp_path / f"{name}.DIGESTS"
+    asked: list[tuple[str, ...]] = []
+
+    def downloading(
+        url: str, target: Path, *unused: object, **ignored: object
+    ) -> None:
+        if target == archive:
+            target.write_bytes(archive_bytes)
+        else:
+            target.write_text(supplied)
+
+    monkeypatch.setattr(fetch, "_newest", lambda *unused: name)
+    monkeypatch.setattr(fetch, "_download", downloading)
+    monkeypatch.setattr(fetch, "_import_release_key", lambda *unused: None)
+
+    with pytest.raises(ArchiveDigestMismatch, match=signed[:16]):
+        fetch._stage3_from(
+            "https://mirror.example",
+            "openrc",
+            fingerprint,
+            tmp_path,
+            _cleartext_runner(fingerprint, cleartext, asked),
+        )
+
+    assert len(asked) == 2
+    assert asked[0] == ("gpg", "--status-fd", "1", "--verify", str(digests))
+    assert "--decrypt" in asked[1]
+    assert asked[1][asked[1].index("--output") + 1] == "-"
+
+
+def test_stage3_refuses_a_digest_after_the_signature(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """A digest after the armor cannot supply an unsigned archive name."""
+    name = "stage3-amd64-openrc.tar.xz"
+    fingerprint = "13EBBDBEDE7A12775DFDB1BABB572E0E2D182910"
+    archive = tmp_path / name
+    archive_bytes = b"unsigned archive"
+    archive.write_bytes(archive_bytes)
+    attacker = fetch._sha512(archive)
+    cleartext = "# SHA512 HASH\n" + "0" * 128 + "  another-stage3.tar.xz\n"
+    supplied = (
+        "-----BEGIN PGP SIGNED MESSAGE-----\n"
+        "Hash: SHA512\n\n"
+        f"{cleartext}"
+        "-----BEGIN PGP SIGNATURE-----\n"
+        "signature\n"
+        "-----END PGP SIGNATURE-----\n"
+        f"# SHA512 HASH\n{attacker}  {name}\n"
+    )
+    digests = tmp_path / f"{name}.DIGESTS"
+    asked: list[tuple[str, ...]] = []
+
+    def downloading(
+        url: str, target: Path, *unused: object, **ignored: object
+    ) -> None:
+        if target == archive:
+            target.write_bytes(archive_bytes)
+        else:
+            target.write_text(supplied)
+
+    monkeypatch.setattr(fetch, "_newest", lambda *unused: name)
+    monkeypatch.setattr(fetch, "_download", downloading)
+    monkeypatch.setattr(fetch, "_import_release_key", lambda *unused: None)
+
+    with pytest.raises(IntegrityError, match="no SHA512 line"):
+        fetch._stage3_from(
+            "https://mirror.example",
+            "openrc",
+            fingerprint,
+            tmp_path,
+            _cleartext_runner(fingerprint, cleartext, asked),
+        )
+
+    assert len(asked) == 2
+    assert asked[0] == ("gpg", "--status-fd", "1", "--verify", str(digests))
+    assert "--decrypt" in asked[1]
+    assert asked[1][asked[1].index("--output") + 1] == "-"
 
 
 def test_a_body_that_stops_early_is_a_download_failure(
@@ -402,7 +532,9 @@ def test_the_stage3_is_hashed_once_for_one_download(
         return real(path)
 
     monkeypatch.setattr(fetch, "_sha512", counted)
-    digest = fetch._verify_digest(archive, digests)
+    digest = fetch._verify_digest(
+        archive, fetch._VerifiedDigests(name=digests.name, text=digests.read_text())
+    )
     assert reads == 1, reads
 
     # What the caller writes into the marker has to be the digest it was

--- a/tests/unit/test_plan.py
+++ b/tests/unit/test_plan.py
@@ -215,7 +215,10 @@ def test_bios_installs_no_efibootmgr() -> None:
 
 def test_dracut_carries_a_module_for_every_layer_of_the_stack() -> None:
     described = " ".join(operation.describe() for operation in plan(config()))
-    assert "so dracut carries" not in described  # plain ext4 needs no extra module
+    # A plain ext4 root needs no dracut module and still needs the bus drivers:
+    # a machine that cannot see its own disk does not boot to be told why.
+    assert "so dracut carries crypt" not in described
+    assert "cloud bus drivers" in described
     with_luks = " ".join(
         operation.describe() for operation in plan(load(FIXTURES / "btrfs-luks.toml"), load_catalog())
     )

--- a/tests/unit/test_plan_boot.py
+++ b/tests/unit/test_plan_boot.py
@@ -113,12 +113,13 @@ def test_dracut_carries_a_module_for_each_layer_of_the_stack() -> None:
     assert kernel.dracut_modules(config(nodes)) == ("mdraid", "crypt", "btrfs")
 
 
-def test_a_plain_layout_asks_dracut_for_nothing_extra() -> None:
+def test_a_plain_layout_writes_cloud_bus_drivers_without_storage_modules() -> None:
     assert kernel.dracut_modules(config()) == ()
-    assert not apply_kernel(config()).files.get(
-        PurePosixPath("/etc/dracut.conf.d/10-gentoo-install.conf")
+    written = apply_kernel(config()).files.get(
+        PurePosixPath("/etc/dracut.conf.d/10-gentoo-install.conf"), ""
     )
-
+    expected = 'add_drivers+=" ' + " ".join(kernel.cloud_drivers()) + ' "\n'
+    assert written == expected, written
 
 def test_the_storage_tools_follow_the_filesystems_in_use() -> None:
     assert set(kernel.storage_packages(config())) == {"sys-fs/dosfstools", "sys-fs/e2fsprogs"}

--- a/tests/unit/test_plan_boot.py
+++ b/tests/unit/test_plan_boot.py
@@ -362,11 +362,13 @@ def zfs_installation() -> InstallConfig:
 
 
 def test_the_zbm_image_is_the_one_generate_zbm_wrote() -> None:
-    """It names the image after the kernel it built from, so the name is looked
-    up: assuming `vmlinuz.EFI` left the fallback path empty and the machine
-    unbootable."""
-    recorder = Recorder()
-    recorder.replies["find"] = "/efi/EFI/zbm/kernel.EFI\n"
+    """`EFI.Versions: false` writes `<kernel-prefix>.EFI`, and generate-zbm
+    reports the current path after moving any previous image to its backup."""
+    recorder = Recorder(
+        replies={
+            "generate-zbm": "Created new UEFI image /efi/EFI/zbm/kernel.EFI\n",
+        }
+    )
     for operation in bootloader.build(zfs_installation()):
         operation.apply(recorder)
     copied = recorder.only("install", "-D", "-m0644")
@@ -376,19 +378,21 @@ def test_the_zbm_image_is_the_one_generate_zbm_wrote() -> None:
 
 
 def test_generate_zbm_writing_nothing_is_a_failure() -> None:
-    recorder = Recorder()
-    recorder.replies["find"] = "\n"
+    recorder = Recorder(replies={"generate-zbm": ""})
     operation = next(
         o for o in bootloader.build(zfs_installation()) if isinstance(o, bootloader.InstallZfsBootMenu)
     )
-    with pytest.raises(NothingToBoot):
+    with pytest.raises(NothingToBoot, match="did not report an EFI image"):
         operation.apply(recorder)
 
 
 def test_zfsbootmenu_sets_bootfs_and_writes_both_efi_paths() -> None:
     zfs = zfs_installation()
-    recorder = Recorder()
-    recorder.replies["find"] = "/efi/EFI/zbm/kernel.EFI\n"
+    recorder = Recorder(
+        replies={
+            "generate-zbm": "Created new UEFI image /efi/EFI/zbm/vmlinuz.EFI\n",
+        }
+    )
     for operation in bootloader.build(zfs):
         operation.apply(recorder)
     assert recorder.only("zpool", "set")[2].startswith("bootfs=zpcala/")

--- a/tests/unit/test_plan_bootloader.py
+++ b/tests/unit/test_plan_bootloader.py
@@ -436,8 +436,8 @@ def test_an_image_built_without_the_unlock_daemon_is_said_rather_than_shipped() 
             self, argv: Sequence[str], *, check: bool = True, input_text: str | None = None
         ) -> CommandOutput:
             self.in_target.append(tuple(argv))
-            if argv[0] == "find":
-                return CommandOutput("/efi/EFI/zbm/kernel.EFI\n", 0)
+            if argv[0] == "generate-zbm":
+                return CommandOutput("Created new UEFI image /efi/EFI/zbm/kernel.EFI\n", 0)
             if argv[0] == "lsinitrd":
                 return CommandOutput(self.answer, 0)
             return CommandOutput("", 0)
@@ -559,9 +559,9 @@ def test_a_probe_that_did_not_run_names_itself_rather_than_the_boot() -> None:
         grub.apply(empty)
 
     built = zfsbootmenu_operation()
-    unlisted = Recorder(replies={"find": CommandOutput("find: /efi/EFI/zbm: no such file", 1)})
-    with pytest.raises(NothingToBoot, match="no EFI image under /efi/EFI/zbm"):
-        built._image(unlisted)
+    unreported = Recorder(replies={"generate-zbm": "generate-zbm produced no image\n"})
+    with pytest.raises(NothingToBoot, match="did not report an EFI image"):
+        built.apply(unreported)
 
 
 def test_a_probe_answering_without_an_exit_status_is_read_as_a_failure() -> None:
@@ -591,19 +591,48 @@ def test_a_probe_answering_without_an_exit_status_is_read_as_a_failure() -> None
 def test_an_image_found_beside_an_unreadable_entry_is_still_installed() -> None:
     """Measured with findutils 4.11.0: `find <dir> -name '*.EFI'` over a
     directory holding one entry with mode 000 prints the matches it reached on
-    stdout and exits 1. The runner merges stderr in, so both arrive together."""
-    built = zfsbootmenu_operation()
+    stdout and exits 1. The runner merges stderr in, so both arrive together.
 
+    generate-zbm reports the fresh image after it replaces the old one, so an
+    unreadable sibling cannot change the boot path by being scanned.
+    """
+    built = zfsbootmenu_operation()
+    current = "/efi/EFI/zbm/vmlinuz-6.12.EFI"
     partial = Recorder(
         replies={
-            "find": CommandOutput(
-                "/efi/EFI/zbm/vmlinuz-6.12.EFI\n"
-                "find: '/efi/EFI/zbm/locked': Permission denied\n",
-                1,
-            )
+            "generate-zbm": CommandOutput(f"Created new UEFI image {current}\n", 0),
         }
     )
-    assert built._image(partial) == "/efi/EFI/zbm/vmlinuz-6.12.EFI"
+
+    built.apply(partial)
+
+    copied = partial.only("install", "-D", "-m0644")
+    assert copied[3] == current
+    assert not partial.argv_starting("find")
+
+
+def test_zfsbootmenu_installs_the_current_image_after_backing_up_the_previous_one() -> None:
+    """`EFI.Versions: false` moves the prior image to `-backup.EFI`; its final
+    success line names the replacement that firmware must boot."""
+    operation = zfsbootmenu_operation()
+    current = f"{operation.esp}/{bootloader.ZBM_DIRECTORY}/vmlinuz-6.12.EFI"
+    backup = current.removesuffix(".EFI") + "-backup.EFI"
+    reused = Recorder(
+        replies={
+            "generate-zbm": (
+                f"Created backup {current} -> {backup}\n"
+                f"Created new UEFI image {current}\n"
+            ),
+        }
+    )
+
+    operation.apply(reused)
+
+    copied = reused.only("install", "-D", "-m0644")
+    assert copied[3] == current
+    assert reused.only("lsinitrd") == ("lsinitrd", current)
+    entry = reused.only("efibootmgr", "--create")
+    assert entry[-1] == "\\EFI\\zbm\\vmlinuz-6.12.EFI"
 
 
 def test_the_zfsbootmenu_describe_changes_with_the_command_line_it_will_set() -> None:
@@ -659,6 +688,8 @@ def test_serial_console_uses_kernel_default_or_rejects_garbage(fixture: str) -> 
 
 
 def test_systemd_boot_image_skips_nvram_and_firmware_failure_degrades() -> None:
+    from gentoo_install.errors import CommandFailed
+
     installation = load(Path("tests/fixtures/vm-sdboot.toml"))
     image = replace(
         installation,
@@ -688,9 +719,41 @@ def test_systemd_boot_image_skips_nvram_and_firmware_failure_degrades() -> None:
         if isinstance(operation, bootloader.InstallSystemdBoot)
     )
     assert bootctl.write_nvram
-    refused = Recorder(failures={"bootctl"})
+
+    class NvramRefuses(Recorder):
+        def run_in_target(self, argv: Sequence[str], *, check: bool = True) -> CommandOutput:
+            if argv[0] == "bootctl" and "--no-variables" not in argv:
+                self.in_target.append(tuple(argv))
+                raise CommandFailed("bootctl: could not write EFI variables")
+            return super().run_in_target(argv, check=check)
+
+    refused = NvramRefuses()
     bootctl.apply(refused)
     assert refused.degraded(bootloader.NVRAM_ENTRY)
+    assert refused.in_target == [
+        ("bootctl", f"--esp-path={bootctl.esp}", "--no-variables", "install"),
+        ("bootctl", f"--esp-path={bootctl.esp}", "install"),
+    ]
+
+def test_systemd_boot_loader_write_failure_stops_the_install() -> None:
+    """The loader copy precedes an optional NVRAM request."""
+    from gentoo_install.errors import CommandFailed
+
+    installation = load(Path("tests/fixtures/vm-sdboot.toml"))
+    bootctl = next(
+        operation
+        for operation in bootloader.build(installation)
+        if isinstance(operation, bootloader.InstallSystemdBoot)
+    )
+    failed = Recorder(failures={"bootctl"})
+
+    with pytest.raises(CommandFailed, match="bootctl exited 1"):
+        bootctl.apply(failed)
+
+    assert not failed.degraded(bootloader.NVRAM_ENTRY)
+    assert failed.in_target == [
+        ("bootctl", f"--esp-path={bootctl.esp}", "--no-variables", "install"),
+    ]
 
 
 def test_grub_description_names_context_resolved_luks_parameters() -> None:
@@ -752,7 +815,11 @@ def test_the_zbm_description_names_the_fallback_it_overwrites() -> None:
     system's loader.
     """
     operation = zfsbootmenu_operation()
-    written = Recorder(replies={"find": "/efi/EFI/zbm/vmlinuz.EFI\n"})
+    written = Recorder(
+        replies={
+            "generate-zbm": "Created new UEFI image /efi/EFI/zbm/vmlinuz.EFI\n",
+        }
+    )
     operation.apply(written)
 
     installed = [

--- a/tests/unit/test_plan_disk.py
+++ b/tests/unit/test_plan_disk.py
@@ -2,6 +2,7 @@
 from __future__ import annotations
 
 from dataclasses import replace
+from decimal import Decimal
 from pathlib import Path, PurePosixPath
 
 import pytest
@@ -28,6 +29,7 @@ from gentoo_install.model.device import (
     PartitionTable,
     RaidLevel,
     RaidMetadata,
+    Share,
     StorageFacts,
     Subvolume,
     Swap,
@@ -199,6 +201,48 @@ def test_an_mbr_partition_is_placed_by_offset_because_parted_needs_one() -> None
     assert made[0][-2:] == ("mklabel", "msdos")
     assert made[1][-3:] == ("primary", "1MiB", "513MiB")
     assert made[-1][-3:] == ("primary", "513MiB", "100%")
+
+
+
+def test_a_percent_share_in_an_mbr_table_advances_later_partitions() -> None:
+    """A later partition must not reuse the percentage partition's start."""
+    nodes: list[Node] = [
+        Existing(id=i("disk"), selector="/dev/disk/by-id/virtio-target", wipe=True),
+        PartitionTable(id=i("table"), disk=i("disk"), table=TableType.MBR),
+        Partition(id=i("one"), table=i("table"), index=1, role=PartitionRole.DATA, size=Size.parse("1GiB")),
+        Partition(
+            id=i("two"),
+            table=i("table"),
+            index=2,
+            role=PartitionRole.DATA,
+            size=None,
+            share=Share(percent=Decimal("50")),
+        ),
+        Partition(id=i("three"), table=i("table"), index=3, role=PartitionRole.DATA, size=Size.parse("8GiB")),
+    ]
+    facts = StorageFacts(capacities={i("disk"): Size.parse("100GiB")})
+    partitions = [
+        operation
+        for operation in disk.build(config(nodes), facts)
+        if isinstance(operation, disk.CreatePartition)
+    ]
+
+    assert [(one.index, one.start, one.size) for one in partitions] == [
+        (1, Size.parse("1MiB"), Size.parse("1GiB")),
+        (2, Size.parse("1025MiB"), Size.parse("46591MiB")),
+        (3, Size.parse("47616MiB"), Size.parse("8GiB")),
+    ]
+    assert "from 1025MiB" in partitions[1].describe()
+    assert "from 47616MiB" in partitions[2].describe()
+
+    recorder = Recorder()
+    for partition in partitions:
+        partition.apply(recorder)
+    assert [argv[-2] for argv in recorder.argv_starting("parted")] == [
+        "1MiB",
+        "1025MiB",
+        "47616MiB",
+    ]
 
 
 def test_partition_table_kind_and_mbr_start_change_the_dry_run() -> None:
@@ -1530,6 +1574,22 @@ def _resolved(body: str, capacity: str) -> Size | None:
     return resolve_share(config.disk.graph, root, facts)
 
 
+def _edited_table_share() -> InstallConfig:
+    """The edited-table fixture with its added partition percentage-sized."""
+    installation = load(Path("tests/fixtures/mbr-edit.toml"))
+    graph = DeviceGraph.build(
+        replace(
+            node,
+            size=None,
+            share=Share(percent=Decimal("40")),
+        )
+        if isinstance(node, Partition) and node.id == i("rootpart")
+        else node
+        for node in installation.disk.graph.nodes.values()
+    )
+    return replace(installation, disk=replace(installation.disk, graph=graph))
+
+
 def test_a_share_is_of_what_the_fixed_sizes_leave_and_its_bounds_hold() -> None:
     """One file for a fleet of unlike disks is the whole point: four tenths of
     a 240 GB disk and four tenths of an 8 TB disk are both wrong on the other
@@ -1567,6 +1627,164 @@ def test_a_share_is_of_what_the_fixed_sizes_leave_and_its_bounds_hold() -> None:
     # And the other two spellings still mean what they meant.
     assert _resolved('size = "rest"', "240G") is None
     assert _resolved('size = "20G"', "240G") == Size.parse("20G")
+
+
+def test_a_share_on_an_edited_table_uses_its_measured_free_space() -> None:
+    """A retained partition is not a model node, so capacity overstates this share."""
+    nodes: list[Node] = [
+        Existing(id=i("disk"), selector="/dev/disk/by-id/virtio-target", wipe=False),
+        PartitionTable(id=i("table"), disk=i("disk"), table=TableType.GPT, create=False),
+        Partition(
+            id=i("added"),
+            table=i("table"),
+            index=2,
+            role=PartitionRole.DATA,
+            size=None,
+            share=Share(percent=Decimal("40")),
+        ),
+    ]
+    free = Extent(
+        start=Size.parse("60GiB").bytes,
+        end=Size.parse("100GiB").bytes - 1,
+    )
+    facts = StorageFacts(
+        capacities={i("disk"): Size.parse("100GiB")},
+        free_extents={i("table"): (free,)},
+    )
+    created = [
+        operation
+        for operation in disk.build(config(nodes), facts)
+        if isinstance(operation, disk.CreatePartition)
+    ]
+    assert len(created) == 1
+    partition = created[0]
+
+    assert partition.size == Size.parse("16GiB")
+    assert "16GiB" in partition.describe()
+    recorder = Recorder()
+    partition.apply(recorder)
+    assert recorder.only("sgdisk")[1:3] == ("--new=2:0:+16G", "--typecode=2:8300")
+
+
+def test_a_share_on_an_edited_table_requires_measured_extents() -> None:
+    """Capacity alone includes retained partitions and cannot resolve this share."""
+    with pytest.raises(InvalidLayout) as refused:
+        disk.build(
+            _edited_table_share(),
+            StorageFacts(capacities={i("disk"): Size.parse("100GiB")}),
+        )
+
+    said = str(refused.value)
+    assert "measured free extents" in said, said
+    assert "probe the table before planning" in said, said
+
+
+def test_a_dry_run_reads_free_extents_for_a_share_on_an_edited_table(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A preview must derive the same percentage size as the real install."""
+    from gentoo_install import cli
+    from gentoo_install.model.hardware import HardwareFacts
+    from gentoo_install.plan.operations import Operation
+
+    expected = StorageFacts(
+        free_extents={
+            i("table"): (
+                Extent(
+                    start=Size.parse("60GiB").bytes,
+                    end=Size.parse("100GiB").bytes - 1,
+                ),
+            )
+        }
+    )
+    seen: list[StorageFacts] = []
+
+    class Reading:
+        def __init__(self, **_: object) -> None:
+            pass
+
+        def hardware(self) -> HardwareFacts:
+            return HardwareFacts()
+
+    def measured(_: InstallConfig, __: object) -> StorageFacts:
+        return expected
+
+    def capacities(_: DeviceGraph, __: object) -> dict[DeviceId, Size]:
+        return {i("disk"): Size.parse("100GiB")}
+
+    def planned(
+        installation: InstallConfig,
+        _: object,
+        *,
+        mirror: str,
+        storage_facts: StorageFacts,
+        layout: object,
+        supports_v3: bool | None,
+        hardware: HardwareFacts,
+    ) -> tuple[Operation, ...]:
+        seen.append(storage_facts)
+        return tuple(disk.build(installation, storage_facts))
+
+    monkeypatch.setattr(cli, "_require_root", lambda arguments: None)
+    monkeypatch.setattr(cli, "_needs_network", lambda arguments: False)
+    monkeypatch.setattr(cli, "load_source", lambda source: _edited_table_share())
+    monkeypatch.setattr(cli, "Probe", Reading)
+    monkeypatch.setattr(cli, "probe_storage_facts", measured)
+    monkeypatch.setattr(cli, "probe_capacities", capacities)
+    monkeypatch.setattr(cli, "build", planned)
+
+    code = cli.main(["--config", str(tmp_path / "edited.toml"), "--dry-run"])
+
+    assert code == cli.EXIT_OK
+    assert seen == [expected]
+    sizes = [
+        operation.size
+        for operation in disk.build(_edited_table_share(), seen[0])
+        if isinstance(operation, disk.CreatePartition)
+    ]
+    assert sizes == [Size.parse("16GiB")]
+
+
+def test_a_share_on_an_edited_mbr_skips_gaps_that_cannot_hold_it() -> None:
+    """A share placed in a too-small gap would overlap retained space."""
+    nodes: list[Node] = [
+        Existing(id=i("disk"), selector="/dev/disk/by-id/virtio-target", wipe=False),
+        PartitionTable(id=i("table"), disk=i("disk"), table=TableType.MBR, create=False),
+        Partition(
+            id=i("added"),
+            table=i("table"),
+            index=2,
+            role=PartitionRole.DATA,
+            size=None,
+            share=Share(percent=Decimal("40")),
+        ),
+    ]
+    small = Extent(
+        start=Size.parse("1GiB").bytes,
+        end=Size.parse("5GiB").bytes - 1,
+    )
+    fitting = Extent(
+        start=Size.parse("60GiB").bytes,
+        end=Size.parse("96GiB").bytes - 1,
+    )
+    facts = StorageFacts(
+        capacities={i("disk"): Size.parse("100GiB")},
+        free_extents={i("table"): (small, fitting)},
+    )
+    created = [
+        operation
+        for operation in disk.build(config(nodes), facts)
+        if isinstance(operation, disk.CreatePartition)
+    ]
+    assert len(created) == 1
+    partition = created[0]
+
+    assert partition.start == Size.parse("60GiB")
+    assert partition.size == Size.parse("16GiB")
+    assert "from 60GiB" in partition.describe()
+    recorder = Recorder()
+    partition.apply(recorder)
+    assert recorder.only("parted")[-3:] == ("primary", "60GiB", "76GiB")
 
 
 def test_a_share_below_its_floor_is_refused_rather_than_raised() -> None:

--- a/tests/vm/cluster.py
+++ b/tests/vm/cluster.py
@@ -658,6 +658,23 @@ def _signing_key(status: str) -> str | None:
     return None
 
 
+def verified_digest_text(digests: Path, key: Path, home: Path) -> str:
+    """The cleartext the pinned key signed, which is the only part to parse.
+
+    The armored file carries text outside the signature, and a digest read
+    from there is one the pinned key never signed.
+    """
+    verify_release_signature(digests, key, home)
+    read = subprocess.run(
+        ["gpg", "--batch", "--homedir", str(home), "--output", "-", "--decrypt", str(digests)],
+        capture_output=True,
+        text=True,
+    )
+    if read.returncode != 0:
+        raise ProxmoxError(f"the signature on {digests.name} does not verify")
+    return read.stdout
+
+
 def verify_release_signature(digests: Path, key: Path, home: Path) -> None:
     """Verify Gentoo's digest signature against the pinned primary key."""
     home.mkdir(mode=0o700, parents=True, exist_ok=True)
@@ -691,8 +708,8 @@ def verify_release_signature(digests: Path, key: Path, home: Path) -> None:
         )
 
 
-def _expected_sha512(digests: Path, name: str) -> str:
-    rows = digests.read_text().splitlines()
+def _expected_sha512(cleartext: str, name: str) -> str:
+    rows = cleartext.splitlines()
     for index, row in enumerate(rows):
         if row.strip().upper().startswith("# SHA512"):
             for candidate in rows[index + 1 :]:
@@ -701,7 +718,7 @@ def _expected_sha512(digests: Path, name: str) -> str:
                     digest = fields[0].lower()
                     if re.fullmatch(r"[0-9a-f]{128}", digest):
                         return digest
-    raise ProxmoxError(f"{digests.name} has no SHA512 line for {name}")
+    raise ProxmoxError(f"the signed digests hold no SHA512 line for {name}")
 
 
 def _medium_name(name: str, sha512: str) -> str:
@@ -800,8 +817,8 @@ def current_minimal() -> tuple[str, tuple[str, ...], str]:
                 for source in MIRRORS:
                     try:
                         _download(f"{source}/{AUTOBUILDS}/{first}.DIGESTS", digests)
-                        verify_release_signature(digests, key, trust / "gnupg")
-                        sha512 = _expected_sha512(digests, original)
+                        cleartext = verified_digest_text(digests, key, trust / "gnupg")
+                        sha512 = _expected_sha512(cleartext, original)
                         return _medium_name(original, sha512), tuple(
                             f"{one}/{AUTOBUILDS}/{first}" for one in MIRRORS
                         ), sha512


### PR DESCRIPTION
An adversarial review of six modules no review had ever opened produced twenty-seven findings that survived two independent refuters. These are the five worth code.

The stage3 digest was read from the whole armored DIGESTS file, so a verified signature said nothing about the digest that was used; the cluster harness carried the same defect in its own copy of that reader. `bootctl install` both copies the loader onto the esp and writes the firmware entry, and the whole command was degraded to a warning, so a run could report success with no bootloader written; the ZFSBootMenu image now comes from the path `generate-zbm` reports rather than from whichever name sorts first, which was the previous build backup.

A percent share was read as taking the rest of the disk, so on an MBR table every partition after one was given that partition own start, and a share on a table the run does not create was taken from the whole disk rather than from its free extents. `WriteDracutModules` is the only operation that writes `add_drivers`, and it was emitted only for a layout that also needed a dracut storage module, so a plain root got no cloud bus drivers. `_record_derived` wiped every record it owned and re-added only what the current step had changed, so a font proposed by an earlier desktop choice could never be withdrawn.