### PR TITLE
portage: keep a binary host failure to the host it belongs to

### DIFF
--- a/gentoo_install/plan/portage.py
+++ b/gentoo_install/plan/portage.py
@@ -15,7 +15,7 @@ import signal
 from dataclasses import dataclass
 from enum import Enum
 from pathlib import PurePosixPath
-from typing import Final, Sequence
+from typing import Final, Iterator, Sequence
 
 from ..errors import CommandFailed, ConfigError
 from ..model import mirrors
@@ -209,6 +209,32 @@ def binhost_trust(name: str) -> str:
     """What one host's own key degrades. The official host's key comes from
     `getuto`, so a community key that failed must not switch it off too."""
     return f"binary packages from {name}"
+
+
+_BINHOST_NAMES: Final[tuple[str, ...]] = ("gentoo", "gentoo-zh")
+
+
+def _known_binhosts(context: Context, hosts: tuple[str, ...]) -> tuple[str, ...]:
+    """The plan's hosts, or the stanzas later operations actually received."""
+    if hosts:
+        return hosts
+    return tuple(name for name in _BINHOST_NAMES if context.read(_binrepos_path(name)))
+
+
+def _binary_host_available(
+    context: Context, *, binary_host: bool, hosts: tuple[str, ...]
+) -> bool:
+    """Whether a configured binary host remains usable."""
+    if not binary_host or context.degraded(BINARY_PACKAGES):
+        return False
+    if hosts:
+        return any(not context.degraded(binhost_trust(name)) for name in hosts)
+    if not any(context.degraded(binhost_trust(name)) for name in _BINHOST_NAMES):
+        return True
+    if known := _known_binhosts(context, ()):
+        return any(not context.degraded(binhost_trust(name)) for name in known)
+    # An operation without host metadata cannot assume an unrecorded peer exists.
+    return False
 
 #: `*/*-bin` is deliberately absent: it would exclude `gentoo-kernel-bin`, the
 #: one package this installer asks a binary host for.
@@ -492,8 +518,8 @@ class SettleBinhostFeature(Operation):
     `binrepos.conf` when there is not. Left alone the installed system says it
     fetches binary packages and has nothing naming where from.
 
-    A degradation during the merges is a different thing and does not reach
-    here: the host is configured and verified, and one package did not arrive.
+    A community key merge can reach here before its host is configured. Its
+    host-scoped degradation removes that host only; another host stays usable.
     """
 
     stage: Stage = Stage.PORTAGE
@@ -1088,6 +1114,8 @@ class Emerge(Operation):
     #: not asked for; `build()` now schedules `DisableBinhost(name="gentoo")`
     #: before any emerge, so that host is gone rather than merely unasked for.
     binary_host: bool = True
+    #: A host-scoped failure falls back to source only when no configured peer remains.
+    hosts: tuple[str, ...] = ()
     #: What to degrade rather than fail, when this emerge is what enables an
     #: optional path. Empty means the install stops, which is right for
     #: everything the machine needs to boot.
@@ -1129,7 +1157,10 @@ class Emerge(Operation):
 
     def apply(self, context: Context) -> None:
         command = self._argv(
-            context, source_only=context.degraded(BINARY_PACKAGES) or not self.binary_host
+            context,
+            source_only=not _binary_host_available(
+                context, binary_host=self.binary_host, hosts=self.hosts
+            ),
         )
         try:
             result = context.run_in_target(command, check=False)
@@ -1224,15 +1255,18 @@ class Emerge(Operation):
     def _note_an_unreadable_index(self, context: Context, result: object) -> None:
         """A host that answers no index does not fail the emerge: Portage says
         so, compiles everything and exits 0. Recorded here or nowhere, and
