### PR TITLE
fix six high-severity defects the sweep found

### DIFF
--- a/gentoo_install/exec/apply.py
+++ b/gentoo_install/exec/apply.py
@@ -376,7 +376,10 @@ def identity(operation: Operation) -> str:
 
 
 def already_degraded(journal: Journal | None) -> set[str]:
-    """What a previous run gave up on, so a resume gives up on it too.
+    """What a completed operation gave up on, so a resume gives up on it too.
+
+    A degradation is durable only after its operation returns: a failed source
+    fallback must not make its next attempt skip every binary package.
 
     Without this a resumed run rebuilt an empty `given_up`: the operation that
     recorded an unusable binary host had already completed and was skipped, so
@@ -386,11 +389,19 @@ def already_degraded(journal: Journal | None) -> set[str]:
     """
     if journal is None:
         return set()
-    return {
-        str(entry["what"])
-        for entry in journal.resume_entries()
-        if entry.get("event") == "degraded" and entry.get("what")
-    }
+    pending: set[str] = set()
+    finished: set[str] = set()
+    for entry in journal.resume_entries():
+        if entry.get("event") == "degraded":
+            if what := entry.get("what"):
+                pending.add(str(what))
+            continue
+        if entry.get("event") != "operation":
+            continue
+        if entry.get("status") == "done":
+            finished.update(pending)
+        pending.clear()
+    return finished
 
 
 def completed(journal: Journal | None) -> frozenset[tuple[int, str]]:

--- a/gentoo_install/exec/convert.py
+++ b/gentoo_install/exec/convert.py
@@ -58,27 +58,27 @@ def _unescape(field: str) -> str:
 
 
 def _mounts_inside(directory: Path, points: frozenset[str]) -> list[str]:
-    """Name every entry of `directory` that is itself a mount point.
+    """Name every mount point below `directory`, at any depth.
 
     A directory that cannot be listed is refused rather than reported as
-    holding nothing. The caller decides from this answer whether the rename
-    is safe, and `[]` from an `OSError` said exactly what `[]` from a
-    directory with nothing mounted below it says: `rename(2)` then answers
-    EBUSY partway through the entries, which is the state its own comment
-    calls one with no clean rollback.
-
-    One level is the depth that matters: renaming a directory with a mount
-    nested further down succeeds, and only renaming the mount point itself
-    answers EBUSY.
+    holding nothing. Moving its contents has no clean rollback after an entry
+    has moved.
     """
     try:
-        entries = sorted(os.listdir(directory))
+        with os.scandir(directory):
+            pass
     except OSError as error:
         raise ConversionFailed(
-            f"{directory} cannot be listed, so whether it holds a mount this "
-            f"conversion cannot move is unknown: {error}"
+            f"{directory} cannot be listed, so this irreversible replacement "
+            f"is refused: {error}"
         ) from error
-    return [one for one in entries if str(directory / one) in points]
+    directory_text = str(directory)
+    prefix = "/" if directory_text == "/" else f"{directory_text}/"
+    return sorted(
+        point[len(prefix) :]
+        for point in points
+        if point != directory_text and point.startswith(prefix)
+    )
 
 
 class Arrival(Enum):