-        recorded once, because it says so on every emerge.
+        recorded once for that host, because it says so on every emerge.
 
         Every reader of a zero exit, not the first one: a retry that succeeded
         left the run saying it fetches binary packages from a host whose index
         it had failed to read.
         """
-        unreadable = _unreadable_index(str(result))
-        if unreadable is not None and not context.degraded(BINARY_PACKAGES):
-            context.degrade(BINARY_PACKAGES, unreadable)
+        if context.degraded(BINARY_PACKAGES):
+            return
+        for unreadable in _unreadable_indexes(str(result)):
+            trust = binhost_trust(unreadable.host)
+            if not context.degraded(trust):
+                context.degrade(trust, unreadable.reason)
 
     def _one_more_binary_try(self, context: Context, command: list[str]) -> str | None:
         """Run the same emerge again, and answer what still names a binary
@@ -1331,14 +1365,35 @@ _INDEX_UNREADABLE: Final[re.Pattern[str]] = re.compile(
 )
 
 
-def _unreadable_index(said: str) -> str | None:
-    """The reason to record when a host's index could not be read."""
-    found = _INDEX_UNREADABLE.search(said)
-    if found is None:
-        return None
-    detail = (found.group("detail") or "").strip()
-    where = f"{found.group('host')} could not read its package index at {found.group('url')}"
-    return f"{where}: {detail}" if detail else where
+@dataclass(frozen=True)
+class _UnreadableBinhostIndex:
+    host: str
+    reason: str
+
+
+def _names_an_unreadable_index(output: str) -> str:
+    """The line proving the failure was the binary host and not a package.
+
+    Looser than `_INDEX_UNREADABLE` on purpose: that pattern reads the host
+    out of Portage's usual two-line shape, and a line in any other shape still
+    says the index could not be read.
+    """
+    for raw in output.splitlines():
+        line = raw.strip()
+        if BINHOST_INDEX_FAILURE in line:
+            return line.removeprefix("!!! ")
+    return ""
+
+
+def _unreadable_indexes(said: str) -> Iterator[_UnreadableBinhostIndex]:
+    """The hosts and reasons to record when their indexes could not be read."""
+    for found in _INDEX_UNREADABLE.finditer(said):
+        detail = (found.group("detail") or "").strip()
+        host = found.group("host")
+        where = f"{host} could not read its package index at {found.group('url')}"
+        yield _UnreadableBinhostIndex(
+            host=host, reason=f"{where}: {detail}" if detail else where
+        )
 
 
 def _binhost_killed_emerge(result: CommandOutput) -> str | None:
@@ -1457,7 +1512,7 @@ class TrustBinhostKey(Operation):
         )
 
     def apply(self, context: Context) -> None:
-        if context.degraded(BINARY_PACKAGES):
+        if context.degraded(BINARY_PACKAGES) or context.degraded(binhost_trust(self.binhost)):
             return
         try:
             self._trust(context)
@@ -1584,6 +1639,8 @@ class VerifyPackages(Operation):
     #: As `Emerge.binary_host`: the pretend has to resolve against the same
     #: package set the real merge will use, or it accepts what emerge refuses.
     binary_host: bool = True
+    #: A host-scoped failure leaves binaries on when this tuple has a usable peer.
+    hosts: tuple[str, ...] = ()
 
     def describe_parts(self) -> tuple[str, tuple[str, ...]]:
         return "resolve {} together before installing the requested packages", (
@@ -1593,7 +1650,11 @@ class VerifyPackages(Operation):
     def apply(self, context: Context) -> None:
         atoms = tuple(request.atom for request in self.requests)
         output = self._resolve(
-            context, atoms, source_only=context.degraded(BINARY_PACKAGES) or not self.binary_host
+            context,
+            atoms,
+            source_only=not _binary_host_available(
+                context, binary_host=self.binary_host, hosts=self.hosts
+            ),
         )
         if output.returncode == 0:
             return
@@ -1673,25 +1734,25 @@ class VerifyPackages(Operation):
         the guaranteed path, so an index that cannot be read degrades to it
         rather than ending the install.
         """
-        unreadable = _binhost_unreadable(str(failed))
-        if unreadable is None or context.degraded(BINARY_PACKAGES):
+        said = str(failed)
+        unreadable = next(_unreadable_indexes(said), None)
+        # The marker without the host, as the deleted `_binhost_unreadable`
+        # matched it: a line Portage prints in another shape still names a
+        # host that cannot be read, and failing the install there is worse
+        # than degrading the whole feature.
+        loose = _names_an_unreadable_index(said)
+        if not loose or context.degraded(BINARY_PACKAGES):
             return failed
         # The same retry `Emerge` makes before giving up on binaries: one
         # dropped connection would otherwise compile the whole install.
         again = self._resolve(context, atoms, source_only=False)
-        if again.returncode == 0 or _binhost_unreadable(str(again)) is None:
+        if again.returncode == 0 or not _names_an_unreadable_index(str(again)):
             return again
-        context.degrade(BINARY_PACKAGES, f"binary host index unreadable: {unreadable}")
+        if unreadable is None or not _known_binhosts(context, self.hosts):
+            context.degrade(BINARY_PACKAGES, f"binary host index unreadable: {loose}")
+        else:
+            context.degrade(binhost_trust(unreadable.host), unreadable.reason)
         return self._resolve(context, atoms, source_only=True)
-
-
-def _binhost_unreadable(output: str) -> str | None:
-    """The line proving the failure was the binary host and not a package."""
-    for raw in output.splitlines():
-        line = raw.strip()
-        if BINHOST_INDEX_FAILURE in line:
-            return line.removeprefix("!!! ")
-    return None
 
 
 def _requesters_ask(request: PackageRequest) -> str:
@@ -1767,6 +1828,7 @@ def build(
     video_cards: tuple[str, ...] = (),
 ) -> list[Operation]:
     portage = config.portage
+    hosts = _binhost_names(portage)
     gentoo = PurePosixPath("/var/db/repos/gentoo")
     operations: list[Operation] = [
         InstallStage3(
@@ -1827,6 +1889,7 @@ def build(
                 packages=("dev-vcs/git",),
                 summary="install git, which every later repository sync needs",
                 repository_bootstrap=True,
+                hosts=hosts,
             ),
             ConfigureRepository(
                 name="gentoo",
@@ -1888,6 +1951,7 @@ def build(
                 packages=("dev-vcs/git",),
                 summary="install git, which the overlays are cloned with",
                 repository_bootstrap=True,
+                hosts=hosts,
             )
         )
     for overlay in portage.overlays:
@@ -1924,6 +1988,7 @@ def build(
                 packages=("app-eselect/eselect-repository",),
                 summary="install eselect-repository, which the named overlays are added with",
                 repository_bootstrap=True,
+                hosts=hosts,
             )
         )
         operations += [
@@ -1941,7 +2006,8 @@ def build(
                 summary="install the key the community binary packages are signed with",
                 source=SourcePolicy.build_all(),
                 repository_bootstrap=True,
-                degrades=BINARY_PACKAGES,
+                degrades=binhost_trust("gentoo-zh"),
+                hosts=hosts,
             ),
             TrustBinhostKey(
                 binhost="gentoo-zh",
@@ -1950,9 +2016,6 @@ def build(
             ),
             ConfigureBinhost(name="gentoo-zh", sync_uri=community_binhost(portage), verify=True),
         ]
-    hosts = tuple(
-        one.name for one in operations if isinstance(one, ConfigureBinhost)
-    )
     if hosts:
         # After every `ConfigureBinhost`, because it is their outcome this
         # reads: `WriteMakeConf` wrote `getbinpkg` before any of them ran.
@@ -2098,9 +2161,20 @@ def _proxy_toml(proxy: ProxyConfig) -> str:
     )
 
 
+def _binhost_names(portage: PortageConfig) -> tuple[str, ...]:
+    """The names this configuration asks the plan to make usable."""
+    if portage.binhost.official:
+        return (
+            ("gentoo", "gentoo-zh")
+            if portage.binhost.community is not BinhostChannel.OFF
+            else ("gentoo",)
+        )
+    return ("gentoo-zh",) if portage.binhost.community is not BinhostChannel.OFF else ()
+
+
 def uses_binhost(portage: PortageConfig) -> bool:
     """Whether any binary host is configured at all."""
-    return portage.binhost.official or portage.binhost.community is not BinhostChannel.OFF
+    return bool(_binhost_names(portage))
 
 
 def _distfiles(portage: PortageConfig) -> tuple[str, ...]:

--- a/tests/unit/test_plan_portage.py
+++ b/tests/unit/test_plan_portage.py
@@ -555,6 +555,33 @@ def test_an_official_key_without_its_local_signature_falls_back_to_source() -> N
     ) in working.in_target
 
 
+def test_a_host_already_degraded_is_not_trusted() -> None:
+    """Trusting a host ConfigureBinhost will omit is unnecessary; its peer is independent."""
+    community = portage.TrustBinhostKey(
+        binhost="gentoo-zh",
+        fingerprint=portage.GENTOOZH_FINGERPRINT,
+        key_path=portage.GENTOOZH_KEY,
+    )
+    recorder = Recorder()
+    recorder.degrade(portage.binhost_trust("gentoo-zh"), "the key package did not merge")
+
+    community.apply(recorder)
+
+    assert not recorder.in_target
+    portage.TrustBinhostKey(
+        binhost="gentoo",
+        fingerprint=portage.RELENG_FINGERPRINT,
+        key_path=portage.RELEASE_KEY,
+    ).apply(recorder)
+    assert (
+        "gpg",
+        "--homedir",
+        "/etc/portage/gnupg",
+        "--import",
+        str(portage.RELEASE_KEY),
+    ) in recorder.in_target
+
+
 def test_the_official_binhost_is_configured_after_its_key_is_trusted() -> None:
     installation = with_portage(binhost=Binhost(official=True, community=BinhostChannel.OFF))
     operations = portage.build(installation, MIRROR)
@@ -832,6 +859,30 @@ def test_a_degraded_binhost_reaches_the_source_path_at_all(
     emerge = next(argv for argv in recorder.in_target if argv[0] == "emerge")
     assert "--usepkg=n" in emerge and "--getbinpkg=n" in emerge
 
+@pytest.mark.parametrize(
+    ("hosts", "source_only"),
+    (
+        (("gentoo",), True),
+        (("gentoo", "gentoo-zh"), False),
+    ),
+    ids=("only-host-degraded", "peer-host-usable"),
+)
+def test_emerge_uses_source_only_when_every_configured_binhost_is_degraded(
+    hosts: tuple[str, ...], source_only: bool
+) -> None:
+    """A host-specific failure does not disable a healthy configured peer."""
+    recorder = Recorder()
+    recorder.degrade(portage.binhost_trust("gentoo"), "its index could not be read")
+
+    portage.Emerge(
+        packages=("sys-boot/grub",),
+        summary="install the bootloader",
+        hosts=hosts,
+    ).apply(recorder)
+
+    emerge = recorder.only("emerge")
+    assert ("--usepkg=n" in emerge) is source_only
+    assert ("--getbinpkg=n" in emerge) is source_only
 
 def test_a_failed_community_key_leaves_the_official_host_alone() -> None:
     """The official host's key comes from `getuto`, so one community key that
@@ -854,6 +905,57 @@ def test_a_failed_community_key_leaves_the_official_host_alone() -> None:
 
     portage.Emerge(packages=("sys-boot/grub",), summary="install the bootloader").apply(recorder)
     assert "--getbinpkg=y" in next(argv for argv in recorder.in_target if argv[0] == "emerge")
+
+
+def test_a_failed_community_key_merge_keeps_the_official_binhost_usable() -> None:
+    """The optional community key is not evidence against the official host."""
+    installation = with_portage(
+        binhost=Binhost(official=True, community=BinhostChannel.STABLE)
+    )
+    operations = portage.build(installation, MIRROR)
+    official = next(
+        one
+        for one in operations
+        if isinstance(one, portage.ConfigureBinhost) and one.name == "gentoo"
+    )
+    key = next(
+        one
+        for one in operations
+        if isinstance(one, portage.Emerge)
+        and one.packages == ("sec-keys/openpgp-keys-gentoozh",)
+    )
+    community = next(
+        one
+        for one in operations
+        if isinstance(one, portage.ConfigureBinhost) and one.name == "gentoo-zh"
+    )
+    settled = next(
+        one for one in operations if isinstance(one, portage.SettleBinhostFeature)
+    )
+    assert operations.index(official) < operations.index(key) < operations.index(community)
+    assert operations.index(community) < operations.index(settled)
+
+    recorder = Recorder(failures={"emerge"})
+    recorder.files[portage.MAKE_CONF] = 'FEATURES="getbinpkg"\n'
+    official.apply(recorder)
+    key.apply(recorder)
+    community.apply(recorder)
+    settled.apply(recorder)
+
+    trust = portage.binhost_trust("gentoo-zh")
+    assert recorder.degraded(trust)
+    assert not recorder.degraded(portage.BINARY_PACKAGES)
+    assert official.destinations()[0] in recorder.files
+    assert community.destinations()[0] not in recorder.files
+    assert 'FEATURES="getbinpkg"' in recorder.files[portage.MAKE_CONF]
+
+    recorder.failures.clear()
+    portage.Emerge(packages=("sys-boot/grub",), summary="install the bootloader").apply(
+        recorder
+    )
+    emerge = [argv for argv in recorder.in_target if argv[0] == "emerge"][-1]
+    assert "--getbinpkg=y" in emerge
+    assert "--usepkg=n" not in emerge
 
 
 def test_a_selected_binary_fetch_failure_retries_from_source() -> None:
@@ -1139,26 +1241,20 @@ def test_a_name_that_would_not_resolve_is_tried_again() -> None:
         assert "--retry 3" in command, command
 
 
-def test_both_binhost_detectors_read_one_marker() -> None:
-    """The failing path finds the line and the succeeding path parses the host
-    and the url out of it. The two spelled Portage's diagnostic separately, so
-    a reworded one would have left half of them silent while the other half
-    went on working.
-    """
+def test_both_binhost_paths_read_one_marker() -> None:
+    """The paths share one parser, so a reworded marker cannot split them."""
     from gentoo_install.plan import portage as plan_portage
 
-    assert plan_portage._binhost_unreadable(BINHOST_TIMED_OUT)
-    assert plan_portage._unreadable_index(BINHOST_TIMED_OUT)
+    assert tuple(plan_portage._unreadable_indexes(BINHOST_TIMED_OUT))
 
     # One marker: a diagnostic that does not carry it is seen by neither.
     reworded = BINHOST_TIMED_OUT.replace(
         plan_portage.BINHOST_INDEX_FAILURE, "Could not read binhost index"
     )
-    assert plan_portage._binhost_unreadable(reworded) is None
-    assert plan_portage._unreadable_index(reworded) is None
+    assert not tuple(plan_portage._unreadable_indexes(reworded))
 
-    # Both spellings answer the sample above, so only the source says whether
-    # there is one marker or two: the pattern has to quote the constant.
+
+    # One parser reads both paths, so the pattern has to quote the constant.
     import ast
     import inspect
 
@@ -1202,7 +1298,7 @@ def test_the_binhost_fallback_fixture_degrades_the_plan_to_source() -> None:
         f"!!! [gentoo] Error fetching binhost package info from '{endpoint}'\n"
         "!!! HTTP Error 404: Not Found\n"
     )