@@ -207,26 +207,23 @@ def convert(
             raise ConversionFailed(f"the staging directory has no {name}")
         if os.path.lexists(old):
             raise ConversionFailed(f"{old} is left from an earlier attempt")
-        # Read once and used twice: the second read decided which replacement
-        # and rollback this entry gets, so a mount appearing between the two
-        # skipped the nested check above and still took the mounted path.
+        # Classify this destination from the snapshot that checked descendants;
+        # a later read could choose an unchecked replacement path.
         mounted = str(destination) in points
-        if mounted:
-            # Counted before anything moves: `rename(2)` answers EBUSY for a
-            # mount point, and finding that out halfway through the entries is
-            # a state with no clean rollback.
+        present = os.path.lexists(destination)
+        if present and not destination.is_symlink():
+            # Checked before anything moves: cleanup must never traverse a
+            # mount that a renamed tree carried into its backup.
             nested = _mounts_inside(destination, points)
             if nested:
                 raise ConversionFailed(
-                    f"{destination} is a separate mount holding {', '.join(nested)}, "
-                    "which rename cannot move"
+                    f"{destination} is holding {', '.join(nested)} mount points, "
+                    "which must not be moved aside"
                 )
         # A distribution without one of these is converted, not refused: a
         # merged-usr Debian has no `/lib64` at all, and renaming what is not
         # there fails half way through with the rest already swapped.
-        destinations.append(
-            (name, destination, staged, old, os.path.lexists(destination), mounted)
-        )
+        destinations.append((name, destination, staged, old, present, mounted))
     # Mount points last: replacing one by content is the only step whose
     # rollback touches more than two renames, so nothing else has to be undone
     # after one of them succeeded.

--- a/gentoo_install/model/compat.py
+++ b/gentoo_install/model/compat.py
@@ -87,11 +87,16 @@ UNSERVED_PROFILES: Final[dict[str, str]] = {
 def unserved_profile_problems(profile: str) -> tuple[str, ...]:
     """The stage3 requirements of profile path segments this installer cannot fetch."""
     segments = set(profile.split("/"))
-    return tuple(
-        f"profile {profile} needs its own stage3: {reason}"
+    reasons = [
+        reason
         for segment, reason in sorted(UNSERVED_PROFILES.items())
         if segment in segments
-    )
+    ]
+    if "prefix" in segments:
+        reasons.append("prefix has no stage3 this installer can unpack into a Linux root")
+    if {"split-usr", "no-multilib"} <= segments:
+        reasons.append("no stage3 is published for both split-usr and no-multilib")
+    return tuple(f"profile {profile} needs its own stage3: {reason}" for reason in reasons)
 
 
 class NetworkField(Enum):
@@ -871,22 +876,20 @@ def traits_of(
     # reads what a device is built from, and a reused array is built from
     # nothing this model knows. Runtime facts identify the assembled array.
     mounted = esp_mount(graph)
-    beneath = {node.id for node in _chain(graph, mounted.id)} if mounted else set()
-    for reused in graph.of_type(Existing):
-        if reused.id not in beneath:
-            continue
-        metadata = facts.metadata_for(reused.id)
-        # `NOT_PROBED` is a plan built without facts and answers nothing.
-        # `UNAVAILABLE` is mdadm asked and unable to say, which cannot be read
-        # as `ABSENT`: an esp on a 1.2 array boots nothing.
-        if metadata is MdraidMetadataState.UNAVAILABLE:
-            found.add(Trait.ESP_MDRAID_UNREADABLE)
-            continue
-        if not isinstance(metadata, RaidMetadata):
-            continue
-        found.add(Trait.ESP_ON_MDRAID)
-        if metadata.superblock_at_start:
-            found.add(Trait.ESP_MDRAID_SUPERBLOCK_AT_START)
+    if mounted is not None:
+        for esp_device in _existing_beneath(graph, mounted.id):
+            metadata = facts.metadata_for(esp_device)
+            # `NOT_PROBED` is a plan built without facts and answers nothing.
+            # `UNAVAILABLE` is mdadm asked and unable to say, which cannot be read
+            # as `ABSENT`: an esp on a 1.2 array boots nothing.
+            if metadata is MdraidMetadataState.UNAVAILABLE:
+                found.add(Trait.ESP_MDRAID_UNREADABLE)
+                continue
+            if not isinstance(metadata, RaidMetadata):
+                continue
+            found.add(Trait.ESP_ON_MDRAID)
+            if metadata.superblock_at_start:
+                found.add(Trait.ESP_MDRAID_SUPERBLOCK_AT_START)
 
     for table in _nodes_under(graph, config.disk.root, PartitionTable):
         if table.table is TableType.GPT and not _has_bios_boot(graph, table.id):
@@ -905,7 +908,7 @@ def traits_of(
     # for.
     if config.system.authorized_keys and not config.kernel.remote_unlock.enabled:
         found.add(Trait.AUTHORIZED_KEYS)
-        if not _a_key_can_log_in(config.system):
+        if config.system.sshd and not _a_key_can_log_in(config.system):
             found.add(Trait.NO_ACCOUNT_A_KEY_CAN_REACH)
     if config.kernel.remote_unlock.enabled:
         found.add(Trait.REMOTE_UNLOCK)

--- a/gentoo_install/model/validate.py
+++ b/gentoo_install/model/validate.py
@@ -89,6 +89,9 @@ PACKAGE_GROUP_FIELDS: Final[tuple[str, ...]] = (
 )
 
 HTTP_SCHEMES: Final[frozenset[str]] = frozenset({"http", "https"})
+#: `useradd` rejects bad account names after storage is written, so its rule lives here.
+_USER_NAME: Final[re.Pattern[str]] = re.compile(r"^[a-z_][a-z0-9_-]{0,31}$")
+
 _HOSTNAME_LABEL: Final[re.Pattern[str]] = re.compile(
     r"[A-Za-z0-9](?:[A-Za-z0-9-]{0,61}[A-Za-z0-9])?"
 )
@@ -451,8 +454,18 @@ _REPOSITORY_NAME: Final[re.Pattern[str]] = re.compile(r"[A-Za-z0-9_][A-Za-z0-9_+
 
 
 def _repository_name_problems(config: InstallConfig) -> list[str]:
-    problems = []
-    shipped = {overlay.name for overlay in config.portage.overlays} | {"gentoo"}
+    problems: list[str] = []
+    shipped = {"gentoo"}
+    for overlay in config.portage.overlays:
+        name = overlay.name
+        if _REPOSITORY_NAME.fullmatch(name) is None:
+            problems.append(f"{name!r} is not a repository name")
+        elif name in shipped:
+            # Two `repos.conf` sections of the same name, and the later
+            # sync-uri replaces the earlier one.
+            problems.append(f"{name} is already configured with its own sync-uri")
+        else:
+            shipped.add(name)
     for name in config.portage.repositories:
         if _REPOSITORY_NAME.fullmatch(name) is None:
             problems.append(f"{name!r} is not a repository name")
@@ -461,6 +474,7 @@ def _repository_name_problems(config: InstallConfig) -> list[str]:
             # sync-uri replaces the earlier one.
             problems.append(f"{name} is already configured with its own sync-uri")
     return problems
+
 
 
 def _l10n_problems(config: InstallConfig) -> list[str]:
@@ -479,12 +493,31 @@ def _locale_problems(config: InstallConfig) -> list[str]:
     return problems
 
 
+def _user_name_problems(system: SystemConfig) -> list[str]:
+    problems = [
+        f"system.users[{index}].name is {user.name!r}, which useradd cannot create"
+        for index, user in enumerate(system.users)
+        if _USER_NAME.fullmatch(user.name) is None
+    ]
+    problems += [
+        f"system.users[{index}].name is root, which is already the target's root account"
+        for index, user in enumerate(system.users)
+        if user.name == "root"
+    ]
+    problems += [
+        f"{count} system.users entries are named {name!r}; user names must be unique"
+        for name, count in Counter(user.name for user in system.users).items()
+        if count > 1
+    ]
+    return problems
+
+
 def _system_value_problems(
     config: InstallConfig,
     available_timezones: Collection[str] | _ShippedValuesNotRead,
 ) -> list[str]:
     system = config.system
-    problems: list[str] = []
+    problems = _user_name_problems(system)
     hostname = system.hostname
     if len(hostname) > _HOSTNAME_MAXIMUM or any(
         _HOSTNAME_LABEL.fullmatch(label) is None for label in hostname.split(".")

--- a/gentoo_install/plan/convert.py
+++ b/gentoo_install/plan/convert.py
@@ -62,6 +62,11 @@ class Staged(Operation):
     def releases_the_machine(self) -> bool:
         return self.inner.releases_the_machine
 
+    @property
+    def survives_a_reboot(self) -> bool:
+        # Failure cleanup removes the staging root, so a resume must rebuild it.
+        return False
+
     def describe(self) -> str:
         return f"{self.inner.describe()}, in {self.staging}"
 

--- a/gentoo_install/plan/disk.py
+++ b/gentoo_install/plan/disk.py
@@ -1453,7 +1453,8 @@ def resolve_share(
 
     A share is a share of what the table can hand out after every absolute
     size on it, so `40%` beside `60%` beside an esp and a swap is a layout
-    that fits. `None` still means the rest, which is what `sgdisk` is told.
+    that fits. `None` means the rest; a bounded rest becomes a size only when
+    its maximum would otherwise be exceeded.
 
     Resolved here rather than at `apply()` so that `describe()` prints the
     number the run will use: a `--dry-run` that says `40%` and an install that
@@ -1465,25 +1466,27 @@ def resolve_share(
     function's docstring says why: answered separately, an operator was told
     their sizes fitted and the install refused them an hour later.
     """
-    if partition.share is None:
+    share = partition.share
+    if share is None:
         return partition.size
-    if partition.share.percent is None:
-        return _bounded(None, partition)
+    if share.percent is None:
+        return _bounded_rest(graph, partition, facts)
     table = _expect(graph, partition.table, PartitionTable)
     base = share_base(graph, table, facts)
     if base is None:
         if not table.create:
             raise InvalidLayout(
-                f"{partition.id} asks for {partition.share.percent}% of free space on "
+                f"{partition.id} asks for {share.percent}% of free space on "
                 f"{table.id}, but no measured free extents were provided; probe the "
                 "table before planning"
             )
         raise InvalidLayout(
-            f"{partition.id} asks for {partition.share.percent}% of {table.disk}, "
+            f"{partition.id} asks for {share.percent}% of {table.disk}, "
             f"and this machine did not report that disk's size"
         )
-    wanted = Size(int(base.bytes * partition.share.percent / 100)).align_down()
+    wanted = Size(int(base.bytes * share.percent / 100)).align_down()
     return _bounded(wanted, partition)
+
 
 
 def share_base(
@@ -1513,6 +1516,59 @@ def share_base(
         table.table is TableType.GPT, SectorSize(512)
     )
     return Size(max(0, usable.bytes - fixed))
+
+def _bounded_rest(
+    graph: DeviceGraph, partition: Partition, facts: StorageFacts
+) -> Size | None:
+    share = partition.share
+    assert share is not None
+    if share.minimum is None and share.maximum is None:
+        return None
+    available = _rest_available(graph, partition, facts)
+    if share.minimum is not None and available < share.minimum:
+        raise InvalidLayout(
+            f"{partition.id} has {available} left, below the {share.minimum} it asks for"
+        )
+    if share.maximum is not None and share.maximum < available:
+        return share.maximum
+    return None
+
+
+def _rest_available(
+    graph: DeviceGraph, partition: Partition, facts: StorageFacts
+) -> Size:
+    table = _expect(graph, partition.table, PartitionTable)
+    if not table.create:
+        extents = facts.free_extents.get(table.id)
+        if extents is None:
+            raise InvalidLayout(
+                f"{partition.id} takes a bounded rest of {table.id}, but no measured free "
+                "extents were provided; probe the table before planning"
+            )
+        start, end = _free_extent_for(graph, table, partition, extents, facts)
+        return Size(max(0, end.bytes - start.bytes))
+    base = share_base(graph, table, facts)
+    if base is None:
+        raise InvalidLayout(
+            f"{partition.id} takes a bounded rest of {table.disk}, and this machine did "
+            "not report that disk's size"
+        )
+    claimed = 0
+    for sibling in graph.of_type(Partition):
+        share = sibling.share
+        if (
+            sibling.table != table.id
+            or sibling.index >= partition.index
+            or share is None
+            or share.percent is None
+        ):
+            continue
+        resolved = resolve_share(graph, sibling, facts)
+        if resolved is None:
+            raise InvalidLayout(f"{sibling.id} does not resolve to a size")
+        claimed += resolved.bytes
+    return Size(max(0, base.bytes - claimed))
+
 
 
 def _bounded(wanted: Size | None, partition: Partition) -> Size | None:
@@ -1603,6 +1659,20 @@ def _into_free_space(
     Every added partition of one table is placed in extent order, so two of
     them do not both take the start of the same gap.
     """
+    start, _ = _free_extent_for(
+        graph, table, partition, free_extents, storage_facts
+    )
+    return start
+
+
+def _free_extent_for(
+    graph: DeviceGraph,
+    table: PartitionTable,
+    partition: Partition,
+    free_extents: tuple[Extent, ...],
+    storage_facts: StorageFacts,
+) -> tuple[Size, Size]:
+    """The selected free extent's start and end."""
     added = [
         one
         for one in sorted(graph.of_type(Partition), key=lambda node: node.index)
@@ -1622,7 +1692,7 @@ def _into_free_space(
             if at.bytes + needed > extent.end + 1:
                 continue
             if one.id == partition.id:
-                return at
+                return at, Size(extent.end + 1).align_down()
             cursor[extent.start] = (at + wanted).align_up() if wanted is not None else at
             break
         else:

--- a/gentoo_install/plan/portage.py
+++ b/gentoo_install/plan/portage.py
@@ -2239,13 +2239,12 @@ def _l10n(config: InstallConfig) -> tuple[str, ...]:
     return tuple(tags)
 
 
-#: The stage3 Gentoo publishes for each profile target, by the profile path
-#: segment that names it. Order matters: `no-multilib` is checked before the
-#: plain base, and `desktop` covers `desktop/plasma` and `desktop/gnome`, for
-#: which Gentoo publishes no stage3 of their own.
+#: The published stage3 variant for profile path segments. `split-usr` and
+#: `no-multilib` precede `desktop`, which publishes no child-specific stage3.
 STAGE3_BY_PROFILE: tuple[tuple[str, str], ...] = (
-    ("/no-multilib", "nomultilib"),
-    ("/desktop", "desktop"),
+    ("/split-usr", "{init}-splitusr"),
+    ("/no-multilib", "nomultilib-{init}"),
+    ("/desktop", "desktop-{init}"),
 )
 
 
@@ -2260,7 +2259,7 @@ def variant_of(config: InstallConfig) -> str:
     """
     init = "systemd" if config.system.init is InitSystem.SYSTEMD else "openrc"
     profile = config.portage.profile
-    for segment, target in STAGE3_BY_PROFILE:
+    for segment, variant in STAGE3_BY_PROFILE:
         if segment in profile:
-            return f"{target}-{init}"
+            return variant.format(init=init)
     return init

--- a/gentoo_install/tui/widgets.py
+++ b/gentoo_install/tui/widgets.py
@@ -583,7 +583,7 @@ class _Menu(Generic[V, A]):
         for offset, one in enumerate(self.preamble):
             screen.write(offset + 1, 2, clip(one, columns - 4))
         above = len(self.preamble)
-        room = lines - 4 - above
+        room = max(0, lines - 4 - above)
         displayed = self._display_rows(columns)
         # A filter can hide every row, and then there is no cursor to keep on
         # screen: an empty list with a count of nothing is the answer, not a
@@ -591,13 +591,11 @@ class _Menu(Generic[V, A]):
         cursor_row = next(
             (row for row, (index, _) in enumerate(displayed) if index == cursor), 0
         )
-        top = max(0, min(cursor_row - room // 2, len(displayed) - room))
+        top = _window(cursor_row, room, len(displayed))
         # On the title row, and only when a row is off the screen: a list that
         # scrolls with nothing to say so reads as the whole list, and the
         # profile screen was read as offering thirteen of its fourteen.
-        counted = (
-            f"{cursor_row + 1}/{len(displayed)}" if len(displayed) > room else ""
-        )
+        counted = f"{cursor_row + 1}/{len(displayed)}" if room and len(displayed) > room else ""
         screen.write(0, 0, spread(clip(self.title, columns), counted, columns))
         for row, (index, text) in enumerate(displayed[top : top + room]):
             if index is None:
@@ -768,14 +766,12 @@ class TextField:
         shown = "*" * len(typed) if self.masked else "".join(typed)
         shown = _tail_that_fits(shown, room - 1)
         if self.detail:
-            # Wrapped, not clipped: the exact string to type is the last thing
-            # in this line and the first thing a clip removes. An operator
-            # whose screen cut the line short typed the row's own name instead.
-            # Bounded so the field and the footer keep their rows: a detail
-            # long enough to fill the screen would otherwise push the box off
-            # the bottom and leave nowhere to type.
-            for one in wrap_to_cells(self.detail, columns)[: max(0, lines - row - 2)]:
-                screen.write(row, 0, one)
+            # The tail names the exact answer; bounding it preserves the field
+            # and footer rows when detail fills the screen.
+            detail_lines = wrap_to_cells(self.detail, columns)
+            start = max(0, len(detail_lines) - max(0, lines - row - 2))
+            for index in range(start, len(detail_lines)):
+                screen.write(row, 0, detail_lines[index])
                 row += 1
             if row < lines - 2:
                 row += 1
@@ -1065,8 +1061,8 @@ MARKER_ROOM: Final[int] = 2
 #: Below this the interface draws nothing and says so. One pane needs a label
 #: it does not have to cut, which is what `LEFT_PANE_MINIMUM` stands for, and
 #: a title, the cursor's row, the two summary lines under it and a footer.
-#: Measured against every widget on 2026-08-21: the narrowest any of them can
-#: still put its content on is 7x5, so this floor is above all of them.
+#: Measured against the widget frames on 2026-08-21: the floor preserves
+#: structural rows, while a preamble can leave a menu body empty.
 MINIMUM_COLUMNS: Final[int] = LEFT_PANE_MINIMUM
 MINIMUM_LINES: Final[int] = 6
 

--- a/tests/unit/test_compat.py
+++ b/tests/unit/test_compat.py
@@ -325,6 +325,7 @@ def a_key_no_account_can_use() -> InstallConfig:
         system=SystemConfig(
             root_password_hash="$6$salt$" + "x" * 86,
             authorized_keys=("ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAI zakk@host",),
+            sshd=True,
         ),
     )
 
@@ -1456,3 +1457,87 @@ def test_every_kernel_package_trait_has_a_reader() -> None:
     assert [one for one in traits if one not in read] == [], sorted(
         one for one in traits if one not in read
     )
+
+
+def test_an_unavailable_disk_below_a_new_esp_is_not_an_unreadable_esp() -> None:
+    from gentoo_install.model.validate import validate
+
+    installation = config()
+    facts = StorageFacts(mdraid_metadata={i("disk"): MdraidMetadataState.UNAVAILABLE})
+
+    assert Trait.ESP_MDRAID_UNREADABLE not in traits_of(installation, facts)
+    validate(installation, storage_facts=facts)
+
+
+def test_authorized_keys_without_sshd_do_not_need_an_ssh_account() -> None:
+    from gentoo_install.model.validate import validate
+
+    base = config()
+    installation = replace(
+        base,
+        system=replace(
+            base.system,
+            authorized_keys=(VALID_KEY,),
+            sshd=False,
+            sshd_root_login=True,
+            users=(
+                User(
+                    name="zakk",
+                    sudo=True,
+                    password_hash=base.system.root_password_hash,
+                ),
+            ),
+        ),
+    )
+
+    present = traits_of(installation)
+    assert Trait.NO_ACCOUNT_A_KEY_CAN_REACH not in present
+    validate(installation)
+
+
+@pytest.mark.parametrize(
+    "profile",
+    (
+        "default/linux/amd64/23.0/split-usr",
+        "default/linux/amd64/23.0/split-usr/desktop",
+    ),
+)
+def test_split_usr_profiles_select_the_published_splitusr_stage3(profile: str) -> None:
+    from gentoo_install.model.config import InitSystem
+    from gentoo_install.model.validate import validate
+    from gentoo_install.plan.portage import variant_of
+
+    base = config()
+    installation = replace(
+        base,
+        portage=replace(base.portage, profile=profile),
+        system=replace(base.system, init=InitSystem.OPENRC),
+    )
+
+    assert compat.unserved_profile_problems(profile) == ()
+    validate(installation)
+    assert variant_of(installation) == "openrc-splitusr"
+
+
+@pytest.mark.parametrize(
+    "profile",
+    (
+        "default/linux/amd64/23.0/split-usr/no-multilib",
+        "default/linux/amd64/23.0/no-multilib/prefix",
+    ),
+)
+def test_profiles_without_a_matching_stage3_are_refused(profile: str) -> None:
+    from gentoo_install.errors import ValidationFailed
+    from gentoo_install.model.config import InitSystem
+    from gentoo_install.model.validate import validate
+
+    base = config()
+    installation = replace(
+        base,
+        portage=replace(base.portage, profile=profile),
+        system=replace(base.system, init=InitSystem.OPENRC),
+    )
+
+    assert compat.unserved_profile_problems(profile)
+    with pytest.raises(ValidationFailed, match="needs its own stage3"):
+        validate(installation)

--- a/tests/unit/test_convert.py
+++ b/tests/unit/test_convert.py
@@ -341,6 +341,54 @@ def test_a_mount_inside_a_mounted_directory_is_refused_before_any_move(
     assert (root / "usr" / "kept.txt").read_text() == "old", "nothing was moved"
 
 
+def test_a_deep_mount_inside_a_mounted_directory_is_refused_before_any_move(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A renamed parent keeps a nested mount attached, and cleanup can walk it."""
+    root = tmp_path / "root"
+    staging = root / "new"
+    for name in ("usr", "var"):
+        (root / name).mkdir(parents=True)
+        (staging / name).mkdir(parents=True)
+    protected = root / "var" / "lib" / "docker" / "operator-data"
+    protected.parent.mkdir(parents=True)
+    protected.write_text("precious")
+    (root / "usr" / "kept.txt").write_text("old")
+
+    _pretend_mounts(monkeypatch, root / "var", protected.parent)
+
+    with pytest.raises(ConversionFailed, match=r"holding lib/docker"):
+        convert.convert(staging, ("usr", "var"), copy=_copy, root=root)
+
+    assert (root / "usr" / "kept.txt").read_text() == "old", "nothing was moved"
+    assert protected.read_text() == "precious", "the mounted tree was touched"
+    assert not (root / "var.gentoo-install.old").exists()
+
+
+def test_a_mount_inside_an_ordinary_directory_is_refused_before_any_move(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A destination need not be a mount to contain a mount that rename carries."""
+    root = tmp_path / "root"
+    staging = root / "new"
+    for name in ("usr", "var"):
+        (root / name).mkdir(parents=True)
+        (staging / name).mkdir(parents=True)
+    protected = root / "var" / "log" / "operator-data"
+    protected.parent.mkdir()
+    protected.write_text("precious")
+    (root / "usr" / "kept.txt").write_text("old")
+
+    _pretend_mounts(monkeypatch, protected.parent)
+
+    with pytest.raises(ConversionFailed, match=r"holding log"):
+        convert.convert(staging, ("usr", "var"), copy=_copy, root=root)
+
+    assert (root / "usr" / "kept.txt").read_text() == "old", "nothing was moved"
+    assert protected.read_text() == "precious", "the mounted tree was touched"
+    assert not (root / "var.gentoo-install.old").exists()
+
+
 def test_a_mounted_directory_is_filled_by_copy_when_rename_cannot_cross(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:

--- a/tests/unit/test_exec.py
+++ b/tests/unit/test_exec.py
@@ -389,6 +389,52 @@ def test_an_unreadable_binhost_is_journalled_and_the_run_finishes(tmp_path: Path
     assert [("--getbinpkg=n" in command) for command in runner.commands] == [False, False, True, True]
 
 
+def test_a_failed_binary_fallback_is_not_replayed_on_resume(tmp_path: Path) -> None:
+    """A failed source retry leaves the binary-host choice uncommitted."""
+    journal = Journal(path=tmp_path / "install.jsonl")
+    binary_failure = "!!! Fetching Binary failed: app-editors/nano-8\n"
+    source_failure = "!!! Couldn't download 'app-editors/nano-8.tar.xz'. Aborting.\n"
+
+    class SourceFails(Runner):
+        def __init__(self) -> None:
+            super().__init__(log=lambda line: None, journal=journal)
+            self.commands: list[tuple[str, ...]] = []
+
+        def in_target(self, target: Path) -> Runner:
+            return self
+
+        def run(
+            self,
+            argv: Sequence[str],
+            *,
+            check: bool = True,
+            input_text: str | None = None,
+            timeout: float | None = None,
+        ) -> Result:
+            command = tuple(argv)
+            self.commands.append(command)
+            assert command[0] == "emerge"
+            output = source_failure if "--getbinpkg=n" in command else binary_failure
+            return Result(command, 1, output, "", 0.0)
+
+    runner = SourceFails()
+    machine = apply.Machine(
+        config=config(),
+        runner=runner,
+        probe=Probe(runner=runner, work=tmp_path),
+        work=tmp_path,
+    )
+    operation = portage.Emerge(packages=("app-editors/nano",), summary="install the editor")
+
+    with pytest.raises(CommandFailed):
+        apply.apply((operation,), machine)
+
+    records = [entry for entry in journal.replay() if entry["event"] == "operation"]
+    assert [entry["status"] for entry in records] == ["failed"]
+    assert [("--getbinpkg=n" in command) for command in runner.commands] == [False, False, True]
+    assert apply.already_degraded(Journal(path=journal.path)) == set()
+
+
 def test_a_live_findmnt_result_enables_the_lazy_unmount_fallback(tmp_path: Path) -> None:
     from gentoo_install.plan.disk import UnmountTarget
 

--- a/tests/unit/test_harness.py
+++ b/tests/unit/test_harness.py
@@ -2623,13 +2623,16 @@ def test_a_console_that_keeps_printing_is_not_ended_by_the_ceiling() -> None:
 
         def __init__(self) -> None:
             self._buffer = b""
+            self._bytes_read = 0
             self.reads = 0
 
         def _read_once(self) -> None:
             self.reads += 1
             clock.sleep(0.01)
             if not self.quiet:
-                self._buffer += b"dev-libs/one/Manifest\n"
+                chunk = b"dev-libs/one/Manifest\n"
+                self._buffer += chunk
+                self._bytes_read += len(chunk)
 
     # Short enough to run, and the same shape: the idle window is a fifth of
     # the ceiling, and output arrives well inside it.
@@ -2646,6 +2649,46 @@ def test_a_console_that_keeps_printing_is_not_ended_by_the_ceiling() -> None:
         quiet.expect("MARK_1_DONE", timeout=1.0, idle=0.2)
     waited = clock.monotonic() - started
     assert waited < 0.6, f"silence ended it at {waited:.2f}s, not at the ceiling"
+
+
+def test_console_activity_past_buffer_limit_is_not_idle(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A retained tail is diagnostic state, not an activity counter."""
+    import time
+
+    from tests.vm.console import ConsoleIdle, ConsoleTimeout, SerialConsole
+
+    clock = [0.0]
+    monkeypatch.setattr(time, "monotonic", lambda: clock[0])
+    output = b"dev-libs/one/Manifest\n"
+
+    class Printing:
+        closed = False
+
+        def __init__(self) -> None:
+            self.reads = 0
+
+        def recv(self, size: int) -> bytes:
+            self.reads += 1
+            clock[0] += 0.01
+            return output
+
+        def sendall(self, data: bytes) -> None:
+            return None
+
+        def close(self) -> None:
+            return None
+
+    guest = Printing()
+    limit = 2 * len(output)
+    console = SerialConsole(guest, BytesIO(), buffer_limit=limit)
+    with pytest.raises(ConsoleTimeout) as timed:
+        console.expect("MARK_1_DONE", timeout=1.0, idle=0.2)
+    assert not isinstance(timed.value, ConsoleIdle)
+    assert guest.reads > 2
+    assert len(console._buffer) == limit
+    assert clock[0] == pytest.approx(1.0)
 
 
 def test_a_cn_run_clones_the_overlay_from_a_chinese_mirror(tmp_path: Path) -> None:
@@ -4744,6 +4787,7 @@ def test_a_conversion_reads_its_exit_code_and_not_the_echo() -> None:
 
         def __init__(self, answer: bytes) -> None:
             self._buffer = b""
+            self._bytes_read = 0
             self.answer = answer
             self.sent: list[str] = []
             # From ten, which is where the marker in the echo first carries a

--- a/tests/unit/test_plan_convert.py
+++ b/tests/unit/test_plan_convert.py
@@ -345,6 +345,16 @@ def test_the_staging_root_is_created_before_anything_is_written() -> None:
     assert isinstance(first.inner, convert.PrepareStaging)
 
 
+def test_a_resumed_conversion_rebuilds_staged_operations() -> None:
+    """Failure cleanup removes the staging root, so its completed work reruns."""
+    staged = [
+        one for one in build(_in_place(), CATALOG, layout=_layout())
+        if isinstance(one, convert.Staged)
+    ]
+    assert staged
+    assert not any(one.survives_a_reboot for one in staged)
+
+
 def test_a_staging_root_left_from_an_earlier_attempt_is_refused() -> None:
     context = _RunningContext()
     context.answers = {"find": "/gentoo-install.new/usr"}

--- a/tests/unit/test_plan_disk.py
+++ b/tests/unit/test_plan_disk.py
@@ -1629,6 +1629,24 @@ def test_a_share_is_of_what_the_fixed_sizes_leave_and_its_bounds_hold() -> None:
     assert _resolved('size = "20G"', "240G") == Size.parse("20G")
 
 
+def test_a_rest_partition_honours_bounds_in_its_plan() -> None:
+    bounded = _with_root_extent('size = "rest"\nmin = "20GiB"\nmax = "100GiB"')
+    facts = StorageFacts(capacities={i("disk"): Size.parse("4TiB")})
+    partition = next(
+        operation
+        for operation in disk.build(bounded, facts)
+        if isinstance(operation, disk.CreatePartition) and operation.partition == i("rootpart")
+    )
+    assert partition.size == Size.parse("100GiB")
+    assert "100GiB" in partition.describe()
+    recorder = Recorder()
+    partition.apply(recorder)
+    assert recorder.only("sgdisk")[1:3] == ("--new=2:0:+100G", "--typecode=2:8300")
+
+    with pytest.raises(InvalidLayout, match="below the"):
+        _resolved('size = "rest"\nmin = "100GiB"', "100GiB")
+
+
 def test_a_share_on_an_edited_table_uses_its_measured_free_space() -> None:
     """A retained partition is not a model node, so capacity overstates this share."""
     nodes: list[Node] = [

--- a/tests/unit/test_resume.py
+++ b/tests/unit/test_resume.py
@@ -453,6 +453,15 @@ def test_an_emerge_after_a_resume_still_builds_from_source(tmp_path: Path) -> No
 
     journal = Journal(tmp_path / "install.jsonl")
     journal.degraded(BINARY_PACKAGES, "the key was never signed")
+    journal.write(
+        "operation",
+        stage="packages",
+        describe="merge",
+        identity="merge",
+        seconds=0.0,
+        status="done",
+        position=0,
+    )
 
     recorder = Recorder()
     for what in already_degraded(journal):

--- a/tests/unit/test_validate.py
+++ b/tests/unit/test_validate.py
@@ -28,6 +28,7 @@ from gentoo_install.model.config import (
     PackagesConfig,
     PortageConfig,
     SystemConfig,
+    User,
 )
 from gentoo_install.model.device import DeviceGraph
 from gentoo_install.model.device import (
@@ -551,6 +552,28 @@ def test_hostname_uses_rfc_1123_label_and_length_boundaries() -> None:
                 system=replace(installation.system, hostname=f"{hostname}a"),
             )
         )
+
+
+@pytest.mark.parametrize(
+    ("users", "said"),
+    (
+        ((User(name="root"),), "root account"),
+        ((User(name="Bad Name"),), "useradd cannot create"),
+        ((User(name="-x"),), "useradd cannot create"),
+        ((User(name="a/b"),), "useradd cannot create"),
+        ((User(name="zakk"), User(name="zakk")), "user names must be unique"),
+    ),
+)
+def test_a_user_name_useradd_cannot_create_is_refused(users: tuple[User, ...], said: str) -> None:
+    installation = config()
+    with pytest.raises(ValidationFailed) as refused:
+        validate(
+            replace(
+                installation,
+                system=replace(installation.system, users=users),
+            )
+        )
+    assert said in str(refused.value), refused.value
 
 
 _PACKAGE_GROUP_CASES: tuple[str, ...] = (
@@ -1540,6 +1563,39 @@ def test_a_repository_name_is_checked_before_it_reaches_eselect() -> None:
             installation, portage=replace(installation.portage, repositories=("science",))
         )
     )
+
+@pytest.mark.parametrize(
+    ("overlays", "said"),
+    (
+        (
+            (Overlay(name="not a name", sync_uri="https://example.invalid/one.git"),),
+            "not a repository name",
+        ),
+        (
+            (Overlay(name="gentoo", sync_uri="https://example.invalid/one.git"),),
+            "already configured",
+        ),
+        (
+            (
+                Overlay(name="example", sync_uri="https://example.invalid/one.git"),
+                Overlay(name="example", sync_uri="https://example.invalid/two.git"),
+            ),
+            "already configured",
+        ),
+    ),
+)
+def test_an_overlay_name_is_checked_before_it_writes_repos_conf(
+    overlays: tuple[Overlay, ...], said: str
+) -> None:
+    installation = config()
+    with pytest.raises(ValidationFailed) as refused:
+        validate(
+            replace(
+                installation,
+                portage=replace(installation.portage, overlays=overlays),
+            )
+        )
+    assert said in str(refused.value), refused.value
 
 
 def test_a_table_this_run_writes_needs_a_disk_this_run_wipes() -> None:

--- a/tests/vm/console.py
+++ b/tests/vm/console.py
@@ -224,6 +224,7 @@ class SerialConsole:
         self._errors = errors
         self._buffer = b""
         self._last_chunk = b""
+        self._bytes_read = 0
         self._buffer_limit = buffer_limit
         self._tokens: Iterator[int] = itertools.count(1)
 
@@ -258,7 +259,7 @@ class SerialConsole:
         ceiling = started + timeout
         idle_deadline = started + idle if idle else ceiling
         deadline = min(ceiling, idle_deadline)
-        seen = len(self._buffer)
+        seen = self._bytes_read
         while time.monotonic() < deadline:
             clean = strip_ansi(self._buffer)
             found = matcher.search(clean)
@@ -268,8 +269,8 @@ class SerialConsole:
                 self._buffer = clean[found.end() :]
                 return clean[: found.end()]
             self._read_once()
-            if idle and len(self._buffer) != seen:
-                seen = len(self._buffer)
+            if idle and self._bytes_read != seen:
+                seen = self._bytes_read
                 idle_deadline = time.monotonic() + idle
                 deadline = min(ceiling, idle_deadline)
         silent = bool(idle) and idle_deadline < ceiling
@@ -410,6 +411,7 @@ class SerialConsole:
             if self._sock.closed:
                 raise ConsoleClosed(self._why_closed())
             return
+        self._bytes_read += len(chunk)
         self._log.write(chunk)
         self._log.flush()
         self._last_chunk = chunk


### PR DESCRIPTION
Six findings that survived two independent refuters, from modules no review had opened.

A filesystem mounted below a directory the conversion replaces was renamed away with that directory, and the cleanup then walked into the still-mounted tree; the guard saw only a mount that was the destination itself or one of its direct children. A resumed conversion skipped every staged operation although the failure path had deleted the staging root those operations built, and a replayed degradation was one no finished operation had recorded.

The esp mdraid rule asked the storage facts about every node under the mount rather than about the esp, and the authorized-key rule required `sshd`, which is off by default, so it never fired. A user name the installed system cannot carry reached `useradd` an hour into the run, `min` and `max` beside a rest partition were written back out and silently discarded, and an overlay name never got the rule a repository name already had.

The console idle window was measured from the buffer length, which stops growing at its limit, so the guest printing the most was the one most likely to be reported silent — and that verdict is what ends a cluster run. A preamble that fills the screen left the menu a negative row count, and a detail whose last line is the string the operator must type was cut with no mark.