-    reason = f"binary host index unreadable: [gentoo] Error fetching binhost package info from '{endpoint}'"
+    reason = f"gentoo could not read its package index at {endpoint}"
     recorder = Recorder()
     attempts: list[tuple[str, ...]] = []
 
@@ -1221,10 +1317,11 @@ def test_the_binhost_fallback_fixture_degrades_the_plan_to_source() -> None:
                 atom="app-editors/nano",
                 requesters=("the `editor` group",),
             ),
-        )
+        ),
+        hosts=("gentoo",),
     ).apply(recorder)
 
-    assert recorder.degradations == {portage.BINARY_PACKAGES: reason}
+    assert recorder.degradations == {portage.binhost_trust("gentoo"): reason}
     assert [("--usepkg=n" in attempt, "--getbinpkg=n" in attempt) for attempt in attempts] == [
         (False, False),
         (False, False),
@@ -1253,11 +1350,13 @@ def test_a_binary_host_that_cannot_be_read_degrades_the_resolve_to_source() -> N
     check = portage.VerifyPackages(
         requests=(
             portage.PackageRequest(atom="gnome-base/gnome", requesters=("the `gnome` group",)),
-        )
+        ),
+        hosts=("gentoo",),
     )
     check.apply(recorder)
 
-    assert recorder.degraded(portage.BINARY_PACKAGES)
+    assert recorder.degraded(portage.binhost_trust("gentoo"))
+    assert not recorder.degraded(portage.BINARY_PACKAGES)
     # One retry with binaries still on before the whole install is committed to
     # compiling, the same as `Emerge` makes.
     assert [("--getbinpkg=n" in one) for one in attempts] == [False, False, True], attempts
@@ -1280,6 +1379,53 @@ def test_a_binary_host_that_cannot_be_read_degrades_the_resolve_to_source() -> N
     with pytest.raises(ConfigError, match="Error fetching binhost package info"):
         check.apply(already)
     assert len(tried) == 1, tried
+
+
+def test_an_unreadable_community_index_during_verification_keeps_the_official_host_usable() -> None:
+    """A failed index identifies its host, not another host that can serve packages."""
+    recorder = Recorder()
+    recorder.files[portage.MAKE_CONF] = 'FEATURES="getbinpkg"\n'
+    official = portage.ConfigureBinhost(
+        name="gentoo", sync_uri="https://official/", verify=True
+    )
+    community = portage.ConfigureBinhost(
+        name="gentoo-zh", sync_uri="https://community/", verify=True
+    )
+    official.apply(recorder)
+    community.apply(recorder)
+    community_index = BINHOST_TIMED_OUT.replace("[gentoo]", "[gentoo-zh]")
+    attempts: list[tuple[str, ...]] = []
+
+    def answer(argv: Sequence[str]) -> CommandOutput:
+        if argv[0] != "emerge":
+            return CommandOutput("", 0)
+        attempts.append(tuple(argv))
+        if "--getbinpkg=n" in argv:
+            return CommandOutput("[ebuild  N    ] app-misc/community-1\n", 0)
+        return CommandOutput(community_index, 1)
+
+    recorder.answering = answer
+    portage.VerifyPackages(
+        requests=(
+            portage.PackageRequest(
+                atom="app-misc/community", requesters=("the `community` group",)
+            ),
+        )
+    ).apply(recorder)
+
+    assert recorder.degraded(portage.binhost_trust("gentoo-zh"))
+    assert not recorder.degraded(portage.BINARY_PACKAGES)
+    assert [("--getbinpkg=n" in attempt) for attempt in attempts] == [False, False, True]
+    portage.SettleBinhostFeature(hosts=("gentoo", "gentoo-zh")).apply(recorder)
+    assert 'FEATURES="getbinpkg"' in recorder.files[portage.MAKE_CONF]
+
+    recorder.answering = lambda argv: CommandOutput("", 0)
+    portage.Emerge(packages=("sys-boot/grub",), summary="install the bootloader").apply(
+        recorder
+    )
+    emerge = [argv for argv in recorder.in_target if argv[0] == "emerge"][-1]
+    assert "--getbinpkg=y" in emerge
+    assert "--usepkg=n" not in emerge
 
 
 def test_a_rejection_that_is_not_the_binary_host_is_never_degraded() -> None:
@@ -2728,9 +2874,8 @@ def test_an_overlay_key_that_cannot_be_fetched_degrades_rather_than_ends_the_run
     packages are signed with, and its distfile is on no Gentoo mirror: a guest
     whose route to `distfiles.gentoozh.org` was down answered `404` from the
     local mirror, `Temporary failure in name resolution` from the rest, and
-    the whole install ended with exit 4 — disk partitioned, stage3 unpacked,
-    machine unusable. Every binary-host failure degrades to source."""
-    from gentoo_install.plan.portage import BINARY_PACKAGES, Emerge, SourcePolicy
+    machine unusable. The optional community key must not stop the run."""
+    from gentoo_install.plan.portage import Emerge, SourcePolicy, binhost_trust
 
     recorder = Recorder()
     recorder.failures.add("emerge")
@@ -2739,19 +2884,20 @@ def test_an_overlay_key_that_cannot_be_fetched_degrades_rather_than_ends_the_run
         summary="install the key the community binary packages are signed with",
         source=SourcePolicy.build_all(),
         repository_bootstrap=True,
-        degrades=BINARY_PACKAGES,
+        degrades=binhost_trust("gentoo-zh"),
     )
 
     operation.apply(recorder)
 
-    assert recorder.degraded(BINARY_PACKAGES), recorder.given_up
-    assert "openpgp-keys-gentoozh" in recorder.degradations[BINARY_PACKAGES]
+    trust = binhost_trust("gentoo-zh")
+    assert recorder.degraded(trust), recorder.given_up
+    assert "openpgp-keys-gentoozh" in recorder.degradations[trust]
 
 
 def test_the_plan_marks_that_key_as_one_the_run_may_lose() -> None:
     """The operation degrades only because the plan says it may. Without this
     the constructor test above passes on an object no planner ever builds."""
-    from gentoo_install.plan.portage import BINARY_PACKAGES, Emerge
+    from gentoo_install.plan.portage import Emerge, binhost_trust
 
     installation = with_portage(
         binhost=Binhost(official=True, community=BinhostChannel.STABLE)
@@ -2764,7 +2910,7 @@ def test_the_plan_marks_that_key_as_one_the_run_may_lose() -> None:
     ]
 
     assert len(keys) == 1, [one.describe() for one in operations]
-    assert keys[0].degrades == BINARY_PACKAGES, keys[0]
+    assert keys[0].degrades == binhost_trust("gentoo-zh"), keys[0]
 
 
 def test_an_emerge_the_machine_needs_still_ends_the_run() -> None:
@@ -2806,14 +2952,62 @@ def test_a_host_that_answers_no_index_is_recorded_rather_than_passed_over() -> N
 
     portage.Emerge(packages=("net-misc/openssh",), summary="install ssh").apply(recorder)
 
-    assert recorder.degraded(portage.BINARY_PACKAGES)
-    reason = recorder.degradations[portage.BINARY_PACKAGES]
+    trust = portage.binhost_trust("gentoo")
+    assert recorder.degraded(trust)
+    assert not recorder.degraded(portage.BINARY_PACKAGES)
+    reason = recorder.degradations[trust]
     assert "mirror.xtom.com.hk" in reason, reason
 
     # The emerge itself succeeded, so it is not retried and not re-run from
     # source: Portage has already built everything it was asked for.
     emerges = [argv for argv in recorder.in_target if argv[0] == "emerge"]
     assert len(emerges) == 1, emerges
+
+
+def test_each_unreadable_index_is_recorded_for_its_host() -> None:
+    """A successful emerge can report more than one inaccessible binary host."""
+    recorder = Recorder()
+    indexes = INDEX_REFUSED + INDEX_REFUSED.replace("[gentoo]", "[gentoo-zh]")
+    recorder.answering = lambda argv: (
+        CommandOutput(indexes, 0) if argv[0] == "emerge" else CommandOutput("", 0)
+    )
+
+    portage.Emerge(packages=("net-misc/openssh",), summary="install ssh").apply(recorder)
+
+    assert recorder.degraded(portage.binhost_trust("gentoo"))
+    assert recorder.degraded(portage.binhost_trust("gentoo-zh"))
+    assert not recorder.degraded(portage.BINARY_PACKAGES)
+
+
+def test_an_unreadable_community_index_keeps_the_official_binhost_usable() -> None:
+    """An index diagnostic identifies one host, not every configured host."""
+    recorder = Recorder()
+    recorder.files[portage.MAKE_CONF] = 'FEATURES="getbinpkg"\n'
+    portage.ConfigureBinhost(name="gentoo", sync_uri="https://official/", verify=True).apply(
+        recorder
+    )
+    community_index = INDEX_REFUSED.replace("[gentoo]", "[gentoo-zh]")
+    recorder.answering = lambda argv: (
+        CommandOutput(community_index, 0)
+        if argv[0] == "emerge" and argv[-1] == "app-misc/community"
+        else CommandOutput("", 0)
+    )
+
+    portage.Emerge(packages=("app-misc/community",), summary="install community").apply(
+        recorder
+    )
+
+    assert recorder.degraded(portage.binhost_trust("gentoo-zh"))
+    assert not recorder.degraded(portage.BINARY_PACKAGES)
+    portage.SettleBinhostFeature(hosts=("gentoo",)).apply(recorder)
+    assert 'FEATURES="getbinpkg"' in recorder.files[portage.MAKE_CONF]
+
+    portage.Emerge(packages=("sys-boot/grub",), summary="install the bootloader").apply(
+        recorder
+    )
+    emerge = [argv for argv in recorder.in_target if argv[0] == "emerge"][-1]
+    assert "--getbinpkg=y" in emerge
+    assert "--usepkg=n" not in emerge
 
 
 def test_a_healthy_binhost_records_nothing() -> None:
@@ -2896,21 +3090,25 @@ def test_the_recorded_reason_carries_portage_own_diagnosis() -> None:
     the reader to the mirror; the guest's resolver is where the fault was."""
     from gentoo_install.plan import portage as plan_portage
 
-    said = plan_portage._unreadable_index(BINHOST_UNRESOLVED)
+    said = next(plan_portage._unreadable_indexes(BINHOST_UNRESOLVED), None)
     assert said is not None
-    assert "name resolution" in said, said
-    assert "answered no package index" not in said, said
+    assert said.host == "gentoo"
+    assert "name resolution" in said.reason, said
+    assert "answered no package index" not in said.reason, said
 
     # The timeout sample carries its own words, and neither reason invents a
     # cause the log does not hold.
-    timed_out = plan_portage._unreadable_index(BINHOST_TIMED_OUT)
-    assert timed_out is not None and "timed out" in timed_out, timed_out
+    timed_out = next(plan_portage._unreadable_indexes(BINHOST_TIMED_OUT), None)
+    assert timed_out is not None and "timed out" in timed_out.reason, timed_out
 
     # Portage sometimes prints the first line alone; that still answers.
-    alone = plan_portage._unreadable_index(
-        "!!! [gentoo] Error fetching binhost package info from 'https://example.invalid/x'\n"
+    alone = next(
+        plan_portage._unreadable_indexes(
+            "!!! [gentoo] Error fetching binhost package info from 'https://example.invalid/x'\n"
+        ),
+        None,
     )
-    assert alone is not None and "example.invalid" in alone, alone
+    assert alone is not None and "example.invalid" in alone.reason, alone
 
 
 
@@ -3317,7 +3515,8 @@ def test_a_retry_that_succeeded_still_records_an_unreadable_index() -> None:
     recorder = Killed()
     portage.Emerge(packages=("app-editors/vim",), summary="install vim").apply(recorder)
 
-    assert recorder.degraded(portage.BINARY_PACKAGES)
+    assert recorder.degraded(portage.binhost_trust("gentoo"))
+    assert not recorder.degraded(portage.BINARY_PACKAGES)
 
 
 def test_a_source_retry_killed_by_the_machine_says_so() -> None:


### PR DESCRIPTION
The merge that installs the community signing key degraded the global binary-package key, so a route to `distfiles.gentoozh.org` being down switched off the official Gentoo host as well — the case `binhost_trust()` exists to prevent, and whose docstring says so. An unreadable package index did the same, and recorded only the first host when two failed.

Each of those now degrades the host it belongs to. `Emerge` carries the hosts it was planned with and asks whether any of them is still usable, the way `SettleBinhostFeature` already did, so a machine whose only host cannot be read still falls back to source while a machine with a healthy peer keeps using it.

`VerifyPackages` kept the looser classification the host-scoped pattern does not cover: a line Portage prints in another shape still says the index could not be read, and ending the install there is worse than degrading.